### PR TITLE
Fix standalone Gradle workspace discovery for CI: include RUNTIME deps and add tooling-api fallback

### DIFF
--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/GradleWorkspaceDiscovery.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/GradleWorkspaceDiscovery.kt
@@ -22,10 +22,19 @@ internal object GradleWorkspaceDiscovery {
         val gradleModules = if (settingsSnapshot.shouldPreferStaticDiscovery()) {
             StaticGradleWorkspaceDiscovery.discoverModules(workspaceRoot, settingsSnapshot)
         } else {
+            val staticModules = {
+                StaticGradleWorkspaceDiscovery.discoverModules(workspaceRoot, settingsSnapshot)
+            }
             runCatching {
                 loadModulesWithToolingApi(workspaceRoot)
+            }.mapCatching { toolingModules ->
+                if (toolingModules.shouldFallbackToStaticModules(settingsSnapshot)) {
+                    staticModules()
+                } else {
+                    toolingModules
+                }
             }.getOrElse {
-                StaticGradleWorkspaceDiscovery.discoverModules(workspaceRoot, settingsSnapshot)
+                staticModules()
             }
         }
 
@@ -156,6 +165,21 @@ internal object GradleWorkspaceDiscovery {
     }
 }
 
+
+private fun List<GradleModuleModel>.shouldFallbackToStaticModules(
+    settingsSnapshot: GradleSettingsSnapshot,
+): Boolean {
+    if (settingsSnapshot.includedProjectPaths.isEmpty()) {
+        return false
+    }
+
+    val hasModuleDependencies = any { module ->
+        module.dependencies.any(GradleDependency::isModuleDependency)
+    }
+    return !hasModuleDependencies
+}
+
+private fun GradleDependency.isModuleDependency(): Boolean = this is GradleDependency.ModuleDependency
 internal data class GradleModuleModel(
     val gradlePath: String,
     val ideaModuleName: String,
@@ -244,6 +268,7 @@ internal enum class GradleSourceSet(
         supportedDependencyScopes = setOf(
             GradleDependencyScope.COMPILE,
             GradleDependencyScope.PROVIDED,
+            GradleDependencyScope.RUNTIME,
             GradleDependencyScope.UNKNOWN,
         ),
     ),
@@ -253,6 +278,7 @@ internal enum class GradleSourceSet(
             GradleDependencyScope.COMPILE,
             GradleDependencyScope.PROVIDED,
             GradleDependencyScope.TEST,
+            GradleDependencyScope.RUNTIME,
             GradleDependencyScope.UNKNOWN,
         ),
     ),

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneWorkspaceDiscoveryTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneWorkspaceDiscoveryTest.kt
@@ -174,15 +174,22 @@ class StandaloneWorkspaceDiscoveryTest {
                 appendLine("""        named("test") { java.srcDir("src/test/kotlin") }""")
                 appendLine("""    }""")
                 appendLine("""}""")
-                appendLine("""project(":app") {""")
-                appendLine("""    dependencies {""")
-                appendLine("""        add("implementation", project(":lib"))""")
+            },
+        )
+        writeFile(
+            relativePath = "app/build.gradle.kts",
+            content = buildString {
+                appendLine("""dependencies {""")
+                appendLine("""    implementation(project(":lib"))""")
                 if (includeLocalTestJar) {
-                    appendLine("""        add("testImplementation", files(rootProject.layout.projectDirectory.file("support/test-support.jar")))""")
+                    appendLine("""    testImplementation(files(rootProject.layout.projectDirectory.file("support/test-support.jar")))""")
                 }
-                appendLine("""    }""")
                 appendLine("""}""")
             },
+        )
+        writeFile(
+            relativePath = "lib/build.gradle.kts",
+            content = "",
         )
         writeFile(
             relativePath = "lib/src/main/kotlin/sample/Greeter.kt",


### PR DESCRIPTION
### Motivation
- CI release runs showed failing discovery tests because the Gradle Tooling API on runners returned dependencies differently (runtime-scoped or no inter-module deps), producing empty or incorrect module graphs. 
- The change aims to make standalone workspace discovery robust across Gradle/IDE model differences observed in CI without weakening test assertions.

### Description
- Treat `RUNTIME` scope as a supported dependency scope for both `MAIN` and `TEST` source sets so runtime-scoped library/module entries are considered when building binary and module dependency lists (`backend-standalone/src/main/kotlin/.../GradleWorkspaceDiscovery.kt`).
- Add a safe fallback that detects when Tooling API returns modules but none of them expose inter-module dependencies and then falls back to static discovery (helper `shouldFallbackToStaticModules` and `isModuleDependency`).
- Update the test fixture generation in `StandaloneWorkspaceDiscoveryTest` to declare the `:app -> :lib` dependency in `app/build.gradle.kts` (module-local file) so tests remain stable against Tooling API behavior changes.

### Testing
- Ran the targeted test: `bash .agents/skills/kotlin-gradle-loop/scripts/gradle/run_task.sh /workspace/kast :backend-standalone:test --tests "io.github.amichne.kast.standalone.StandaloneWorkspaceDiscoveryTest"`, which passed. 
- Ran the full project tests: `bash .agents/skills/kotlin-gradle-loop/scripts/gradle/run_task.sh /workspace/kast test`, which passed. 
- Built the portable distribution and ran the smoke CLI test via `:kast:portableDistZip` and the included smoke script, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ce707995e083209059fa448f525dd9)