### PR TITLE
Implemented the phased-startup flow end to end.

### DIFF
--- a/.agents/skills/kast/SKILL.md
+++ b/.agents/skills/kast/SKILL.md
@@ -41,18 +41,23 @@ KAST_STDERR="$KAST_TMP/stderr.log"
 ```
 
 All kast commands in this session write results to `$KAST_RESULT` and daemon notes to
-`$KAST_STDERR`. Read `$KAST_RESULT` for the JSON output. Only read `$KAST_STDERR` when
-the exit code is non-zero.
+`$KAST_STDERR`. Read `$KAST_RESULT` for the JSON output. When the exit code is
+non-zero, read `$KAST_STDERR` for the error details. On success, `$KAST_STDERR`
+may still contain a daemon note, such as an auto-start message or
+`state: INDEXING`.
 
-Then ensure the workspace daemon is ready:
+Optional: prewarm the workspace when you want a separate readiness step:
 
 ```bash
 "$KAST" workspace ensure --workspace-root="$(git rev-parse --show-toplevel)" \
   > "$KAST_RESULT" 2> "$KAST_STDERR"
 ```
 
-`workspace ensure` starts the daemon if none exists, reuses an existing healthy one,
-and blocks until the daemon reaches `READY` (60 s timeout). Exit 0 = daemon ready.
+`workspace ensure` starts the daemon if none exists, reuses an existing healthy
+one, and waits until the daemon reaches `READY` by default (60 s timeout). Add
+`--accept-indexing=true` when you only need a servable daemon and can tolerate
+`INDEXING` while enrichment finishes. If you skip this step, the first
+runtime-dependent command auto-starts the daemon for you.
 
 ### If `workspace ensure` fails
 
@@ -73,10 +78,10 @@ Do not retry `workspace ensure` without first resolving the root cause shown in 
 
 ---
 
-## 1. Index Validation (after first ensure in a new workspace)
+## 1. Index Validation (after first startup in a new workspace)
 
-`workspace ensure` reaching `READY` does not guarantee the index is serving semantic
-results. Validate once with a known symbol before doing real work:
+Even after the first successful startup, validate once with a known symbol
+before doing real work:
 
 ```bash
 # Pick any class declaration in the workspace — adjust paths as needed
@@ -106,9 +111,11 @@ Then validate the index:
   > "$KAST_RESULT" 2> "$KAST_STDERR"
 ```
 
-Read `$KAST_RESULT` for the JSON. If `symbol.fqName` is present, the index is healthy.
-If it returns `NOT_FOUND` and state is `READY`, wait 15 seconds and retry — the initial
-index pass may still be running.
+Read `$KAST_RESULT` for the JSON. If `symbol.fqName` is present, the index is
+healthy. If stderr reports `state: INDEXING`, wait until
+`"$KAST" workspace status --workspace-root=...` shows `READY`, then retry. If
+the daemon is already `READY`, treat `NOT_FOUND` as an offset, save, or
+workspace-refresh problem rather than as background indexing.
 
 ---
 
@@ -372,11 +379,11 @@ When a build fails or a file has unknown errors:
 | Error / Symptom | Cause | Fix |
 |-----------------|-------|-----|
 | `VALIDATION_ERROR` (400) | Bad parameters | Fix the file path, offset, or name and retry |
-| `NOT_FOUND` (404) | Offset on whitespace or still indexing | Recompute offset to land on the identifier. If state is `READY`, wait 15 s and retry. |
+| `NOT_FOUND` (404) | Offset on whitespace, unsaved file, or daemon still indexing | Recompute offset to land on the identifier. If stderr or `workspace status` reports `INDEXING`, wait for `READY`; otherwise treat it as an offset, save, or refresh problem. |
 | `CONFLICT` (409) | Files changed since rename plan | Re-run `kast-rename.sh` — it produces a fresh plan |
 | `CAPABILITY_NOT_SUPPORTED` (501) | Capability absent | Run `"$KAST" capabilities` to confirm. Use grep for text search; kast does not do it. |
 | `APPLY_PARTIAL_FAILURE` (500) | Disk or permissions error mid-apply | Inspect `details` map; fix the root cause and apply remaining edits manually |
-| `workspace ensure` timeout | Daemon failed before reaching READY | Read `.kast/logs/standalone-daemon.log` — the cause is always there |
+| `workspace ensure` timeout | Daemon failed before becoming servable | Read `.kast/logs/standalone-daemon.log` — the cause is always there |
 
 ---
 

--- a/.agents/skills/kast/references/cloud-setup.md
+++ b/.agents/skills/kast/references/cloud-setup.md
@@ -80,7 +80,8 @@ export PATH="$PWD/kast/build/scripts:$PATH"
 
 ## CI Pattern
 
-Standard pattern for GitHub Actions or any CI runner:
+Standard pattern for GitHub Actions or any CI runner when you want an explicit
+startup and cleanup phase:
 
 ```yaml
 # .github/workflows/analyze.yml (illustrative)
@@ -115,7 +116,10 @@ steps:
 ```
 
 **Key points:**
-- Always run `workspace ensure` before analysis commands.
+- Run `workspace ensure` when later steps assume a separate readiness phase. If
+  you skip it, the first runtime-dependent command auto-starts the daemon.
+- Add `--accept-indexing=true` to `workspace ensure` when later steps only need
+  a servable daemon.
 - Always run `daemon stop` in a cleanup step (use `|| true` — ok if already stopped).
 - Use absolute paths for `--workspace-root` and all file arguments.
 - In containers, `$GITHUB_WORKSPACE` (or equivalent) is the workspace root.

--- a/.agents/skills/kast/references/command-reference.md
+++ b/.agents/skills/kast/references/command-reference.md
@@ -5,10 +5,11 @@ Full syntax, JSON schemas, and request-file formats for all public kast commands
 > **Output redirection:** The JSON-returning command examples below show bare
 > invocations for readability. In practice, redirect them per the SKILL.md
 > bootstrap pattern: `> "$KAST_RESULT" 2> "$KAST_STDERR"`. Read
-> `$KAST_RESULT` for the JSON result. Only read `$KAST_STDERR` when the exit
-> code is non-zero. `kast smoke` follows the same JSON-first contract by
-> default and only switches to human-readable markdown when you pass
-> `--format=markdown`.
+> `$KAST_RESULT` for the JSON result. When the exit code is non-zero, read
+> `$KAST_STDERR` for the error. On success, `$KAST_STDERR` may still contain a
+> daemon note, such as an auto-start message or `state: INDEXING`. `kast smoke`
+> follows the same JSON-first contract by default and only switches to
+> human-readable markdown when you pass `--format=markdown`.
 
 ---
 
@@ -19,10 +20,14 @@ Every command accepts:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--workspace-root=` | absolute path | required | Workspace root to analyze |
-| `--wait-timeout-ms=` | integer ms | 60000 | Max wait for a ready daemon |
+| `--wait-timeout-ms=` | integer ms | 60000 | Max wait for the daemon state required by the command |
 | `--request-file=` | absolute path | — | JSON request payload on disk |
 
 All options use `--key=value` syntax. No positional arguments.
+
+Runtime-dependent read, mutation, and refresh commands also accept
+`--no-auto-start=true`. `workspace ensure` accepts `--accept-indexing=true`
+and still waits for `READY` by default.
 
 ---
 
@@ -36,43 +41,47 @@ Inspect daemon descriptors, liveness, and readiness.
 kast workspace status --workspace-root=/absolute/path
 ```
 
-**Output — array of `RuntimeStatusResponse`:**
+**Output — `WorkspaceStatusResult`:**
 
-```json
-[
-  {
-    "state": "READY",
-    "healthy": true,
-    "active": true,
-    "indexing": false,
-    "backendName": "kotlin-analysis",
-    "backendVersion": "1.0.0",
-    "workspaceRoot": "/absolute/path",
-    "message": null,
-    "schemaVersion": 1
-  }
-]
-```
+- `workspaceRoot` — absolute workspace root
+- `descriptorDirectory` — absolute `.kast/instances` directory
+- `selected` — the preferred `RuntimeCandidateStatus`, or `null`
+- `candidates` — every registered `RuntimeCandidateStatus` for the workspace
 
-`state` values: `STARTING` | `INDEXING` | `READY` | `DEGRADED`
+Each `RuntimeCandidateStatus` includes:
 
-`active` = the selected daemon (true for at most one entry). `healthy` = process is live and responding. `indexing` = still building the index (queries may be slow or empty).
+- `descriptorPath` and the parsed `descriptor`
+- `pidAlive`, `reachable`, and `ready`
+- optional `runtimeStatus`, including `state`
+  (`STARTING` | `INDEXING` | `READY` | `DEGRADED`)
+- optional `capabilities`
+- optional `errorMessage`
 
-**Errors:** None specific. Exit 0 with empty array if no descriptor exists.
+**Errors:** None specific. Exit 0 with `selected = null` and an empty
+`candidates` array if no descriptor exists.
 
 ---
 
 ### `workspace ensure`
 
-Reuse a ready daemon or start one; waits until ready before returning.
+Explicitly prewarm or reuse a standalone daemon.
 
 ```
 kast workspace ensure \
   --workspace-root=/absolute/path \
-  [--wait-timeout-ms=60000]
+  [--wait-timeout-ms=60000] \
+  [--accept-indexing=true]
 ```
 
-**Output — `RuntimeStatusResponse`** (same schema as above, `state` = `READY`).
+By default, `workspace ensure` waits for `READY`. Add
+`--accept-indexing=true` to return once the daemon is servable in `INDEXING`.
+
+**Output — `WorkspaceEnsureResult`:**
+
+- `workspaceRoot`
+- `started` — `true` when this command launched a new daemon
+- optional `logFile`
+- `selected` — the chosen `RuntimeCandidateStatus`
 
 **Errors:**
 - Timeout exceeded: exit non-zero, message on stderr.
@@ -92,7 +101,10 @@ kast daemon start \
   [--wait-timeout-ms=60000]
 ```
 
-**Output — `RuntimeStatusResponse`** (`state` = `READY`).
+This command is deprecated. Prefer `workspace ensure` or let analysis commands
+auto-start the daemon.
+
+**Output — `WorkspaceEnsureResult`** (`selected.runtimeStatus.state` = `READY`).
 
 **Errors:** Same timeout behavior as `workspace ensure`.
 
@@ -106,7 +118,8 @@ Stop the registered daemon for a workspace and remove its descriptor.
 kast daemon stop --workspace-root=/absolute/path
 ```
 
-**Output — `RuntimeStatusResponse`** (the state of the daemon just before it was stopped).
+**Output — `DaemonStopResult`** with `stopped`, optional `descriptorPath`, and
+optional `pid`.
 
 **Errors:** Exit non-zero if no daemon is registered.
 
@@ -114,13 +127,16 @@ kast daemon stop --workspace-root=/absolute/path
 
 ## `capabilities`
 
-Print the capability set of the ready daemon.
+Print the capability set of a servable daemon.
 
 ```
 kast capabilities \
   --workspace-root=/absolute/path \
   [--wait-timeout-ms=60000]
 ```
+
+This command auto-starts the daemon when needed unless you add
+`--no-auto-start=true`.
 
 **Output — `BackendCapabilities`:**
 

--- a/.agents/skills/kast/references/troubleshooting.md
+++ b/.agents/skills/kast/references/troubleshooting.md
@@ -6,7 +6,8 @@ Decision trees for every known failure mode.
 
 ## Daemon Won't Start
 
-**Symptom:** `workspace ensure` or `daemon start` exits non-zero; daemon never reaches `READY`.
+**Symptom:** `workspace ensure`, `daemon start`, or a runtime-dependent command
+exits non-zero; daemon never reaches a servable state.
 
 **First step — always read the log:**
 ```bash
@@ -40,10 +41,11 @@ Is Java 21+ available?
 `java.net.SocketException: Operation not permitted` during socket bind; `workspace status`
 returns `selected: null` and `candidates: []`.
 
-**Cause:** The operating environment (macOS app sandbox, container seccomp profile,
-CI runner policy) is blocking Unix domain socket creation. This is a transport constraint,
-not an indexing or configuration problem. The daemon JVM starts successfully but cannot
-bind its communication socket, so it exits before reaching `READY`.
+**Cause:** The operating environment (macOS app sandbox, container seccomp
+profile, CI runner policy) is blocking Unix domain socket creation. This is a
+transport constraint, not an indexing or configuration problem. The daemon JVM
+starts successfully but cannot bind its communication socket, so it exits
+before it becomes servable.
 
 ```
 Verify UDS is blocked:
@@ -60,15 +62,17 @@ Recovery option 2 — Container/CI:
   → See references/cloud-setup.md for CI-specific guidance.
 ```
 
-**Important:** Once the transport constraint is resolved, kast reaches `READY` and the
-index is typically available immediately. The underlying indexing is not affected by this
-failure — only the daemon's ability to communicate.
+**Important:** Once the transport constraint is resolved, kast starts normally
+again and can progress through `INDEXING` to `READY`. The underlying indexing
+is not affected by this failure — only the daemon's ability to communicate.
 
 ---
 
 ## Daemon Not Ready / Timeout
 
-**Symptom:** `workspace ensure` returns but `state` is `STARTING` or `INDEXING`, or the command times out.
+**Symptom:** `workspace ensure --accept-indexing=true` returns with
+`state = INDEXING`, a runtime-dependent command reports `state: INDEXING` on
+stderr, or the command times out.
 
 A timeout is a symptom, not the root cause. When `workspace ensure` times out, always
 inspect the daemon log before retrying:
@@ -88,9 +92,12 @@ state = STARTING
   → Increase timeout: --wait-timeout-ms=120000
 
 state = INDEXING
-  → Initial index build in progress. Analysis commands will return empty or
-    partial results. Wait until state = READY.
-  → For large workspaces, first ensure can take 30–120s.
+  → The daemon is servable, but background enrichment or the initial index
+    build is still running.
+  → Analysis commands can return partial or empty results. Wait until
+    workspace status reports state = READY when you need stable semantic
+    answers.
+  → For large workspaces, the first startup can still take 30–120s.
 
 state = DEGRADED
   → Daemon is unhealthy. workspace ensure will attempt to restart it.
@@ -98,7 +105,7 @@ state = DEGRADED
   → Check disk space and memory (JVM heap may need tuning).
 
 workspace status returns selected: null, candidates: []
-  → The daemon started but exited before registering a ready descriptor.
+  → The daemon started but exited before registering a servable descriptor.
   → This does NOT mean "no daemon configured" — it means startup failed silently.
   → Read .kast/logs/standalone-daemon.log for the exit reason.
 ```
@@ -189,7 +196,7 @@ will produce offset conflicts.
 **Symptom:** `diagnostics` returns an empty array when errors are expected.
 
 ```
-Is the daemon still indexing?
+Does stderr or workspace status still report INDEXING?
 ├─ Yes → Wait for state = READY, then retry.
 └─ No
    Are the file paths absolute?
@@ -271,7 +278,7 @@ Is the offset pointing to a symbol token?
 ├─ No  → Offset may land on whitespace, a comment, a string literal, or a
 │         keyword. Adjust offset to the first character of the identifier.
 └─ Yes
-   Is the daemon state READY (not INDEXING)?
+   Does stderr or workspace status report READY rather than INDEXING?
    ├─ No  → Wait for READY and retry.
    └─ Yes
       Is the file saved to disk?

--- a/.agents/skills/kotlin-standards/SKILL.md
+++ b/.agents/skills/kotlin-standards/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: kotlin-standards
+description: >
+  Produce production-grade Kotlin that is type-driven, boundary-aware, and easy
+  to verify. Use when writing, reviewing, or refactoring Kotlin code that
+  benefits from strong domain modeling, parse-don't-validate boundaries, value
+  classes, sealed types, explicit error semantics, coroutine correctness, or
+  rigorous testing. Trigger for Kotlin implementation work, domain modeling,
+  API design, refactors away from primitive obsession, null-heavy logic,
+  boolean flags, or validation-heavy code.
+---
+
+# Kotlin Mastery
+
+Write Kotlin that makes illegal states hard or impossible to represent. Parse
+untrusted input at boundaries, move invariants into types, and prove behavior
+with executable verification instead of explanation alone.
+
+## Core stance
+
+- Prefer types over comments, conventions, and repeated runtime checks.
+- Parse once at trust boundaries, then operate on trusted domain models.
+- Keep side effects and infrastructure at the edges; keep core rules pure.
+- Preserve existing public behavior unless the task explicitly calls for a
+  breaking change.
+- Reuse repository-native patterns when they are clearly established in the
+  immediate context; do not introduce a second version of the same idea.
+- Match the repository's established style before introducing new abstractions.
+
+## Non-negotiable standards
+
+### Domain modeling
+
+- Replace primitive obsession with value classes, enums, or sealed hierarchies
+  when domain meaning matters.
+- Use sealed types for closed state machines and mutually exclusive outcomes.
+- Prefer immutable models with `val`; justify `var` and mutable collections.
+- Eliminate illegal states instead of documenting them.
+
+### Boundary discipline
+
+- Treat network payloads, files, environment variables, database rows, CLI
+  arguments, and user input as untrusted.
+- Parse external input into trusted types at the boundary.
+- Avoid `require`, `check`, and exception-first construction for ordinary input
+  rejection; prefer parsing or factories that return typed outcomes.
+- Do not re-parse the same invariant deeper in the system unless crossing a new
+  trust boundary.
+
+### Error semantics
+
+- When replacing throws or designing non-throwing flows, inspect the immediate
+  repository context first for existing error ADTs, typed outcomes, or
+  repository-standard wrappers and use those as the reference pattern.
+- If no local typed-error pattern exists, prefer Kotlin standard-library
+  primitives such as `Result` over inventing a new generic wrapper or bringing
+  in an ad hoc abstraction.
+- Reserve exceptions for truly exceptional conditions or
+  repository-established contracts.
+- Keep error types precise enough for callers and tests to assert on behavior.
+
+### API and implementation quality
+
+- Keep public APIs small, coherent, and hard to misuse.
+- Prefer explicit names over boolean traps and nullable control flags.
+- Hide internals aggressively with `private` or `internal`.
+- Use KDoc for public APIs and non-obvious invariants.
+
+### Concurrency and state
+
+- Prefer immutable state and confinement over shared mutation.
+- When coroutines are present, preserve structured concurrency and make
+  cancellation behavior explicit.
+- Avoid `GlobalScope`, ambient context assumptions, and hidden shared state.
+
+### Verification
+
+- Add or update tests for any meaningful behavior change.
+- Run the repository's real verification commands before claiming success.
+- Do not infer build or test success from static inspection alone.
+
+## Reference map
+
+Read extra references only when they help the current task:
+
+- `references/parse-dont-validate-examples.md` for boundary refactors and
+  before/after transformations
+- `references/types-domain-modeling.md` for value classes, sealed state
+  modeling, nullability elimination, and immutability
+- `references/types-dsls-and-generics.md` for DSL scoping, variance, reified
+  generics, and context receivers
+- `references/types-errors-and-testing.md` for typed outcomes, type-safety
+  anti-patterns, and verification techniques
+- `references/type-safety-patterns.md` as a router when the type-system
+  subtopic is not clear yet
+- `references/kotlin-antipatterns.md` for smell detection
+- `references/idioms.md` for Kotlin-native expression and DSL style
+- `references/api-parameter-selection.md` for plain parameters, named
+  arguments, overloads, lambda flavours, and constructor-versus-builder choices
+- `references/api-builders-and-configuration.md` for builders, receiver
+  lambdas, configuration objects, and contract details
+- `references/api-extensions-and-factories.md` for extension APIs, framework
+  integration, factory naming, and reified shortcuts
+- `references/api-surface-stability.md` for visibility, opt-in tiers, and
+  mutable-versus-read-only exposure
+- `references/api-review-guides.md` for decision flowcharts and API
+  anti-pattern review
+- `references/api-dsl-choices.md` as a router when the API-design subtopic is
+  not clear yet
+
+Prefer the narrowest leaf reference over a router file. Load multiple
+references only when the task truly crosses multiple subtopics.
+
+## Workflow
+
+1. **Frame the task**
+   - Identify the boundary inputs, trusted outputs, domain invariants, and
+     behavior that must remain stable.
+   - Note ambiguity explicitly instead of inventing business rules.
+2. **Assess the current design**
+   - Scan for primitive obsession, nullable state encoding, boolean flags,
+     `Map<String, Any>`, unchecked casts, `!!`, repeated validation,
+     exception-driven control flow, and hidden shared mutation.
+   - Inspect the immediate package, module, and nearby tests for established
+     local patterns before introducing a well-known abstraction yourself:
+     error ADTs, result wrappers, identifiers, time abstractions, builders,
+     DSL markers, and parser entry points.
+   - Record the highest-risk issues before editing.
+3. **Design the types**
+   - Introduce the smallest set of types that capture the real domain: value
+     classes, sealed hierarchies, explicit configuration types, and focused
+     error models.
+   - Prefer the repository's existing best-practice implementation of a common
+     pattern when one is present; otherwise fall back to Kotlin standard
+     library or already-established general-purpose solutions.
+   - Keep constructors private when parsing or invariants must be enforced.
+4. **Implement in thin vertical slices**
+   - Start with core domain types and pure logic.
+   - Add boundary parsers or translators.
+   - Integrate with IO, frameworks, or concurrency only after the types are
+     stable.
+   - Keep diffs small and easy to verify.
+5. **Verify behavior**
+   - Run the narrowest useful tests while iterating.
+   - Run the repository's standard build or test commands before finishing.
+   - Treat verification failures as feedback, not as a side note.
+6. **Iterate until the quality bar is met**
+   - Re-score the change using the scorecard below.
+   - Fix the highest-severity failing dimension first.
+   - Repeat until all mandatory dimensions pass or an external blocker
+     remains.
+
+## Quality scorecard
+
+Score each dimension as `Pass`, `Concern`, or `Fail`.
+
+### 1. Domain fidelity
+
+- `Pass`: Types encode the important business concepts and illegal states are
+  difficult or impossible to construct.
+- `Concern`: Some important concepts remain primitive or only partially
+  encoded.
+- `Fail`: Core invariants still rely on comments, scattered checks, or caller
+  discipline.
+
+### 2. Boundary parsing
+
+- `Pass`: Untrusted input is parsed once into trusted types with clear failure
+  modes.
+- `Concern`: Parsing exists but some unchecked or repeated validation remains.
+- `Fail`: Raw external data flows through core logic or constructors throw on
+  ordinary input mistakes.
+
+### 3. Error design
+
+- `Pass`: Expected failures are explicit, typed, and testable.
+- `Concern`: Error paths exist but are coarse, leaky, or hard to assert on.
+- `Fail`: Behavior depends on generic exceptions, `null`, or ambiguous
+  booleans.
+
+### 4. API ergonomics
+
+- `Pass`: Call sites are clear, misuse is difficult, and public surface area is
+  minimal.
+- `Concern`: API is workable but exposes avoidable flags, nulls, or internals.
+- `Fail`: API invites invalid combinations, temporal coupling, or stringly
+  typed usage.
+
+### 5. State and concurrency safety
+
+- `Pass`: State is immutable or intentionally synchronized, and coroutine
+  behavior is explicit.
+- `Concern`: Some mutable or concurrent behavior is safe but underexplained.
+- `Fail`: Hidden shared mutation, lifecycle leaks, or unstructured concurrency
+  can cause correctness bugs.
+
+### 6. Test coverage and executability
+
+- `Pass`: Tests cover core success paths, boundary failures, and relevant edge
+  cases; verification commands were run.
+- `Concern`: Some important edges or failure cases lack tests.
+- `Fail`: Changes rely on reasoning alone or unverifiable claims.
+
+### 7. Kotlin idiomatic quality
+
+- `Pass`: Code uses Kotlin-native constructs clearly and avoids Java-shaped
+  ceremony.
+- `Concern`: Code works but misses obvious Kotlin improvements.
+- `Fail`: Code fights the language with unnecessary mutability, reflection, or
+  unsafe casts.
+
+## Improvement loop
+
+Use this loop whenever the first draft is not clearly good enough:
+
+1. Write a short findings list ordered by risk.
+2. Choose the single highest-value improvement that increases correctness or
+   reduces invalid states.
+3. Make the smallest change that resolves that issue without widening scope.
+4. Re-run the relevant verification commands.
+5. Re-score the affected scorecard dimensions.
+6. Repeat until the remaining concerns are minor, intentional, or blocked by
+   constraints.
+
+When reviewing existing code, report findings in this format:
+
+- `Issue`: what is wrong
+- `Why it matters`: the correctness, safety, or maintenance risk
+- `Proposed type/design change`: the smallest credible fix
+- `Verification`: which test or command proves the improvement
+
+## Testing expectations
+
+Always include:
+
+- Unit tests for pure domain logic
+- Boundary tests for parse failures and error typing
+- Regression tests for any bug fix or behavior-sensitive refactor
+
+Include when relevant:
+
+- Property-based tests for reducers, parsers, ordering, or combinator-heavy
+  logic
+- Concurrency tests for shared state or cancellation-sensitive code
+- Serialization or fixture tests for external formats
+
+## Completion gate
+
+Do not declare the task complete until all of the following are true:
+
+- The code satisfies the mandatory scorecard dimensions without any `Fail`
+  ratings.
+- Behavior claims are backed by executed tests or build commands.
+- Public or reusable APIs document non-obvious invariants and error semantics.
+- Any remaining `Concern` ratings are explicitly called out with rationale or
+  follow-up suggestions.

--- a/.agents/skills/kotlin-standards/references/api-builders-and-configuration.md
+++ b/.agents/skills/kotlin-standards/references/api-builders-and-configuration.md
@@ -1,0 +1,386 @@
+# Kotlin API Builders and Configuration
+
+Use this reference for builder-style APIs, receiver lambdas, immutable configuration objects, and the implementation details that make builder entry points safe and ergonomic.
+
+## Included sections
+
+- 3. Lambda with Receiver (`Type.() -> Unit`)
+- 4. DSL Builder (`build*` + `Builder` class)
+- 7. `Configuration` Data Class
+- 11. `@PublishedApi internal` vs `internal` Constructor
+- 13. `inline` and Kotlin Contracts
+
+## 3. Lambda with Receiver (`Type.() -> Unit`)
+
+Use a lambda with receiver when:
+
+1. **Configuring an existing object or scope** from outside (not constructing a new one)
+2. **The block is called exactly once** (use `contract { callsInPlace(block, EXACTLY_ONCE) }`)
+3. **Caller needs access to `this`** inside the block (e.g., call methods, set properties)
+4. **One level of nesting** — the block itself does not take further builder lambdas
+
+<details><summary>Reasoning</summary>
+
+The receiver type `T` in `T.() -> Unit` provides the caller with implicit `this` — all properties and methods of `T` are directly accessible without qualification. This is the pattern used by `buildString { append("…") }`, `apply { … }`, and all Ktor plugin installers. The `callsInPlace(EXACTLY_ONCE)` contract is required so the compiler can prove the block runs, enabling `val` definite assignment, smart casts, and null-safety inference inside the block — without it, the compiler assumes the lambda may not execute at all. The single-nesting constraint prevents two receivers from being simultaneously in scope, which would cause `@DslMarker` to be required at multiple levels and confuse IDE autocomplete.
+
+</details>
+
+### Examples from canonical libraries
+
+```kotlin
+// ✅ Kotlin stdlib — buildString configures a StringBuilder, returns immutable String
+inline fun buildString(builderAction: StringBuilder.() -> Unit): String {
+    contract { callsInPlace(builderAction, InvocationKind.EXACTLY_ONCE) }
+    return StringBuilder().apply(builderAction).toString()
+}
+
+// ✅ kotlinx.serialization — Json { } configures a sealed Json instance
+fun Json(from: Json = Json.Default, builderAction: JsonBuilder.() -> Unit): Json
+
+// ✅ Ktor — HttpClient { } configures the HTTP engine and plugins
+val client = HttpClient(CIO) {
+    install(ContentNegotiation) { json() }
+    defaultRequest { url("https://api.example.com") }
+}
+
+// ✅ MCP SDK — Server configures itself in the init block
+class Server(..., block: Server.() -> Unit = {}) {
+    init { block(this) }
+}
+```
+
+### The `@DslMarker` rule for receivers
+
+Any class that appears as a DSL receiver **must** be annotated with `@McpDsl` (or equivalent `@DslMarker`).
+This prevents implicit access to outer scopes — a subtle source of bugs in nested DSLs:
+
+```kotlin
+@DslMarker
+annotation class McpDsl
+
+@McpDsl
+class CallToolRequestBuilder { ... }
+```
+
+If a class is used as a receiver but not annotated with `@DslMarker`, it allows
+calling methods from an outer builder's `this` inside the inner block — a silent bug.
+
+<details><summary>Reasoning</summary>
+
+Without `@DslMarker`, Kotlin's implicit `this` resolution can silently dispatch a call to the _outer_ receiver when the inner receiver does not have the method. For example, inside a `BarBuilder` block nested inside a `FooBuilder` block, an unqualified `fooMethod()` call compiles successfully but modifies the outer `FooBuilder` — a completely unintended side-effect. The `@DslMarker` annotation causes the compiler to reject any unqualified call that would resolve through an outer `this`, turning the silent bug into a compile error. Real-world examples include `@HtmlTagMarker` in the Kotlin HTML DSL and `@KtorDsl` in Ktor, both of which enforce this boundary explicitly.
+
+</details>
+
+### `@RestrictsSuspension` for coroutine-scope builders
+
+When a lambda with receiver is used inside a coroutine builder where only a specific
+set of `suspend` functions should be callable (not arbitrary suspension), annotate the
+receiver class with `@RestrictsSuspension`:
+
+```kotlin
+// ✅ Kotlin stdlib — only yield/yieldAll can be called inside sequence { }
+@RestrictsSuspension
+public abstract class SequenceScope<in T> internal constructor() {
+    abstract suspend fun yield(value: T)
+    abstract suspend fun yieldAll(iterator: Iterator<T>)
+}
+
+// Usage — calling delay() or other arbitrary suspend functions inside is a compile error
+val fibs = sequence {
+    yield(0); yield(1)
+    // delay(100) ← compile error: restricted suspension
+}
+```
+
+Use `@RestrictsSuspension` when the lambda's receiver restricts which suspend functions
+are legal to call. This prevents accidental misuse of the builder scope as a general
+coroutine scope.
+
+<details><summary>Reasoning</summary>
+
+The Kotlin stdlib's `SequenceScope` (`stdlib/src/kotlin/collections/SequenceBuilder.kt`) is annotated `@RestrictsSuspension` and its KDoc states exactly the reason: "restricted when used as receivers for extension `suspend` functions — can only invoke other member or extension `suspend` functions on this particular receiver and are restricted from calling arbitrary suspension functions." Without this annotation, a caller could write `delay(100)` inside `sequence { }`, which silently violates the lazy evaluation contract — sequences execute on a synchronous continuation that cannot suspend arbitrarily. The annotation turns that misuse into a compile-time error.
+
+</details>
+
+---
+
+## 4. DSL Builder (`build*` + `Builder` class)
+
+Use a DSL builder when **any** of the following hold:
+
+1. **≥ 3 independently settable properties**, where at least one is optional
+2. **Nested sub-builders** — a property itself requires a lambda to configure
+3. **Mixed required and optional fields** that must be validated at `build()` time
+4. **The constructed object is stored** (assigned to a `val` or passed to multiple callers)
+
+<details><summary>Reasoning</summary>
+
+The canonical model is `buildList` in the Kotlin stdlib (`stdlib/src/kotlin/collections/Collections.kt`): an `inline` top-level function with `contract { callsInPlace(builderAction, EXACTLY_ONCE) }` that applies a `MutableList.() -> Unit` lambda and returns an immutable `List`. The same pattern appears in `buildJsonObject`/`buildJsonArray` in kotlinx.serialization. The threshold "≥ 3 independently settable properties, at least one optional" reflects where named arguments stop being self-labelling: each `var name = value` assignment in a builder block is inherently self-documenting and IDE-guided, while a 7-argument named call requires the reader to scan the full list. Nested sub-builders (condition 2) make named-argument style structurally impossible — a lambda cannot be a default argument value. Stored objects (condition 4) warrant a builder because they are typically inspected after construction, which requires a stable type rather than a transient parameter list.
+
+</details>
+
+### Structure rules
+
+```
+buildFoo { ... }               ← inline top-level function, uses contract
+    └── FooBuilder             ← annotated @McpDsl, @PublishedApi internal constructor
+            ├── var requiredField: Type? = null
+            ├── var optionalField: Type? = null
+            ├── fun subBuilder(block: BarBuilder.() -> Unit)   ← delegates to BarBuilder
+            └── @PublishedApi internal fun build(): Foo        ← validates, constructs
+```
+
+<details><summary>Reasoning</summary>
+
+The `@PublishedApi` annotation is defined in `stdlib/src/kotlin/Annotations.kt` with this KDoc: "Public inline functions cannot use non-public API, since if they are inlined, those non-public API references would violate access restrictions at a call site. To overcome this restriction an `internal` declaration can be annotated with `@PublishedApi`." The builder constructor must be `@PublishedApi internal` (not `public`) because: (1) it prevents callers from instantiating the builder directly — they must go through the `buildFoo { }` entry point; (2) the `inline` entry function can still call it after inlining at the call site. The stdlib's own `HexFormat.Builder` (`stdlib/src/kotlin/text/HexFormat.kt`) uses exactly this pattern: `public class Builder @PublishedApi internal constructor()`.
+
+</details>
+
+### Examples from canonical libraries
+
+```kotlin
+// ✅ Kotlin stdlib — buildList is the canonical DSL builder pattern
+inline fun <E> buildList(builderAction: MutableList<E>.() -> Unit): List<E> {
+    contract { callsInPlace(builderAction, InvocationKind.EXACTLY_ONCE) }
+    return mutableListOf<E>().apply(builderAction)
+}
+
+// ✅ kotlinx.serialization — buildJsonObject follows the same structure
+inline fun buildJsonObject(builderAction: JsonObjectBuilder.() -> Unit): JsonObject {
+    contract { callsInPlace(builderAction, InvocationKind.EXACTLY_ONCE) }
+    return JsonObjectBuilder().apply(builderAction).build()
+}
+
+// ✅ MCP SDK — top-level inline entry point following the same convention
+@OptIn(ExperimentalContracts::class)
+@ExperimentalMcpApi
+inline fun buildCallToolRequest(block: CallToolRequestBuilder.() -> Unit): CallToolRequest {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return CallToolRequestBuilder().apply(block).build()
+}
+
+// ✅ Builder with required + optional fields
+@McpDsl
+class CallToolRequestBuilder @PublishedApi internal constructor() : RequestBuilder() {
+    var name: String? = null       // required — validated in build()
+
+    fun arguments(block: JsonObjectBuilder.() -> Unit)   // optional, sub-builder
+    fun arguments(arguments: JsonObject)                  // plain overload
+
+    @PublishedApi
+    override fun build(): CallToolRequest {
+        val name = requireNotNull(name) { "Missing required field 'name'..." }
+        return CallToolRequest(CallToolRequestParams(name = name, ...))
+    }
+}
+```
+
+### Require-vs-optional convention
+
+| Field state | How to declare | How to validate |
+|---|---|---|
+| Required | `var field: Type? = null` | `requireNotNull(field) { "Missing..." }` in `build()` |
+| Optional with default | `var field: Type = default` | No validation needed |
+| Optional nullable | `var field: Type? = null` | Pass through as `null` |
+
+---
+
+## 7. `Configuration` Data Class
+
+Canonical Kotlin libraries distinguish three separate patterns for optional parameters. The choice
+is **not** driven by count — it depends on whether the configuration needs to survive past the
+constructor call.
+
+### Three patterns and when to use each
+
+| Pattern | Use when | Canonical examples |
+|---|---|---|
+| **Named parameters** | Options consumed at construction; not stored or exposed afterward | `MutableSharedFlow`, `Channel` |
+| **Immutable `FooConfiguration` object** | Config is stored on the object and exposed read-only for diagnostics/inspection | `JsonConfiguration`, `CborConfiguration` |
+| **Mutable DSL builder class** | Config is expressed inside a plugin `install { }` block, used in-place then discarded | Ktor `WebSocketOptions` |
+
+<details><summary>Reasoning</summary>
+
+`MutableSharedFlow(replay, extraBufferCapacity, onBufferOverflow)` uses named parameters because the options drive internal buffer setup and are never exposed publicly — there is nothing to inspect after construction. `Json` uses `JsonConfiguration` (stored as `val configuration: JsonConfiguration` on the sealed class) because callers legitimately inspect `json.configuration.encodeDefaults` after construction, for example inside custom serializers via `JsonDecoder` and `JsonEncoder`. Ktor's `WebSocketOptions` uses a mutable builder class because it is only meaningful inside the `install(WebSockets) { … }` block and is discarded after the plugin is configured — storing it would waste memory and expose a mutable object after its window of use.
+
+</details>
+
+### When to prefer `Configuration` over named arguments
+
+| Named parameters | Immutable `FooConfiguration` object |
+|---|---|
+| Options consumed at construction only | Config **stored** on the created object (`val configuration: JsonConfiguration`) |
+| Options not accessible after creation | Config exposed read-only for logging, comparison, or diagnostics |
+| Options don't form an inspectable unit | Options form one cohesive, inspectable configuration object |
+
+The parameter **count is not the trigger**. `MutableSharedFlow` has 3 named parameters and no
+`Configuration` class; `JsonConfiguration` has 17 properties and is stored on `Json` because
+callers may inspect `json.configuration.encodeDefaults` after construction.
+
+<details><summary>Reasoning</summary>
+
+`JsonConfiguration` (`formats/json/commonMain/src/…/JsonConfiguration.kt`) has 17 `val` properties and an `internal constructor` — it cannot be instantiated externally. It is stored on `sealed class Json(val configuration: JsonConfiguration, …)` and its KDoc states: "Can be used for debug purposes and for custom Json-specific serializers via `JsonEncoder` and `JsonDecoder`." This is the concrete evidence that inspectability after construction — not count — is the deciding factor. Counting parameters and picking a pattern based on that number alone would have given the wrong answer here.
+
+</details>
+
+### Named parameters — `MutableSharedFlow` (kotlinx.coroutines)
+
+```kotlin
+// 3 named params with defaults — no Configuration class.
+// Options drive internal buffer setup and are NOT stored publicly.
+@Suppress("FunctionName")
+public fun <T> MutableSharedFlow(
+    replay: Int = 0,
+    extraBufferCapacity: Int = 0,
+    onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND,
+): MutableSharedFlow<T> = ...
+
+// Channel follows the same pattern
+public fun <E> Channel(
+    capacity: Int = Channel.RENDEZVOUS,
+    onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND,
+    onUndeliveredElement: ((E) -> Unit)? = null,
+): Channel<E> = ...
+```
+
+### Immutable configuration object — `JsonConfiguration` (kotlinx.serialization)
+
+```kotlin
+// 17 val properties — internal constructor prevents external instantiation.
+// Stored on the format object: sealed class Json(val configuration: JsonConfiguration, ...)
+public class JsonConfiguration internal constructor(
+    public val encodeDefaults: Boolean = false,
+    public val ignoreUnknownKeys: Boolean = false,
+    public val isLenient: Boolean = false,
+    // ... 14 more val properties ...
+) {
+    override fun toString(): String = "JsonConfiguration(...)"  // for diagnostics
+}
+
+// Paired with a mutable builder used only inside the DSL block
+public class JsonBuilder internal constructor(json: Json) {
+    public var encodeDefaults: Boolean = json.configuration.encodeDefaults
+    public var ignoreUnknownKeys: Boolean = json.configuration.ignoreUnknownKeys
+    // ...
+    internal fun build(): JsonConfiguration = JsonConfiguration(encodeDefaults, ...)
+}
+
+// Usage
+val json = Json { ignoreUnknownKeys = true }
+val cfg: JsonConfiguration = json.configuration  // inspectable after construction
+```
+
+### Mutable DSL builder — `WebSocketOptions` (Ktor)
+
+```kotlin
+// var properties — builder used in-place, NOT stored on the plugin object afterward.
+@KtorDsl
+public class WebSocketOptions {
+    public var pingPeriodMillis: Long = PINGER_DISABLED
+    public var timeoutMillis: Long = 15_000L
+    public var maxFrameSize: Long = Long.MAX_VALUE
+    public var masking: Boolean = false
+    public var contentConverter: WebsocketContentConverter? = null
+}
+
+// The install block mutates the builder directly; it is not retained afterward.
+install(WebSockets) {
+    pingPeriodMillis = 5_000L
+    timeoutMillis = 30_000L
+}
+```
+
+### Migration path: deprecating flat parameters
+
+When flat parameters are outgrown, deprecate the old constructor with `@Deprecated` and a
+`replaceWith`:
+
+```kotlin
+@Deprecated(
+    "Use constructor with Configuration",
+    // ReplaceWith requires real parameter names to be IDE-applicable; fill them in:
+    replaceWith = ReplaceWith(
+        "MyClass(MyClass.Configuration(optionA = optionA, optionB = optionB))"
+    ),
+)
+constructor(optionA: Boolean = false, optionB: String = "")
+    : this(Configuration(optionA, optionB))
+```
+
+This gives callers a migration path without breaking existing code.
+
+<details><summary>Reasoning</summary>
+
+`JsonConfiguration` itself demonstrates the consequence of not providing a migration path: its `classDiscriminatorMode` property carries `@set:Deprecated(…, level = DeprecationLevel.ERROR)` with the message "JsonConfiguration is not meant to be mutable, and will be made read-only in a future release. The `Json(from = …) {}` copy builder should be used instead." Without a `@Deprecated` + `replaceWith`, callers have no IDE-guided migration and both the old and new APIs silently coexist — creating confusion about which is canonical. The `ReplaceWith` expression must contain real parameter names to be IDE-applicable (the IDE can auto-apply it).
+
+</details>
+
+---
+
+## 11. `@PublishedApi internal` vs `internal` Constructor
+
+Both hide the builder constructor from public use, but the choice depends on whether the factory is `inline`:
+
+| Factory is `inline` | Constructor visibility |
+|---|---|
+| Yes (most DSL builders) | `@PublishedApi internal constructor` — the `inline` function must access internal members after inlining |
+| No (heavyweight factories like `Json { }`) | Plain `internal constructor` — no inlining occurs, `@PublishedApi` is unnecessary |
+
+<details><summary>Reasoning</summary>
+
+The stdlib's `@PublishedApi` KDoc (`stdlib/src/kotlin/Annotations.kt`) states the exact rule: "Public inline functions cannot use non-public API, since if they are inlined, those non-public API references would violate access restrictions at a call site." When `buildFoo { }` is `inline`, the compiler copies its body — including the `FooBuilder()` constructor call — into the caller's module. If the constructor is plain `internal`, the caller's module cannot access it after inlining, causing a compilation error. `@PublishedApi` makes `internal` declarations accessible at inline call sites while keeping them hidden from non-inline usage. `JsonBuilder` uses plain `internal constructor` because `fun Json(…)` is not `inline` — no inlining occurs, so `@PublishedApi` is unnecessary overhead.
+
+</details>
+
+```kotlin
+// ✅ inline factory → @PublishedApi internal constructor
+inline fun buildCallToolRequest(block: CallToolRequestBuilder.() -> Unit): CallToolRequest {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return CallToolRequestBuilder().apply(block).build()   // needs @PublishedApi
+}
+class CallToolRequestBuilder @PublishedApi internal constructor()
+
+// ✅ non-inline factory (Json-style) → plain internal constructor
+fun Json(from: Json = Json.Default, builderAction: JsonBuilder.() -> Unit): Json {
+    val builder = JsonBuilder(from)
+    builder.builderAction()                                // no inlining — plain internal is fine
+    return JsonImpl(builder.build(), builder.serializersModule)
+}
+class JsonBuilder internal constructor(json: Json)
+```
+
+---
+
+## 13. `inline` and Kotlin Contracts
+
+Every **top-level DSL entry function** should be `inline` with a contract:
+
+```kotlin
+@OptIn(ExperimentalContracts::class)
+inline fun buildFoo(block: FooBuilder.() -> Unit): Foo {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return FooBuilder().apply(block).build()
+}
+```
+
+**Why `inline`:** Avoids lambda object allocation. Also required so that `@PublishedApi internal`
+members of the builder (constructor, `build()`) are accessible at the call site after inlining.
+
+**Why `contract`:** Lets the compiler know the lambda runs exactly once, enabling:
+- Definite assignment of `val` variables inside the block
+- Smart casts that survive the block
+- Better null-safety analysis
+
+`contract` is **not** restricted to `inline` functions — `coroutineScope`, `supervisorScope`,
+and `withContext` all use `contract { callsInPlace(block, EXACTLY_ONCE) }` without being `inline`.
+What `inline` adds is allocation-free lambda passing and `@PublishedApi` access.
+
+Do **not** add `contract` to builder methods that may be called zero or more times.
+
+<details><summary>Reasoning</summary>
+
+`buildList` in `stdlib/src/kotlin/collections/Collections.kt` is the canonical reference: it is `inline` and declares `contract { callsInPlace(builderAction, InvocationKind.EXACTLY_ONCE) }`. The `inline` keyword eliminates the lambda object allocation on every call — for DSL builders called frequently (e.g., building protocol messages in a tight loop), this avoids garbage pressure. The `contract` is what allows `val x: String; buildList { x = "hello" }; println(x)` to compile — without it, the compiler cannot prove `x` is initialised after the block. `coroutineScope { }` in kotlinx.coroutines uses the same contract without being `inline`, demonstrating that the two features are independent: `inline` is about allocation; `contract` is about compiler flow analysis.
+
+</details>
+
+---

--- a/.agents/skills/kotlin-standards/references/api-dsl-choices.md
+++ b/.agents/skills/kotlin-standards/references/api-dsl-choices.md
@@ -1,0 +1,23 @@
+# Kotlin API Design Guide
+
+Use this file as a router when you know you need API-design guidance but the
+subtopic is not clear yet. Prefer reading one targeted file below instead of
+loading the whole API design corpus.
+
+## Read this when
+
+- `api-parameter-selection.md`: choose between plain parameters, named
+  arguments, overloads, lambda flavours, and constructors versus builders.
+- `api-builders-and-configuration.md`: design receiver lambdas, DSL builders,
+  immutable configuration objects, and builder implementation details.
+- `api-extensions-and-factories.md`: design extension-based APIs, framework
+  integrations, factory naming, and reified convenience shortcuts.
+- `api-surface-stability.md`: set visibility rules, opt-in tiers, and
+  mutable/read-only exposure boundaries.
+- `api-review-guides.md`: review an API with flowcharts and anti-pattern
+  checklists.
+
+## Loading rule
+
+Start with the most specific file that matches the task. Only return to this
+router when the request spans multiple API design concerns.

--- a/.agents/skills/kotlin-standards/references/api-extensions-and-factories.md
+++ b/.agents/skills/kotlin-standards/references/api-extensions-and-factories.md
@@ -1,0 +1,345 @@
+# Kotlin API Extensions and Factories
+
+Use this reference when shaping extension-based APIs, framework integrations, factory naming, or reified convenience overloads.
+
+## Included sections
+
+- 8. Extension Functions on Framework Types
+- 9. Naming Factory Functions
+- 16. `reified` Inline Shortcuts
+
+## 8. Extension Functions on Framework Types
+
+When integrating with an existing framework (Ktor, coroutines, etc.), prefer extension functions
+over companion objects, standalone functions, or wrapper classes.
+
+### When to write an extension function
+
+- You need to operate _within_ a framework scope (`Route`, `Application`, `HttpClient`)
+- The framework type provides mandatory runtime context (routing tree, HTTP engine, etc.)
+- Installation of framework plugins is part of the operation
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+Extension functions on framework types encode the dependency on the framework at the type level: the function cannot be called unless the caller already has a `Route`, `Application`, or `HttpClient` in scope. This prevents the API from being misused outside the correct lifecycle. A standalone `fun mcpSseTransport(client: HttpClient, …)` would work, but it does not prevent being called with an unconfigured client or outside a Ktor application context. Extension functions also participate in the framework's DSL scope resolution, enabling `@KtorDsl` to prevent calls outside the routing DSL.
+
+</details>
+
+```kotlin
+// ✅ HttpClient extensions — client is required infrastructure, not optional
+fun HttpClient.mcpSseTransport(urlString: String? = null, ...): SseClientTransport
+fun HttpClient.mcpStreamableHttpTransport(urlString: String, ...): StreamableHttpClientTransport
+suspend fun HttpClient.mcpSse(urlString: String? = null, ...): Client      // factory shortcut
+suspend fun HttpClient.mcpStreamableHttp(urlString: String, ...): Client
+
+// ✅ Ktor server routing extensions
+fun Route.mcp(path: String, block: ServerSSESession.() -> Server)
+fun Application.mcp(block: ServerSSESession.() -> Server)         // installs SSE automatically
+fun Application.mcpStreamableHttp(path: String, ..., block: RoutingContext.() -> Server)
+```
+
+### `@KtorDsl` (and framework-specific DSL markers)
+
+When writing extension functions that are part of a framework's DSL, annotate them with the
+framework's own DSL marker, not just your own:
+
+```kotlin
+@KtorDsl                               // Ktor's marker — prevents use outside Ktor DSL context
+public fun Route.mcp(path: String, block: ServerSSESession.() -> Server)
+```
+
+Use `@KtorDsl` (or equivalent) when the function is _only_ meaningful inside a specific framework
+DSL block. This prevents callers from accidentally calling it at the top level.
+
+<details><summary>Reasoning</summary>
+
+`@KtorDsl` is Ktor's own `@DslMarker` annotation. When applied to an extension function on `Route` or `Application`, the Kotlin compiler enforces that it can only be called from within the corresponding Ktor DSL receiver scope. Without it, an IDE provides no warning when `mcp("/sse") { }` is called at the top level of a file or inside an unrelated class — resulting in a runtime error because the routing tree is not being built. The same principle applies to any framework DSL marker: `@HtmlTagMarker`, `@KtorDsl`, `@McpDsl` — they all leverage `@DslMarker` to restrict call sites to the intended scope.
+
+</details>
+
+### The escape-hatch lambda (`requestBuilder: HttpRequestBuilder.() -> Unit = {}`)
+
+When wrapping a framework type, expose an optional lambda that lets callers customise the
+underlying framework object without your API enumerating every option:
+
+```kotlin
+// ✅ Three Ktor transports all follow the same pattern:
+fun HttpClient.mcpSseTransport(
+    urlString: String? = null,
+    reconnectionTime: Duration? = null,
+    requestBuilder: HttpRequestBuilder.() -> Unit = {},   // ← escape hatch
+): SseClientTransport
+
+fun HttpClient.mcpStreamableHttpTransport(
+    url: String,
+    reconnectionTime: Duration? = null,
+    requestBuilder: HttpRequestBuilder.() -> Unit = {},   // ← escape hatch
+): StreamableHttpClientTransport
+```
+
+**Rules for the escape-hatch lambda:**
+
+1. Always provide an empty default (`= {}`): it is opt-in, never forced on the caller.
+2. Name it consistently (`requestBuilder`, `block`, `configure`) across related APIs in the same module.
+3. Its type is the framework's own builder type — do not wrap it in your own abstraction.
+4. Place it as the last parameter so callers can use trailing-lambda syntax when they need it.
+
+The escape-hatch avoids the "add a new parameter for every header" treadmill while keeping the
+primary parameters clean and explicit.
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+Without an escape hatch, every new HTTP header or request option that a caller needs forces a new parameter on the transport function — an unbounded treadmill. The empty-default rule (`= {}`) keeps the escape hatch completely invisible to callers who do not need it: the function's primary parameters stay clean. Placing it last enables trailing-lambda syntax (`mcpSseTransport(url) { bearerAuth(token) }`), which reads naturally. Using the framework's own builder type (`HttpRequestBuilder`) avoids forcing callers to learn an intermediate abstraction — they already know the Ktor DSL.
+
+</details>
+
+### Where to place extension functions and how to name files
+
+Extension functions in the Kotlin ecosystem follow predictable file-placement conventions. The
+driving question is: **whose vocabulary do these extensions belong to?**
+
+#### Co-locate with your own type (same file)
+
+If extensions are few and tightly coupled to a class you own, place them in the same file:
+
+```
+io/modelcontextprotocol/kotlin/sdk/client/
+    McpClient.kt        // class McpClient + its direct extensions
+```
+
+#### Separate file named after the receiver type
+
+When extensions on a third-party type grow beyond a handful, extract them into a dedicated file.
+Name it `<ReceiverType>Extensions.kt` (or a descriptive verb noun when a clear theme exists):
+
+```
+// stdlib pattern — one file per extended type/concept
+Collections.kt          // extensions on Collection, List, Map, …
+Strings.kt              // extensions on String, Char, CharSequence
+Sequences.kt            // extensions on Sequence<T>
+
+// coroutines pattern — action-oriented when the theme is a behaviour
+Builders.common.kt      // launch, async, withContext, …
+Delay.kt                // delay, withTimeout, …
+Flow.kt                 // Flow interface + core operators
+```
+
+Apply the same logic in your own modules:
+
+```
+// ✅ Good — theme is the receiver type or a clear action
+HttpClientExtensions.kt     // extensions on HttpClient
+RouteExtensions.kt          // extensions on Route / Application
+FlowExtensions.kt           // Flow operators for your domain
+
+// ❌ Avoid — name reveals nothing about the receiver or intent
+Utils.kt
+Helpers.kt
+Misc.kt
+```
+
+#### Package placement rules
+
+| Scenario | Package for the extension file |
+|---|---|
+| Extension adds to your own public API | Same package as the extended type |
+| Extension bridges two libraries you own | Package of the _calling_ library |
+| Extension is purely internal | `internal` sub-package, e.g. `…sdk.internal` |
+
+```kotlin
+// ✅ Extending HttpClient — file lives in the client module's package
+// File: kotlin-sdk-client/…/client/HttpClientExtensions.kt
+package io.modelcontextprotocol.kotlin.sdk.client
+
+fun HttpClient.mcpSseTransport(...): SseClientTransport = ...
+```
+
+#### `@file:JvmName` on JVM
+
+When a file contains only extension functions (no classes), the compiler generates a class named
+`<FileName>Kt` by default. Provide a cleaner JVM name for Java callers:
+
+```kotlin
+// File: FlowExtensions.kt
+@file:JvmName("McpFlows")  // Java sees McpFlows.collectMessages(flow, ...)
+
+package io.modelcontextprotocol.kotlin.sdk
+
+fun Flow<JsonRpcMessage>.collectMessages(...) { ... }
+```
+
+#### Summary checklist
+
+- One concept / receiver type → one file.
+- File name = `<ReceiverType>Extensions.kt` or descriptive action noun (`Builders.kt`, `Operators.kt`).
+- Place in the package of the module that _owns_ the integration.
+- Add `@file:JvmName` when the file contains only top-level functions and Java interop matters.
+
+<details><summary>Reasoning</summary>
+
+The Kotlin stdlib organises extensions by receiver type: `Collections.kt` for `Collection`/`List`/`Map` extensions, `Strings.kt` for `String`/`CharSequence`, `Sequences.kt` for `Sequence<T>`. kotlinx.coroutines uses action-oriented names when the theme is a behaviour: `Builders.common.kt` (with `@file:JvmName("BuildersKt")`) for `launch`/`async`/`withContext`, `Delay.kt` for `delay`/`withTimeout`. The `@file:JvmName` annotation on `Builders.common.kt` gives Java callers a predictable class name (`BuildersKt`) instead of the compiler-generated `Builders_commonKt`. Files named `Utils.kt` or `Helpers.kt` fail this convention — they reveal nothing about the receiver type or theme, making discovery impossible without an IDE search.
+
+</details>
+
+---
+
+## 9. Naming Factory Functions
+
+The name of a factory function signals its relationship to the type it creates.
+
+### `build*` prefix — for protocol/message objects
+
+Use `build*` when the factory creates a **data/message object** from a builder.
+The prefix makes it clear the function runs a builder, not a constructor.
+
+<details><summary>Reasoning</summary>
+
+kotlinx.serialization uses `buildJsonObject` and `buildJsonArray` (`formats/json/commonMain/src/…/JsonElementBuilders.kt`) as the entry points to their respective builders. The `build*` prefix signals three things simultaneously: (1) a `Builder` class is involved internally; (2) the result is a freshly constructed value, not a singleton; (3) the function is the primary intended call site — callers should not instantiate `JsonObjectBuilder` directly. This distinguishes `buildJsonObject { }` (one-shot construction) from `Json { }` (heavyweight singleton), which would be confusing if both used the same `build*` prefix.
+
+</details>
+
+```kotlin
+// ✅ Protocol message types — callers build many of these
+fun buildCallToolRequest(block: CallToolRequestBuilder.() -> Unit): CallToolRequest
+fun buildCreateMessageRequest(block: CreateMessageRequestBuilder.() -> Unit): CreateMessageRequest
+```
+
+### Type-named factory — for format/service singletons
+
+When the result is a **heavyweight singleton** (a format, a client, a service) with
+a large, optional configuration surface, name the factory after the type itself.
+This reads as a pseudo-constructor.
+
+```kotlin
+// ✅ kotlinx.serialization — Json is a sealed class, `Json { }` is its factory
+fun Json(from: Json = Json.Default, builderAction: JsonBuilder.() -> Unit): Json
+
+// Callers read naturally:
+val json = Json { ignoreUnknownKeys = true }
+val debug = Json(json) { prettyPrint = true }  // ← copy builder with "from"
+```
+
+**Rules:**
+- The type must be `sealed` or `abstract` so callers cannot instantiate it directly.
+- The companion can serve as the default instance (`Json.Default`).
+- Add an optional `from: T = T.Default` first parameter for the **copy builder** pattern.
+
+<details><summary>Reasoning</summary>
+
+`Json` in kotlinx.serialization (`formats/json/commonMain/src/…/Json.kt`) is a `sealed class` with a `fun Json(from: Json = Json.Default, builderAction: JsonBuilder.() -> Unit): Json` factory. The `sealed` constraint is load-bearing: it prevents external subclassing, which would break the library's internal dispatch. The type-named factory reads as a pseudo-constructor — `val json = Json { ignoreUnknownKeys = true }` is idiomatic and immediately legible even to newcomers. `CoroutineScope(context)` and `MainScope()` in kotlinx.coroutines follow the same pattern: factory functions named after the interface they return, with `@Suppress("FunctionName")` to silence the lint warning.
+
+</details>
+
+### Copy builder pattern — `fun Type(from: Type = Type.Default, block: TypeBuilder.() -> Unit)`
+
+When an existing instance should be the baseline for a new one with overrides:
+
+```kotlin
+// ✅ kotlinx.serialization copy builder
+val defaultJson = Json { encodeDefaults = true }
+val debugJson = Json(defaultJson) { prettyPrint = true }   // inherits encodeDefaults
+
+// In MCP SDK — extend existing config without repeating every field
+val strictJson = Json(McpJson) { explicitNulls = true }
+```
+
+The `from` parameter seeds all builder properties from the given instance, so only
+the changed fields need to be specified. This is more maintainable than re-specifying
+everything when one option changes.
+
+<details><summary>Reasoning</summary>
+
+`Json.kt` documents this pattern explicitly in its KDoc: "Json format configuration can be refined using the corresponding constructor: `val debugEndpointJson = Json(defaultJson) { prettyPrint = true }` — will inherit the properties of defaultJson." `JsonBuilder` is initialised from the given `Json` instance: `var encodeDefaults = json.configuration.encodeDefaults`, and so on for all 17 properties. Without the copy builder, every derived configuration must repeat every field — a maintenance hazard when the base configuration changes. The `from = Default` parameter makes the pattern opt-in: callers who do not need inheritance simply omit it.
+
+</details>
+
+### `@Suppress("FunctionName")` for type-named factories
+
+When a factory function is named after the type it creates (pseudo-constructor style),
+Kotlin's lint raises a `FunctionName` warning because the name starts with an uppercase letter.
+Suppress it explicitly so the intent is clear:
+
+```kotlin
+// ✅ kotlinx.coroutines — factory function named after the interface
+@Suppress("FunctionName")
+public fun CoroutineScope(context: CoroutineContext): CoroutineScope = ContextScope(...)
+
+@Suppress("FunctionName")
+public fun MainScope(): CoroutineScope = ContextScope(SupervisorJob() + Dispatchers.Main)
+
+@Suppress("FunctionName")
+public fun <T> MutableStateFlow(value: T): MutableStateFlow<T> = StateFlowImpl(value)
+```
+
+**Rule:** Every top-level factory function whose name starts with an uppercase letter
+**must** have `@Suppress("FunctionName")`. Without it, Kotlin's IDE and linters report
+a spurious warning that signals incorrect style.
+
+<details><summary>Reasoning</summary>
+
+`CoroutineScope.kt` in kotlinx.coroutines has `@Suppress("FunctionName")` on `fun MainScope()` and `fun CoroutineScope(context)` at lines 121 and 297 respectively. `StateFlow.kt` has it on `fun MutableStateFlow(value)`. The Kotlin `FunctionName` inspection requires function names to start with a lowercase letter — an intentional convention for regular functions. Type-named factories deliberately violate this convention to read as pseudo-constructors. `@Suppress("FunctionName")` is the correct signal that the uppercase name is intentional, not a mistake. Without it, CI lint tools and IDE inspections produce false positives at every occurrence, training reviewers to ignore real issues.
+
+</details>
+
+### Immutable configuration object vs mutable `Builder`
+
+For heavyweight configured types, split into two classes:
+
+| Class | Constructor | Mutability | Purpose |
+|---|---|---|---|
+| `FooBuilder` | `internal` | mutable `var` | Used during configuration block |
+| `FooConfiguration` | `internal` | immutable `val` | Stored on, and exposed by, the created instance |
+
+```kotlin
+// ✅ Pattern from kotlinx.serialization
+class JsonBuilder internal constructor(json: Json) {
+    var encodeDefaults: Boolean = json.configuration.encodeDefaults
+    // ...
+    internal fun build(): JsonConfiguration = JsonConfiguration(encodeDefaults, ...)
+}
+
+sealed class Json(val configuration: JsonConfiguration, ...) {
+    // configuration is read-only and immutable — callers cannot mutate it
+}
+```
+
+This means `configuration` on the live instance is always stable and immutable.
+It can safely be shared across threads and used for diagnostics.
+
+<details><summary>Reasoning</summary>
+
+`JsonConfiguration` has `internal constructor` — external code cannot create or modify it. `JsonBuilder` has `var` properties that mirror it, and `internal fun build(): JsonConfiguration` that produces the immutable configuration object. `Json` stores the result as `val configuration: JsonConfiguration`. This split is the reason custom serializers can safely read `json.configuration.encodeDefaults` from any thread without synchronization — the `val` fields of `JsonConfiguration` are final on the JVM. If configuration were stored as a mutable `JsonBuilder`, it could be modified after construction, breaking thread-safety and diagnostics.
+
+</details>
+
+---
+
+## 16. `reified` Inline Shortcuts
+
+When an API requires an explicit serializer or type token, always add an `inline reified`
+overload that infers the type from the call site:
+
+```kotlin
+// ✅ kotlinx.serialization — explicit serializer (required for interop and custom serializers)
+fun <T> StringFormat.encodeToString(serializer: SerializationStrategy<T>, value: T): String
+
+// ✅ Reified shortcut — callers use this 95% of the time
+inline fun <reified T> StringFormat.encodeToString(value: T): String =
+    encodeToString(serializersModule.serializer(), value)
+```
+
+**Rule:** Add the reified overload as an extension function, not a member, so it doesn't
+pollute the core interface. Always keep the explicit-serializer version — it is needed
+for interop, reflection-free environments, and custom serializers.
+
+<details><summary>Reasoning</summary>
+
+`core/commonMain/src/kotlinx/serialization/SerialFormat.kt` shows both overloads side by side: `fun <T> StringFormat.encodeToString(serializer: SerializationStrategy<T>, value: T): String` is the member (interface method), and `inline fun <reified T> StringFormat.encodeToString(value: T): String = encodeToString(serializersModule.serializer(), value)` is the extension. The extension delegates to `serializersModule.serializer<T>()` which uses reflection — unavailable in some multiplatform targets and incompatible with custom serializers. Keeping the explicit-serializer overload is therefore not optional: it is the only correct path in reflection-free environments (e.g., native with IR). The reified overload is purely a convenience shortcut for the 95% case.
+
+</details>
+
+---

--- a/.agents/skills/kotlin-standards/references/api-parameter-selection.md
+++ b/.agents/skills/kotlin-standards/references/api-parameter-selection.md
@@ -1,0 +1,380 @@
+# Kotlin API Parameter Selection
+
+Use this reference when choosing between plain parameters, named arguments, overloads, lambda flavours, and constructor or builder entry points.
+
+## Included sections
+
+- Quick Reference
+- 1. Plain Method Parameters
+- 2. Named Arguments with Default Values
+- 5. Dual Overloads: Value + Lambda
+- 6. Lambda Flavours
+- 10. Constructor vs. Builder vs. Plain Function
+- Summary: The Numbers and the Questions
+
+## Quick Reference
+
+| Pattern | Parameters | Required fields | Nesting | Reuse |
+|---|---|---|---|---|
+| Plain parameters | ≤ 3 | All required | None | Irrelevant |
+| Named arguments + defaults | 2–6 | Mix of required/optional | None | Irrelevant |
+| Immutable configuration object | — | All optional | None | Stored on object; exposed read-only for diagnostics |
+| Configuration lambda (`T.() -> Unit`) | — | — | 1 level, single concern | Not stored |
+| Factory lambda (`() -> T`) | — | — | None | New object per call |
+| Factory lambda with context (`Ctx.() -> T`) | — | — | 1 level | New object per call |
+| Escape-hatch lambda (`T.() -> Unit = {}`) | — | — | 1 level | Optional customization |
+| Coroutine builder lambda (`suspend CoroutineScope.() -> T`) | — | — | Structured concurrency scope | Bounded by parent scope |
+| Action lambda (`(A, B) -> R`) | — | — | None | Synchronous computation |
+| DSL builder (`build*` + `*Builder`) | — | Mix + required | ≥ 2 levels _or_ ≥ 3 fields | Object is stored |
+| Extension on framework type | — | — | Framework scope | Framework-bound |
+| Mutable/read-only pair (`_backing` + `val prop`) | — | — | None | Hot stream / shared state |
+
+---
+
+## 1. Plain Method Parameters
+
+Use plain parameters when **all three** conditions hold:
+
+1. **≤ 3 parameters** after removing the trailing lambda (if any)
+2. **All parameters are required** or have obvious, universal defaults
+3. **Parameters are primitives or well-known SDK types** (no complex nesting)
+
+<details><summary>Reasoning</summary>
+
+At ≤ 3 required parameters, positional calls remain readable — the reader maps each argument to its parameter without names. Beyond 3, callers start making argument-ordering errors. The Kotlin stdlib confirms the threshold: `Channel(capacity, onBufferOverflow, onUndeliveredElement)` and `MutableSharedFlow(replay, extraBufferCapacity, onBufferOverflow)` both use exactly 3 named parameters without a `Configuration` class. The "all required or obvious defaults" and "primitives or SDK types" conditions prevent ambiguity from optional parameters and complex nesting, which respectively warrant named arguments (§2) or a DSL builder (§4).
+
+</details>
+
+### Representative examples
+
+```kotlin
+// ✅ Three meaningful inputs with one obvious default
+fun registerAsset(
+    uri: String,
+    name: String,
+    description: String,
+    mimeType: String = "text/plain",
+)
+
+// ✅ One enum parameter — nothing to name or configure
+fun remove(mode: RemovalMode): Boolean
+
+// ✅ Atomic query — caller has all values, no builder needed
+fun findSession(id: SessionId): Session?
+```
+
+### Counter-examples (do NOT use plain parameters)
+
+```kotlin
+// ❌ 7 parameters — even with defaults, call sites become unreadable
+fun addTool(name, description, inputSchema, title, outputSchema, toolAnnotations, meta, handler)
+// → Prefer named arguments with defaults (see §2) or a builder (see §3)
+
+// ❌ Optional nullable parameters mixed with required ones cause confusion
+fun Tool(name: String, inputSchema: ToolSchema, description: String? = null,
+         outputSchema: ToolSchema? = null, title: String? = null, ...)
+// → A dedicated builder makes required vs optional obvious
+```
+
+---
+
+## 2. Named Arguments with Default Values
+
+Use named arguments when **at least one** condition holds _and_ nesting is absent:
+
+1. **2–6 parameters** with clear, independent semantics
+2. **Some parameters are optional** with reasonable defaults
+3. **All parameters are "flat"** — no parameter accepts another lambda or builder
+
+<details><summary>Reasoning</summary>
+
+Named arguments eliminate positional ambiguity for optional parameters and make call sites self-documenting. The 2–6 range is derived from readability: at 4+ arguments, callers begin making argument-ordering mistakes; at 7+, the call site becomes a wall of values requiring the reader to count positions. The "flat" constraint is critical — once a parameter itself accepts a lambda, trailing-lambda syntax is no longer available at the call site and a DSL builder (§4) provides better readability. The `@Suppress("LongParameterList")` signal is mechanical evidence that the Kotlin IDE inspection has already fired, confirming the list has exceeded the readable threshold.
+
+</details>
+
+### Measurable threshold: the `@Suppress("LongParameterList")` smell
+
+When you add `@Suppress("LongParameterList")`, that is a signal to consider a builder.
+If you add it and any parameter itself takes a lambda, switch to a DSL builder immediately.
+
+<details><summary>Reasoning</summary>
+
+The `LongParameterList` inspection fires at 6+ parameters by default in IntelliJ/Kotlin inspections. Suppressing it with an annotation is an explicit acknowledgement that the code has exceeded readable limits. Using that suppression as a migration trigger prevents gradual drift toward unreadable constructors. The "any parameter takes a lambda" addendum is stricter: once a parameter itself is a lambda, trailing-lambda syntax is unavailable for any other trailing lambda, making the call site structurally unreadable. A DSL builder resolves this by making every property a named `var` assignment.
+
+</details>
+
+### Representative examples
+
+```kotlin
+// ✅ Named arguments — flat inputs with a few optional settings
+fun registerCommand(
+    name: String,
+    description: String? = null,
+    aliases: List<String> = emptyList(),
+    enabled: Boolean = true,
+)
+
+// ✅ Boolean flag with default — tiny optional customization
+fun refresh(notifyListeners: Boolean = false)
+
+// ✅ Configuration class with defaults — all flat, no nesting
+data class RetryOptions(
+    val maxAttempts: Int = 3,
+    val backoff: Duration = 250.milliseconds,
+)
+```
+
+---
+
+## 5. Dual Overloads: Value + Lambda
+
+When a property accepts a structured value (e.g., `JsonObject`) that callers may want
+to build inline, provide **both** overloads:
+
+```kotlin
+// Accept a pre-built value (interop, testing, stored references)
+fun arguments(arguments: JsonObject)
+
+// Accept a builder lambda (inline construction in DSL context)
+fun arguments(block: JsonObjectBuilder.() -> Unit): Unit = arguments(buildJsonObject(block))
+```
+
+**Rule:** Provide the lambda overload only when the type itself has a well-known builder
+(e.g., `buildJsonObject`, `buildList`). Do not invent builders just to add a lambda overload.
+
+<details><summary>Reasoning</summary>
+
+kotlinx.serialization's `JsonObjectBuilder` (`formats/json/commonMain/src/…/JsonElementBuilders.kt`) demonstrates both overloads side by side: `fun put(key: String, element: JsonElement)` accepts a pre-built value, while the extension `fun JsonObjectBuilder.putJsonObject(key: String, builderAction: JsonObjectBuilder.() -> Unit)` delegates to `put(key, buildJsonObject(builderAction))` for inline construction. The value overload is essential for testing (injecting fixtures), interop (receiving a `JsonObject` from another layer), and stored references. The lambda overload reduces boilerplate at inline DSL call sites. Providing only the lambda forces `buildJsonObject { }` even when the object already exists; providing only the value forces manual `buildJsonObject { }` at every DSL site. The "well-known builder" constraint prevents circular invention — a lambda overload is only justified when the builder already exists for other reasons.
+
+</details>
+
+---
+
+## 6. Lambda Flavours
+
+Not all lambdas with receivers serve the same purpose. Choose based on intent:
+
+### 6.1 Configuration lambda — `T.() -> Unit`
+
+**Use when:** The object already exists; the lambda mutates or registers things on it.
+The lambda is invoked once during construction or registration and does not return a value.
+
+<details><summary>Reasoning</summary>
+
+The `T.() -> Unit` receiver pattern is the foundation of `buildString` (`stdlib/src/kotlin/text/StringBuilder.kt`): `StringBuilder` already exists inside the function and the lambda configures it. The caller never sees the mutable builder — only the immutable `String` result. The same applies to `apply { }` in the stdlib and all Ktor plugin installers (`install(WebSockets) { … }`). The constraint "invoked once" is enforced by `contract { callsInPlace(block, EXACTLY_ONCE) }`, which lets the compiler prove the block runs — enabling `val` definite assignment inside it.
+
+</details>
+
+```kotlin
+// ✅ Kotlin stdlib — StringBuilder already exists, lambda configures it
+val s = buildString {
+    append("Hello, ")
+    appendLine("World!")
+}
+
+// ✅ Ktor — HttpClient exists, lambda installs plugins and sets defaults
+val client = HttpClient(CIO) {
+    install(ContentNegotiation) { json() }
+    defaultRequest { bearerAuth(token) }
+}
+
+// ✅ MCP SDK — Server exists, lambda registers tools/resources on `this`
+val server = Server(info, options) {
+    addTool("greet", "Say hello") { _ -> ... }
+    addResource("file://data", "Data", "...") { _ -> ... }
+}
+```
+
+### 6.2 Factory lambda — `() -> T`
+
+**Use when:** A new instance must be created per invocation (e.g., one Server per HTTP connection).
+There is no shared state; the block is a pure factory.
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+The `() -> T` shape is the minimal factory signature: no receiver, no input, a new value out. Ktor uses it for `webSocket(handler: suspend DefaultWebSocketServerSession.() -> Unit)` — each incoming WebSocket connection invokes the handler independently. The key distinction from `T.() -> Unit` is that the object does not exist yet when the route is registered; the block is *stored* and called later on each connection. Using a configuration lambda (`Server.() -> Unit`) would be wrong here because there is no `Server` instance to configure at registration time.
+
+</details>
+
+```kotlin
+// ✅ Ktor — each WebSocket connection gets a fresh handler
+fun Route.webSocket(path: String, handler: suspend DefaultWebSocketServerSession.() -> Unit)
+
+// ✅ MCP SDK — each WebSocket connection gets a fresh Server
+fun Route.mcpWebSocket(block: () -> Server)
+fun Application.mcpWebSocket(block: () -> Server)
+
+// Usage
+routing {
+    mcpWebSocket { configureServer() }   // called once per connection
+}
+```
+
+**Why not `Server.() -> Unit` here?** Because the server doesn't exist yet when the route
+is registered. The block is stored and called each time a connection arrives.
+
+### 6.3 Factory lambda with context — `Ctx.() -> T`
+
+**Use when:** A new object must be created _and_ the factory needs read-only access to
+a framework-provided context (e.g., request headers, session data).
+The receiver is for _reading_, not mutating.
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+This flavour combines `() -> T` (creates a new object) with a receiver (provides context). The receiver is the framework's session/request object — not something you configure, but something you read from (`call.request.header("Authorization")`). If the receiver were mutable, it would blur the boundary between "reading context" and "mutating the session", which is a correctness hazard. The `Ctx.() -> T` signature makes the intent unambiguous: `Ctx` is read-only input, `T` is the produced output.
+
+</details>
+
+```kotlin
+// ✅ SSE — lambda receives the session to inspect headers, returns a new Server
+fun Route.mcp(path: String, block: ServerSSESession.() -> Server)
+
+// Usage — receiver used to read auth headers, not configure the session
+routing {
+    mcp("/sse") {
+        val token = call.request.header("Authorization")
+        configureServer(token)
+    }
+}
+```
+
+### 6.4 Action lambda — `(A, B, ...) -> R`
+
+**Use when:** The lambda is not a configuration block but a computation called by the API.
+It performs work on data provided by the caller and reports a result back.
+
+```kotlin
+// ✅ kotlinx-io: readFromHead delegates reading to the caller's lambda,
+//    which returns the number of bytes it consumed
+inline fun readFromHead(
+    buffer: Buffer,
+    readAction: (bytes: ByteArray, startIndexInclusive: Int, endIndexExclusive: Int) -> Int
+): Int {
+    contract { callsInPlace(readAction, EXACTLY_ONCE) }
+    ...
+}
+```
+
+Action lambdas are always `inline` with `callsInPlace(EXACTLY_ONCE)` when called exactly once.
+They look like callbacks but they run synchronously and return a meaningful value.
+
+<details><summary>Reasoning</summary>
+
+kotlinx-io's `UnsafeBufferOperations.readFromHead` (`core/common/src/unsafe/UnsafeBufferOperations.kt`) is the canonical example: the library provides a `ByteArray` slice to the caller's lambda, which returns the number of bytes consumed. The lambda is `inline` and `callsInPlace(EXACTLY_ONCE)` — this means: (1) no lambda object is allocated (critical for hot I/O paths); (2) the compiler knows the lambda runs exactly once, so `val` variables assigned inside it are definitively initialised afterward. Without `inline`, a closure allocation would occur on every call — unacceptable for a zero-copy buffer API. The `(A, B) -> R` shape (no receiver, explicit inputs, meaningful return) signals to readers that this is a computation, not a configuration block.
+
+</details>
+
+### 6.5 Coroutine builder lambda — `suspend CoroutineScope.() -> T`
+
+**Use when:** The lambda is a coroutine body that executes within a structured concurrency
+scope. The receiver is the `CoroutineScope` so that child coroutines can be launched
+and will be bounded by the parent scope's lifetime.
+
+```kotlin
+// ✅ kotlinx.coroutines — launch/async take a suspend lambda with CoroutineScope receiver
+fun CoroutineScope.launch(
+    context: CoroutineContext = EmptyCoroutineContext,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    block: suspend CoroutineScope.() -> Unit  // ← coroutine builder lambda
+): Job
+
+// ✅ coroutineScope / supervisorScope — create a new scope, wait for all children
+suspend fun <R> coroutineScope(block: suspend CoroutineScope.() -> R): R {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    ...
+}
+```
+
+**Key properties:**
+- Always `suspend` — can only be called from a coroutine or another suspend function
+- Receiver is `CoroutineScope` — child coroutines launched inside are bounded by this scope
+- Annotated with `contract { callsInPlace(block, EXACTLY_ONCE) }` when the block runs exactly once
+- Distinct from `() -> T` (which is not `suspend` and does not provide a coroutine scope)
+
+<details><summary>Reasoning</summary>
+
+`kotlinx.coroutines`' `launch` and `async` (`Builders.common.kt`) take `suspend CoroutineScope.() -> Unit/T`. The `CoroutineScope` receiver is what makes structured concurrency work: any coroutine launched inside the block with `launch { }` or `async { }` becomes a child of the outer scope's `Job`, so cancellation propagates automatically and the parent waits for all children before completing. Without the `CoroutineScope` receiver, child coroutines would have no parent job and would escape the structured hierarchy. `coroutineScope { }` and `supervisorScope { }` use `contract { callsInPlace(block, EXACTLY_ONCE) }` so the compiler can perform definite assignment analysis across the suspension boundary.
+
+</details>
+
+| Flavour | Receiver purpose | Suspend? | Returns |
+|---|---|---|---|
+| `T.() -> Unit` | Mutate / register on existing `T` | No | `Unit` |
+| `() -> T` | Create a new `T` from scratch | No | new `T` |
+| `Ctx.() -> T` | Read context `Ctx`, create a new `T` | No | new `T` |
+| `(A, B) -> R` | Compute a result using inputs from the API | No | computed value |
+| `suspend CoroutineScope.() -> T` | Run coroutine body in a bounded scope | Yes | `T` |
+
+---
+
+## 10. Constructor vs. Builder vs. Plain Function
+
+| Scenario | Recommended form |
+|---|---|
+| Data class with all-required fields | Primary constructor |
+| Data class with many optional fields | Named parameters + defaults |
+| 5+ optional options forming one concept | `Configuration` data class |
+| Protocol/message object built frequently | `build*` DSL builder |
+| Heavyweight singleton (format, service) | Type-named factory `fun Type(block)` |
+| Derivative of existing instance | Copy builder `fun Type(from = Default, block)` |
+| Framework integration | Extension function on framework type |
+| One-shot factory for internal use | Plain `fun create*(...)` |
+| Common result shapes | Companion object factory |
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+This table consolidates all the individual rules from §1–§9 into a single decision matrix. The choices are not arbitrary — each row corresponds to a principle established in earlier sections and demonstrated by canonical library examples. The primary constructor is the simplest form (data class with all-required fields); each step down the table adds complexity only when the simpler form cannot express the design. Choosing a more complex form when a simpler one suffices is over-engineering; choosing a simpler form when complexity is warranted produces unreadable call sites.
+
+</details>
+
+```kotlin
+// Companion factory — for common result shapes, not full construction
+fun CallToolResult.Companion.success(content: String, meta: JsonObject? = null): CallToolResult
+fun CallToolResult.Companion.error(content: String, meta: JsonObject? = null): CallToolResult
+```
+
+---
+
+## Summary: The Numbers and the Questions
+
+**Parameter-count thresholds:**
+
+- **≤ 3 required → plain parameters**
+- **4–6 with defaults, all flat → named arguments**
+- **Config stored on the object and exposed for diagnostics → immutable `Configuration` object** (regardless of count — see §7)
+- **≥ 3 with optionals or any nesting → DSL builder**
+
+**Lambda selection questions:**
+
+1. Does the lambda configure an existing object? → `T.() -> Unit`
+2. Does the lambda create a new object per call? → `() -> T`
+3. Does it need read-only access to a framework context to create a new object? → `Ctx.() -> T`
+4. Is it an optional extension point on a framework call? → `T.() -> Unit = {}`
+5. Is it a coroutine body that must be bounded by a structured scope? → `suspend CoroutineScope.() -> T`
+6. Is it a synchronous computation on API-provided data? → `(A, B) -> R` (inline + `callsInPlace`)
+7. Should the lambda's receiver restrict which suspend functions can be called? → `@RestrictsSuspension`
+
+**Framework integration:**
+
+- Use extension functions on framework types, not standalone wrappers
+- Annotate with the framework's own DSL marker (`@KtorDsl`)
+- Expose an escape-hatch lambda as the last parameter for underlying request customisation
+
+**Coroutines and shared state:**
+
+- Factory functions named after types need `@Suppress("FunctionName")`
+- Hot data streams: expose read-only interface (`StateFlow`, `SharedFlow`), back with private mutable (`_backing`)
+- Dangerous global state (e.g., `GlobalScope`) must carry `@DelicateCoroutinesApi`
+- Use `@ExperimentalForInheritanceFooApi` when an interface is stable to _use_ but not to _extend_
+
+These numbers are not arbitrary: at 3 required parameters, positional calls remain readable.
+At 4+, callers start making argument-ordering errors.
+At 5+ optional parameters, a `Configuration` class is easier to pass between layers than a long
+function signature. At 3+ fields with optionals, a builder's `var` assignments outperform named
+arguments in readability because each line is self-labelled and IDE autocomplete guides construction.

--- a/.agents/skills/kotlin-standards/references/api-review-guides.md
+++ b/.agents/skills/kotlin-standards/references/api-review-guides.md
@@ -1,0 +1,280 @@
+# Kotlin API Review Guides
+
+Use this reference when reviewing an API design and you need compact decision aids, flowcharts, or a checklist of common anti-patterns.
+
+## Included sections
+
+- 17. Decision Flowcharts
+- 18. Anti-patterns
+
+## 17. Decision Flowcharts
+
+### Choosing parameter style
+
+```mermaid
+flowchart TD
+    A["Define a new API element"] --> B{"Constructing a new object?"}
+
+    B -->|"No — lambda role?"| C{"What does the lambda do?"}
+    C --> C1["Mutates / configures\nexisting object\n→ T.() -> Unit"]
+    C --> C2["Creates object,\nneeds framework context\n→ Ctx.() -> T"]
+    C --> C3["Creates fresh object,\nno context needed\n→ () -> T"]
+    C --> C4["Optional, delegates to\nunderlying framework\n→ T.() -> Unit = {}"]
+    C --> C5["Coroutine body,\nneeds structured scope\n→ suspend CoroutineScope.() -> T"]
+    C --> C6["Computation on\nAPI-provided data\n→ (A, B) -> R"]
+
+    B -->|"Yes — field count?"| D{"How many fields?"}
+    D -->|"1–3, all required"| D1["Primary constructor\nor plain function"]
+    D -->|"4–6, some optional, all flat"| D2["Named parameters\nwith defaults"]
+    D -->|"Config stored on object\nand exposed for diagnostics"| D3["Immutable Configuration\nobject\n(JsonConfiguration pattern)"]
+    D -->|"≥3 with optionals\nor nested sub-objects"| D4{"Any field\nneeds its own builder?"}
+    D4 -->|"Yes"| D4Y["Nested DSL builder\n(@McpDsl sub-builder)"]
+    D4 -->|"No"| D4N["Single-level builder\nwith var properties"]
+```
+
+### Choosing a lambda flavour
+
+```mermaid
+flowchart TD
+    L["Choose a lambda flavour"] --> Q1{"Does it configure\nan existing object?"}
+    Q1 -->|"Yes"| R1["T.() -> Unit\nconfiguration lambda"]
+    Q1 -->|"No"| Q2{"Does it create\na new object?"}
+    Q2 -->|"No"| Q3{"Does it compute\na result?"}
+    Q3 -->|"Yes"| R4["(A, B) -> R\naction lambda\n(always inline + callsInPlace)"]
+    Q3 -->|"No"| R5["() -> Unit\nevent handler / callback"]
+    Q2 -->|"Yes"| Q4{"Needs read-only\naccess to a context?"}
+    Q4 -->|"Yes"| R2["Ctx.() -> T\nfactory with context"]
+    Q4 -->|"No"| Q5{"Is it a coroutine body\nin a structured scope?"}
+    Q5 -->|"Yes"| R6["suspend CoroutineScope.() -> T\ncoroutine builder lambda"]
+    Q5 -->|"No"| Q6{"Is it optional,\ndelegates to framework?"}
+    Q6 -->|"Yes"| R7["T.() -> Unit = {}\nescape-hatch lambda"]
+    Q6 -->|"No"| R3["() -> T\nfactory lambda"]
+```
+
+### Framework integration
+
+```mermaid
+flowchart TD
+    FW["Integrating with a framework?"] -->|"Yes"| E1["Extension function\non the framework type"]
+    E1 --> E2{"Part of the\nframework's DSL?"}
+    E2 -->|"Yes"| E2Y["Add @KtorDsl /\nframework @DslMarker"]
+    E2 -->|"No"| E2N["Plain extension function"]
+    E1 --> E3{"Exposes underlying\nrequest customisation?"}
+    E3 -->|"Yes"| E3Y["Add escape-hatch lambda\nas last parameter\n(T.() -> Unit = {})"]
+    FW -->|"No"| E4["Standalone function\nor companion factory"]
+```
+
+---
+
+## 18. Anti-patterns
+
+### 18.1 Builder without `@DslMarker`
+
+```kotlin
+// ❌ Missing @McpDsl — outer scope bleeds in
+class RequestBuilder {
+    fun meta(block: RequestMetaBuilder.() -> Unit) { ... }
+}
+
+class RequestMetaBuilder {
+    fun put(key: String, value: String) { ... }
+    // Caller can accidentally call RequestBuilder methods here
+}
+```
+
+```kotlin
+// ✅ @McpDsl prevents implicit outer-scope access
+@McpDsl class RequestMetaBuilder { ... }
+```
+
+<details><summary>Reasoning</summary>
+
+See §3 `@DslMarker` rule — the reasoning there covers this anti-pattern directly. The concrete failure mode: inside a `RequestMetaBuilder` block, calling an unqualified `meta(…)` resolves to `RequestBuilder.meta(…)` on the outer receiver, silently nesting builders incorrectly. `@McpDsl` on `RequestMetaBuilder` causes the compiler to reject this unqualified call, because `RequestBuilder` is also annotated `@McpDsl` and two same-marker receivers cannot be in implicit scope simultaneously.
+
+</details>
+
+### 18.2 Builder for single-field objects
+
+```kotlin
+// ❌ Overkill — one field, no nesting, no validation
+class PingRequestBuilder {
+    var id: String? = null
+    fun build() = PingRequest(id)
+}
+```
+
+```kotlin
+// ✅ Plain constructor or companion factory
+fun buildPingRequest(id: String? = null): PingRequest = PingRequest(id)
+```
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+A builder allocates an object (`PingRequestBuilder`), stores the one field on it, validates it (trivially), and constructs the result — three steps instead of one. At a single-field call site, `buildPingRequest { id = "x" }` is strictly worse than `buildPingRequest(id = "x")` or `PingRequest("x")`: more syntax, more indirection, no benefit. The DSL builder pattern earns its weight only when there are ≥ 3 independently settable properties or nested sub-builders (see §4). Below that threshold, it is ceremonial complexity.
+
+</details>
+
+### 18.3 Missing contract on inline entry function
+
+```kotlin
+// ❌ No contract — compiler cannot track val initialization inside block
+inline fun buildFoo(block: FooBuilder.() -> Unit): Foo =
+    FooBuilder().apply(block).build()
+```
+
+```kotlin
+// ✅
+inline fun buildFoo(block: FooBuilder.() -> Unit): Foo {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return FooBuilder().apply(block).build()
+}
+```
+
+<details><summary>Reasoning</summary>
+
+`buildList` in `stdlib/src/kotlin/collections/Collections.kt` has `contract { callsInPlace(builderAction, InvocationKind.EXACTLY_ONCE) }`. Without it, the Kotlin compiler treats the lambda body as code that *may or may not run*, which means: `val name: String; buildFoo { name = "x" }` fails with "variable 'name' must be initialized" because the compiler cannot prove the assignment executes. This breaks a natural Kotlin idiom — capturing a result from inside a builder block into a `val`. The fix is one line of code; the cost of omitting it is forcing callers to use `lateinit var` or nullable types unnecessarily.
+
+</details>
+
+### 18.4 Lambda overload without a corresponding value overload
+
+```kotlin
+// ❌ Lambda-only — forces callers to use DSL even for pre-built values
+fun arguments(block: JsonObjectBuilder.() -> Unit)
+```
+
+```kotlin
+// ✅ Both — callers choose
+fun arguments(arguments: JsonObject)
+fun arguments(block: JsonObjectBuilder.() -> Unit) = arguments(buildJsonObject(block))
+```
+
+<details><summary>Reasoning</summary>
+
+See §5 — the same reasoning applies. The concrete failure here: lambda-only forces `arguments { put("key", "value") }` even when the caller already has a `val args: JsonObject` from a previous computation or test fixture. This is ergonomically hostile in testing, where a pre-built object is passed to multiple assertions. `JsonObjectBuilder.put(key, JsonElement)` and `JsonObjectBuilder.putJsonObject(key, builderAction)` in `JsonElementBuilders.kt` demonstrate that both overloads coexist without conflict.
+
+</details>
+
+### 18.5 Public mutable builder constructor
+
+```kotlin
+// ❌ Anyone can call new FooBuilder() directly
+class FooBuilder constructor() { ... }
+```
+
+```kotlin
+// ✅ Only accessible via the inline entry function after inlining
+class FooBuilder @PublishedApi internal constructor() { ... }
+```
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+A public constructor means callers can do `val b = FooBuilder(); b.name = "x"; b.name = "y"; b.build()` — constructing a builder directly, mutating it arbitrarily, and calling `build()` multiple times. This breaks the intended single-use contract and bypasses any validation in the entry function. `@PublishedApi internal constructor` makes the constructor effectively invisible to external callers while remaining accessible inside the `inline buildFoo { }` function after inlining. The stdlib's `HexFormat.Builder` and kotlinx.serialization's `JsonObjectBuilder` both follow this pattern.
+
+</details>
+
+### 18.6 Using a configuration lambda when a factory lambda is needed
+
+```kotlin
+// ❌ Wrong flavour — block is stored and called per connection, not once at construction
+fun Route.mcpWebSocket(block: Server.() -> Unit)
+// Server doesn't exist yet at route-registration time;
+// calling block() here constructs nothing
+
+// ✅ Factory lambda — creates a new Server each time a connection arrives
+fun Route.mcpWebSocket(block: () -> Server)
+```
+
+Rule: if the lambda needs to produce a new object on each invocation, use `() -> T`.
+If the object already exists and the lambda configures it, use `T.() -> Unit`.
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+The concrete failure: `fun Route.mcpWebSocket(block: Server.() -> Unit)` requires a `Server` instance to exist at route-registration time, but no connection has arrived yet — there is nothing to call `block` on. The block would have to be stored and called later, but `Server.() -> Unit` has no way to produce a `Server` — it can only mutate one. The `() -> Server` signature makes the intent unambiguous: "call this to get a new `Server` per connection." Passing `Server.() -> Unit` here is a type-level category error: configuration lambda vs. factory lambda.
+
+</details>
+
+### 18.7 Wrapping an escape hatch in your own abstraction
+
+```kotlin
+// ❌ Forces callers to learn a custom abstraction instead of the framework's API
+fun HttpClient.mcpSse(urlString: String?, config: McpRequestConfig): SseClientTransport
+
+// ✅ Delegate directly to the framework's own builder
+fun HttpClient.mcpSse(
+    urlString: String? = null,
+    requestBuilder: HttpRequestBuilder.() -> Unit = {},
+): SseClientTransport
+```
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+`McpRequestConfig` forces callers to learn a custom intermediate type and its property mapping to Ktor concepts. The escape-hatch lambda (`HttpRequestBuilder.() -> Unit = {}`) delegates directly to Ktor's own builder — callers apply knowledge they already have. Every custom wrapper type is a new vocabulary item that must be documented, maintained, and kept in sync with the underlying framework. The escape hatch is zero-maintenance by design: it grows with Ktor automatically.
+
+</details>
+
+### 18.8 Do deprecate superseded flat-parameter constructors
+
+When you migrate flat parameters to a `Configuration` class, always mark the old constructor
+`@Deprecated` with `replaceWith`. Without it, callers have no migration path and the two forms
+silently coexist, causing confusion about which is canonical.
+
+<details><summary>Reasoning</summary>
+
+`JsonConfiguration` in kotlinx.serialization demonstrates the cost of not following this rule: the `classDiscriminatorMode` setter was made `@Deprecated(level = ERROR)` with message "JsonConfiguration is not meant to be mutable… The `Json(from = …) {}` copy builder should be used instead." Without `replaceWith`, the IDE cannot offer a one-click fix — the caller must manually discover and apply the replacement. When two forms coexist without deprecation, documentation becomes the only guide, and over time code bases accumulate a mix of old and new style with no clear winner.
+
+</details>
+
+### 18.9 Missing `@KtorDsl` on Ktor extension functions
+
+```kotlin
+// ❌ Callable anywhere — IDE gives no warning if used outside routing { }
+fun Route.mcp(path: String, block: ServerSSESession.() -> Server)
+```
+
+```kotlin
+// ✅ Scoped to Ktor DSL context
+@KtorDsl
+fun Route.mcp(path: String, block: ServerSSESession.() -> Server)
+```
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+Without `@KtorDsl`, the Kotlin compiler allows `Route.mcp(…)` to be called from any context — including outside `routing { }` — where no routing tree is being built. The call compiles but produces no effect (or a runtime error), because the route registration has nowhere to attach. `@KtorDsl` is a `@DslMarker` annotation; applying it limits the function to contexts where a `Route` or `Application` DSL receiver is in scope. See §8 and §3 `@DslMarker` for the underlying mechanism.
+
+</details>
+
+### 18.10 Missing `@Suppress("FunctionName")` on type-named factory functions
+
+```kotlin
+// ❌ Lint warning: function name should start with a lowercase letter
+public fun CoroutineScope(context: CoroutineContext): CoroutineScope = ...
+public fun MutableStateFlow(value: T): MutableStateFlow<T> = ...
+```
+
+```kotlin
+// ✅ Suppress the spurious FunctionName warning explicitly
+@Suppress("FunctionName")
+public fun CoroutineScope(context: CoroutineContext): CoroutineScope = ...
+```
+
+Without the suppression, every call site appears to have an incorrectly named function,
+and lint tools report false positives. The annotation makes the intentional naming explicit.
+
+<details><summary>Reasoning</summary>
+
+See §9 `@Suppress("FunctionName")` rule — the concrete evidence is in `CoroutineScope.kt` at lines 121 and 297, and `StateFlow.kt` for `MutableStateFlow`. The failure mode: CI lint and IntelliJ inspections flag every type-named factory as a `FunctionName` violation, generating noise that trains reviewers to ignore lint output. When real naming problems appear (e.g., an accidentally capitalised utility function), they are buried in the false-positive flood. The `@Suppress` annotation documents the intentional exception at the point of definition.
+
+</details>
+
+---

--- a/.agents/skills/kotlin-standards/references/api-surface-stability.md
+++ b/.agents/skills/kotlin-standards/references/api-surface-stability.md
@@ -1,0 +1,253 @@
+# Kotlin API Surface and Stability
+
+Use this reference for public-surface design, visibility boundaries, opt-in tiers, and mutable versus read-only exposure patterns.
+
+## Included sections
+
+- 14. Visibility Rules
+- 15. API Stability Tiers (`@OptIn` Annotations)
+- 19. Mutable/Read-Only Pairing
+
+## 14. Visibility Rules
+
+| Element | Visibility |
+|---|---|
+| Top-level `build*` function | `public` |
+| Builder class | `public` |
+| Builder constructor | `@PublishedApi internal` (prevents direct instantiation, allows `inline`) |
+| `build()` method | `@PublishedApi internal` (called only by `inline` entry point) |
+| Builder helper methods | `public` (they form the DSL surface) |
+| Intermediate state fields | `private` or `protected` |
+
+Using `@PublishedApi internal` on the constructor and `build()` method is the correct
+pattern: it hides them from normal usage while allowing the `inline` top-level function
+to call them after inlining.
+
+<details><summary>Reasoning</summary>
+
+The stdlib's `HexFormat.Builder` (`stdlib/src/kotlin/text/HexFormat.kt`) is `public class Builder @PublishedApi internal constructor()` — the class is public so it can appear in the DSL surface and type signatures, but the constructor is `@PublishedApi internal` so only the inline `HexFormat { }` entry point can create it. `build()` is `@PublishedApi internal` for the same reason: it is called inside the inline factory after inlining, but must not be callable from external code. Making `build()` `public` would allow callers to invoke it on a partially-configured builder, bypassing the validation in the `buildFoo { }` entry function.
+
+</details>
+
+---
+
+## 15. API Stability Tiers (`@OptIn` Annotations)
+
+Both `kotlinx-io` and `kotlinx.serialization` use **multiple distinct opt-in annotations**
+to communicate different risk levels. Use the same multi-tier approach in your own API.
+
+### Multi-tier model
+
+kotlinx-io uses three distinct annotations. kotlinx.serialization adds a fourth.
+Choose the ones that fit your API's risk profile:
+
+| Annotation | `RequiresOptIn` level | Who should opt in | When to use |
+|---|---|---|---|
+| `@InternalFooApi` | `ERROR` | No one — internal only | Implementation details not for public use |
+| `@DelicateFooApi` | `WARNING` | Expert users only | Correct but easy to misuse |
+| `@ExperimentalFooApi` | `WARNING` | Early adopters | Stable in shape, may change |
+| `@UnsafeFooApi` | `WARNING` | Experts with documented care | Causes data corruption if misused |
+
+<details><summary>Reasoning</summary>
+
+kotlinx-io's `Annotations.kt` (`core/common/src/Annotations.kt`) defines all three tiers with explicit, distinct messages. `@InternalIoApi` is `ERROR` because its KDoc says "subject to change or removal and is not intended for use outside the library." `@DelicateIoApi` is `WARNING` because the API is "correct but careful use required." `@UnsafeIoApi` is `WARNING` because it "may cause data corruption or loss." kotlinx.coroutines' `Annotations.kt` follows the same `ERROR` for `@InternalCoroutinesApi`, `WARNING` for `@DelicateCoroutinesApi` and `@ExperimentalCoroutinesApi`. Using a single `@Experimental` annotation for all risk levels loses information — a caller opting in to an experimental API has no idea whether they risk data corruption or merely an API rename.
+
+</details>
+
+```kotlin
+// kotlinx-io model — three distinct warnings
+@RequiresOptIn(level = ERROR)   annotation class InternalIoApi
+@RequiresOptIn(level = WARNING) annotation class DelicateIoApi   // correct but careful use required
+@RequiresOptIn(level = WARNING) annotation class UnsafeIoApi     // data corruption risk
+
+// kotlinx.serialization model
+@RequiresOptIn(level = WARNING) annotation class ExperimentalSerializationApi
+@RequiresOptIn(level = ERROR)   annotation class InternalSerializationApi
+@RequiresOptIn(level = ERROR)   annotation class SealedSerializationApi  // don't inherit
+```
+
+### `sealed interface` / `sealed class` as "use but don't implement"
+
+`kotlinx-io`'s `Source` and `Sink` are `sealed interface`. This means:
+
+- Callers can use, pass, and store instances freely
+- Callers cannot implement the interface without opting in
+- New methods can be added in future versions without breaking existing implementations
+
+```kotlin
+// ✅ kotlinx-io pattern — sealed prevents uncontrolled implementations
+public sealed interface Source : RawSource {
+    @InternalIoApi
+    val buffer: Buffer             // internal details hidden behind opt-in
+    fun exhausted(): Boolean
+    fun readByte(): Byte
+    // ...
+}
+```
+
+Use `sealed interface` or `sealed class` for public API types when:
+- The type is used by callers but should not be extended by callers
+- You need freedom to add new methods in future versions
+- Implementations are fully under your control
+
+<details><summary>Reasoning</summary>
+
+kotlinx-io's `Source` (`core/common/src/Source.kt`) is `public sealed interface Source : RawSource`. Its KDoc states: "Thread-safety guarantees — until stated otherwise, `Source` implementations are not thread safe." The `sealed` modifier means external code can call `Source` methods freely but cannot implement the interface — if a new `suspend fun peek()` method is added in a future version, no external implementation breaks because there are none. Without `sealed`, adding any new abstract method to a `Source` interface would be a binary-breaking change for all callers who implemented it.
+
+</details>
+
+### Inheritance-specific opt-in tiers
+
+kotlinx.coroutines adds two more opt-in annotations specifically for the "safe to _use_,
+unsafe to _inherit_ from" case:
+
+```kotlin
+// ✅ kotlinx.coroutines — WARNING: new methods may be added in future, breaking inheritance
+@Target(AnnotationTarget.CLASS)
+@RequiresOptIn(level = WARNING, message = "...")
+annotation class ExperimentalForInheritanceCoroutinesApi
+
+// ✅ for types with predefined instances handled specially by the library
+@Target(AnnotationTarget.CLASS)
+@RequiresOptIn(level = WARNING, message = "...")
+annotation class InternalForInheritanceCoroutinesApi
+```
+
+Use these (or your own equivalents) when:
+- The interface is stable for _calling_ but not for _implementing_
+- You need the freedom to add new abstract/open methods in future versions
+- The `Flow` interface documents this informally in KDoc ("not stable for inheritance")
+  but these annotations enforce it at the compiler level
+
+<details><summary>Reasoning</summary>
+
+kotlinx.coroutines' `Annotations.kt` defines `@ExperimentalForInheritanceCoroutinesApi` with the message: "Either new methods may be added in the future, which would break the inheritance, or correctly inheriting from it requires fulfilling contracts that may change in the future." `@InternalForInheritanceCoroutinesApi` adds: "the library may handle predefined instances of this in a special manner." `MutableStateFlow` carries this annotation — the interface has predefined internal implementations that the coroutines library dispatches on specially. External implementations would not benefit from these optimisations and would silently produce incorrect behaviour at dispatch boundaries.
+
+</details>
+
+**Updated 5-tier model:**
+
+| Annotation | Level | Who opts in | Purpose |
+|---|---|---|---|
+| `@InternalFooApi` | `ERROR` | No one | Implementation details |
+| `@DelicateFooApi` | `WARNING` | Expert users | Correct but easy to misuse |
+| `@ExperimentalFooApi` | `WARNING` | Early adopters | May change shape |
+| `@UnsafeFooApi` | `WARNING` | Experts with documented care | Data corruption risk |
+| `@ExperimentalForInheritanceFooApi` | `WARNING` | Library extenders only | Adding methods in future |
+
+### Helpful `@Deprecated(level = ERROR)` overloads
+
+When users commonly try to call a function in a context where it cannot work correctly
+(e.g., calling `launch` outside a `CoroutineScope`), add a `@Deprecated(level = ERROR)`
+overload with a descriptive message pointing to the correct approach. This turns an opaque
+"unresolved reference" compile error into a diagnostic message with a clear migration path:
+
+```kotlin
+// ✅ kotlinx.coroutines Guidance.kt — impossible usage becomes a compile error
+@Deprecated(
+    "'launch' can not be called without the corresponding coroutine scope. " +
+    "Consider wrapping 'launch' in 'coroutineScope { }', using 'runBlocking { }', ...",
+    level = DeprecationLevel.ERROR
+)
+@kotlin.internal.LowPriorityInOverloadResolution
+public fun launch(context: CoroutineContext = ..., block: suspend CoroutineScope.() -> Unit): Job {
+    throw UnsupportedOperationException("Should never be called")
+}
+```
+
+The `@LowPriorityInOverloadResolution` ensures this overload only matches when no valid
+overload is applicable. Callers using the correct `CoroutineScope.launch` see nothing.
+
+<details><summary>Reasoning</summary>
+
+`Guidance.kt` in kotlinx.coroutines defines a top-level `fun launch(…)` annotated with `@Deprecated(level = ERROR)` and `@LowPriorityInOverloadResolution`. Without it, a caller who writes `launch { }` outside a `CoroutineScope` would get an "unresolved reference" compile error — confusing for beginners who do not know they need a scope. With the guidance overload, the error message becomes "'launch' can not be called without the corresponding coroutine scope. Consider wrapping 'launch' in 'coroutineScope { }'…" — a directly actionable diagnostic. `@LowPriorityInOverloadResolution` ensures the guidance overload loses to the real `CoroutineScope.launch` when a scope is in context, so it is completely invisible to correct usage.
+
+</details>
+
+### Grouping unsafe operations into a singleton `object`
+
+When a group of functions is dangerous but necessary, put them in a named `object`
+rather than top-level functions. The call site (`UnsafeBufferOperations.readFromHead(...)`)
+makes the danger explicit at every use point.
+
+```kotlin
+// ✅ kotlinx-io — singleton object draws attention at every call site
+@UnsafeIoApi
+object UnsafeBufferOperations {
+    inline fun readFromHead(buffer: Buffer, readAction: (ByteArray, Int, Int) -> Int): Int
+    inline fun writeToTail(buffer: Buffer, minimumCapacity: Int, writeAction: (ByteArray, Int, Int) -> Int): Int
+}
+
+// Call site always names the object — no way to "accidentally" call it
+UnsafeBufferOperations.readFromHead(buf) { bytes, start, end -> ... }
+```
+
+<details><summary>Reasoning</summary>
+
+`UnsafeBufferOperations` in kotlinx-io (`core/common/src/unsafe/UnsafeBufferOperations.kt`) is annotated `@UnsafeIoApi` and declared as `object`. Its KDoc warns: "Attempts to write data into [bytes] array once it was moved may lead to data corruption." Placing dangerous operations in a named `object` makes the qualified call site `UnsafeBufferOperations.readFromHead(…)` a visual red flag at every use point. A top-level `readFromHead(…)` would look identical to any other buffer utility at the call site — the danger is invisible. The `object` wrapper adds zero runtime overhead while making the risk explicitly visible in every diff and code review.
+
+</details>
+
+---
+
+## 19. Mutable/Read-Only Pairing
+
+When a data-holder type has both read-only consumers and a single mutable producer,
+separate the concerns into two interfaces and back the public property with a private
+mutable instance:
+
+```kotlin
+// ✅ kotlinx.coroutines pattern — StateFlow / MutableStateFlow
+class CounterModel {
+    private val _counter = MutableStateFlow(0)  // private mutable
+    val counter: StateFlow<Int> = _counter.asStateFlow()  // public read-only — structural wrapper, not type upcast
+
+    fun inc() {
+        _counter.update { it + 1 }
+    }
+}
+
+// ✅ SharedFlow variant
+class EventBus {
+    private val _events = MutableSharedFlow<Event>()
+    val events: SharedFlow<Event> = _events.asSharedFlow()
+
+    suspend fun publish(event: Event) = _events.emit(event)
+}
+```
+
+### Rules for mutable/read-only pairing
+
+1. **Name the backing field** with a leading underscore: `_counter`, `_events`.
+2. **Expose the public property** with the read-only type and no underscore: `counter`, `events`.
+3. **Use `.asXxx()` conversion** (`asStateFlow()`, `asSharedFlow()`) rather than relying on
+   type upcasting, so the exposed type is structurally read-only even if upcast-assignable.
+4. **Put the mutable interface** in `MutableXxx` naming: `MutableStateFlow`, `MutableSharedFlow`.
+   The read-only base interface has no prefix: `StateFlow`, `SharedFlow`.
+5. **Never expose the mutable type** as a public property or return value;
+   it must remain an implementation detail.
+
+<details><summary>Reasoning</summary>
+
+`StateFlow.kt` in kotlinx.coroutines (`kotlinx-coroutines-core/common/src/flow/StateFlow.kt`) is the canonical reference. Its KDoc uses exactly the `_counter`/`counter` pattern: `private val _counter = MutableStateFlow(0)` and `val counter = _counter.asStateFlow()`. Rule 3 (`.asStateFlow()` over upcast) is stated in the source: `asStateFlow()` returns a `ReadonlyStateFlow` wrapper — if you upcast `val counter: StateFlow<Int> = _counter`, a caller can downcast back to `MutableStateFlow` and mutate it. `asStateFlow()` prevents this. Rule 5 is structural: `MutableStateFlow` is documented as "not stable for inheritance" (`@InternalForInheritanceCoroutinesApi`), confirming it has special internal dispatch — exposing it publicly would allow callers to depend on that special behaviour, which is fragile.
+
+</details>
+
+### When to apply this pattern
+
+| Scenario | Apply? |
+|---|---|
+| A hot data stream read by multiple consumers | Yes |
+| A UI state model updated by the ViewModel | Yes |
+| An internal buffer accessed only within one class | No — keep as `var` |
+| A configuration object set once at startup | No — use immutable `val` |
+
+<details><summary>Reasoning</summary>
+
+**Why: The reason is unknown**
+
+The pattern adds two objects (`MutableStateFlow` + its `ReadonlyStateFlow` wrapper) and a layer of indirection. That cost is justified only when multiple consumers observe the same hot stream. For a configuration set once at startup, an immutable `val` is cheaper and clearer — there is no mutation to encapsulate and no observer to protect. For an internal buffer accessed within one class, the mutation is already private — the pattern provides no additional encapsulation and only adds ceremony.
+
+</details>
+
+---

--- a/.agents/skills/kotlin-standards/references/idioms.md
+++ b/.agents/skills/kotlin-standards/references/idioms.md
@@ -1,0 +1,463 @@
+# Kotlin Idioms
+
+## Table of Contents
+
+- [Quick Reference](#quick-reference)
+- [Type-Safe Builders](#type-safe-builders)
+- [Lambda with Receiver](#lambda-with-receiver)
+- [Scope Functions](#scope-functions)
+- [Extension Functions](#extension-functions)
+- [Delegated Properties](#delegated-properties)
+- [Infix Functions](#infix-functions)
+- [Operator Overloading](#operator-overloading)
+- [Sealed Classes & When](#sealed-classes--when)
+- [Inline & Reified](#inline--reified)
+
+## Quick Reference
+
+| Idiom                     | Purpose                      |
+|---------------------------|------------------------------|
+| `let`                     | Transform & null check       |
+| `run`                     | Execute block, return result |
+| `with`                    | Operate on object            |
+| `apply`                   | Configure object             |
+| `also`                    | Side effects                 |
+| `takeIf/takeUnless`       | Conditional return           |
+| `by lazy`                 | Lazy initialization          |
+| `by Delegates.observable` | Observe changes              |
+| `inline fun`              | Eliminate lambda overhead    |
+| `reified`                 | Access type at runtime       |
+| `@JvmInline`              | Zero-cost wrapper            |
+| `infix`                   | Custom operators             |
+| `operator`                | Operator overloading         |
+| `sealed class`            | Restricted hierarchies       |
+
+
+## Type-Safe Builders
+
+```kotlin
+// HTML DSL example
+class Tag(val name: String) {
+    val children = mutableListOf<Tag>()
+    val attributes = mutableMapOf<String, String>()
+
+    fun <T : Tag> initTag(
+        tag: T,
+        init: T.() -> Unit
+    ): T {
+        tag.init()
+        children.add(tag)
+        return tag
+    }
+
+    override fun toString(): String {
+        val attrs = attributes.entries.joinToString(" ") { "${it.key}=\"${it.value}\"" }
+        val content = children.joinToString("")
+        return "<$name${if (attrs.isNotEmpty()) " $attrs" else ""}>$content</$name>"
+    }
+}
+
+class HTML : Tag("html") {
+    fun head(init: Head.() -> Unit) = initTag(Head(), init)
+    fun body(init: Body.() -> Unit) = initTag(Body(), init)
+}
+
+class Head : Tag("head") {
+    fun title(init: Title.() -> Unit) = initTag(Title(), init)
+}
+
+class Title : Tag("title") {
+    operator fun String.unaryPlus() {
+        children.add(TextNode(this))
+    }
+}
+
+class Body : Tag("body") {
+    fun div(
+        classes: String? = null,
+        init: Div.() -> Unit
+    ) =
+        initTag(Div(), init).apply {
+            classes?.let { attributes["class"] = it }
+        }
+}
+
+class Div : Tag("div") {
+    fun p(init: P.() -> Unit) = initTag(P(), init)
+}
+
+class P : Tag("p") {
+    operator fun String.unaryPlus() {
+        children.add(TextNode(this))
+    }
+}
+
+class TextNode(private val text: String) : Tag("") {
+    override fun toString() = text
+}
+
+// Usage
+fun html(init: HTML.() -> Unit): HTML {
+    val html = HTML()
+    html.init()
+    return html
+}
+
+val page = html {
+    head {
+        title { +"My Page" }
+    }
+    body {
+        div("container") {
+            p { +"Hello, World!" }
+        }
+    }
+}
+```
+
+## Lambda with Receiver
+
+```kotlin
+// Configuration DSL
+class DatabaseConfig {
+    var host: String = "localhost"
+    var port: Int = 5432
+    var username: String = ""
+    var password: String = ""
+    var database: String = ""
+}
+
+fun database(config: DatabaseConfig.() -> Unit): DatabaseConfig {
+    return DatabaseConfig().apply(config)
+}
+
+// Usage
+val dbConfig = database {
+    host = "db.example.com"
+    port = 3306
+    username = "admin"
+    password = "secret"
+    database = "myapp"
+}
+
+// Builder pattern with type-safe DSL
+class User private constructor(
+    val id: String,
+    val name: String,
+    val email: String,
+    val age: Int?
+) {
+    class Builder {
+        var id: String = ""
+        var name: String = ""
+        var email: String = ""
+        var age: Int? = null
+
+        fun build(): User {
+            require(id.isNotBlank()) { "ID is required" }
+            require(name.isNotBlank()) { "Name is required" }
+            require(email.isNotBlank()) { "Email is required" }
+            return User(id, name, email, age)
+        }
+    }
+}
+
+fun user(init: User.Builder.() -> Unit): User =
+    User.Builder().apply(init).build()
+
+// Usage
+val user = user {
+    id = "123"
+    name = "John Doe"
+    email = "john@example.com"
+    age = 30
+}
+```
+
+## Scope Functions
+
+```kotlin
+// let - transform and null check
+val result = user?.let { u ->
+    "${u.name} (${u.email})"
+}
+
+// run - execute block and return result
+val greeting = run {
+    val name = getName()
+    val title = getTitle()
+    "$title $name"
+}
+
+// with - operate on object
+val message = with(user) {
+    "User: $name, Email: $email, Active: $isActive"
+}
+
+// apply - configure object
+val user = User().apply {
+    name = "John"
+    email = "john@example.com"
+    isActive = true
+}
+
+// also - side effects
+val saved = user
+    .also { logger.info("Saving user: ${it.name}") }
+    .also { validate(it) }
+    .also { repository.save(it) }
+
+// takeIf/takeUnless - conditional returns
+val adult = user.takeIf { it.age >= 18 }
+val minor = user.takeUnless { it.age >= 18 }
+```
+
+## Extension Functions
+
+```kotlin
+// String extensions
+fun String.isValidEmail(): Boolean =
+    matches(Regex("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\$"))
+
+fun String.truncate(
+    length: Int,
+    ellipsis: String = "..."
+): String =
+    if (this.length <= length) this
+    else "${take(length - ellipsis.length)}$ellipsis"
+
+// Collection extensions
+fun <T> List<T>.second(): T = this[1]
+
+fun <T> List<T>.secondOrNull(): T? = if (size >= 2) this[1] else null
+
+inline fun <T> Iterable<T>.sumOf(selector: (T) -> Double): Double {
+    var sum = 0.0
+    for (element in this) {
+        sum += selector(element)
+    }
+    return sum
+}
+
+// Generic extensions
+inline fun <T> T.applyIf(
+    condition: Boolean,
+    block: T.() -> Unit
+): T =
+    if (condition) apply(block) else this
+
+// Usage
+val email = "user@example.com"
+    .applyIf(email.isValidEmail()) {
+        toLowerCase()
+    }
+```
+
+## Delegated Properties
+
+```kotlin
+import kotlin.properties.Delegates
+
+// Lazy initialization
+class Repository {
+    val database: Database by lazy {
+        Database.connect("jdbc:postgresql://localhost/db")
+    }
+}
+
+// Observable property
+class User {
+    var name: String by Delegates.observable("<not set>") { prop, old, new ->
+        println("${prop.name} changed from $old to $new")
+    }
+}
+
+// Vetoable property (can reject changes)
+class Account {
+    var balance: Double by Delegates.vetoable(0.0) { _, old, new ->
+        new >= 0 // Only allow non-negative balance
+    }
+}
+
+// Custom delegate
+class Preference<T>(
+    private val key: String,
+    private val default: T
+) {
+    operator fun getValue(
+        thisRef: Any?,
+        property: KProperty<*>
+    ): T =
+        preferences.get(key) as? T ?: default
+
+    operator fun setValue(
+        thisRef: Any?,
+        property: KProperty<*>,
+        value: T
+    ) {
+        preferences.set(key, value)
+    }
+}
+
+class Settings {
+    var theme: String by Preference("theme", "light")
+    var fontSize: Int by Preference("fontSize", 14)
+}
+
+// Map delegation
+class UserData(map: Map<String, Any?>) {
+    val name: String by map
+    val age: Int by map
+    val email: String by map
+}
+
+val userData = UserData(
+    mapOf(
+        "name" to "John",
+        "age" to 30,
+        "email" to "john@example.com"
+    )
+)
+```
+
+## Infix Functions
+
+```kotlin
+// Custom infix operators
+infix fun <T> T.shouldBe(expected: T) {
+    if (this != expected) {
+        throw AssertionError("Expected $expected but got $this")
+    }
+}
+
+infix fun String.matches(regex: Regex): Boolean =
+    this.matches(regex)
+
+// Usage
+val result = 2 + 2
+result shouldBe 4
+
+"test@example.com" matches Regex(".*@.*\\..*")
+
+// DSL with infix
+class Route(val path: String) {
+    infix fun to(handler: () -> Unit): RouteDefinition =
+        RouteDefinition(path, handler)
+}
+
+data class RouteDefinition(
+    val path: String,
+    val handler: () -> Unit
+)
+
+infix fun String.GET(handler: () -> Unit): RouteDefinition =
+    Route(this) to handler
+
+// Usage
+val route = "/users" GET { println("Get users") }
+```
+
+## Operator Overloading
+
+```kotlin
+data class Vector(
+    val x: Double,
+    val y: Double
+) {
+    operator fun plus(other: Vector) =
+        Vector(x + other.x, y + other.y)
+
+    operator fun minus(other: Vector) =
+        Vector(x - other.x, y - other.y)
+
+    operator fun times(scalar: Double) =
+        Vector(x * scalar, y * scalar)
+
+    operator fun unaryMinus() =
+        Vector(-x, -y)
+
+    operator fun get(index: Int): Double = when (index) {
+        0 -> x
+        1 -> y
+        else -> throw IndexOutOfBoundsException()
+    }
+}
+
+// Usage
+val v1 = Vector(1.0, 2.0)
+val v2 = Vector(3.0, 4.0)
+val v3 = v1 + v2
+val v4 = v1 * 2.0
+val x = v1[0]
+
+// Invoke operator
+class Greeter(private val greeting: String) {
+    operator fun invoke(name: String) = "$greeting, $name!"
+}
+
+val greet = Greeter("Hello")
+println(greet("World")) // Hello, World!
+```
+
+## Sealed Classes & When
+
+```kotlin
+sealed class Result<out T> {
+    data class Success<T>(val data: T) : Result<T>()
+    data class Error(val exception: Exception) : Result<Nothing>()
+    object Loading : Result<Nothing>()
+}
+
+// Exhaustive when
+fun <T> handleResult(result: Result<T>): String = when (result) {
+    is Result.Success -> "Data: ${result.data}"
+    is Result.Error -> "Error: ${result.exception.message}"
+    Result.Loading -> "Loading..."
+}
+
+// Sealed interface for more flexibility
+sealed interface UiState {
+    object Loading : UiState
+    data class Success(val data: List<String>) : UiState
+    data class Error(val message: String) : UiState
+}
+```
+
+## Inline & Reified
+
+```kotlin
+// Inline function
+inline fun <T> measureTime(block: () -> T): Pair<T, Long> {
+    val start = System.currentTimeMillis()
+    val result = block()
+    val duration = System.currentTimeMillis() - start
+    return result to duration
+}
+
+// Reified type parameters
+inline fun <reified T> parseJson(json: String): T =
+    Json.decodeFromString<T>(json)
+
+inline fun <reified T : Any> Intent.getParcelableExtraCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelableExtra(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelableExtra(key) as? T
+    }
+
+// Value class (inline class)
+@JvmInline
+value class UserId(val value: String)
+
+@JvmInline
+value class Email(val value: String) {
+    init {
+        require(value.contains("@")) { "Invalid email" }
+    }
+}
+
+// Usage - zero runtime overhead
+val userId = UserId("123")
+val email = Email("test@example.com")
+```

--- a/.agents/skills/kotlin-standards/references/kotlin-antipatterns.md
+++ b/.agents/skills/kotlin-standards/references/kotlin-antipatterns.md
@@ -1,0 +1,128 @@
+# Kotlin Antipatterns and Code Smells
+
+## Table of Contents
+
+- [Type Safety Violations](#type-safety-violations)
+- [Concurrency Issues](#concurrency-issues)
+- [API Design Flaws](#api-design-flaws)
+- [Performance Antipatterns](#performance-antipatterns)
+- [Architecture Smells](#architecture-smells)
+- [Enterprise-Specific Issues](#enterprise-specific-issues)
+- [Testing Antipatterns](#testing-antipatterns)
+- [Documentation Gaps](#documentation-gaps)
+
+## Type Safety Violations
+
+### Unsafe Casts and Null Handling
+- **Using `!!` operator**: Almost always a code smell. Indicates missing null-safety guarantees.
+- **Unchecked casts (`as`)**: Use `as?` with proper handling or refactor to eliminate the cast.
+- **Platform types leaking**: JVM interop should be wrapped with explicit nullability annotations.
+
+### Any/Star Projections
+- **Excessive `Any` usage**: Loss of type information, especially in library APIs.
+- **Star projections in public APIs**: `List<*>` forces consumers into unsafe territory.
+- **Generic type erasure workarounds**: Reified generics or witness patterns preferred over runtime checks.
+
+## Concurrency Issues
+
+### Mutable Shared State
+- **var in concurrent contexts**: Use immutable data structures or explicit synchronization.
+- **Unprotected collections**: MutableList/Map accessed from multiple threads without locks.
+- **Missing @Volatile**: Shared flags without proper memory barriers.
+
+### Coroutine Misuse
+- **GlobalScope usage**: Almost never appropriate; ties lifecycle to application lifetime.
+- **Blocking in suspend functions**: Use withContext(Dispatchers.IO) for blocking operations.
+- **Missing cancellation handling**: Suspend functions should respect Job cancellation.
+- **Structured concurrency violations**: Launching coroutines without proper scope management.
+
+## API Design Flaws
+
+### Overly Permissive Types
+- **Exposing mutable collections**: Return List, not MutableList. Use immutable interfaces.
+- **var properties in data classes**: Breaks immutability guarantees and thread safety.
+- **Open classes by default**: Seal or finalize unless extension is intentional.
+
+### Leaky Abstractions
+- **Implementation details in interfaces**: Keep internal concerns internal.
+- **Concrete types in API boundaries**: Depend on abstractions (interfaces), not implementations.
+- **Exception types leaking internals**: Wrap third-party exceptions in domain exceptions.
+
+### Poor Error Handling
+- **Throwing checked exceptions from Kotlin**: Use Result, Either, or sealed class hierarchies.
+- **Generic exceptions**: Use specific exception types or typed error representations.
+- **Missing error context**: Exceptions should carry enough information for debugging.
+
+## Performance Antipatterns
+
+### Allocation Hotspots
+- **Excessive object creation in loops**: Cache or use object pools for hot paths.
+- **String concatenation in loops**: Use StringBuilder or joinToString.
+- **Defensive copying overuse**: Profile before optimizing; immutability often eliminates need.
+
+### Collection Operations
+- **Multiple passes over collections**: Chain operations to single pass where possible.
+- **Sequences misuse**: Use for large collections or when intermediate results not needed.
+- **Missing inline for HOFs**: Performance-critical higher-order functions should be inline.
+
+### Reflection Overuse
+- **Runtime reflection for type info**: Use compile-time mechanisms (sealed classes, enums).
+- **Annotation processing at runtime**: Move to compile-time with KSP/kapt.
+
+## Architecture Smells
+
+### Tight Coupling
+- **Singleton abuse**: Makes testing hard, hides dependencies.
+- **Static state**: Breaks testability and concurrent usage.
+- **Constructor over-injection**: >5 dependencies suggests SRP violation.
+
+### Missing Abstractions
+- **Concrete class dependencies**: Depend on interfaces for flexibility and testing.
+- **No separation of concerns**: Business logic mixed with infrastructure.
+- **God objects**: Classes with too many responsibilities.
+
+### Inappropriate Inheritance
+- **Inheritance for code reuse**: Prefer composition.
+- **Deep inheritance hierarchies**: >3 levels is usually a smell.
+- **Non-sealed hierarchies**: Use sealed classes for closed type hierarchies.
+
+## Enterprise-Specific Issues
+
+### Missing Observability Hooks
+- **No metrics/tracing integration points**: APIs should expose hooks for instrumentation.
+- **Opaque execution**: No way to observe internal state or behavior.
+- **Missing context propagation**: Correlation IDs, trace contexts should flow through.
+
+### Backwards Compatibility Breaks
+- **Removing public APIs**: Use @Deprecated with migration path first.
+- **Changing sealed class hierarchies**: Adding cases breaks exhaustive when.
+- **Modifying data class properties**: Changes equality/hashCode semantics.
+
+### Configuration Rigidity
+- **Hardcoded values**: Configuration should be externalized and overridable.
+- **No feature flags**: Large systems need runtime control.
+- **Missing version negotiation**: APIs should handle multiple versions gracefully.
+
+## Testing Antipatterns
+
+### Untestable Design
+- **Final classes with no interfaces**: Cannot mock.
+- **Hidden dependencies**: Using ServiceLoader or global state.
+- **Time dependencies**: Use Clock abstraction, not Instant.now().
+
+### Poor Test Coverage
+- **Only happy path tests**: Error cases and edge cases are critical.
+- **No property-based testing**: Complex logic benefits from generative testing.
+- **Missing integration tests**: Unit tests don't catch composition issues.
+
+## Documentation Gaps
+
+### Missing KDoc
+- **Public APIs without documentation**: All public members need KDoc.
+- **No usage examples**: Complex APIs need code samples.
+- **Missing @since/@deprecated**: Version info aids migration.
+
+### Undocumented Invariants
+- **Thread-safety assumptions**: Document synchronization requirements.
+- **Preconditions/postconditions**: Use contracts or document explicitly.
+- **Performance characteristics**: Big-O complexity for collections/algorithms.

--- a/.agents/skills/kotlin-standards/references/parse-dont-validate-examples.md
+++ b/.agents/skills/kotlin-standards/references/parse-dont-validate-examples.md
@@ -1,0 +1,86 @@
+# Parse, Don't Validate — Concrete Examples
+
+Concrete Kotlin transformations illustrating the "Parse, Don't Validate" discipline from `kotlin-mastery`.
+
+---
+
+## Email — validation to parsing
+
+```kotlin
+// BEFORE (validate)
+data class Email(val value: String) {
+    init {
+        require(value.contains("@")) { "Invalid email" }
+    }
+}
+
+// AFTER (parse)
+@JvmInline
+value class Email private constructor(val value: String) {
+    companion object {
+        fun parse(input: String): Result<Email> =
+            if (input.contains("@")) Result.success(Email(input))
+            else Result.failure(InvalidEmailException(input))
+    }
+}
+```
+
+**What changed**: The type's constructor is private; invalid `Email` instances cannot be constructed. Calling code receives a `Result<Email>` and must handle failure at the boundary.
+
+---
+
+## Config/Timeout — nullable to sealed type
+
+```kotlin
+// BEFORE
+data class Config(val timeout: Long? = null)
+
+// AFTER
+sealed interface Timeout {
+    data class Finite(val millis: PositiveLong) : Timeout
+    object Infinite : Timeout
+}
+data class Config(val timeout: Timeout)
+```
+
+**What changed**: `null` no longer silently means "infinite". The two valid states are explicit and exhaustively matchable.
+
+---
+
+## User — boolean flags to sealed type
+
+```kotlin
+// BEFORE
+data class User(val name: String, val isAdmin: Boolean, val isBanned: Boolean)
+
+// AFTER
+sealed interface UserStatus {
+    data class Active(val name: NonEmptyString) : UserStatus
+    data class Admin(val name: NonEmptyString) : UserStatus
+    data class Banned(val reason: String) : UserStatus
+}
+```
+
+**What changed**: The old model allows `isAdmin = true, isBanned = true` simultaneously — an illegal state. The sealed hierarchy makes co-occurrence impossible.
+
+---
+
+## Key Techniques
+
+| Technique | When to use |
+|-----------|-------------|
+| `@JvmInline value class` with private constructor | Zero-cost wrapping of primitives (IDs, tokens, emails) |
+| `sealed interface` hierarchy | State machines, variants, mutually exclusive states |
+| `data class` with private constructor + companion factory | Multi-field invariants requiring coordinated validation |
+| `Result<T>` or custom sealed result | Parse outcomes at system boundaries |
+| Companion object `parse()` / `of()` factory | Single, explicit entry point that returns typed success/failure |
+
+---
+
+## Anti-Patterns to Identify
+
+- **Primitive obsession**: `String`, `Int`, `Double` where a domain type belongs
+- **`require()`/`check()` in `init`**: throws exceptions instead of returning typed errors
+- **Boolean flags or nullable fields** encoding state machines
+- **Repeated validation** of the same constraint in multiple places
+- **Comments explaining invariants** that the type system could enforce

--- a/.agents/skills/kotlin-standards/references/type-safety-patterns.md
+++ b/.agents/skills/kotlin-standards/references/type-safety-patterns.md
@@ -1,0 +1,20 @@
+# Kotlin Type Safety Guide
+
+Use this file as a router when you need stronger type-system guidance but the
+exact topic is not obvious yet. Prefer loading one focused file below instead
+of the whole type-safety corpus.
+
+## Read this when
+
+- `types-domain-modeling.md`: model domain constraints with value classes,
+  sealed types, nullability elimination, and immutable products.
+- `types-dsls-and-generics.md`: design DSL receivers, variance, reified
+  generics, or context-based APIs.
+- `types-errors-and-testing.md`: shape typed outcomes, review type-safety
+  anti-patterns, and choose testing techniques that prove compile-time
+  guarantees.
+
+## Loading rule
+
+Start with the narrowest matching file. Read multiple files only when the task
+crosses domain modeling, advanced generics, and verification concerns.

--- a/.agents/skills/kotlin-standards/references/types-domain-modeling.md
+++ b/.agents/skills/kotlin-standards/references/types-domain-modeling.md
@@ -1,0 +1,257 @@
+# Kotlin Type-Safe Domain Modeling
+
+Use this reference for value classes, state-encoding types, nullability removal, immutability, and other patterns that make invalid domain states hard to construct.
+
+## Included sections
+
+- Compile-Time Guarantees
+- Nullability Elimination
+- Immutability Patterns
+- Type Aliases for Clarity
+
+## Compile-Time Guarantees
+
+### Phantom Types
+Encode state transitions in the type system to prevent invalid operations at compile time.
+
+```kotlin
+sealed interface State
+sealed interface Disconnected : State
+sealed interface Connected : State
+sealed interface Authenticated : State
+
+class Client<S : State> private constructor() {
+    companion object {
+        fun create(): Client<Disconnected> = Client()
+    }
+    
+    fun connect(): Client<Connected> = Client()
+}
+
+fun Client<Connected>.authenticate(): Client<Authenticated> = Client()
+fun Client<Authenticated>.sendRequest(req: Request): Response = TODO()
+
+// Compile error: cannot send request on disconnected client
+// val client = Client.create()
+// client.sendRequest(request) // Won't compile!
+
+// Must follow the state progression
+val client = Client.create()
+    .connect()
+    .authenticate()
+    .sendRequest(request) // OK!
+```
+
+### Inline Value Classes
+Zero-cost type safety for primitive values:
+
+```kotlin
+@JvmInline
+value class UserId(val value: String)
+
+@JvmInline
+value class OrderId(val value: String)
+
+// Compile error: cannot pass UserId where OrderId expected
+fun getOrder(id: OrderId): Order
+
+val userId = UserId("user-123")
+getOrder(userId) // Won't compile!
+```
+
+### Type-Level Computation
+Use the type system to enforce invariants:
+
+```kotlin
+// Non-empty list guaranteed at compile time
+sealed interface NonEmptyList<out T> {
+    val head: T
+    val tail: List<T>
+    
+    data class Single<T>(override val head: T) : NonEmptyList<T> {
+        override val tail: List<T> = emptyList()
+    }
+    
+    data class Cons<T>(
+        override val head: T,
+        override val tail: NonEmptyList<T>
+    ) : NonEmptyList<T>
+}
+
+// Functions that require non-empty lists can guarantee it
+fun <T> max(list: NonEmptyList<T>): T where T : Comparable<T> {
+    // No need to check if list is empty!
+    return list.tail.fold(list.head) { acc, item ->
+        if (item > acc) item else acc
+    }
+}
+```
+
+## Nullability Elimination
+
+### Non-Null by Construction
+Design APIs that make null impossible:
+
+```kotlin
+// Bad: Nullable return requires null checks
+fun findUser(id: String): User?
+
+// Good: Explicit outcome type
+sealed interface UserLookup {
+    data class Found(val user: User) : UserLookup
+    data object NotFound : UserLookup
+}
+
+fun findUser(id: String): UserLookup
+```
+
+### Late Initialization Alternatives
+Avoid lateinit with safer patterns:
+
+```kotlin
+// Bad: lateinit can throw
+class Service {
+    private lateinit var dependency: Dependency
+    fun initialize(dep: Dependency) { dependency = dep }
+}
+
+// Good: Require in constructor
+class Service(private val dependency: Dependency)
+
+// Good: Use lazy for computed values
+class Service {
+    private val dependency: Dependency by lazy { createDependency() }
+}
+
+// Good: Explicit initialization state
+class Service {
+    private var dependency: Dependency? = null
+    val isInitialized get() = dependency != null
+    
+    fun initialize(dep: Dependency) {
+        check(dependency == null) { "Already initialized" }
+        dependency = dep
+    }
+}
+```
+
+### Optional vs Null
+Use explicit Option/Maybe type when nullability has semantic meaning:
+
+```kotlin
+sealed interface Option<out T> {
+    data class Some<T>(val value: T) : Option<T>
+    data object None : Option<Nothing>
+}
+
+// Makes "no value" explicit in the API
+fun getConfig(key: String): Option<String>
+```
+
+## Immutability Patterns
+
+### Data Class Immutability
+All fields should be val, not var:
+
+```kotlin
+// Good: Immutable data class
+data class User(
+    val id: UserId,
+    val name: String,
+    val email: String
+)
+
+// Use copy for modifications
+val updated = user.copy(name = "New Name")
+
+// Bad: Mutable data class
+data class User(
+    var id: UserId,
+    var name: String,
+    var email: String
+)
+```
+
+### Immutable Collections
+Expose read-only collection interfaces:
+
+```kotlin
+// Good: Return immutable interface
+class Repository {
+    private val items = mutableListOf<Item>()
+    
+    fun getItems(): List<Item> = items.toList() // Defensive copy
+    // Or: return items.asUnmodifiable() if copying is expensive
+}
+
+// Bad: Expose mutable collection
+class Repository {
+    val items = mutableListOf<Item>() // Direct access!
+}
+```
+
+### Builder Pattern for Complex Objects
+Use builders for objects with many optional fields:
+
+```kotlin
+data class Config private constructor(
+    val host: String,
+    val port: Int,
+    val timeout: Duration,
+    val retries: Int,
+    val useSsl: Boolean
+) {
+    class Builder {
+        private var host: String? = null
+        private var port: Int = 8080
+        private var timeout: Duration = 30.seconds
+        private var retries: Int = 3
+        private var useSsl: Boolean = true
+        
+        fun host(value: String) = apply { host = value }
+        fun port(value: Int) = apply { port = value }
+        fun timeout(value: Duration) = apply { timeout = value }
+        fun retries(value: Int) = apply { retries = value }
+        fun useSsl(value: Boolean) = apply { useSsl = value }
+        
+        fun build(): Config {
+            val host = checkNotNull(host) { "host required" }
+            require(port > 0) { "port must be positive" }
+            return Config(host, port, timeout, retries, useSsl)
+        }
+    }
+    
+    companion object {
+        fun builder() = Builder()
+    }
+}
+```
+
+## Type Aliases for Clarity
+
+### Semantic Type Names
+```kotlin
+typealias UserId = String
+typealias Timestamp = Long
+typealias Json = String
+
+// Makes intent clear
+fun getUser(id: UserId): User
+fun parseEvent(json: Json, timestamp: Timestamp): Event
+
+// Better than
+fun getUser(id: String): User
+fun parseEvent(json: String, timestamp: Long): Event
+```
+
+### Complex Type Simplification
+```kotlin
+typealias UserCache = Map<UserId, User>
+typealias EventHandler = (Event) -> Unit
+typealias ValidationRule<T> = (T) -> Boolean
+
+// Simpler signatures
+fun cacheUsers(cache: UserCache, users: List<User>)
+fun registerHandler(handler: EventHandler)
+fun validate(value: String, rule: ValidationRule<String>): Boolean
+```

--- a/.agents/skills/kotlin-standards/references/types-dsls-and-generics.md
+++ b/.agents/skills/kotlin-standards/references/types-dsls-and-generics.md
@@ -1,0 +1,178 @@
+# Kotlin Type-Safe DSLs and Generics
+
+Use this reference for DSL scoping, variance, reified generics, and context receivers when the design question is about compile-time guarantees in expressive APIs.
+
+## Included sections
+
+- Type-Safe DSLs
+- Variance and Type Bounds
+- Reified Generics
+- Context Receivers (Experimental)
+
+## Type-Safe DSLs
+
+### Scope Control with Receivers
+Use scoped functions to create type-safe configuration DSLs:
+
+```kotlin
+class ConfigBuilder {
+    var timeout: Duration = 30.seconds
+    var retries: Int = 3
+    
+    fun build() = Config(timeout, retries)
+}
+
+fun config(block: ConfigBuilder.() -> Unit): Config {
+    return ConfigBuilder().apply(block).build()
+}
+
+// Usage
+val cfg = config {
+    timeout = 60.seconds
+    retries = 5
+}
+```
+
+### Marker Interfaces for DSL Scoping
+Prevent invalid nesting:
+
+```kotlin
+@DslMarker
+annotation class HtmlDsl
+
+@HtmlDsl
+interface Element {
+    fun render(): String
+}
+
+@HtmlDsl
+class Html : Element {
+    private val children = mutableListOf<Element>()
+    
+    fun body(block: Body.() -> Unit) {
+        children.add(Body().apply(block))
+    }
+    
+    override fun render() = children.joinToString { it.render() }
+}
+
+@HtmlDsl
+class Body : Element {
+    private val children = mutableListOf<Element>()
+    
+    fun div(block: Div.() -> Unit) {
+        children.add(Div().apply(block))
+    }
+    
+    override fun render() = "<body>${children.joinToString { it.render() }}</body>"
+}
+
+// DSL marker prevents invalid nesting
+html {
+    body {
+        div {
+            // body { } // Compile error! Can't nest body in div
+        }
+    }
+}
+```
+
+## Variance and Type Bounds
+
+### Covariance for Producers
+Use `out` for types that only produce values:
+
+```kotlin
+interface Producer<out T> {
+    fun produce(): T
+    // Cannot have methods that consume T
+}
+
+val stringProducer: Producer<String> = TODO()
+val anyProducer: Producer<Any> = stringProducer // OK, covariant
+```
+
+### Contravariance for Consumers
+Use `in` for types that only consume values:
+
+```kotlin
+interface Consumer<in T> {
+    fun consume(value: T)
+    // Cannot have methods that produce T
+}
+
+val anyConsumer: Consumer<Any> = TODO()
+val stringConsumer: Consumer<String> = anyConsumer // OK, contravariant
+```
+
+### Type Bounds for Constraints
+Constrain generic types to ensure required capabilities:
+
+```kotlin
+// Upper bound
+fun <T : Comparable<T>> max(a: T, b: T): T = if (a > b) a else b
+
+// Multiple bounds
+interface Persistable {
+    fun save()
+}
+
+fun <T> persist(item: T) where T : Serializable, T : Persistable {
+    // T is both Serializable and Persistable
+}
+```
+
+## Reified Generics
+
+### Type-Safe Casting
+Use reified generics to access type information at runtime:
+
+```kotlin
+inline fun <reified T> JsonNode.parse(): T {
+    return when (T::class) {
+        String::class -> this.asText() as T
+        Int::class -> this.asInt() as T
+        else -> objectMapper.treeToValue(this, T::class.java)
+    }
+}
+
+// Usage
+val value: String = jsonNode.parse() // Type-safe!
+```
+
+### Instance Checks
+```kotlin
+inline fun <reified T> Any.isInstanceOf(): Boolean = this is T
+
+val obj: Any = "Hello"
+obj.isInstanceOf<String>() // true
+obj.isInstanceOf<Int>() // false
+```
+
+## Context Receivers (Experimental)
+
+### Type-Safe Context Propagation
+```kotlin
+interface LoggingContext {
+    fun log(message: String)
+}
+
+interface DatabaseContext {
+    fun query(sql: String): ResultSet
+}
+
+// Function requires both contexts
+context(LoggingContext, DatabaseContext)
+fun fetchUser(id: String): User {
+    log("Fetching user $id")
+    val result = query("SELECT * FROM users WHERE id = ?")
+    return parseUser(result)
+}
+
+// Must be called with both contexts
+with(loggingCtx) {
+    with(dbCtx) {
+        fetchUser("123")
+    }
+}
+```

--- a/.agents/skills/kotlin-standards/references/types-errors-and-testing.md
+++ b/.agents/skills/kotlin-standards/references/types-errors-and-testing.md
@@ -1,0 +1,152 @@
+# Kotlin Type Safety Error Design and Testing
+
+Use this reference for typed outcomes, anti-pattern checks, and techniques that prove type-level guarantees through tests.
+
+## Included sections
+
+- Error Handling Without Wrappers
+- Anti-Patterns to Avoid
+- Testing Type Safety
+
+## Error Handling Without Wrappers
+
+### Sealed Class Outcomes
+Represent success/failure as part of the domain, not as a wrapper type:
+
+```kotlin
+// Good: Domain-specific outcomes
+sealed interface EvaluationOutcome<out T> {
+    data class Enabled<T>(val value: T) : EvaluationOutcome<T>
+    data object Disabled : EvaluationOutcome<Nothing>
+    // No error case exposed - handled internally
+}
+
+// Bad: Generic wrapper exposes errors
+sealed interface Result<out T, out E> {
+    data class Success<T>(val value: T) : Result<T, Nothing>
+    data class Failure<E>(val error: E) : Result<Nothing, E>
+}
+```
+
+### Internal Error Containment
+Errors should be handled internally and not leak to consumers:
+
+```kotlin
+class FeatureFlags internal constructor(
+    private val config: Config,
+    private val evaluator: Evaluator
+) {
+    // All errors caught and converted to Disabled
+    fun evaluate(feature: String): EvaluationOutcome<Config> {
+        return try {
+            when (val result = evaluator.evaluate(feature, config)) {
+                is InternalSuccess -> Enabled(result.config)
+                is InternalFailure -> {
+                    logger.error("Evaluation failed", result.error)
+                    Disabled
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("Unexpected error", e)
+            Disabled
+        }
+    }
+}
+
+// Internal error types never exposed
+private sealed interface InternalResult
+private data class InternalSuccess(val config: Config) : InternalResult
+private data class InternalFailure(val error: Throwable) : InternalResult
+```
+
+### Exhaustive When Expressions
+Use sealed classes to ensure all cases are handled:
+
+```kotlin
+sealed interface Message {
+    data class Text(val content: String) : Message
+    data class Image(val url: String) : Message
+    data class Video(val url: String) : Message
+}
+
+fun handle(message: Message): Unit = when (message) {
+    is Message.Text -> handleText(message.content)
+    is Message.Image -> handleImage(message.url)
+    is Message.Video -> handleVideo(message.url)
+    // Compiler enforces exhaustiveness - no else needed
+}
+```
+
+## Anti-Patterns to Avoid
+
+### Unchecked Casts
+```kotlin
+// Bad: Unsafe cast
+val user = obj as User
+
+// Good: Safe cast with handling
+val user = obj as? User ?: return null
+```
+
+### Any Abuse
+```kotlin
+// Bad: Loss of type information
+fun process(data: Any): Any
+
+// Good: Generic with constraints
+fun <T : Processable> process(data: T): T
+```
+
+### Reflection for Type Checking
+```kotlin
+// Bad: Runtime type checking
+if (obj::class == User::class) { }
+
+// Good: Use sealed classes or is checks
+when (obj) {
+    is User -> handleUser(obj)
+    is Admin -> handleAdmin(obj)
+}
+```
+
+### Nullable Types When Not Needed
+```kotlin
+// Bad: Null for "not found" semantics
+fun find(id: String): User?
+
+// Good: Explicit result type
+sealed interface FindResult {
+    data class Found(val user: User) : FindResult
+    data object NotFound : FindResult
+}
+fun find(id: String): FindResult
+```
+
+## Testing Type Safety
+
+### Compile-Time Test
+```kotlin
+// Test that certain operations don't compile
+// Place in separate source set that's expected to fail compilation
+
+fun testCannotSendOnDisconnected() {
+    val client = Client.create()
+    // client.sendRequest(request) // Should not compile
+}
+
+fun testCannotPassWrongId() {
+    val userId = UserId("123")
+    // getOrder(userId) // Should not compile
+}
+```
+
+### Property-Based Testing
+```kotlin
+// Test type invariants hold for all inputs
+@Test
+fun `NonEmptyList always has at least one element`() = runTest {
+    checkAll(Arb.nonEmptyList(Arb.int())) { list ->
+        assertTrue(list.size >= 1)
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ Run smoke validation for a named instance with:
 ## How to use it
 
 Use `kast --help` for the grouped command overview before you move into the
-JSON-returning commands.
+JSON-returning commands. Analysis commands auto-start the standalone daemon when
+needed. Use `workspace ensure` when you want an explicit prewarm step or a
+separate readiness check.
 
-Start or reuse a runtime for a workspace:
+Optional: prewarm a runtime for a workspace:
 
 ```bash
 kast \
@@ -85,7 +87,12 @@ kast \
   --workspace-root=/absolute/path/to/workspace
 ```
 
-Run analysis commands the same way:
+By default, `workspace ensure` waits for `READY`. Add
+`--accept-indexing=true` when you only need a servable daemon and can tolerate
+`INDEXING` while background enrichment finishes.
+
+Run analysis commands the same way. The first one can start the daemon for you
+when you skip `workspace ensure`:
 
 ```bash
 kast \
@@ -105,6 +112,9 @@ kast \
   --request-file=/absolute/path/to/query.json
 ```
 
+If you want a runtime-dependent command to fail instead of auto-starting a
+daemon, add `--no-auto-start=true`.
+
 Kast refreshes `edits apply` results immediately and watches source roots for
 most external `.kt` file changes. If you need to force recovery after a missed
 change, run:
@@ -123,7 +133,8 @@ kast \
   --workspace-root=/absolute/path/to/workspace
 ```
 
-Successful commands print JSON on stdout. Daemon lifecycle notes go to stderr.
+Successful commands print JSON on stdout. Daemon lifecycle notes go to stderr,
+including successful auto-start and reuse paths.
 
 `call hierarchy` is available through the public CLI and returns bounded trees
 with traversal stats plus truncation metadata.

--- a/analysis-api/build.gradle.kts
+++ b/analysis-api/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("kast.kotlin-serialization")
+    id("kast.kotlin-library")
 }
 
 dependencies {

--- a/analysis-server/build.gradle.kts
+++ b/analysis-server/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("kast.kotlin-serialization")
+    id("kast.kotlin-library")
 }
 
 dependencies {

--- a/backend-standalone/build.gradle.kts
+++ b/backend-standalone/build.gradle.kts
@@ -25,6 +25,7 @@ import java.util.zip.ZipFile
 
 plugins {
     id("kast.standalone-app")
+    id("kast.kotlin-serialization")
 }
 
 private val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")

--- a/backend-standalone/build.gradle.kts
+++ b/backend-standalone/build.gradle.kts
@@ -25,7 +25,7 @@ import java.util.zip.ZipFile
 
 plugins {
     id("kast.standalone-app")
-    id("kast.kotlin-serialization")
+    id("kast.kotlin-library")
 }
 
 private val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/CacheManager.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/CacheManager.kt
@@ -1,0 +1,95 @@
+package io.github.amichne.kast.standalone
+
+import java.nio.file.Path
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+internal const val defaultCacheWriteDelayMillis = 5_000L
+
+internal class CacheManager(
+    workspaceRoot: Path,
+    envReader: (String) -> String? = System::getenv,
+) : AutoCloseable {
+    private val writeLock = Any()
+    private val writeExecutor = Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "kast-cache-manager-write").apply {
+            isDaemon = true
+        }
+    }
+    private val cacheDirectory = kastCacheDirectory(normalizeStandalonePath(workspaceRoot))
+    private val enabled = !isCacheDisabled(envReader)
+    private val pendingWrites = linkedMapOf<String, PendingCacheWrite>()
+
+    fun isEnabled(): Boolean = enabled
+
+    fun runNow(action: () -> Unit) {
+        if (!enabled) {
+            return
+        }
+        runCatching(action)
+    }
+
+    fun schedule(
+        key: String,
+        delayMillis: Long = defaultCacheWriteDelayMillis,
+        action: () -> Unit,
+    ) {
+        if (!enabled) {
+            return
+        }
+        synchronized(writeLock) {
+            pendingWrites.remove(key)?.future?.cancel(false)
+            lateinit var future: ScheduledFuture<*>
+            future = writeExecutor.schedule(
+                {
+                    synchronized(writeLock) {
+                        pendingWrites.remove(key)
+                    }
+                    runCatching(action)
+                },
+                delayMillis,
+                TimeUnit.MILLISECONDS,
+            )
+            pendingWrites[key] = PendingCacheWrite(action = action, future = future)
+        }
+    }
+
+    fun invalidateAll() {
+        synchronized(writeLock) {
+            pendingWrites.values.forEach { pendingWrite ->
+                pendingWrite.future.cancel(false)
+            }
+            pendingWrites.clear()
+        }
+        cacheDirectory.toFile().deleteRecursively()
+    }
+
+    override fun close() {
+        val pendingActions = synchronized(writeLock) {
+            pendingWrites.values.map(PendingCacheWrite::action).also {
+                pendingWrites.values.forEach { pendingWrite ->
+                    pendingWrite.future.cancel(false)
+                }
+                pendingWrites.clear()
+            }
+        }
+        pendingActions.forEach { action ->
+            runCatching(action)
+        }
+        writeExecutor.shutdownNow()
+    }
+}
+
+private data class PendingCacheWrite(
+    val action: () -> Unit,
+    val future: ScheduledFuture<*>,
+)
+
+internal fun isCacheDisabled(envReader: (String) -> String? = System::getenv): Boolean =
+    envReader("KAST_CACHE_DISABLED").isTruthy()
+
+private fun String?.isTruthy(): Boolean = when (this?.trim()?.lowercase()) {
+    "1", "true", "yes", "on" -> true
+    else -> false
+}

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/FileManifest.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/FileManifest.kt
@@ -1,0 +1,101 @@
+package io.github.amichne.kast.standalone
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.extension
+
+private const val fileManifestSchemaVersion = 1
+
+private val fileManifestJson = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+}
+
+internal class FileManifest(
+    workspaceRoot: Path,
+    private val enabled: Boolean = true,
+    private val json: Json = fileManifestJson,
+) {
+    internal val manifestPath: Path = kastCacheDirectory(workspaceRoot).resolve("file-manifest.json")
+
+    fun load(): Map<String, Long>? {
+        if (!enabled || !Files.isRegularFile(manifestPath)) {
+            return null
+        }
+
+        val payload = json.decodeFromString<FileManifestPayload>(Files.readString(manifestPath))
+        if (payload.schemaVersion != fileManifestSchemaVersion) {
+            return null
+        }
+        return payload.fileLastModifiedMillisByPath
+    }
+
+    fun snapshot(sourceRoots: List<Path>): FileManifestSnapshot {
+        val previousManifest = load().orEmpty()
+        val currentManifest = scanTrackedKotlinFileTimestamps(sourceRoots)
+        return FileManifestSnapshot(
+            currentPathsByLastModifiedMillis = currentManifest,
+            newPaths = (currentManifest.keys - previousManifest.keys).sorted(),
+            modifiedPaths = currentManifest.entries
+                .asSequence()
+                .filter { (path, lastModifiedMillis) -> previousManifest[path]?.let { it != lastModifiedMillis } == true }
+                .map(Map.Entry<String, Long>::key)
+                .sorted()
+                .toList(),
+            deletedPaths = (previousManifest.keys - currentManifest.keys).sorted(),
+        )
+    }
+
+    fun save(currentManifest: Map<String, Long>) {
+        if (!enabled) {
+            return
+        }
+        writeCacheFileAtomically(
+            path = manifestPath,
+            payload = json.encodeToString(
+                FileManifestPayload(
+                    fileLastModifiedMillisByPath = currentManifest,
+                ),
+            ),
+        )
+    }
+}
+
+internal data class FileManifestSnapshot(
+    val currentPathsByLastModifiedMillis: Map<String, Long>,
+    val newPaths: List<String>,
+    val modifiedPaths: List<String>,
+    val deletedPaths: List<String>,
+)
+
+@Serializable
+private data class FileManifestPayload(
+    val schemaVersion: Int = fileManifestSchemaVersion,
+    val fileLastModifiedMillisByPath: Map<String, Long>,
+)
+
+internal fun scanTrackedKotlinFileTimestamps(sourceRoots: List<Path>): Map<String, Long> = buildMap {
+    sourceRoots
+        .distinct()
+        .sorted()
+        .forEach { sourceRoot ->
+            if (!Files.isDirectory(sourceRoot)) {
+                return@forEach
+            }
+
+            Files.walk(sourceRoot).use { paths ->
+                paths
+                    .filter { path -> Files.isRegularFile(path) && path.extension == "kt" }
+                    .forEach { file ->
+                        put(
+                            normalizeStandalonePath(file).toString(),
+                            Files.getLastModifiedTime(file).toMillis(),
+                        )
+                    }
+            }
+        }
+}

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/GradleWorkspaceDiscovery.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/GradleWorkspaceDiscovery.kt
@@ -8,6 +8,7 @@ import org.gradle.tooling.model.idea.IdeaProject
 import org.gradle.tooling.model.idea.IdeaSingleEntryLibraryDependency
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -18,6 +19,14 @@ import kotlin.io.path.readText
 internal const val maxIncludedProjectsForToolingApi = 200
 internal const val defaultToolingApiTimeoutMillis = 30_000L
 
+internal fun resolveToolingApiTimeoutMillis(
+    moduleCount: Int,
+    envReader: (String) -> String? = System::getenv,
+): Long {
+    envReader("KAST_GRADLE_TOOLING_TIMEOUT_MS")?.toLongOrNull()?.let { return it }
+    return (moduleCount * 200L).coerceIn(defaultToolingApiTimeoutMillis, 300_000L)
+}
+
 internal data class WorkspaceDiscoveryDiagnostics(
     val warnings: List<String> = emptyList(),
 )
@@ -27,34 +36,125 @@ internal data class GradleWorkspaceDiscoveryResult(
     val diagnostics: WorkspaceDiscoveryDiagnostics = WorkspaceDiscoveryDiagnostics(),
 )
 
+internal data class PhasedDiscoveryResult(
+    val initialLayout: StandaloneWorkspaceLayout,
+    val enrichmentFuture: CompletableFuture<StandaloneWorkspaceLayout>?,
+)
+
 internal object GradleWorkspaceDiscovery {
     fun discover(
         workspaceRoot: Path,
         extraClasspathRoots: List<Path>,
-    ): StandaloneWorkspaceLayout {
-        val settingsSnapshot = GradleSettingsSnapshot.read(workspaceRoot)
-        val staticModules = {
+        settingsSnapshot: GradleSettingsSnapshot = GradleSettingsSnapshot.read(workspaceRoot),
+        staticModulesProvider: () -> List<GradleModuleModel> = {
             StaticGradleWorkspaceDiscovery.discoverModules(workspaceRoot, settingsSnapshot)
-        }
+        },
+        toolingApiLoader: (Path, Long) -> List<GradleModuleModel> = { root, timeoutMillis ->
+            loadModulesWithToolingApi(root, timeoutMillis)
+        },
+        warningSink: (String) -> Unit = ::logWorkspaceDiscoveryWarning,
+    ): StandaloneWorkspaceLayout {
+        val toolingApiTimeoutMillis = resolveToolingApiTimeoutMillis(settingsSnapshot.includedProjectPaths.size)
         val discoveryResult = if (settingsSnapshot.shouldPreferStaticDiscovery()) {
-            val resolvedStaticModules = staticModules()
-            enrichStaticModulesWithToolingApiLibraries(workspaceRoot, resolvedStaticModules)
+            val resolvedStaticModules = staticModulesProvider()
+            enrichStaticModulesWithToolingApiLibraries(
+                workspaceRoot = workspaceRoot,
+                staticModules = resolvedStaticModules,
+                timeoutMillis = toolingApiTimeoutMillis,
+                toolingApiLoader = toolingApiLoader,
+                warningSink = warningSink,
+            )
         } else {
             discoverToolingApiModules(
                 workspaceRoot = workspaceRoot,
                 settingsSnapshot = settingsSnapshot,
-                staticModules = staticModules,
+                staticModules = staticModulesProvider,
+                timeoutMillis = toolingApiTimeoutMillis,
+                toolingApiLoader = toolingApiLoader,
+                warningSink = warningSink,
             )
         }
-        val diagnostics = WorkspaceDiscoveryDiagnostics(
-            warnings = (discoveryResult.diagnostics.warnings + detectIncompleteClasspath(discoveryResult.modules))
-                .distinct(),
-        )
 
         return buildStandaloneWorkspaceLayout(
             gradleModules = discoveryResult.modules,
             extraClasspathRoots = extraClasspathRoots,
-            diagnostics = diagnostics,
+            diagnostics = workspaceDiscoveryDiagnostics(
+                modules = discoveryResult.modules,
+                warnings = discoveryResult.diagnostics.warnings,
+            ),
+        )
+    }
+
+    fun discoverPhased(
+        workspaceRoot: Path,
+        extraClasspathRoots: List<Path>,
+        settingsSnapshot: GradleSettingsSnapshot = GradleSettingsSnapshot.read(workspaceRoot),
+        staticModulesProvider: () -> List<GradleModuleModel> = {
+            StaticGradleWorkspaceDiscovery.discoverModules(workspaceRoot, settingsSnapshot)
+        },
+        toolingApiLoader: (Path, Long) -> List<GradleModuleModel> = { root, timeoutMillis ->
+            loadModulesWithToolingApi(root, timeoutMillis)
+        },
+        warningSink: (String) -> Unit = ::logWorkspaceDiscoveryWarning,
+    ): PhasedDiscoveryResult {
+        if (!settingsSnapshot.shouldPreferStaticDiscovery()) {
+            return PhasedDiscoveryResult(
+                initialLayout = discover(
+                    workspaceRoot = workspaceRoot,
+                    extraClasspathRoots = extraClasspathRoots,
+                    settingsSnapshot = settingsSnapshot,
+                    staticModulesProvider = staticModulesProvider,
+                    toolingApiLoader = toolingApiLoader,
+                    warningSink = warningSink,
+                ),
+                enrichmentFuture = null,
+            )
+        }
+
+        val staticModules = staticModulesProvider()
+        val initialLayout = buildStandaloneWorkspaceLayout(
+            gradleModules = staticModules,
+            extraClasspathRoots = extraClasspathRoots,
+            diagnostics = workspaceDiscoveryDiagnostics(staticModules),
+        )
+        val toolingApiTimeoutMillis = resolveToolingApiTimeoutMillis(settingsSnapshot.includedProjectPaths.size)
+        val enrichmentFuture = CompletableFuture.supplyAsync {
+            val enrichedResult = runCatching {
+                val toolingModules = toolingApiLoader(workspaceRoot, toolingApiTimeoutMillis)
+                GradleWorkspaceDiscoveryResult(
+                    modules = if (toolingModules.isEmpty()) {
+                        staticModules
+                    } else {
+                        mergeToolingAndStaticModules(
+                            toolingModules = toolingModules,
+                            staticModules = staticModules,
+                        )
+                    },
+                )
+            }.getOrElse { error ->
+                val warning = toolingApiFailureWarning(
+                    prefix = "Gradle Tooling API library enrichment failed; using static workspace discovery results",
+                    error = error,
+                )
+                warningSink(warning)
+                GradleWorkspaceDiscoveryResult(
+                    modules = staticModules,
+                    diagnostics = WorkspaceDiscoveryDiagnostics(warnings = listOf(warning)),
+                )
+            }
+            buildStandaloneWorkspaceLayout(
+                gradleModules = enrichedResult.modules,
+                extraClasspathRoots = extraClasspathRoots,
+                diagnostics = workspaceDiscoveryDiagnostics(
+                    modules = enrichedResult.modules,
+                    warnings = enrichedResult.diagnostics.warnings,
+                ),
+            )
+        }
+
+        return PhasedDiscoveryResult(
+            initialLayout = initialLayout,
+            enrichmentFuture = enrichmentFuture,
         )
     }
 
@@ -114,12 +214,15 @@ internal object GradleWorkspaceDiscovery {
     internal fun enrichStaticModulesWithToolingApiLibraries(
         workspaceRoot: Path,
         staticModules: List<GradleModuleModel>,
-        toolingApiLoader: (Path) -> List<GradleModuleModel> = { root -> loadModulesWithToolingApi(root) },
+        timeoutMillis: Long = defaultToolingApiTimeoutMillis,
+        toolingApiLoader: (Path, Long) -> List<GradleModuleModel> = { root, loaderTimeoutMillis ->
+            loadModulesWithToolingApi(root, loaderTimeoutMillis)
+        },
         warningSink: (String) -> Unit = ::logWorkspaceDiscoveryWarning,
     ): GradleWorkspaceDiscoveryResult {
         val warnings = mutableListOf<String>()
         val toolingModules = runCatching {
-            toolingApiLoader(workspaceRoot)
+            toolingApiLoader(workspaceRoot, timeoutMillis)
         }.onFailure { error ->
             val warning = toolingApiFailureWarning(
                 prefix = "Gradle Tooling API library enrichment failed; using static workspace discovery results",
@@ -249,17 +352,20 @@ private fun discoverToolingApiModules(
     workspaceRoot: Path,
     settingsSnapshot: GradleSettingsSnapshot,
     staticModules: () -> List<GradleModuleModel>,
+    timeoutMillis: Long,
+    toolingApiLoader: (Path, Long) -> List<GradleModuleModel>,
+    warningSink: (String) -> Unit,
 ): GradleWorkspaceDiscoveryResult {
     val warnings = mutableListOf<String>()
     val toolingModules = runCatching {
-        GradleWorkspaceDiscovery.loadModulesWithToolingApi(workspaceRoot)
+        toolingApiLoader(workspaceRoot, timeoutMillis)
     }.onFailure { error ->
         val warning = toolingApiFailureWarning(
             prefix = "Gradle Tooling API workspace discovery failed; falling back to static workspace discovery",
             error = error,
         )
         warnings += warning
-        logWorkspaceDiscoveryWarning(warning)
+        warningSink(warning)
     }.getOrNull()
         ?: return GradleWorkspaceDiscoveryResult(
             modules = staticModules(),
@@ -280,6 +386,13 @@ private fun discoverToolingApiModules(
         diagnostics = WorkspaceDiscoveryDiagnostics(warnings = warnings),
     )
 }
+
+private fun workspaceDiscoveryDiagnostics(
+    modules: List<GradleModuleModel>,
+    warnings: List<String> = emptyList(),
+): WorkspaceDiscoveryDiagnostics = WorkspaceDiscoveryDiagnostics(
+    warnings = (warnings + detectIncompleteClasspath(modules)).distinct(),
+)
 
 internal fun detectIncompleteClasspath(modules: List<GradleModuleModel>): List<String> = modules
     .filter { module -> module.dependencies.isEmpty() && module.hasSourceRoots() }
@@ -389,12 +502,11 @@ private fun List<GradleModuleModel>.shouldFallbackToStaticModules(
     }
 
     val hasModuleDependencies = any { module ->
-        module.dependencies.any(GradleDependency::isModuleDependency)
+        module.dependencies.any { dependency -> dependency is GradleDependency.ModuleDependency }
     }
     return !hasModuleDependencies
 }
 
-private fun GradleDependency.isModuleDependency(): Boolean = this is GradleDependency.ModuleDependency
 internal data class GradleModuleModel(
     val gradlePath: String,
     val ideaModuleName: String,

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/GradleWorkspaceDiscovery.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/GradleWorkspaceDiscovery.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.standalone
 
+import kotlinx.serialization.Serializable
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.model.idea.IdeaDependency
 import org.gradle.tooling.model.idea.IdeaModule
@@ -27,10 +28,12 @@ internal fun resolveToolingApiTimeoutMillis(
     return (moduleCount * 200L).coerceIn(defaultToolingApiTimeoutMillis, 300_000L)
 }
 
+@Serializable
 internal data class WorkspaceDiscoveryDiagnostics(
     val warnings: List<String> = emptyList(),
 )
 
+@Serializable
 internal data class GradleWorkspaceDiscoveryResult(
     val modules: List<GradleModuleModel>,
     val diagnostics: WorkspaceDiscoveryDiagnostics = WorkspaceDiscoveryDiagnostics(),
@@ -54,6 +57,13 @@ internal object GradleWorkspaceDiscovery {
         },
         warningSink: (String) -> Unit = ::logWorkspaceDiscoveryWarning,
     ): StandaloneWorkspaceLayout {
+        cachedWorkspaceLayout(
+            workspaceRoot = workspaceRoot,
+            extraClasspathRoots = extraClasspathRoots,
+        )?.let { cachedLayout ->
+            return cachedLayout
+        }
+
         val toolingApiTimeoutMillis = resolveToolingApiTimeoutMillis(settingsSnapshot.includedProjectPaths.size)
         val discoveryResult = if (settingsSnapshot.shouldPreferStaticDiscovery()) {
             val resolvedStaticModules = staticModulesProvider()
@@ -82,7 +92,12 @@ internal object GradleWorkspaceDiscovery {
                 modules = discoveryResult.modules,
                 warnings = discoveryResult.diagnostics.warnings,
             ),
-        )
+        ).also {
+            persistWorkspaceDiscoveryCache(
+                workspaceRoot = workspaceRoot,
+                result = discoveryResult,
+            )
+        }
     }
 
     fun discoverPhased(
@@ -97,6 +112,16 @@ internal object GradleWorkspaceDiscovery {
         },
         warningSink: (String) -> Unit = ::logWorkspaceDiscoveryWarning,
     ): PhasedDiscoveryResult {
+        cachedWorkspaceLayout(
+            workspaceRoot = workspaceRoot,
+            extraClasspathRoots = extraClasspathRoots,
+        )?.let { cachedLayout ->
+            return PhasedDiscoveryResult(
+                initialLayout = cachedLayout,
+                enrichmentFuture = null,
+            )
+        }
+
         if (!settingsSnapshot.shouldPreferStaticDiscovery()) {
             return PhasedDiscoveryResult(
                 initialLayout = discover(
@@ -149,7 +174,12 @@ internal object GradleWorkspaceDiscovery {
                     modules = enrichedResult.modules,
                     warnings = enrichedResult.diagnostics.warnings,
                 ),
-            )
+            ).also {
+                persistWorkspaceDiscoveryCache(
+                    workspaceRoot = workspaceRoot,
+                    result = enrichedResult,
+                )
+            }
         }
 
         return PhasedDiscoveryResult(
@@ -252,6 +282,7 @@ internal object GradleWorkspaceDiscovery {
         gradleModules: List<GradleModuleModel>,
         extraClasspathRoots: List<Path>,
         diagnostics: WorkspaceDiscoveryDiagnostics = WorkspaceDiscoveryDiagnostics(),
+        dependentModuleNamesBySourceModuleName: Map<String, Set<String>>? = null,
     ): StandaloneWorkspaceLayout {
         val moduleModelsByIdeaName = buildMap {
             gradleModules.forEach { module ->
@@ -274,6 +305,8 @@ internal object GradleWorkspaceDiscovery {
         return StandaloneWorkspaceLayout(
             sourceModules = sourceModules,
             diagnostics = diagnostics,
+            dependentModuleNamesBySourceModuleName = dependentModuleNamesBySourceModuleName
+                ?: buildDependentModuleNamesBySourceModuleName(sourceModules),
         )
     }
 
@@ -345,6 +378,34 @@ internal object GradleWorkspaceDiscovery {
                 ?.let { file -> GradleDependency.LibraryDependency(binaryRoot = file, scope = scope) }
             else -> null
         }
+    }
+}
+
+private fun cachedWorkspaceLayout(
+    workspaceRoot: Path,
+    extraClasspathRoots: List<Path>,
+): StandaloneWorkspaceLayout? {
+    val cachedDiscovery = runCatching {
+        WorkspaceDiscoveryCache().read(workspaceRoot)
+    }.getOrNull() ?: return null
+
+    return GradleWorkspaceDiscovery.buildStandaloneWorkspaceLayout(
+        gradleModules = cachedDiscovery.discoveryResult.modules,
+        extraClasspathRoots = extraClasspathRoots,
+        diagnostics = workspaceDiscoveryDiagnostics(
+            modules = cachedDiscovery.discoveryResult.modules,
+            warnings = cachedDiscovery.discoveryResult.diagnostics.warnings,
+        ),
+        dependentModuleNamesBySourceModuleName = cachedDiscovery.dependentModuleNamesBySourceModuleName,
+    )
+}
+
+private fun persistWorkspaceDiscoveryCache(
+    workspaceRoot: Path,
+    result: GradleWorkspaceDiscoveryResult,
+) {
+    runCatching {
+        WorkspaceDiscoveryCache().write(workspaceRoot, result)
     }
 }
 
@@ -507,14 +568,21 @@ private fun List<GradleModuleModel>.shouldFallbackToStaticModules(
     return !hasModuleDependencies
 }
 
+@Serializable
 internal data class GradleModuleModel(
     val gradlePath: String,
     val ideaModuleName: String,
+    @Serializable(with = PathListAsStringSerializer::class)
     val mainSourceRoots: List<Path>,
+    @Serializable(with = PathListAsStringSerializer::class)
     val testSourceRoots: List<Path>,
+    @Serializable(with = PathListAsStringSerializer::class)
     val testFixturesSourceRoots: List<Path> = emptyList(),
+    @Serializable(with = PathListAsStringSerializer::class)
     val mainOutputRoots: List<Path>,
+    @Serializable(with = PathListAsStringSerializer::class)
     val testOutputRoots: List<Path>,
+    @Serializable(with = PathListAsStringSerializer::class)
     val testFixturesOutputRoots: List<Path> = emptyList(),
     val dependencies: List<GradleDependency>,
 ) {
@@ -670,15 +738,19 @@ private data class ResolvedSourceSetDependencies(
     val testDependencyNames: List<String>,
 )
 
+@Serializable
 internal sealed interface GradleDependency {
     val scope: GradleDependencyScope
 
+    @Serializable
     data class ModuleDependency(
         val targetIdeaModuleName: String,
         override val scope: GradleDependencyScope,
     ) : GradleDependency
 
+    @Serializable
     data class LibraryDependency(
+        @Serializable(with = PathAsStringSerializer::class)
         val binaryRoot: Path,
         override val scope: GradleDependencyScope,
     ) : GradleDependency
@@ -720,6 +792,7 @@ internal enum class GradleSourceSet(
     ),
 }
 
+@Serializable
 internal enum class GradleDependencyScope {
     COMPILE,
     PROVIDED,

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/PathSerializers.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/PathSerializers.kt
@@ -1,0 +1,38 @@
+package io.github.amichne.kast.standalone
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.nio.file.Path
+
+internal object PathAsStringSerializer : KSerializer<Path> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Path", PrimitiveKind.STRING)
+
+    override fun serialize(
+        encoder: Encoder,
+        value: Path,
+    ) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): Path = Path.of(decoder.decodeString())
+}
+
+internal object PathListAsStringSerializer : KSerializer<List<Path>> {
+    private val delegate = ListSerializer(PathAsStringSerializer)
+
+    override val descriptor: SerialDescriptor = delegate.descriptor
+
+    override fun serialize(
+        encoder: Encoder,
+        value: List<Path>,
+    ) {
+        delegate.serialize(encoder, value)
+    }
+
+    override fun deserialize(decoder: Decoder): List<Path> = delegate.deserialize(decoder)
+}

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/SourceIndexCache.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/SourceIndexCache.kt
@@ -1,0 +1,102 @@
+package io.github.amichne.kast.standalone
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+private const val sourceIndexCacheSchemaVersion = 1
+
+private val sourceIndexCacheJson = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+}
+
+internal class SourceIndexCache(
+    workspaceRoot: Path,
+    private val enabled: Boolean = true,
+    private val json: Json = sourceIndexCacheJson,
+) {
+    internal val cacheDirectory: Path = kastCacheDirectory(workspaceRoot)
+    internal val indexCachePath: Path = cacheDirectory.resolve("source-identifier-index.json")
+    private val fileManifest = FileManifest(workspaceRoot = workspaceRoot, enabled = enabled)
+
+    fun save(
+        index: MutableSourceIdentifierIndex,
+        sourceRoots: List<Path>,
+    ) {
+        if (!enabled) {
+            return
+        }
+        val manifest = fileManifest.snapshot(sourceRoots).currentPathsByLastModifiedMillis
+        writeCacheFileAtomically(
+            path = indexCachePath,
+            payload = json.encodeToString(
+                SourceIdentifierIndexCachePayload(
+                    candidatePathsByIdentifier = index.toSerializableMap(),
+                ),
+            ),
+        )
+        fileManifest.save(manifest)
+    }
+
+    fun load(sourceRoots: List<Path>): IncrementalIndexResult? {
+        if (!enabled) {
+            return null
+        }
+        if (!Files.isRegularFile(indexCachePath)) {
+            return null
+        }
+
+        val cachedIndex = json.decodeFromString<SourceIdentifierIndexCachePayload>(Files.readString(indexCachePath))
+        if (cachedIndex.schemaVersion != sourceIndexCacheSchemaVersion) {
+            return null
+        }
+
+        val manifestSnapshot = fileManifest.snapshot(sourceRoots)
+        return IncrementalIndexResult(
+            index = MutableSourceIdentifierIndex.fromCandidatePathsByIdentifier(cachedIndex.candidatePathsByIdentifier),
+            newPaths = manifestSnapshot.newPaths,
+            modifiedPaths = manifestSnapshot.modifiedPaths,
+            deletedPaths = manifestSnapshot.deletedPaths,
+        )
+    }
+}
+
+internal data class IncrementalIndexResult(
+    val index: MutableSourceIdentifierIndex,
+    val newPaths: List<String>,
+    val modifiedPaths: List<String>,
+    val deletedPaths: List<String>,
+)
+
+@Serializable
+private data class SourceIdentifierIndexCachePayload(
+    val schemaVersion: Int = sourceIndexCacheSchemaVersion,
+    val candidatePathsByIdentifier: Map<String, List<String>>,
+)
+
+internal fun kastCacheDirectory(workspaceRoot: Path): Path = workspaceRoot.resolve(".kast").resolve("cache")
+
+internal fun writeCacheFileAtomically(
+    path: Path,
+    payload: String,
+) {
+    val parent = requireNotNull(path.parent) { "Cache path must have a parent directory: $path" }
+    Files.createDirectories(parent)
+    val tempFile = Files.createTempFile(parent, "${path.fileName}.tmp-", null)
+    try {
+        Files.writeString(tempFile, payload)
+        try {
+            Files.move(tempFile, path, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(tempFile, path, StandardCopyOption.REPLACE_EXISTING)
+        }
+    } finally {
+        Files.deleteIfExists(tempFile)
+    }
+}

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.analysis.api.components.collectDiagnostics
 import org.jetbrains.kotlin.psi.KtFile
 
 @OptIn(KaExperimentalApi::class)
-class StandaloneAnalysisBackend internal constructor(
+internal class StandaloneAnalysisBackend internal constructor(
     private val workspaceRoot: Path,
     private val limits: ServerLimits,
     private val session: StandaloneAnalysisSession,
@@ -94,18 +94,25 @@ class StandaloneAnalysisBackend internal constructor(
     override suspend fun runtimeStatus(): RuntimeStatusResponse {
         val capabilities = capabilities()
         val warnings = session.workspaceDiagnostics
+        val isIndexing = !session.isEnrichmentComplete() || !session.isInitialSourceIndexReady()
+        val state = if (isIndexing) RuntimeState.INDEXING else RuntimeState.READY
+        val statusMessage = if (isIndexing) {
+            "Standalone analysis session is indexing"
+        } else {
+            "Standalone analysis session is initialized"
+        }
         return RuntimeStatusResponse(
-            state = RuntimeState.READY,
+            state = state,
             healthy = true,
             active = true,
-            indexing = false,
+            indexing = isIndexing,
             backendName = capabilities.backendName,
             backendVersion = capabilities.backendVersion,
             workspaceRoot = capabilities.workspaceRoot,
             message = if (warnings.isEmpty()) {
-                "Standalone analysis session is initialized"
+                statusMessage
             } else {
-                "Standalone analysis session is initialized with warnings: ${warnings.joinToString(separator = " ")}"
+                "$statusMessage with warnings: ${warnings.joinToString(separator = " ")}"
             },
             warnings = warnings,
         )

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -309,9 +309,9 @@ internal class StandaloneAnalysisBackend internal constructor(
 
     override suspend fun refresh(query: RefreshQuery): RefreshResult {
         return if (query.filePaths.isEmpty()) {
-            session.refreshWorkspace()
+            session.refreshWorkspace(invalidateCaches = true)
         } else {
-            session.refreshFiles(query.filePaths.toSet())
+            session.refreshFileContents(query.filePaths.toSet())
         }
     }
 

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -311,7 +311,7 @@ internal class StandaloneAnalysisBackend internal constructor(
         return if (query.filePaths.isEmpty()) {
             session.refreshWorkspace(invalidateCaches = true)
         } else {
-            session.refreshFileContents(query.filePaths.toSet())
+            session.refreshFiles(query.filePaths.toSet())
         }
     }
 

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -368,9 +368,8 @@ internal class StandaloneAnalysisSession(
         if (enrichmentFuture == null) {
             enrichmentComplete = true
             enrichmentReady.complete(Unit)
-    private fun rebuildWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {
-        analysisSessionLock.write {
-            val previousSessionDisposable = sessionStateDisposable
+            return
+        }
         }
 
         enrichmentFuture.whenComplete { enrichedLayout, error ->

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -1,11 +1,14 @@
 package io.github.amichne.kast.standalone
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileTypes.BinaryFileTypeDecompilers
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.compiled.ClassFileDecompilers
 import com.intellij.psi.PsiManager
+import com.intellij.psi.impl.PsiManagerEx
 import com.intellij.lang.LanguageParserDefinitions
 import com.intellij.lang.java.JavaLanguage
 import com.intellij.lang.java.JavaParserDefinition
@@ -41,19 +44,31 @@ internal class StandaloneAnalysisSession(
     moduleName: String,
     private val initialSourceIndexBuilder: (() -> Map<String, List<String>>)? = null,
     private val phasedDiscoveryResult: PhasedDiscoveryResult? = null,
+    private val sourceIndexFileReader: (Path) -> String = Files::readString,
+    private val sourceIndexCacheSaveDelayMillis: Long = defaultSourceIndexCacheSaveDelayMillis,
+    private val cacheEnvReader: (String) -> String? = System::getenv,
 ) : AutoCloseable {
+    private val normalizedWorkspaceRoot = normalizeStandalonePath(workspaceRoot)
     private val disposable: Disposable = Disposer.newDisposable("kast-standalone")
     private val ktFilesByPath = ConcurrentHashMap<String, KtFile>()
     private val targetedKtFilesByPath = ConcurrentHashMap<String, KtFile>()
+    private val ktFileLastModifiedMillisByPath = ConcurrentHashMap<String, Long>()
     private val targetedCandidatePathsByLookupKey = ConcurrentHashMap<CandidateLookupKey, List<String>>()
     private val sourceIdentifierIndex = AtomicReference<MutableSourceIdentifierIndex?>(null)
     @Volatile
     private var initialSourceIndexReady = CompletableFuture<Unit>()
     private val pendingSourceIndexRefreshPaths = ConcurrentHashMap.newKeySet<String>()
     private val sourceIndexGeneration = AtomicInteger(0)
+    private val analysisStateGeneration = AtomicInteger(0)
     private val enrichmentReady = CompletableFuture<Unit>()
     private val fullKtFileMapLoadLock = Any()
     private val analysisSessionLock = ReentrantReadWriteLock()
+    private val cacheManager = CacheManager(normalizedWorkspaceRoot, envReader = cacheEnvReader)
+    private val fileManifest = FileManifest(normalizedWorkspaceRoot, enabled = cacheManager.isEnabled())
+    private val sourceIndexCache = SourceIndexCache(
+        workspaceRoot = normalizedWorkspaceRoot,
+        enabled = cacheManager.isEnabled(),
+    )
     @Volatile
     private var workspaceRefreshWatcher: WorkspaceRefreshWatcher? = null
     @Volatile
@@ -83,19 +98,20 @@ internal class StandaloneAnalysisSession(
 
     init {
         val workspaceLayout = phasedDiscoveryResult?.initialLayout ?: discoverStandaloneWorkspaceLayout(
-            workspaceRoot = workspaceRoot,
+            workspaceRoot = normalizedWorkspaceRoot,
             sourceRoots = sourceRoots,
             classpathRoots = classpathRoots,
             moduleName = moduleName,
         )
         require(workspaceLayout.sourceModules.isNotEmpty()) {
-            "No source roots were found under ${normalizeStandalonePath(workspaceRoot)}"
+            "No source roots were found under $normalizedWorkspaceRoot"
         }
         applyWorkspaceLayout(workspaceLayout)
 
         val initialAnalysisState = buildAnalysisState()
         sessionStateDisposable = initialAnalysisState.disposable
         session = initialAnalysisState.session
+        analysisStateGeneration.incrementAndGet()
         initializeJvmDecompilerServices()
         sourceModules = initialAnalysisState.sourceModules
         check(sourceModules.isNotEmpty()) {
@@ -132,12 +148,81 @@ internal class StandaloneAnalysisSession(
             )
     }
 
+    fun refreshFileContents(paths: Set<String>): RefreshResult {
+        val normalizedPaths = normalizeTrackedKotlinPaths(paths)
+        if (normalizedPaths.isEmpty()) {
+            return RefreshResult(
+                refreshedFiles = emptyList(),
+                removedFiles = emptyList(),
+                fullRefresh = false,
+            )
+        }
+
+        analysisSessionLock.write {
+            val cachedEntriesByPath = normalizedPaths.associateWith { normalizedPath ->
+                ktFilesByPath[normalizedPath] to targetedKtFilesByPath[normalizedPath]
+            }
+            val virtualFileManager = VirtualFileManager.getInstance()
+            normalizedPaths.forEach { normalizedPath ->
+                val filePath = Path.of(normalizedPath)
+                virtualFileManager.refreshAndFindFileByNioPath(filePath)
+            }
+            val fileManager = PsiManagerEx.getInstanceEx(session.project).fileManager
+            val cachedVirtualFilesToInvalidate = normalizedPaths.asSequence()
+                .flatMap { normalizedPath ->
+                    cachedEntriesByPath.getValue(normalizedPath)
+                        .toList()
+                        .filterNotNull()
+                        .mapNotNull { ktFile -> ktFile.virtualFile }
+                        .asSequence()
+                }
+                .distinct()
+                .toList()
+            if (cachedVirtualFilesToInvalidate.isNotEmpty()) {
+                ApplicationManager.getApplication().runWriteAction {
+                    cachedVirtualFilesToInvalidate.forEach { virtualFile ->
+                        fileManager.setViewProvider(virtualFile, null)
+                    }
+                }
+                PsiManager.getInstance(session.project).dropResolveCaches()
+            }
+
+            normalizedPaths.forEach { normalizedPath ->
+                val (cachedKtFile, cachedTargetedKtFile) = cachedEntriesByPath.getValue(normalizedPath)
+                val hadKtFileEntry = cachedKtFile != null
+                val hadTargetedEntry = cachedTargetedKtFile != null
+                ktFilesByPath.remove(normalizedPath)
+                targetedKtFilesByPath.remove(normalizedPath)
+                ktFileLastModifiedMillisByPath.remove(normalizedPath)
+                if (!Files.isRegularFile(Path.of(normalizedPath))) {
+                    return@forEach
+                }
+                if (!fullKtFileMapLoaded && !hadKtFileEntry && !hadTargetedEntry) {
+                    return@forEach
+                }
+
+                if (fullKtFileMapLoaded || hadKtFileEntry) {
+                    val refreshedKtFile = loadKtFileByPath(normalizedPath)
+                    if (refreshedKtFile != null) {
+                        ktFilesByPath[normalizedPath] = refreshedKtFile
+                    }
+                }
+                if (fullKtFileMapLoaded || hadTargetedEntry) {
+                    val refreshedTargetedKtFile = loadKtFileByPath(normalizedPath)
+                    if (refreshedTargetedKtFile != null) {
+                        targetedKtFilesByPath[normalizedPath] = refreshedTargetedKtFile
+                    }
+                }
+            }
+        }
+
+        refreshSourceIdentifierIndex(normalizedPaths)
+        targetedCandidatePathsByLookupKey.clear()
+        return buildRefreshResult(normalizedPaths, fullRefresh = false)
+    }
+
     fun refreshFiles(paths: Set<String>): RefreshResult {
-        val normalizedPaths = paths.asSequence()
-            .map { path -> normalizePath(Path.of(path)).toString() }
-            .distinct()
-            .filter { normalizedPath -> isTrackedKotlinFilePath(Path.of(normalizedPath)) }
-            .toList()
+        val normalizedPaths = normalizeTrackedKotlinPaths(paths)
         if (normalizedPaths.isEmpty()) {
             return RefreshResult(
                 refreshedFiles = emptyList(),
@@ -151,43 +236,29 @@ internal class StandaloneAnalysisSession(
                 VirtualFileManager.getInstance().refreshAndFindFileByNioPath(Path.of(normalizedPath))
             }
 
-            val previousSessionDisposable = sessionStateDisposable
-            val rebuiltAnalysisState = buildAnalysisState()
-            session = rebuiltAnalysisState.session
-            sourceModules = rebuiltAnalysisState.sourceModules
-            sessionStateDisposable = rebuiltAnalysisState.disposable
-            targetedKtFilesByPath.clear()
-            ktFilesByPath.clear()
-            fullKtFileMapLoaded = false
+            refreshStructureLocked()
 
             normalizedPaths.forEach { normalizedPath ->
                 val refreshedFile = loadKtFileByPath(
                     normalizedPath = normalizedPath,
-                    analysisSession = rebuiltAnalysisState.session,
+                    analysisSession = session,
                 )
                 if (refreshedFile != null) {
                     targetedKtFilesByPath[normalizedPath] = refreshedFile
                     ktFilesByPath[normalizedPath] = refreshedFile
                 }
             }
-
-            Disposer.dispose(previousSessionDisposable)
         }
 
-        sourceIdentifierIndex.get()?.let { index ->
-            normalizedPaths.forEach { normalizedPath ->
-                refreshSourceIdentifierIndex(index, normalizedPath)
-            }
-        } ?: pendingSourceIndexRefreshPaths.addAll(normalizedPaths)
+        refreshSourceIdentifierIndex(normalizedPaths)
         targetedCandidatePathsByLookupKey.clear()
-        return RefreshResult(
-            refreshedFiles = normalizedPaths.filter { normalizedPath -> Files.isRegularFile(Path.of(normalizedPath)) }.sorted(),
-            removedFiles = normalizedPaths.filterNot { normalizedPath -> Files.isRegularFile(Path.of(normalizedPath)) }.sorted(),
-            fullRefresh = false,
-        )
+        return buildRefreshResult(normalizedPaths, fullRefresh = false)
     }
 
-    fun refreshWorkspace(): RefreshResult {
+    fun refreshWorkspace(invalidateCaches: Boolean = false): RefreshResult {
+        if (invalidateCaches) {
+            cacheManager.invalidateAll()
+        }
         val currentPaths = allTrackedKotlinSourcePaths()
         val knownPaths = buildSet {
             addAll(ktFilesByPath.keys)
@@ -207,6 +278,8 @@ internal class StandaloneAnalysisSession(
     internal fun awaitInitialSourceIndex() {
         initialSourceIndexReady.join()
     }
+
+    internal fun currentAnalysisStateGeneration(): Int = analysisStateGeneration.get()
 
     fun isEnrichmentComplete(): Boolean = enrichmentComplete
 
@@ -263,6 +336,12 @@ internal class StandaloneAnalysisSession(
 
     override fun close() {
         closed = true
+        sourceIdentifierIndex.get()?.let { index ->
+            runCatching {
+                sourceIndexCache.save(index = index, sourceRoots = resolvedSourceRoots)
+            }
+        }
+        cacheManager.close()
         workspaceRefreshWatcher = null
         if (!enrichmentReady.isDone) {
             enrichmentReady.complete(Unit)
@@ -273,7 +352,9 @@ internal class StandaloneAnalysisSession(
     private fun applyWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {
         sourceModuleSpecs = workspaceLayout.sourceModules
         workspaceDiagnostics = workspaceLayout.diagnostics.warnings
-        dependentModuleNamesBySourceModuleName = buildDependentModuleNamesBySourceModuleName(sourceModuleSpecs)
+        dependentModuleNamesBySourceModuleName = workspaceLayout.dependentModuleNamesBySourceModuleName
+            .takeIf { it.isNotEmpty() }
+            ?: buildDependentModuleNamesBySourceModuleName(sourceModuleSpecs)
         resolvedSourceRoots = workspaceLayout.sourceModules
             .flatMap { module -> module.sourceRoots }
             .distinct()
@@ -324,10 +405,12 @@ internal class StandaloneAnalysisSession(
             applyWorkspaceLayout(workspaceLayout)
             val rebuiltAnalysisState = buildAnalysisState()
             session = rebuiltAnalysisState.session
+            analysisStateGeneration.incrementAndGet()
             sourceModules = rebuiltAnalysisState.sourceModules
             sessionStateDisposable = rebuiltAnalysisState.disposable
             targetedKtFilesByPath.clear()
             ktFilesByPath.clear()
+            ktFileLastModifiedMillisByPath.clear()
             targetedCandidatePathsByLookupKey.clear()
             sourceIdentifierIndex.set(null)
             initialSourceIndexReady = CompletableFuture()
@@ -418,22 +501,19 @@ internal class StandaloneAnalysisSession(
 
     private fun loadKtFilesByPath(analysisSession: StandaloneAnalysisAPISession): Map<String, KtFile> {
         val loadedFiles = linkedMapOf<String, KtFile>()
-
-        resolvedSourceRoots.forEach { sourceRoot ->
-            if (!Files.isDirectory(sourceRoot)) {
-                return@forEach
+        val currentPathsByLastModifiedMillis = fileManifest.snapshot(resolvedSourceRoots).currentPathsByLastModifiedMillis
+        currentPathsByLastModifiedMillis.forEach { (normalizedPath, lastModifiedMillis) ->
+            val cachedKtFile = ktFilesByPath[normalizedPath]
+            if (cachedKtFile != null && ktFileLastModifiedMillisByPath[normalizedPath] == lastModifiedMillis) {
+                loadedFiles[normalizedPath] = cachedKtFile
+            } else {
+                loadKtFileByPath(normalizedPath, analysisSession)?.let { ktFile ->
+                    loadedFiles[normalizedPath] = ktFile
+                }
             }
-
-            Files.walk(sourceRoot).use { paths ->
-                paths
-                    .filter { path -> Files.isRegularFile(path) && path.extension == "kt" }
-                    .forEach { file ->
-                        val normalizedPath = normalizePath(file).toString()
-                        loadKtFileByPath(normalizedPath, analysisSession)?.let { ktFile ->
-                            loadedFiles[normalizedPath] = ktFile
-                        }
-                    }
-            }
+        }
+        (ktFileLastModifiedMillisByPath.keys - currentPathsByLastModifiedMillis.keys).forEach { removedPath ->
+            ktFileLastModifiedMillisByPath.remove(removedPath)
         }
 
         return loadedFiles
@@ -450,7 +530,7 @@ internal class StandaloneAnalysisSession(
         analysisSession: StandaloneAnalysisAPISession,
     ): KtFile? {
         val filePath = Path.of(normalizedPath)
-        if (!isTrackedKotlinFilePath(filePath)) {
+        if (!isTrackedKotlinFilePath(filePath) || !Files.isRegularFile(filePath)) {
             return null
         }
 
@@ -458,8 +538,9 @@ internal class StandaloneAnalysisSession(
             ?: VirtualFileManager.getInstance().refreshAndFindFileByNioPath(filePath)
             ?: return null
 
-        return PsiManager.getInstance(analysisSession.project)
-            .findFile(virtualFile) as? KtFile
+        return (PsiManager.getInstance(analysisSession.project)
+            .findFile(virtualFile) as? KtFile)
+            ?.also { ktFileLastModifiedMillisByPath[normalizedPath] = Files.getLastModifiedTime(filePath).toMillis() }
     }
 
     private fun buildAnalysisState(): AnalysisState {
@@ -520,6 +601,12 @@ internal class StandaloneAnalysisSession(
         return filePath.extension == "kt" && resolvedSourceRoots.any(filePath::startsWith)
     }
 
+    internal fun refreshStructure() {
+        analysisSessionLock.write {
+            refreshStructureLocked()
+        }
+    }
+
     private fun startInitialSourceIndex() {
         val generation = sourceIndexGeneration.incrementAndGet()
         val readiness = initialSourceIndexReady
@@ -532,7 +619,7 @@ internal class StandaloneAnalysisSession(
                 initialSourceIndexBuilder
                     ?.invoke()
                     ?.let(MutableSourceIdentifierIndex::fromCandidatePathsByIdentifier)
-                    ?: buildSourceIdentifierIndex()
+                    ?: loadOrBuildSourceIdentifierIndex()
             }
                 .onSuccess { builtIndex ->
                     if (closed || sourceIndexGeneration.get() != generation) {
@@ -540,6 +627,7 @@ internal class StandaloneAnalysisSession(
                     }
                     applyPendingSourceIndexRefreshes(builtIndex)
                     sourceIdentifierIndex.set(builtIndex)
+                    persistSourceIndexCache(generation, builtIndex)
                     readiness.complete(Unit)
                 }
                 .onFailure { error ->
@@ -551,28 +639,31 @@ internal class StandaloneAnalysisSession(
         }
     }
 
+    private fun loadOrBuildSourceIdentifierIndex(): MutableSourceIdentifierIndex {
+        val incrementalIndex = runCatching {
+            sourceIndexCache.load(resolvedSourceRoots)
+        }.getOrNull()
+        val index = incrementalIndex?.index ?: return buildSourceIdentifierIndex()
+        incrementalIndex.deletedPaths.forEach(index::removeFile)
+        (incrementalIndex.newPaths + incrementalIndex.modifiedPaths).forEach { normalizedPath ->
+            refreshSourceIdentifierIndex(index, normalizedPath)
+        }
+        return index
+    }
+
     private fun buildSourceIdentifierIndex(): MutableSourceIdentifierIndex {
         val candidatePathsByIdentifier = ConcurrentHashMap<String, MutableSet<String>>()
         val identifiersByPath = ConcurrentHashMap<String, Set<String>>()
 
-        resolvedSourceRoots.forEach { sourceRoot ->
-            if (!Files.isDirectory(sourceRoot)) {
-                return@forEach
-            }
-
-            Files.walk(sourceRoot).use { paths ->
-                paths
-                    .filter { path -> Files.isRegularFile(path) && path.extension == "kt" }
-                    .forEach { file ->
-                        val normalizedFilePath = normalizePath(file).toString()
-                        val identifiers = identifierRegex.findAll(Files.readString(file)).map { match -> match.value }.toSet()
-                        identifiersByPath[normalizedFilePath] = identifiers
-                        identifiers.forEach { identifier ->
-                            candidatePathsByIdentifier
-                                .computeIfAbsent(identifier) { ConcurrentHashMap.newKeySet() }
-                                .add(normalizedFilePath)
-                        }
-                    }
+        allTrackedKotlinSourcePaths().forEach { normalizedFilePath ->
+            val identifiers = identifierRegex.findAll(sourceIndexFileReader(Path.of(normalizedFilePath)))
+                .map { match -> match.value }
+                .toSet()
+            identifiersByPath[normalizedFilePath] = identifiers
+            identifiers.forEach { identifier ->
+                candidatePathsByIdentifier
+                    .computeIfAbsent(identifier) { ConcurrentHashMap.newKeySet() }
+                    .add(normalizedFilePath)
             }
         }
 
@@ -599,22 +690,20 @@ internal class StandaloneAnalysisSession(
             return
         }
 
-        index.updateFile(normalizedPath, Files.readString(filePath))
+        index.updateFile(normalizedPath, sourceIndexFileReader(filePath))
     }
 
-    private fun allTrackedKotlinSourcePaths(): Set<String> = buildSet {
-        resolvedSourceRoots.forEach { sourceRoot ->
-            if (!Files.isDirectory(sourceRoot)) {
-                return@forEach
+    private fun refreshSourceIdentifierIndex(normalizedPaths: List<String>) {
+        sourceIdentifierIndex.get()?.let { index ->
+            normalizedPaths.forEach { normalizedPath ->
+                refreshSourceIdentifierIndex(index, normalizedPath)
             }
-
-            Files.walk(sourceRoot).use { paths ->
-                paths
-                    .filter { path -> Files.isRegularFile(path) && path.extension == "kt" }
-                    .forEach { file -> add(normalizePath(file).toString()) }
-            }
-        }
+            scheduleSourceIndexCacheWrite()
+        } ?: pendingSourceIndexRefreshPaths.addAll(normalizedPaths)
     }
+
+    private fun allTrackedKotlinSourcePaths(): Set<String> =
+        fileManifest.snapshot(resolvedSourceRoots).currentPathsByLastModifiedMillis.keys
 
     private fun buildTargetedCandidatePaths(identifier: String): List<String> = buildList {
         resolvedSourceRoots.forEach { sourceRoot ->
@@ -710,8 +799,62 @@ internal class StandaloneAnalysisSession(
         return runCatching { normalizePath(Path.of(location.toURI())) }.getOrNull()
     }
 
+    private fun normalizeTrackedKotlinPaths(paths: Set<String>): List<String> = paths.asSequence()
+        .map { path -> normalizePath(Path.of(path)).toString() }
+        .distinct()
+        .filter { normalizedPath -> isTrackedKotlinFilePath(Path.of(normalizedPath)) }
+        .toList()
+
+    private fun buildRefreshResult(
+        normalizedPaths: List<String>,
+        fullRefresh: Boolean,
+    ): RefreshResult = RefreshResult(
+        refreshedFiles = normalizedPaths.filter { normalizedPath -> Files.isRegularFile(Path.of(normalizedPath)) }.sorted(),
+        removedFiles = normalizedPaths.filterNot { normalizedPath -> Files.isRegularFile(Path.of(normalizedPath)) }.sorted(),
+        fullRefresh = fullRefresh,
+    )
+
+    private fun refreshStructureLocked() {
+        val previousSessionDisposable = sessionStateDisposable
+        val rebuiltAnalysisState = buildAnalysisState()
+        session = rebuiltAnalysisState.session
+        analysisStateGeneration.incrementAndGet()
+        sourceModules = rebuiltAnalysisState.sourceModules
+        sessionStateDisposable = rebuiltAnalysisState.disposable
+        targetedKtFilesByPath.clear()
+        ktFilesByPath.clear()
+        ktFileLastModifiedMillisByPath.clear()
+        targetedCandidatePathsByLookupKey.clear()
+        fullKtFileMapLoaded = false
+        Disposer.dispose(previousSessionDisposable)
+    }
+
     private fun normalizePath(path: Path): Path {
         return normalizeStandalonePath(path)
+    }
+
+    private fun scheduleSourceIndexCacheWrite() {
+        val generation = sourceIndexGeneration.get()
+        cacheManager.schedule(
+            key = "source-index-cache",
+            delayMillis = sourceIndexCacheSaveDelayMillis,
+        ) {
+            sourceIdentifierIndex.get()?.let { index ->
+                persistSourceIndexCache(generation, index)
+            }
+        }
+    }
+
+    private fun persistSourceIndexCache(
+        generation: Int,
+        index: MutableSourceIdentifierIndex,
+    ) {
+        if (closed || sourceIndexGeneration.get() != generation) {
+            return
+        }
+        runCatching {
+            sourceIndexCache.save(index = index, sourceRoots = resolvedSourceRoots)
+        }
     }
 }
 
@@ -727,6 +870,13 @@ internal class MutableSourceIdentifierIndex(
 ) {
     fun candidatePathsFor(identifier: String): List<String> =
         pathsByIdentifier[identifier]?.toList()?.sorted().orEmpty()
+
+    fun toSerializableMap(): Map<String, List<String>> = pathsByIdentifier.entries
+        .asSequence()
+        .sortedBy(Map.Entry<String, MutableSet<String>>::key)
+        .associate { (identifier, paths) ->
+            identifier to paths.toList().sorted()
+        }
 
     fun updateFile(
         normalizedPath: String,
@@ -793,6 +943,8 @@ private data class CandidateLookupKey(
     val anchorSourceModuleName: String?,
 )
 
+private const val defaultSourceIndexCacheSaveDelayMillis = 5_000L
+
 private val identifierRegex = Regex("""\b[A-Za-z_][A-Za-z0-9_]*\b""")
 
 private fun String.isIndexableIdentifier(): Boolean = identifierRegex.matches(this)
@@ -819,7 +971,7 @@ private fun String.identifierOccurrenceOffsets(identifier: String): Sequence<Int
 
 private fun Char.isKastIdentifierPart(): Boolean = this == '_' || isLetterOrDigit()
 
-private fun buildDependentModuleNamesBySourceModuleName(
+internal fun buildDependentModuleNamesBySourceModuleName(
     sourceModules: List<StandaloneSourceModuleSpec>,
 ): Map<String, Set<String>> {
     val reverseDependencies = linkedMapOf<String, MutableSet<String>>()
@@ -847,6 +999,7 @@ private fun buildDependentModuleNamesBySourceModuleName(
 internal data class StandaloneWorkspaceLayout(
     val sourceModules: List<StandaloneSourceModuleSpec>,
     val diagnostics: WorkspaceDiscoveryDiagnostics = WorkspaceDiscoveryDiagnostics(),
+    val dependentModuleNamesBySourceModuleName: Map<String, Set<String>> = emptyMap(),
 )
 
 internal data class StandaloneSourceModuleSpec(
@@ -921,7 +1074,21 @@ internal fun discoverStandaloneWorkspaceLayoutPhased(
 
 internal fun normalizeStandalonePath(path: Path): Path {
     val absolutePath = path.toAbsolutePath().normalize()
-    return runCatching { absolutePath.toRealPath().normalize() }.getOrDefault(absolutePath)
+    return runCatching { absolutePath.toRealPath().normalize() }
+        .getOrElse {
+            normalizeStandaloneMissingPath(absolutePath)
+        }
+}
+
+private fun normalizeStandaloneMissingPath(path: Path): Path {
+    var existingAncestor: Path? = path.parent
+    while (existingAncestor != null && !Files.exists(existingAncestor)) {
+        existingAncestor = existingAncestor.parent
+    }
+    val normalizedAncestor = existingAncestor
+        ?.let { ancestor -> runCatching { ancestor.toRealPath().normalize() }.getOrDefault(ancestor) }
+        ?: return path
+    return normalizedAncestor.resolve(existingAncestor.relativize(path)).normalize()
 }
 
 internal fun normalizeStandaloneModelPath(path: Path): Path = path.toAbsolutePath().normalize()

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -32,11 +32,14 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.collections.asSequence
+import kotlin.collections.associate
 import kotlin.concurrent.thread
 import kotlin.concurrent.read
 import kotlin.concurrent.write
 import kotlin.io.path.extension
 
+@Suppress("UnstableApiUsage")
 internal class StandaloneAnalysisSession(
     workspaceRoot: Path,
     sourceRoots: List<Path>,
@@ -368,10 +371,9 @@ internal class StandaloneAnalysisSession(
         if (enrichmentFuture == null) {
             enrichmentComplete = true
             enrichmentReady.complete(Unit)
-    private fun rebuildWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {
-        analysisSessionLock.write {
-            val previousSessionDisposable = sessionStateDisposable
+            return
         }
+
 
         enrichmentFuture.whenComplete { enrichedLayout, error ->
             if (closed) {
@@ -404,15 +406,7 @@ internal class StandaloneAnalysisSession(
         val previousSessionDisposable = sessionStateDisposable
         analysisSessionLock.write {
             applyWorkspaceLayout(workspaceLayout)
-            val rebuiltAnalysisState = buildAnalysisState()
-            session = rebuiltAnalysisState.session
-            analysisStateGeneration.incrementAndGet()
-            sourceModules = rebuiltAnalysisState.sourceModules
-            sessionStateDisposable = rebuiltAnalysisState.disposable
-            targetedKtFilesByPath.clear()
-            ktFilesByPath.clear()
-            ktFileLastModifiedMillisByPath.clear()
-            targetedCandidatePathsByLookupKey.clear()
+            buildAnalysisStateAndCache()
             sourceIdentifierIndex.set(null)
             initialSourceIndexReady = CompletableFuture()
             fullKtFileMapLoaded = false
@@ -817,6 +811,12 @@ internal class StandaloneAnalysisSession(
 
     private fun refreshStructureLocked() {
         val previousSessionDisposable = sessionStateDisposable
+        buildAnalysisStateAndCache()
+        fullKtFileMapLoaded = false
+        Disposer.dispose(previousSessionDisposable)
+    }
+
+    private fun buildAnalysisStateAndCache() {
         val rebuiltAnalysisState = buildAnalysisState()
         session = rebuiltAnalysisState.session
         analysisStateGeneration.incrementAndGet()
@@ -826,8 +826,6 @@ internal class StandaloneAnalysisSession(
         ktFilesByPath.clear()
         ktFileLastModifiedMillisByPath.clear()
         targetedCandidatePathsByLookupKey.clear()
-        fullKtFileMapLoaded = false
-        Disposer.dispose(previousSessionDisposable)
     }
 
     private fun normalizePath(path: Path): Path {

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -403,8 +403,8 @@ internal class StandaloneAnalysisSession(
     }
 
     private fun rebuildWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {
-        val previousSessionDisposable = sessionStateDisposable
         analysisSessionLock.write {
+            val previousSessionDisposable = sessionStateDisposable
             applyWorkspaceLayout(workspaceLayout)
             buildAnalysisStateAndCache()
             sourceIdentifierIndex.set(null)

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -368,7 +368,9 @@ internal class StandaloneAnalysisSession(
         if (enrichmentFuture == null) {
             enrichmentComplete = true
             enrichmentReady.complete(Unit)
-            return
+    private fun rebuildWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {
+        analysisSessionLock.write {
+            val previousSessionDisposable = sessionStateDisposable
         }
 
         enrichmentFuture.whenComplete { enrichedLayout, error ->

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -395,7 +395,9 @@ internal class StandaloneAnalysisSession(
             enrichmentComplete = true
             enrichmentReady.complete(Unit)
             workspaceRefreshWatcher?.refreshSourceRoots(resolvedSourceRoots)
-        }
+    private fun rebuildWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {
+        analysisSessionLock.write {
+            val previousSessionDisposable = sessionStateDisposable
     }
 
     private fun rebuildWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -201,16 +201,15 @@ internal class StandaloneAnalysisSession(
                     return@forEach
                 }
 
-                if (fullKtFileMapLoaded || hadKtFileEntry) {
+                if (fullKtFileMapLoaded || hadKtFileEntry || hadTargetedEntry) {
                     val refreshedKtFile = loadKtFileByPath(normalizedPath)
                     if (refreshedKtFile != null) {
-                        ktFilesByPath[normalizedPath] = refreshedKtFile
-                    }
-                }
-                if (fullKtFileMapLoaded || hadTargetedEntry) {
-                    val refreshedTargetedKtFile = loadKtFileByPath(normalizedPath)
-                    if (refreshedTargetedKtFile != null) {
-                        targetedKtFilesByPath[normalizedPath] = refreshedTargetedKtFile
+                        if (fullKtFileMapLoaded || hadKtFileEntry) {
+                            ktFilesByPath[normalizedPath] = refreshedKtFile
+                        }
+                        if (fullKtFileMapLoaded || hadTargetedEntry) {
+                            targetedKtFilesByPath[normalizedPath] = refreshedKtFile
+                        }
                     }
                 }
             }

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -27,43 +27,62 @@ import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantReadWriteLock
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.concurrent.read
 import kotlin.concurrent.write
 import kotlin.io.path.extension
 
-class StandaloneAnalysisSession(
+internal class StandaloneAnalysisSession(
     workspaceRoot: Path,
     sourceRoots: List<Path>,
     classpathRoots: List<Path>,
     moduleName: String,
     private val initialSourceIndexBuilder: (() -> Map<String, List<String>>)? = null,
+    private val phasedDiscoveryResult: PhasedDiscoveryResult? = null,
 ) : AutoCloseable {
     private val disposable: Disposable = Disposer.newDisposable("kast-standalone")
     private val ktFilesByPath = ConcurrentHashMap<String, KtFile>()
     private val targetedKtFilesByPath = ConcurrentHashMap<String, KtFile>()
     private val targetedCandidatePathsByLookupKey = ConcurrentHashMap<CandidateLookupKey, List<String>>()
     private val sourceIdentifierIndex = AtomicReference<MutableSourceIdentifierIndex?>(null)
-    private val initialSourceIndexReady = CompletableFuture<Unit>()
+    @Volatile
+    private var initialSourceIndexReady = CompletableFuture<Unit>()
     private val pendingSourceIndexRefreshPaths = ConcurrentHashMap.newKeySet<String>()
+    private val sourceIndexGeneration = AtomicInteger(0)
+    private val enrichmentReady = CompletableFuture<Unit>()
     private val fullKtFileMapLoadLock = Any()
     private val analysisSessionLock = ReentrantReadWriteLock()
     @Volatile
+    private var workspaceRefreshWatcher: WorkspaceRefreshWatcher? = null
+    @Volatile
+    private var enrichmentComplete = false
+    @Volatile
+    private var closed = false
+    @Volatile
     private var fullKtFileMapLoaded = false
 
-    private val sourceModuleSpecs: List<StandaloneSourceModuleSpec>
-    private val dependentModuleNamesBySourceModuleName: Map<String, Set<String>>
-    lateinit var sourceModules: List<KaSourceModule>
+    @Volatile
+    private var sourceModuleSpecs: List<StandaloneSourceModuleSpec> = emptyList()
+    @Volatile
+    private var dependentModuleNamesBySourceModuleName: Map<String, Set<String>> = emptyMap()
+    @Volatile
+    var sourceModules: List<KaSourceModule> = emptyList()
         private set
-    val resolvedSourceRoots: List<Path>
-    val workspaceDiagnostics: List<String>
-    private val resolvedClasspathRoots: List<Path>
+    @Volatile
+    var resolvedSourceRoots: List<Path> = emptyList()
+        private set
+    @Volatile
+    var workspaceDiagnostics: List<String> = emptyList()
+        private set
+    @Volatile
+    private var resolvedClasspathRoots: List<Path> = emptyList()
     private lateinit var sessionStateDisposable: Disposable
     private lateinit var session: StandaloneAnalysisAPISession
 
     init {
-        val workspaceLayout = discoverStandaloneWorkspaceLayout(
+        val workspaceLayout = phasedDiscoveryResult?.initialLayout ?: discoverStandaloneWorkspaceLayout(
             workspaceRoot = workspaceRoot,
             sourceRoots = sourceRoots,
             classpathRoots = classpathRoots,
@@ -72,19 +91,7 @@ class StandaloneAnalysisSession(
         require(workspaceLayout.sourceModules.isNotEmpty()) {
             "No source roots were found under ${normalizeStandalonePath(workspaceRoot)}"
         }
-        sourceModuleSpecs = workspaceLayout.sourceModules
-        workspaceDiagnostics = workspaceLayout.diagnostics.warnings
-        dependentModuleNamesBySourceModuleName = buildDependentModuleNamesBySourceModuleName(sourceModuleSpecs)
-
-        resolvedSourceRoots = workspaceLayout.sourceModules
-            .flatMap { module -> module.sourceRoots }
-            .distinct()
-            .sorted()
-        val defaultClasspathRoots = defaultClasspathRoots()
-        resolvedClasspathRoots = (
-            defaultClasspathRoots +
-                workspaceLayout.sourceModules.flatMap { module -> module.binaryRoots }
-        ).distinct().sorted()
+        applyWorkspaceLayout(workspaceLayout)
 
         val initialAnalysisState = buildAnalysisState()
         sessionStateDisposable = initialAnalysisState.disposable
@@ -95,6 +102,7 @@ class StandaloneAnalysisSession(
             "The standalone Analysis API session did not create any source modules"
         }
         startInitialSourceIndex()
+        beginEnrichment(phasedDiscoveryResult?.enrichmentFuture)
     }
 
     fun allKtFiles(): List<KtFile> = analysisSessionLock.read {
@@ -200,6 +208,17 @@ class StandaloneAnalysisSession(
         initialSourceIndexReady.join()
     }
 
+    fun isEnrichmentComplete(): Boolean = enrichmentComplete
+
+    fun awaitEnrichment() {
+        enrichmentReady.join()
+    }
+
+    internal fun attachWorkspaceRefreshWatcher(watcher: WorkspaceRefreshWatcher) {
+        workspaceRefreshWatcher = watcher
+        watcher.refreshSourceRoots(resolvedSourceRoots)
+    }
+
     internal inline fun <T> withReadAccess(action: () -> T): T = analysisSessionLock.read { action() }
 
     internal fun candidateKotlinFilePaths(identifier: String): List<String> {
@@ -243,7 +262,84 @@ class StandaloneAnalysisSession(
     internal fun isFullKtFileMapLoaded(): Boolean = fullKtFileMapLoaded
 
     override fun close() {
+        closed = true
+        workspaceRefreshWatcher = null
+        if (!enrichmentReady.isDone) {
+            enrichmentReady.complete(Unit)
+        }
         Disposer.dispose(disposable)
+    }
+
+    private fun applyWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {
+        sourceModuleSpecs = workspaceLayout.sourceModules
+        workspaceDiagnostics = workspaceLayout.diagnostics.warnings
+        dependentModuleNamesBySourceModuleName = buildDependentModuleNamesBySourceModuleName(sourceModuleSpecs)
+        resolvedSourceRoots = workspaceLayout.sourceModules
+            .flatMap { module -> module.sourceRoots }
+            .distinct()
+            .sorted()
+        resolvedClasspathRoots = (
+            defaultClasspathRoots() +
+                workspaceLayout.sourceModules.flatMap { module -> module.binaryRoots }
+            ).distinct().sorted()
+    }
+
+    private fun beginEnrichment(enrichmentFuture: CompletableFuture<StandaloneWorkspaceLayout>?) {
+        if (enrichmentFuture == null) {
+            enrichmentComplete = true
+            enrichmentReady.complete(Unit)
+            return
+        }
+
+        enrichmentFuture.whenComplete { enrichedLayout, error ->
+            if (closed) {
+                enrichmentComplete = true
+                enrichmentReady.complete(Unit)
+                return@whenComplete
+            }
+            if (error != null) {
+                logSessionEnrichmentWarning(error)
+                enrichmentComplete = true
+                enrichmentReady.complete(Unit)
+                return@whenComplete
+            }
+            if (enrichedLayout == null) {
+                enrichmentComplete = true
+                enrichmentReady.complete(Unit)
+                return@whenComplete
+            }
+
+            runCatching {
+                rebuildWorkspaceLayout(enrichedLayout)
+            }.onFailure(::logSessionEnrichmentWarning)
+            enrichmentComplete = true
+            enrichmentReady.complete(Unit)
+            workspaceRefreshWatcher?.refreshSourceRoots(resolvedSourceRoots)
+        }
+    }
+
+    private fun rebuildWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {
+        val previousSessionDisposable = sessionStateDisposable
+        analysisSessionLock.write {
+            applyWorkspaceLayout(workspaceLayout)
+            val rebuiltAnalysisState = buildAnalysisState()
+            session = rebuiltAnalysisState.session
+            sourceModules = rebuiltAnalysisState.sourceModules
+            sessionStateDisposable = rebuiltAnalysisState.disposable
+            targetedKtFilesByPath.clear()
+            ktFilesByPath.clear()
+            targetedCandidatePathsByLookupKey.clear()
+            sourceIdentifierIndex.set(null)
+            initialSourceIndexReady = CompletableFuture()
+            fullKtFileMapLoaded = false
+            startInitialSourceIndex()
+            Disposer.dispose(previousSessionDisposable)
+        }
+    }
+
+    private fun logSessionEnrichmentWarning(error: Throwable) {
+        val details = error.message?.takeIf(String::isNotBlank) ?: error::class.java.simpleName
+        System.err.println("kast standalone enrichment warning: $details")
     }
 
     /**
@@ -425,6 +521,8 @@ class StandaloneAnalysisSession(
     }
 
     private fun startInitialSourceIndex() {
+        val generation = sourceIndexGeneration.incrementAndGet()
+        val readiness = initialSourceIndexReady
         thread(
             start = true,
             isDaemon = true,
@@ -437,11 +535,19 @@ class StandaloneAnalysisSession(
                     ?: buildSourceIdentifierIndex()
             }
                 .onSuccess { builtIndex ->
+                    if (closed || sourceIndexGeneration.get() != generation) {
+                        return@onSuccess
+                    }
                     applyPendingSourceIndexRefreshes(builtIndex)
                     sourceIdentifierIndex.set(builtIndex)
-                    initialSourceIndexReady.complete(Unit)
+                    readiness.complete(Unit)
                 }
-                .onFailure(initialSourceIndexReady::completeExceptionally)
+                .onFailure { error ->
+                    if (closed || sourceIndexGeneration.get() != generation) {
+                        return@onFailure
+                    }
+                    readiness.completeExceptionally(error)
+                }
         }
     }
 
@@ -785,6 +891,31 @@ internal fun discoverStandaloneWorkspaceLayout(
                 dependencyModuleNames = emptyList(),
             ),
         ),
+    )
+}
+
+internal fun discoverStandaloneWorkspaceLayoutPhased(
+    workspaceRoot: Path,
+    sourceRoots: List<Path>,
+    classpathRoots: List<Path>,
+    moduleName: String,
+): PhasedDiscoveryResult {
+    val normalizedWorkspaceRoot = normalizeStandalonePath(workspaceRoot)
+    if (sourceRoots.isNotEmpty() || !looksLikeGradleWorkspace(normalizedWorkspaceRoot)) {
+        return PhasedDiscoveryResult(
+            initialLayout = discoverStandaloneWorkspaceLayout(
+                workspaceRoot = normalizedWorkspaceRoot,
+                sourceRoots = sourceRoots,
+                classpathRoots = classpathRoots,
+                moduleName = moduleName,
+            ),
+            enrichmentFuture = null,
+        )
+    }
+
+    return GradleWorkspaceDiscovery.discoverPhased(
+        workspaceRoot = normalizedWorkspaceRoot,
+        extraClasspathRoots = normalizeStandalonePaths(classpathRoots),
     )
 }
 

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -395,9 +395,7 @@ internal class StandaloneAnalysisSession(
             enrichmentComplete = true
             enrichmentReady.complete(Unit)
             workspaceRefreshWatcher?.refreshSourceRoots(resolvedSourceRoots)
-    private fun rebuildWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {
-        analysisSessionLock.write {
-            val previousSessionDisposable = sessionStateDisposable
+        }
     }
 
     private fun rebuildWorkspaceLayout(workspaceLayout: StandaloneWorkspaceLayout) {

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneRuntime.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneRuntime.kt
@@ -6,7 +6,7 @@ import io.github.amichne.kast.server.AnalysisServer
 import io.github.amichne.kast.server.AnalysisServerConfig
 import io.github.amichne.kast.server.RunningAnalysisServer
 
-class RunningStandaloneRuntime(
+internal class RunningStandaloneRuntime(
     val server: RunningAnalysisServer,
     private val session: StandaloneAnalysisSession,
     private val watcher: AutoCloseable,
@@ -23,13 +23,20 @@ class RunningStandaloneRuntime(
 }
 
 object StandaloneRuntime {
-    fun start(options: StandaloneServerOptions): RunningStandaloneRuntime {
+    internal fun start(options: StandaloneServerOptions): RunningStandaloneRuntime {
         System.setProperty("java.awt.headless", "true")
+        val phasedDiscoveryResult = discoverStandaloneWorkspaceLayoutPhased(
+            workspaceRoot = options.workspaceRoot,
+            sourceRoots = options.sourceRoots,
+            classpathRoots = options.classpathRoots,
+            moduleName = options.moduleName,
+        )
         val session = StandaloneAnalysisSession(
             workspaceRoot = options.workspaceRoot,
             sourceRoots = options.sourceRoots,
             classpathRoots = options.classpathRoots,
             moduleName = options.moduleName,
+            phasedDiscoveryResult = phasedDiscoveryResult,
         )
         val backend = StandaloneAnalysisBackend(
             workspaceRoot = options.workspaceRoot,
@@ -41,6 +48,7 @@ object StandaloneRuntime {
             session = session,
         )
         val watcher = WorkspaceRefreshWatcher(session)
+        session.attachWorkspaceRefreshWatcher(watcher)
         val server = AnalysisServer(
             backend = backend,
             config = AnalysisServerConfig(

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StaticGradleWorkspaceDiscovery.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StaticGradleWorkspaceDiscovery.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.standalone
 
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
@@ -222,19 +223,50 @@ internal object StaticGradleWorkspaceDiscovery {
 internal fun conventionalGradleSourceRootCandidates(
     projectDirectory: Path,
     sourceSet: GradleSourceSet,
-): List<Path> = when (sourceSet) {
-    GradleSourceSet.MAIN -> listOf(
-        projectDirectory.resolve("src/main/kotlin"),
-        projectDirectory.resolve("src/main/java"),
-    )
-    GradleSourceSet.TEST -> listOf(
-        projectDirectory.resolve("src/test/kotlin"),
-        projectDirectory.resolve("src/test/java"),
-    )
-    GradleSourceSet.TEST_FIXTURES -> listOf(
-        projectDirectory.resolve("src/testFixtures/kotlin"),
-        projectDirectory.resolve("src/testFixtures/java"),
-    )
+): List<Path> = (
+    when (sourceSet) {
+        GradleSourceSet.MAIN -> listOf(
+            projectDirectory.resolve("src/main/kotlin"),
+            projectDirectory.resolve("src/main/java"),
+        )
+        GradleSourceSet.TEST -> listOf(
+            projectDirectory.resolve("src/test/kotlin"),
+            projectDirectory.resolve("src/test/java"),
+        )
+        GradleSourceSet.TEST_FIXTURES -> listOf(
+            projectDirectory.resolve("src/testFixtures/kotlin"),
+            projectDirectory.resolve("src/testFixtures/java"),
+        )
+    } +
+        discoverAdditionalSourceSets(projectDirectory)
+            .filter { (sourceSetName, _) -> mapsToGradleSourceSet(sourceSetName, sourceSet) }
+            .flatMap { (_, roots) -> roots }
+    ).distinct()
+
+internal fun discoverAdditionalSourceSets(projectDirectory: Path): List<Pair<String, List<Path>>> {
+    val sourceDirectory = projectDirectory.resolve("src")
+    if (!sourceDirectory.isDirectory()) {
+        return emptyList()
+    }
+
+    return Files.list(sourceDirectory).use { sourceSetDirectories ->
+        sourceSetDirectories
+            .iterator()
+            .asSequence()
+            .filter(Files::isDirectory)
+            .map { sourceSetDirectory ->
+                val sourceSetName = sourceSetDirectory.fileName.toString()
+                sourceSetName to listOf(
+                    sourceSetDirectory.resolve("kotlin"),
+                    sourceSetDirectory.resolve("java"),
+                ).filter(Path::isDirectory)
+            }
+            .filter { (sourceSetName, roots) ->
+                roots.isNotEmpty() && sourceSetName !in knownGradleSourceSetNames
+            }
+            .sortedBy { (sourceSetName, _) -> sourceSetName }
+            .toList()
+    }
 }
 
 internal fun conventionalGradleOutputRootCandidates(
@@ -259,4 +291,25 @@ internal fun conventionalGradleOutputRootCandidates(
         projectDirectory.resolve("build/classes/kotlin/testFixtures"),
         projectDirectory.resolve("build/resources/testFixtures"),
     )
+}
+
+private val knownGradleSourceSetNames = setOf(
+    GradleSourceSet.MAIN.id,
+    GradleSourceSet.TEST.id,
+    GradleSourceSet.TEST_FIXTURES.id,
+)
+
+private fun mapsToGradleSourceSet(
+    sourceSetName: String,
+    targetSourceSet: GradleSourceSet,
+): Boolean = when (additionalSourceSetScope(sourceSetName)) {
+    GradleDependencyScope.TEST_FIXTURES -> targetSourceSet == GradleSourceSet.TEST_FIXTURES
+    GradleDependencyScope.TEST -> targetSourceSet == GradleSourceSet.TEST
+    else -> targetSourceSet == GradleSourceSet.MAIN
+}
+
+private fun additionalSourceSetScope(sourceSetName: String): GradleDependencyScope = when {
+    sourceSetName.contains("fixture", ignoreCase = true) -> GradleDependencyScope.TEST_FIXTURES
+    sourceSetName.contains("test", ignoreCase = true) -> GradleDependencyScope.TEST
+    else -> GradleDependencyScope.COMPILE
 }

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/WorkspaceDiscoveryCache.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/WorkspaceDiscoveryCache.kt
@@ -1,0 +1,124 @@
+package io.github.amichne.kast.standalone
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+
+private const val workspaceDiscoveryCacheSchemaVersion = 1
+
+private val workspaceDiscoveryCacheJson = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+}
+
+internal class WorkspaceDiscoveryCache(
+    private val enabled: Boolean = !isCacheDisabled(),
+    private val json: Json = workspaceDiscoveryCacheJson,
+) {
+    fun read(workspaceRoot: Path): CachedWorkspaceDiscovery? {
+        if (!enabled) {
+            return null
+        }
+        val normalizedWorkspaceRoot = normalizeStandalonePath(workspaceRoot)
+        val cacheFilePath = workspaceDiscoveryCachePath(normalizedWorkspaceRoot)
+        if (!Files.isRegularFile(cacheFilePath)) {
+            return null
+        }
+
+        val payload = json.decodeFromString<CachedWorkspaceDiscoveryPayload>(Files.readString(cacheFilePath))
+        if (payload.schemaVersion != workspaceDiscoveryCacheSchemaVersion) {
+            return null
+        }
+        if (payload.cacheKey != computeWorkspaceDiscoveryCacheKey(normalizedWorkspaceRoot)) {
+            return null
+        }
+
+        return CachedWorkspaceDiscovery(
+            discoveryResult = payload.discoveryResult,
+            dependentModuleNamesBySourceModuleName = payload.dependentModuleNamesBySourceModuleName
+                .mapValues { (_, moduleNames) -> moduleNames.toSet() },
+        )
+    }
+
+    fun write(
+        workspaceRoot: Path,
+        result: GradleWorkspaceDiscoveryResult,
+    ) {
+        if (!enabled) {
+            return
+        }
+        val normalizedWorkspaceRoot = normalizeStandalonePath(workspaceRoot)
+        val dependentModuleNamesBySourceModuleName = GradleWorkspaceDiscovery
+            .buildStandaloneWorkspaceLayout(
+                gradleModules = result.modules,
+                extraClasspathRoots = emptyList(),
+            )
+            .dependentModuleNamesBySourceModuleName
+            .mapValues { (_, moduleNames) -> moduleNames.toList().sorted() }
+        writeCacheFileAtomically(
+            path = workspaceDiscoveryCachePath(normalizedWorkspaceRoot),
+            payload = json.encodeToString(
+                CachedWorkspaceDiscoveryPayload(
+                    cacheKey = computeWorkspaceDiscoveryCacheKey(normalizedWorkspaceRoot),
+                    discoveryResult = result,
+                    dependentModuleNamesBySourceModuleName = dependentModuleNamesBySourceModuleName,
+                ),
+            ),
+        )
+    }
+}
+
+internal data class CachedWorkspaceDiscovery(
+    val discoveryResult: GradleWorkspaceDiscoveryResult,
+    val dependentModuleNamesBySourceModuleName: Map<String, Set<String>>,
+)
+
+@Serializable
+private data class CachedWorkspaceDiscoveryPayload(
+    val schemaVersion: Int = workspaceDiscoveryCacheSchemaVersion,
+    val cacheKey: String,
+    val discoveryResult: GradleWorkspaceDiscoveryResult,
+    val dependentModuleNamesBySourceModuleName: Map<String, List<String>>,
+)
+
+private fun workspaceDiscoveryCachePath(workspaceRoot: Path): Path =
+    kastCacheDirectory(workspaceRoot).resolve("gradle-workspace.json")
+
+private fun computeWorkspaceDiscoveryCacheKey(workspaceRoot: Path): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    trackedGradleBuildFiles(workspaceRoot).forEach { file ->
+        digest.update(workspaceRoot.relativize(file).toString().replace('\\', '/').toByteArray(StandardCharsets.UTF_8))
+        digest.update(0.toByte())
+        digest.update(Files.readAllBytes(file))
+        digest.update(0.toByte())
+    }
+    return digest.digest().joinToString(separator = "") { byte -> "%02x".format(byte) }
+}
+
+private fun trackedGradleBuildFiles(workspaceRoot: Path): List<Path> {
+    if (!Files.isDirectory(workspaceRoot)) {
+        return emptyList()
+    }
+
+    return Files.walk(workspaceRoot).use { paths ->
+        paths
+            .filter(Files::isRegularFile)
+            .filter { path ->
+                when (path.fileName.toString()) {
+                    "settings.gradle",
+                    "settings.gradle.kts",
+                    "build.gradle",
+                    "build.gradle.kts",
+                    -> true
+                    else -> false
+                }
+            }
+            .toList()
+            .sorted()
+    }
+}

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/WorkspaceDiscoveryCache.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/WorkspaceDiscoveryCache.kt
@@ -5,11 +5,31 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.nio.charset.StandardCharsets
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
 import java.security.MessageDigest
+import java.nio.file.attribute.BasicFileAttributes
 
 private const val workspaceDiscoveryCacheSchemaVersion = 1
+
+private val trackedGradleBuildFileNames = setOf(
+    "settings.gradle",
+    "settings.gradle.kts",
+    "build.gradle",
+    "build.gradle.kts",
+)
+
+private val trackedGradleBuildSkipDirs = setOf(
+    ".git",
+    ".gradle",
+    ".kast",
+    "build",
+    "out",
+    "node_modules",
+    ".idea",
+)
 
 private val workspaceDiscoveryCacheJson = Json {
     encodeDefaults = true
@@ -105,20 +125,27 @@ private fun trackedGradleBuildFiles(workspaceRoot: Path): List<Path> {
         return emptyList()
     }
 
-    return Files.walk(workspaceRoot).use { paths ->
-        paths
-            .filter(Files::isRegularFile)
-            .filter { path ->
-                when (path.fileName.toString()) {
-                    "settings.gradle",
-                    "settings.gradle.kts",
-                    "build.gradle",
-                    "build.gradle.kts",
-                    -> true
-                    else -> false
-                }
+    val trackedFiles = mutableListOf<Path>()
+    Files.walkFileTree(workspaceRoot, object : SimpleFileVisitor<Path>() {
+        override fun preVisitDirectory(
+            dir: Path,
+            attrs: BasicFileAttributes,
+        ): FileVisitResult {
+            if (dir != workspaceRoot && dir.fileName?.toString() in trackedGradleBuildSkipDirs) {
+                return FileVisitResult.SKIP_SUBTREE
             }
-            .toList()
-            .sorted()
-    }
+            return FileVisitResult.CONTINUE
+        }
+
+        override fun visitFile(
+            file: Path,
+            attrs: BasicFileAttributes,
+        ): FileVisitResult {
+            if (attrs.isRegularFile && file.fileName?.toString() in trackedGradleBuildFileNames) {
+                trackedFiles.add(file)
+            }
+            return FileVisitResult.CONTINUE
+        }
+    })
+    return trackedFiles.sorted()
 }

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/WorkspaceRefreshWatcher.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/WorkspaceRefreshWatcher.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.standalone
 
+import io.github.amichne.kast.api.RefreshResult
 import java.nio.file.ClosedWatchServiceException
 import java.nio.file.FileSystems
 import java.nio.file.Files
@@ -16,6 +17,8 @@ import kotlin.io.path.extension
 internal class WorkspaceRefreshWatcher(
     private val session: StandaloneAnalysisSession,
     private val debounceMillis: Long = 200,
+    private val contentRefresh: (Set<String>) -> RefreshResult = session::refreshFileContents,
+    private val fullRefresh: () -> RefreshResult = session::refreshWorkspace,
 ) : AutoCloseable {
     private val watchService: WatchService = FileSystems.getDefault().newWatchService()
     private val directoriesByWatchKey = ConcurrentHashMap<WatchKey, Path>()
@@ -143,9 +146,9 @@ internal class WorkspaceRefreshWatcher(
     ) {
         runCatching {
             if (forceFullRefresh) {
-                session.refreshWorkspace()
+                fullRefresh()
             } else if (changedPaths.isNotEmpty()) {
-                session.refreshFiles(changedPaths)
+                contentRefresh(changedPaths)
             }
         }.onFailure { error ->
             System.err.println(

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/WorkspaceRefreshWatcher.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/WorkspaceRefreshWatcher.kt
@@ -20,6 +20,7 @@ internal class WorkspaceRefreshWatcher(
     private val watchService: WatchService = FileSystems.getDefault().newWatchService()
     private val directoriesByWatchKey = ConcurrentHashMap<WatchKey, Path>()
     private val watchKeysByDirectory = ConcurrentHashMap<Path, WatchKey>()
+    private val sourceRoots = ConcurrentHashMap.newKeySet<Path>()
     @Volatile
     private var closed = false
     private val worker = thread(
@@ -31,7 +32,7 @@ internal class WorkspaceRefreshWatcher(
     }
 
     init {
-        session.resolvedSourceRoots.forEach(::registerDirectoryRecursively)
+        refreshSourceRoots(session.resolvedSourceRoots)
     }
 
     override fun close() {
@@ -110,6 +111,32 @@ internal class WorkspaceRefreshWatcher(
         }
     }
 
+    fun refreshSourceRoots(newSourceRoots: List<Path>) {
+        val normalizedSourceRoots = newSourceRoots
+            .map { sourceRoot -> sourceRoot.toAbsolutePath().normalize() }
+            .toSet()
+        val previousSourceRoots = sourceRoots.toSet()
+        val removedSourceRoots = previousSourceRoots - normalizedSourceRoots
+
+        sourceRoots.clear()
+        sourceRoots.addAll(normalizedSourceRoots)
+
+        (normalizedSourceRoots - previousSourceRoots)
+            .sorted()
+            .forEach(::registerDirectoryRecursively)
+        if (removedSourceRoots.isEmpty()) {
+            return
+        }
+
+        watchKeysByDirectory.entries
+            .filter { (directory, _) ->
+                removedSourceRoots.any(directory::startsWith) &&
+                    normalizedSourceRoots.none(directory::startsWith)
+            }
+            .map { entry -> entry.value }
+            .forEach(::unregister)
+    }
+
     private fun flushPendingChanges(
         changedPaths: Set<String>,
         forceFullRefresh: Boolean,
@@ -160,6 +187,7 @@ internal class WorkspaceRefreshWatcher(
     }
 
     private fun unregister(watchKey: WatchKey) {
+        watchKey.cancel()
         val directory = directoriesByWatchKey.remove(watchKey) ?: return
         watchKeysByDirectory.remove(directory, watchKey)
     }

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/CacheManagerTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/CacheManagerTest.kt
@@ -1,0 +1,193 @@
+package io.github.amichne.kast.standalone
+
+import io.github.amichne.kast.api.RefreshQuery
+import io.github.amichne.kast.api.ServerLimits
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+class CacheManagerTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `cache manager debounces writes`() {
+        val cacheManager = CacheManager(workspaceRoot)
+        val cacheFile = kastCacheDirectory(normalizeStandalonePath(workspaceRoot)).resolve("debounce.txt")
+        val writeCount = AtomicInteger(0)
+
+        repeat(10) {
+            cacheManager.schedule(key = "debounce", delayMillis = 25) {
+                val nextCount = writeCount.incrementAndGet()
+                writeCacheFileAtomically(cacheFile, nextCount.toString())
+            }
+        }
+
+        waitUntil { writeCount.get() == 1 }
+        assertEquals("1", Files.readString(cacheFile))
+        cacheManager.close()
+    }
+
+    @Test
+    fun `cache manager writes atomically`() {
+        val cacheManager = CacheManager(workspaceRoot)
+        val cacheFile = kastCacheDirectory(normalizeStandalonePath(workspaceRoot)).resolve("atomic.txt")
+        val oldPayload = "old"
+        val newPayload = "new".repeat(8_192)
+        val observedPayloads = linkedSetOf<String>()
+        writeCacheFileAtomically(cacheFile, oldPayload)
+
+        val writer = thread(start = true) {
+            cacheManager.runNow {
+                writeCacheFileAtomically(cacheFile, newPayload)
+            }
+        }
+
+        while (writer.isAlive) {
+            observedPayloads += Files.readString(cacheFile)
+        }
+        writer.join()
+        observedPayloads += Files.readString(cacheFile)
+
+        assertTrue(observedPayloads.all { payload -> payload == oldPayload || payload == newPayload })
+        cacheManager.close()
+    }
+
+    @Test
+    fun `KAST_CACHE_DISABLED prevents cache reads and writes`() {
+        createGradleWorkspace()
+        val disabledCacheManager = CacheManager(
+            workspaceRoot = workspaceRoot,
+            envReader = { name -> if (name == "KAST_CACHE_DISABLED") "true" else null },
+        )
+        assertFalse(disabledCacheManager.isEnabled())
+
+        val sourceFile = writeSourceFile("sample/App.kt", "package sample\n\nfun welcome(): String = \"hi\"\n")
+        val sourceIndexCache = SourceIndexCache(
+            workspaceRoot = normalizeStandalonePath(workspaceRoot),
+            enabled = disabledCacheManager.isEnabled(),
+        )
+        sourceIndexCache.save(
+            index = MutableSourceIdentifierIndex.fromCandidatePathsByIdentifier(
+                mapOf("welcome" to listOf(normalizeStandalonePath(sourceFile).toString())),
+            ),
+            sourceRoots = sourceRoots(),
+        )
+        WorkspaceDiscoveryCache(enabled = disabledCacheManager.isEnabled()).write(
+            workspaceRoot = workspaceRoot,
+            result = workspaceDiscoveryResult(),
+        )
+
+        assertFalse(Files.exists(kastCacheDirectory(normalizeStandalonePath(workspaceRoot))))
+        assertNull(sourceIndexCache.load(sourceRoots()))
+        assertNull(WorkspaceDiscoveryCache(enabled = disabledCacheManager.isEnabled()).read(workspaceRoot))
+        disabledCacheManager.close()
+    }
+
+    @Test
+    fun `workspace refresh invalidates all caches`() = runBlocking {
+        createGradleWorkspace()
+        writeSourceFile("sample/App.kt", "package sample\n\nfun welcome(): String = \"hi\"\n")
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = sourceRoots(),
+            classpathRoots = emptyList(),
+            moduleName = "sample",
+        )
+        session.use { session ->
+            session.awaitInitialSourceIndex()
+            WorkspaceDiscoveryCache().write(workspaceRoot, workspaceDiscoveryResult())
+            val cacheDirectory = kastCacheDirectory(normalizeStandalonePath(workspaceRoot))
+            assertTrue(Files.isRegularFile(cacheDirectory.resolve("source-identifier-index.json")))
+            assertTrue(Files.isRegularFile(cacheDirectory.resolve("gradle-workspace.json")))
+
+            val backend = StandaloneAnalysisBackend(
+                workspaceRoot = workspaceRoot,
+                limits = ServerLimits(
+                    maxResults = 100,
+                    requestTimeoutMillis = 30_000,
+                    maxConcurrentRequests = 4,
+                ),
+                session = session,
+            )
+
+            backend.refresh(RefreshQuery(filePaths = emptyList()))
+
+            assertFalse(Files.exists(cacheDirectory.resolve("source-identifier-index.json")))
+            assertFalse(Files.exists(cacheDirectory.resolve("gradle-workspace.json")))
+            assertFalse(Files.exists(cacheDirectory.resolve("file-manifest.json")))
+        }
+    }
+
+    private fun createGradleWorkspace() {
+        writeFile(
+            relativePath = "settings.gradle.kts",
+            content = """
+                rootProject.name = "workspace"
+                include(":app")
+            """.trimIndent() + "\n",
+        )
+        writeFile(relativePath = "app/build.gradle.kts", content = "")
+    }
+
+    private fun workspaceDiscoveryResult(): GradleWorkspaceDiscoveryResult = GradleWorkspaceDiscoveryResult(
+        modules = listOf(
+            GradleModuleModel(
+                gradlePath = ":app",
+                ideaModuleName = ":app",
+                mainSourceRoots = listOf(normalizeStandalonePath(workspaceRoot.resolve("src/main/kotlin"))),
+                testSourceRoots = emptyList(),
+                mainOutputRoots = emptyList(),
+                testOutputRoots = emptyList(),
+                dependencies = emptyList(),
+            ),
+        ),
+    )
+
+    private fun sourceRoots(): List<Path> = listOf(normalizeStandalonePath(workspaceRoot.resolve("src/main/kotlin")))
+
+    private fun writeSourceFile(
+        relativePath: String,
+        content: String,
+    ): Path {
+        val file = workspaceRoot.resolve("src/main/kotlin").resolve(relativePath)
+        file.parent.createDirectories()
+        file.writeText(content)
+        return file
+    }
+
+    private fun writeFile(
+        relativePath: String,
+        content: String,
+    ): Path {
+        val file = workspaceRoot.resolve(relativePath)
+        file.parent.createDirectories()
+        file.writeText(content)
+        return file
+    }
+
+    private fun waitUntil(
+        timeoutMillis: Long = 5_000,
+        pollMillis: Long = 25,
+        condition: () -> Boolean,
+    ) {
+        val deadline = System.nanoTime() + timeoutMillis * 1_000_000
+        while (System.nanoTime() < deadline) {
+            if (condition()) {
+                return
+            }
+            Thread.sleep(pollMillis)
+        }
+        error("Condition was not met within ${timeoutMillis}ms")
+    }
+}

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/FileManifestTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/FileManifestTest.kt
@@ -1,0 +1,102 @@
+package io.github.amichne.kast.standalone
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.FileTime
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+class FileManifestTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `file manifest detects new files`() {
+        val existingFile = writeSourceFile("sample/App.kt", "package sample\n\nfun welcome(): String = \"hi\"\n")
+        val fileManifest = FileManifest(normalizeStandalonePath(workspaceRoot))
+        fileManifest.save(scanTrackedKotlinFileTimestamps(sourceRoots()))
+
+        val newFile = writeSourceFile("sample/NewFile.kt", "package sample\n\nfun salute(): String = \"hello\"\n")
+        bumpLastModified(newFile)
+
+        val snapshot = fileManifest.snapshot(sourceRoots())
+        assertEquals(listOf(normalizeStandalonePath(newFile).toString()), snapshot.newPaths)
+        assertTrue(snapshot.modifiedPaths.isEmpty())
+        assertTrue(snapshot.deletedPaths.isEmpty())
+        assertTrue(snapshot.currentPathsByLastModifiedMillis.containsKey(normalizeStandalonePath(existingFile).toString()))
+    }
+
+    @Test
+    fun `file manifest detects deleted files`() {
+        val file = writeSourceFile("sample/App.kt", "package sample\n\nfun welcome(): String = \"hi\"\n")
+        val fileManifest = FileManifest(normalizeStandalonePath(workspaceRoot))
+        fileManifest.save(scanTrackedKotlinFileTimestamps(sourceRoots()))
+
+        Files.delete(file)
+
+        val snapshot = fileManifest.snapshot(sourceRoots())
+        assertEquals(listOf(normalizeStandalonePath(file).toString()), snapshot.deletedPaths)
+        assertTrue(snapshot.newPaths.isEmpty())
+        assertTrue(snapshot.modifiedPaths.isEmpty())
+    }
+
+    @Test
+    fun `file manifest detects modified files`() {
+        val file = writeSourceFile("sample/App.kt", "package sample\n\nfun welcome(): String = \"hi\"\n")
+        val fileManifest = FileManifest(normalizeStandalonePath(workspaceRoot))
+        fileManifest.save(scanTrackedKotlinFileTimestamps(sourceRoots()))
+
+        file.writeText("package sample\n\nfun welcome(): String = \"hello\"\n")
+        bumpLastModified(file)
+
+        val snapshot = fileManifest.snapshot(sourceRoots())
+        assertEquals(listOf(normalizeStandalonePath(file).toString()), snapshot.modifiedPaths)
+        assertTrue(snapshot.newPaths.isEmpty())
+        assertTrue(snapshot.deletedPaths.isEmpty())
+    }
+
+    @Test
+    fun `file manifest scan narrows work to changed files`() {
+        repeat(100) { index ->
+            writeSourceFile(
+                relativePath = "sample/File$index.kt",
+                content = "package sample\n\nfun value$index(): Int = $index\n",
+            )
+        }
+        val fileManifest = FileManifest(normalizeStandalonePath(workspaceRoot))
+        fileManifest.save(scanTrackedKotlinFileTimestamps(sourceRoots()))
+
+        val changedFile = workspaceRoot.resolve("src/main/kotlin/sample/File42.kt")
+        changedFile.writeText("package sample\n\nfun renamedValue42(): Int = 42\n")
+        bumpLastModified(changedFile)
+
+        val snapshot = fileManifest.snapshot(sourceRoots())
+        val fullTrackedPaths = scanTrackedKotlinFileTimestamps(sourceRoots()).keys
+
+        assertEquals(1, snapshot.modifiedPaths.size)
+        assertTrue(snapshot.modifiedPaths.size < fullTrackedPaths.size)
+    }
+
+    private fun sourceRoots(): List<Path> = listOf(normalizeStandalonePath(workspaceRoot.resolve("src/main/kotlin")))
+
+    private fun writeSourceFile(
+        relativePath: String,
+        content: String,
+    ): Path {
+        val file = workspaceRoot.resolve("src/main/kotlin").resolve(relativePath)
+        file.parent.createDirectories()
+        file.writeText(content)
+        return file
+    }
+
+    private fun bumpLastModified(file: Path) {
+        Files.setLastModifiedTime(
+            file,
+            FileTime.fromMillis(Files.getLastModifiedTime(file).toMillis() + 1_000),
+        )
+    }
+}

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/GradleWorkspaceDiscoveryTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/GradleWorkspaceDiscoveryTest.kt
@@ -2,12 +2,32 @@ package io.github.amichne.kast.standalone
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 class GradleWorkspaceDiscoveryTest {
+    @Test
+    fun `resolve tooling api timeout millis scales with module count`() {
+        assertEquals(defaultToolingApiTimeoutMillis, resolveToolingApiTimeoutMillis(moduleCount = 50))
+        assertEquals(60_000L, resolveToolingApiTimeoutMillis(moduleCount = 300))
+        assertEquals(300_000L, resolveToolingApiTimeoutMillis(moduleCount = 2_000))
+    }
+
+    @Test
+    fun `resolve tooling api timeout millis respects env var override`() {
+        val timeoutMillis = resolveToolingApiTimeoutMillis(
+            moduleCount = 950,
+            envReader = { name -> if (name == "KAST_GRADLE_TOOLING_TIMEOUT_MS") "123456" else null },
+        )
+
+        assertEquals(123_456L, timeoutMillis)
+    }
+
     @Test
     fun `build standalone workspace layout preserves main, testFixtures, and test source set semantics`() {
         val lib = GradleModuleModel(
@@ -310,7 +330,7 @@ class GradleWorkspaceDiscoveryTest {
         val result = GradleWorkspaceDiscovery.enrichStaticModulesWithToolingApiLibraries(
             workspaceRoot = Path.of("/workspace"),
             staticModules = staticModules,
-            toolingApiLoader = {
+            toolingApiLoader = { _, _ ->
                 throw TimeoutException("tooling api timed out")
             },
             warningSink = { warning -> warningMessages.add(warning) },
@@ -347,7 +367,7 @@ class GradleWorkspaceDiscoveryTest {
         val result = GradleWorkspaceDiscovery.enrichStaticModulesWithToolingApiLibraries(
             workspaceRoot = Path.of("/workspace"),
             staticModules = staticModules,
-            toolingApiLoader = {
+            toolingApiLoader = { _, _ ->
                 listOf(
                     GradleModuleModel(
                         gradlePath = ":app",
@@ -366,4 +386,208 @@ class GradleWorkspaceDiscoveryTest {
         assertTrue(mergedDependencies.contains(moduleDependency))
         assertTrue(mergedDependencies.contains(libraryDependency))
     }
+
+    @Test
+    fun `discoverPhased returns static layout immediately when tooling api is slow`() {
+        val staticModules = listOf(
+            gradleModule(
+                gradlePath = ":app",
+                mainSourceRoots = listOf(Path.of("/workspace/app/src/main/kotlin")),
+            ),
+        )
+        val settingsSnapshot = largeSettingsSnapshot(moduleCount = 250)
+        val unblockToolingApi = CountDownLatch(1)
+
+        val startNanos = System.nanoTime()
+        val result = GradleWorkspaceDiscovery.discoverPhased(
+            workspaceRoot = Path.of("/workspace"),
+            extraClasspathRoots = emptyList(),
+            settingsSnapshot = settingsSnapshot,
+            staticModulesProvider = { staticModules },
+            toolingApiLoader = { _, _ ->
+                unblockToolingApi.await()
+                staticModules
+            },
+        )
+        val elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos)
+
+        try {
+            assertTrue(elapsedMillis < 100, "expected phased discovery to return immediately, took ${elapsedMillis}ms")
+            assertEquals(
+                GradleWorkspaceDiscovery.buildStandaloneWorkspaceLayout(staticModules, extraClasspathRoots = emptyList()).sourceModules,
+                result.initialLayout.sourceModules,
+            )
+            assertFalse(checkNotNull(result.enrichmentFuture).isDone)
+            unblockToolingApi.countDown()
+            assertEquals(
+                result.initialLayout.sourceModules,
+                result.enrichmentFuture.get(1, TimeUnit.SECONDS).sourceModules,
+            )
+        } finally {
+            unblockToolingApi.countDown()
+        }
+    }
+
+    @Test
+    fun `discoverPhased enrichment future merges tooling api results`() {
+        val staticModules = listOf(
+            gradleModule(
+                gradlePath = ":app",
+                mainSourceRoots = listOf(Path.of("/workspace/app/src/main/kotlin")),
+                dependencies = listOf(
+                    GradleDependency.ModuleDependency(
+                        targetIdeaModuleName = ":lib",
+                        scope = GradleDependencyScope.COMPILE,
+                    ),
+                ),
+            ),
+            gradleModule(
+                gradlePath = ":lib",
+                mainSourceRoots = listOf(Path.of("/workspace/lib/src/main/kotlin")),
+            ),
+        )
+        val libraryDependency = GradleDependency.LibraryDependency(
+            binaryRoot = Path.of("/deps/runtime.jar"),
+            scope = GradleDependencyScope.RUNTIME,
+        )
+
+        val result = GradleWorkspaceDiscovery.discoverPhased(
+            workspaceRoot = Path.of("/workspace"),
+            extraClasspathRoots = emptyList(),
+            settingsSnapshot = largeSettingsSnapshot(moduleCount = 250),
+            staticModulesProvider = { staticModules },
+            toolingApiLoader = { _, _ ->
+                listOf(
+                    gradleModule(
+                        gradlePath = ":app",
+                        mainSourceRoots = listOf(Path.of("/workspace/app/src/main/kotlin")),
+                        dependencies = listOf(libraryDependency),
+                    ),
+                    gradleModule(
+                        gradlePath = ":lib",
+                        mainSourceRoots = listOf(Path.of("/workspace/lib/src/main/kotlin")),
+                    ),
+                )
+            },
+        )
+
+        val enrichedLayout = checkNotNull(result.enrichmentFuture).get(1, TimeUnit.SECONDS)
+        val modulesByName = enrichedLayout.sourceModules.associateBy(StandaloneSourceModuleSpec::name)
+
+        assertEquals(listOf(":lib[main]"), modulesByName.getValue(":app[main]").dependencyModuleNames)
+        assertTrue(modulesByName.getValue(":app[main]").binaryRoots.contains(Path.of("/deps/runtime.jar")))
+    }
+
+    @Test
+    fun `discoverPhased enrichment future tolerates tooling api failure`() {
+        val staticModules = listOf(
+            gradleModule(
+                gradlePath = ":app",
+                mainSourceRoots = listOf(Path.of("/workspace/app/src/main/kotlin")),
+            ),
+        )
+
+        val result = GradleWorkspaceDiscovery.discoverPhased(
+            workspaceRoot = Path.of("/workspace"),
+            extraClasspathRoots = emptyList(),
+            settingsSnapshot = largeSettingsSnapshot(moduleCount = 250),
+            staticModulesProvider = { staticModules },
+            toolingApiLoader = { _, _ ->
+                throw TimeoutException("tooling api timed out")
+            },
+        )
+
+        val enrichedLayout = checkNotNull(result.enrichmentFuture).get(1, TimeUnit.SECONDS)
+
+        assertEquals(result.initialLayout.sourceModules, enrichedLayout.sourceModules)
+        assertTrue(enrichedLayout.diagnostics.warnings.any { warning -> warning.contains("timed out") })
+    }
+
+    @Test
+    fun `discoverPhased with small project skips phased approach`() {
+        val staticModules = listOf(
+            gradleModule(
+                gradlePath = ":app",
+                mainSourceRoots = listOf(Path.of("/workspace/app/src/main/kotlin")),
+                dependencies = listOf(
+                    GradleDependency.ModuleDependency(
+                        targetIdeaModuleName = ":lib",
+                        scope = GradleDependencyScope.COMPILE,
+                    ),
+                ),
+            ),
+            gradleModule(
+                gradlePath = ":lib",
+                mainSourceRoots = listOf(Path.of("/workspace/lib/src/main/kotlin")),
+            ),
+        )
+        val toolingModules = listOf(
+            gradleModule(
+                gradlePath = ":app",
+                mainSourceRoots = listOf(Path.of("/workspace/app/src/main/kotlin")),
+                dependencies = listOf(
+                    GradleDependency.ModuleDependency(
+                        targetIdeaModuleName = ":lib",
+                        scope = GradleDependencyScope.COMPILE,
+                    ),
+                    GradleDependency.LibraryDependency(
+                        binaryRoot = Path.of("/deps/runtime.jar"),
+                        scope = GradleDependencyScope.RUNTIME,
+                    ),
+                ),
+            ),
+            gradleModule(
+                gradlePath = ":lib",
+                mainSourceRoots = listOf(Path.of("/workspace/lib/src/main/kotlin")),
+            ),
+        )
+        val settingsSnapshot = GradleSettingsSnapshot(
+            includedProjectPaths = listOf(":app", ":lib"),
+            hasCompositeBuilds = false,
+        )
+
+        val phased = GradleWorkspaceDiscovery.discoverPhased(
+            workspaceRoot = Path.of("/workspace"),
+            extraClasspathRoots = emptyList(),
+            settingsSnapshot = settingsSnapshot,
+            staticModulesProvider = { staticModules },
+            toolingApiLoader = { _, _ -> toolingModules },
+        )
+        val direct = GradleWorkspaceDiscovery.discover(
+            workspaceRoot = Path.of("/workspace"),
+            extraClasspathRoots = emptyList(),
+            settingsSnapshot = settingsSnapshot,
+            staticModulesProvider = { staticModules },
+            toolingApiLoader = { _, _ -> toolingModules },
+        )
+
+        assertNull(phased.enrichmentFuture)
+        assertEquals(direct, phased.initialLayout)
+    }
+
+    private fun gradleModule(
+        gradlePath: String,
+        mainSourceRoots: List<Path>,
+        testSourceRoots: List<Path> = emptyList(),
+        testFixturesSourceRoots: List<Path> = emptyList(),
+        mainOutputRoots: List<Path> = emptyList(),
+        testOutputRoots: List<Path> = emptyList(),
+        testFixturesOutputRoots: List<Path> = emptyList(),
+        dependencies: List<GradleDependency> = emptyList(),
+    ): GradleModuleModel = GradleModuleModel(
+        gradlePath = gradlePath,
+        ideaModuleName = gradlePath,
+        mainSourceRoots = mainSourceRoots,
+        testSourceRoots = testSourceRoots,
+        testFixturesSourceRoots = testFixturesSourceRoots,
+        mainOutputRoots = mainOutputRoots,
+        testOutputRoots = testOutputRoots,
+        testFixturesOutputRoots = testFixturesOutputRoots,
+        dependencies = dependencies,
+    )
+
+    private fun largeSettingsSnapshot(moduleCount: Int): GradleSettingsSnapshot = GradleSettingsSnapshot(
+        includedProjectPaths = (1..moduleCount).map { index -> ":module$index" },
+        hasCompositeBuilds = false,
+    )
 }

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/SourceIndexCacheTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/SourceIndexCacheTest.kt
@@ -1,0 +1,268 @@
+package io.github.amichne.kast.standalone
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.FileTime
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+class SourceIndexCacheTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `source index cache round-trips correctly`() {
+        val appFile = writeSourceFile(
+            relativePath = "sample/App.kt",
+            content = """
+                package sample
+
+                fun welcome(): String = helper()
+            """.trimIndent() + "\n",
+        )
+        val helperFile = writeSourceFile(
+            relativePath = "sample/Helper.kt",
+            content = """
+                package sample
+
+                fun helper(): String = "hi"
+            """.trimIndent() + "\n",
+        )
+        val cache = SourceIndexCache(normalizeStandalonePath(workspaceRoot))
+
+        cache.save(
+            index = MutableSourceIdentifierIndex.fromCandidatePathsByIdentifier(
+                mapOf(
+                    "welcome" to listOf(normalizeStandalonePath(appFile).toString()),
+                    "helper" to listOf(
+                        normalizeStandalonePath(appFile).toString(),
+                        normalizeStandalonePath(helperFile).toString(),
+                    ),
+                ),
+            ),
+            sourceRoots = sourceRoots(),
+        )
+
+        val loaded = requireNotNull(cache.load(sourceRoots()))
+        assertEquals(listOf(normalizeStandalonePath(appFile).toString()), loaded.index.candidatePathsFor("welcome"))
+        assertEquals(
+            listOf(
+                normalizeStandalonePath(appFile).toString(),
+                normalizeStandalonePath(helperFile).toString(),
+            ),
+            loaded.index.candidatePathsFor("helper"),
+        )
+        assertTrue(loaded.newPaths.isEmpty())
+        assertTrue(loaded.modifiedPaths.isEmpty())
+        assertTrue(loaded.deletedPaths.isEmpty())
+    }
+
+    @Test
+    fun `source index cache detects modified files`() {
+        val file = writeSourceFile(
+            relativePath = "sample/App.kt",
+            content = """
+                package sample
+
+                fun welcome(): String = "hi"
+            """.trimIndent() + "\n",
+        )
+        val cache = saveSimpleCache(file)
+
+        file.writeText(
+            """
+                package sample
+
+                fun welcome(): String = "hello"
+            """.trimIndent() + "\n",
+        )
+        bumpLastModified(file)
+
+        val loaded = requireNotNull(cache.load(sourceRoots()))
+        assertEquals(listOf(normalizeStandalonePath(file).toString()), loaded.modifiedPaths)
+    }
+
+    @Test
+    fun `source index cache detects new files`() {
+        val file = writeSourceFile(
+            relativePath = "sample/App.kt",
+            content = """
+                package sample
+
+                fun welcome(): String = "hi"
+            """.trimIndent() + "\n",
+        )
+        val cache = saveSimpleCache(file)
+        val newFile = writeSourceFile(
+            relativePath = "sample/NewFile.kt",
+            content = """
+                package sample
+
+                fun salute(): String = "hello"
+            """.trimIndent() + "\n",
+        )
+        bumpLastModified(newFile)
+
+        val loaded = requireNotNull(cache.load(sourceRoots()))
+        assertEquals(listOf(normalizeStandalonePath(newFile).toString()), loaded.newPaths)
+    }
+
+    @Test
+    fun `source index cache detects deleted files`() {
+        val file = writeSourceFile(
+            relativePath = "sample/App.kt",
+            content = """
+                package sample
+
+                fun welcome(): String = "hi"
+            """.trimIndent() + "\n",
+        )
+        val cache = saveSimpleCache(file)
+
+        Files.delete(file)
+
+        val loaded = requireNotNull(cache.load(sourceRoots()))
+        assertEquals(listOf(normalizeStandalonePath(file).toString()), loaded.deletedPaths)
+    }
+
+    @Test
+    fun `incremental index startup only reads changed files`() {
+        repeat(10) { index ->
+            writeSourceFile(
+                relativePath = "sample/File$index.kt",
+                content = """
+                    package sample
+
+                    fun value$index(): Int = $index
+                """.trimIndent() + "\n",
+            )
+        }
+
+        StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = sourceRoots(),
+            classpathRoots = emptyList(),
+            moduleName = "sample",
+        ).use { session ->
+            session.awaitInitialSourceIndex()
+        }
+
+        val changedFile = workspaceRoot.resolve("src/main/kotlin/sample/File4.kt")
+        changedFile.writeText(
+            """
+                package sample
+
+                fun renamedValue4(): Int = 4
+            """.trimIndent() + "\n",
+        )
+        bumpLastModified(changedFile)
+
+        var readCount = 0
+        StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = sourceRoots(),
+            classpathRoots = emptyList(),
+            moduleName = "sample",
+            sourceIndexFileReader = { path ->
+                readCount += 1
+                Files.readString(path)
+            },
+        ).use { session ->
+            session.awaitInitialSourceIndex()
+        }
+
+        assertEquals(1, readCount)
+    }
+
+    @Test
+    fun `source index cache is updated after refresh`() {
+        val file = writeSourceFile(
+            relativePath = "sample/App.kt",
+            content = """
+                package sample
+
+                fun welcome(): String = "hi"
+            """.trimIndent() + "\n",
+        )
+        val normalizedFile = normalizeStandalonePath(file).toString()
+        val cache = SourceIndexCache(normalizeStandalonePath(workspaceRoot))
+
+        StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = sourceRoots(),
+            classpathRoots = emptyList(),
+            moduleName = "sample",
+            sourceIndexCacheSaveDelayMillis = 25,
+        ).use { session ->
+            session.awaitInitialSourceIndex()
+
+            file.writeText(
+                """
+                    package sample
+
+                    fun salute(): String = welcome()
+                """.trimIndent() + "\n",
+            )
+            bumpLastModified(file)
+
+            session.refreshFileContents(setOf(file.toString()))
+
+            waitUntil {
+                val loaded = cache.load(sourceRoots()) ?: return@waitUntil false
+                loaded.newPaths.isEmpty() &&
+                    loaded.modifiedPaths.isEmpty() &&
+                    loaded.deletedPaths.isEmpty() &&
+                    loaded.index.candidatePathsFor("salute") == listOf(normalizedFile)
+            }
+        }
+    }
+
+    private fun saveSimpleCache(file: Path): SourceIndexCache {
+        val cache = SourceIndexCache(normalizeStandalonePath(workspaceRoot))
+        cache.save(
+            index = MutableSourceIdentifierIndex.fromCandidatePathsByIdentifier(
+                mapOf("welcome" to listOf(normalizeStandalonePath(file).toString())),
+            ),
+            sourceRoots = sourceRoots(),
+        )
+        return cache
+    }
+
+    private fun sourceRoots(): List<Path> = listOf(normalizeStandalonePath(workspaceRoot.resolve("src/main/kotlin")))
+
+    private fun writeSourceFile(
+        relativePath: String,
+        content: String,
+    ): Path {
+        val file = workspaceRoot.resolve("src/main/kotlin").resolve(relativePath)
+        file.parent.createDirectories()
+        file.writeText(content)
+        return file
+    }
+
+    private fun bumpLastModified(file: Path) {
+        Files.setLastModifiedTime(
+            file,
+            FileTime.fromMillis(Files.getLastModifiedTime(file).toMillis() + 1_000),
+        )
+    }
+
+    private fun waitUntil(
+        timeoutMillis: Long = 5_000,
+        pollMillis: Long = 25,
+        condition: () -> Boolean,
+    ) {
+        val deadline = System.nanoTime() + timeoutMillis * 1_000_000
+        while (System.nanoTime() < deadline) {
+            if (condition()) {
+                return
+            }
+            Thread.sleep(pollMillis)
+        }
+        error("Condition was not met within ${timeoutMillis}ms")
+    }
+}

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendDiagnosticsTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendDiagnosticsTest.kt
@@ -2,6 +2,7 @@ package io.github.amichne.kast.standalone
 
 import io.github.amichne.kast.api.DiagnosticSeverity
 import io.github.amichne.kast.api.DiagnosticsQuery
+import io.github.amichne.kast.api.RefreshQuery
 import io.github.amichne.kast.api.ReadCapability
 import io.github.amichne.kast.api.ServerLimits
 import kotlinx.coroutines.test.TestResult
@@ -60,6 +61,77 @@ class StandaloneAnalysisBackendDiagnosticsTest {
     }
 
     @Test
+    fun `targeted refresh rebuilds analysis state for structural dependency changes`(): TestResult = runTest {
+        val usageFile = writeFile(
+            relativePath = "src/main/kotlin/sample/Use.kt",
+            content = """
+                package sample
+
+                fun use(): String = greet()
+            """.trimIndent() + "\n",
+        )
+        val helperFile = workspaceRoot.resolve("src/main/kotlin/sample/Greeter.kt")
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "sources",
+        )
+        session.use { session ->
+            val backend = StandaloneAnalysisBackend(
+                workspaceRoot = workspaceRoot,
+                limits = ServerLimits(
+                    maxResults = 100,
+                    requestTimeoutMillis = 30_000,
+                    maxConcurrentRequests = 4,
+                ),
+                session = session,
+            )
+
+            val initialDiagnostics = backend.diagnostics(
+                DiagnosticsQuery(
+                    filePaths = listOf(usageFile.toString()),
+                ),
+            )
+
+            assertTrue(initialDiagnostics.diagnostics.any { diagnostic -> diagnostic.code == "UNRESOLVED_REFERENCE" })
+
+            Files.createDirectories(helperFile.parent)
+            helperFile.writeText(
+                """
+                    package sample
+
+                    fun greet(): String = "hi"
+                """.trimIndent() + "\n",
+            )
+
+            val createdRefresh = backend.refresh(RefreshQuery(filePaths = listOf(helperFile.toString())))
+
+            assertEquals(listOf(normalizePath(helperFile)), createdRefresh.refreshedFiles)
+            assertTrue(
+                backend.diagnostics(
+                    DiagnosticsQuery(
+                        filePaths = listOf(usageFile.toString()),
+                    ),
+                ).diagnostics.isEmpty(),
+            )
+
+            Files.delete(helperFile)
+
+            val deletedRefresh = backend.refresh(RefreshQuery(filePaths = listOf(helperFile.toString())))
+
+            assertEquals(listOf(normalizePath(helperFile)), deletedRefresh.removedFiles)
+            assertTrue(
+                backend.diagnostics(
+                    DiagnosticsQuery(
+                        filePaths = listOf(usageFile.toString()),
+                    ),
+                ).diagnostics.any { diagnostic -> diagnostic.code == "UNRESOLVED_REFERENCE" },
+            )
+        }
+    }
+
+    @Test
     fun `capabilities advertise diagnostics after implementation`(): TestResult = runTest {
         writeFile(
             relativePath = "src/main/kotlin/sample/Broken.kt",
@@ -103,7 +175,6 @@ class StandaloneAnalysisBackendDiagnosticsTest {
     }
 
     private fun normalizePath(path: Path): String {
-        val absolutePath = path.toAbsolutePath().normalize()
-        return runCatching { absolutePath.toRealPath().normalize().toString() }.getOrDefault(absolutePath.toString())
+        return normalizeStandalonePath(path).toString()
     }
 }

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneWorkspaceDiscoveryTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneWorkspaceDiscoveryTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
@@ -413,6 +414,49 @@ class StandaloneWorkspaceDiscoveryTest {
     }
 
     @Test
+    fun `content-only refresh keeps shared KtFile instance for partially loaded maps`() {
+        val changedFile = writeFile(
+            relativePath = "src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun greet(): String = "ready"
+            """.trimIndent() + "\n",
+        )
+        val sourceRoot = workspaceRoot.resolve("src/main/kotlin")
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = listOf(sourceRoot),
+            classpathRoots = emptyList(),
+            moduleName = "main",
+        )
+
+        session.use { standaloneSession ->
+            val normalizedPath = normalizePath(changedFile)
+            standaloneSession.findKtFile(changedFile.toString())
+            assertFalse(standaloneSession.isFullKtFileMapLoaded())
+
+            changedFile.writeText(
+                """
+                    package sample
+
+                    fun welcome(): String = "updated"
+                """.trimIndent() + "\n",
+            )
+
+            standaloneSession.refreshFileContents(setOf(changedFile.toString()))
+
+            val refreshedKtFilesByPath = ktFileCache(standaloneSession, "ktFilesByPath")
+            val refreshedTargetedKtFilesByPath = ktFileCache(standaloneSession, "targetedKtFilesByPath")
+            assertSame(
+                refreshedKtFilesByPath.getValue(normalizedPath),
+                refreshedTargetedKtFilesByPath.getValue(normalizedPath),
+            )
+            assertTrue(refreshedKtFilesByPath.getValue(normalizedPath).text.contains("welcome"))
+        }
+    }
+
+    @Test
     fun `content-only refresh preserves full KtFile map`() {
         val changedFile = writeFile(
             relativePath = "src/main/kotlin/sample/App.kt",
@@ -439,6 +483,7 @@ class StandaloneWorkspaceDiscoveryTest {
         )
 
         session.use { standaloneSession ->
+            val normalizedChangedPath = normalizePath(changedFile)
             standaloneSession.allKtFiles()
             assertTrue(standaloneSession.isFullKtFileMapLoaded())
             val unchangedKtFile = standaloneSession.findKtFile(unchangedFile.toString())
@@ -459,6 +504,12 @@ class StandaloneWorkspaceDiscoveryTest {
                 standaloneSession.allKtFiles().map { file -> file.virtualFilePath }.toSet(),
             )
             assertSame(unchangedKtFile, standaloneSession.findKtFile(unchangedFile.toString()))
+            val refreshedKtFilesByPath = ktFileCache(standaloneSession, "ktFilesByPath")
+            val refreshedTargetedKtFilesByPath = ktFileCache(standaloneSession, "targetedKtFilesByPath")
+            assertSame(
+                refreshedKtFilesByPath.getValue(normalizedChangedPath),
+                refreshedTargetedKtFilesByPath.getValue(normalizedChangedPath),
+            )
             assertTrue(standaloneSession.findKtFile(changedFile.toString()).text.contains("other()"))
         }
     }
@@ -1351,6 +1402,16 @@ class StandaloneWorkspaceDiscoveryTest {
     private fun normalizePath(path: Path): String {
         val absolutePath = path.toAbsolutePath().normalize()
         return runCatching { absolutePath.toRealPath().normalize().toString() }.getOrDefault(absolutePath.toString())
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun ktFileCache(
+        session: StandaloneAnalysisSession,
+        fieldName: String,
+    ): Map<String, KtFile> {
+        val field = StandaloneAnalysisSession::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(session) as Map<String, KtFile>
     }
 
     private fun manualWorkspaceLayout(vararg sourceModules: StandaloneSourceModuleSpec): StandaloneWorkspaceLayout =

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneWorkspaceDiscoveryTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneWorkspaceDiscoveryTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -329,6 +330,164 @@ class StandaloneWorkspaceDiscoveryTest {
             assertFalse(session.isInitialSourceIndexReady())
             unblockIndexBuild.countDown()
             session.awaitInitialSourceIndex()
+        }
+    }
+
+    @Test
+    fun `content-only refresh does not rebuild K2 session`() {
+        val appFile = writeFile(
+            relativePath = "src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun greet(): String = "ready"
+            """.trimIndent() + "\n",
+        )
+        val sourceRoot = workspaceRoot.resolve("src/main/kotlin")
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = listOf(sourceRoot),
+            classpathRoots = emptyList(),
+            moduleName = "main",
+        )
+
+        session.use { standaloneSession ->
+            val initialAnalysisStateGeneration = standaloneSession.currentAnalysisStateGeneration()
+
+            assertTrue(standaloneSession.findKtFile(appFile.toString()).text.contains("greet"))
+
+            appFile.writeText(
+                """
+                    package sample
+
+                    fun welcome(): String = "updated"
+                """.trimIndent() + "\n",
+            )
+
+            standaloneSession.refreshFileContents(setOf(appFile.toString()))
+
+            assertEquals(initialAnalysisStateGeneration, standaloneSession.currentAnalysisStateGeneration())
+            assertTrue(standaloneSession.findKtFile(appFile.toString()).text.contains("welcome"))
+            assertFalse(standaloneSession.findKtFile(appFile.toString()).text.contains("greet"))
+        }
+    }
+
+    @Test
+    fun `content-only refresh updates source identifier index`() {
+        val appFile = writeFile(
+            relativePath = "src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun greet(): String = "ready"
+            """.trimIndent() + "\n",
+        )
+        val sourceRoot = workspaceRoot.resolve("src/main/kotlin")
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = listOf(sourceRoot),
+            classpathRoots = emptyList(),
+            moduleName = "main",
+        )
+
+        session.use { standaloneSession ->
+            standaloneSession.awaitInitialSourceIndex()
+            assertTrue(standaloneSession.candidateKotlinFilePaths("welcome").isEmpty())
+
+            appFile.writeText(
+                """
+                    package sample
+
+                    fun welcome(): String = "updated"
+                """.trimIndent() + "\n",
+            )
+
+            standaloneSession.refreshFileContents(setOf(appFile.toString()))
+
+            assertEquals(
+                setOf(normalizePath(appFile)),
+                standaloneSession.candidateKotlinFilePaths("welcome").toSet(),
+            )
+            assertTrue(standaloneSession.candidateKotlinFilePaths("greet").isEmpty())
+        }
+    }
+
+    @Test
+    fun `content-only refresh preserves full KtFile map`() {
+        val changedFile = writeFile(
+            relativePath = "src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun app(): String = "ready"
+            """.trimIndent() + "\n",
+        )
+        val unchangedFile = writeFile(
+            relativePath = "src/main/kotlin/sample/Other.kt",
+            content = """
+                package sample
+
+                fun other(): String = "stable"
+            """.trimIndent() + "\n",
+        )
+        val sourceRoot = workspaceRoot.resolve("src/main/kotlin")
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = listOf(sourceRoot),
+            classpathRoots = emptyList(),
+            moduleName = "main",
+        )
+
+        session.use { standaloneSession ->
+            standaloneSession.allKtFiles()
+            assertTrue(standaloneSession.isFullKtFileMapLoaded())
+            val unchangedKtFile = standaloneSession.findKtFile(unchangedFile.toString())
+
+            changedFile.writeText(
+                """
+                    package sample
+
+                    fun app(): String = other()
+                """.trimIndent() + "\n",
+            )
+
+            standaloneSession.refreshFileContents(setOf(changedFile.toString()))
+
+            assertTrue(standaloneSession.isFullKtFileMapLoaded())
+            assertEquals(
+                setOf(normalizePath(changedFile), normalizePath(unchangedFile)),
+                standaloneSession.allKtFiles().map { file -> file.virtualFilePath }.toSet(),
+            )
+            assertSame(unchangedKtFile, standaloneSession.findKtFile(unchangedFile.toString()))
+            assertTrue(standaloneSession.findKtFile(changedFile.toString()).text.contains("other()"))
+        }
+    }
+
+    @Test
+    fun `structural refresh rebuilds K2 session`() {
+        val appFile = writeFile(
+            relativePath = "src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun greet(): String = "ready"
+            """.trimIndent() + "\n",
+        )
+        val sourceRoot = workspaceRoot.resolve("src/main/kotlin")
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = listOf(sourceRoot),
+            classpathRoots = emptyList(),
+            moduleName = "main",
+        )
+
+        session.use { standaloneSession ->
+            val initialAnalysisStateGeneration = standaloneSession.currentAnalysisStateGeneration()
+
+            Files.delete(appFile)
+            standaloneSession.refreshFiles(setOf(appFile.toString()))
+
+            assertTrue(standaloneSession.currentAnalysisStateGeneration() > initialAnalysisStateGeneration)
         }
     }
 

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneWorkspaceDiscoveryTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneWorkspaceDiscoveryTest.kt
@@ -1,6 +1,7 @@
 package io.github.amichne.kast.standalone
 
 import io.github.amichne.kast.api.FilePosition
+import io.github.amichne.kast.api.RuntimeState
 import io.github.amichne.kast.api.ServerLimits
 import io.github.amichne.kast.api.SymbolKind
 import io.github.amichne.kast.api.SymbolQuery
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
@@ -113,6 +115,68 @@ class StandaloneWorkspaceDiscoveryTest {
                     targetIdeaModuleName = ":lib",
                     scope = GradleDependencyScope.TEST_FIXTURES,
                 ),
+            ),
+        )
+    }
+
+    @Test
+    fun `static discovery finds gatling source roots`() {
+        writeFile(
+            relativePath = "settings.gradle.kts",
+            content = """
+                rootProject.name = "workspace"
+                include(":app")
+            """.trimIndent() + "\n",
+        )
+        writeFile(relativePath = "app/build.gradle.kts", content = "")
+        writeFile(
+            relativePath = "app/src/gatling/kotlin/sample/Simulation.kt",
+            content = """
+                package sample
+
+                class Simulation
+            """.trimIndent() + "\n",
+        )
+
+        val modulesByPath = StaticGradleWorkspaceDiscovery.discoverModules(
+            workspaceRoot,
+            GradleSettingsSnapshot.read(workspaceRoot),
+        ).associateBy(GradleModuleModel::gradlePath)
+
+        assertTrue(
+            modulesByPath.getValue(":app").mainSourceRoots.contains(
+                normalizeStandalonePath(workspaceRoot.resolve("app/src/gatling/kotlin")),
+            ),
+        )
+    }
+
+    @Test
+    fun `static discovery finds custom source sets`() {
+        writeFile(
+            relativePath = "settings.gradle.kts",
+            content = """
+                rootProject.name = "workspace"
+                include(":app")
+            """.trimIndent() + "\n",
+        )
+        writeFile(relativePath = "app/build.gradle.kts", content = "")
+        writeFile(
+            relativePath = "app/src/integrationTest/kotlin/sample/IntegrationTest.kt",
+            content = """
+                package sample
+
+                class IntegrationTest
+            """.trimIndent() + "\n",
+        )
+
+        val modulesByPath = StaticGradleWorkspaceDiscovery.discoverModules(
+            workspaceRoot,
+            GradleSettingsSnapshot.read(workspaceRoot),
+        ).associateBy(GradleModuleModel::gradlePath)
+
+        assertTrue(
+            modulesByPath.getValue(":app").testSourceRoots.contains(
+                normalizeStandalonePath(workspaceRoot.resolve("app/src/integrationTest/kotlin")),
             ),
         )
     }
@@ -265,6 +329,151 @@ class StandaloneWorkspaceDiscoveryTest {
             assertFalse(session.isInitialSourceIndexReady())
             unblockIndexBuild.countDown()
             session.awaitInitialSourceIndex()
+        }
+    }
+
+    @Test
+    fun `phased session serves requests before enrichment completes`() {
+        val appFile = writeFile(
+            relativePath = "app/src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun app(): String = "ready"
+            """.trimIndent() + "\n",
+        )
+        val libFile = writeFile(
+            relativePath = "lib/src/main/kotlin/sample/Lib.kt",
+            content = """
+                package sample
+
+                fun lib(): String = "later"
+            """.trimIndent() + "\n",
+        )
+        val appRoot = normalizeStandalonePath(workspaceRoot.resolve("app/src/main/kotlin"))
+        val libRoot = normalizeStandalonePath(workspaceRoot.resolve("lib/src/main/kotlin"))
+        val enrichmentFuture = CompletableFuture<StandaloneWorkspaceLayout>()
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "ignored",
+            phasedDiscoveryResult = PhasedDiscoveryResult(
+                initialLayout = manualWorkspaceLayout(
+                    sourceModule(name = ":app[main]", sourceRoots = listOf(appRoot)),
+                ),
+                enrichmentFuture = enrichmentFuture,
+            ),
+        )
+
+        session.use { phasedSession ->
+            assertEquals(normalizePath(appFile), phasedSession.findKtFile(appFile.toString()).virtualFilePath)
+            assertFalse(phasedSession.isEnrichmentComplete())
+
+            enrichmentFuture.complete(
+                manualWorkspaceLayout(
+                    sourceModule(
+                        name = ":app[main]",
+                        sourceRoots = listOf(appRoot),
+                        dependencyModuleNames = listOf(":lib[main]"),
+                    ),
+                    sourceModule(name = ":lib[main]", sourceRoots = listOf(libRoot)),
+                ),
+            )
+
+            phasedSession.awaitEnrichment()
+
+            assertTrue(phasedSession.isEnrichmentComplete())
+            assertEquals(normalizePath(libFile), phasedSession.findKtFile(libFile.toString()).virtualFilePath)
+        }
+    }
+
+    @Test
+    fun `phased session rebuilds K2 session after enrichment`() {
+        writeFile(
+            relativePath = "app/src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun app(): String = lib()
+            """.trimIndent() + "\n",
+        )
+        val libFile = writeFile(
+            relativePath = "lib/src/main/kotlin/sample/Lib.kt",
+            content = """
+                package sample
+
+                fun lib(): String = "later"
+            """.trimIndent() + "\n",
+        )
+        val appRoot = normalizeStandalonePath(workspaceRoot.resolve("app/src/main/kotlin"))
+        val libRoot = normalizeStandalonePath(workspaceRoot.resolve("lib/src/main/kotlin"))
+        val enrichmentFuture = CompletableFuture<StandaloneWorkspaceLayout>()
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "ignored",
+            phasedDiscoveryResult = PhasedDiscoveryResult(
+                initialLayout = manualWorkspaceLayout(
+                    sourceModule(name = ":app[main]", sourceRoots = listOf(appRoot)),
+                ),
+                enrichmentFuture = enrichmentFuture,
+            ),
+        )
+
+        session.use { phasedSession ->
+            enrichmentFuture.complete(
+                manualWorkspaceLayout(
+                    sourceModule(
+                        name = ":app[main]",
+                        sourceRoots = listOf(appRoot),
+                        dependencyModuleNames = listOf(":lib[main]"),
+                    ),
+                    sourceModule(name = ":lib[main]", sourceRoots = listOf(libRoot)),
+                ),
+            )
+
+            phasedSession.awaitEnrichment()
+            phasedSession.awaitInitialSourceIndex()
+
+            assertTrue(phasedSession.sourceModules.any { module -> module.name == ":lib[main]" })
+            assertEquals(normalizePath(libFile), phasedSession.findKtFile(libFile.toString()).virtualFilePath)
+        }
+    }
+
+    @Test
+    fun `phased session source index works during enrichment`() {
+        val appFile = writeFile(
+            relativePath = "app/src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun greetDuringIndexing(): String = "ready"
+            """.trimIndent() + "\n",
+        )
+        val appRoot = normalizeStandalonePath(workspaceRoot.resolve("app/src/main/kotlin"))
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "ignored",
+            phasedDiscoveryResult = PhasedDiscoveryResult(
+                initialLayout = manualWorkspaceLayout(
+                    sourceModule(name = ":app[main]", sourceRoots = listOf(appRoot)),
+                ),
+                enrichmentFuture = CompletableFuture<StandaloneWorkspaceLayout>(),
+            ),
+        )
+
+        session.use { phasedSession ->
+            phasedSession.awaitInitialSourceIndex()
+
+            assertEquals(
+                setOf(normalizePath(appFile)),
+                phasedSession.candidateKotlinFilePaths("greetDuringIndexing").toSet(),
+            )
+            assertFalse(phasedSession.isEnrichmentComplete())
         }
     }
 
@@ -471,6 +680,55 @@ class StandaloneWorkspaceDiscoveryTest {
             assertFalse(status.warnings.isEmpty())
             assertTrue(status.warnings.any { warning -> warning.contains(":lib") })
             assertTrue(checkNotNull(status.message).contains("warnings"))
+        }
+    }
+
+    @Test
+    fun `runtime status reports INDEXING during enrichment`(): TestResult = runTest {
+        writeFile(
+            relativePath = "app/src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun app(): String = "ready"
+            """.trimIndent() + "\n",
+        )
+        val appRoot = normalizeStandalonePath(workspaceRoot.resolve("app/src/main/kotlin"))
+        val enrichmentFuture = CompletableFuture<StandaloneWorkspaceLayout>()
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = emptyList(),
+            classpathRoots = emptyList(),
+            moduleName = "ignored",
+            phasedDiscoveryResult = PhasedDiscoveryResult(
+                initialLayout = manualWorkspaceLayout(
+                    sourceModule(name = ":app[main]", sourceRoots = listOf(appRoot)),
+                ),
+                enrichmentFuture = enrichmentFuture,
+            ),
+        )
+        session.use { phasedSession ->
+            val backend = StandaloneAnalysisBackend(
+                workspaceRoot = workspaceRoot,
+                limits = ServerLimits(
+                    maxResults = 100,
+                    requestTimeoutMillis = 30_000,
+                    maxConcurrentRequests = 4,
+                ),
+                session = phasedSession,
+            )
+
+            assertEquals(RuntimeState.INDEXING, backend.runtimeStatus().state)
+
+            enrichmentFuture.complete(
+                manualWorkspaceLayout(
+                    sourceModule(name = ":app[main]", sourceRoots = listOf(appRoot)),
+                ),
+            )
+            phasedSession.awaitEnrichment()
+            phasedSession.awaitInitialSourceIndex()
+
+            assertEquals(RuntimeState.READY, backend.runtimeStatus().state)
         }
     }
 
@@ -935,4 +1193,19 @@ class StandaloneWorkspaceDiscoveryTest {
         val absolutePath = path.toAbsolutePath().normalize()
         return runCatching { absolutePath.toRealPath().normalize().toString() }.getOrDefault(absolutePath.toString())
     }
+
+    private fun manualWorkspaceLayout(vararg sourceModules: StandaloneSourceModuleSpec): StandaloneWorkspaceLayout =
+        StandaloneWorkspaceLayout(sourceModules = sourceModules.toList())
+
+    private fun sourceModule(
+        name: String,
+        sourceRoots: List<Path>,
+        binaryRoots: List<Path> = emptyList(),
+        dependencyModuleNames: List<String> = emptyList(),
+    ): StandaloneSourceModuleSpec = StandaloneSourceModuleSpec(
+        name = name,
+        sourceRoots = sourceRoots,
+        binaryRoots = binaryRoots,
+        dependencyModuleNames = dependencyModuleNames,
+    )
 }

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/WorkspaceDiscoveryCacheTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/WorkspaceDiscoveryCacheTest.kt
@@ -1,0 +1,211 @@
+package io.github.amichne.kast.standalone
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+class WorkspaceDiscoveryCacheTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `workspace discovery cache round-trips GradleModuleModel correctly`() {
+        createGradleWorkspace()
+        val result = workspaceDiscoveryResult()
+        val cache = WorkspaceDiscoveryCache()
+
+        cache.write(workspaceRoot, result)
+
+        val loaded = requireNotNull(cache.read(workspaceRoot))
+        assertEquals(result, loaded.discoveryResult)
+        assertEquals(
+            GradleWorkspaceDiscovery.buildStandaloneWorkspaceLayout(
+                gradleModules = result.modules,
+                extraClasspathRoots = emptyList(),
+            ).dependentModuleNamesBySourceModuleName,
+            loaded.dependentModuleNamesBySourceModuleName,
+        )
+    }
+
+    @Test
+    fun `workspace discovery cache invalidates when settings file changes`() {
+        createGradleWorkspace()
+        val cache = WorkspaceDiscoveryCache()
+        cache.write(workspaceRoot, workspaceDiscoveryResult())
+
+        writeFile(
+            relativePath = "settings.gradle.kts",
+            content = """
+                rootProject.name = "workspace"
+                include(":app", ":lib", ":extra")
+            """.trimIndent() + "\n",
+        )
+
+        assertNull(cache.read(workspaceRoot))
+    }
+
+    @Test
+    fun `workspace discovery cache invalidates when build file changes`() {
+        createGradleWorkspace()
+        val cache = WorkspaceDiscoveryCache()
+        cache.write(workspaceRoot, workspaceDiscoveryResult())
+
+        writeFile(
+            relativePath = "app/build.gradle.kts",
+            content = """
+                plugins { kotlin("jvm") version "2.2.20" }
+
+                dependencies {
+                    implementation(project(":lib"))
+                    implementation("org.example:runtime:2.0")
+                }
+            """.trimIndent() + "\n",
+        )
+
+        assertNull(cache.read(workspaceRoot))
+    }
+
+    @Test
+    fun `workspace discovery cache is used when valid`() {
+        createGradleWorkspace()
+        WorkspaceDiscoveryCache().write(workspaceRoot, workspaceDiscoveryResult())
+        var staticModulesProviderCalls = 0
+        var toolingApiLoaderCalls = 0
+
+        val layout = GradleWorkspaceDiscovery.discover(
+            workspaceRoot = workspaceRoot,
+            extraClasspathRoots = emptyList(),
+            settingsSnapshot = GradleSettingsSnapshot.read(workspaceRoot),
+            staticModulesProvider = {
+                staticModulesProviderCalls += 1
+                error("static discovery should not run when cache is valid")
+            },
+            toolingApiLoader = { _, _ ->
+                toolingApiLoaderCalls += 1
+                error("tooling api should not run when cache is valid")
+            },
+        )
+
+        assertEquals(0, staticModulesProviderCalls)
+        assertEquals(0, toolingApiLoaderCalls)
+        assertEquals(
+            setOf(":app[main]", ":app[test]", ":lib[main]"),
+            layout.sourceModules.map(StandaloneSourceModuleSpec::name).toSet(),
+        )
+    }
+
+    @Test
+    fun `workspace discovery cache survives phased restart`() {
+        createGradleWorkspace()
+        WorkspaceDiscoveryCache().write(workspaceRoot, workspaceDiscoveryResult())
+        var staticModulesProviderCalls = 0
+        var toolingApiLoaderCalls = 0
+
+        val phased = GradleWorkspaceDiscovery.discoverPhased(
+            workspaceRoot = workspaceRoot,
+            extraClasspathRoots = emptyList(),
+            settingsSnapshot = GradleSettingsSnapshot.read(workspaceRoot),
+            staticModulesProvider = {
+                staticModulesProviderCalls += 1
+                error("static discovery should not run when cache is valid")
+            },
+            toolingApiLoader = { _, _ ->
+                toolingApiLoaderCalls += 1
+                error("tooling api should not run when cache is valid")
+            },
+        )
+
+        assertNotNull(phased.initialLayout)
+        assertNull(phased.enrichmentFuture)
+        assertEquals(0, staticModulesProviderCalls)
+        assertEquals(0, toolingApiLoaderCalls)
+    }
+
+    private fun createGradleWorkspace() {
+        writeFile(
+            relativePath = "settings.gradle.kts",
+            content = """
+                rootProject.name = "workspace"
+                include(":app", ":lib")
+            """.trimIndent() + "\n",
+        )
+        writeFile(
+            relativePath = "app/build.gradle.kts",
+            content = """
+                plugins { kotlin("jvm") version "2.2.20" }
+
+                dependencies {
+                    implementation(project(":lib"))
+                    runtimeOnly(files("libs/runtime.jar"))
+                }
+            """.trimIndent() + "\n",
+        )
+        writeFile(relativePath = "lib/build.gradle.kts", content = "")
+    }
+
+    private fun workspaceDiscoveryResult(): GradleWorkspaceDiscoveryResult = GradleWorkspaceDiscoveryResult(
+        modules = listOf(
+            gradleModule(
+                gradlePath = ":app",
+                mainSourceRoots = listOf(workspaceRoot.resolve("app/src/main/kotlin")),
+                testSourceRoots = listOf(workspaceRoot.resolve("app/src/test/kotlin")),
+                mainOutputRoots = listOf(workspaceRoot.resolve("app/build/classes/kotlin/main")),
+                testOutputRoots = listOf(workspaceRoot.resolve("app/build/classes/kotlin/test")),
+                dependencies = listOf(
+                    GradleDependency.ModuleDependency(
+                        targetIdeaModuleName = ":lib",
+                        scope = GradleDependencyScope.COMPILE,
+                    ),
+                    GradleDependency.LibraryDependency(
+                        binaryRoot = normalizeStandalonePath(workspaceRoot.resolve("app/libs/runtime.jar")),
+                        scope = GradleDependencyScope.RUNTIME,
+                    ),
+                ),
+            ),
+            gradleModule(
+                gradlePath = ":lib",
+                mainSourceRoots = listOf(workspaceRoot.resolve("lib/src/main/kotlin")),
+                mainOutputRoots = listOf(workspaceRoot.resolve("lib/build/classes/kotlin/main")),
+            ),
+        ),
+        diagnostics = WorkspaceDiscoveryDiagnostics(
+            warnings = listOf("tooling api enrichment warning"),
+        ),
+    )
+
+    private fun gradleModule(
+        gradlePath: String,
+        mainSourceRoots: List<Path>,
+        testSourceRoots: List<Path> = emptyList(),
+        testFixturesSourceRoots: List<Path> = emptyList(),
+        mainOutputRoots: List<Path> = emptyList(),
+        testOutputRoots: List<Path> = emptyList(),
+        testFixturesOutputRoots: List<Path> = emptyList(),
+        dependencies: List<GradleDependency> = emptyList(),
+    ): GradleModuleModel = GradleModuleModel(
+        gradlePath = gradlePath,
+        ideaModuleName = gradlePath,
+        mainSourceRoots = mainSourceRoots.map(::normalizeStandalonePath),
+        testSourceRoots = testSourceRoots.map(::normalizeStandalonePath),
+        testFixturesSourceRoots = testFixturesSourceRoots.map(::normalizeStandalonePath),
+        mainOutputRoots = mainOutputRoots.map(::normalizeStandalonePath),
+        testOutputRoots = testOutputRoots.map(::normalizeStandalonePath),
+        testFixturesOutputRoots = testFixturesOutputRoots.map(::normalizeStandalonePath),
+        dependencies = dependencies,
+    )
+
+    private fun writeFile(
+        relativePath: String,
+        content: String,
+    ): Path {
+        val file = workspaceRoot.resolve(relativePath)
+        file.parent.createDirectories()
+        file.writeText(content)
+        return file
+    }
+}

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/WorkspaceDiscoveryCacheTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/WorkspaceDiscoveryCacheTest.kt
@@ -71,6 +71,29 @@ class WorkspaceDiscoveryCacheTest {
     }
 
     @Test
+    fun `workspace discovery cache ignores build files under skipped directories`() {
+        createGradleWorkspace()
+        val result = workspaceDiscoveryResult()
+        val cache = WorkspaceDiscoveryCache()
+        cache.write(workspaceRoot, result)
+
+        listOf(
+            ".gradle/caches/settings.gradle.kts",
+            ".kast/cache/build.gradle.kts",
+            ".git/hooks/build.gradle",
+            ".idea/modules/settings.gradle",
+            "app/build/generated/build.gradle.kts",
+            "node_modules/example/build.gradle.kts",
+            "out/generated/settings.gradle.kts",
+        ).forEach { relativePath ->
+            writeFile(relativePath = relativePath, content = "// ignored\n")
+        }
+
+        val loaded = requireNotNull(cache.read(workspaceRoot))
+        assertEquals(result, loaded.discoveryResult)
+    }
+
+    @Test
     fun `workspace discovery cache is used when valid`() {
         createGradleWorkspace()
         WorkspaceDiscoveryCache().write(workspaceRoot, workspaceDiscoveryResult())

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/WorkspaceRefreshWatcherTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/WorkspaceRefreshWatcherTest.kt
@@ -1,5 +1,7 @@
 package io.github.amichne.kast.standalone
 
+import io.github.amichne.kast.api.RefreshResult
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -53,12 +55,78 @@ class WorkspaceRefreshWatcherTest {
         }
     }
 
+    @Test
+    fun `watcher uses content-only refresh for ENTRY_MODIFY`() {
+        val changedFile = writeFile(
+            relativePath = "app/src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun app(): String = "ready"
+            """.trimIndent() + "\n",
+        )
+        val contentRefreshes = mutableListOf<Set<String>>()
+        var fullRefreshCount = 0
+        val sourceRoot = workspaceRoot.resolve("app/src/main/kotlin")
+
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = listOf(sourceRoot),
+            classpathRoots = emptyList(),
+            moduleName = "main",
+        )
+        session.use { standaloneSession ->
+            WorkspaceRefreshWatcher(
+                session = standaloneSession,
+                contentRefresh = { paths ->
+                    contentRefreshes += paths
+                    RefreshResult(
+                        refreshedFiles = paths.toList().sorted(),
+                        removedFiles = emptyList(),
+                        fullRefresh = false,
+                    )
+                },
+                fullRefresh = {
+                    fullRefreshCount += 1
+                    RefreshResult(
+                        refreshedFiles = emptyList(),
+                        removedFiles = emptyList(),
+                        fullRefresh = true,
+                    )
+                },
+            ).use { watcher ->
+                flushPendingChanges(
+                    watcher = watcher,
+                    changedPaths = setOf(changedFile.toString()),
+                    forceFullRefresh = false,
+                )
+
+                assertEquals(listOf(setOf(changedFile.toString())), contentRefreshes)
+                assertEquals(0, fullRefreshCount)
+            }
+        }
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun watchedDirectories(watcher: WorkspaceRefreshWatcher): Set<Path> {
         val field = WorkspaceRefreshWatcher::class.java.getDeclaredField("watchKeysByDirectory")
         field.isAccessible = true
         val watchKeys = field.get(watcher) as ConcurrentHashMap<Path, WatchKey>
         return watchKeys.keys.toSet()
+    }
+
+    private fun flushPendingChanges(
+        watcher: WorkspaceRefreshWatcher,
+        changedPaths: Set<String>,
+        forceFullRefresh: Boolean,
+    ) {
+        val method = WorkspaceRefreshWatcher::class.java.getDeclaredMethod(
+            "flushPendingChanges",
+            Set::class.java,
+            Boolean::class.javaPrimitiveType,
+        )
+        method.isAccessible = true
+        method.invoke(watcher, changedPaths, forceFullRefresh)
     }
 
     private fun writeFile(

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/WorkspaceRefreshWatcherTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/WorkspaceRefreshWatcherTest.kt
@@ -1,0 +1,73 @@
+package io.github.amichne.kast.standalone
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.nio.file.WatchKey
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+class WorkspaceRefreshWatcherTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `watcher registers new directories after source root refresh`() {
+        writeFile(
+            relativePath = "app/src/main/kotlin/sample/App.kt",
+            content = """
+                package sample
+
+                fun app(): String = "ready"
+            """.trimIndent() + "\n",
+        )
+        writeFile(
+            relativePath = "generated/src/main/kotlin/sample/Generated.kt",
+            content = """
+                package sample
+
+                fun generated(): String = "later"
+            """.trimIndent() + "\n",
+        )
+        val initialRoot = workspaceRoot.resolve("app/src/main/kotlin")
+        val refreshedRoot = workspaceRoot.resolve("generated/src/main/kotlin")
+
+        val session = StandaloneAnalysisSession(
+            workspaceRoot = workspaceRoot,
+            sourceRoots = listOf(initialRoot),
+            classpathRoots = emptyList(),
+            moduleName = "main",
+        )
+        session.use { standaloneSession ->
+            WorkspaceRefreshWatcher(standaloneSession).use { watcher ->
+                watcher.refreshSourceRoots(listOf(initialRoot, refreshedRoot))
+
+                assertTrue(
+                    watchedDirectories(watcher).any { directory ->
+                        directory.startsWith(refreshedRoot.toAbsolutePath().normalize())
+                    },
+                )
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun watchedDirectories(watcher: WorkspaceRefreshWatcher): Set<Path> {
+        val field = WorkspaceRefreshWatcher::class.java.getDeclaredField("watchKeysByDirectory")
+        field.isAccessible = true
+        val watchKeys = field.get(watcher) as ConcurrentHashMap<Path, WatchKey>
+        return watchKeys.keys.toSet()
+    }
+
+    private fun writeFile(
+        relativePath: String,
+        content: String,
+    ): Path {
+        val path = workspaceRoot.resolve(relativePath)
+        path.parent?.createDirectories()
+        path.writeText(content)
+        return path
+    }
+}

--- a/build-logic/src/main/kotlin/kast.kotlin-serialization.gradle.kts
+++ b/build-logic/src/main/kotlin/kast.kotlin-serialization.gradle.kts
@@ -2,3 +2,10 @@ plugins {
     id("kast.kotlin-library")
     kotlin("plugin.serialization")
 }
+
+
+private val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+dependencies {
+    implementation(catalog.findLibrary("serialization.json").get())
+}

--- a/build-logic/src/main/kotlin/kast.standalone-serialization-app.gradle.kts
+++ b/build-logic/src/main/kotlin/kast.standalone-serialization-app.gradle.kts
@@ -2,3 +2,9 @@ plugins {
     id("kast.standalone-app")
     kotlin("plugin.serialization")
 }
+
+private val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+dependencies {
+    implementation(catalog.findLibrary("serialization.json").get())
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -32,6 +32,12 @@ stdout. Daemon notes, when present, print on stderr after the command.
 `kast smoke` follows the same default and can render a markdown report when you
 pass `--format=markdown`.
 
+Runtime-dependent commands can auto-start a standalone daemon when needed. They
+attach once the daemon is servable, which can happen during `INDEXING`. Pass
+`--no-auto-start=true` when automation must fail instead of starting a daemon.
+`workspace ensure` remains the explicit prewarm command and waits for `READY`
+unless you add `--accept-indexing=true`.
+
 When Kast detects an interactive terminal, the help pages use ANSI color. If
 you need color in another context, set `CLICOLOR_FORCE=1` before you run the
 help command.
@@ -54,15 +60,18 @@ for one workspace.
 | Command | Purpose | Key options | Notes |
 | --- | --- | --- | --- |
 | `workspace status` | Inspect registered descriptors, liveness, and readiness | `--workspace-root` | Reports the selected daemon plus any additional descriptors for the same workspace |
-| `workspace ensure` | Reuse a ready daemon or start one | `--workspace-root`, `--wait-timeout-ms` | Uses a `60000` millisecond wait timeout unless you override it |
+| `workspace ensure` | Explicitly prewarm or reuse a standalone daemon | `--workspace-root`, `--wait-timeout-ms`, optional `--accept-indexing=true` | Waits for `READY` by default; `--accept-indexing=true` returns once the daemon is servable in `INDEXING` |
 | `workspace refresh` | Force a targeted or full workspace state refresh | `--workspace-root`, optional `--file-paths` | Use this as a manual recovery path; omit `--file-paths` for a full refresh |
-| `daemon start` | Start a detached standalone daemon explicitly | `--workspace-root`, `--wait-timeout-ms` | Useful when you want a direct start instead of an ensure |
+| `daemon start` | Start a detached standalone daemon explicitly | `--workspace-root`, `--wait-timeout-ms` | Deprecated; use `workspace ensure` or let analysis commands auto-start |
 | `daemon stop` | Stop the selected standalone daemon | `--workspace-root` | Removes the selected descriptor and reports what stopped |
 
 ## Read commands
 
-Use these commands when you want read-only analysis against a ready workspace
+Use these commands when you want read-only analysis against a live workspace
 runtime.
+
+All read commands also accept `--no-auto-start=true` when you want them to fail
+instead of creating a daemon implicitly.
 
 | Command | Purpose | Input shape | Notes |
 | --- | --- | --- | --- |
@@ -76,6 +85,8 @@ runtime.
 
 Use these commands when you want Kast to produce or apply code edits through
 the supported mutation flow.
+
+Mutation commands also accept `--no-auto-start=true`.
 
 | Command | Purpose | Input shape | Notes |
 | --- | --- | --- | --- |

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,9 +1,12 @@
 ---
 title: Get started
-description: Install Kast, start a workspace runtime, verify it is ready, and
-  stop it cleanly.
+description: Install Kast, prewarm or auto-start a workspace runtime, verify
+  it, and stop it cleanly.
 icon: lucide/play
 ---
+
+This guide installs Kast, shows the optional explicit prewarm step, and then
+walks through the first workspace commands.
 
 ## Prerequisites
 
@@ -104,11 +107,11 @@ and the supported `--key=value` options.
 4. Run `kast --help` if you want the grouped help page before the first
    workspace command.
 
-## Start or reuse a workspace runtime
+## Optional: prewarm a workspace runtime
 
-Use `workspace ensure` to attach Kast to one workspace. The command reuses a
-healthy daemon when one already exists, or starts a new daemon when it does
-not.
+Analysis commands can start the daemon on demand, so you do not need
+`workspace ensure` before every session. Use it when you want a separate
+startup step or when you want to block for `READY` before the first query.
 
 1. Run the command with an absolute workspace path:
 
@@ -120,12 +123,15 @@ not.
 
 2. Read the JSON result on stdout for the selected runtime metadata.
 3. Read the daemon note on stderr to see whether Kast started a daemon or
-   reused one that was already ready.
+    reused one that was already ready.
+4. Optional: Pass `--accept-indexing=true` when you only need a servable daemon
+   and can tolerate `INDEXING` while background enrichment finishes.
 
-## Verify that the workspace is ready
+## Verify or reuse the workspace runtime
 
-Check status first, then inspect capabilities, so you know the runtime is live
-and the features you plan to call are actually advertised.
+If you skipped the explicit prewarm step, `capabilities` can be your first
+runtime-dependent command. It auto-starts the daemon when needed and returns
+once the daemon is servable.
 
 1. Inspect the workspace runtime:
 
@@ -144,7 +150,9 @@ and the features you plan to call are actually advertised.
    ```
 
 The second command is the fastest way to confirm which read and mutation
-operations the current runtime supports.
+operations the current runtime supports. When `workspace status` reports
+`INDEXING`, semantic commands can still return partial or empty results until
+the state becomes `READY`.
 
 ## Stop the runtime when you are done
 
@@ -199,6 +207,8 @@ mistakes.
   `--key=value` form.
 - If Kast cannot find the workspace or a file, convert the path to an absolute
   path and rerun the command.
+- If you want runtime-dependent commands to fail instead of starting a daemon
+  implicitly, add `--no-auto-start=true` to the command.
 - If the daemon misses an external `.kt` file change, run
   `kast workspace refresh --workspace-root=/absolute/path/to/workspace` to
   force a rescan. Add `--file-paths=...` when you want a targeted refresh.
@@ -227,7 +237,7 @@ mistakes.
 
 ## Next steps
 
-Once the workspace runtime is ready, you can move on to the common analysis
+Once the workspace runtime is live, you can move on to the common analysis
 tasks and the compact reference page.
 
 - [Run analysis commands](run-analysis-commands.md)

--- a/docs/llm-scaffolding-reference.md
+++ b/docs/llm-scaffolding-reference.md
@@ -31,7 +31,7 @@ skill is doing before it runs the public commands.
 | Layer | What the skill handles | When you need to care |
 | --- | --- | --- |
 | CLI discovery | Runs `bash "$SKILL_ROOT/scripts/resolve-kast.sh"` to find `kast` on `PATH`, in local build output, or in `dist/` | When the binary cannot be found or you need to reproduce the exact invocation |
-| Workspace lifecycle | Runs `workspace ensure` before analysis | When a query hits a cold, indexing, or degraded workspace |
+| Workspace lifecycle | Uses `workspace ensure` when you want an explicit prewarm step, or lets the first runtime-dependent command auto-start the daemon | When a query hits a cold, indexing, or degraded workspace |
 | Conversational lookup bridge | Searches for candidate declarations from a class, function, or property reference, then uses `"$SKILL_ROOT/scripts/find-symbol-offset.py"` to turn the chosen candidate into declaration-first UTF-16 offsets | When a human reference is ambiguous or you need to debug why one symbol won |
 | Semantic verification | Resolves the chosen position with `symbol resolve` before it expands to `references`, `call hierarchy`, or `rename` | When the first match is not the symbol you meant |
 | Failure handling | Treats stderr as daemon notes and must surface missing capabilities, `NOT_FOUND`, and truncation honestly | When automation must distinguish "no result" from "bad input" |
@@ -52,12 +52,14 @@ repeatable automation.
 ## Use the minimal command sequence
 
 When you need to reproduce the packaged flow by hand, keep the command
-sequence short. Resolve the binary, ensure the workspace, resolve the symbol,
-and only then expand into references or call hierarchy.
+sequence short. Resolve the binary, optionally prewarm the workspace, resolve
+the symbol, and only then expand into references or call hierarchy.
 
 ```bash
 SKILL_ROOT=/absolute/path/to/your/installed/kast-skill
 KAST=$(bash "$SKILL_ROOT/scripts/resolve-kast.sh")
+# Optional explicit prewarm. Skip this command if you want the first semantic
+# query to auto-start the daemon instead.
 "$KAST" workspace ensure --workspace-root=/absolute/path/to/workspace
 "$KAST" symbol resolve \
   --workspace-root=/absolute/path/to/workspace \
@@ -75,6 +77,10 @@ KAST=$(bash "$SKILL_ROOT/scripts/resolve-kast.sh")
   --direction=incoming \
   --depth=2
 ```
+
+When stderr reports `state: INDEXING`, the daemon is already servable, but
+background enrichment is still running. Early semantic results can still be
+partial or empty until the daemon reaches `READY`.
 
 ## Bridge a human reference into a CLI position
 
@@ -145,6 +151,8 @@ mistakes and interpretation errors.
 - A line and column passed as though they were the raw `offset`
 - An offset that lands on whitespace, comments, or string contents
 - A missing capability that the caller never checked
+- An unexpected auto-start when the caller meant to require an existing daemon;
+  add `--no-auto-start=true` in that case
 - A `call hierarchy` request that omits direction or ignores truncation
   metadata
 

--- a/docs/run-analysis-commands.md
+++ b/docs/run-analysis-commands.md
@@ -1,22 +1,38 @@
 ---
 title: Run analysis commands
 description: Use the supported read and mutation commands once a workspace
-  runtime is ready.
+  runtime is live.
 icon: lucide/search
 ---
 
-Once `kast workspace ensure` has selected a ready daemon, you can run the
-supported analysis commands through the same CLI. This page focuses on the
-common tasks people reach for during normal workspace analysis. If you are
-starting from a human description of a class or property instead of a known
-file position, move to the [human-first agent
-guide](use-kast-from-an-llm-agent.md) first.
+Once `kast workspace ensure` has prewarmed a daemon, or the first
+runtime-dependent command has auto-started one, you can run the supported
+analysis commands through the same CLI. This page focuses on the common tasks
+people reach for during normal workspace analysis. If you are starting from a
+human description of a class or property instead of a known file position, move
+to the [human-first agent guide](use-kast-from-an-llm-agent.md) first.
 
 Note: If you use the packaged `kast` skill or the repo-local launcher resolver,
 you can bring local builds or explicit paths into the discovery cascade with
 `KAST_CLI_PATH` (point at a specific executable) and `KAST_SOURCE_ROOT` (use
 local build outputs or trigger `:kast:writeWrapperScript` when Java 21+ is
 available). See the Get started guide for examples.
+
+> **Note:** Analysis and refresh commands can attach while the daemon reports
+> `INDEXING`. Early semantic results can still be partial or empty until the
+> daemon reaches `READY`.
+
+## Control startup behavior
+
+Use the startup mode that matches the level of control you need before the
+first semantic query.
+
+- Run `kast workspace ensure --workspace-root=/absolute/path/to/workspace` when
+  you want an explicit prewarm step that waits for `READY`.
+- Add `--accept-indexing=true` to `workspace ensure` when a servable
+  `INDEXING` daemon is enough for the next step.
+- Add `--no-auto-start=true` to any runtime-dependent command when automation
+  must fail instead of starting a daemon implicitly.
 
 ## Choose inline options or a request file
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -95,6 +95,18 @@ internal object CliCommandCatalog {
         usage = "--wait-timeout-ms=60000",
         description = "Maximum time to wait for a ready daemon when a command needs one.",
     )
+    private val acceptIndexingOption = CliOptionMetadata(
+        key = "accept-indexing",
+        usage = "--accept-indexing=true",
+        description = "Allow workspace ensure to return once the daemon is servable in INDEXING. Defaults to false.",
+        completionKind = CliOptionCompletionKind.BOOLEAN,
+    )
+    private val noAutoStartOption = CliOptionMetadata(
+        key = "no-auto-start",
+        usage = "--no-auto-start=true",
+        description = "Fail instead of auto-starting a standalone daemon when none is servable. Defaults to false.",
+        completionKind = CliOptionCompletionKind.BOOLEAN,
+    )
     private val requestFileOption = CliOptionMetadata(
         key = "request-file",
         usage = "--request-file=/absolute/path/to/query.json",
@@ -265,12 +277,12 @@ internal object CliCommandCatalog {
         CliCommandMetadata(
             path = listOf("workspace", "ensure"),
             group = CliCommandGroup.WORKSPACE_LIFECYCLE,
-            summary = "Reuse a ready daemon or start one for the workspace.",
-            description = "Ensures a healthy standalone daemon exists before returning runtime metadata.",
+            summary = "Ensure a healthy standalone daemon for the workspace.",
+            description = "Ensures a healthy standalone daemon exists. Analysis commands auto-start the daemon when needed, so this command is mainly for pre-warming the runtime or checking readiness ahead of time.",
             usages = listOf(
-                "$CLI_EXECUTABLE_NAME workspace ensure --workspace-root=/absolute/path/to/workspace [--wait-timeout-ms=60000]",
+                "$CLI_EXECUTABLE_NAME workspace ensure --workspace-root=/absolute/path/to/workspace [--wait-timeout-ms=60000] [--accept-indexing=true]",
             ),
-            options = listOf(workspaceRootOption, waitTimeoutOption),
+            options = listOf(workspaceRootOption, waitTimeoutOption, acceptIndexingOption, noAutoStartOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME workspace ensure --workspace-root=/absolute/path/to/workspace",
             ),
@@ -284,7 +296,7 @@ internal object CliCommandCatalog {
                 "$CLI_EXECUTABLE_NAME workspace refresh --workspace-root=/absolute/path/to/workspace [--file-paths=/absolute/A.kt,/absolute/B.kt]",
                 "$CLI_EXECUTABLE_NAME workspace refresh --workspace-root=/absolute/path/to/workspace --request-file=/absolute/path/to/query.json",
             ),
-            options = listOf(workspaceRootOption, waitTimeoutOption, requestFileOption, filePathsOption),
+            options = listOf(workspaceRootOption, waitTimeoutOption, noAutoStartOption, requestFileOption, filePathsOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME workspace refresh --workspace-root=/absolute/path/to/workspace",
                 "$CLI_EXECUTABLE_NAME workspace refresh --workspace-root=/absolute/path/to/workspace --file-paths=/absolute/path/to/File.kt",
@@ -294,7 +306,7 @@ internal object CliCommandCatalog {
             path = listOf("daemon", "start"),
             group = CliCommandGroup.WORKSPACE_LIFECYCLE,
             summary = "Start a detached standalone daemon for a workspace.",
-            description = "Starts a standalone daemon when none is ready, then waits until it reports readiness.",
+            description = "Deprecated: use `workspace ensure` or let analysis commands auto-start the daemon. This command still starts a standalone daemon and waits until it reports readiness.",
             usages = listOf(
                 "$CLI_EXECUTABLE_NAME daemon start --workspace-root=/absolute/path/to/workspace [--wait-timeout-ms=60000]",
             ),
@@ -319,12 +331,12 @@ internal object CliCommandCatalog {
         CliCommandMetadata(
             path = listOf("capabilities"),
             group = CliCommandGroup.ANALYSIS,
-            summary = "Print the advertised capabilities for the ready workspace daemon.",
-            description = "Ensures the workspace has a ready daemon, then returns its current capability set as JSON.",
+            summary = "Print the advertised capabilities for the workspace daemon.",
+            description = "Ensures the workspace has a servable daemon, then returns its current capability set as JSON.",
             usages = listOf(
                 "$CLI_EXECUTABLE_NAME capabilities --workspace-root=/absolute/path/to/workspace [--wait-timeout-ms=60000]",
             ),
-            options = listOf(workspaceRootOption, waitTimeoutOption),
+            options = listOf(workspaceRootOption, waitTimeoutOption, noAutoStartOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME capabilities --workspace-root=/absolute/path/to/workspace",
             ),
@@ -338,7 +350,7 @@ internal object CliCommandCatalog {
                 "$CLI_EXECUTABLE_NAME symbol resolve --workspace-root=/absolute/path/to/workspace --request-file=/absolute/path/to/query.json",
                 "$CLI_EXECUTABLE_NAME symbol resolve --workspace-root=/absolute/path/to/workspace --file-path=/absolute/path/to/File.kt --offset=123",
             ),
-            options = listOf(workspaceRootOption, waitTimeoutOption, requestFileOption, filePathOption, offsetOption),
+            options = listOf(workspaceRootOption, waitTimeoutOption, noAutoStartOption, requestFileOption, filePathOption, offsetOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME symbol resolve --workspace-root=/absolute/path/to/workspace --request-file=/absolute/path/to/query.json",
             ),
@@ -355,6 +367,7 @@ internal object CliCommandCatalog {
             options = listOf(
                 workspaceRootOption,
                 waitTimeoutOption,
+                noAutoStartOption,
                 requestFileOption,
                 filePathOption,
                 offsetOption,
@@ -376,6 +389,7 @@ internal object CliCommandCatalog {
             options = listOf(
                 workspaceRootOption,
                 waitTimeoutOption,
+                noAutoStartOption,
                 requestFileOption,
                 filePathOption,
                 offsetOption,
@@ -402,6 +416,7 @@ internal object CliCommandCatalog {
             options = listOf(
                 workspaceRootOption,
                 waitTimeoutOption,
+                noAutoStartOption,
                 requestFileOption,
                 filePathOption,
                 offsetOption,
@@ -425,6 +440,7 @@ internal object CliCommandCatalog {
             options = listOf(
                 workspaceRootOption,
                 waitTimeoutOption,
+                noAutoStartOption,
                 requestFileOption,
                 filePathOption,
                 offsetOption,
@@ -443,7 +459,7 @@ internal object CliCommandCatalog {
                 "$CLI_EXECUTABLE_NAME diagnostics --workspace-root=/absolute/path/to/workspace --request-file=/absolute/path/to/query.json",
                 "$CLI_EXECUTABLE_NAME diagnostics --workspace-root=/absolute/path/to/workspace --file-paths=/absolute/A.kt,/absolute/B.kt",
             ),
-            options = listOf(workspaceRootOption, waitTimeoutOption, requestFileOption, filePathsOption),
+            options = listOf(workspaceRootOption, waitTimeoutOption, noAutoStartOption, requestFileOption, filePathsOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME diagnostics --workspace-root=/absolute/path/to/workspace --request-file=/absolute/path/to/query.json",
             ),
@@ -460,6 +476,7 @@ internal object CliCommandCatalog {
             options = listOf(
                 workspaceRootOption,
                 waitTimeoutOption,
+                noAutoStartOption,
                 requestFileOption,
                 filePathOption,
                 offsetOption,
@@ -479,7 +496,7 @@ internal object CliCommandCatalog {
                 "$CLI_EXECUTABLE_NAME imports optimize --workspace-root=/absolute/path/to/workspace --request-file=/absolute/path/to/query.json",
                 "$CLI_EXECUTABLE_NAME imports optimize --workspace-root=/absolute/path/to/workspace --file-paths=/absolute/A.kt,/absolute/B.kt",
             ),
-            options = listOf(workspaceRootOption, waitTimeoutOption, requestFileOption, filePathsOption),
+            options = listOf(workspaceRootOption, waitTimeoutOption, noAutoStartOption, requestFileOption, filePathsOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME imports optimize --workspace-root=/absolute/path/to/workspace --file-paths=/absolute/path/to/File.kt",
             ),
@@ -492,7 +509,7 @@ internal object CliCommandCatalog {
             usages = listOf(
                 "$CLI_EXECUTABLE_NAME edits apply --workspace-root=/absolute/path/to/workspace --request-file=/absolute/path/to/query.json",
             ),
-            options = listOf(workspaceRootOption, waitTimeoutOption, requestFileOption),
+            options = listOf(workspaceRootOption, waitTimeoutOption, noAutoStartOption, requestFileOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME edits apply --workspace-root=/absolute/path/to/workspace --request-file=/absolute/path/to/query.json",
             ),

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
@@ -189,6 +189,8 @@ internal data class ParsedArguments(
             backendName = requestedBackendName,
             waitTimeoutMillis = options["wait-timeout-ms"]?.toLongOrNull() ?: 60_000L,
             standaloneOptions = standaloneOptions,
+            acceptIndexing = optionalBoolean("accept-indexing", false),
+            noAutoStart = optionalBoolean("no-auto-start", false),
         )
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliDaemonStatusNotes.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliDaemonStatusNotes.kt
@@ -25,6 +25,7 @@ internal fun daemonNoteFor(result: WorkspaceStatusResult): String? {
 }
 
 internal fun daemonNoteFor(result: WorkspaceEnsureResult): String? {
+    result.note?.let { return it }
     val action = if (result.started) "started" else "using"
     val summary = "daemon: $action ${result.selected.describeDaemon()}"
     return if (result.started && result.logFile != null) {
@@ -44,7 +45,7 @@ internal fun daemonNoteFor(result: DaemonStopResult): String? {
 internal fun daemonNoteForRuntime(runtime: RuntimeCandidateStatus): String =
     "daemon: using ${runtime.describeDaemon()}"
 
-private fun RuntimeCandidateStatus.describeDaemon(): String {
+internal fun RuntimeCandidateStatus.describeDaemon(): String {
     val endpoint = descriptor.socketPath
     val stateText = when {
         ready -> "ready"

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
@@ -24,6 +24,7 @@ internal data class CliExecutionResult(
 internal data class RuntimeAttachedResult<out T>(
     val payload: T,
     val runtime: RuntimeCandidateStatus,
+    val daemonNote: String? = null,
 )
 
 internal interface CliCommandExecutor {
@@ -68,7 +69,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.workspaceRefresh(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 
@@ -92,7 +93,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.capabilities(command.options)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 
@@ -100,7 +101,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.resolveSymbol(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 
@@ -108,7 +109,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.findReferences(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 
@@ -116,7 +117,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.callHierarchy(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 
@@ -124,7 +125,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.typeHierarchy(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 
@@ -132,7 +133,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.semanticInsertionPoint(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 
@@ -140,7 +141,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.diagnostics(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 
@@ -148,7 +149,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.rename(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 
@@ -156,7 +157,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.optimizeImports(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 
@@ -164,7 +165,7 @@ internal class DefaultCliCommandExecutor(
                 val result = cliService.applyEdits(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
-                    daemonNote = daemonNoteForRuntime(result.runtime),
+                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
                 )
             }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
@@ -48,9 +48,9 @@ internal class CliService(
     ): RuntimeAttachedResult<RefreshResult> {
         val runtime = runtimeManager.ensureRuntime(options)
         requireMutationCapability(runtime.selected, MutationCapability.REFRESH_WORKSPACE)
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = rpcClient.post(runtime.selected.descriptor, "workspace/refresh", query),
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
 
@@ -65,9 +65,9 @@ internal class CliService(
         val capabilities = checkNotNull(runtime.selected.capabilities) {
             "Runtime capabilities were not loaded after ensure for ${runtime.selected.descriptor.backendName}"
         }
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = capabilities,
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
 
@@ -77,9 +77,9 @@ internal class CliService(
     ): RuntimeAttachedResult<SymbolResult> {
         val runtime = runtimeManager.ensureRuntime(options)
         requireReadCapability(runtime.selected, ReadCapability.RESOLVE_SYMBOL)
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = rpcClient.post(runtime.selected.descriptor, "symbol/resolve", query),
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
 
@@ -89,9 +89,9 @@ internal class CliService(
     ): RuntimeAttachedResult<ReferencesResult> {
         val runtime = runtimeManager.ensureRuntime(options)
         requireReadCapability(runtime.selected, ReadCapability.FIND_REFERENCES)
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = rpcClient.post(runtime.selected.descriptor, "references", query),
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
 
@@ -101,9 +101,9 @@ internal class CliService(
     ): RuntimeAttachedResult<CallHierarchyResult> {
         val runtime = runtimeManager.ensureRuntime(options)
         requireReadCapability(runtime.selected, ReadCapability.CALL_HIERARCHY)
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = rpcClient.post(runtime.selected.descriptor, "call-hierarchy", query),
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
 
@@ -113,9 +113,9 @@ internal class CliService(
     ): RuntimeAttachedResult<TypeHierarchyResult> {
         val runtime = runtimeManager.ensureRuntime(options)
         requireReadCapability(runtime.selected, ReadCapability.TYPE_HIERARCHY)
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = rpcClient.post(runtime.selected.descriptor, "type-hierarchy", query),
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
 
@@ -125,9 +125,9 @@ internal class CliService(
     ): RuntimeAttachedResult<DiagnosticsResult> {
         val runtime = runtimeManager.ensureRuntime(options)
         requireReadCapability(runtime.selected, ReadCapability.DIAGNOSTICS)
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = rpcClient.post(runtime.selected.descriptor, "diagnostics", query),
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
 
@@ -137,9 +137,9 @@ internal class CliService(
     ): RuntimeAttachedResult<SemanticInsertionResult> {
         val runtime = runtimeManager.ensureRuntime(options)
         requireReadCapability(runtime.selected, ReadCapability.SEMANTIC_INSERTION_POINT)
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = rpcClient.post(runtime.selected.descriptor, "semantic-insertion-point", query),
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
 
@@ -149,9 +149,9 @@ internal class CliService(
     ): RuntimeAttachedResult<RenameResult> {
         val runtime = runtimeManager.ensureRuntime(options)
         requireMutationCapability(runtime.selected, MutationCapability.RENAME)
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = rpcClient.post(runtime.selected.descriptor, "rename", query),
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
 
@@ -161,9 +161,9 @@ internal class CliService(
     ): RuntimeAttachedResult<ImportOptimizeResult> {
         val runtime = runtimeManager.ensureRuntime(options)
         requireMutationCapability(runtime.selected, MutationCapability.OPTIMIZE_IMPORTS)
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = rpcClient.post(runtime.selected.descriptor, "imports/optimize", query),
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
 
@@ -182,11 +182,20 @@ internal class CliService(
         if (query.fileOperations.isNotEmpty()) {
             requireMutationCapability(runtime.selected, MutationCapability.FILE_OPERATIONS)
         }
-        return RuntimeAttachedResult(
+        return attachedResult(
             payload = rpcClient.post(runtime.selected.descriptor, "edits/apply", query),
-            runtime = runtime.selected,
+            runtime = runtime,
         )
     }
+
+    private fun <T> attachedResult(
+        payload: T,
+        runtime: WorkspaceEnsureResult,
+    ): RuntimeAttachedResult<T> = RuntimeAttachedResult(
+        payload = payload,
+        runtime = runtime.selected,
+        daemonNote = runtime.note,
+    )
 
     private fun requireReadCapability(
         candidate: RuntimeCandidateStatus,

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastHttpClient.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastHttpClient.kt
@@ -1,9 +1,11 @@
 package io.github.amichne.kast.cli
 
 import io.github.amichne.kast.api.ApiErrorResponse
+import io.github.amichne.kast.api.BackendCapabilities
 import io.github.amichne.kast.api.JsonRpcErrorResponse
 import io.github.amichne.kast.api.JsonRpcRequest
 import io.github.amichne.kast.api.JsonRpcSuccessResponse
+import io.github.amichne.kast.api.RuntimeStatusResponse
 import io.github.amichne.kast.api.ServerInstanceDescriptor
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -18,9 +20,21 @@ import java.nio.channels.SocketChannel
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 
+internal interface RuntimeRpcClient {
+    fun runtimeStatus(descriptor: ServerInstanceDescriptor): RuntimeStatusResponse
+
+    fun capabilities(descriptor: ServerInstanceDescriptor): BackendCapabilities
+}
+
 internal class KastRpcClient(
     private val json: Json,
-) {
+) : RuntimeRpcClient {
+    override fun runtimeStatus(descriptor: ServerInstanceDescriptor): RuntimeStatusResponse =
+        get(descriptor = descriptor, method = "runtime/status")
+
+    override fun capabilities(descriptor: ServerInstanceDescriptor): BackendCapabilities =
+        get(descriptor = descriptor, method = "capabilities")
+
     inline fun <reified Response> get(
         descriptor: ServerInstanceDescriptor,
         method: String,

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/RuntimeCommandOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/RuntimeCommandOptions.kt
@@ -8,4 +8,6 @@ internal data class RuntimeCommandOptions(
     val backendName: String?,
     val waitTimeoutMillis: Long,
     val standaloneOptions: StandaloneServerOptions? = null,
+    val acceptIndexing: Boolean = false,
+    val noAutoStart: Boolean = false,
 )

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/WorkspaceEnsureResult.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/WorkspaceEnsureResult.kt
@@ -9,5 +9,6 @@ internal data class WorkspaceEnsureResult(
     val started: Boolean,
     val logFile: String? = null,
     val selected: RuntimeCandidateStatus,
+    val note: String? = null,
     val schemaVersion: Int = SCHEMA_VERSION,
 )

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManager.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManager.kt
@@ -16,8 +16,9 @@ import kotlin.io.path.createDirectories
 import kotlin.time.Duration.Companion.milliseconds
 
 internal class WorkspaceRuntimeManager(
-    private val rpcClient: KastRpcClient,
+    private val rpcClient: RuntimeRpcClient,
     private val processLauncher: ProcessLauncher,
+    private val processLivenessChecker: (Long) -> Boolean = ::isProcessAlive,
 ) {
     suspend fun workspaceStatus(options: RuntimeCommandOptions): WorkspaceStatusResult {
         val inspection = inspectWorkspace(options, pruneStaleDescriptors = false)
@@ -30,7 +31,11 @@ internal class WorkspaceRuntimeManager(
     }
 
     suspend fun workspaceEnsure(options: RuntimeCommandOptions): WorkspaceEnsureResult =
-        ensureRuntime(options)
+        ensureRuntime(
+            options = options,
+            requireReady = !options.acceptIndexing,
+            purpose = EnsureRuntimePurpose.WORKSPACE_ENSURE,
+        )
 
     suspend fun daemonStart(options: RuntimeCommandOptions): WorkspaceEnsureResult {
         val standaloneOptions = options.requireStandaloneBackend()
@@ -44,6 +49,10 @@ internal class WorkspaceRuntimeManager(
                 workspaceRoot = options.workspaceRoot.toString(),
                 started = false,
                 selected = readyRuntime,
+                note = deprecatedDaemonStartNote(
+                    workspaceRoot = options.workspaceRoot,
+                    selected = readyRuntime,
+                ),
             )
         }
 
@@ -52,6 +61,8 @@ internal class WorkspaceRuntimeManager(
                 standaloneOptions = standaloneOptions,
                 backendName = "standalone",
             ),
+            requireReady = true,
+            purpose = EnsureRuntimePurpose.DAEMON_START,
         )
     }
 
@@ -72,9 +83,17 @@ internal class WorkspaceRuntimeManager(
         )
     }
 
-    suspend fun ensureRuntime(options: RuntimeCommandOptions): WorkspaceEnsureResult {
+    suspend fun ensureRuntime(
+        options: RuntimeCommandOptions,
+        requireReady: Boolean = false,
+        purpose: EnsureRuntimePurpose = EnsureRuntimePurpose.COMMAND,
+    ): WorkspaceEnsureResult {
         val inspection = inspectWorkspace(options, pruneStaleDescriptors = true)
-        selectReadyCandidate(inspection.candidates, options.backendName)?.let { selected ->
+        selectServableCandidate(
+            candidates = inspection.candidates,
+            backendName = options.backendName,
+            acceptIndexing = !requireReady,
+        )?.let { selected ->
             return WorkspaceEnsureResult(
                 workspaceRoot = options.workspaceRoot.toString(),
                 started = false,
@@ -85,23 +104,39 @@ internal class WorkspaceRuntimeManager(
         val liveStandalone = inspection.candidates.firstOrNull { it.descriptor.backendName == "standalone" }
         if (liveStandalone != null) {
             if (!liveStandalone.reachable || liveStandalone.runtimeStatus?.state == RuntimeState.DEGRADED) {
+                if (options.noAutoStart) {
+                    throw noAutoStartFailure(options, liveStandalone)
+                }
                 stopCandidate(inspection.descriptorDirectory, liveStandalone)
             } else {
                 return WorkspaceEnsureResult(
                     workspaceRoot = options.workspaceRoot.toString(),
                     started = false,
-                    selected = waitForReady(
+                    selected = waitForServable(
                         options = options.copy(backendName = "standalone"),
                         backendName = "standalone",
+                        acceptIndexing = !requireReady,
                     ),
                 )
             }
         }
 
-        return startStandaloneAndWait(options)
+        if (options.noAutoStart) {
+            throw noAutoStartFailure(options)
+        }
+
+        return startStandaloneAndWait(
+            options = options,
+            requireReady = requireReady,
+            purpose = purpose,
+        )
     }
 
-    private suspend fun startStandaloneAndWait(options: RuntimeCommandOptions): WorkspaceEnsureResult {
+    private suspend fun startStandaloneAndWait(
+        options: RuntimeCommandOptions,
+        requireReady: Boolean,
+        purpose: EnsureRuntimePurpose,
+    ): WorkspaceEnsureResult {
         val standaloneOptions = options.requireStandaloneBackend()
         val logFile = workspaceMetadataDirectory(options.workspaceRoot)
             .resolve("logs")
@@ -114,36 +149,52 @@ internal class WorkspaceRuntimeManager(
             arguments = standaloneOptions.toCliArguments(),
         )
 
+        val selected = waitForServable(
+            options = options.copy(
+                backendName = "standalone",
+                standaloneOptions = standaloneOptions,
+            ),
+            backendName = "standalone",
+            acceptIndexing = !requireReady,
+            launchedProcess = launched,
+        )
         return WorkspaceEnsureResult(
             workspaceRoot = options.workspaceRoot.toString(),
             started = true,
             logFile = logFile.toString(),
-            selected = waitForReady(
-                options = options.copy(
-                    backendName = "standalone",
-                    standaloneOptions = standaloneOptions,
-                ),
-                backendName = "standalone",
-                launchedProcess = launched,
-            ),
+            selected = selected,
+            note = when (purpose) {
+                EnsureRuntimePurpose.COMMAND -> autoStartedDaemonNote(
+                    workspaceRoot = options.workspaceRoot,
+                    selected = selected,
+                )
+                EnsureRuntimePurpose.WORKSPACE_ENSURE -> null
+                EnsureRuntimePurpose.DAEMON_START -> deprecatedDaemonStartNote(
+                    workspaceRoot = options.workspaceRoot,
+                    selected = selected,
+                    logFile = logFile,
+                    started = true,
+                )
+            },
         )
     }
 
-    private suspend fun waitForReady(
+    private suspend fun waitForServable(
         options: RuntimeCommandOptions,
         backendName: String,
+        acceptIndexing: Boolean,
         launchedProcess: StartedProcess? = null,
     ): RuntimeCandidateStatus {
         val deadline = System.nanoTime() + options.waitTimeoutMillis * 1_000_000
         while (System.nanoTime() < deadline) {
             val inspection = inspectWorkspace(options, pruneStaleDescriptors = true)
-            inspection.candidates
-                .firstOrNull { candidate ->
-                    candidate.descriptor.backendName == backendName && candidate.ready
-                }
-                ?.let { return it }
+            selectServableCandidate(
+                candidates = inspection.candidates,
+                backendName = backendName,
+                acceptIndexing = acceptIndexing,
+            )?.let { return it }
 
-            if (launchedProcess != null && !isProcessAlive(launchedProcess.pid)) {
+            if (launchedProcess != null && !processLivenessChecker(launchedProcess.pid)) {
                 throw CliFailure(
                     code = "DAEMON_START_FAILED",
                     message = "The standalone daemon exited before it became ready",
@@ -157,10 +208,48 @@ internal class WorkspaceRuntimeManager(
             delay(250.milliseconds)
         }
 
+        val targetState = if (acceptIndexing) "servable" else "ready"
         throw CliFailure(
             code = "RUNTIME_TIMEOUT",
-            message = "Timed out waiting for $backendName runtime to become ready for ${options.workspaceRoot}",
+            message = "Timed out waiting for $backendName runtime to become $targetState for ${options.workspaceRoot}",
         )
+    }
+
+    private fun noAutoStartFailure(
+        options: RuntimeCommandOptions,
+        existingCandidate: RuntimeCandidateStatus? = null,
+    ): CliFailure = CliFailure(
+        code = "DAEMON_NOT_RUNNING",
+        message = existingCandidate?.let { candidate ->
+            "No servable standalone daemon is available for ${options.workspaceRoot}; the existing daemon is ${candidate.currentStateLabel()}. Rerun without --no-auto-start or start one with `kast workspace ensure`."
+        } ?: "No standalone daemon is registered for ${options.workspaceRoot}. Rerun without --no-auto-start or start one with `kast workspace ensure`.",
+    )
+
+    private fun autoStartedDaemonNote(
+        workspaceRoot: Path,
+        selected: RuntimeCandidateStatus,
+    ): String = "kast: started daemon for $workspaceRoot (state: ${selected.currentStateLabel()})"
+
+    private fun deprecatedDaemonStartNote(
+        workspaceRoot: Path,
+        selected: RuntimeCandidateStatus,
+        logFile: Path? = null,
+        started: Boolean = false,
+    ): String = buildString {
+        append("daemon: ")
+        append(if (started) "started" else "using")
+        append(' ')
+        append(selected.describeDaemon())
+        if (started && logFile != null) {
+            append(" (log: $logFile)")
+        }
+        append(" — deprecated: use `kast workspace ensure --workspace-root=$workspaceRoot` or let analysis commands auto-start the daemon.")
+    }
+
+    internal enum class EnsureRuntimePurpose {
+        COMMAND,
+        WORKSPACE_ENSURE,
+        DAEMON_START,
     }
 
     private suspend fun inspectWorkspace(
@@ -189,7 +278,7 @@ internal class WorkspaceRuntimeManager(
         registered: RegisteredDescriptor,
         pruneStaleDescriptors: Boolean,
     ): RuntimeCandidateStatus {
-        val pidAlive = isProcessAlive(registered.descriptor.pid)
+        val pidAlive = processLivenessChecker(registered.descriptor.pid)
         if (!pidAlive && pruneStaleDescriptors) {
             registry.delete(registered.path)
         }
@@ -207,14 +296,14 @@ internal class WorkspaceRuntimeManager(
 
         val runtimeStatusResult = withContext(Dispatchers.IO) {
             runCatching {
-                rpcClient.get<RuntimeStatusResponse>(registered.descriptor, "runtime/status")
+                rpcClient.runtimeStatus(registered.descriptor)
             }
         }
         val runtimeStatus = runtimeStatusResult.getOrNull()
         val capabilities = if (runtimeStatus != null) {
             withContext(Dispatchers.IO) {
                 runCatching {
-                    rpcClient.get<BackendCapabilities>(registered.descriptor, "capabilities")
+                    rpcClient.capabilities(registered.descriptor)
                 }.getOrNull()
             }
         } else {
@@ -275,18 +364,31 @@ internal data class WorkspaceInspection(
     val selected: RuntimeCandidateStatus?,
 )
 
+internal fun RuntimeStatusResponse?.isServable(): Boolean = this != null &&
+    (state == RuntimeState.READY || state == RuntimeState.INDEXING) &&
+    healthy &&
+    active
+
 internal fun RuntimeStatusResponse?.isReady(): Boolean = this != null &&
     state == RuntimeState.READY &&
     healthy &&
     active &&
     !indexing
 
-internal fun selectReadyCandidate(
+internal fun selectServableCandidate(
     candidates: List<RuntimeCandidateStatus>,
     backendName: String?,
+    acceptIndexing: Boolean,
 ): RuntimeCandidateStatus? = candidates
     .filter { candidate -> backendName == null || candidate.descriptor.backendName == backendName }
-    .filter(RuntimeCandidateStatus::ready).minByOrNull(RuntimeCandidateStatus::descriptorPath)
+    .filter { candidate ->
+        if (acceptIndexing) {
+            candidate.runtimeStatus.isServable()
+        } else {
+            candidate.ready
+        }
+    }
+    .minByOrNull(RuntimeCandidateStatus::descriptorPath)
 
 internal fun selectStatusCandidate(
     candidates: List<RuntimeCandidateStatus>,
@@ -298,6 +400,14 @@ internal fun selectStatusCandidate(
             .thenBy(RuntimeCandidateStatus::descriptorPath),
     )
     .firstOrNull()
+
+internal fun RuntimeCandidateStatus.currentStateLabel(): String = when {
+    runtimeStatus?.state == RuntimeState.INDEXING || runtimeStatus?.indexing == true -> "INDEXING, enrichment in progress"
+    runtimeStatus != null -> runtimeStatus.state.name
+    reachable -> "STARTING"
+    pidAlive -> "UNREACHABLE"
+    else -> "STOPPED"
+}
 
 private fun isProcessAlive(pid: Long): Boolean = ProcessHandle.of(pid)
     .takeIf { it.isPresent }

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
@@ -107,6 +107,40 @@ class CliCommandParserTest {
     }
 
     @Test
+    fun `workspace ensure parses accept indexing`() {
+        val command = parser.parse(
+            arrayOf(
+                "workspace",
+                "ensure",
+                "--workspace-root=$tempDir",
+                "--accept-indexing=true",
+            ),
+        )
+
+        assertTrue(command is CliCommand.WorkspaceEnsure)
+        val ensureCommand = command as CliCommand.WorkspaceEnsure
+        assertTrue(ensureCommand.options.acceptIndexing)
+    }
+
+    @Test
+    fun `symbol resolve parses no auto start`() {
+        val command = parser.parse(
+            arrayOf(
+                "symbol",
+                "resolve",
+                "--workspace-root=$tempDir",
+                "--file-path=$tempDir/Sample.kt",
+                "--offset=12",
+                "--no-auto-start=true",
+            ),
+        )
+
+        assertTrue(command is CliCommand.ResolveSymbol)
+        val resolveCommand = command as CliCommand.ResolveSymbol
+        assertTrue(resolveCommand.options.noAutoStart)
+    }
+
+    @Test
     fun `type hierarchy parses from inline options`() {
         val command = parser.parse(
             arrayOf(

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliDaemonStatusNotesTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliDaemonStatusNotesTest.kt
@@ -77,6 +77,22 @@ class CliDaemonStatusNotesTest {
         assertTrue(note.contains("standalone-daemon.log"))
     }
 
+    @Test
+    fun `workspace ensure note prefers explicit override`() {
+        val note = daemonNoteFor(
+            WorkspaceEnsureResult(
+                workspaceRoot = "/tmp/workspace",
+                started = true,
+                logFile = "/tmp/workspace/.kast/logs/standalone-daemon.log",
+                selected = candidate(pid = 71),
+                note = "kast: started daemon for /tmp/workspace (state: INDEXING, enrichment in progress)",
+            ),
+        )
+
+        assertTrue(checkNotNull(note).contains("INDEXING"))
+        assertTrue(!note.contains("standalone-daemon.log"))
+    }
+
     private fun candidate(
         pid: Long,
         pidAlive: Boolean = true,

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManagerTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManagerTest.kt
@@ -1,0 +1,277 @@
+package io.github.amichne.kast.cli
+
+import io.github.amichne.kast.api.BackendCapabilities
+import io.github.amichne.kast.api.MutationCapability
+import io.github.amichne.kast.api.ReadCapability
+import io.github.amichne.kast.api.RuntimeState
+import io.github.amichne.kast.api.RuntimeStatusResponse
+import io.github.amichne.kast.api.ServerInstanceDescriptor
+import io.github.amichne.kast.api.ServerLimits
+import io.github.amichne.kast.api.defaultDescriptorDirectory
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+class WorkspaceRuntimeManagerTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `ensureRuntime returns immediately when daemon is INDEXING and requireReady is false`() = runTest {
+        val workspaceRoot = tempDir.resolve("workspace-indexing").createDirectories()
+        val descriptor = writeDescriptor(
+            workspaceRoot = workspaceRoot,
+            descriptor = descriptor(workspaceRoot = workspaceRoot, pid = 41),
+        )
+        val manager = WorkspaceRuntimeManager(
+            rpcClient = FakeRuntimeRpcClient(
+                runtimeStatuses = mapOf(
+                    descriptor.socketPath to listOf(
+                        runtimeStatus(
+                            workspaceRoot = workspaceRoot,
+                            state = RuntimeState.INDEXING,
+                            indexing = true,
+                        ),
+                    ),
+                ),
+            ),
+            processLauncher = FakeProcessLauncher(),
+            processLivenessChecker = { pid -> pid == 41L },
+        )
+
+        val result = manager.ensureRuntime(options = runtimeOptions(workspaceRoot), requireReady = false)
+
+        assertFalse(result.started)
+        assertEquals(RuntimeState.INDEXING, result.selected.runtimeStatus?.state)
+    }
+
+    @Test
+    fun `ensureRuntime waits for READY when requireReady is true`() = runTest {
+        val workspaceRoot = tempDir.resolve("workspace-ready").createDirectories()
+        val descriptor = writeDescriptor(
+            workspaceRoot = workspaceRoot,
+            descriptor = descriptor(workspaceRoot = workspaceRoot, pid = 52),
+        )
+        val manager = WorkspaceRuntimeManager(
+            rpcClient = FakeRuntimeRpcClient(
+                runtimeStatuses = mapOf(
+                    descriptor.socketPath to listOf(
+                        runtimeStatus(
+                            workspaceRoot = workspaceRoot,
+                            state = RuntimeState.INDEXING,
+                            indexing = true,
+                        ),
+                        runtimeStatus(
+                            workspaceRoot = workspaceRoot,
+                            state = RuntimeState.READY,
+                            indexing = false,
+                        ),
+                    ),
+                ),
+            ),
+            processLauncher = FakeProcessLauncher(),
+            processLivenessChecker = { pid -> pid == 52L },
+        )
+
+        val result = manager.ensureRuntime(options = runtimeOptions(workspaceRoot), requireReady = true)
+
+        assertFalse(result.started)
+        assertTrue(result.selected.ready)
+        assertEquals(RuntimeState.READY, result.selected.runtimeStatus?.state)
+    }
+
+    @Test
+    fun `workspaceEnsure returns during INDEXING when accept-indexing is true`() = runTest {
+        val workspaceRoot = tempDir.resolve("workspace-ensure-indexing").createDirectories()
+        val descriptor = writeDescriptor(
+            workspaceRoot = workspaceRoot,
+            descriptor = descriptor(workspaceRoot = workspaceRoot, pid = 61),
+        )
+        val manager = WorkspaceRuntimeManager(
+            rpcClient = FakeRuntimeRpcClient(
+                runtimeStatuses = mapOf(
+                    descriptor.socketPath to listOf(
+                        runtimeStatus(
+                            workspaceRoot = workspaceRoot,
+                            state = RuntimeState.INDEXING,
+                            indexing = true,
+                        ),
+                    ),
+                ),
+            ),
+            processLauncher = FakeProcessLauncher(),
+            processLivenessChecker = { pid -> pid == 61L },
+        )
+
+        val result = manager.workspaceEnsure(
+            runtimeOptions(workspaceRoot).copy(acceptIndexing = true),
+        )
+
+        assertFalse(result.started)
+        assertEquals(RuntimeState.INDEXING, result.selected.runtimeStatus?.state)
+    }
+
+    @Test
+    fun `ensureRuntime auto-start note appears when command starts daemon`() = runTest {
+        val workspaceRoot = tempDir.resolve("workspace-autostart").createDirectories()
+        val launchedDescriptor = descriptor(workspaceRoot = workspaceRoot, pid = 77)
+        val manager = WorkspaceRuntimeManager(
+            rpcClient = FakeRuntimeRpcClient(
+                runtimeStatuses = mapOf(
+                    launchedDescriptor.socketPath to listOf(
+                        runtimeStatus(
+                            workspaceRoot = workspaceRoot,
+                            state = RuntimeState.INDEXING,
+                            indexing = true,
+                        ),
+                    ),
+                ),
+            ),
+            processLauncher = FakeProcessLauncher { workingDirectory, _, _ ->
+                writeDescriptor(
+                    workspaceRoot = workingDirectory,
+                    descriptor = launchedDescriptor,
+                )
+                StartedProcess(
+                    pid = launchedDescriptor.pid,
+                    logFile = workspaceRoot.resolve(".kast/logs/standalone-daemon.log"),
+                )
+            },
+            processLivenessChecker = { pid -> pid == 77L },
+        )
+
+        val result = manager.ensureRuntime(options = runtimeOptions(workspaceRoot))
+
+        assertTrue(result.started)
+        assertTrue(checkNotNull(result.note).contains("state: INDEXING"))
+    }
+
+    @Test
+    fun `ensureRuntime with no-auto-start fails when no daemon exists`() = runTest {
+        val workspaceRoot = tempDir.resolve("workspace-no-autostart").createDirectories()
+        val manager = WorkspaceRuntimeManager(
+            rpcClient = FakeRuntimeRpcClient(runtimeStatuses = emptyMap()),
+            processLauncher = FakeProcessLauncher(),
+            processLivenessChecker = { false },
+        )
+
+        val failure = runCatching {
+            manager.ensureRuntime(
+                options = runtimeOptions(workspaceRoot).copy(noAutoStart = true),
+            )
+        }.exceptionOrNull() as? CliFailure
+
+        checkNotNull(failure) {
+            "Expected ensureRuntime to fail when no-auto-start is enabled"
+        }
+
+        assertEquals("DAEMON_NOT_RUNNING", failure.code)
+        assertTrue(failure.message.contains("--no-auto-start"))
+    }
+
+    private fun runtimeOptions(workspaceRoot: Path): RuntimeCommandOptions = RuntimeCommandOptions(
+        workspaceRoot = workspaceRoot,
+        backendName = "standalone",
+        waitTimeoutMillis = 2_000L,
+    )
+
+    private fun descriptor(
+        workspaceRoot: Path,
+        pid: Long,
+    ): ServerInstanceDescriptor = ServerInstanceDescriptor(
+        workspaceRoot = workspaceRoot.toString(),
+        backendName = "standalone",
+        backendVersion = "0.1.0-SNAPSHOT",
+        socketPath = workspaceRoot.resolve(".kast/socket").toString(),
+        pid = pid,
+    )
+
+    private fun runtimeStatus(
+        workspaceRoot: Path,
+        state: RuntimeState,
+        indexing: Boolean,
+    ): RuntimeStatusResponse = RuntimeStatusResponse(
+        state = state,
+        healthy = true,
+        active = true,
+        indexing = indexing,
+        backendName = "standalone",
+        backendVersion = "0.1.0-SNAPSHOT",
+        workspaceRoot = workspaceRoot.toString(),
+        message = state.name,
+    )
+
+    private fun sampleCapabilities(workspaceRoot: Path): BackendCapabilities = BackendCapabilities(
+        backendName = "standalone",
+        backendVersion = "0.1.0-SNAPSHOT",
+        workspaceRoot = workspaceRoot.toString(),
+        readCapabilities = setOf(ReadCapability.DIAGNOSTICS),
+        mutationCapabilities = setOf(MutationCapability.RENAME),
+        limits = ServerLimits(
+            maxResults = 500,
+            requestTimeoutMillis = 30_000,
+            maxConcurrentRequests = 4,
+        ),
+    )
+
+    private fun writeDescriptor(
+        workspaceRoot: Path,
+        descriptor: ServerInstanceDescriptor,
+    ): ServerInstanceDescriptor {
+        val registryDirectory = defaultDescriptorDirectory(workspaceRoot)
+        registryDirectory.createDirectories()
+        registryDirectory.resolve("${descriptor.pid}.json").writeText(
+            defaultCliJson().encodeToString(ServerInstanceDescriptor.serializer(), descriptor),
+        )
+        return descriptor
+    }
+
+    private class FakeRuntimeRpcClient(
+        runtimeStatuses: Map<String, List<RuntimeStatusResponse>>,
+    ) : RuntimeRpcClient {
+        private val statusQueues = runtimeStatuses.mapValues { (_, statuses) -> ArrayDeque(statuses) }
+
+        override fun runtimeStatus(descriptor: ServerInstanceDescriptor): RuntimeStatusResponse {
+            val queue = statusQueues[descriptor.socketPath]
+                ?: throw CliFailure(code = "DAEMON_UNREACHABLE", message = "No runtime status for ${descriptor.socketPath}")
+            if (queue.size > 1) {
+                return queue.removeFirst()
+            }
+            return checkNotNull(queue.firstOrNull())
+        }
+
+        override fun capabilities(descriptor: ServerInstanceDescriptor): BackendCapabilities =
+            BackendCapabilities(
+                backendName = "standalone",
+                backendVersion = "0.1.0-SNAPSHOT",
+                workspaceRoot = descriptor.workspaceRoot,
+                readCapabilities = setOf(ReadCapability.DIAGNOSTICS),
+                mutationCapabilities = setOf(MutationCapability.RENAME),
+                limits = ServerLimits(
+                    maxResults = 500,
+                    requestTimeoutMillis = 30_000,
+                    maxConcurrentRequests = 4,
+                ),
+            )
+    }
+
+    private class FakeProcessLauncher(
+        private val onStart: (Path, Path, List<String>) -> StartedProcess = { _, logFile, _ ->
+            StartedProcess(pid = 999, logFile = logFile)
+        },
+    ) : ProcessLauncher {
+        override fun startDetached(
+            mainClassName: String,
+            workingDirectory: Path,
+            logFile: Path,
+            arguments: List<String>,
+        ): StartedProcess = onStart(workingDirectory, logFile, arguments)
+    }
+}

--- a/smoke.sh
+++ b/smoke.sh
@@ -185,7 +185,7 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════════════════
-# 2. Workspace ensure
+# 2. Workspace ensure (smoke keeps an explicit READY prewarm step)
 # ══════════════════════════════════════════════════════════════════════════════
 log_step "Step 2: workspace ensure"
 if "$KAST" workspace ensure \


### PR DESCRIPTION
This PR introduces three connected features for the Kast standalone daemon:
Phased workspace discovery: GradleWorkspaceDiscovery.discoverPhased() returns a static layout immediately, while Tooling API enrichment runs asynchronously via a CompletableFuture. The daemon becomes servable in INDEXING state before enrichment completes.
Auto-start: Runtime-dependent commands (analysis, mutation, refresh) now auto-start the daemon when none exists, instead of requiring workspace ensure first. A --no-auto-start=true flag opts out.
--accept-indexing: workspace ensure gains --accept-indexing=true to return once the daemon is servable (INDEXING or READY) rather than blocking for READY.
The flow becomes:
# Before: explicit ensure required
kast workspace ensure ...
kast symbol resolve ...
# After: auto-start on first command
kast symbol resolve ...  # starts daemon
# stderr: "kast: started daemon (state: INDEXING)"
Key new abstractions:
PhasedDiscoveryResult(initialLayout, enrichmentFuture?)
selectServableCandidate(candidates, backendName, acceptIndexing)
EnsureRuntimePurpose.COMMAND | WORKSPACE_ENSURE | DAEMON_START
RuntimeRpcClient interface (enables testing WorkspaceRuntimeManager)


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amichne/kast/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
