### PR TITLE
Implement bounded callHierarchy traversal for standalone backend

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyQuery.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyQuery.kt
@@ -7,4 +7,7 @@ data class CallHierarchyQuery(
     val position: FilePosition,
     val direction: CallDirection,
     val depth: Int = 3,
+    val maxTotalCalls: Int = 500,
+    val maxChildrenPerNode: Int = 100,
+    val timeoutMillis: Long = 2_000,
 )

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyResult.kt
@@ -5,5 +5,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CallHierarchyResult(
     val root: CallNode,
+    val totalCalls: Int = 0,
+    val truncated: Boolean = false,
+    val truncationReasons: Set<CallHierarchyTruncationReason> = emptySet(),
+    val gitCommitSha: String? = null,
     val schemaVersion: Int = SCHEMA_VERSION,
 )

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyTruncationReason.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/CallHierarchyTruncationReason.kt
@@ -1,0 +1,12 @@
+package io.github.amichne.kast.api
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class CallHierarchyTruncationReason {
+    DEPTH_LIMIT,
+    MAX_TOTAL_CALLS,
+    MAX_CHILDREN_PER_NODE,
+    TIMEOUT,
+    CYCLE,
+}

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -2,12 +2,14 @@ package io.github.amichne.kast.standalone
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiReference
 import io.github.amichne.kast.api.AnalysisBackend
 import io.github.amichne.kast.api.ApplyEditsQuery
 import io.github.amichne.kast.api.ApplyEditsResult
 import io.github.amichne.kast.api.BackendCapabilities
 import io.github.amichne.kast.api.CallHierarchyQuery
 import io.github.amichne.kast.api.CallHierarchyResult
+import io.github.amichne.kast.api.CallHierarchyTruncationReason
 import io.github.amichne.kast.api.DiagnosticsQuery
 import io.github.amichne.kast.api.DiagnosticsResult
 import io.github.amichne.kast.api.FileHash
@@ -26,6 +28,8 @@ import io.github.amichne.kast.api.SymbolQuery
 import io.github.amichne.kast.api.SymbolResult
 import io.github.amichne.kast.api.TextEdit
 import java.nio.file.Path
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
@@ -33,6 +37,7 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.KaDiagnosticCheckerFilter
 import org.jetbrains.kotlin.analysis.api.components.collectDiagnostics
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
 
 @OptIn(KaExperimentalApi::class)
 class StandaloneAnalysisBackend(
@@ -49,6 +54,7 @@ class StandaloneAnalysisBackend(
         readCapabilities = setOf(
             ReadCapability.RESOLVE_SYMBOL,
             ReadCapability.FIND_REFERENCES,
+            ReadCapability.CALL_HIERARCHY,
             ReadCapability.DIAGNOSTICS,
         ),
         mutationCapabilities = setOf(
@@ -100,8 +106,38 @@ class StandaloneAnalysisBackend(
         )
     }
 
-    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult {
-        throw unsupported(ReadCapability.CALL_HIERARCHY)
+    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult = withContext(readDispatcher) {
+        require(query.depth >= 0) { "depth must be >= 0" }
+        require(query.maxTotalCalls > 0) { "maxTotalCalls must be > 0" }
+        require(query.maxChildrenPerNode > 0) { "maxChildrenPerNode must be > 0" }
+        require(query.timeoutMillis > 0) { "timeoutMillis must be > 0" }
+
+        val file = session.findKtFile(query.position.filePath)
+        val target = resolveTarget(file, query.position.offset)
+        val targetSymbol = analyze(file) { target.toSymbolModel(containingDeclaration = null) }
+        val gitCommitSha = workspaceRoot.findGitCommitSha()
+
+        val state = CallHierarchyTraversalState(
+            maxTotalCalls = query.maxTotalCalls,
+            maxChildrenPerNode = query.maxChildrenPerNode,
+            deadlineNanos = System.nanoTime() + query.timeoutMillis.toDuration(DurationUnit.MILLISECONDS).inWholeNanoseconds,
+        )
+        val root = buildCallHierarchyNode(
+            target = target,
+            remainingDepth = query.depth,
+            direction = query.direction,
+            ancestry = setOf(target.symbolKey()),
+            state = state,
+            fallbackSymbol = targetSymbol,
+        )
+
+        CallHierarchyResult(
+            root = root,
+            totalCalls = state.totalCalls,
+            truncated = state.truncationReasons.isNotEmpty(),
+            truncationReasons = state.truncationReasons.toSet(),
+            gitCommitSha = gitCommitSha,
+        )
     }
 
     override suspend fun diagnostics(query: DiagnosticsQuery): DiagnosticsResult = withContext(readDispatcher) {
@@ -195,8 +231,193 @@ class StandaloneAnalysisBackend(
 
     private fun currentFileHashes(filePaths: Collection<String>): List<FileHash> = LocalDiskEditApplier.currentHashes(filePaths)
 
-    private fun unsupported(capability: ReadCapability) = io.github.amichne.kast.api.CapabilityNotSupportedException(
-        capability = capability.name,
-        message = "The standalone backend does not support $capability",
+    private fun buildCallHierarchyNode(
+        target: PsiElement,
+        remainingDepth: Int,
+        direction: io.github.amichne.kast.api.CallDirection,
+        ancestry: Set<String>,
+        state: CallHierarchyTraversalState,
+        fallbackSymbol: io.github.amichne.kast.api.Symbol? = null,
+    ): io.github.amichne.kast.api.CallNode {
+        val symbol = runCatching {
+            analyze(target.containingFile as KtFile) { target.toSymbolModel(containingDeclaration = null) }
+        }.getOrElse { fallbackSymbol ?: target.toSymbolModel(containingDeclaration = null) }
+
+        if (remainingDepth == 0) {
+            val hasMore = when (direction) {
+                io.github.amichne.kast.api.CallDirection.OUTGOING -> outgoingCalls(target).isNotEmpty()
+                io.github.amichne.kast.api.CallDirection.INCOMING -> incomingCalls(target).isNotEmpty()
+            }
+            if (hasMore) {
+                state.truncate(CallHierarchyTruncationReason.DEPTH_LIMIT)
+            }
+            return io.github.amichne.kast.api.CallNode(symbol = symbol, children = emptyList())
+        }
+
+        val callSites = when (direction) {
+            io.github.amichne.kast.api.CallDirection.OUTGOING -> outgoingCalls(target)
+            io.github.amichne.kast.api.CallDirection.INCOMING -> incomingCalls(target)
+        }.sortedWith(
+            compareBy<CallSite>(
+                { it.location.filePath },
+                { it.location.startOffset },
+                { it.location.endOffset },
+                { it.symbol.fqName },
+            ),
+        )
+
+        val children = mutableListOf<io.github.amichne.kast.api.CallNode>()
+        for (callSite in callSites) {
+            if (state.isTimedOut()) {
+                state.truncate(CallHierarchyTruncationReason.TIMEOUT)
+                break
+            }
+            if (children.size >= state.maxChildrenPerNode) {
+                state.truncate(CallHierarchyTruncationReason.MAX_CHILDREN_PER_NODE)
+                break
+            }
+            if (state.totalCalls >= state.maxTotalCalls) {
+                state.truncate(CallHierarchyTruncationReason.MAX_TOTAL_CALLS)
+                break
+            }
+
+            state.totalCalls += 1
+            val nextKey = callSite.declaration.symbolKey()
+            val child = if (nextKey in ancestry) {
+                state.truncate(CallHierarchyTruncationReason.CYCLE)
+                io.github.amichne.kast.api.CallNode(
+                    symbol = callSite.symbol,
+                    children = emptyList(),
+                )
+            } else {
+                buildCallHierarchyNode(
+                    target = callSite.declaration,
+                    remainingDepth = remainingDepth - 1,
+                    direction = direction,
+                    ancestry = ancestry + nextKey,
+                    state = state,
+                    fallbackSymbol = callSite.symbol,
+                )
+            }
+            children += child
+        }
+
+        return io.github.amichne.kast.api.CallNode(
+            symbol = symbol,
+            children = children,
+        )
+    }
+
+    private fun outgoingCalls(target: PsiElement): List<CallSite> {
+        val calls = mutableListOf<CallSite>()
+        target.accept(
+            object : PsiRecursiveElementWalkingVisitor() {
+                override fun visitElement(element: PsiElement) {
+                    element.references.forEach { reference ->
+                        val declaration = reference.resolve() ?: return@forEach
+                        val callable = declaration.enclosingCallableDeclaration() ?: declaration
+                        val symbol = analyze(callable.containingFile as KtFile) {
+                            callable.toSymbolModel(containingDeclaration = null)
+                        }
+                        calls += CallSite(
+                            declaration = callable,
+                            symbol = symbol,
+                            location = reference.toKastLocation(),
+                        )
+                    }
+                    super.visitElement(element)
+                }
+            },
+        )
+        return calls
+    }
+
+    private fun incomingCalls(target: PsiElement): List<CallSite> {
+        val calls = mutableListOf<CallSite>()
+        session.allKtFiles().forEach { candidateFile ->
+            candidateFile.accept(
+                object : PsiRecursiveElementWalkingVisitor() {
+                    override fun visitElement(element: PsiElement) {
+                        element.references.forEach { reference ->
+                            val resolved = reference.resolve()
+                            if (resolved == target || resolved?.isEquivalentTo(target) == true) {
+                                val caller = reference.element.enclosingCallableDeclaration() ?: return@forEach
+                                val symbol = analyze(caller.containingFile as KtFile) {
+                                    caller.toSymbolModel(containingDeclaration = null)
+                                }
+                                calls += CallSite(
+                                    declaration = caller,
+                                    symbol = symbol,
+                                    location = reference.toKastLocation(),
+                                )
+                            }
+                        }
+                        super.visitElement(element)
+                    }
+                },
+            )
+        }
+        return calls
+    }
+
+    private fun PsiReference.toKastLocation(): io.github.amichne.kast.api.Location = element.toKastLocation(
+        com.intellij.openapi.util.TextRange(
+            element.textRange.startOffset + rangeInElement.startOffset,
+            element.textRange.startOffset + rangeInElement.endOffset,
+        ),
     )
+
+    private fun PsiElement.enclosingCallableDeclaration(): PsiElement? = generateSequence(this) { it.parent }
+        .firstOrNull { candidate ->
+            candidate is org.jetbrains.kotlin.psi.KtNamedFunction ||
+                candidate is org.jetbrains.kotlin.psi.KtSecondaryConstructor ||
+                (candidate is KtNamedDeclaration && candidate.nameIdentifier != null) ||
+                candidate is com.intellij.psi.PsiMethod
+        }
+
+    private fun PsiElement.symbolKey(): String {
+        val location = toKastLocation()
+        return "${location.filePath}:${location.startOffset}:${location.endOffset}:${javaClass.name}"
+    }
+
+    private fun Path.findGitCommitSha(): String? {
+        var current: Path? = toAbsolutePath().normalize()
+        while (current != null) {
+            val gitDir = current.resolve(".git")
+            val headPath = gitDir.resolve("HEAD")
+            if (java.nio.file.Files.isRegularFile(headPath)) {
+                val head = java.nio.file.Files.readString(headPath).trim()
+                if (head.startsWith("ref: ")) {
+                    val refPath = gitDir.resolve(head.removePrefix("ref: ").trim())
+                    if (java.nio.file.Files.isRegularFile(refPath)) {
+                        return java.nio.file.Files.readString(refPath).trim().takeIf { it.isNotBlank() }
+                    }
+                }
+                return head.takeIf { it.isNotBlank() }
+            }
+            current = current.parent
+        }
+        return null
+    }
+
+    private data class CallSite(
+        val declaration: PsiElement,
+        val symbol: io.github.amichne.kast.api.Symbol,
+        val location: io.github.amichne.kast.api.Location,
+    )
+
+    private class CallHierarchyTraversalState(
+        val maxTotalCalls: Int,
+        val maxChildrenPerNode: Int,
+        val deadlineNanos: Long,
+    ) {
+        var totalCalls: Int = 0
+        val truncationReasons: MutableSet<CallHierarchyTruncationReason> = linkedSetOf()
+
+        fun truncate(reason: CallHierarchyTruncationReason) {
+            truncationReasons += reason
+        }
+
+        fun isTimedOut(): Boolean = System.nanoTime() >= deadlineNanos
+    }
 }

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendCallHierarchyTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendCallHierarchyTest.kt
@@ -1,0 +1,169 @@
+package io.github.amichne.kast.standalone
+
+import io.github.amichne.kast.api.CallDirection
+import io.github.amichne.kast.api.CallHierarchyQuery
+import io.github.amichne.kast.api.CallHierarchyTruncationReason
+import io.github.amichne.kast.api.FilePosition
+import io.github.amichne.kast.api.ReadCapability
+import io.github.amichne.kast.api.ServerLimits
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+class StandaloneAnalysisBackendCallHierarchyTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `outgoing hierarchy preserves duplicate call sites and depth semantics`() = runTest {
+        val file = writeSampleSource()
+        withBackend { backend ->
+            val fileContent = Files.readString(file)
+            val callerOffset = fileContent.indexOf("caller")
+
+            val depthZeroResult = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = callerOffset),
+                    direction = CallDirection.OUTGOING,
+                    depth = 0,
+                ),
+            )
+            assertEquals(0, depthZeroResult.root.children.size)
+            assertTrue(CallHierarchyTruncationReason.DEPTH_LIMIT in depthZeroResult.truncationReasons)
+
+            val depthOneResult = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = callerOffset),
+                    direction = CallDirection.OUTGOING,
+                    depth = 1,
+                ),
+            )
+            assertEquals(listOf("sample.leaf", "sample.leaf", "sample.cycleA"), depthOneResult.root.children.map { it.symbol.fqName })
+        }
+    }
+
+    @Test
+    fun `incoming hierarchy orders children by call site and keeps duplicates`() = runTest {
+        val file = writeSampleSource()
+        withBackend { backend ->
+            val fileContent = Files.readString(file)
+            val leafOffset = fileContent.indexOf("leaf")
+
+            val result = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = leafOffset),
+                    direction = CallDirection.INCOMING,
+                    depth = 1,
+                ),
+            )
+
+            assertEquals(
+                listOf("sample.caller", "sample.caller", "sample.callerTwo"),
+                result.root.children.map { it.symbol.fqName },
+            )
+        }
+    }
+
+    @Test
+    fun `cycle and max total call truncation are surfaced explicitly`() = runTest {
+        val file = writeSampleSource()
+        withBackend { backend ->
+            val fileContent = Files.readString(file)
+            val cycleOffset = fileContent.indexOf("cycleA")
+            val callerOffset = fileContent.indexOf("caller")
+
+            val cycleResult = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = cycleOffset),
+                    direction = CallDirection.OUTGOING,
+                    depth = 5,
+                ),
+            )
+            assertTrue(CallHierarchyTruncationReason.CYCLE in cycleResult.truncationReasons)
+            assertEquals("sample.cycleB", cycleResult.root.children.single().symbol.fqName)
+            assertEquals("sample.cycleA", cycleResult.root.children.single().children.single().symbol.fqName)
+            assertEquals(0, cycleResult.root.children.single().children.single().children.size)
+
+            val maxCallsResult = backend.callHierarchy(
+                CallHierarchyQuery(
+                    position = FilePosition(filePath = file.toString(), offset = callerOffset),
+                    direction = CallDirection.OUTGOING,
+                    depth = 3,
+                    maxTotalCalls = 1,
+                ),
+            )
+            assertEquals(1, maxCallsResult.totalCalls)
+            assertEquals(1, maxCallsResult.root.children.size)
+            assertTrue(CallHierarchyTruncationReason.MAX_TOTAL_CALLS in maxCallsResult.truncationReasons)
+        }
+    }
+
+    @Test
+    fun `capabilities advertise call hierarchy`() = runTest {
+        writeSampleSource()
+        withBackend { backend ->
+            val capabilities = backend.capabilities()
+            assertTrue(ReadCapability.CALL_HIERARCHY in capabilities.readCapabilities)
+        }
+    }
+
+    private suspend fun withBackend(block: suspend (StandaloneAnalysisBackend) -> Unit) {
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "sources",
+        )
+        try {
+            block(
+                StandaloneAnalysisBackend(
+                    workspaceRoot = workspaceRoot,
+                    limits = ServerLimits(
+                        maxResults = 100,
+                        requestTimeoutMillis = 30_000,
+                        maxConcurrentRequests = 4,
+                    ),
+                    session = session,
+                ),
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    private fun writeSampleSource(): Path {
+        val file = workspaceRoot.resolve("src/main/kotlin/sample/Calls.kt")
+        Files.createDirectories(file.parent)
+        file.writeText(
+            """
+            package sample
+
+            fun leaf() {}
+
+            fun cycleA() {
+                cycleB()
+            }
+
+            fun cycleB() {
+                cycleA()
+            }
+
+            fun caller() {
+                leaf()
+                leaf()
+                cycleA()
+            }
+
+            fun callerTwo() {
+                leaf()
+            }
+            """.trimIndent() + "\n",
+        )
+        return file
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a practical, bounded implementation of `callHierarchy` in the standalone backend so callers can request call trees with clear resource limits and deterministic behavior.
- Surface explicit truncation metadata so clients can reason about incomplete results and choose safe follow-up behavior.

### Description
- Added bounds and timeouts to the API by extending `CallHierarchyQuery` with `maxTotalCalls`, `maxChildrenPerNode`, and `timeoutMillis` and added `CallHierarchyTruncationReason` enum to describe truncation causes.
- Extended `CallHierarchyResult` with `totalCalls`, `truncated`, `truncationReasons`, and `gitCommitSha` to report traversal metrics and the repository SHA when available.
- Implemented `StandaloneAnalysisBackend.callHierarchy` using a deterministic traversal that preserves duplicate call-sites, enforces `depth` semantics (root-only for `depth=0`, one-edge for `depth=1`), truncates on cycles/limits/timeouts, and orders children stably by call-site location (path/start/end/fallback fqName).
- Added incoming/outgoing call-site collectors, a small traversal state implementation, `symbolKey()` to detect cycles, and a helper to read `.git/HEAD` for the optional `gitCommitSha` field, and enabled `CALL_HIERARCHY` in the standalone `capabilities()`.
- Added unit tests `StandaloneAnalysisBackendCallHierarchyTest` exercising depth semantics, duplicate preservation, deterministic ordering, cycle truncation, max-total-calls truncation, and capability advertising.

### Testing
- Ran `./gradlew :backend-standalone:test` and the task completed successfully (tests passed).
- Ran `./gradlew :analysis-api:test :analysis-server:test :kast:test` to validate cross-module changes and those tasks completed successfully as well.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ceacf674cc83209862a81360a55864)