### PR TITLE
Implement deterministic, bounded call hierarchy in standalone backend

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyQuery.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyQuery.kt
@@ -7,4 +7,8 @@ data class CallHierarchyQuery(
     val position: FilePosition,
     val direction: CallDirection,
     val depth: Int = 3,
+    val maxTotalCalls: Int = 1_000,
+    val maxChildrenPerNode: Int = 200,
+    val timeoutMillis: Long? = null,
+    val persistToWorkspace: Boolean = false,
 )

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyResult.kt
@@ -5,5 +5,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CallHierarchyResult(
     val root: CallNode,
+    val totalNodes: Int,
+    val totalEdges: Int,
+    val persistedSnapshot: PersistedCallHierarchySnapshot? = null,
     val schemaVersion: Int = SCHEMA_VERSION,
+)
+
+@Serializable
+data class PersistedCallHierarchySnapshot(
+    val gitSha: String?,
+    val relativePath: String,
 )

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallNode.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallNode.kt
@@ -5,5 +5,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CallNode(
     val symbol: Symbol,
+    val callSite: Location? = null,
+    val expansion: CallNodeExpansion = CallNodeExpansion.EXPANDED,
     val children: List<CallNode>,
 )
+
+@Serializable
+enum class CallNodeExpansion {
+    EXPANDED,
+    MAX_DEPTH,
+    CYCLE_TRUNCATED,
+    MAX_TOTAL_CALLS_TRUNCATED,
+    MAX_CHILDREN_TRUNCATED,
+    TIMEOUT_TRUNCATED,
+}

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisApplication.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisApplication.kt
@@ -121,8 +121,18 @@ fun Application.kastModule(
                 requireReadCapability(backend, ReadCapability.CALL_HIERARCHY)
                 val query = call.receive<CallHierarchyQuery>()
                 validateFilePosition(query.position.filePath, query.position.offset)
-                if (query.depth < 1) {
-                    throw ValidationException("Call hierarchy depth must be greater than zero")
+                if (query.depth < 0) {
+                    throw ValidationException("Call hierarchy depth must be zero or greater")
+                }
+                if (query.maxTotalCalls < 1) {
+                    throw ValidationException("Call hierarchy maxTotalCalls must be greater than zero")
+                }
+                if (query.maxChildrenPerNode < 1) {
+                    throw ValidationException("Call hierarchy maxChildrenPerNode must be greater than zero")
+                }
+                val timeoutMillis = query.timeoutMillis
+                if (timeoutMillis != null && timeoutMillis < 1) {
+                    throw ValidationException("Call hierarchy timeoutMillis must be greater than zero")
                 }
                 val response = execute(config) {
                     backend.callHierarchy(query)

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
@@ -149,8 +149,18 @@ class AnalysisDispatcher(
                 backend.callHierarchy(
                     decodeParams(CallHierarchyQuery.serializer(), params).also { query ->
                         validateFilePosition(query.position.filePath, query.position.offset)
-                        if (query.depth < 1) {
-                            throw ValidationException("Call hierarchy depth must be greater than zero")
+                        if (query.depth < 0) {
+                            throw ValidationException("Call hierarchy depth must be zero or greater")
+                        }
+                        if (query.maxTotalCalls < 1) {
+                            throw ValidationException("Call hierarchy maxTotalCalls must be greater than zero")
+                        }
+                        if (query.maxChildrenPerNode < 1) {
+                            throw ValidationException("Call hierarchy maxChildrenPerNode must be greater than zero")
+                        }
+                        val timeoutMillis = query.timeoutMillis
+                        if (timeoutMillis != null && timeoutMillis < 1) {
+                            throw ValidationException("Call hierarchy timeoutMillis must be greater than zero")
                         }
                         requireReadCapability(ReadCapability.CALL_HIERARCHY)
                     },

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
@@ -3,6 +3,9 @@ package io.github.amichne.kast.server
 import io.github.amichne.kast.api.ApplyEditsQuery
 import io.github.amichne.kast.api.ApplyEditsResult
 import io.github.amichne.kast.api.BackendCapabilities
+import io.github.amichne.kast.api.CallDirection
+import io.github.amichne.kast.api.CallHierarchyQuery
+import io.github.amichne.kast.api.CallHierarchyResult
 import io.github.amichne.kast.api.DiagnosticsQuery
 import io.github.amichne.kast.api.FileHash
 import io.github.amichne.kast.api.FileHashing
@@ -92,6 +95,25 @@ class AnalysisDispatcherTest {
 
         assertEquals("sample.greet", result.declaration?.fqName)
         assertEquals(1, result.references.size)
+    }
+
+    @Test
+    fun `call hierarchy dispatches without HTTP`() {
+        val file = sampleFile()
+
+        val result = dispatchSuccess<CallHierarchyResult>(
+            method = "call-hierarchy",
+            params = json.encodeToJsonElement(
+                CallHierarchyQuery.serializer(),
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = 20),
+                    direction = CallDirection.OUTGOING,
+                    depth = 0,
+                ),
+            ),
+        )
+
+        assertEquals("sample.greet", result.root.symbol.fqName)
     }
 
     @Test

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -8,12 +8,17 @@ import io.github.amichne.kast.api.ApplyEditsResult
 import io.github.amichne.kast.api.BackendCapabilities
 import io.github.amichne.kast.api.CallHierarchyQuery
 import io.github.amichne.kast.api.CallHierarchyResult
+import io.github.amichne.kast.api.CallNode
+import io.github.amichne.kast.api.CallNodeExpansion
 import io.github.amichne.kast.api.DiagnosticsQuery
 import io.github.amichne.kast.api.DiagnosticsResult
 import io.github.amichne.kast.api.FileHash
+import io.github.amichne.kast.api.FileHashing
 import io.github.amichne.kast.api.HealthResponse
 import io.github.amichne.kast.api.LocalDiskEditApplier
+import io.github.amichne.kast.api.Location
 import io.github.amichne.kast.api.MutationCapability
+import io.github.amichne.kast.api.PersistedCallHierarchySnapshot
 import io.github.amichne.kast.api.ReadCapability
 import io.github.amichne.kast.api.ReferencesQuery
 import io.github.amichne.kast.api.ReferencesResult
@@ -25,14 +30,20 @@ import io.github.amichne.kast.api.ServerLimits
 import io.github.amichne.kast.api.SymbolQuery
 import io.github.amichne.kast.api.SymbolResult
 import io.github.amichne.kast.api.TextEdit
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.KaDiagnosticCheckerFilter
 import org.jetbrains.kotlin.analysis.api.components.collectDiagnostics
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtReferenceExpression
 
 @OptIn(KaExperimentalApi::class)
 class StandaloneAnalysisBackend(
@@ -41,6 +52,11 @@ class StandaloneAnalysisBackend(
     private val session: StandaloneAnalysisSession,
 ) : AnalysisBackend {
     private val readDispatcher = Dispatchers.IO.limitedParallelism(limits.maxConcurrentRequests)
+    private val json = Json {
+        encodeDefaults = true
+        explicitNulls = false
+        prettyPrint = true
+    }
 
     override suspend fun capabilities(): BackendCapabilities = BackendCapabilities(
         backendName = "standalone",
@@ -49,6 +65,7 @@ class StandaloneAnalysisBackend(
         readCapabilities = setOf(
             ReadCapability.RESOLVE_SYMBOL,
             ReadCapability.FIND_REFERENCES,
+            ReadCapability.CALL_HIERARCHY,
             ReadCapability.DIAGNOSTICS,
         ),
         mutationCapabilities = setOf(
@@ -100,8 +117,31 @@ class StandaloneAnalysisBackend(
         )
     }
 
-    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult {
-        throw unsupported(ReadCapability.CALL_HIERARCHY)
+    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult = withContext(readDispatcher) {
+        val effectiveTimeoutMillis = query.timeoutMillis?.coerceAtMost(limits.requestTimeoutMillis)
+            ?: limits.requestTimeoutMillis
+        val timeoutDeadlineNanos = System.nanoTime() + effectiveTimeoutMillis * 1_000_000
+        val file = session.findKtFile(query.position.filePath)
+        val rootTarget = resolveTarget(file, query.position.offset)
+        val stats = CallHierarchyStats()
+        val rootNode = buildHierarchyNode(
+            symbolElement = rootTarget,
+            direction = query.direction,
+            remainingDepth = query.depth,
+            query = query,
+            stats = stats,
+            ancestorSymbols = setOf(rootTarget.symbolIdentity()),
+            callSite = null,
+            timeoutDeadlineNanos = timeoutDeadlineNanos,
+        )
+        val resultWithoutSnapshot = CallHierarchyResult(
+            root = rootNode,
+            totalNodes = stats.totalNodes,
+            totalEdges = stats.totalEdges,
+        )
+        resultWithoutSnapshot.copy(
+            persistedSnapshot = persistCallHierarchySnapshot(query, resultWithoutSnapshot),
+        )
     }
 
     override suspend fun diagnostics(query: DiagnosticsQuery): DiagnosticsResult = withContext(readDispatcher) {
@@ -195,8 +235,206 @@ class StandaloneAnalysisBackend(
 
     private fun currentFileHashes(filePaths: Collection<String>): List<FileHash> = LocalDiskEditApplier.currentHashes(filePaths)
 
+    private fun buildHierarchyNode(
+        symbolElement: PsiElement,
+        direction: io.github.amichne.kast.api.CallDirection,
+        remainingDepth: Int,
+        query: CallHierarchyQuery,
+        stats: CallHierarchyStats,
+        ancestorSymbols: Set<String>,
+        callSite: Location?,
+        timeoutDeadlineNanos: Long,
+    ): CallNode {
+        stats.totalNodes += 1
+        if (System.nanoTime() >= timeoutDeadlineNanos) {
+            return CallNode(
+                symbol = symbolElement.toSymbolModel(containingDeclaration = null),
+                callSite = callSite,
+                expansion = CallNodeExpansion.TIMEOUT_TRUNCATED,
+                children = emptyList(),
+            )
+        }
+        if (remainingDepth == 0) {
+            return CallNode(
+                symbol = symbolElement.toSymbolModel(containingDeclaration = null),
+                callSite = callSite,
+                expansion = CallNodeExpansion.MAX_DEPTH,
+                children = emptyList(),
+            )
+        }
+
+        val callRelations = when (direction) {
+            io.github.amichne.kast.api.CallDirection.INCOMING -> findIncomingCalls(symbolElement)
+            io.github.amichne.kast.api.CallDirection.OUTGOING -> findOutgoingCalls(symbolElement)
+        }.sortedWith(
+            compareBy<CallRelation>(
+                { it.callSite.filePath },
+                { it.callSite.startOffset },
+                { it.callSite.endOffset },
+                { it.callee.toSymbolModel(containingDeclaration = null).fqName },
+                { it.callee.containingFile.virtualFile.path },
+                { it.callee.textRange.startOffset },
+            ),
+        )
+
+        var expansion = CallNodeExpansion.EXPANDED
+        val children = mutableListOf<CallNode>()
+        for (relation in callRelations) {
+            if (children.size >= query.maxChildrenPerNode) {
+                expansion = CallNodeExpansion.MAX_CHILDREN_TRUNCATED
+                break
+            }
+            if (stats.totalEdges >= query.maxTotalCalls) {
+                expansion = CallNodeExpansion.MAX_TOTAL_CALLS_TRUNCATED
+                break
+            }
+            val nextSymbol = if (direction == io.github.amichne.kast.api.CallDirection.INCOMING) relation.caller else relation.callee
+            val symbolIdentity = nextSymbol.symbolIdentity()
+            val child = if (ancestorSymbols.contains(symbolIdentity)) {
+                stats.totalNodes += 1
+                CallNode(
+                    symbol = nextSymbol.toSymbolModel(containingDeclaration = null),
+                    callSite = relation.callSite,
+                    expansion = CallNodeExpansion.CYCLE_TRUNCATED,
+                    children = emptyList(),
+                )
+            } else {
+                buildHierarchyNode(
+                    symbolElement = nextSymbol,
+                    direction = direction,
+                    remainingDepth = remainingDepth - 1,
+                    query = query,
+                    stats = stats,
+                    ancestorSymbols = ancestorSymbols + symbolIdentity,
+                    callSite = relation.callSite,
+                    timeoutDeadlineNanos = timeoutDeadlineNanos,
+                )
+            }
+            stats.totalEdges += 1
+            children += child
+        }
+
+        return CallNode(
+            symbol = symbolElement.toSymbolModel(containingDeclaration = null),
+            callSite = callSite,
+            expansion = expansion,
+            children = children,
+        )
+    }
+
+    private fun findIncomingCalls(target: PsiElement): List<CallRelation> = session.allKtFiles()
+        .flatMap { candidateFile ->
+            val calls = mutableListOf<CallRelation>()
+            candidateFile.accept(
+                object : PsiRecursiveElementWalkingVisitor() {
+                    override fun visitElement(element: PsiElement) {
+                        if (element is KtReferenceExpression) {
+                            element.references.forEach { reference ->
+                                val resolved = reference.resolve()
+                                if (resolved == target || resolved?.isEquivalentTo(target) == true) {
+                                    val caller = element.parentsWithSelf()
+                                        .firstOrNull { parent -> parent is KtNamedDeclaration }
+                                        ?: return@forEach
+                                    calls += CallRelation(
+                                        caller = caller,
+                                        callee = target,
+                                        callSite = reference.element.toKastLocation(
+                                            com.intellij.openapi.util.TextRange(
+                                                reference.element.textRange.startOffset + reference.rangeInElement.startOffset,
+                                                reference.element.textRange.startOffset + reference.rangeInElement.endOffset,
+                                            ),
+                                        ),
+                                    )
+                                }
+                            }
+                        }
+                        super.visitElement(element)
+                    }
+                },
+            )
+            calls
+        }
+
+    private fun findOutgoingCalls(caller: PsiElement): List<CallRelation> {
+        val declaration = caller as? KtNamedDeclaration ?: return emptyList()
+        val relations = mutableListOf<CallRelation>()
+        declaration.accept(
+            object : PsiRecursiveElementWalkingVisitor() {
+                override fun visitElement(element: PsiElement) {
+                    if (element is KtReferenceExpression) {
+                        element.references.forEach { reference ->
+                            val resolved = reference.resolve() ?: return@forEach
+                            val callee = resolved as? KtNamedDeclaration ?: return@forEach
+                            relations += CallRelation(
+                                caller = declaration,
+                                callee = callee,
+                                callSite = reference.element.toKastLocation(
+                                    com.intellij.openapi.util.TextRange(
+                                        reference.element.textRange.startOffset + reference.rangeInElement.startOffset,
+                                        reference.element.textRange.startOffset + reference.rangeInElement.endOffset,
+                                    ),
+                                ),
+                            )
+                        }
+                    }
+                    super.visitElement(element)
+                }
+            },
+        )
+        return relations
+    }
+
+    private fun persistCallHierarchySnapshot(
+        query: CallHierarchyQuery,
+        result: CallHierarchyResult,
+    ): PersistedCallHierarchySnapshot? {
+        if (!query.persistToWorkspace) {
+            return null
+        }
+        val relativeDirectory = Path.of(".kast", "call-hierarchy")
+        val gitSha = gitHeadSha()
+        val identityPayload = json.encodeToString(CallHierarchyQuery.serializer(), query)
+        val snapshotHash = FileHashing.sha256(identityPayload)
+        val relativePath = relativeDirectory
+            .resolve(gitSha ?: "no-git-sha")
+            .resolve("$snapshotHash.json")
+        val outputFile = workspaceRoot.resolve(relativePath)
+        Files.createDirectories(outputFile.parent)
+        Files.writeString(outputFile, json.encodeToString(CallHierarchyResult.serializer(), result), StandardCharsets.UTF_8)
+        return PersistedCallHierarchySnapshot(
+            gitSha = gitSha,
+            relativePath = relativePath.toString(),
+        )
+    }
+
+    private fun gitHeadSha(): String? = runCatching {
+        val process = ProcessBuilder("git", "-C", workspaceRoot.toString(), "rev-parse", "HEAD")
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText().trim()
+        if (process.waitFor() == 0 && output.isNotBlank()) output else null
+    }.getOrNull()
+
+    private fun PsiElement.parentsWithSelf(): Sequence<PsiElement> = generateSequence(this) { it.parent }
+    private fun PsiElement.symbolIdentity(): String {
+        val location = toKastLocation()
+        val fqName = toSymbolModel(containingDeclaration = null).fqName
+        return "$fqName@${location.filePath}:${location.startOffset}-${location.endOffset}"
+    }
+
     private fun unsupported(capability: ReadCapability) = io.github.amichne.kast.api.CapabilityNotSupportedException(
         capability = capability.name,
         message = "The standalone backend does not support $capability",
     )
 }
+
+private data class CallRelation(
+    val caller: PsiElement,
+    val callee: PsiElement,
+    val callSite: Location,
+)
+
+private data class CallHierarchyStats(
+    var totalNodes: Int = 0,
+    var totalEdges: Int = 0,
+)

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendCallHierarchyTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendCallHierarchyTest.kt
@@ -1,0 +1,154 @@
+package io.github.amichne.kast.standalone
+
+import io.github.amichne.kast.api.CallDirection
+import io.github.amichne.kast.api.CallHierarchyQuery
+import io.github.amichne.kast.api.CallNodeExpansion
+import io.github.amichne.kast.api.FilePosition
+import io.github.amichne.kast.api.ReadCapability
+import io.github.amichne.kast.api.ServerLimits
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+class StandaloneAnalysisBackendCallHierarchyTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `depth zero returns only the selected declaration root`() = runTest {
+        val sourceFile = writeFile(
+            relativePath = "src/main/kotlin/sample/Calls.kt",
+            content = """
+                package sample
+
+                fun root() {
+                    leaf()
+                }
+
+                fun leaf() = Unit
+            """.trimIndent() + "\n",
+        )
+        val queryOffset = Files.readString(sourceFile).indexOf("root")
+        val session = session()
+        try {
+            val backend = backend(session)
+            val result = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = sourceFile.toString(), offset = queryOffset),
+                    direction = CallDirection.OUTGOING,
+                    depth = 0,
+                ),
+            )
+
+            assertEquals("sample.root", result.root.symbol.fqName)
+            assertEquals(CallNodeExpansion.MAX_DEPTH, result.root.expansion)
+            assertTrue(result.root.children.isEmpty())
+            assertEquals(1, result.totalNodes)
+            assertEquals(0, result.totalEdges)
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun `outgoing hierarchy keeps duplicate call sites and truncates cycles deterministically`() = runTest {
+        val sourceFile = writeFile(
+            relativePath = "src/main/kotlin/sample/Calls.kt",
+            content = """
+                package sample
+
+                fun root() {
+                    alpha()
+                    alpha()
+                    beta()
+                }
+
+                fun alpha() {
+                    beta()
+                }
+
+                fun beta() {
+                    alpha()
+                }
+            """.trimIndent() + "\n",
+        )
+        val queryOffset = Files.readString(sourceFile).indexOf("root")
+        val session = session()
+        try {
+            val backend = backend(session)
+            val result = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = sourceFile.toString(), offset = queryOffset),
+                    direction = CallDirection.OUTGOING,
+                    depth = 3,
+                    maxTotalCalls = 100,
+                ),
+            )
+
+            assertEquals(listOf("sample.alpha", "sample.alpha", "sample.beta"), result.root.children.map { it.symbol.fqName })
+            assertEquals(
+                listOf(4, 5, 6),
+                result.root.children.map { it.callSite?.startLine },
+            )
+            val cycleTruncatedNodes = result.root.children
+                .flatMap { child -> child.children }
+                .flatMap { child -> child.children }
+                .filter { node -> node.expansion == CallNodeExpansion.CYCLE_TRUNCATED }
+            assertTrue(cycleTruncatedNodes.isNotEmpty())
+        } finally {
+            session.close()
+        }
+    }
+
+    @Test
+    fun `capabilities advertise call hierarchy after implementation`() = runTest {
+        writeFile(
+            relativePath = "src/main/kotlin/sample/Calls.kt",
+            content = """
+                package sample
+
+                fun root() = Unit
+            """.trimIndent() + "\n",
+        )
+        val session = session()
+        try {
+            val backend = backend(session)
+            val capabilities = backend.capabilities()
+            assertTrue(ReadCapability.CALL_HIERARCHY in capabilities.readCapabilities)
+        } finally {
+            session.close()
+        }
+    }
+
+    private fun session(): StandaloneAnalysisSession = StandaloneAnalysisSession(
+        workspaceRoot = workspaceRoot,
+        sourceRoots = emptyList(),
+        classpathRoots = emptyList(),
+        moduleName = "sources",
+    )
+
+    private fun backend(session: StandaloneAnalysisSession): StandaloneAnalysisBackend = StandaloneAnalysisBackend(
+        workspaceRoot = workspaceRoot,
+        limits = ServerLimits(
+            maxResults = 100,
+            requestTimeoutMillis = 30_000,
+            maxConcurrentRequests = 4,
+        ),
+        session = session,
+    )
+
+    private fun writeFile(
+        relativePath: String,
+        content: String,
+    ): Path {
+        val path = workspaceRoot.resolve(relativePath)
+        Files.createDirectories(path.parent)
+        path.writeText(content)
+        return path
+    }
+}

--- a/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
+++ b/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
@@ -8,6 +8,7 @@ import io.github.amichne.kast.api.CallDirection
 import io.github.amichne.kast.api.CallHierarchyQuery
 import io.github.amichne.kast.api.CallHierarchyResult
 import io.github.amichne.kast.api.CallNode
+import io.github.amichne.kast.api.CallNodeExpansion
 import io.github.amichne.kast.api.Diagnostic
 import io.github.amichne.kast.api.DiagnosticSeverity
 import io.github.amichne.kast.api.DiagnosticsQuery
@@ -92,6 +93,13 @@ class FakeAnalysisBackend private constructor(
 
     override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult {
         requireAnchor(query.position)
+        if (query.depth == 0) {
+            return CallHierarchyResult(
+                root = CallNode(symbol = symbol, expansion = CallNodeExpansion.MAX_DEPTH, children = emptyList()),
+                totalNodes = 1,
+                totalEdges = 0,
+            )
+        }
         val outgoingReference = referenceLocations.firstOrNull() ?: symbol.location
         val child = if (query.direction == CallDirection.OUTGOING) {
             CallNode(
@@ -100,14 +108,17 @@ class FakeAnalysisBackend private constructor(
                     kind = SymbolKind.FUNCTION,
                     location = outgoingReference,
                 ),
+                expansion = CallNodeExpansion.MAX_DEPTH,
                 children = emptyList(),
             )
         } else {
-            CallNode(symbol = symbol, children = emptyList())
+            CallNode(symbol = symbol, expansion = CallNodeExpansion.MAX_DEPTH, children = emptyList())
         }
 
         return CallHierarchyResult(
             root = CallNode(symbol = symbol, children = listOf(child)),
+            totalNodes = 2,
+            totalEdges = 1,
         )
     }
 


### PR DESCRIPTION
### Motivation

- Provide a concrete `callHierarchy` implementation to close the product gap and make call-graph information available from the standalone backend.
- Give callers safe, predictable boundaries for potentially unbounded graphs via depth, total-call, child limits, and timeouts.
- Make truncation explicit and reproducible and optionally persist snapshots tied to the workspace Git SHA for later inspection.

### Description

- Implemented `callHierarchy` in `backend-standalone` with bounded traversal and deterministic ordering, tracking expansion reasons and preserving duplicate call sites; cycle detection truncates repeated symbols on the active path and annotates nodes with `CallNodeExpansion` variants.
- Extended the API: `CallHierarchyQuery` gains `maxTotalCalls`, `maxChildrenPerNode`, `timeoutMillis`, and `persistToWorkspace`; `CallNode` now includes `callSite` and `expansion`; `CallHierarchyResult` now includes `totalNodes`, `totalEdges`, and optional `PersistedCallHierarchySnapshot` metadata.
- Added optional persistence that writes `.kast/call-hierarchy/<git-sha>/<query-hash>.json` when `persistToWorkspace=true` and returns the relative path and `gitSha` in the response.
- Updated server-side validation to accept `depth=0` (root-only) and validate the new bounds, added a dispatcher test for `call-hierarchy`, updated the `FakeAnalysisBackend` to satisfy the new contract, and added `StandaloneAnalysisBackendCallHierarchyTest` exercising depth semantics, duplicate call-site preservation, deterministic ordering, cycle truncation, and capability advertising.

### Testing

- Ran the cross-module test invocation via the project script: `bash .agents/skills/kotlin-gradle-loop/scripts/gradle/run_task.sh /workspace/kast :analysis-api:test :analysis-server:test :shared-testing:test :backend-standalone:test` and iterated until compilation issues were fixed.
- Final test run completed successfully and all automated tests for the affected modules passed (`:analysis-api:test`, `:analysis-server:test`, `:shared-testing:test`, `:backend-standalone:test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ceacf674cc83209862a81360a55864)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amichne/kast/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
