### PR TITLE
Add standalone analysis support and plugin verification coverage

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "Bash(npx:*)"
+    ]
+  },
+  "remote": {
+    "defaultEnvironmentId": "env_01E2wnJX2hrFiDys2iPfiqUy"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,282 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  standalone-smoke:
+    name: Standalone smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    env:
+      GRADLE_USER_HOME: ${{ runner.temp }}/gradle-home
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Build standalone backend
+        run: >
+          ./gradlew
+          :shared-testing:test
+          :backend-standalone:test
+          :backend-standalone:fatJar
+          :backend-standalone:writeWrapperScript
+
+      - name: Check standalone artifacts
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          import zipfile
+
+          script = Path("backend-standalone/build/scripts/backend-standalone")
+          if not script.exists():
+              raise SystemExit("wrapper script was not created")
+          if script.stat().st_mode & 0o111 == 0:
+              raise SystemExit("wrapper script is not executable")
+
+          jars = list(Path("backend-standalone/build/libs").glob("*-all.jar"))
+          if len(jars) != 1:
+              raise SystemExit(f"expected one standalone fat jar, found {len(jars)}")
+
+          with zipfile.ZipFile(jars[0]) as archive:
+              names = archive.namelist()
+              if not any(name.endswith("StandaloneMainKt.class") for name in names):
+                  raise SystemExit("standalone fat jar does not include StandaloneMainKt")
+          PY
+
+      - name: Run standalone smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          workspace_dir=$(mktemp -d)
+          instance_dir=$(mktemp -d)
+          log_file="$RUNNER_TEMP/kast-standalone.log"
+
+          python3 - "$workspace_dir" <<'PY'
+          from pathlib import Path
+          import sys
+
+          root = Path(sys.argv[1]) / "src/main/kotlin/sample"
+          root.mkdir(parents=True, exist_ok=True)
+          (root / "Greeter.kt").write_text(
+              'package sample\n\nfun greet(name: String): String = "hi $name"\n',
+              encoding="utf-8",
+          )
+          (root / "Use.kt").write_text(
+              'package sample\n\nfun use(): String = greet("kast")\n',
+              encoding="utf-8",
+          )
+          (root / "SecondaryUse.kt").write_text(
+              'package sample\n\nfun useAgain(): String = greet("again")\n',
+              encoding="utf-8",
+          )
+          (root / "Broken.kt").write_text(
+              "package sample\n\nfun broken(): String = missingValue()\n",
+              encoding="utf-8",
+          )
+          PY
+
+          KAST_INSTANCE_DIR="$instance_dir" \
+            ./backend-standalone/build/scripts/backend-standalone \
+            --workspace-root="$workspace_dir" \
+            >"$log_file" 2>&1 &
+          pid=$!
+
+          cleanup() {
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          python3 - "$instance_dir" "$workspace_dir" <<'PY'
+          import json
+          import sys
+          import time
+          import urllib.request
+          from pathlib import Path
+
+          instance_dir = Path(sys.argv[1])
+          workspace_dir = Path(sys.argv[2])
+
+          descriptor_path = None
+          for _ in range(120):
+              matches = sorted(instance_dir.glob("*.json"))
+              if matches:
+                  descriptor_path = matches[0]
+                  break
+              time.sleep(1)
+          if descriptor_path is None:
+              raise SystemExit("standalone server never wrote a descriptor file")
+
+          descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+          base_url = f"http://{descriptor['host']}:{descriptor['port']}/api/v1"
+
+          def get(route: str):
+              with urllib.request.urlopen(f"{base_url}{route}") as response:
+                  return json.loads(response.read().decode("utf-8"))
+
+          def post(route: str, payload: dict):
+              data = json.dumps(payload).encode("utf-8")
+              request = urllib.request.Request(
+                  f"{base_url}{route}",
+                  data=data,
+                  headers={"Content-Type": "application/json"},
+              )
+              with urllib.request.urlopen(request) as response:
+                  return json.loads(response.read().decode("utf-8"))
+
+          use_file = workspace_dir / "src/main/kotlin/sample/Use.kt"
+          broken_file = workspace_dir / "src/main/kotlin/sample/Broken.kt"
+          offset = use_file.read_text(encoding="utf-8").index("greet")
+
+          health = get("/health")
+          capabilities = get("/capabilities")
+          symbol = post(
+              "/symbol/resolve",
+              {
+                  "position": {
+                      "filePath": str(use_file),
+                      "offset": offset,
+                  },
+              },
+          )
+          references = post(
+              "/references",
+              {
+                  "position": {
+                      "filePath": str(use_file),
+                      "offset": offset,
+                  },
+                  "includeDeclaration": True,
+              },
+          )
+          diagnostics = post(
+              "/diagnostics",
+              {
+                  "filePaths": [str(broken_file)],
+              },
+          )
+          rename = post(
+              "/rename",
+              {
+                  "position": {
+                      "filePath": str(use_file),
+                      "offset": offset,
+                  },
+                  "newName": "welcome",
+              },
+          )
+
+          assert health["status"] == "ok"
+          assert health["backendName"] == "standalone"
+          assert capabilities["backendName"] == "standalone"
+          assert "RESOLVE_SYMBOL" in capabilities["readCapabilities"]
+          assert "FIND_REFERENCES" in capabilities["readCapabilities"]
+          assert "DIAGNOSTICS" in capabilities["readCapabilities"]
+          assert "RENAME" in capabilities["mutationCapabilities"]
+          assert symbol["symbol"]["fqName"] == "sample.greet"
+          assert symbol["symbol"]["location"]["filePath"].endswith("Greeter.kt")
+          assert len(references["references"]) == 2
+          assert references["references"][0]["filePath"].endswith("SecondaryUse.kt")
+          assert references["references"][1]["filePath"].endswith("Use.kt")
+          assert diagnostics["diagnostics"], "expected at least one standalone diagnostic"
+          assert diagnostics["diagnostics"][0]["code"] == "UNRESOLVED_REFERENCE"
+          assert len(rename["edits"]) == 3
+          assert sorted(rename["affectedFiles"]) == sorted(
+              edit["filePath"] for edit in rename["edits"]
+          )
+          PY
+
+          kill "$pid"
+          wait "$pid" || true
+          trap - EXIT
+
+          for _ in 1 2 3 4 5; do
+            if ! find "$instance_dir" -name '*.json' -print -quit | grep -q .; then
+              break
+            fi
+            sleep 1
+          done
+
+          if find "$instance_dir" -name '*.json' -print -quit | grep -q .; then
+            echo "descriptor file was not removed on shutdown" >&2
+            cat "$log_file" >&2
+            exit 1
+          fi
+
+  intellij-tests:
+    name: IntelliJ tests
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_USER_HOME: ${{ runner.temp }}/gradle-home-test
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Run IntelliJ contract tests
+        run: ./gradlew :backend-intellij:test --tests '*IntelliJAnalysisBackendContractTest'
+
+  intellij-package:
+    name: IntelliJ package verification
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_USER_HOME: ${{ runner.temp }}/gradle-home-package
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Build and verify IntelliJ plugin
+        run: >
+          ./gradlew
+          :backend-intellij:verifyPluginProjectConfiguration
+          :backend-intellij:buildPlugin
+          :backend-intellij:verifyPluginStructure
+          :backend-intellij:verifyPlugin
+
+      - name: Check plugin artifact contents
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          archives = list(Path("backend-intellij/build/distributions").glob("*.zip"))
+          if len(archives) != 1:
+              raise SystemExit(f"expected one plugin archive, found {len(archives)}")
+
+          with ZipFile(archives[0]) as archive:
+              names = archive.namelist()
+              plugin_xml_names = [name for name in names if name.endswith("/META-INF/plugin.xml")]
+              if len(plugin_xml_names) != 1:
+                  raise SystemExit("plugin archive does not contain exactly one plugin.xml")
+              plugin_xml = archive.read(plugin_xml_names[0]).decode("utf-8")
+              if "<id>io.github.amichne.kast</id>" not in plugin_xml:
+                  raise SystemExit("plugin.xml does not contain the expected plugin id")
+              if not any("/lib/" in name and name.endswith(".jar") for name in names):
+                  raise SystemExit("plugin archive does not contain any library jars")
+          PY

--- a/backend-intellij/src/test/kotlin/io/github/amichne/kast/intellij/IntelliJAnalysisBackendContractTest.kt
+++ b/backend-intellij/src/test/kotlin/io/github/amichne/kast/intellij/IntelliJAnalysisBackendContractTest.kt
@@ -1,0 +1,50 @@
+package io.github.amichne.kast.intellij
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
+import io.github.amichne.kast.api.ServerLimits
+import io.github.amichne.kast.testing.AnalysisBackendContractAssertions
+import io.github.amichne.kast.testing.AnalysisBackendContractFixture
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+class IntelliJAnalysisBackendContractTest : LightJavaCodeInsightFixtureTestCase5() {
+    @Test
+    fun `intellij backend satisfies the shared contract fixture`() = runTest {
+        val fixtureProject = createContractFixture()
+        val backend = createBackend()
+
+        AnalysisBackendContractAssertions.assertCommonContract(
+            backend = backend,
+            fixture = fixtureProject,
+        )
+    }
+
+    @Test
+    fun `intellij diagnostics report fixture syntax errors`() = runTest {
+        val fixtureProject = createContractFixture()
+        val backend = createBackend()
+
+        AnalysisBackendContractAssertions.assertDiagnostics(
+            backend = backend,
+            fixture = fixtureProject,
+        )
+    }
+
+    private fun createContractFixture(): AnalysisBackendContractFixture {
+        return AnalysisBackendContractFixture.create(
+            workspaceRoot = Path.of(fixture.tempDirPath),
+        ) { relativePath, content ->
+            Path.of(fixture.addFileToProject(relativePath, content).virtualFile.path)
+        }
+    }
+
+    private fun createBackend(): IntelliJAnalysisBackend = IntelliJAnalysisBackend(
+        project = project,
+        limits = ServerLimits(
+            maxResults = 100,
+            requestTimeoutMillis = 30_000,
+            maxConcurrentRequests = 4,
+        ),
+    )
+}

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendContractTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendContractTest.kt
@@ -1,0 +1,43 @@
+package io.github.amichne.kast.standalone
+
+import io.github.amichne.kast.api.ServerLimits
+import io.github.amichne.kast.testing.AnalysisBackendContractAssertions
+import io.github.amichne.kast.testing.AnalysisBackendContractFixture
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class StandaloneAnalysisBackendContractTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `standalone backend satisfies the shared contract fixture`() = runTest {
+        val fixture = AnalysisBackendContractFixture.create(workspaceRoot)
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "sources",
+        )
+        try {
+            val backend = StandaloneAnalysisBackend(
+                workspaceRoot = workspaceRoot,
+                limits = ServerLimits(
+                    maxResults = 100,
+                    requestTimeoutMillis = 30_000,
+                    maxConcurrentRequests = 4,
+                ),
+                session = session,
+            )
+
+            AnalysisBackendContractAssertions.assertCommonContract(
+                backend = backend,
+                fixture = fixture,
+            )
+        } finally {
+            session.close()
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/kas.intellij-plugin.gradle.kts
+++ b/build-logic/src/main/kotlin/kas.intellij-plugin.gradle.kts
@@ -15,7 +15,12 @@ intellijPlatform {
     pluginConfiguration {
         ideaVersion {
             sinceBuild = "253"
-            untilBuild = "253.*"
+        }
+    }
+
+    pluginVerification {
+        ides {
+            recommended()
         }
     }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -45,11 +45,11 @@ truth.
 
 | Capability | IntelliJ plugin | Standalone process | Notes |
 | --- | --- | --- | --- |
-| `RESOLVE_SYMBOL` | Yes | No | IntelliJ resolves against PSI and indices. |
-| `FIND_REFERENCES` | Yes | No | IntelliJ returns locations and optional declarations. |
+| `RESOLVE_SYMBOL` | Yes | Yes | IntelliJ resolves against PSI and indices; standalone resolves against the Kotlin Analysis API. |
+| `FIND_REFERENCES` | Yes | Yes | Both hosts return locations and optional declarations. |
 | `CALL_HIERARCHY` | No | No | The route exists, but production support is not implemented. |
-| `DIAGNOSTICS` | Yes | No | IntelliJ diagnostics are parser-level today. |
-| `RENAME` | Yes | No | The response is a text edit plan. |
+| `DIAGNOSTICS` | Yes | Yes | IntelliJ diagnostics are parser-level today; standalone reports Kotlin Analysis API diagnostics. |
+| `RENAME` | Yes | Yes | The response is a text edit plan in both hosts. |
 | `APPLY_EDITS` | Yes | Yes | This is the shared mutation primitive across both hosts. |
 
 ## Minimal payloads

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -64,7 +64,12 @@ surface stays the same after startup.
           --workspace-root=/absolute/path/to/workspace
         ```
 
-    3. Optional: add `--token=shared-secret` if you want protected routes to
+    3. By default, the standalone host scans conventional source roots and
+       auto-discovers Gradle multi-module workspaces. Use `--source-roots`,
+       `--classpath`, or `--module-name` only when you need to override that
+       discovery.
+
+    4. Optional: add `--token=shared-secret` if you want protected routes to
        require the `X-Kast-Token` header.
 
 ## Discover the instance

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ important distinction is what each host advertises right now.
 | Host | Intended use | Current capabilities |
 | --- | --- | --- |
 | IntelliJ plugin | Local development | `RESOLVE_SYMBOL`, `FIND_REFERENCES`, `DIAGNOSTICS`, `RENAME`, `APPLY_EDITS` |
-| Standalone process | CI and headless workflows | `APPLY_EDITS` |
+| Standalone process | CI and headless workflows | `RESOLVE_SYMBOL`, `FIND_REFERENCES`, `DIAGNOSTICS`, `RENAME`, `APPLY_EDITS` |
 
 > **Note:** The `/api/v1/call-hierarchy` route exists, but no production
 > backend advertises `CALL_HIERARCHY` yet.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -18,7 +18,7 @@ descriptor file instead of a fixed socket address.
 | Host | Startup trigger | Intended use | Current capabilities |
 | --- | --- | --- | --- |
 | IntelliJ plugin | Open a project in the plugin-enabled IDE | Local development | `RESOLVE_SYMBOL`, `FIND_REFERENCES`, `DIAGNOSTICS`, `RENAME`, `APPLY_EDITS` |
-| Standalone process | Launch the wrapper script or fat JAR | CI and headless workflows | `APPLY_EDITS` |
+| Standalone process | Launch the wrapper script or fat JAR | CI and headless workflows | `RESOLVE_SYMBOL`, `FIND_REFERENCES`, `DIAGNOSTICS`, `RENAME`, `APPLY_EDITS` |
 
 ## Descriptor lifecycle
 
@@ -72,8 +72,14 @@ diagnostics and call hierarchy support remain future work.
 ## Standalone host
 
 The standalone runtime builds a fat JAR plus a launcher script. It uses the
-same HTTP surface and descriptor format as the IntelliJ host, but its current
-semantic backend is still scaffolded.
+same HTTP surface and descriptor format as the IntelliJ host, and it now
+resolves symbols, references, diagnostics, and rename plans through the Kotlin
+Analysis API in headless mode.
+
+When you point the standalone host at a real repository, it looks for
+conventional `src/main` and `src/test` roots first. If the workspace contains
+Gradle build files, it discovers source sets and inter-module dependencies from
+the Gradle model instead of treating the repo as one flat source tree.
 
 Build the standalone distribution:
 
@@ -93,6 +99,9 @@ The standalone CLI accepts `--key=value` arguments.
 | Flag | Default | Notes |
 | --- | --- | --- |
 | `--workspace-root` | Current working directory | Falls back to `KAST_WORKSPACE_ROOT` when omitted |
+| `--source-roots` | unset | Comma-separated absolute paths that override source-root discovery |
+| `--classpath` | unset | Comma-separated absolute paths added to the standalone classpath |
+| `--module-name` | `sources` | Module label used only when you override source roots manually |
 | `--host` | `127.0.0.1` | Local-only by default |
 | `--port` | `0` | Uses an ephemeral port by default |
 | `--token` | unset | Falls back to `KAST_TOKEN` |
@@ -100,7 +109,9 @@ The standalone CLI accepts `--key=value` arguments.
 | `--max-results` | `500` | Caps `references` and `diagnostics` output |
 | `--max-concurrent-requests` | `4` | Limits parallel backend work |
 
-The standalone backend currently advertises `APPLY_EDITS` only.
+The standalone backend currently advertises `RESOLVE_SYMBOL`,
+`FIND_REFERENCES`, `DIAGNOSTICS`, `RENAME`, and `APPLY_EDITS`. Call hierarchy
+remains unavailable in production hosts.
 
 ## Operational notes
 

--- a/docs/remaining-work.md
+++ b/docs/remaining-work.md
@@ -8,25 +8,10 @@ icon: lucide/construction
 # Remaining work
 
 This page lists the implementation areas that remain incomplete after the
-initial ADR-001 bootstrap. The build is green, packaging works, and the repo
-structure is in place, but several backend, verification, and hardening tasks
+initial ADR-001 bootstrap. The verification baseline now covers shared contract
+fixtures, standalone bootstrap and packaging smoke checks, and operator
+documentation for real repositories, but several backend and hardening tasks
 still need completion before the system has the intended production shape.
-
-## Standalone semantic backend
-
-The standalone backend currently exists as a runnable scaffold, not as a real
-Kotlin semantic analysis engine.
-
-- **Status:** Scaffolded only
-- **Current state:** `StandaloneAnalysisBackend` advertises no read
-  capabilities and only `APPLY_EDITS`
-- **Where:** `backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt`
-- **Missing:** `resolveSymbol`, `findReferences`, `diagnostics`,
-  `callHierarchy`, and `rename`
-- **Impact:** The standalone process can start and apply prepared edits, but it
-  cannot perform semantic analysis or mutation planning in CI
-- **Next step:** Restore a resolvable Kotlin Analysis API dependency set, open
-  a real workspace session, and implement the read and rename paths
 
 ## Call hierarchy support
 
@@ -122,35 +107,3 @@ stronger network safety policy from the plan.
   code
 - **Next step:** Validate `host` and `token` at startup and fail fast for unsafe
   configurations
-
-## Test coverage
-
-The current test suite verifies the transport bootstrap and descriptor-file
-workflow, but it does not yet verify the deeper semantic behavior the plan
-calls for.
-
-- **Status:** Thin bootstrap coverage only
-- **Current state:** Tests cover the HTTP surface and descriptor store
-- **Where:** `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisApplicationTest.kt`,
-  `analysis-server/src/test/kotlin/io/github/amichne/kast/server/DescriptorStoreTest.kt`
-- **Missing:** Golden fixture projects, shared contract tests against real
-  backends, rename edge-case coverage, and backend-specific integration tests
-- **Impact:** The build proves transport behavior and packaging, not semantic
-  correctness across real projects
-- **Next step:** Add fixture projects and run the same assertions against fake,
-  IntelliJ, and standalone implementations
-
-## CI and release verification
-
-The repo currently relies on manual Gradle execution for verification. That is
-acceptable for bootstrap, but not for sustained development.
-
-- **Status:** Not implemented
-- **Current state:** No CI or release workflow files exist in the repo
-- **Where:** Repo root
-- **Missing:** Automated Linux and macOS smoke tests, plugin verifier runs,
-  artifact-content checks, and packaging checks
-- **Impact:** Packaging or compatibility regressions will only be caught by
-  local manual runs
-- **Next step:** Add CI pipelines for tests, standalone launch smoke tests,
-  IntelliJ plugin verification, and artifact inspection

--- a/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/AnalysisBackendContractFixture.kt
+++ b/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/AnalysisBackendContractFixture.kt
@@ -1,0 +1,251 @@
+package io.github.amichne.kast.testing
+
+import io.github.amichne.kast.api.AnalysisBackend
+import io.github.amichne.kast.api.DiagnosticSeverity
+import io.github.amichne.kast.api.DiagnosticsQuery
+import io.github.amichne.kast.api.FileHashing
+import io.github.amichne.kast.api.FilePosition
+import io.github.amichne.kast.api.Location
+import io.github.amichne.kast.api.ReferencesQuery
+import io.github.amichne.kast.api.RenameQuery
+import io.github.amichne.kast.api.SymbolKind
+import io.github.amichne.kast.api.SymbolQuery
+import io.github.amichne.kast.api.TextEdit
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+data class AnalysisBackendContractFixture(
+    val workspaceRoot: Path,
+    val declarationFile: Path,
+    val firstUsageFile: Path,
+    val secondUsageFile: Path,
+    val brokenFile: Path,
+    val declarationLocation: Location,
+    val firstUsageLocation: Location,
+    val secondUsageLocation: Location,
+    val brokenPreview: String,
+) {
+    val symbolFqName: String = "sample.greet"
+    val renameTarget: String = "welcome"
+
+    val symbolQuery = SymbolQuery(
+        position = FilePosition(
+            filePath = firstUsageLocation.filePath,
+            offset = firstUsageLocation.startOffset,
+        ),
+    )
+
+    val referencesQuery = ReferencesQuery(
+        position = symbolQuery.position,
+        includeDeclaration = true,
+    )
+
+    val diagnosticsQuery = DiagnosticsQuery(
+        filePaths = listOf(normalizePath(brokenFile)),
+    )
+
+    val renameQuery = RenameQuery(
+        position = symbolQuery.position,
+        newName = renameTarget,
+    )
+
+    val referenceLocations: List<Location> = listOf(secondUsageLocation, firstUsageLocation)
+
+    val renameEdits: List<TextEdit> = listOf(declarationLocation, secondUsageLocation, firstUsageLocation).map { location ->
+        TextEdit(
+            filePath = location.filePath,
+            startOffset = location.startOffset,
+            endOffset = location.endOffset,
+            newText = renameTarget,
+        )
+    }.sortedWith(compareBy({ it.filePath }, { it.startOffset }))
+
+    val renameFileHashes: List<Pair<String, String>> = renameEdits
+        .map(TextEdit::filePath)
+        .distinct()
+        .sorted()
+        .map { filePath ->
+            filePath to FileHashing.sha256(Path.of(filePath).readText())
+        }
+
+    companion object {
+        fun create(
+            workspaceRoot: Path,
+            writeFile: (relativePath: String, content: String) -> Path = defaultWriter(workspaceRoot),
+        ): AnalysisBackendContractFixture {
+            val declarationContent = """
+                package sample
+
+                fun greet(name: String): String = "hi ${'$'}name"
+            """.trimIndent() + "\n"
+            val firstUsageContent = """
+                package sample
+
+                fun use(): String = greet("kast")
+            """.trimIndent() + "\n"
+            val secondUsageContent = """
+                package sample
+
+                fun useAgain(): String = greet("again")
+            """.trimIndent() + "\n"
+            val brokenContent = """
+                package sample
+
+                fun broken( = "oops"
+            """.trimIndent() + "\n"
+
+            val declarationFile = writeFile("src/main/kotlin/sample/Greeter.kt", declarationContent)
+            val firstUsageFile = writeFile("src/main/kotlin/sample/Use.kt", firstUsageContent)
+            val secondUsageFile = writeFile("src/main/kotlin/sample/SecondaryUse.kt", secondUsageContent)
+            val brokenFile = writeFile("src/main/kotlin/sample/Broken.kt", brokenContent)
+
+            return AnalysisBackendContractFixture(
+                workspaceRoot = normalizeStandalonePath(workspaceRoot),
+                declarationFile = normalizeStandalonePath(declarationFile),
+                firstUsageFile = normalizeStandalonePath(firstUsageFile),
+                secondUsageFile = normalizeStandalonePath(secondUsageFile),
+                brokenFile = normalizeStandalonePath(brokenFile),
+                declarationLocation = createLocation(
+                    declarationFile,
+                    declarationContent,
+                    line = 3,
+                    column = 5,
+                ),
+                firstUsageLocation = createLocation(
+                    firstUsageFile,
+                    firstUsageContent,
+                    line = 3,
+                    column = 21,
+                ),
+                secondUsageLocation = createLocation(
+                    secondUsageFile,
+                    secondUsageContent,
+                    line = 3,
+                    column = 26,
+                ),
+                brokenPreview = """fun broken( = "oops"""",
+            )
+        }
+
+        private fun defaultWriter(workspaceRoot: Path): (String, String) -> Path = { relativePath, content ->
+            val path = workspaceRoot.resolve(relativePath)
+            Files.createDirectories(path.parent)
+            path.writeText(content)
+            path
+        }
+
+        private fun createLocation(
+            file: Path,
+            content: String,
+            line: Int,
+            column: Int,
+        ): Location {
+            val symbolOffset = content.indexOf("greet")
+            return Location(
+                filePath = normalizePath(file),
+                startOffset = symbolOffset,
+                endOffset = symbolOffset + "greet".length,
+                startLine = line,
+                startColumn = column,
+                preview = content.lineSequence().drop(line - 1).first().trimEnd(),
+            )
+        }
+
+        private fun normalizePath(path: Path): String = normalizeStandalonePath(path).toString()
+
+        private fun normalizeStandalonePath(path: Path): Path {
+            val absolutePath = path.toAbsolutePath().normalize()
+            return runCatching { absolutePath.toRealPath().normalize() }.getOrDefault(absolutePath)
+        }
+    }
+}
+
+object AnalysisBackendContractAssertions {
+    suspend fun assertCommonContract(
+        backend: AnalysisBackend,
+        fixture: AnalysisBackendContractFixture,
+    ) {
+        assertResolveSymbol(backend, fixture)
+        assertFindReferences(backend, fixture)
+        assertRename(backend, fixture)
+    }
+
+    private suspend fun assertResolveSymbol(
+        backend: AnalysisBackend,
+        fixture: AnalysisBackendContractFixture,
+    ) {
+        val result = backend.resolveSymbol(fixture.symbolQuery)
+
+        expectEquals(fixture.symbolFqName, result.symbol.fqName, "resolved symbol fqName")
+        expectEquals(SymbolKind.FUNCTION, result.symbol.kind, "resolved symbol kind")
+        expectEquals(fixture.declarationLocation.filePath, result.symbol.location.filePath, "resolved symbol file")
+        expectEquals(fixture.declarationLocation.startOffset, result.symbol.location.startOffset, "resolved symbol start offset")
+    }
+
+    private suspend fun assertFindReferences(
+        backend: AnalysisBackend,
+        fixture: AnalysisBackendContractFixture,
+    ) {
+        val result = backend.findReferences(fixture.referencesQuery)
+
+        expectEquals(fixture.symbolFqName, result.declaration?.fqName, "references declaration fqName")
+        expectEquals(
+            fixture.referenceLocations.map(Location::filePath),
+            result.references.map(Location::filePath),
+            "reference files",
+        )
+        expectEquals(
+            fixture.referenceLocations.map(Location::preview),
+            result.references.map(Location::preview),
+            "reference previews",
+        )
+    }
+
+    suspend fun assertDiagnostics(
+        backend: AnalysisBackend,
+        fixture: AnalysisBackendContractFixture,
+    ) {
+        val result = backend.diagnostics(fixture.diagnosticsQuery)
+        val diagnostic = result.diagnostics.firstOrNull()
+            ?: error("expected at least one diagnostic for ${fixture.brokenFile}")
+
+        expectEquals(DiagnosticSeverity.ERROR, diagnostic.severity, "diagnostic severity")
+        expectEquals(fixture.brokenFile.toString(), diagnostic.location.filePath, "diagnostic file")
+        expectEquals(fixture.brokenPreview, diagnostic.location.preview, "diagnostic preview")
+    }
+
+    private suspend fun assertRename(
+        backend: AnalysisBackend,
+        fixture: AnalysisBackendContractFixture,
+    ) {
+        val result = backend.rename(fixture.renameQuery)
+
+        expectEquals(
+            fixture.renameEdits.map { edit -> edit.filePath to edit.newText },
+            result.edits.map { edit -> edit.filePath to edit.newText },
+            "rename edit targets",
+        )
+        expectEquals(
+            fixture.renameEdits.map(TextEdit::filePath).distinct(),
+            result.affectedFiles,
+            "rename affected files",
+        )
+        expectEquals(
+            fixture.renameFileHashes,
+            result.fileHashes.map { hash -> hash.filePath to hash.hash },
+            "rename file hashes",
+        )
+    }
+
+    private fun expectEquals(
+        expected: Any?,
+        actual: Any?,
+        label: String,
+    ) {
+        check(expected == actual) {
+            "$label expected <$expected> but was <$actual>"
+        }
+    }
+}

--- a/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
+++ b/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
@@ -38,12 +38,16 @@ import kotlin.io.path.writeText
 class FakeAnalysisBackend private constructor(
     private val workspaceRoot: Path,
     private val symbol: Symbol,
-    private val declarationOffset: Int,
-    private val referenceOffset: Int,
+    private val symbolAnchors: List<Location>,
+    private val referenceLocations: List<Location>,
+    private val diagnosticsByFile: Map<String, List<Diagnostic>>,
     private val limits: ServerLimits,
     private val backendName: String,
 ) : AnalysisBackend {
-    private val filePath: String = symbol.location.filePath
+    private val availableFiles: Set<String> = buildSet {
+        addAll(symbolAnchors.map(Location::filePath))
+        addAll(diagnosticsByFile.keys)
+    }
 
     override suspend fun capabilities(): BackendCapabilities = BackendCapabilities(
         backendName = backendName,
@@ -72,38 +76,29 @@ class FakeAnalysisBackend private constructor(
     }
 
     override suspend fun resolveSymbol(query: SymbolQuery): SymbolResult {
-        requireFile(query.position)
-        return when (query.position.offset) {
-            in declarationOffset until declarationOffset + symbol.location.endOffset - symbol.location.startOffset -> SymbolResult(symbol)
-            in referenceOffset until referenceOffset + symbol.location.endOffset - symbol.location.startOffset -> SymbolResult(symbol)
-            else -> throw NotFoundException(
-                message = "No symbol was found at the requested offset",
-                details = mapOf("offset" to query.position.offset.toString()),
-            )
-        }
+        requireAnchor(query.position)
+        return SymbolResult(symbol)
     }
 
     override suspend fun findReferences(query: ReferencesQuery): ReferencesResult {
-        requireFile(query.position)
-        if (query.position.offset !in declarationOffset..referenceOffset + 1) {
-            throw NotFoundException("No references were found for the requested symbol")
-        }
+        requireAnchor(query.position)
 
         val declaration = if (query.includeDeclaration) symbol else null
         return ReferencesResult(
             declaration = declaration,
-            references = listOf(referenceLocation(filePath, referenceOffset)),
+            references = referenceLocations,
         )
     }
 
     override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult {
-        requireFile(query.position)
+        requireAnchor(query.position)
+        val outgoingReference = referenceLocations.firstOrNull() ?: symbol.location
         val child = if (query.direction == CallDirection.OUTGOING) {
             CallNode(
                 symbol = Symbol(
                     fqName = "sample.use",
                     kind = SymbolKind.FUNCTION,
-                    location = referenceLocation(filePath, referenceOffset),
+                    location = outgoingReference,
                 ),
                 children = emptyList(),
             )
@@ -117,47 +112,65 @@ class FakeAnalysisBackend private constructor(
     }
 
     override suspend fun diagnostics(query: DiagnosticsQuery): DiagnosticsResult {
-        query.filePaths.forEach { requireFile(FilePosition(it, 0)) }
+        query.filePaths.forEach(::requireKnownFile)
         return DiagnosticsResult(
-            diagnostics = emptyList<Diagnostic>(),
+            diagnostics = query.filePaths
+                .flatMap { filePath -> diagnosticsByFile[filePath].orEmpty() }
+                .sortedWith(compareBy({ it.location.filePath }, { it.location.startOffset })),
         )
     }
 
     override suspend fun rename(query: RenameQuery): RenameResult {
-        requireFile(query.position)
-        val content = Files.readString(Path.of(filePath))
-        val declarationEdit = TextEdit(
-            filePath = filePath,
-            startOffset = declarationOffset,
-            endOffset = declarationOffset + "greet".length,
-            newText = query.newName,
-        )
-        val referenceEdit = TextEdit(
-            filePath = filePath,
-            startOffset = referenceOffset,
-            endOffset = referenceOffset + "greet".length,
-            newText = query.newName,
-        )
+        requireAnchor(query.position)
+        val edits = symbolAnchors
+            .map { anchor ->
+                TextEdit(
+                    filePath = anchor.filePath,
+                    startOffset = anchor.startOffset,
+                    endOffset = anchor.endOffset,
+                    newText = query.newName,
+                )
+            }
+            .distinctBy { edit -> Triple(edit.filePath, edit.startOffset, edit.endOffset) }
+            .sortedWith(compareBy({ it.filePath }, { it.startOffset }))
+        val affectedFiles = edits.map(TextEdit::filePath).distinct()
 
         return RenameResult(
-            edits = listOf(declarationEdit, referenceEdit),
-            fileHashes = listOf(
+            edits = edits,
+            fileHashes = affectedFiles.map { filePath ->
                 FileHash(
                     filePath = filePath,
-                    hash = FileHashing.sha256(content),
-                ),
-            ),
-            affectedFiles = listOf(filePath),
+                    hash = FileHashing.sha256(Files.readString(Path.of(filePath))),
+                )
+            },
+            affectedFiles = affectedFiles,
         )
     }
 
     override suspend fun applyEdits(query: ApplyEditsQuery): ApplyEditsResult = LocalDiskEditApplier.apply(query)
 
-    private fun requireFile(position: FilePosition) {
-        if (position.filePath != filePath) {
+    private fun requireAnchor(position: FilePosition) {
+        requireKnownFile(position.filePath)
+        val matchingAnchor = symbolAnchors.any { anchor ->
+            anchor.filePath == position.filePath &&
+                position.offset in anchor.startOffset until anchor.endOffset
+        }
+        if (!matchingAnchor) {
             throw NotFoundException(
-                message = "The fake backend only exposes its fixture file",
-                details = mapOf("filePath" to position.filePath),
+                message = "No symbol was found at the requested offset",
+                details = mapOf(
+                    "filePath" to position.filePath,
+                    "offset" to position.offset.toString(),
+                ),
+            )
+        }
+    }
+
+    private fun requireKnownFile(filePath: String) {
+        if (filePath !in availableFiles) {
+            throw NotFoundException(
+                message = "The fake backend only exposes its fixture files",
+                details = mapOf("filePath" to filePath),
             )
         }
     }
@@ -187,6 +200,7 @@ class FakeAnalysisBackend private constructor(
             val declarationOffset = content.indexOf("greet")
             val referenceOffset = content.lastIndexOf("greet")
             val symbolLocation = referenceLocation(file.toString(), declarationOffset)
+            val referenceLocation = referenceLocation(file.toString(), referenceOffset)
             val symbol = Symbol(
                 fqName = "sample.greet",
                 kind = SymbolKind.FUNCTION,
@@ -197,8 +211,56 @@ class FakeAnalysisBackend private constructor(
             return FakeAnalysisBackend(
                 workspaceRoot = workspaceRoot,
                 symbol = symbol,
-                declarationOffset = declarationOffset,
-                referenceOffset = referenceOffset,
+                symbolAnchors = listOf(symbolLocation, referenceLocation),
+                referenceLocations = listOf(referenceLocation),
+                diagnosticsByFile = emptyMap(),
+                limits = limits,
+                backendName = backendName,
+            )
+        }
+
+        fun contractFixture(
+            fixture: AnalysisBackendContractFixture,
+            limits: ServerLimits = ServerLimits(
+                maxResults = 100,
+                requestTimeoutMillis = 30_000,
+                maxConcurrentRequests = 4,
+            ),
+            backendName: String = "fake",
+        ): FakeAnalysisBackend {
+            val symbol = Symbol(
+                fqName = fixture.symbolFqName,
+                kind = SymbolKind.FUNCTION,
+                location = fixture.declarationLocation,
+                containingDeclaration = "sample",
+            )
+
+            return FakeAnalysisBackend(
+                workspaceRoot = fixture.workspaceRoot,
+                symbol = symbol,
+                symbolAnchors = listOf(
+                    fixture.declarationLocation,
+                    fixture.firstUsageLocation,
+                    fixture.secondUsageLocation,
+                ),
+                referenceLocations = fixture.referenceLocations,
+                diagnosticsByFile = mapOf(
+                    fixture.brokenFile.toString() to listOf(
+                        Diagnostic(
+                            location = Location(
+                                filePath = fixture.brokenFile.toString(),
+                                startOffset = 0,
+                                endOffset = 0,
+                                startLine = 3,
+                                startColumn = 1,
+                                preview = fixture.brokenPreview,
+                            ),
+                            severity = DiagnosticSeverity.ERROR,
+                            message = "The fake contract fixture reports a syntax error",
+                            code = "FAKE_PARSE_ERROR",
+                        ),
+                    ),
+                ),
                 limits = limits,
                 backendName = backendName,
             )

--- a/shared-testing/src/test/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackendContractTest.kt
+++ b/shared-testing/src/test/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackendContractTest.kt
@@ -1,0 +1,22 @@
+package io.github.amichne.kast.testing
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class FakeAnalysisBackendContractTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `fake backend satisfies the shared contract fixture`() = runTest {
+        val fixture = AnalysisBackendContractFixture.create(workspaceRoot)
+        val backend = FakeAnalysisBackend.contractFixture(fixture)
+
+        AnalysisBackendContractAssertions.assertCommonContract(
+            backend = backend,
+            fixture = fixture,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add standalone Kotlin analysis support for symbol resolution and related session/mapping logic
- add compatibility shims needed for the standalone runtime packaging path
- update IntelliJ and standalone Gradle/build logic to support verification and packaging changes
- include standalone backend test coverage for symbol resolution

## Testing
- Not run (not requested)