### PR TITLE
Restore standalone analysis bootstrap

### DIFF
--- a/backend-standalone/build.gradle.kts
+++ b/backend-standalone/build.gradle.kts
@@ -72,9 +72,12 @@ val buildIdeCompatJar by tasks.registering(Jar::class) {
             provider { ideaHome.resolve("plugins/Kotlin/kotlinc/lib/kotlin-compiler.jar") },
         ),
     ) {
-        // Include all com.intellij.ide.plugins classes that the AA (PluginStructureProvider)
-        // needs in their OLD (kotlin-compiler.jar) form.
+        // Include all plugin-descriptor parsing classes that the AA
+        // (PluginStructureProvider) needs in their OLD (kotlin-compiler.jar) form.
         include("com/intellij/ide/plugins/**/*.class")
+        // ListenerDescriptor moved out of the compiler copy in IJ 2025.3's runtime libs,
+        // but the AA still writes the old mutable pluginDescriptor field.
+        include("com/intellij/util/messages/ListenerDescriptor.class")
         // ContainerDescriptor — replaced by our hybrid above.
         exclude("com/intellij/ide/plugins/ContainerDescriptor.class")
         // IdeaPluginDescriptorImpl — must use the IJ 2025.3 app.jar version (abstract class)

--- a/backend-standalone/src/compat/java/com/intellij/ide/plugins/ContainerDescriptor.java
+++ b/backend-standalone/src/compat/java/com/intellij/ide/plugins/ContainerDescriptor.java
@@ -1,7 +1,9 @@
 package com.intellij.ide.plugins;
 
+import com.intellij.openapi.components.ServiceDescriptor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Hybrid ContainerDescriptor that satisfies two incompatible API versions simultaneously:
@@ -10,6 +12,8 @@ import java.util.List;
  * <ul>
  *   <li>no-arg constructor</li>
  *   <li>{@code getServices()} method</li>
+ *   <li>{@code addService(ServiceDescriptor)} method</li>
+ *   <li>{@code getDistinctExtensionPointCount()}/{@code setDistinctExtensionPointCount(int)}</li>
  *   <li>mutable public fields {@code listeners}, {@code extensionPoints}</li>
  * </ul>
  *
@@ -24,14 +28,16 @@ import java.util.List;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public final class ContainerDescriptor {
 
-    // Private backing field for services (old API accesses via getServices()).
-    // AA's PluginStructureProvider calls getServices(), not a direct field access.
-    private List _services = new ArrayList();
+    // Public services field for the new API plus getter/addService for the old API.
+    public List services = new ArrayList();
 
     // Public mutable fields (old API) — AA reads these directly via getfield bytecode.
     public List components = new ArrayList();
     public List listeners = new ArrayList();
     public List extensionPoints = new ArrayList();
+    public transient Map extensions;
+
+    private int distinctExtensionPointCount;
 
     /** No-arg constructor from the old API. */
     public ContainerDescriptor() {}
@@ -41,7 +47,7 @@ public final class ContainerDescriptor {
      * Parameter order: services, components, listeners, extensionPoints.
      */
     public ContainerDescriptor(List services, List components, List listeners, List extensionPoints) {
-        this._services = services != null ? services : new ArrayList();
+        this.services = services != null ? services : new ArrayList();
         this.components = components != null ? components : new ArrayList();
         this.listeners = listeners != null ? listeners : new ArrayList();
         this.extensionPoints = extensionPoints != null ? extensionPoints : new ArrayList();
@@ -49,17 +55,25 @@ public final class ContainerDescriptor {
 
     /** Returns the services list. Called by AA's {@code PluginStructureProvider.getServices()}. */
     public List getServices() {
-        return _services;
+        return services;
     }
 
     /** Adds a service descriptor. Part of the old API used by some AA initialisation paths. */
-    public void addService(Object descriptor) {
-        _services.add(descriptor);
+    public void addService(ServiceDescriptor descriptor) {
+        services.add(descriptor);
+    }
+
+    public int getDistinctExtensionPointCount() {
+        return distinctExtensionPointCount;
+    }
+
+    public void setDistinctExtensionPointCount(int distinctExtensionPointCount) {
+        this.distinctExtensionPointCount = distinctExtensionPointCount;
     }
 
     @Override
     public String toString() {
-        return "ContainerDescriptor(services=" + _services
+        return "ContainerDescriptor(services=" + services
                 + ", components=" + components
                 + ", listeners=" + listeners
                 + ", extensionPoints=" + extensionPoints + ")";

--- a/backend-standalone/src/compat/java/com/intellij/ide/plugins/PluginXmlPathResolver.java
+++ b/backend-standalone/src/compat/java/com/intellij/ide/plugins/PluginXmlPathResolver.java
@@ -8,9 +8,13 @@ import com.intellij.util.xml.dom.StaxFactory;
 import org.codehaus.stax2.XMLStreamReader2;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Bridge PluginXmlPathResolver that implements the bridge {@link PathResolver} interface,
@@ -52,16 +56,11 @@ public final class PluginXmlPathResolver implements PathResolver {
             DataLoader dataLoader,
             String base,
             String relativePath) {
-        InputStream stream;
-        try {
-            stream = dataLoader.load(relativePath, /* ignoreNotFound = */ true);
-        } catch (Exception e) {
-            return false;
-        }
-        if (stream == null) return false;
-        try {
+        ResolvedResource resource = resolveResource(dataLoader, base, relativePath, /* ignoreNotFound = */ true);
+        if (resource == null) return false;
+        try (InputStream stream = resource.stream) {
             com.intellij.ide.plugins.XmlReader.readModuleDescriptor(
-                    stream, context, this, dataLoader, base, descriptor, null);
+                    stream, context, this, dataLoader, resource.path, descriptor, null);
             return true;
         } catch (Exception e) {
             return false;
@@ -74,16 +73,11 @@ public final class PluginXmlPathResolver implements PathResolver {
             DataLoader dataLoader,
             String relativePath,
             RawPluginDescriptor descriptor) {
-        InputStream stream;
-        try {
-            stream = dataLoader.load(relativePath, /* ignoreNotFound = */ false);
-        } catch (Exception e) {
-            return null;
-        }
-        if (stream == null) return null;
-        try {
+        ResolvedResource resource = resolveResource(dataLoader, null, relativePath, /* ignoreNotFound = */ false);
+        if (resource == null) return null;
+        try (InputStream stream = resource.stream) {
             return com.intellij.ide.plugins.XmlReader.readModuleDescriptor(
-                    stream, readContext, this, dataLoader, relativePath, descriptor, null);
+                    stream, readContext, this, dataLoader, resource.path, descriptor, null);
         } catch (Exception e) {
             return null;
         }
@@ -104,13 +98,8 @@ public final class PluginXmlPathResolver implements PathResolver {
     public XIncludeLoader.LoadedXIncludeReference loadXIncludeReference(
             DataLoader dataLoader,
             String relativePath) {
-        try {
-            InputStream stream = dataLoader.load(relativePath, /* ignoreNotFound = */ true);
-            if (stream == null) return null;
-            return new XIncludeLoader.LoadedXIncludeReference(stream, relativePath);
-        } catch (Exception e) {
-            return null;
-        }
+        ResolvedResource resource = resolveResource(dataLoader, null, relativePath, /* ignoreNotFound = */ true);
+        return resource == null ? null : new XIncludeLoader.LoadedXIncludeReference(resource.stream, resource.path);
     }
 
     @Override
@@ -118,14 +107,9 @@ public final class PluginXmlPathResolver implements PathResolver {
             PluginDescriptorReaderContext context,
             DataLoader dataLoader,
             String relativePath) {
-        InputStream stream;
-        try {
-            stream = dataLoader.load(relativePath, /* ignoreNotFound = */ false);
-        } catch (Exception e) {
-            return null;
-        }
-        if (stream == null) return null;
-        try {
+        ResolvedResource resource = resolveResource(dataLoader, null, relativePath, /* ignoreNotFound = */ false);
+        if (resource == null) return null;
+        try (InputStream stream = resource.stream) {
             XIncludeLoader xil = PathResolverKt.toXIncludeLoader(this, dataLoader);
             PluginDescriptorFromXmlStreamConsumer consumer =
                     new PluginDescriptorFromXmlStreamConsumer(context, xil);
@@ -144,5 +128,96 @@ public final class PluginXmlPathResolver implements PathResolver {
             DataLoader dataLoader,
             String relativePath) {
         return resolvePath(context, dataLoader, relativePath);
+    }
+
+    private ResolvedResource resolveResource(
+            DataLoader dataLoader,
+            String base,
+            String relativePath,
+            boolean ignoreNotFound) {
+        for (String candidatePath : candidatePaths(base, relativePath)) {
+            try {
+                InputStream stream = dataLoader.load(candidatePath, ignoreNotFound);
+                if (stream != null) {
+                    return new ResolvedResource(stream, candidatePath);
+                }
+            } catch (Exception ignored) {
+                // Try the next candidate path. The bridge intentionally preserves lenient loading.
+            }
+        }
+        return null;
+    }
+
+    private List<String> candidatePaths(String base, String relativePath) {
+        Set<String> candidates = new LinkedHashSet<>();
+        addCandidate(candidates, normalizePath(relativePath));
+        addCandidate(candidates, stripLeadingSlash(normalizePath(relativePath)));
+
+        if (base != null && relativePath != null && !relativePath.startsWith("/")) {
+            String resolvedPath = resolveAgainstBase(base, relativePath);
+            addCandidate(candidates, resolvedPath);
+            addCandidate(candidates, stripLeadingSlash(resolvedPath));
+        }
+
+        return new ArrayList<>(candidates);
+    }
+
+    private void addCandidate(Set<String> candidates, String candidatePath) {
+        if (candidatePath == null || candidatePath.isEmpty()) {
+            return;
+        }
+        candidates.add(candidatePath);
+    }
+
+    private String resolveAgainstBase(String base, String relativePath) {
+        String normalizedBase = normalizePath(base);
+        int lastSlash = normalizedBase.lastIndexOf('/');
+        String directory = lastSlash >= 0 ? normalizedBase.substring(0, lastSlash + 1) : "";
+        return normalizePath(directory + relativePath);
+    }
+
+    private String normalizePath(String path) {
+        if (path == null || path.isEmpty()) {
+            return path;
+        }
+
+        boolean absolute = path.startsWith("/");
+        String[] segments = path.split("/");
+        Deque<String> normalizedSegments = new ArrayDeque<>();
+        for (String segment : segments) {
+            if (segment.isEmpty() || ".".equals(segment)) {
+                continue;
+            }
+            if ("..".equals(segment)) {
+                if (!normalizedSegments.isEmpty()) {
+                    normalizedSegments.removeLast();
+                }
+                continue;
+            }
+            normalizedSegments.addLast(segment);
+        }
+
+        String joined = String.join("/", normalizedSegments);
+        if (!absolute) {
+            return joined;
+        }
+        return joined.isEmpty() ? "/" : "/" + joined;
+    }
+
+    private String stripLeadingSlash(String path) {
+        if (path == null || path.isEmpty() || !path.startsWith("/")) {
+            return path;
+        }
+        return path.substring(1);
+    }
+
+    private static final class ResolvedResource {
+        private final InputStream stream;
+        private final String path;
+
+        private ResolvedResource(InputStream stream, String path) {
+            this.stream = stream;
+            this.path = path;
+        }
     }
 }

--- a/backend-standalone/src/compat/java/com/intellij/openapi/fileTypes/BinaryFileTypeDecompilers.java
+++ b/backend-standalone/src/compat/java/com/intellij/openapi/fileTypes/BinaryFileTypeDecompilers.java
@@ -1,0 +1,61 @@
+package com.intellij.openapi.fileTypes;
+
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.util.KeyedLazyInstance;
+
+/**
+ * Guarded drop-in replacement for the IJ 2025.3 BinaryFileTypeDecompilers.
+ *
+ * <p>The standalone Analysis API host disposes the application environment in-process.
+ * During teardown, extension change notifications can race with application shutdown and
+ * queue an EDT task after the application has already been cleared from ApplicationManager.
+ * The stock implementation then throws from FileDocumentManager.getInstance().</p>
+ */
+public final class BinaryFileTypeDecompilers extends FileTypeExtension<BinaryFileDecompiler> {
+    private static final ExtensionPointName<KeyedLazyInstance<BinaryFileDecompiler>> EP_NAME =
+            new ExtensionPointName<>("com.intellij.filetype.decompiler");
+    private static final BinaryFileTypeDecompilers FALLBACK_INSTANCE = new BinaryFileTypeDecompilers(false);
+
+    public BinaryFileTypeDecompilers() {
+        this(true);
+    }
+
+    private BinaryFileTypeDecompilers(boolean registerChangeListener) {
+        super(EP_NAME);
+
+        Application application = ApplicationManager.getApplication();
+        if (registerChangeListener && application != null && !application.isUnitTestMode()) {
+            EP_NAME.addChangeListener(this::notifyDecompilerSetChange, application);
+        }
+    }
+
+    public void notifyDecompilerSetChange() {
+        Application application = ApplicationManager.getApplication();
+        if (application == null || application.isDisposed()) {
+            return;
+        }
+
+        application.invokeLater(() -> {
+            Application currentApplication = ApplicationManager.getApplication();
+            if (currentApplication == null || currentApplication.isDisposed()) {
+                return;
+            }
+
+            FileDocumentManager.getInstance().reloadBinaryFiles();
+        }, ModalityState.nonModal());
+    }
+
+    public static BinaryFileTypeDecompilers getInstance() {
+        Application application = ApplicationManager.getApplication();
+        if (application == null || application.isDisposed()) {
+            return FALLBACK_INSTANCE;
+        }
+
+        BinaryFileTypeDecompilers service = application.getService(BinaryFileTypeDecompilers.class);
+        return service != null ? service : FALLBACK_INSTANCE;
+    }
+}

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -2,6 +2,8 @@ package io.github.amichne.kast.standalone
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.fileTypes.BinaryFileTypeDecompilers
+import com.intellij.psi.compiled.ClassFileDecompilers
 import io.github.amichne.kast.api.NotFoundException
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaSourceModule
 import org.jetbrains.kotlin.analysis.api.standalone.StandaloneAnalysisAPISession
@@ -75,6 +77,7 @@ class StandaloneAnalysisSession(
         }
 
         session = createdSession
+        initializeJvmDecompilerServices()
         sourceModule = checkNotNull(createdSourceModule) {
             "The standalone Analysis API session did not create a source module"
         }
@@ -97,6 +100,16 @@ class StandaloneAnalysisSession(
 
     override fun close() {
         Disposer.dispose(disposable)
+    }
+
+    /**
+     * `ClassFileDecompilers` notifies `BinaryFileTypeDecompilers` on extension changes.
+     * If the binary decompiler service is still lazy when the application starts disposing,
+     * IntelliJ tries to instantiate it under an already-disposed parent and fails loudly.
+     */
+    private fun initializeJvmDecompilerServices() {
+        ClassFileDecompilers.getInstance()
+        BinaryFileTypeDecompilers.getInstance()
     }
 
     private fun normalizeFileLookupPath(file: KtFile): String {

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendResolveSymbolTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendResolveSymbolTest.kt
@@ -63,7 +63,7 @@ class StandaloneAnalysisBackendResolveSymbolTest {
 
             assertEquals("sample.greet", result.symbol.fqName)
             assertEquals(SymbolKind.FUNCTION, result.symbol.kind)
-            assertEquals(declarationFile.toString(), result.symbol.location.filePath)
+            assertEquals(normalizePath(declarationFile), result.symbol.location.filePath)
         } finally {
             session.close()
         }
@@ -77,5 +77,10 @@ class StandaloneAnalysisBackendResolveSymbolTest {
         Files.createDirectories(path.parent)
         path.writeText(content)
         return path
+    }
+
+    private fun normalizePath(path: Path): String {
+        val absolutePath = path.toAbsolutePath().normalize()
+        return runCatching { absolutePath.toRealPath().normalize().toString() }.getOrDefault(absolutePath.toString())
     }
 }


### PR DESCRIPTION
This change restores the standalone Analysis API bootstrap described in `docs/adr-001.md` by fixing the compat layer that sits between `analysis-api-standalone-for-ide:2.3.20-ij253-87` and the stable IntelliJ 2025.3 runtime.

The user-visible failure was that the standalone backend never reached a usable analysis session. The bootstrap got past the earlier `com.intellij.ide.plugins` class-loading conflicts, but then failed while registering FIR services because `KotlinAsJavaSupport` was never available. That blocked `JavaElementFinder`, so even the first `resolveSymbol` integration test died before it could exercise any real analysis behavior.

The root cause was not a missing Kotlin plugin jar. It was a descriptor-loading mismatch across old and new IntelliJ APIs. The standalone bootstrap parses `/META-INF/analysis-api/analysis-api-fir-standalone-base.xml`, which includes `analysis-api-fir.xml`, which in turn includes `symbol-light-classes.xml`. Our compat `PluginXmlPathResolver` was forwarding include paths too literally, so classloader-backed resource lookups failed on leading-slash resource names and did not preserve the resolved include path for nested XML reads. Once that was corrected, the bootstrap advanced far enough to expose two additional compatibility seams: the old Analysis API still expects the older `ContainerDescriptor` member shape and the older mutable `ListenerDescriptor.pluginDescriptor` field. Those are now supplied by the compat jar. I also added a guarded compat override for `BinaryFileTypeDecompilers` plus eager JVM decompiler service initialization so shutdown no longer regresses into disposal-time assertions after the session succeeds.

The implementation does four concrete things. First, `PluginXmlPathResolver` now resolves candidate include paths more defensively, strips leading slashes for classloader resource loading, carries the resolved path into nested descriptor reads, and preserves the old/new API bridge surface. Second, `ContainerDescriptor` now models the union of the old and new APIs instead of only a partial subset. Third, the compat jar assembly now includes the older `ListenerDescriptor` class so the standalone parser can still write the field that the old Analysis API expects. Fourth, `StandaloneAnalysisSession` eagerly initializes the JVM decompiler services, and the resolve-symbol integration test now asserts against the canonicalized path form that the standalone session returns on macOS temp directories.

Validation is attached to code, not assumptions. I rebuilt the edited files through the IDE-backed project build, ran the focused regression test while iterating on the bootstrap fixes, and then ran the required module build for the owning unit:

- `./gradlew :backend-standalone:test --tests io.github.amichne.kast.standalone.StandaloneAnalysisBackendResolveSymbolTest --rerun-tasks`
- `./gradlew :backend-standalone:build`
