### PR TITLE
Implement bounded call-hierarchy traversal with deterministic truncation and persistence

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyQuery.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyQuery.kt
@@ -7,4 +7,8 @@ data class CallHierarchyQuery(
     val position: FilePosition,
     val direction: CallDirection,
     val depth: Int = 3,
+    val maxTotalCalls: Int = 256,
+    val maxChildrenPerNode: Int = 64,
+    val timeoutMillis: Long? = null,
+    val persistToGitShaCache: Boolean = false,
 )

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyResult.kt
@@ -5,5 +5,24 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CallHierarchyResult(
     val root: CallNode,
+    val stats: CallHierarchyStats,
+    val persistence: CallHierarchyPersistence? = null,
     val schemaVersion: Int = SCHEMA_VERSION,
+)
+
+@Serializable
+data class CallHierarchyStats(
+    val totalNodes: Int,
+    val totalEdges: Int,
+    val truncatedNodes: Int,
+    val maxDepthReached: Int,
+    val timeoutReached: Boolean,
+    val maxTotalCallsReached: Boolean,
+    val maxChildrenPerNodeReached: Boolean,
+)
+
+@Serializable
+data class CallHierarchyPersistence(
+    val gitSha: String,
+    val cacheFilePath: String,
 )

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallNode.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallNode.kt
@@ -5,5 +5,21 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CallNode(
     val symbol: Symbol,
+    val callSite: Location? = null,
+    val truncation: CallNodeTruncation? = null,
     val children: List<CallNode>,
 )
+
+@Serializable
+data class CallNodeTruncation(
+    val reason: CallNodeTruncationReason,
+    val details: String? = null,
+)
+
+@Serializable
+enum class CallNodeTruncationReason {
+    CYCLE,
+    MAX_TOTAL_CALLS,
+    MAX_CHILDREN_PER_NODE,
+    TIMEOUT,
+}

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisApplication.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisApplication.kt
@@ -121,8 +121,18 @@ fun Application.kastModule(
                 requireReadCapability(backend, ReadCapability.CALL_HIERARCHY)
                 val query = call.receive<CallHierarchyQuery>()
                 validateFilePosition(query.position.filePath, query.position.offset)
-                if (query.depth < 1) {
-                    throw ValidationException("Call hierarchy depth must be greater than zero")
+                if (query.depth < 0) {
+                    throw ValidationException("Call hierarchy depth must be greater than or equal to zero")
+                }
+                if (query.maxTotalCalls < 1) {
+                    throw ValidationException("Call hierarchy maxTotalCalls must be greater than zero")
+                }
+                if (query.maxChildrenPerNode < 1) {
+                    throw ValidationException("Call hierarchy maxChildrenPerNode must be greater than zero")
+                }
+                val timeoutMillis = query.timeoutMillis
+                if (timeoutMillis != null && timeoutMillis < 1) {
+                    throw ValidationException("Call hierarchy timeoutMillis must be greater than zero when provided")
                 }
                 val response = execute(config) {
                     backend.callHierarchy(query)

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
@@ -149,8 +149,18 @@ class AnalysisDispatcher(
                 backend.callHierarchy(
                     decodeParams(CallHierarchyQuery.serializer(), params).also { query ->
                         validateFilePosition(query.position.filePath, query.position.offset)
-                        if (query.depth < 1) {
-                            throw ValidationException("Call hierarchy depth must be greater than zero")
+                        if (query.depth < 0) {
+                            throw ValidationException("Call hierarchy depth must be greater than or equal to zero")
+                        }
+                        if (query.maxTotalCalls < 1) {
+                            throw ValidationException("Call hierarchy maxTotalCalls must be greater than zero")
+                        }
+                        if (query.maxChildrenPerNode < 1) {
+                            throw ValidationException("Call hierarchy maxChildrenPerNode must be greater than zero")
+                        }
+                        val timeoutMillis = query.timeoutMillis
+                        if (timeoutMillis != null && timeoutMillis < 1) {
+                            throw ValidationException("Call hierarchy timeoutMillis must be greater than zero when provided")
                         }
                         requireReadCapability(ReadCapability.CALL_HIERARCHY)
                     },

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
@@ -3,6 +3,9 @@ package io.github.amichne.kast.server
 import io.github.amichne.kast.api.ApplyEditsQuery
 import io.github.amichne.kast.api.ApplyEditsResult
 import io.github.amichne.kast.api.BackendCapabilities
+import io.github.amichne.kast.api.CallDirection
+import io.github.amichne.kast.api.CallHierarchyQuery
+import io.github.amichne.kast.api.CallHierarchyResult
 import io.github.amichne.kast.api.DiagnosticsQuery
 import io.github.amichne.kast.api.FileHash
 import io.github.amichne.kast.api.FileHashing
@@ -95,6 +98,26 @@ class AnalysisDispatcherTest {
     }
 
     @Test
+    fun `call hierarchy dispatches without HTTP`() {
+        val file = sampleFile()
+
+        val result = dispatchSuccess<CallHierarchyResult>(
+            method = "call-hierarchy",
+            params = json.encodeToJsonElement(
+                CallHierarchyQuery.serializer(),
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = 20),
+                    direction = CallDirection.INCOMING,
+                    depth = 1,
+                ),
+            ),
+        )
+
+        assertEquals("sample.greet", result.root.symbol.fqName)
+        assertEquals(2, result.stats.totalNodes)
+    }
+
+    @Test
     fun `rename dispatches without HTTP`() {
         val file = sampleFile()
 
@@ -162,6 +185,28 @@ class AnalysisDispatcherTest {
         )
         assertEquals("VALIDATION_ERROR", error.error.data?.code)
         assertTrue(checkNotNull(error.error.data?.details?.get("filePath")).contains("relative/File.kt"))
+    }
+
+    @Test
+    fun `invalid call hierarchy depth returns rpc error payload`() {
+        val file = sampleFile()
+        val response = dispatchRaw(
+            method = "call-hierarchy",
+            params = json.encodeToJsonElement(
+                CallHierarchyQuery.serializer(),
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = 20),
+                    direction = CallDirection.OUTGOING,
+                    depth = -1,
+                ),
+            ),
+        )
+
+        val error = json.decodeFromJsonElement(
+            JsonRpcErrorResponse.serializer(),
+            response,
+        )
+        assertEquals("VALIDATION_ERROR", error.error.data?.code)
     }
 
     private fun sampleFile(): Path = tempDir.resolve("src").resolve("Sample.kt")

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -1,18 +1,27 @@
 package io.github.amichne.kast.standalone
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import io.github.amichne.kast.api.CallDirection
 import io.github.amichne.kast.api.AnalysisBackend
 import io.github.amichne.kast.api.ApplyEditsQuery
 import io.github.amichne.kast.api.ApplyEditsResult
 import io.github.amichne.kast.api.BackendCapabilities
+import io.github.amichne.kast.api.CallHierarchyPersistence
 import io.github.amichne.kast.api.CallHierarchyQuery
 import io.github.amichne.kast.api.CallHierarchyResult
+import io.github.amichne.kast.api.CallHierarchyStats
+import io.github.amichne.kast.api.CallNode
+import io.github.amichne.kast.api.CallNodeTruncation
+import io.github.amichne.kast.api.CallNodeTruncationReason
 import io.github.amichne.kast.api.DiagnosticsQuery
 import io.github.amichne.kast.api.DiagnosticsResult
 import io.github.amichne.kast.api.FileHash
+import io.github.amichne.kast.api.FileHashing
 import io.github.amichne.kast.api.HealthResponse
 import io.github.amichne.kast.api.LocalDiskEditApplier
+import io.github.amichne.kast.api.Location
 import io.github.amichne.kast.api.MutationCapability
 import io.github.amichne.kast.api.ReadCapability
 import io.github.amichne.kast.api.ReferencesQuery
@@ -25,14 +34,18 @@ import io.github.amichne.kast.api.ServerLimits
 import io.github.amichne.kast.api.SymbolQuery
 import io.github.amichne.kast.api.SymbolResult
 import io.github.amichne.kast.api.TextEdit
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.KaDiagnosticCheckerFilter
 import org.jetbrains.kotlin.analysis.api.components.collectDiagnostics
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
 
 @OptIn(KaExperimentalApi::class)
 class StandaloneAnalysisBackend(
@@ -41,6 +54,7 @@ class StandaloneAnalysisBackend(
     private val session: StandaloneAnalysisSession,
 ) : AnalysisBackend {
     private val readDispatcher = Dispatchers.IO.limitedParallelism(limits.maxConcurrentRequests)
+    private val json = Json { prettyPrint = true }
 
     override suspend fun capabilities(): BackendCapabilities = BackendCapabilities(
         backendName = "standalone",
@@ -49,6 +63,7 @@ class StandaloneAnalysisBackend(
         readCapabilities = setOf(
             ReadCapability.RESOLVE_SYMBOL,
             ReadCapability.FIND_REFERENCES,
+            ReadCapability.CALL_HIERARCHY,
             ReadCapability.DIAGNOSTICS,
         ),
         mutationCapabilities = setOf(
@@ -100,8 +115,32 @@ class StandaloneAnalysisBackend(
         )
     }
 
-    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult {
-        throw unsupported(ReadCapability.CALL_HIERARCHY)
+    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult = withContext(readDispatcher) {
+        val file = session.findKtFile(query.position.filePath)
+        val rootTarget = resolveTarget(file, query.position.offset)
+        val budget = CallHierarchyBudget(
+            maxTotalCalls = query.maxTotalCalls,
+            maxChildrenPerNode = query.maxChildrenPerNode,
+            timeoutMillis = query.timeoutMillis ?: limits.requestTimeoutMillis,
+        )
+
+        val root = buildCallNode(
+            target = rootTarget,
+            parentCallSite = null,
+            direction = query.direction,
+            depthRemaining = query.depth,
+            pathKeys = emptySet(),
+            budget = budget,
+            currentDepth = 0,
+        )
+        val stats = budget.toStats()
+        val persistence = if (query.persistToGitShaCache) persistCallHierarchy(query, root, stats) else null
+
+        CallHierarchyResult(
+            root = root,
+            stats = stats,
+            persistence = persistence,
+        )
     }
 
     override suspend fun diagnostics(query: DiagnosticsQuery): DiagnosticsResult = withContext(readDispatcher) {
@@ -195,8 +234,280 @@ class StandaloneAnalysisBackend(
 
     private fun currentFileHashes(filePaths: Collection<String>): List<FileHash> = LocalDiskEditApplier.currentHashes(filePaths)
 
+    private fun buildCallNode(
+        target: PsiElement,
+        parentCallSite: Location?,
+        direction: CallDirection,
+        depthRemaining: Int,
+        pathKeys: Set<String>,
+        budget: CallHierarchyBudget,
+        currentDepth: Int,
+    ): CallNode {
+        val symbol = target.toSymbolModel(containingDeclaration = null)
+        val nodeKey = symbolIdentityKey(target, symbol)
+        budget.observeDepth(currentDepth)
+        budget.nodes += 1
+
+        if (budget.timeoutReached()) {
+            return CallNode(
+                symbol = symbol,
+                callSite = parentCallSite,
+                truncation = CallNodeTruncation(CallNodeTruncationReason.TIMEOUT, "Traversal timeout reached"),
+                children = emptyList(),
+            ).also { budget.truncatedNodes += 1 }
+        }
+        if (depthRemaining == 0) {
+            return CallNode(symbol = symbol, callSite = parentCallSite, children = emptyList())
+        }
+
+        val edges = findCallEdges(target, direction)
+        val children = mutableListOf<CallNode>()
+        var truncation: CallNodeTruncation? = null
+
+        for ((index, edge) in edges.withIndex()) {
+            if (budget.timeoutReached()) {
+                truncation = CallNodeTruncation(CallNodeTruncationReason.TIMEOUT, "Traversal timeout reached")
+                budget.timeoutHit = true
+                break
+            }
+            if (budget.edges >= budget.maxTotalCalls) {
+                truncation = CallNodeTruncation(
+                    CallNodeTruncationReason.MAX_TOTAL_CALLS,
+                    "Reached maxTotalCalls=${budget.maxTotalCalls}",
+                )
+                budget.maxTotalCallsHit = true
+                break
+            }
+            if (children.size >= budget.maxChildrenPerNode) {
+                truncation = CallNodeTruncation(
+                    CallNodeTruncationReason.MAX_CHILDREN_PER_NODE,
+                    "Reached maxChildrenPerNode=${budget.maxChildrenPerNode}",
+                )
+                budget.maxChildrenHit = true
+                break
+            }
+
+            budget.edges += 1
+            val childKey = symbolIdentityKey(edge.target, edge.symbol)
+            val child = if (childKey in pathKeys || childKey == nodeKey) {
+                budget.nodes += 1
+                budget.truncatedNodes += 1
+                CallNode(
+                    symbol = edge.symbol,
+                    callSite = edge.callSite,
+                    truncation = CallNodeTruncation(
+                        CallNodeTruncationReason.CYCLE,
+                        "Cycle detected on symbol=$childKey",
+                    ),
+                    children = emptyList(),
+                )
+            } else {
+                buildCallNode(
+                    target = edge.target,
+                    parentCallSite = edge.callSite,
+                    direction = direction,
+                    depthRemaining = depthRemaining - 1,
+                    pathKeys = pathKeys + nodeKey,
+                    budget = budget,
+                    currentDepth = currentDepth + 1,
+                )
+            }
+            children += child
+
+            if (index == edges.lastIndex) {
+                // keep deterministic iteration even when no truncation happened
+                continue
+            }
+        }
+
+        if (truncation != null) {
+            budget.truncatedNodes += 1
+        }
+        return CallNode(
+            symbol = symbol,
+            callSite = parentCallSite,
+            truncation = truncation,
+            children = children,
+        )
+    }
+
+    private fun findCallEdges(
+        target: PsiElement,
+        direction: CallDirection,
+    ): List<CallEdge> = when (direction) {
+        CallDirection.INCOMING -> incomingCallEdges(target)
+        CallDirection.OUTGOING -> outgoingCallEdges(target)
+    }.sortedWith(
+        compareBy<CallEdge>(
+            { it.callSite.filePath },
+            { it.callSite.startOffset },
+            { it.callSite.endOffset },
+            { it.symbol.fqName },
+            { it.symbol.kind.name },
+        ),
+    )
+
+    private fun incomingCallEdges(target: PsiElement): List<CallEdge> {
+        val edges = mutableListOf<CallEdge>()
+        session.allKtFiles().forEach { candidateFile ->
+            candidateFile.accept(
+                object : PsiRecursiveElementWalkingVisitor() {
+                    override fun visitElement(element: PsiElement) {
+                        element.references.forEach { reference ->
+                            val resolved = reference.resolve()
+                            if (resolved == target || resolved?.isEquivalentTo(target) == true) {
+                                val caller = reference.element.parentsWithSelf()
+                                    .filterIsInstance<PsiNamedElement>()
+                                    .firstOrNull { !it.name.isNullOrBlank() }
+                                    ?: return@forEach
+                                val callerSymbol = caller.toSymbolModel(containingDeclaration = null)
+                                val callSite = reference.element.toKastLocation(
+                                    com.intellij.openapi.util.TextRange(
+                                        reference.element.textRange.startOffset + reference.rangeInElement.startOffset,
+                                        reference.element.textRange.startOffset + reference.rangeInElement.endOffset,
+                                    ),
+                                )
+                                edges += CallEdge(target = caller, symbol = callerSymbol, callSite = callSite)
+                            }
+                        }
+                        super.visitElement(element)
+                    }
+                },
+            )
+        }
+        return edges
+    }
+
+    private fun outgoingCallEdges(target: PsiElement): List<CallEdge> {
+        val declaration = target.parentsWithSelf()
+            .filterIsInstance<KtNamedDeclaration>()
+            .firstOrNull()
+            ?: return emptyList()
+        val edges = mutableListOf<CallEdge>()
+        declaration.accept(
+            object : PsiRecursiveElementWalkingVisitor() {
+                override fun visitElement(element: PsiElement) {
+                    element.references.forEach { reference ->
+                        val resolved = reference.resolve() ?: return@forEach
+                        val symbol = resolved.toSymbolModel(containingDeclaration = null)
+                        val callSite = reference.element.toKastLocation(
+                            com.intellij.openapi.util.TextRange(
+                                reference.element.textRange.startOffset + reference.rangeInElement.startOffset,
+                                reference.element.textRange.startOffset + reference.rangeInElement.endOffset,
+                            ),
+                        )
+                        edges += CallEdge(target = resolved, symbol = symbol, callSite = callSite)
+                    }
+                    super.visitElement(element)
+                }
+            },
+        )
+        return edges
+    }
+
+    private fun symbolIdentityKey(
+        target: PsiElement,
+        symbol: io.github.amichne.kast.api.Symbol,
+    ): String = buildString {
+        append(symbol.fqName)
+        append('|')
+        append(target.containingFile.virtualFile?.path ?: symbol.location.filePath)
+        append(':')
+        append(symbol.location.startOffset)
+        append('-')
+        append(symbol.location.endOffset)
+    }
+
+    private fun PsiElement.parentsWithSelf(): Sequence<PsiElement> = generateSequence(this) { it.parent }
+
+    private fun persistCallHierarchy(
+        query: CallHierarchyQuery,
+        root: CallNode,
+        stats: CallHierarchyStats,
+    ): CallHierarchyPersistence? {
+        val gitSha = resolveGitSha() ?: return null
+        val cacheRoot = workspaceRoot.resolve(".kast").resolve("call-hierarchy").resolve(gitSha)
+        Files.createDirectories(cacheRoot)
+        val cacheKey = FileHashing.sha256(
+            listOf(
+                query.position.filePath,
+                query.position.offset.toString(),
+                query.direction.name,
+                query.depth.toString(),
+                query.maxTotalCalls.toString(),
+                query.maxChildrenPerNode.toString(),
+                query.timeoutMillis?.toString() ?: "null",
+            ).joinToString("|"),
+        )
+        val cacheFile = cacheRoot.resolve("$cacheKey.json")
+        val payload = CallHierarchyResult(root = root, stats = stats, schemaVersion = io.github.amichne.kast.api.SCHEMA_VERSION)
+        Files.writeString(cacheFile, json.encodeToString(CallHierarchyResult.serializer(), payload))
+        return CallHierarchyPersistence(
+            gitSha = gitSha,
+            cacheFilePath = cacheFile.toString(),
+        )
+    }
+
+    private fun resolveGitSha(): String? = runCatching {
+        val process = ProcessBuilder("git", "-C", workspaceRoot.toString(), "rev-parse", "HEAD")
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText().trim()
+        val exitCode = process.waitFor()
+        if (exitCode == 0 && output.matches(Regex("^[0-9a-fA-F]{40}$"))) output else null
+    }.getOrNull()
+
     private fun unsupported(capability: ReadCapability) = io.github.amichne.kast.api.CapabilityNotSupportedException(
         capability = capability.name,
         message = "The standalone backend does not support $capability",
     )
+
+    private data class CallEdge(
+        val target: PsiElement,
+        val symbol: io.github.amichne.kast.api.Symbol,
+        val callSite: Location,
+    )
+
+    private class CallHierarchyBudget(
+        val maxTotalCalls: Int,
+        val maxChildrenPerNode: Int,
+        timeoutMillis: Long,
+    ) {
+        private val startedAtNanos = System.nanoTime()
+        private val timeoutNanos = timeoutMillis * 1_000_000
+        var nodes: Int = 0
+        var edges: Int = 0
+        var truncatedNodes: Int = 0
+        var maxDepthReached: Int = 0
+        var timeoutHit: Boolean = false
+        var maxTotalCallsHit: Boolean = false
+        var maxChildrenHit: Boolean = false
+
+        fun observeDepth(depth: Int) {
+            if (depth > maxDepthReached) {
+                maxDepthReached = depth
+            }
+        }
+
+        fun timeoutReached(): Boolean {
+            if (timeoutHit) {
+                return true
+            }
+            val elapsed = System.nanoTime() - startedAtNanos
+            if (elapsed >= timeoutNanos) {
+                timeoutHit = true
+            }
+            return timeoutHit
+        }
+
+        fun toStats(): CallHierarchyStats = CallHierarchyStats(
+            totalNodes = nodes,
+            totalEdges = edges,
+            truncatedNodes = truncatedNodes,
+            maxDepthReached = maxDepthReached,
+            timeoutReached = timeoutHit,
+            maxTotalCallsReached = maxTotalCallsHit,
+            maxChildrenPerNodeReached = maxChildrenHit,
+        )
+    }
 }

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendCallHierarchyTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendCallHierarchyTest.kt
@@ -1,0 +1,167 @@
+package io.github.amichne.kast.standalone
+
+import io.github.amichne.kast.api.CallDirection
+import io.github.amichne.kast.api.CallHierarchyQuery
+import io.github.amichne.kast.api.CallNodeTruncationReason
+import io.github.amichne.kast.api.FilePosition
+import io.github.amichne.kast.api.ReadCapability
+import io.github.amichne.kast.api.ServerLimits
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+class StandaloneAnalysisBackendCallHierarchyTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `depth zero returns only root node`() = runTest {
+        val file = writeFile(
+            relativePath = "src/main/kotlin/sample/Greeter.kt",
+            content = """
+                package sample
+
+                fun greet(): String = "hi"
+                fun use(): String = greet()
+            """.trimIndent() + "\n",
+        )
+        val queryOffset = Files.readString(file).indexOf("greet()")
+
+        withBackend { backend ->
+            val result = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(file.toString(), queryOffset),
+                    direction = CallDirection.INCOMING,
+                    depth = 0,
+                ),
+            )
+
+            assertEquals("sample.greet", result.root.symbol.fqName)
+            assertTrue(result.root.children.isEmpty())
+            assertEquals(1, result.stats.totalNodes)
+            assertEquals(0, result.stats.totalEdges)
+        }
+    }
+
+    @Test
+    fun `incoming hierarchy keeps duplicate call sites and stable ordering`() = runTest {
+        val declarationFile = writeFile(
+            relativePath = "src/main/kotlin/sample/Greeter.kt",
+            content = """
+                package sample
+
+                fun greet(): String = "hi"
+            """.trimIndent() + "\n",
+        )
+        val firstCaller = writeFile(
+            relativePath = "src/main/kotlin/sample/A.kt",
+            content = """
+                package sample
+
+                fun alpha(): String = greet() + greet()
+            """.trimIndent() + "\n",
+        )
+        val secondCaller = writeFile(
+            relativePath = "src/main/kotlin/sample/B.kt",
+            content = """
+                package sample
+
+                fun beta(): String = greet()
+            """.trimIndent() + "\n",
+        )
+        val queryOffset = Files.readString(declarationFile).indexOf("greet")
+
+        withBackend { backend ->
+            val result = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(declarationFile.toString(), queryOffset),
+                    direction = CallDirection.INCOMING,
+                    depth = 1,
+                    maxTotalCalls = 10,
+                ),
+            )
+
+            assertEquals(3, result.root.children.size)
+            assertEquals(
+                listOf(firstCaller.toString(), firstCaller.toString(), secondCaller.toString()),
+                result.root.children.map { child -> child.callSite?.filePath },
+            )
+            assertEquals(3, result.stats.totalEdges)
+            val callSites = result.root.children.map { child -> child.callSite }
+            assertNotNull(callSites[0])
+            assertNotNull(callSites[1])
+            assertTrue(checkNotNull(callSites[0]).startOffset < checkNotNull(callSites[1]).startOffset)
+        }
+    }
+
+    @Test
+    fun `outgoing hierarchy truncates cycles and advertises capability`() = runTest {
+        val content = """
+                package sample
+
+                fun a(): String = b()
+                fun b(): String = a()
+            """.trimIndent() + "\n"
+        val file = writeFile(
+            relativePath = "src/main/kotlin/sample/Cycle.kt",
+            content = content,
+        )
+        val queryOffset = content.indexOf("fun a") + "fun ".length
+
+        withBackend { backend ->
+            val capabilities = backend.capabilities()
+            assertTrue(ReadCapability.CALL_HIERARCHY in capabilities.readCapabilities)
+
+            val result = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(file.toString(), queryOffset),
+                    direction = CallDirection.OUTGOING,
+                    depth = 5,
+                    maxTotalCalls = 10,
+                ),
+            )
+
+            val outgoing = result.root.children.single()
+            val recursiveBackEdge = outgoing.children.single()
+            assertEquals("sample.b", outgoing.symbol.fqName)
+            assertEquals("sample.a", recursiveBackEdge.symbol.fqName)
+            assertEquals(CallNodeTruncationReason.CYCLE, recursiveBackEdge.truncation?.reason)
+        }
+    }
+
+    private suspend fun withBackend(block: suspend (StandaloneAnalysisBackend) -> Unit) {
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "sources",
+        )
+        try {
+            val backend = StandaloneAnalysisBackend(
+                workspaceRoot = workspaceRoot,
+                limits = ServerLimits(
+                    maxResults = 100,
+                    requestTimeoutMillis = 30_000,
+                    maxConcurrentRequests = 4,
+                ),
+                session = session,
+            )
+            block(backend)
+        } finally {
+            session.close()
+        }
+    }
+
+    private fun writeFile(relativePath: String, content: String): Path {
+        val path = workspaceRoot.resolve(relativePath)
+        Files.createDirectories(path.parent)
+        path.writeText(content)
+        return path
+    }
+}

--- a/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
+++ b/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
@@ -7,6 +7,7 @@ import io.github.amichne.kast.api.BackendCapabilities
 import io.github.amichne.kast.api.CallDirection
 import io.github.amichne.kast.api.CallHierarchyQuery
 import io.github.amichne.kast.api.CallHierarchyResult
+import io.github.amichne.kast.api.CallHierarchyStats
 import io.github.amichne.kast.api.CallNode
 import io.github.amichne.kast.api.Diagnostic
 import io.github.amichne.kast.api.DiagnosticSeverity
@@ -108,6 +109,15 @@ class FakeAnalysisBackend private constructor(
 
         return CallHierarchyResult(
             root = CallNode(symbol = symbol, children = listOf(child)),
+            stats = CallHierarchyStats(
+                totalNodes = 2,
+                totalEdges = 1,
+                truncatedNodes = 0,
+                maxDepthReached = 1,
+                timeoutReached = false,
+                maxTotalCallsReached = false,
+                maxChildrenPerNodeReached = false,
+            ),
         )
     }
 


### PR DESCRIPTION
### Motivation
- Provide a real `callHierarchy` implementation so the server can return a bounded, deterministic call tree rooted at a selected declaration instead of advertising an unsupported capability.
- Allow callers to constrain work with explicit boundaries (`depth`, `maxTotalCalls`, `maxChildrenPerNode`, `timeoutMillis`) and make truncation/cycle behavior transparent for consumers and debugging.
- Optionally persist results keyed by the repository git SHA to avoid recomputing large traversals when the workspace state matches a known revision.

### Description
- Added request parameters to `CallHierarchyQuery`: `maxTotalCalls`, `maxChildrenPerNode`, `timeoutMillis`, and `persistToGitShaCache` so callers can bound traversal work. (`analysis-api/src/main/kotlin/.../CallHierarchyQuery.kt`).
- Extended the response model with edge metadata and truncation info: `CallNode` now carries `callSite` and optional `CallNodeTruncation`, added `CallNodeTruncationReason`, and added `CallHierarchyStats` plus optional `CallHierarchyPersistence` in `CallHierarchyResult` for stats and optional cache metadata. (`analysis-api/src/main/kotlin/.../CallNode.kt`, `CallHierarchyResult.kt`).
- Implemented server-side validation for the new parameters and allowed `depth = 0` (root-only) in both JSON-RPC dispatcher and HTTP application. (`analysis-server/src/main/kotlin/.../AnalysisDispatcher.kt`, `AnalysisApplication.kt`).
- Implemented the standalone backend traversal in `StandaloneAnalysisBackend.callHierarchy` with:
  - deterministic child ordering (stable sort by file path/offsets/symbol identity),
  - path-based cycle detection that inserts `CallNodeTruncation(reason=CYCLE)` for recursive/mutual recursion,
  - a `CallHierarchyBudget` that enforces `maxTotalCalls`, `maxChildrenPerNode`, and `timeoutMillis`, and produces `CallHierarchyStats`,
  - optional persistence to `.kast/call-hierarchy/<gitSha>/<cacheKey>.json` when `persistToGitShaCache` is set and a valid git SHA is found. (`backend-standalone/src/main/kotlin/.../StandaloneAnalysisBackend.kt`).
- Advertised `CALL_HIERARCHY` capability for the standalone backend and updated the `FakeAnalysisBackend` test fixture to include the new stats fields, and added unit tests for dispatcher and standalone backend behaviors. (`shared-testing/src/main/kotlin/.../FakeAnalysisBackend.kt`, tests in `analysis-server` and `backend-standalone`).

### Testing
- Ran the full target set `./gradlew :analysis-server:test :backend-standalone:test`; the initial run surfaced compilation/validation problems which were addressed during the rollout and the final run completed successfully. (final run returned success). 
- Ran the focused backend test `./gradlew :backend-standalone:test --tests io.github.amichne.kast.standalone.StandaloneAnalysisBackendCallHierarchyTest` and it passed. 
- Added dispatcher tests exercising `call-hierarchy` JSON-RPC validation and dispatch, and they were executed as part of the `analysis-server` test run and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ceacf674cc83209862a81360a55864)