### PR TITLE
Implement bounded call hierarchy in standalone backend

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyQuery.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyQuery.kt
@@ -7,4 +7,8 @@ data class CallHierarchyQuery(
     val position: FilePosition,
     val direction: CallDirection,
     val depth: Int = 3,
+    val maxTotalCalls: Int = 200,
+    val maxChildrenPerNode: Int = 50,
+    val timeoutMillis: Long? = null,
+    val includeExternalSymbols: Boolean = false,
 )

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -1,11 +1,14 @@
 package io.github.amichne.kast.standalone
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
 import io.github.amichne.kast.api.AnalysisBackend
 import io.github.amichne.kast.api.ApplyEditsQuery
 import io.github.amichne.kast.api.ApplyEditsResult
 import io.github.amichne.kast.api.BackendCapabilities
+import io.github.amichne.kast.api.CallDirection
+import io.github.amichne.kast.api.CallNode
 import io.github.amichne.kast.api.CallHierarchyQuery
 import io.github.amichne.kast.api.CallHierarchyResult
 import io.github.amichne.kast.api.DiagnosticsQuery
@@ -26,6 +29,7 @@ import io.github.amichne.kast.api.SymbolQuery
 import io.github.amichne.kast.api.SymbolResult
 import io.github.amichne.kast.api.TextEdit
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
@@ -49,6 +53,7 @@ class StandaloneAnalysisBackend(
         readCapabilities = setOf(
             ReadCapability.RESOLVE_SYMBOL,
             ReadCapability.FIND_REFERENCES,
+            ReadCapability.CALL_HIERARCHY,
             ReadCapability.DIAGNOSTICS,
         ),
         mutationCapabilities = setOf(
@@ -100,8 +105,25 @@ class StandaloneAnalysisBackend(
         )
     }
 
-    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult {
-        throw unsupported(ReadCapability.CALL_HIERARCHY)
+    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult = withContext(readDispatcher) {
+        require(query.depth >= 0) { "depth must be >= 0" }
+        require(query.maxTotalCalls >= 0) { "maxTotalCalls must be >= 0" }
+        require(query.maxChildrenPerNode >= 1) { "maxChildrenPerNode must be >= 1" }
+        val requestedTimeoutMillis = query.timeoutMillis
+        require(requestedTimeoutMillis == null || requestedTimeoutMillis > 0) { "timeoutMillis must be > 0 when provided" }
+        val timeoutMillis = requestedTimeoutMillis ?: limits.requestTimeoutMillis
+
+        val file = session.findKtFile(query.position.filePath)
+        val target = resolveTarget(file, query.position.offset)
+        val builder = CallHierarchyBuilder(
+            query = query,
+            callBudget = query.maxTotalCalls,
+            deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis),
+        )
+
+        CallHierarchyResult(
+            root = builder.buildNode(target, remainingDepth = query.depth, ancestry = emptySet()),
+        )
     }
 
     override suspend fun diagnostics(query: DiagnosticsQuery): DiagnosticsResult = withContext(readDispatcher) {
@@ -194,6 +216,134 @@ class StandaloneAnalysisBackend(
     }
 
     private fun currentFileHashes(filePaths: Collection<String>): List<FileHash> = LocalDiskEditApplier.currentHashes(filePaths)
+
+    private inner class CallHierarchyBuilder(
+        private val query: CallHierarchyQuery,
+        private var callBudget: Int,
+        private val deadlineNanos: Long,
+    ) {
+        fun buildNode(target: PsiElement, remainingDepth: Int, ancestry: Set<String>): CallNode {
+            val symbol = target.toSymbol(target.containingDeclarationName())
+            val key = symbol.symbolKey()
+            if (remainingDepth == 0 || callBudget == 0 || System.nanoTime() >= deadlineNanos) {
+                return CallNode(symbol = symbol, children = emptyList())
+            }
+
+            val nextAncestry = ancestry + key
+            val children = mutableListOf<CallNode>()
+            val edges = callEdges(target)
+                .asSequence()
+                .filter { edge -> query.includeExternalSymbols || edge.symbol.location.filePath.startsWith(workspaceRoot.toString()) }
+                .take(query.maxChildrenPerNode)
+                .toList()
+
+            for (edge in edges) {
+                if (callBudget == 0 || System.nanoTime() >= deadlineNanos) {
+                    break
+                }
+
+                callBudget -= 1
+                val childKey = edge.symbol.symbolKey()
+                children += if (childKey in nextAncestry) {
+                    CallNode(symbol = edge.symbol, children = emptyList())
+                } else {
+                    buildNode(edge.element, remainingDepth - 1, nextAncestry)
+                }
+            }
+
+            return CallNode(symbol = symbol, children = children)
+        }
+
+        private fun callEdges(target: PsiElement): List<CallEdge> = when (query.direction) {
+            CallDirection.INCOMING -> incomingEdges(target)
+            CallDirection.OUTGOING -> outgoingEdges(target)
+        }.sortedWith(
+            compareBy<CallEdge>({ it.callSite.filePath }, { it.callSite.startOffset }, { it.callSite.endOffset }, { it.symbol.fqName }),
+        )
+
+        private fun incomingEdges(target: PsiElement): List<CallEdge> = session.allKtFiles()
+            .flatMap { candidateFile -> candidateFile.findCallSitesTo(target) }
+
+        private fun outgoingEdges(target: PsiElement): List<CallEdge> {
+            val edges = mutableListOf<CallEdge>()
+
+            target.accept(
+                object : PsiRecursiveElementWalkingVisitor() {
+                    override fun visitElement(element: PsiElement) {
+                        element.references.forEach { reference ->
+                            val resolved = reference.resolve() ?: return@forEach
+                            if (resolved == target || resolved.isEquivalentTo(target)) {
+                                return@forEach
+                            }
+
+                            val referenceRange = com.intellij.openapi.util.TextRange(
+                                reference.element.textRange.startOffset + reference.rangeInElement.startOffset,
+                                reference.element.textRange.startOffset + reference.rangeInElement.endOffset,
+                            )
+                            edges += CallEdge(
+                                element = resolved,
+                                symbol = resolved.toSymbol(resolved.containingDeclarationName()),
+                                callSite = reference.element.toKastLocation(referenceRange),
+                            )
+                        }
+                        super.visitElement(element)
+                    }
+                },
+            )
+
+            return edges
+        }
+    }
+
+    private data class CallEdge(
+        val element: PsiElement,
+        val symbol: io.github.amichne.kast.api.Symbol,
+        val callSite: io.github.amichne.kast.api.Location,
+    )
+
+    private fun KtFile.findCallSitesTo(target: PsiElement): List<CallEdge> {
+        val edges = mutableListOf<CallEdge>()
+        accept(
+            object : PsiRecursiveElementWalkingVisitor() {
+                override fun visitElement(element: PsiElement) {
+                    element.references.forEach { reference ->
+                        val resolved = reference.resolve()
+                        if (resolved == target || resolved?.isEquivalentTo(target) == true) {
+                            val caller = reference.element.closestNamedCaller() ?: return@forEach
+                            val referenceRange = com.intellij.openapi.util.TextRange(
+                                reference.element.textRange.startOffset + reference.rangeInElement.startOffset,
+                                reference.element.textRange.startOffset + reference.rangeInElement.endOffset,
+                            )
+                            edges += CallEdge(
+                                element = caller,
+                                symbol = caller.toSymbol(caller.containingDeclarationName()),
+                                callSite = reference.element.toKastLocation(referenceRange),
+                            )
+                        }
+                    }
+                    super.visitElement(element)
+                }
+            },
+        )
+
+        return edges
+    }
+
+    private fun PsiElement.closestNamedCaller(): PsiElement? =
+        generateSequence(this) { element -> element.parent }
+            .firstOrNull { element -> element is PsiNamedElement && !element.name.isNullOrBlank() }
+
+    private fun PsiElement.containingDeclarationName(): String? =
+        generateSequence(parent) { element -> element.parent }
+            .filterIsInstance<PsiNamedElement>()
+            .firstOrNull { named -> !named.name.isNullOrBlank() }
+            ?.name
+
+    private fun PsiElement.toSymbol(containingDeclaration: String?) =
+        toSymbolModel(containingDeclaration = containingDeclaration)
+
+    private fun io.github.amichne.kast.api.Symbol.symbolKey(): String =
+        "${fqName}|${location.filePath}:${location.startOffset}-${location.endOffset}"
 
     private fun unsupported(capability: ReadCapability) = io.github.amichne.kast.api.CapabilityNotSupportedException(
         capability = capability.name,

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendCallHierarchyTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendCallHierarchyTest.kt
@@ -1,0 +1,193 @@
+package io.github.amichne.kast.standalone
+
+import io.github.amichne.kast.api.CallDirection
+import io.github.amichne.kast.api.CallHierarchyQuery
+import io.github.amichne.kast.api.FilePosition
+import io.github.amichne.kast.api.ReadCapability
+import io.github.amichne.kast.api.ServerLimits
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+class StandaloneAnalysisBackendCallHierarchyTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `outgoing hierarchy preserves repeated call-sites and respects depth`() = runTest {
+        val file = writeFile(
+            relativePath = "src/main/kotlin/sample/Calls.kt",
+            content = """
+                package sample
+
+                fun root(): String {
+                    return helper() + helper()
+                }
+
+                fun helper(): String = leaf()
+
+                fun leaf(): String = "ok"
+            """.trimIndent() + "\n",
+        )
+        val queryOffset = Files.readString(file).indexOf("root")
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "sources",
+        )
+        try {
+            val backend = backend(session)
+
+            val depthOne = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = queryOffset),
+                    direction = CallDirection.OUTGOING,
+                    depth = 1,
+                ),
+            )
+            val depthTwo = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = queryOffset),
+                    direction = CallDirection.OUTGOING,
+                    depth = 2,
+                ),
+            )
+
+            assertEquals("sample.root", depthOne.root.symbol.fqName)
+            assertEquals(listOf("sample.helper", "sample.helper"), depthOne.root.children.map { child -> child.symbol.fqName })
+            assertTrue(depthOne.root.children.all { child -> child.children.isEmpty() })
+            assertEquals(listOf(listOf("sample.leaf"), listOf("sample.leaf")), depthTwo.root.children.map { it.children.map { c -> c.symbol.fqName } })
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun `incoming hierarchy truncates recursive cycles deterministically`() = runTest {
+        val file = writeFile(
+            relativePath = "src/main/kotlin/sample/Recursive.kt",
+            content = """
+                package sample
+
+                fun a() { b() }
+                fun b() { a() }
+            """.trimIndent() + "\n",
+        )
+        val queryOffset = Files.readString(file).indexOf("fun a") + "fun ".length
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "sources",
+        )
+        try {
+            val backend = backend(session)
+
+            val result = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = queryOffset),
+                    direction = CallDirection.INCOMING,
+                    depth = 3,
+                ),
+            )
+
+            assertEquals("sample.a", result.root.symbol.fqName)
+            assertEquals(listOf("sample.b"), result.root.children.map { child -> child.symbol.fqName })
+            assertEquals(listOf("sample.a"), result.root.children.single().children.map { child -> child.symbol.fqName })
+            assertTrue(result.root.children.single().children.single().children.isEmpty())
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun `call hierarchy boundaries cap total calls`() = runTest {
+        val file = writeFile(
+            relativePath = "src/main/kotlin/sample/Bounded.kt",
+            content = """
+                package sample
+
+                fun root() {
+                    one()
+                    two()
+                    three()
+                }
+
+                fun one() {}
+                fun two() {}
+                fun three() {}
+            """.trimIndent() + "\n",
+        )
+        val queryOffset = Files.readString(file).indexOf("root")
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "sources",
+        )
+        try {
+            val backend = backend(session)
+            val result = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = queryOffset),
+                    direction = CallDirection.OUTGOING,
+                    depth = 2,
+                    maxTotalCalls = 2,
+                ),
+            )
+
+            assertEquals(2, result.root.children.size)
+            assertEquals(listOf("sample.one", "sample.two"), result.root.children.map { child -> child.symbol.fqName })
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun `capabilities advertise call hierarchy after implementation`() = runTest {
+        writeFile(
+            relativePath = "src/main/kotlin/sample/Greeter.kt",
+            content = """
+                package sample
+
+                fun greet(): String = "hi"
+            """.trimIndent() + "\n",
+        )
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "sources",
+        )
+        try {
+            val backend = backend(session)
+            val capabilities = backend.capabilities()
+            assertTrue(ReadCapability.CALL_HIERARCHY in capabilities.readCapabilities)
+        } finally {
+            session.close()
+        }
+    }
+
+    private fun backend(session: StandaloneAnalysisSession) = StandaloneAnalysisBackend(
+        workspaceRoot = workspaceRoot,
+        limits = ServerLimits(
+            maxResults = 100,
+            requestTimeoutMillis = 30_000,
+            maxConcurrentRequests = 4,
+        ),
+        session = session,
+    )
+
+    private fun writeFile(relativePath: String, content: String): Path {
+        val path = workspaceRoot.resolve(relativePath)
+        Files.createDirectories(path.parent)
+        path.writeText(content)
+        return path
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a usable `callHierarchy` capability for the standalone backend with sensible, testable traversal boundaries and stable/deterministic behavior. 
- Expose client-configurable limits for practical usage: depth, total call budget, per-node children cap, and timeout to avoid unbounded work. 
- Preserve call-site semantics (duplicate call-sites matter) and make cycle truncation explicit so the tree is finite and understandable. 
- Persistence of snapshots was considered but not implemented in this change; the pragmatic approach is to cache snapshots keyed by workspace git SHA under `.kast/call-hierarchy/<sha>/...` and invalidate on SHA changes. 

### Description
- Added new fields to the query model: `CallHierarchyQuery` now includes `maxTotalCalls`, `maxChildrenPerNode`, `timeoutMillis`, and `includeExternalSymbols` in addition to `depth` and `direction` (`analysis-api/src/main/kotlin/.../CallHierarchyQuery.kt`).
- Implemented `callHierarchy` in `StandaloneAnalysisBackend` and advertised `ReadCapability.CALL_HIERARCHY` in `capabilities()` (backend-standalone/src/main/kotlin/.../StandaloneAnalysisBackend.kt). 
- Introduced an inner `CallHierarchyBuilder` that enforces the supplied bounds (depth semantics: `depth=0 => root only`, `depth=1 => root + one edge`), maintains a global call budget, and enforces a deadline based on `timeoutMillis` or server limits; cycles are truncated deterministically by tracking ancestry symbol keys and duplicate call-sites are preserved (call-site dedup not applied). 
- Implemented stable ordering for children by call-site file path, start offset, end offset, then symbol fqName so results are deterministic across runs. 
- Added focused unit tests exercising outgoing duplicate call-sites and depth behavior, incoming recursion truncation, `maxTotalCalls` behavior, and capability advertising (`backend-standalone/src/test/kotlin/.../StandaloneAnalysisBackendCallHierarchyTest.kt`).

### Testing
- Ran the focused backend unit tests: `./gradlew :backend-standalone:test --tests io.github.amichne.kast.standalone.StandaloneAnalysisBackendCallHierarchyTest` and they passed. 
- Ran the broader backend test suite: `./gradlew :backend-standalone:test` and it passed. 
- Ran the server tests: `./gradlew :analysis-server:test` and they passed. 
- All automated tests mentioned above completed successfully after fixing test offsets and compilation issues encountered during iteration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ceacf674cc83209862a81360a55864)