### PR TITLE
Refactor kast skill around structured wrapper scripts

### DIFF
--- a/.agents/skills/kast/SKILL.md
+++ b/.agents/skills/kast/SKILL.md
@@ -1,26 +1,34 @@
 ---
 name: kast
 description: >
-  Use this skill for any Kotlin/JVM semantic code intelligence task: resolve a symbol,
-  find references, expand call hierarchies, run diagnostics, plan a rename, apply
-  edits. Triggers on: "resolve symbol", "find references", "call hierarchy",
-  "who calls", "incoming callers", "outgoing callers", "kast", "rename symbol",
-  "run diagnostics", "apply edits", "symbol at offset", "semantic analysis",
-  "kotlin analysis daemon". The daemon lifecycle is fully managed by this skill.
-  Single pathway for every operation.
+  Use this skill for any Kotlin/JVM semantic code intelligence task: resolve a
+  symbol, find references, expand call hierarchies, run diagnostics, assess
+  edit impact, plan a rename, or apply rename edits through the packaged
+  wrapper scripts. Triggers on: "resolve symbol", "find references",
+  "call hierarchy", "who calls", "incoming callers", "outgoing callers",
+  "kast", "rename symbol", "run diagnostics", "apply edits", "symbol at
+  offset", "semantic analysis", "kotlin analysis daemon". Every multi-step
+  operation goes through `scripts/` and emits structured JSON on stdout.
 ---
 
-# Kast Skill
+# Kast skill
 
-kast is a Kotlin semantic analysis daemon. It provides symbol resolution,
-reference finding, call hierarchy expansion, diagnostics, rename planning, and
-edit application for Kotlin/JVM workspaces.
+kast is a Kotlin semantic analysis daemon. This skill wraps the CLI in
+structured scripts so the agent can stay on JSON instead of brittle shell
+pipelines.
 
----
+## 0. Core principle
 
-## 0. Bootstrap (run once per session)
+Never interact with raw terminal output for workflows that already have a
+wrapper. Every multi-step kast operation goes through a script in `scripts/`.
+Each wrapper emits structured JSON on stdout, writes raw stderr and daemon
+notes to `log_file`, and cleans up its temp files on exit. Read the wrapper
+JSON first. Open `log_file` only when `ok=false` or you need daemon notes.
 
-Locate the skill root and resolve the kast binary. Do this before anything else.
+## 1. Bootstrap (run once per session)
+
+Locate the skill root first. Resolve the raw `kast` binary only for commands
+that do not have a wrapper yet.
 
 ```bash
 SKILL_ROOT="$(cd "$(dirname "$(find "$(git rev-parse --show-toplevel)" \
@@ -28,315 +36,115 @@ SKILL_ROOT="$(cd "$(dirname "$(find "$(git rev-parse --show-toplevel)" \
 KAST="$(bash "$SKILL_ROOT/scripts/resolve-kast.sh")"
 ```
 
-`$KAST` is the verified kast binary. `$SKILL_ROOT` is the absolute path to bundled
-scripts. Use both variables for every subsequent invocation in this session.
+`$SKILL_ROOT` is the packaged skill root. The wrappers resolve `kast`
+internally, so you do not need temp files, redirects, or manual stderr
+capture.
 
-Next, set up a session temp directory for capturing command output:
+Optional: prewarm the workspace when you want a separate readiness step before
+you call a wrapper.
 
 ```bash
-KAST_TMP="$(mktemp -d)"
-trap 'rm -rf "$KAST_TMP"' EXIT
-KAST_RESULT="$KAST_TMP/result.json"
-KAST_STDERR="$KAST_TMP/stderr.log"
+"$KAST" workspace ensure --workspace-root="$(git rev-parse --show-toplevel)"
 ```
 
-All kast commands in this session write results to `$KAST_RESULT` and daemon notes to
-`$KAST_STDERR`. Read `$KAST_RESULT` for the JSON output. When the exit code is
-non-zero, read `$KAST_STDERR` for the error details. On success, `$KAST_STDERR`
-may still contain a daemon note, such as an auto-start message or
-`state: INDEXING`.
+If `workspace ensure` fails, read
+`$(git rev-parse --show-toplevel)/.kast/logs/standalone-daemon.log` before you
+retry.
 
-Optional: prewarm the workspace when you want a separate readiness step:
+## 2. Symbol lookup
 
-```bash
-"$KAST" workspace ensure --workspace-root="$(git rev-parse --show-toplevel)" \
-  > "$KAST_RESULT" 2> "$KAST_STDERR"
-```
-
-`workspace ensure` starts the daemon if none exists, reuses an existing healthy
-one, and waits until the daemon reaches `READY` by default (60 s timeout). Add
-`--accept-indexing=true` when you only need a servable daemon and can tolerate
-`INDEXING` while enrichment finishes. If you skip this step, the first
-runtime-dependent command auto-starts the daemon for you.
-
-### If `workspace ensure` fails
-
-Read the daemon log — it is the authoritative source for the failure:
+Resolve a named symbol with the wrapper. It handles declaration search, UTF-16
+offset discovery, `symbol resolve`, and identity confirmation.
 
 ```bash
-cat "$(git rev-parse --show-toplevel)/.kast/logs/standalone-daemon.log" | tail -60
-```
-
-| Log message | Fix |
-|-------------|-----|
-| `SocketException: Operation not permitted` | Unix domain sockets are blocked. Run this command outside the sandboxed environment. |
-| `Address already in use` | Run `"$KAST" daemon stop --workspace-root=<abs-path>` then re-run `workspace ensure`. |
-| `OutOfMemoryError` | Export `KAST_DAEMON_OPTS=-Xmx2g` and re-run `workspace ensure`. |
-| Java version errors | Install Java 21+ and re-run. |
-
-Do not retry `workspace ensure` without first resolving the root cause shown in the log.
-
----
-
-## 1. Index Validation (after first startup in a new workspace)
-
-Even after the first successful startup, validate once with a known symbol
-before doing real work:
-
-```bash
-# Pick any class declaration in the workspace — adjust paths as needed
-grep -rn "^class \|^object \|^interface " --include="*.kt" \
-  "$(git rev-parse --show-toplevel)/src" | head -1
-```
-
-Take the file path and symbol name from that output, then compute the offset:
-
-```bash
-python3 -c "
-import sys
-path, sym = sys.argv[1], sys.argv[2]
-text = open(path).read()
-idx = text.find(sym)
-print(idx if idx >= 0 else -1)
-" /absolute/path/to/File.kt SymbolName
-```
-
-Then validate the index:
-
-```bash
-"$KAST" symbol resolve \
+bash "$SKILL_ROOT/scripts/kast-resolve.sh" \
   --workspace-root="$(git rev-parse --show-toplevel)" \
-  --file-path=/absolute/path/to/File.kt \
-  --offset=<offset-from-above> \
-  > "$KAST_RESULT" 2> "$KAST_STDERR"
+  --symbol=AnalysisServer
 ```
 
-Read `$KAST_RESULT` for the JSON. If `symbol.fqName` is present, the index is
-healthy. If stderr reports `state: INDEXING`, wait until
-`"$KAST" workspace status --workspace-root=...` shows `READY`, then retry. If
-the daemon is already `READY`, treat `NOT_FOUND` as an offset, save, or
-workspace-refresh problem rather than as background indexing.
+Add `--file=...`, `--kind=class|function|property`, or
+`--containing-type=OuterType` when the human reference is ambiguous.
 
----
+## 3. Analysis commands
 
-## 2. Symbol Lookup (name → offset)
+Use the wrappers for every multi-step workflow the skill already covers.
 
-All kast commands require `--offset` (a zero-based UTF-16 character offset). When the
-user gives a symbol by name, derive the offset in two steps.
+### Resolve a symbol
 
-**Step 1 — Find the declaration:**
+Use `kast-resolve.sh` when the user gives a symbol name instead of a raw file
+offset.
 
 ```bash
-# class / object / interface / sealed / enum
-grep -rn "\bclass SymbolName\b\|\bobject SymbolName\b\|\binterface SymbolName\b" \
-  --include="*.kt" "$(git rev-parse --show-toplevel)"
-
-# function
-grep -rn "\bfun SymbolName\b" --include="*.kt" "$(git rev-parse --show-toplevel)"
-
-# val / var property
-grep -rn "\bval SymbolName\b\|\bvar SymbolName\b" \
-  --include="*.kt" "$(git rev-parse --show-toplevel)"
-```
-
-Pick the declaration line (the hit that contains `class`/`fun`/`val`/`var`/etc.)
-over plain usage lines.
-
-**Step 2 — Compute the offset:**
-
-```bash
-python3 -c "
-import sys
-path, sym = sys.argv[1], sys.argv[2]
-text = open(path).read()
-idx = text.find(sym)
-print(idx if idx >= 0 else -1)
-" /absolute/path/to/File.kt SymbolName
-```
-
-This prints the zero-based character offset of the first occurrence of `SymbolName`.
-If the symbol appears multiple times and you need a specific line, target by line number:
-
-```bash
-python3 -c "
-import sys
-path = sys.argv[1]; line_no = int(sys.argv[2]) - 1  # 1-based to 0-based
-text = open(path).read()
-lines = text.splitlines(keepends=True)
-print(sum(len(l) for l in lines[:line_no]))
-" /absolute/path/to/File.kt <1-based-line>
-```
-
-**Step 3 — Confirm identity:**
-
-```bash
-"$KAST" symbol resolve \
+bash "$SKILL_ROOT/scripts/kast-resolve.sh" \
   --workspace-root=/absolute/workspace/path \
-  --file-path=/absolute/path/to/File.kt \
-  --offset=<offset> \
-  > "$KAST_RESULT" 2> "$KAST_STDERR"
+  --symbol=AnalysisServer \
+  --file=analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisServer.kt
 ```
 
-Read `$KAST_RESULT`. Check that `symbol.fqName` matches what the user described. If not,
-advance the offset by a few characters toward the start of the identifier and retry.
+Key output: `ok`, `symbol`, `file_path`, `offset`, `candidate`, `log_file`
 
----
+### Find references
 
-## 3. Analysis Commands
-
-All commands: Redirect stdout to `$KAST_RESULT` and stderr to `$KAST_STDERR`. Read
-`$KAST_RESULT` for the JSON result. Check exit code first — if non-zero, read
-`$KAST_STDERR` for the error.
-
-- Use `--key=value` for every flag
-- Require absolute paths for `--workspace-root`, `--file-path`, and `--file-paths`
-- `--offset` = zero-based UTF-16 character offset from start of file
-- `call hierarchy` also requires `--direction=incoming|outgoing`
-
-### symbol resolve
+Use `kast-references.sh` to resolve the symbol and run `references` in one
+step.
 
 ```bash
-"$KAST" symbol resolve \
+bash "$SKILL_ROOT/scripts/kast-references.sh" \
   --workspace-root=/absolute/workspace/path \
-  --file-path=/absolute/path/to/File.kt \
-  --offset=<offset> \
-  > "$KAST_RESULT" 2> "$KAST_STDERR"
+  --symbol=AnalysisServer \
+  --include-declaration=true
 ```
 
-Key output: `symbol.fqName`, `symbol.kind`, `symbol.location`, `symbol.type`
+Key output: `ok`, `symbol`, `references`, `search_scope`, `declaration`,
+`log_file`
 
-### references
+### Expand callers or callees
 
-```bash
-"$KAST" references \
-  --workspace-root=/absolute/workspace/path \
-  --file-path=/absolute/path/to/File.kt \
-  --offset=<offset> \
-  --include-declaration=true \
-  > "$KAST_RESULT" 2> "$KAST_STDERR"
-```
-
-Key output: `references` (array of `Location`), `declaration`, `page.truncated`
-
-If `page.truncated = true`, the result is capped at `limits.maxResults`. There is no
-pagination — this is the full available set.
-
-### call hierarchy
+Use `kast-callers.sh` to resolve the symbol and run `call hierarchy` with the
+requested direction and depth.
 
 ```bash
-"$KAST" call hierarchy \
+bash "$SKILL_ROOT/scripts/kast-callers.sh" \
   --workspace-root=/absolute/workspace/path \
-  --file-path=/absolute/path/to/File.kt \
-  --offset=<offset> \
+  --symbol=AnalysisServer \
   --direction=incoming \
-  --depth=2 \
-  > "$KAST_RESULT" 2> "$KAST_STDERR"
+  --depth=2
 ```
 
-Optional flags: `--max-total-calls`, `--max-children-per-node`,
-`--timeout-millis`, `--persist-to-git-sha-cache=true`
+Key output: `ok`, `symbol`, `root`, `stats`, `log_file`
 
-Key output: `root`, `stats`, optional `persistence`
+### Run diagnostics
 
-`children[].callSite` identifies the edge. Any node `truncation` plus
-`stats.timeoutReached`, `stats.maxTotalCallsReached`, or
-`stats.maxChildrenPerNodeReached` means the tree is bounded and incomplete.
-
-### diagnostics
+Use `kast-diagnostics.sh` when you need structured diagnostics for one or more
+files.
 
 ```bash
-"$KAST" diagnostics \
+bash "$SKILL_ROOT/scripts/kast-diagnostics.sh" \
   --workspace-root=/absolute/workspace/path \
-  --file-paths=/absolute/A.kt,/absolute/B.kt \
-  > "$KAST_RESULT" 2> "$KAST_STDERR"
+  --file-paths=/absolute/A.kt,/absolute/B.kt
 ```
 
-Key output: `diagnostics[].severity` (`ERROR`|`WARNING`|`INFO`), `.message`, `.location`
+Key output: `ok`, `clean`, `error_count`, `warning_count`, `diagnostics`,
+`log_file`
 
-An empty `diagnostics` array means the files are clean.
+### Assess edit impact
 
-### rename (dry-run plan)
+Use `kast-impact.sh` before you change a symbol. It resolves the symbol, finds
+references, and can include incoming callers in the same result.
 
 ```bash
-"$KAST" rename \
+bash "$SKILL_ROOT/scripts/kast-impact.sh" \
   --workspace-root=/absolute/workspace/path \
-  --file-path=/absolute/path/to/File.kt \
-  --offset=<offset> \
-  --new-name=NewSymbolName \
-  --dry-run=true \
-  > "$KAST_TMP/rename-plan.json" 2> "$KAST_STDERR"
+  --symbol=AnalysisServer \
+  --include-callers=true
 ```
 
-Key output: `edits`, `fileHashes` (SHA-256 integrity tokens), `affectedFiles`
+Key output: `ok`, `symbol`, `references`, `search_scope`, optional
+`call_hierarchy`, `log_file`
 
-Pass `fileHashes` unchanged to `edits apply`. Do not recompute or manipulate them.
+### Rename a symbol safely
 
-### edits apply
-
-Always supply the apply request via `--request-file`. Never construct inline JSON.
-Use `kast-plan-utils.py` to extract the request from the rename plan output:
-
-```bash
-"$KAST" rename \
-  --workspace-root=/absolute/workspace/path \
-  --file-path=/absolute/path/to/File.kt \
-  --offset=<offset> \
-  --new-name=NewSymbolName \
-  --dry-run=true \
-  > "$KAST_TMP/rename-plan.json" 2> "$KAST_STDERR"
-
-python3 "$SKILL_ROOT/scripts/kast-plan-utils.py" \
-  extract-apply-request "$KAST_TMP/rename-plan.json" "$KAST_TMP/apply-request.json"
-
-"$KAST" edits apply \
-  --workspace-root=/absolute/workspace/path \
-  --request-file="$KAST_TMP/apply-request.json" \
-  > "$KAST_RESULT" 2> "$KAST_STDERR"
-```
-
-Key output: `applied` (written edits), `affectedFiles`
-
----
-
-## 4. Workflows
-
-### Resolve or find references for a named symbol
-
-```
-1. Bootstrap (Section 0)
-2. grep for declaration → identify file + symbol name
-3. Compute offset (Section 2 Step 2) → take first offset
-4. symbol resolve → read $KAST_RESULT, confirm fqName
-5. references → read $KAST_RESULT for results
-```
-
-### Caller or callee exploration
-
-```
-1. Bootstrap (Section 0)
-2. Symbol lookup (Section 2) → offset
-3. symbol resolve → read $KAST_RESULT, confirm identity and kind
-4. call hierarchy --direction=incoming|outgoing --depth=<n> → read $KAST_RESULT
-5. Check stats + truncation before claiming the tree is complete
-```
-
-### Pre-edit impact assessment
-
-Before modifying a symbol:
-
-```
-1. Bootstrap (Section 0)
-2. Symbol lookup (Section 2) → offset
-3. symbol resolve → read $KAST_RESULT, confirm identity and kind
-4. references or call hierarchy → read $KAST_RESULT, assess impact before editing
-```
-
-### Safe rename
-
-Use the one-shot script. It runs workspace ensure, plans the rename, extracts the apply
-request without `jq`, applies the edits, runs diagnostics, and exits non-zero if any
-`ERROR`-severity diagnostics remain. The script already follows the file-redirect pattern
-internally — it is the canonical example of this workflow.
+Use the one-shot rename wrapper for the full mutation workflow.
 
 ```bash
 bash "$SKILL_ROOT/scripts/kast-rename.sh" \
@@ -346,76 +154,105 @@ bash "$SKILL_ROOT/scripts/kast-rename.sh" \
   --new-name=NewSymbolName
 ```
 
-If `kast-rename.sh` exits non-zero due to `CONFLICT`: files changed between plan and
-apply. Re-run `kast-rename.sh` — it will produce a fresh plan with updated hashes.
+`kast-rename.sh` runs `workspace ensure`, plans the rename, extracts the
+apply-request with `kast-plan-utils.py`, applies the edits, runs diagnostics on
+affected files, and exits non-zero if any `ERROR` diagnostics remain.
+
+### Raw CLI fallback
+
+Use raw `"$KAST"` only when a wrapper does not exist yet, such as
+`type hierarchy`, `semantic insertion-point`, `imports optimize`, or a custom
+rename-plan flow. Keep `kast-plan-utils.py` in the loop for rename JSON.
+
+```bash
+"$KAST" rename \
+  --workspace-root=/absolute/workspace/path \
+  --file-path=/absolute/path/to/File.kt \
+  --offset=<offset> \
+  --new-name=NewSymbolName \
+  --dry-run=true > /tmp/rename-plan.json
+
+python3 "$SKILL_ROOT/scripts/kast-plan-utils.py" \
+  extract-apply-request /tmp/rename-plan.json /tmp/apply-request.json
+
+"$KAST" edits apply \
+  --workspace-root=/absolute/workspace/path \
+  --request-file=/tmp/apply-request.json
+```
+
+## 4. Workflows
+
+Use these wrapper combinations for the common agent tasks.
+
+### Resolve or find references for a named symbol
+
+Start with `kast-resolve.sh` when you only need the declaration. Use
+`kast-references.sh` when the next step is a reference list.
+
+### Caller or callee exploration
+
+Use `kast-callers.sh` with `--direction=incoming` for callers and
+`--direction=outgoing` for callees. Always read `stats` and any node
+`truncation` before you report the tree as complete.
+
+### Pre-edit impact assessment
+
+Use `kast-impact.sh` before you edit a symbol. Treat
+`search_scope.exhaustive=false`, `stats.timeoutReached=true`, or any truncation
+marker as proof that the result is bounded.
 
 ### Post-edit validation
 
-After any code change (rename, manual edit, or generated edit):
+After any code change, run `kast-diagnostics.sh` on the modified files. When
+you need a quick contract check for the wrappers themselves, run
+`validate-wrapper-json.sh`.
 
-```
-1. workspace ensure --workspace-root=<abs-path> > "$KAST_RESULT" 2> "$KAST_STDERR"
-2. diagnostics --file-paths=<comma-separated list of modified files> > "$KAST_RESULT" 2> "$KAST_STDERR"
-3. python3 "$SKILL_ROOT/scripts/kast-plan-utils.py" check-diagnostics "$KAST_RESULT"
-4. Fix any ERROR-severity diagnostic, then repeat from step 2
-```
-
-### Diagnostic triage
-
-When a build fails or a file has unknown errors:
-
-```
-1. Bootstrap (Section 0)
-2. diagnostics --file-paths=<file> > "$KAST_RESULT" 2> "$KAST_STDERR"
-3. Read $KAST_RESULT; for each ERROR: symbol resolve at diagnostic startOffset → identify the symbol
-4. references → read $KAST_RESULT, check for broken call sites
-5. Fix, then diagnostics again to confirm clean
+```bash
+bash "$SKILL_ROOT/scripts/validate-wrapper-json.sh" \
+  "$(git rev-parse --show-toplevel)"
 ```
 
----
+## 5. Error reference
 
-## 5. Error Reference
+Use the wrapper JSON as the first failure surface. The wrapper `message`,
+`stage`, and `log_file` tell you whether the failure came from argument
+validation, workspace startup, candidate lookup, or the underlying CLI call.
 
-| Error / Symptom | Cause | Fix |
-|-----------------|-------|-----|
-| `VALIDATION_ERROR` (400) | Bad parameters | Fix the file path, offset, or name and retry |
-| `NOT_FOUND` (404) | Offset on whitespace, unsaved file, or daemon still indexing | Recompute offset to land on the identifier. If stderr or `workspace status` reports `INDEXING`, wait for `READY`; otherwise treat it as an offset, save, or refresh problem. |
-| `CONFLICT` (409) | Files changed since rename plan | Re-run `kast-rename.sh` — it produces a fresh plan |
-| `CAPABILITY_NOT_SUPPORTED` (501) | Capability absent | Run `"$KAST" capabilities` to confirm. Use grep for text search; kast does not do it. |
-| `APPLY_PARTIAL_FAILURE` (500) | Disk or permissions error mid-apply | Inspect `details` map; fix the root cause and apply remaining edits manually |
-| `workspace ensure` timeout | Daemon failed before becoming servable | Read `.kast/logs/standalone-daemon.log` — the cause is always there |
-
----
+| Error or symptom | Cause | Fix |
+| --- | --- | --- |
+| `argument_validation` | Missing or invalid wrapper arguments | Fix the wrapper flags and rerun |
+| `candidate_search` | No declaration candidate matched the symbol query | Add `--file`, `--kind`, or `--containing-type`, or confirm the symbol exists |
+| `workspace_ensure` | The daemon did not become ready | Read `.kast/logs/standalone-daemon.log` before retrying |
+| `NOT_FOUND` in `log_file` | Offset landed on the wrong token or the file is not indexed | Re-run `kast-resolve.sh` with a better file hint, or wait for `READY` |
+| `CONFLICT` from `kast-rename.sh` | Files changed between plan and apply | Re-run `kast-rename.sh` to generate a fresh plan |
+| `clean=false` from `kast-diagnostics.sh` | Diagnostics found `ERROR` results | Fix the errors, then rerun diagnostics |
 
 ## 6. Rules
 
-- Use `--key=value` syntax for every flag.
-- All `--workspace-root`, `--file-path`, and `--file-paths` values must be absolute paths.
-- Always use `--request-file` for `edits apply`. Never construct inline JSON.
-- Never use `jq` — use `kast-plan-utils.py` for all JSON operations.
-- Call `call hierarchy` only after you confirm the declaration offset.
-- Always read call hierarchy `stats` and node `truncation` before you report
-  the tree as complete.
-- Never use hyphenated pseudo-commands (`workspace-status`, `symbol-resolve`, `edits-apply`).
-- When `workspace ensure` fails, read the log before doing anything else.
-- Always redirect stdout to `$KAST_RESULT` and stderr to `$KAST_STDERR`. Never read kast JSON output from the terminal — always read it from the result file.
-
----
+- Always use the wrapper scripts for multi-step operations.
+- Use raw `kast` CLI only when a wrapper does not exist yet.
+- Keep `--key=value` syntax for raw CLI calls.
+- Use absolute `--workspace-root`, `--file-path`, and `--file-paths` values
+  for raw CLI calls.
+- Use `kast-plan-utils.py` for rename-plan JSON. Never use `jq`.
+- Treat `search_scope.exhaustive=false`, `stats.timeoutReached=true`,
+  `stats.maxTotalCallsReached=true`, `stats.maxChildrenPerNodeReached=true`,
+  or node `truncation` as proof that the result is bounded.
+- Read the wrapper `log_file` before you retry a workspace-startup failure.
+- Never claim a symbol match, reference list, or call tree is complete unless
+  the wrapper result supports that claim.
 
 ## 7. Integration
 
-| Task | Tool |
-|------|------|
-| Resolve a symbol at an offset | kast `symbol resolve` |
-| Find all references across workspace | kast `references` |
-| Inspect callers or callees for a symbol | kast `call hierarchy` |
-| Get compile errors for a file | kast `diagnostics` |
-| Rename a symbol safely | `kast-rename.sh` |
-| Find text in comments or strings | Grep — kast does not search text |
-| Build the project | `kotlin-gradle-loop` skill / configured `project.gradleHook` |
-| Run tests | `kotlin-gradle-loop` skill / targeted Gradle tasks plus final `gradleHook` |
+Use the narrowest tool that owns the task.
 
-kast = semantic intelligence (what is this symbol, who calls it, where is it
-used, rename it).
-kotlin-gradle-loop = build, test, and final build-health validation through the
-configured `gradleHook`.
+| Task | Tool |
+| --- | --- |
+| Resolve a symbol name to a real declaration | `kast-resolve.sh` |
+| Find references for a named symbol | `kast-references.sh` |
+| Explore callers or callees for a named symbol | `kast-callers.sh` |
+| Assess pre-edit impact | `kast-impact.sh` |
+| Run structured diagnostics for changed files | `kast-diagnostics.sh` |
+| Rename a symbol end to end | `kast-rename.sh` |
+| Build the project | `kotlin-gradle-loop` skill or targeted Gradle tasks |
+| Run tests | `kotlin-gradle-loop` skill or targeted Gradle tasks |

--- a/.agents/skills/kast/agents/openai.yaml
+++ b/.agents/skills/kast/agents/openai.yaml
@@ -1,7 +1,9 @@
 interface:
   display_name: "Kast"
-  short_description: "Kotlin semantic code intelligence via the kast daemon"
+  short_description: "Structured Kotlin semantic analysis via packaged kast wrappers"
   default_prompt: >
-    Discover the kast CLI using resolve-kast.sh, then run the requested
-    command. Always run workspace ensure before any analysis command.
-    Use --key=value syntax and absolute paths throughout.
+    Locate the packaged kast skill root, then use the wrapper scripts in
+    scripts/ for resolve, references, callers, diagnostics, impact, and rename
+    workflows. Trust the wrapper JSON on stdout and inspect log_file only when
+    ok=false or daemon notes matter. Use raw kast CLI only when a wrapper does
+    not exist.

--- a/.agents/skills/kast/references/command-reference.md
+++ b/.agents/skills/kast/references/command-reference.md
@@ -703,9 +703,138 @@ filters match no declarations.
 
 ## Helper Scripts
 
-The packaged kast skill ships two scripts in `"$SKILL_ROOT/scripts/"` that eliminate
-common shell-quoting pitfalls in automation workflows. Set `SKILL_ROOT` to the absolute
-path of the installed skill directory (e.g. `/your/workspace/.agents/skills/kast`).
+The packaged kast skill ships wrapper scripts and helper utilities in
+`"$SKILL_ROOT/scripts/"` so automation can stay on structured JSON instead of
+shell quoting. Set `SKILL_ROOT` to the absolute path of the installed skill
+directory (for example `/your/workspace/.agents/skills/kast`).
+
+Each wrapper emits structured JSON on stdout with a top-level `ok` boolean and
+`log_file`. The raw `kast` CLI still exists for commands without wrappers, but
+the wrappers are the default path for symbol lookup, references, callers,
+diagnostics, impact assessment, and full rename flows.
+
+| Script | Purpose | Key output |
+| --- | --- | --- |
+| `kast-resolve.sh` | Resolve a human symbol query to a confirmed declaration | `symbol`, `file_path`, `offset`, `candidate`, `log_file` |
+| `kast-references.sh` | Resolve a symbol query and expand references | `symbol`, `references`, `search_scope`, `declaration`, `log_file` |
+| `kast-callers.sh` | Resolve a symbol query and expand incoming or outgoing callers | `symbol`, `root`, `stats`, `log_file` |
+| `kast-diagnostics.sh` | Run structured diagnostics on one or more files | `clean`, `error_count`, `warning_count`, `diagnostics`, `log_file` |
+| `kast-impact.sh` | Resolve a symbol query, gather references, and optionally gather incoming callers | `references`, `search_scope`, optional `call_hierarchy`, `log_file` |
+| `kast-rename.sh` | Run the full rename workflow end to end | `ApplyEditsResult` JSON on stdout; step log on stderr |
+| `kast-plan-utils.py` | Extract or inspect rename-plan JSON | Plan metadata or apply-request JSON |
+| `find-symbol-offset.py` | Compute declaration-first UTF-16 offsets inside one file | Tab-separated candidates |
+| `validate-wrapper-json.sh` | Smoke-test wrapper success and failure JSON contracts | Aggregated validation JSON |
+
+---
+
+### `kast-resolve.sh` — Resolve a human symbol query
+
+Use this wrapper when the user names a symbol instead of giving a file offset.
+It searches for declaration candidates, computes UTF-16 offsets with
+`find-symbol-offset.py`, runs `symbol resolve`, and confirms the match before
+it returns.
+
+```bash
+bash "$SKILL_ROOT/scripts/kast-resolve.sh" \
+  --workspace-root=/absolute/path \
+  --symbol=AnalysisServer \
+  --file=analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisServer.kt
+```
+
+Optional flags:
+- `--file=<absolute path, workspace-relative path, or glob>`
+- `--kind=class|function|property`
+- `--containing-type=OuterType`
+
+**stdout:** wrapper JSON with `ok`, `symbol`, `file_path`, `offset`,
+`candidate`, and `log_file`.
+
+---
+
+### `kast-references.sh` — References from a human symbol query
+
+Use this wrapper when you want the declaration and the reference list in one
+call.
+
+```bash
+bash "$SKILL_ROOT/scripts/kast-references.sh" \
+  --workspace-root=/absolute/path \
+  --symbol=AnalysisServer \
+  --include-declaration=true
+```
+
+Optional flags:
+- `--file=<absolute path, workspace-relative path, or glob>`
+- `--kind=class|function|property`
+- `--containing-type=OuterType`
+- `--include-declaration=true|false`
+
+**stdout:** wrapper JSON with `ok`, `symbol`, `references`, `search_scope`,
+optional `declaration`, and `log_file`.
+
+---
+
+### `kast-callers.sh` — Incoming or outgoing call hierarchy
+
+Use this wrapper when you need callers or callees from a named symbol query.
+
+```bash
+bash "$SKILL_ROOT/scripts/kast-callers.sh" \
+  --workspace-root=/absolute/path \
+  --symbol=AnalysisServer \
+  --direction=incoming \
+  --depth=2
+```
+
+Optional flags:
+- `--file=<absolute path, workspace-relative path, or glob>`
+- `--kind=class|function|property`
+- `--containing-type=OuterType`
+- `--direction=incoming|outgoing`
+- `--depth=<non-negative integer>`
+
+**stdout:** wrapper JSON with `ok`, `symbol`, `root`, `stats`, and `log_file`.
+
+---
+
+### `kast-diagnostics.sh` — Structured diagnostics
+
+Use this wrapper when you need diagnostics on one or more files without
+managing temp files or parsing stderr.
+
+```bash
+bash "$SKILL_ROOT/scripts/kast-diagnostics.sh" \
+  --workspace-root=/absolute/path \
+  --file-paths=/absolute/A.kt,/absolute/B.kt
+```
+
+`--file-paths` accepts comma-separated absolute or workspace-relative paths.
+
+**stdout:** wrapper JSON with `ok`, `clean`, `error_count`, `warning_count`,
+`info_count`, `diagnostics`, and `log_file`.
+
+---
+
+### `kast-impact.sh` — Pre-edit impact assessment
+
+Use this wrapper before you change a symbol. It resolves the symbol, expands
+references, and can include incoming callers in the same result.
+
+```bash
+bash "$SKILL_ROOT/scripts/kast-impact.sh" \
+  --workspace-root=/absolute/path \
+  --symbol=AnalysisServer \
+  --include-callers=true
+```
+
+Optional flags:
+- `--file=<absolute path, workspace-relative path, or glob>`
+- `--kind=class|function|property`
+- `--containing-type=OuterType`
+- `--include-callers=true|false`
+
+**stdout:** wrapper JSON with `ok`, `symbol`, `references`, `search_scope`,
+optional `call_hierarchy`, and `log_file`.
 
 ---
 
@@ -732,6 +861,23 @@ bash "$SKILL_ROOT/scripts/kast-rename.sh" \
 **Exit codes:**
 - `0` — edits applied, diagnostics clean.
 - `1` — ERROR-severity diagnostics found, or apply/plan step failed.
+
+---
+
+### `find-symbol-offset.py` — Declaration-first offsets inside one file
+
+Use this helper when you already know the file and need candidate UTF-16
+offsets for a named symbol.
+
+```bash
+python3 "$SKILL_ROOT/scripts/find-symbol-offset.py" \
+  /absolute/path/to/File.kt \
+  --symbol AnalysisServer
+```
+
+**stdout:** one candidate per line as
+`<offset>\t<line>\t<col>\t<context-snippet>`, with declaration-like matches
+first.
 
 ---
 
@@ -781,9 +927,28 @@ python3 "$UTILS" check-diagnostics "$KAST_RESULT" || echo "Errors found — see 
 
 ---
 
+### `validate-wrapper-json.sh` — Smoke validation for wrapper contracts
+
+Use this helper when you want a quick check that each wrapper still emits valid
+JSON on both success and failure paths.
+
+```bash
+bash "$SKILL_ROOT/scripts/validate-wrapper-json.sh" \
+  /absolute/path/to/workspace
+```
+
+The script discovers a sample Kotlin declaration from the workspace, runs the
+wrappers against that workspace, and emits aggregated validation JSON on
+stdout.
+
+---
+
 ## Error Response Format
 
-All errors return `ApiErrorResponse` on stdout with a non-zero exit code:
+Raw CLI error payloads can surface on stdout or stderr depending on the command
+path and runtime state. The wrappers normalize that surface by always writing
+raw notes to `log_file` and wrapper JSON to stdout. When you drop to raw CLI,
+expect the same `ApiErrorResponse` shape even if it arrives on stderr:
 
 ```json
 {

--- a/.agents/skills/kast/scripts/find-symbol-offset.py
+++ b/.agents/skills/kast/scripts/find-symbol-offset.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def utf16_units(value: str) -> int:
+    return len(value.encode("utf-16-le")) // 2
+
+
+def build_symbol_patterns(symbol: str) -> list[re.Pattern[str]]:
+    stripped = symbol.strip("`")
+    patterns = [
+        re.compile(rf"(?<![A-Za-z0-9_`]){re.escape(stripped)}(?![A-Za-z0-9_`])"),
+    ]
+    if stripped == symbol:
+        patterns.append(re.compile(re.escape(f"`{symbol}`")))
+    return patterns
+
+
+def build_declaration_patterns(symbol: str) -> list[tuple[int, re.Pattern[str]]]:
+    stripped = symbol.strip("`")
+    token = rf"`?{re.escape(stripped)}`?"
+    return [
+        (
+            0,
+            re.compile(
+                rf"\b(?:class|object|interface|typealias)\s+{token}\b|"
+                rf"\b(?:enum|annotation|value)\s+class\s+{token}\b",
+            ),
+        ),
+        (
+            1,
+            re.compile(rf"\bfun\b[^\n{{=]*{token}\s*\("),
+        ),
+        (
+            2,
+            re.compile(rf"\b(?:val|var)\s+{token}\b"),
+        ),
+    ]
+
+
+@dataclass(frozen=True)
+class Candidate:
+    priority: int
+    offset: int
+    line: int
+    column: int
+    context: str
+
+
+def classify(line: str, start: int, end: int, declaration_patterns: list[tuple[int, re.Pattern[str]]]) -> int:
+    for priority, pattern in declaration_patterns:
+        for match in pattern.finditer(line):
+            if match.start() <= start and end <= match.end():
+                return priority
+    stripped = line.lstrip()
+    if stripped.startswith("import "):
+        return 4
+    if stripped.startswith("package "):
+        return 5
+    return 6
+
+
+def find_candidates(path: Path, symbol: str) -> list[Candidate]:
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    symbol_patterns = build_symbol_patterns(symbol)
+    declaration_patterns = build_declaration_patterns(symbol)
+    seen_offsets: set[int] = set()
+    candidates: list[Candidate] = []
+    line_offset_utf16 = 0
+
+    for line_number, line in enumerate(lines, start=1):
+        line_without_newline = line.rstrip("\r\n")
+        matches = []
+        for pattern in symbol_patterns:
+            matches.extend(pattern.finditer(line_without_newline))
+        matches.sort(key=lambda match: (match.start(), match.end()))
+
+        for match in matches:
+            column = utf16_units(line_without_newline[:match.start()]) + 1
+            offset = line_offset_utf16 + column - 1
+            if offset in seen_offsets:
+                continue
+            seen_offsets.add(offset)
+            candidates.append(
+                Candidate(
+                    priority=classify(
+                        line_without_newline,
+                        match.start(),
+                        match.end(),
+                        declaration_patterns,
+                    ),
+                    offset=offset,
+                    line=line_number,
+                    column=column,
+                    context=line_without_newline,
+                ),
+            )
+
+        line_offset_utf16 += utf16_units(line)
+
+    candidates.sort(key=lambda item: (item.priority, item.line, item.column, item.context))
+    return candidates
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Find declaration-first UTF-16 offsets for a symbol inside a Kotlin file.",
+    )
+    parser.add_argument("file_path")
+    parser.add_argument("--symbol", required=True)
+    args = parser.parse_args()
+
+    path = Path(args.file_path).resolve()
+    if not path.is_file():
+        parser.error(f"File not found: {path}")
+
+    for candidate in find_candidates(path, args.symbol):
+        print(f"{candidate.offset}\t{candidate.line}\t{candidate.column}\t{candidate.context}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/kast/scripts/kast-callers.sh
+++ b/.agents/skills/kast/scripts/kast-callers.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/kast-common.sh"
+
+WORKSPACE_ROOT=""
+SYMBOL=""
+FILE_HINT=""
+DIRECTION="incoming"
+DEPTH="2"
+KIND=""
+CONTAINING_TYPE=""
+
+for arg in "$@"; do
+    case "${arg}" in
+        --workspace-root=*) WORKSPACE_ROOT="${arg#*=}" ;;
+        --symbol=*) SYMBOL="${arg#*=}" ;;
+        --file=*) FILE_HINT="${arg#*=}" ;;
+        --direction=*) DIRECTION="${arg#*=}" ;;
+        --depth=*) DEPTH="${arg#*=}" ;;
+        --kind=*) KIND="${arg#*=}" ;;
+        --containing-type=*) CONTAINING_TYPE="${arg#*=}" ;;
+        *)
+            printf 'Unknown argument: %s\n' "${arg}" >&2
+            exit 1
+            ;;
+    esac
+done
+
+kast_wrapper_init "kast-callers"
+
+emit_failure() {
+    local stage="$1"
+    local message="$2"
+    local error_file="${3:-}"
+    local log_path
+    log_path="$(kast_preserve_log_file)"
+
+    python3 - "${stage}" "${message}" "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" \
+        "${CONTAINING_TYPE}" "${DIRECTION}" "${DEPTH}" "${log_path}" "${error_file}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    stage,
+    message,
+    workspace_root,
+    symbol,
+    file_hint,
+    kind,
+    containing_type,
+    direction,
+    depth,
+    log_file,
+    error_file,
+) = sys.argv[1:]
+
+payload = {
+    "ok": False,
+    "stage": stage,
+    "message": message,
+    "query": {
+        "workspace_root": workspace_root,
+        "symbol": symbol,
+        "file_hint": file_hint or None,
+        "kind": kind or None,
+        "containing_type": containing_type or None,
+        "direction": direction,
+        "depth": int(depth),
+    },
+    "log_file": log_file,
+}
+
+if error_file:
+    error_path = Path(error_file)
+    if error_path.exists():
+        raw = error_path.read_text(encoding="utf-8").strip()
+        if raw:
+            try:
+                payload["error"] = json.loads(raw)
+            except json.JSONDecodeError:
+                payload["error_text"] = raw
+
+print(json.dumps(payload, indent=2))
+PY
+}
+
+if [[ -z "${WORKSPACE_ROOT}" || -z "${SYMBOL}" ]]; then
+    emit_failure "argument_validation" "Both --workspace-root and --symbol are required."
+    exit 1
+fi
+
+if [[ "${DIRECTION}" != "incoming" && "${DIRECTION}" != "outgoing" ]]; then
+    emit_failure "argument_validation" "--direction must be incoming or outgoing."
+    exit 1
+fi
+
+if ! [[ "${DEPTH}" =~ ^[0-9]+$ ]]; then
+    emit_failure "argument_validation" "--depth must be a non-negative integer."
+    exit 1
+fi
+
+if ! kast_resolve_named_symbol_query "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" "${CONTAINING_TYPE}"; then
+    emit_failure "${RESOLVE_ERROR_STAGE}" "${RESOLVE_ERROR_MESSAGE}" "${RESOLVE_ERROR_JSON_FILE:-}"
+    exit 1
+fi
+
+CALLERS_RESULT="${TMP_DIR}/callers.json"
+if ! kast_run_json \
+    "${CALLERS_RESULT}" \
+    "${KAST}" call hierarchy \
+    --workspace-root="${WORKSPACE_ROOT}" \
+    --file-path="${RESOLVED_FILE_PATH}" \
+    --offset="${RESOLVED_OFFSET}" \
+    --direction="${DIRECTION}" \
+    --depth="${DEPTH}"; then
+    emit_failure "call_hierarchy" "kast call hierarchy failed." "${CALLERS_RESULT}"
+    exit 1
+fi
+
+LOG_PATH="$(kast_preserve_log_file)"
+python3 - "${RESOLVED_JSON_FILE}" "${CALLERS_RESULT}" "${RESOLVED_FILE_PATH}" "${RESOLVED_OFFSET}" \
+    "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" "${CONTAINING_TYPE}" \
+    "${DIRECTION}" "${DEPTH}" "${LOG_PATH}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    resolve_file,
+    callers_file,
+    file_path,
+    offset,
+    workspace_root,
+    symbol,
+    file_hint,
+    kind,
+    containing_type,
+    direction,
+    depth,
+    log_file,
+) = sys.argv[1:]
+
+resolve_result = json.loads(Path(resolve_file).read_text(encoding="utf-8"))
+callers_result = json.loads(Path(callers_file).read_text(encoding="utf-8"))
+payload = {
+    "ok": True,
+    "query": {
+        "workspace_root": workspace_root,
+        "symbol": symbol,
+        "file_hint": file_hint or None,
+        "kind": kind or None,
+        "containing_type": containing_type or None,
+        "direction": direction,
+        "depth": int(depth),
+    },
+    "symbol": resolve_result["symbol"],
+    "file_path": file_path,
+    "offset": int(offset),
+    "root": callers_result.get("root"),
+    "stats": callers_result.get("stats"),
+    "log_file": log_file,
+}
+print(json.dumps(payload, indent=2))
+PY

--- a/.agents/skills/kast/scripts/kast-common.sh
+++ b/.agents/skills/kast/scripts/kast-common.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+kast_wrapper_init() {
+    WRAPPER_NAME="$1"
+    TMP_DIR="$(mktemp -d)"
+    LOG_DIR="${TMP_DIR}/logs"
+    mkdir -p "${LOG_DIR}"
+    LOG_FILE="${LOG_DIR}/${WRAPPER_NAME}.log"
+    : > "${LOG_FILE}"
+    PRESERVED_LOG_FILE=""
+    trap kast_wrapper_cleanup EXIT
+}
+
+kast_wrapper_cleanup() {
+    if [[ -n "${TMP_DIR:-}" && -d "${TMP_DIR}" ]]; then
+        rm -rf "${TMP_DIR}"
+    fi
+}
+
+kast_preserve_log_file() {
+    if [[ -z "${PRESERVED_LOG_FILE:-}" ]]; then
+        PRESERVED_LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/${WRAPPER_NAME}.log.XXXXXX")"
+        if [[ -f "${LOG_FILE}" ]]; then
+            cp "${LOG_FILE}" "${PRESERVED_LOG_FILE}"
+        else
+            : > "${PRESERVED_LOG_FILE}"
+        fi
+    fi
+    printf '%s\n' "${PRESERVED_LOG_FILE}"
+}
+
+kast_resolve_binary() {
+    if [[ -n "${KAST:-}" ]]; then
+        return 0
+    fi
+    KAST="$(bash "${SCRIPT_DIR}/resolve-kast.sh" 2>>"${LOG_FILE}")"
+}
+
+kast_run_json() {
+    local output_file="$1"
+    local exit_code
+    shift
+    : > "${output_file}"
+    if "$@" >"${output_file}" 2>>"${LOG_FILE}"; then
+        if [[ -s "${output_file}" ]]; then
+            return 0
+        fi
+        return 3
+    else
+        exit_code=$?
+        return "${exit_code}"
+    fi
+}
+
+kast_build_search_regex() {
+    python3 - "$1" "${2:-}" <<'PY'
+import re
+import sys
+
+symbol = sys.argv[1].strip("`")
+kind = sys.argv[2].strip().lower()
+escaped = re.escape(symbol)
+optional_backticks = rf"`?{escaped}`?"
+
+patterns_by_kind = {
+    "class": [
+        rf"\bclass\s+{optional_backticks}\b",
+        rf"\bobject\s+{optional_backticks}\b",
+        rf"\binterface\s+{optional_backticks}\b",
+        rf"\benum\s+class\s+{optional_backticks}\b",
+        rf"\bannotation\s+class\s+{optional_backticks}\b",
+        rf"\bvalue\s+class\s+{optional_backticks}\b",
+        rf"\btypealias\s+{optional_backticks}\b",
+    ],
+    "function": [
+        rf"\bfun\b[^\n{{=]*{optional_backticks}\s*\(",
+    ],
+    "property": [
+        rf"\b(?:val|var)\s+{optional_backticks}\b",
+    ],
+}
+
+selected = []
+for key in ("class", "function", "property"):
+    if kind in ("", key):
+        selected.extend(patterns_by_kind[key])
+
+print("|".join(selected))
+PY
+}
+
+kast_collect_candidate_files() {
+    local workspace_root="$1"
+    local symbol="$2"
+    local file_hint="${3:-}"
+    local kind="${4:-}"
+    local candidate_file="${TMP_DIR}/candidate-files.raw"
+    local regex
+    local status
+
+    regex="$(kast_build_search_regex "${symbol}" "${kind}")"
+    : > "${candidate_file}"
+
+    if (cd "${workspace_root}" && rg -l --glob '*.kt' -e "${regex}" . >"${candidate_file}") 2>>"${LOG_FILE}"; then
+        :
+    else
+        status=$?
+        if [[ "${status}" -gt 1 ]]; then
+            printf 'rg declaration search failed with exit status %s\n' "${status}" >>"${LOG_FILE}"
+        fi
+    fi
+
+    if [[ ! -s "${candidate_file}" ]]; then
+        printf 'No declaration-pattern candidates found for %s; widening to plain symbol search.\n' \
+            "${symbol}" >>"${LOG_FILE}"
+        if (cd "${workspace_root}" && rg -l -F --glob '*.kt' -- "${symbol}" . >"${candidate_file}") 2>>"${LOG_FILE}"; then
+            :
+        else
+            status=$?
+            if [[ "${status}" -gt 1 ]]; then
+                printf 'rg fallback search failed with exit status %s\n' "${status}" >>"${LOG_FILE}"
+            fi
+        fi
+    fi
+
+    python3 - "${workspace_root}" "${file_hint}" "${candidate_file}" <<'PY'
+from fnmatch import fnmatchcase
+from pathlib import Path
+import sys
+
+workspace_root = Path(sys.argv[1]).resolve()
+file_hint = sys.argv[2].strip()
+candidate_file = Path(sys.argv[3])
+
+paths: list[Path] = []
+seen: set[Path] = set()
+for raw_line in candidate_file.read_text(encoding="utf-8").splitlines():
+    value = raw_line.strip()
+    if not value:
+        continue
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        normalized = (workspace_root / value.lstrip("./")).resolve()
+    else:
+        normalized = candidate.resolve()
+    if normalized in seen or not normalized.exists():
+        continue
+    seen.add(normalized)
+    paths.append(normalized)
+
+if not file_hint:
+    for path in paths:
+        print(path)
+    raise SystemExit(0)
+
+hint_path = Path(file_hint)
+exact_path = None
+if hint_path.is_absolute():
+    exact_path = hint_path.resolve()
+else:
+    candidate = (workspace_root / file_hint).resolve()
+    if candidate.exists():
+        exact_path = candidate
+
+has_glob = any(char in file_hint for char in "*?[")
+
+def safe_relative(path: Path) -> str:
+    try:
+        return path.relative_to(workspace_root).as_posix()
+    except ValueError:
+        return str(path)
+
+def matches(path: Path) -> bool:
+    absolute = str(path)
+    relative = safe_relative(path)
+    name = path.name
+    if exact_path is not None:
+        return path == exact_path
+    if has_glob:
+        return (
+            fnmatchcase(relative, file_hint)
+            or fnmatchcase(name, file_hint)
+            or fnmatchcase(absolute, file_hint)
+        )
+    return (
+        file_hint in relative
+        or file_hint in name
+        or file_hint in absolute
+    )
+
+for path in paths:
+    if matches(path):
+        print(path)
+PY
+}
+
+kast_result_matches_query() {
+    local result_file="$1"
+    local symbol="$2"
+    local kind="${3:-}"
+    local containing_type="${4:-}"
+
+    python3 - "${result_file}" "${symbol}" "${kind}" "${containing_type}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+result_file = Path(sys.argv[1])
+symbol = sys.argv[2]
+kind = sys.argv[3].strip().lower()
+containing_type = sys.argv[4].strip()
+
+data = json.loads(result_file.read_text(encoding="utf-8"))
+candidate = None
+if isinstance(data.get("symbol"), dict):
+    candidate = data["symbol"]
+elif isinstance(data.get("declaration"), dict):
+    candidate = data["declaration"]
+elif isinstance(data.get("root"), dict) and isinstance(data["root"].get("symbol"), dict):
+    candidate = data["root"]["symbol"]
+
+if not candidate:
+    raise SystemExit(1)
+
+fq_name = candidate.get("fqName") or ""
+preview = ""
+location = candidate.get("location") or {}
+if isinstance(location, dict):
+    preview = location.get("preview") or ""
+
+needles = []
+if symbol:
+    needles.append(symbol)
+trimmed = symbol.strip("`")
+if trimmed and trimmed not in needles:
+    needles.append(trimmed)
+
+if not any(needle and (needle in fq_name or needle in preview) for needle in needles):
+    raise SystemExit(1)
+
+actual_kind = (candidate.get("kind") or "").upper()
+
+def kind_matches(expected: str, actual: str) -> bool:
+    if not expected:
+        return True
+    if expected == "class":
+        return actual.endswith("CLASS") or actual in {"OBJECT", "INTERFACE", "TYPEALIAS", "ENUM_ENTRY"}
+    if expected == "function":
+        return actual in {"FUNCTION", "CONSTRUCTOR"}
+    if expected == "property":
+        return actual in {"PROPERTY", "FIELD", "LOCAL_VARIABLE", "VALUE_PARAMETER"}
+    return True
+
+if not kind_matches(kind, actual_kind):
+    raise SystemExit(1)
+
+if containing_type and containing_type not in fq_name:
+    raise SystemExit(1)
+PY
+}
+
+kast_resolve_named_symbol_query() {
+    local workspace_root="$1"
+    local symbol="$2"
+    local file_hint="${3:-}"
+    local kind="${4:-}"
+    local containing_type="${5:-}"
+    local ensure_file="${TMP_DIR}/workspace-ensure.json"
+    local candidate_files="${TMP_DIR}/candidate-files.txt"
+    local offsets_file="${TMP_DIR}/offsets.tsv"
+    local resolve_file="${TMP_DIR}/resolve.json"
+    local attempt_file="${TMP_DIR}/resolve-attempt.json"
+    local last_error_file=""
+
+    kast_resolve_binary
+
+    if ! kast_run_json "${ensure_file}" "${KAST}" workspace ensure --workspace-root="${workspace_root}"; then
+        RESOLVE_ERROR_STAGE="workspace_ensure"
+        RESOLVE_ERROR_MESSAGE="workspace ensure failed"
+        RESOLVE_ERROR_JSON_FILE="${ensure_file}"
+        return 1
+    fi
+
+    kast_collect_candidate_files "${workspace_root}" "${symbol}" "${file_hint}" "${kind}" >"${candidate_files}"
+    if [[ ! -s "${candidate_files}" ]]; then
+        RESOLVE_ERROR_STAGE="candidate_search"
+        RESOLVE_ERROR_MESSAGE="No declaration candidates matched the symbol query."
+        RESOLVE_ERROR_JSON_FILE=""
+        return 1
+    fi
+
+    while IFS= read -r candidate_file; do
+        if ! python3 "${SCRIPT_DIR}/find-symbol-offset.py" "${candidate_file}" --symbol "${symbol}" >"${offsets_file}" 2>>"${LOG_FILE}"; then
+            continue
+        fi
+        if [[ ! -s "${offsets_file}" ]]; then
+            continue
+        fi
+
+        while IFS=$'\t' read -r offset line column context; do
+            if kast_run_json \
+                "${attempt_file}" \
+                "${KAST}" symbol resolve \
+                --workspace-root="${workspace_root}" \
+                --file-path="${candidate_file}" \
+                --offset="${offset}"; then
+                if kast_result_matches_query "${attempt_file}" "${symbol}" "${kind}" "${containing_type}"; then
+                    cp "${attempt_file}" "${resolve_file}"
+                    RESOLVED_FILE_PATH="${candidate_file}"
+                    RESOLVED_OFFSET="${offset}"
+                    RESOLVED_LINE="${line}"
+                    RESOLVED_COLUMN="${column}"
+                    RESOLVED_CONTEXT="${context}"
+                    RESOLVED_JSON_FILE="${resolve_file}"
+                    return 0
+                fi
+            else
+                last_error_file="${attempt_file}"
+            fi
+        done <"${offsets_file}"
+    done <"${candidate_files}"
+
+    RESOLVE_ERROR_STAGE="symbol_resolve"
+    RESOLVE_ERROR_MESSAGE="No resolved symbol matched the symbol query."
+    RESOLVE_ERROR_JSON_FILE="${last_error_file}"
+    return 1
+}

--- a/.agents/skills/kast/scripts/kast-diagnostics.sh
+++ b/.agents/skills/kast/scripts/kast-diagnostics.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/kast-common.sh"
+
+WORKSPACE_ROOT=""
+FILE_PATHS=""
+
+for arg in "$@"; do
+    case "${arg}" in
+        --workspace-root=*) WORKSPACE_ROOT="${arg#*=}" ;;
+        --file-paths=*) FILE_PATHS="${arg#*=}" ;;
+        *)
+            printf 'Unknown argument: %s\n' "${arg}" >&2
+            exit 1
+            ;;
+    esac
+done
+
+kast_wrapper_init "kast-diagnostics"
+
+emit_failure() {
+    local stage="$1"
+    local message="$2"
+    local error_file="${3:-}"
+    local log_path
+    log_path="$(kast_preserve_log_file)"
+
+    python3 - "${stage}" "${message}" "${WORKSPACE_ROOT}" "${FILE_PATHS}" "${log_path}" "${error_file}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+stage, message, workspace_root, file_paths, log_file, error_file = sys.argv[1:]
+payload = {
+    "ok": False,
+    "stage": stage,
+    "message": message,
+    "query": {
+        "workspace_root": workspace_root,
+        "file_paths": [entry for entry in file_paths.split(",") if entry],
+    },
+    "log_file": log_file,
+}
+
+if error_file:
+    error_path = Path(error_file)
+    if error_path.exists():
+        raw = error_path.read_text(encoding="utf-8").strip()
+        if raw:
+            try:
+                payload["error"] = json.loads(raw)
+            except json.JSONDecodeError:
+                payload["error_text"] = raw
+
+print(json.dumps(payload, indent=2))
+PY
+}
+
+if [[ -z "${WORKSPACE_ROOT}" || -z "${FILE_PATHS}" ]]; then
+    emit_failure "argument_validation" "Both --workspace-root and --file-paths are required."
+    exit 1
+fi
+
+NORMALIZED_FILE_PATHS="$(
+    python3 - "${WORKSPACE_ROOT}" "${FILE_PATHS}" <<'PY'
+from pathlib import Path
+import sys
+
+workspace_root = Path(sys.argv[1]).resolve()
+entries = [entry.strip() for entry in sys.argv[2].split(",") if entry.strip()]
+normalized = []
+for entry in entries:
+    path = Path(entry)
+    if path.is_absolute():
+        normalized.append(str(path.resolve()))
+    else:
+        normalized.append(str((workspace_root / entry).resolve()))
+print(",".join(normalized))
+PY
+)"
+
+if ! kast_resolve_binary; then
+    emit_failure "resolve_kast" "Could not resolve the kast binary."
+    exit 1
+fi
+
+ENSURE_RESULT="${TMP_DIR}/workspace-ensure.json"
+if ! kast_run_json "${ENSURE_RESULT}" "${KAST}" workspace ensure --workspace-root="${WORKSPACE_ROOT}"; then
+    emit_failure "workspace_ensure" "workspace ensure failed." "${ENSURE_RESULT}"
+    exit 1
+fi
+
+DIAGNOSTICS_RESULT="${TMP_DIR}/diagnostics.json"
+if ! kast_run_json \
+    "${DIAGNOSTICS_RESULT}" \
+    "${KAST}" diagnostics \
+    --workspace-root="${WORKSPACE_ROOT}" \
+    --file-paths="${NORMALIZED_FILE_PATHS}"; then
+    emit_failure "diagnostics" "kast diagnostics failed." "${DIAGNOSTICS_RESULT}"
+    exit 1
+fi
+
+ERROR_COUNT="$(
+    python3 "${SCRIPT_DIR}/kast-plan-utils.py" check-diagnostics "${DIAGNOSTICS_RESULT}" 2>>"${LOG_FILE}" || true
+)"
+
+LOG_PATH="$(kast_preserve_log_file)"
+python3 - "${DIAGNOSTICS_RESULT}" "${NORMALIZED_FILE_PATHS}" "${WORKSPACE_ROOT}" "${ERROR_COUNT}" "${LOG_PATH}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+diagnostics_file, file_paths_csv, workspace_root, error_count, log_file = sys.argv[1:]
+diagnostics_result = json.loads(Path(diagnostics_file).read_text(encoding="utf-8"))
+diagnostics = diagnostics_result.get("diagnostics", [])
+warning_count = sum(1 for item in diagnostics if item.get("severity") == "WARNING")
+info_count = sum(1 for item in diagnostics if item.get("severity") == "INFO")
+
+payload = {
+    "ok": True,
+    "query": {
+        "workspace_root": workspace_root,
+        "file_paths": [entry for entry in file_paths_csv.split(",") if entry],
+    },
+    "clean": int(error_count or "0") == 0,
+    "error_count": int(error_count or "0"),
+    "warning_count": warning_count,
+    "info_count": info_count,
+    "diagnostics": diagnostics,
+    "log_file": log_file,
+}
+print(json.dumps(payload, indent=2))
+PY

--- a/.agents/skills/kast/scripts/kast-impact.sh
+++ b/.agents/skills/kast/scripts/kast-impact.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/kast-common.sh"
+
+WORKSPACE_ROOT=""
+SYMBOL=""
+FILE_HINT=""
+INCLUDE_CALLERS="true"
+KIND=""
+CONTAINING_TYPE=""
+
+for arg in "$@"; do
+    case "${arg}" in
+        --workspace-root=*) WORKSPACE_ROOT="${arg#*=}" ;;
+        --symbol=*) SYMBOL="${arg#*=}" ;;
+        --file=*) FILE_HINT="${arg#*=}" ;;
+        --include-callers=*) INCLUDE_CALLERS="${arg#*=}" ;;
+        --kind=*) KIND="${arg#*=}" ;;
+        --containing-type=*) CONTAINING_TYPE="${arg#*=}" ;;
+        *)
+            printf 'Unknown argument: %s\n' "${arg}" >&2
+            exit 1
+            ;;
+    esac
+done
+
+kast_wrapper_init "kast-impact"
+
+emit_failure() {
+    local stage="$1"
+    local message="$2"
+    local error_file="${3:-}"
+    local log_path
+    log_path="$(kast_preserve_log_file)"
+
+    python3 - "${stage}" "${message}" "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" \
+        "${CONTAINING_TYPE}" "${INCLUDE_CALLERS}" "${log_path}" "${error_file}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    stage,
+    message,
+    workspace_root,
+    symbol,
+    file_hint,
+    kind,
+    containing_type,
+    include_callers,
+    log_file,
+    error_file,
+) = sys.argv[1:]
+
+payload = {
+    "ok": False,
+    "stage": stage,
+    "message": message,
+    "query": {
+        "workspace_root": workspace_root,
+        "symbol": symbol,
+        "file_hint": file_hint or None,
+        "kind": kind or None,
+        "containing_type": containing_type or None,
+        "include_callers": include_callers == "true",
+    },
+    "log_file": log_file,
+}
+
+if error_file:
+    error_path = Path(error_file)
+    if error_path.exists():
+        raw = error_path.read_text(encoding="utf-8").strip()
+        if raw:
+            try:
+                payload["error"] = json.loads(raw)
+            except json.JSONDecodeError:
+                payload["error_text"] = raw
+
+print(json.dumps(payload, indent=2))
+PY
+}
+
+if [[ -z "${WORKSPACE_ROOT}" || -z "${SYMBOL}" ]]; then
+    emit_failure "argument_validation" "Both --workspace-root and --symbol are required."
+    exit 1
+fi
+
+if [[ "${INCLUDE_CALLERS}" != "true" && "${INCLUDE_CALLERS}" != "false" ]]; then
+    emit_failure "argument_validation" "--include-callers must be true or false."
+    exit 1
+fi
+
+if ! kast_resolve_named_symbol_query "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" "${CONTAINING_TYPE}"; then
+    emit_failure "${RESOLVE_ERROR_STAGE}" "${RESOLVE_ERROR_MESSAGE}" "${RESOLVE_ERROR_JSON_FILE:-}"
+    exit 1
+fi
+
+REFERENCES_RESULT="${TMP_DIR}/references.json"
+if ! kast_run_json \
+    "${REFERENCES_RESULT}" \
+    "${KAST}" references \
+    --workspace-root="${WORKSPACE_ROOT}" \
+    --file-path="${RESOLVED_FILE_PATH}" \
+    --offset="${RESOLVED_OFFSET}" \
+    --include-declaration=true; then
+    emit_failure "references" "kast references failed." "${REFERENCES_RESULT}"
+    exit 1
+fi
+
+CALLERS_RESULT=""
+if [[ "${INCLUDE_CALLERS}" == "true" ]]; then
+    CALLERS_RESULT="${TMP_DIR}/callers.json"
+    if ! kast_run_json \
+        "${CALLERS_RESULT}" \
+        "${KAST}" call hierarchy \
+        --workspace-root="${WORKSPACE_ROOT}" \
+        --file-path="${RESOLVED_FILE_PATH}" \
+        --offset="${RESOLVED_OFFSET}" \
+        --direction=incoming \
+        --depth=2; then
+        emit_failure "call_hierarchy" "kast call hierarchy failed." "${CALLERS_RESULT}"
+        exit 1
+    fi
+fi
+
+LOG_PATH="$(kast_preserve_log_file)"
+python3 - "${RESOLVED_JSON_FILE}" "${REFERENCES_RESULT}" "${CALLERS_RESULT}" "${RESOLVED_FILE_PATH}" \
+    "${RESOLVED_OFFSET}" "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" \
+    "${CONTAINING_TYPE}" "${INCLUDE_CALLERS}" "${LOG_PATH}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    resolve_file,
+    references_file,
+    callers_file,
+    file_path,
+    offset,
+    workspace_root,
+    symbol,
+    file_hint,
+    kind,
+    containing_type,
+    include_callers,
+    log_file,
+) = sys.argv[1:]
+
+resolve_result = json.loads(Path(resolve_file).read_text(encoding="utf-8"))
+references_result = json.loads(Path(references_file).read_text(encoding="utf-8"))
+payload = {
+    "ok": True,
+    "query": {
+        "workspace_root": workspace_root,
+        "symbol": symbol,
+        "file_hint": file_hint or None,
+        "kind": kind or None,
+        "containing_type": containing_type or None,
+        "include_callers": include_callers == "true",
+    },
+    "symbol": resolve_result["symbol"],
+    "file_path": file_path,
+    "offset": int(offset),
+    "references": references_result.get("references", []),
+    "search_scope": references_result.get("searchScope"),
+    "declaration": references_result.get("declaration"),
+    "log_file": log_file,
+}
+
+if callers_file:
+    callers_result = json.loads(Path(callers_file).read_text(encoding="utf-8"))
+    payload["call_hierarchy"] = {
+        "direction": "incoming",
+        "root": callers_result.get("root"),
+        "stats": callers_result.get("stats"),
+    }
+
+print(json.dumps(payload, indent=2))
+PY

--- a/.agents/skills/kast/scripts/kast-plan-utils.py
+++ b/.agents/skills/kast/scripts/kast-plan-utils.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_json(path: str) -> dict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def write_json(path: str, value: object) -> None:
+    Path(path).write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def command_extract_apply_request(args: argparse.Namespace) -> int:
+    plan = load_json(args.plan_file)
+    write_json(
+        args.out_file,
+        {
+            "edits": plan.get("edits", []),
+            "fileHashes": plan.get("fileHashes", []),
+        },
+    )
+    return 0
+
+
+def iter_affected_files(plan: dict) -> list[str]:
+    affected = plan.get("affectedFiles")
+    if isinstance(affected, list) and affected:
+        return [str(item) for item in affected]
+
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for section in ("edits", "fileHashes"):
+        for item in plan.get(section, []):
+            if not isinstance(item, dict):
+                continue
+            file_path = item.get("filePath")
+            if not file_path or file_path in seen:
+                continue
+            seen.add(file_path)
+            ordered.append(str(file_path))
+    return ordered
+
+
+def command_affected_files_csv(args: argparse.Namespace) -> int:
+    plan = load_json(args.plan_file)
+    print(",".join(iter_affected_files(plan)))
+    return 0
+
+
+def command_affected_files_list(args: argparse.Namespace) -> int:
+    plan = load_json(args.plan_file)
+    for file_path in iter_affected_files(plan):
+        print(file_path)
+    return 0
+
+
+def command_count_edits(args: argparse.Namespace) -> int:
+    plan = load_json(args.plan_file)
+    print(len(plan.get("edits", [])))
+    return 0
+
+
+def command_check_diagnostics(args: argparse.Namespace) -> int:
+    diagnostics_result = load_json(args.diagnostics_file)
+    diagnostics = diagnostics_result.get("diagnostics", [])
+    errors = [
+        diagnostic
+        for diagnostic in diagnostics
+        if isinstance(diagnostic, dict) and diagnostic.get("severity") == "ERROR"
+    ]
+
+    print(len(errors))
+    if not errors:
+        return 0
+
+    for diagnostic in errors:
+        location = diagnostic.get("location") or {}
+        file_path = location.get("filePath", "<unknown>")
+        line = location.get("startLine", "?")
+        column = location.get("startColumn", "?")
+        message = diagnostic.get("message", "<no message>")
+        print(f"{file_path}:{line}:{column}: {message}", file=sys.stderr)
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Utilities for kast rename plans and diagnostics results.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    extract = subparsers.add_parser("extract-apply-request")
+    extract.add_argument("plan_file")
+    extract.add_argument("out_file")
+    extract.set_defaults(func=command_extract_apply_request)
+
+    csv_parser = subparsers.add_parser("affected-files-csv")
+    csv_parser.add_argument("plan_file")
+    csv_parser.set_defaults(func=command_affected_files_csv)
+
+    list_parser = subparsers.add_parser("affected-files-list")
+    list_parser.add_argument("plan_file")
+    list_parser.set_defaults(func=command_affected_files_list)
+
+    count_parser = subparsers.add_parser("count-edits")
+    count_parser.add_argument("plan_file")
+    count_parser.set_defaults(func=command_count_edits)
+
+    diagnostics_parser = subparsers.add_parser("check-diagnostics")
+    diagnostics_parser.add_argument("diagnostics_file")
+    diagnostics_parser.set_defaults(func=command_check_diagnostics)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/kast/scripts/kast-references.sh
+++ b/.agents/skills/kast/scripts/kast-references.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/kast-common.sh"
+
+WORKSPACE_ROOT=""
+SYMBOL=""
+FILE_HINT=""
+INCLUDE_DECLARATION="true"
+KIND=""
+CONTAINING_TYPE=""
+
+for arg in "$@"; do
+    case "${arg}" in
+        --workspace-root=*) WORKSPACE_ROOT="${arg#*=}" ;;
+        --symbol=*) SYMBOL="${arg#*=}" ;;
+        --file=*) FILE_HINT="${arg#*=}" ;;
+        --include-declaration=*) INCLUDE_DECLARATION="${arg#*=}" ;;
+        --kind=*) KIND="${arg#*=}" ;;
+        --containing-type=*) CONTAINING_TYPE="${arg#*=}" ;;
+        *)
+            printf 'Unknown argument: %s\n' "${arg}" >&2
+            exit 1
+            ;;
+    esac
+done
+
+kast_wrapper_init "kast-references"
+
+emit_failure() {
+    local stage="$1"
+    local message="$2"
+    local error_file="${3:-}"
+    local log_path
+    log_path="$(kast_preserve_log_file)"
+
+    python3 - "${stage}" "${message}" "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" \
+        "${CONTAINING_TYPE}" "${INCLUDE_DECLARATION}" "${log_path}" "${error_file}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    stage,
+    message,
+    workspace_root,
+    symbol,
+    file_hint,
+    kind,
+    containing_type,
+    include_declaration,
+    log_file,
+    error_file,
+) = sys.argv[1:]
+
+payload = {
+    "ok": False,
+    "stage": stage,
+    "message": message,
+    "query": {
+        "workspace_root": workspace_root,
+        "symbol": symbol,
+        "file_hint": file_hint or None,
+        "kind": kind or None,
+        "containing_type": containing_type or None,
+        "include_declaration": include_declaration == "true",
+    },
+    "log_file": log_file,
+}
+
+if error_file:
+    error_path = Path(error_file)
+    if error_path.exists():
+        raw = error_path.read_text(encoding="utf-8").strip()
+        if raw:
+            try:
+                payload["error"] = json.loads(raw)
+            except json.JSONDecodeError:
+                payload["error_text"] = raw
+
+print(json.dumps(payload, indent=2))
+PY
+}
+
+if [[ -z "${WORKSPACE_ROOT}" || -z "${SYMBOL}" ]]; then
+    emit_failure "argument_validation" "Both --workspace-root and --symbol are required."
+    exit 1
+fi
+
+if [[ "${INCLUDE_DECLARATION}" != "true" && "${INCLUDE_DECLARATION}" != "false" ]]; then
+    emit_failure "argument_validation" "--include-declaration must be true or false."
+    exit 1
+fi
+
+if ! kast_resolve_named_symbol_query "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" "${CONTAINING_TYPE}"; then
+    emit_failure "${RESOLVE_ERROR_STAGE}" "${RESOLVE_ERROR_MESSAGE}" "${RESOLVE_ERROR_JSON_FILE:-}"
+    exit 1
+fi
+
+REFERENCES_RESULT="${TMP_DIR}/references.json"
+if ! kast_run_json \
+    "${REFERENCES_RESULT}" \
+    "${KAST}" references \
+    --workspace-root="${WORKSPACE_ROOT}" \
+    --file-path="${RESOLVED_FILE_PATH}" \
+    --offset="${RESOLVED_OFFSET}" \
+    --include-declaration="${INCLUDE_DECLARATION}"; then
+    emit_failure "references" "kast references failed." "${REFERENCES_RESULT}"
+    exit 1
+fi
+
+LOG_PATH="$(kast_preserve_log_file)"
+python3 - "${RESOLVED_JSON_FILE}" "${REFERENCES_RESULT}" "${RESOLVED_FILE_PATH}" "${RESOLVED_OFFSET}" \
+    "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" "${CONTAINING_TYPE}" \
+    "${INCLUDE_DECLARATION}" "${LOG_PATH}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    resolve_file,
+    references_file,
+    file_path,
+    offset,
+    workspace_root,
+    symbol,
+    file_hint,
+    kind,
+    containing_type,
+    include_declaration,
+    log_file,
+) = sys.argv[1:]
+
+resolve_result = json.loads(Path(resolve_file).read_text(encoding="utf-8"))
+references_result = json.loads(Path(references_file).read_text(encoding="utf-8"))
+payload = {
+    "ok": True,
+    "query": {
+        "workspace_root": workspace_root,
+        "symbol": symbol,
+        "file_hint": file_hint or None,
+        "kind": kind or None,
+        "containing_type": containing_type or None,
+        "include_declaration": include_declaration == "true",
+    },
+    "symbol": resolve_result["symbol"],
+    "file_path": file_path,
+    "offset": int(offset),
+    "references": references_result.get("references", []),
+    "search_scope": references_result.get("searchScope"),
+    "declaration": references_result.get("declaration"),
+    "log_file": log_file,
+}
+print(json.dumps(payload, indent=2))
+PY

--- a/.agents/skills/kast/scripts/kast-resolve.sh
+++ b/.agents/skills/kast/scripts/kast-resolve.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/kast-common.sh"
+
+WORKSPACE_ROOT=""
+SYMBOL=""
+FILE_HINT=""
+KIND=""
+CONTAINING_TYPE=""
+
+for arg in "$@"; do
+    case "${arg}" in
+        --workspace-root=*) WORKSPACE_ROOT="${arg#*=}" ;;
+        --symbol=*) SYMBOL="${arg#*=}" ;;
+        --file=*) FILE_HINT="${arg#*=}" ;;
+        --kind=*) KIND="${arg#*=}" ;;
+        --containing-type=*) CONTAINING_TYPE="${arg#*=}" ;;
+        *)
+            printf 'Unknown argument: %s\n' "${arg}" >&2
+            exit 1
+            ;;
+    esac
+done
+
+kast_wrapper_init "kast-resolve"
+
+emit_failure() {
+    local stage="$1"
+    local message="$2"
+    local error_file="${3:-}"
+    local log_path
+    log_path="$(kast_preserve_log_file)"
+
+    python3 - "${stage}" "${message}" "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" \
+        "${CONTAINING_TYPE}" "${log_path}" "${error_file}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+stage, message, workspace_root, symbol, file_hint, kind, containing_type, log_file, error_file = sys.argv[1:]
+payload = {
+    "ok": False,
+    "stage": stage,
+    "message": message,
+    "query": {
+        "workspace_root": workspace_root,
+        "symbol": symbol,
+        "file_hint": file_hint or None,
+        "kind": kind or None,
+        "containing_type": containing_type or None,
+    },
+    "log_file": log_file,
+}
+
+if error_file:
+    error_path = Path(error_file)
+    if error_path.exists():
+        raw = error_path.read_text(encoding="utf-8").strip()
+        if raw:
+            try:
+                payload["error"] = json.loads(raw)
+            except json.JSONDecodeError:
+                payload["error_text"] = raw
+
+print(json.dumps(payload, indent=2))
+PY
+}
+
+if [[ -z "${WORKSPACE_ROOT}" || -z "${SYMBOL}" ]]; then
+    emit_failure "argument_validation" "Both --workspace-root and --symbol are required."
+    exit 1
+fi
+
+if ! kast_resolve_named_symbol_query "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" "${KIND}" "${CONTAINING_TYPE}"; then
+    emit_failure "${RESOLVE_ERROR_STAGE}" "${RESOLVE_ERROR_MESSAGE}" "${RESOLVE_ERROR_JSON_FILE:-}"
+    exit 1
+fi
+
+LOG_PATH="$(kast_preserve_log_file)"
+python3 - "${RESOLVED_JSON_FILE}" "${RESOLVED_FILE_PATH}" "${RESOLVED_OFFSET}" "${RESOLVED_LINE}" \
+    "${RESOLVED_COLUMN}" "${RESOLVED_CONTEXT}" "${WORKSPACE_ROOT}" "${SYMBOL}" "${FILE_HINT}" \
+    "${KIND}" "${CONTAINING_TYPE}" "${LOG_PATH}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    resolve_file,
+    file_path,
+    offset,
+    line,
+    column,
+    context,
+    workspace_root,
+    symbol,
+    file_hint,
+    kind,
+    containing_type,
+    log_file,
+) = sys.argv[1:]
+
+result = json.loads(Path(resolve_file).read_text(encoding="utf-8"))
+payload = {
+    "ok": True,
+    "query": {
+        "workspace_root": workspace_root,
+        "symbol": symbol,
+        "file_hint": file_hint or None,
+        "kind": kind or None,
+        "containing_type": containing_type or None,
+    },
+    "symbol": result["symbol"],
+    "file_path": file_path,
+    "offset": int(offset),
+    "candidate": {
+        "line": int(line),
+        "column": int(column),
+        "context": context,
+    },
+    "log_file": log_file,
+}
+print(json.dumps(payload, indent=2))
+PY

--- a/.agents/skills/kast/scripts/validate-wrapper-json.sh
+++ b/.agents/skills/kast/scripts/validate-wrapper-json.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="${1:-$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+DISCOVERY_TEXT="${TMP_DIR}/discovery.txt"
+if ! rg -n --glob '*.kt' '^\s*(class|object|interface)\s+[A-Za-z_][A-Za-z0-9_]*' \
+    "${WORKSPACE_ROOT}" >"${DISCOVERY_TEXT}"; then
+    python3 - "${DISCOVERY_TEXT}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+log_path = Path(sys.argv[1])
+payload = {
+    "ok": False,
+    "stage": "discovery",
+    "message": "Could not discover a Kotlin class, object, or interface in the workspace.",
+    "log_file": str(log_path),
+}
+print(json.dumps(payload, indent=2))
+PY
+    exit 1
+fi
+
+read -r SAMPLE_SYMBOL SAMPLE_FILE <<<"$(
+    python3 - "${DISCOVERY_TEXT}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+pattern = re.compile(r"^(.*?):\d+:\s*(?:class|object|interface)\s+([A-Za-z_][A-Za-z0-9_]*)")
+for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
+    match = pattern.match(line)
+    if match:
+        print(match.group(2), match.group(1))
+        break
+else:
+    raise SystemExit("No sample symbol found in discovery output.")
+PY
+)"
+
+MISSING_SYMBOL="DefinitelyMissingSymbolForWrapperValidation"
+SUCCESS_DIAGNOSTICS_FILE="${SAMPLE_FILE}"
+FAILURE_DIAGNOSTICS_FILE="${WORKSPACE_ROOT}/definitely-missing-file.kt"
+
+declare -a CHECKS=(
+    "kast-resolve.sh|success|bash \"${SCRIPT_DIR}/kast-resolve.sh\" --workspace-root=\"${WORKSPACE_ROOT}\" --symbol=\"${SAMPLE_SYMBOL}\" --file=\"${SAMPLE_FILE}\"|true"
+    "kast-resolve.sh|failure|bash \"${SCRIPT_DIR}/kast-resolve.sh\" --workspace-root=\"${WORKSPACE_ROOT}\" --symbol=\"${MISSING_SYMBOL}\"|false"
+    "kast-references.sh|success|bash \"${SCRIPT_DIR}/kast-references.sh\" --workspace-root=\"${WORKSPACE_ROOT}\" --symbol=\"${SAMPLE_SYMBOL}\" --file=\"${SAMPLE_FILE}\"|true"
+    "kast-references.sh|failure|bash \"${SCRIPT_DIR}/kast-references.sh\" --workspace-root=\"${WORKSPACE_ROOT}\" --symbol=\"${MISSING_SYMBOL}\"|false"
+    "kast-callers.sh|success|bash \"${SCRIPT_DIR}/kast-callers.sh\" --workspace-root=\"${WORKSPACE_ROOT}\" --symbol=\"${SAMPLE_SYMBOL}\" --file=\"${SAMPLE_FILE}\"|true"
+    "kast-callers.sh|failure|bash \"${SCRIPT_DIR}/kast-callers.sh\" --workspace-root=\"${WORKSPACE_ROOT}\" --symbol=\"${MISSING_SYMBOL}\"|false"
+    "kast-diagnostics.sh|success|bash \"${SCRIPT_DIR}/kast-diagnostics.sh\" --workspace-root=\"${WORKSPACE_ROOT}\" --file-paths=\"${SUCCESS_DIAGNOSTICS_FILE}\"|true"
+    "kast-diagnostics.sh|failure|bash \"${SCRIPT_DIR}/kast-diagnostics.sh\" --workspace-root=\"${WORKSPACE_ROOT}\" --file-paths=\"${FAILURE_DIAGNOSTICS_FILE}\"|false"
+    "kast-impact.sh|success|bash \"${SCRIPT_DIR}/kast-impact.sh\" --workspace-root=\"${WORKSPACE_ROOT}\" --symbol=\"${SAMPLE_SYMBOL}\" --file=\"${SAMPLE_FILE}\"|true"
+    "kast-impact.sh|failure|bash \"${SCRIPT_DIR}/kast-impact.sh\" --workspace-root=\"${WORKSPACE_ROOT}\" --symbol=\"${MISSING_SYMBOL}\"|false"
+)
+
+RESULTS_FILE="${TMP_DIR}/results.jsonl"
+: > "${RESULTS_FILE}"
+
+for check in "${CHECKS[@]}"; do
+    IFS='|' read -r script_name mode command expected_ok <<<"${check}"
+    STDOUT_FILE="${TMP_DIR}/${script_name}.${mode}.json"
+    STDERR_FILE="${TMP_DIR}/${script_name}.${mode}.stderr"
+
+    if eval "${command}" >"${STDOUT_FILE}" 2>"${STDERR_FILE}"; then
+        EXIT_CODE=0
+    else
+        EXIT_CODE=$?
+    fi
+
+    python3 - "${script_name}" "${mode}" "${expected_ok}" "${EXIT_CODE}" "${STDOUT_FILE}" "${STDERR_FILE}" >>"${RESULTS_FILE}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+script_name, mode, expected_ok, exit_code, stdout_file, stderr_file = sys.argv[1:]
+stdout_text = Path(stdout_file).read_text(encoding="utf-8")
+stderr_text = Path(stderr_file).read_text(encoding="utf-8")
+entry = {
+    "script": script_name,
+    "mode": mode,
+    "expected_ok": expected_ok == "true",
+    "exit_code": int(exit_code),
+    "stderr": stderr_text.strip() or None,
+}
+
+try:
+    payload = json.loads(stdout_text)
+    entry["valid_json"] = True
+    entry["ok_value"] = payload.get("ok")
+    entry["log_file"] = payload.get("log_file")
+    entry["matches_expectation"] = payload.get("ok") == (expected_ok == "true")
+except json.JSONDecodeError as error:
+    entry["valid_json"] = False
+    entry["matches_expectation"] = False
+    entry["parse_error"] = str(error)
+    entry["stdout"] = stdout_text
+
+print(json.dumps(entry))
+PY
+done
+
+python3 - "${RESULTS_FILE}" "${WORKSPACE_ROOT}" "${SAMPLE_SYMBOL}" "${SAMPLE_FILE}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+results = [json.loads(line) for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines() if line.strip()]
+ok = all(item.get("valid_json") and item.get("matches_expectation") for item in results)
+payload = {
+    "ok": ok,
+    "workspace_root": sys.argv[2],
+    "sample_symbol": sys.argv[3],
+    "sample_file": sys.argv[4],
+    "checks": results,
+}
+print(json.dumps(payload, indent=2))
+raise SystemExit(0 if ok else 1)
+PY

--- a/kast-cli/build.gradle.kts
+++ b/kast-cli/build.gradle.kts
@@ -17,8 +17,17 @@ val embeddedSkillFiles = listOf(
     "references/cloud-setup.md",
     "references/command-reference.md",
     "references/troubleshooting.md",
+    "scripts/find-symbol-offset.py",
+    "scripts/kast-callers.sh",
+    "scripts/kast-common.sh",
+    "scripts/kast-diagnostics.sh",
+    "scripts/kast-impact.sh",
+    "scripts/kast-plan-utils.py",
     "scripts/kast-rename.sh",
+    "scripts/kast-references.sh",
+    "scripts/kast-resolve.sh",
     "scripts/resolve-kast.sh",
+    "scripts/validate-wrapper-json.sh",
 )
 
 application {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/EmbeddedSkillResources.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/EmbeddedSkillResources.kt
@@ -41,8 +41,17 @@ internal class EmbeddedSkillResources(
             "references/cloud-setup.md",
             "references/command-reference.md",
             "references/troubleshooting.md",
+            "scripts/find-symbol-offset.py",
+            "scripts/kast-callers.sh",
+            "scripts/kast-common.sh",
+            "scripts/kast-diagnostics.sh",
+            "scripts/kast-impact.sh",
+            "scripts/kast-plan-utils.py",
             "scripts/kast-rename.sh",
+            "scripts/kast-references.sh",
+            "scripts/kast-resolve.sh",
             "scripts/resolve-kast.sh",
+            "scripts/validate-wrapper-json.sh",
         )
     }
 }

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/InstallSkillServiceTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/InstallSkillServiceTest.kt
@@ -33,7 +33,16 @@ class InstallSkillServiceTest {
         assertTrue(Files.isDirectory(installedSkillDir))
         assertTrue(Files.isRegularFile(installedSkillDir.resolve("SKILL.md")))
         assertTrue(Files.isRegularFile(installedSkillDir.resolve("agents/openai.yaml")))
+        assertTrue(Files.isRegularFile(installedSkillDir.resolve("scripts/find-symbol-offset.py")))
+        assertTrue(Files.isRegularFile(installedSkillDir.resolve("scripts/kast-callers.sh")))
+        assertTrue(Files.isRegularFile(installedSkillDir.resolve("scripts/kast-common.sh")))
+        assertTrue(Files.isRegularFile(installedSkillDir.resolve("scripts/kast-diagnostics.sh")))
+        assertTrue(Files.isRegularFile(installedSkillDir.resolve("scripts/kast-impact.sh")))
+        assertTrue(Files.isRegularFile(installedSkillDir.resolve("scripts/kast-plan-utils.py")))
+        assertTrue(Files.isRegularFile(installedSkillDir.resolve("scripts/kast-references.sh")))
+        assertTrue(Files.isRegularFile(installedSkillDir.resolve("scripts/kast-resolve.sh")))
         assertTrue(Files.isRegularFile(installedSkillDir.resolve("scripts/resolve-kast.sh")))
+        assertTrue(Files.isRegularFile(installedSkillDir.resolve("scripts/validate-wrapper-json.sh")))
         assertEquals("1.2.3", Files.readString(installedSkillDir.resolve(".kast-version")).trim())
     }
 


### PR DESCRIPTION
## Summary
- add shared helper scripts for symbol lookup, plan extraction, diagnostics checks, and wrapper validation
- add wrapper commands for resolve, references, callers, diagnostics, and impact workflows with structured JSON output
- rewrite the kast skill docs and embedded skill metadata to prefer wrapper-driven flows over raw shell pipelines
- package the new skill scripts in `kast-cli` and extend the install-skill test coverage

## Testing
- `bash -n .agents/skills/kast/scripts/kast-common.sh .agents/skills/kast/scripts/kast-resolve.sh .agents/skills/kast/scripts/kast-references.sh .agents/skills/kast/scripts/kast-callers.sh .agents/skills/kast/scripts/kast-diagnostics.sh .agents/skills/kast/scripts/kast-impact.sh .agents/skills/kast/scripts/kast-rename.sh .agents/skills/kast/scripts/resolve-kast.sh .agents/skills/kast/scripts/validate-wrapper-json.sh`
- `python3 -m py_compile .agents/skills/kast/scripts/kast-plan-utils.py .agents/skills/kast/scripts/find-symbol-offset.py`
- `bash .agents/skills/kast/scripts/validate-wrapper-json.sh /Users/amichne/.codex/worktrees/564d/kast`
- `./gradlew :kast-cli:test --tests io.github.amichne.kast.cli.InstallSkillServiceTest`
- `python /Users/amichne/code/apollo/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/kast` (in a temporary venv with `PyYAML` installed)