### PR TITLE
docs: reorganize docs around audience paths and CLI command tiers

### DIFF
--- a/docs/architecture-deep-dive.md
+++ b/docs/architecture-deep-dive.md
@@ -1,0 +1,173 @@
+---
+title: Architecture deep dive
+description: Explore module boundaries, architectural choices, and full
+  operation scope for advanced users and contributors.
+icon: lucide/git-branch-plus
+---
+
+This page is for advanced users and developers who need a defensible,
+module-level model of Kast. It explains what each module owns, why the
+boundaries exist, and how the command surface maps to deeper runtime
+capabilities.
+
+## High-level architecture
+
+Kast follows a client-daemon design. The CLI stays lightweight, while the
+backend keeps Kotlin semantic state warm.
+
+```mermaid
+flowchart LR
+    subgraph Client plane
+      CLI[kast CLI\nkast-cli + kast]
+    end
+
+    subgraph Contract and transport plane
+      API[analysis-api\nshared models and capabilities]
+      SERVER[analysis-server\nJSON-RPC dispatch and descriptors]
+    end
+
+    subgraph Runtime plane
+      STANDALONE[backend-standalone\nworkspace + session + semantic ops]
+      IDEA[backend-intellij\nIDE-hosted backend]
+      SHARED[backend-shared\nshared analysis utilities]
+    end
+
+    subgraph Quality and delivery plane
+      TESTING[shared-testing]
+      BUILD[build-logic + packaging scripts]
+    end
+
+    CLI --> API
+    CLI --> SERVER
+    SERVER --> STANDALONE
+    SERVER --> IDEA
+    STANDALONE --> SHARED
+    IDEA --> SHARED
+    STANDALONE --> TESTING
+    IDEA --> TESTING
+    BUILD --> CLI
+    BUILD --> SERVER
+    BUILD --> STANDALONE
+    BUILD --> IDEA
+```
+
+The core decision is to isolate semantic runtime cost in long-lived backends,
+so repeat queries reuse session state instead of rebuilding compiler context on
+every command.
+
+## Module ownership map
+
+The following map reflects the current ownership model used across the repo.
+
+| Module | Owns | Why this boundary exists |
+| --- | --- | --- |
+| `analysis-api` | Shared contract, serializable models, capability flags, and edit validation types | Keeps protocol semantics stable across CLI and backends |
+| `kast-cli` | Operator-facing command parsing, lifecycle orchestration, and native entrypoint | Keeps user workflows centralized and scriptable |
+| `kast` | JVM shell and wrapper packaging, including `internal daemon-run` | Separates runtime packaging concerns from control-plane parsing |
+| `analysis-server` | JSON-RPC transport, dispatch, descriptor lifecycle, and local binding rules | Isolates transport concerns from semantic logic |
+| `backend-standalone` | Headless runtime, workspace discovery, K2 session bootstrap, indexing, and semantic operations | Concentrates stateful analysis behavior in one runtime |
+| `backend-intellij` | IDE-hosted runtime, plugin lifecycle, and project service wiring | Reuses IntelliJ project model when the IDE is already running |
+| `backend-shared` | Shared analysis helpers used by both runtime hosts | Avoids duplicate semantic utility code |
+| `shared-testing` | Contract fixtures and fake backend infrastructure | Pins behavior consistency across implementations |
+| `build-logic` | Gradle conventions, wrapper generation, and runtime-lib sync | Keeps build and packaging rules centralized |
+
+## Design choices and rationale
+
+Kast keeps several explicit design choices that shape everyday behavior.
+
+### Choice 1: JSON-RPC contract as the stable center
+
+The contract is explicit and capability-gated. This keeps clients from assuming
+an operation exists when a backend cannot provide it.
+
+### Choice 2: Stateful daemon for semantic work
+
+Kotlin semantic analysis has meaningful startup and indexing cost. A daemonized
+model pays that cost once per workspace, then serves warm-path queries faster.
+
+### Choice 3: Bounded advanced traversals
+
+Operations such as `call-hierarchy` are intentionally bounded by depth,
+fan-out, total edges, and time limits. The result includes truncation metadata,
+so callers can distinguish complete from bounded answers.
+
+### Choice 4: Planned mutation over blind rewrite
+
+Rename and edit application use plan-and-apply semantics with expected file
+hashes. This protects against stale plans and reduces accidental drift between
+analysis time and write time.
+
+## Command granularity model
+
+Kast exposes one CLI, but not every command has the same audience.
+
+### Tier 1: Primary commands (most usable)
+
+These commands are the default operational path for most teams.
+
+- Workspace lifecycle: `workspace ensure`, `workspace status`, `workspace stop`
+- Runtime contract check: `capabilities`
+- Core read analysis: `resolve`, `references`, `diagnostics`
+- Controlled mutation: `rename`, `apply-edits`
+
+### Tier 2: Advanced primitives
+
+These commands are powerful building blocks that are often consumed by experts,
+agent workflows, or automation requiring higher precision.
+
+- `call-hierarchy`
+- `outline`
+- `workspace-symbol`
+- `type-hierarchy`
+- `insertion-point`
+- `workspace refresh`
+- `optimize-imports`
+
+Treat Tier 2 commands as supported primitives, not hidden features. They are
+critical for advanced workflows even when they are not part of the default
+human path.
+
+## End-to-end lifecycle for one request
+
+This sequence shows how a single semantic query moves across layers.
+
+```mermaid
+sequenceDiagram
+    participant U as User or LLM agent
+    participant C as kast CLI
+    participant S as analysis-server
+    participant B as backend runtime
+    participant K as K2 session and indexes
+
+    U->>C: Run command (for example, resolve)
+    C->>S: Send JSON-RPC request
+    S->>B: Dispatch typed backend call
+    B->>K: Resolve symbol in workspace session
+    K-->>B: Semantic result
+    B-->>S: Typed response
+    S-->>C: JSON-RPC response
+    C-->>U: Structured JSON output
+```
+
+## Full supported scope in one view
+
+Across standalone and IntelliJ-hosted backends, Kast supports:
+
+- Symbol resolution, references, diagnostics, and file outline
+- Workspace symbol search, call hierarchy, and type hierarchy
+- Semantic insertion point queries
+- Rename planning and edit application
+- Import optimization and workspace refresh
+- Workspace lifecycle and capability reporting
+
+Use `capabilities` in automation before relying on any operation, especially
+when switching runtime hosts.
+
+## Next steps
+
+After you absorb this model, continue with command-level details or the
+LLM-specific integration path.
+
+- [Run analysis commands](run-analysis-commands.md)
+- [Command reference](command-reference.md)
+- [Use Kast from an LLM agent](use-kast-from-an-llm-agent.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,80 +4,95 @@ description: IDE-grade Kotlin code intelligence for terminals, CI, and IDEs.
 icon: lucide/network
 ---
 
-Kast gives you IDE-grade Kotlin code intelligence wherever you need it. It
-uses the Kotlin K2 Analysis API to answer semantic questions about real
-workspaces and returns structured JSON that scripts, CI jobs, and LLM agents
-can consume directly. Kast runs as a standalone CLI daemon or as an IntelliJ
-IDEA plugin — both expose the same JSON-RPC protocol.
+Kast is a Kotlin semantic analysis system that returns structured JSON for
+humans, scripts, CI, and LLM-driven workflows. The fastest way to use these
+docs is to choose the perspective that matches your goal, then follow that path
+end to end.
 
-Kast is built to answer questions such as:
+## Choose your path
 
-- What symbol is at this location, and where is it declared?
-- Where is this symbol used, and what calls this function?
-- What changes if I rename this, and can I apply those edits safely?
-- What declarations does this file contain, and how are they nested?
-- Where is a symbol by name when you don't already know the file and offset?
-
-Start with the page that matches how you want to approach the tool.
+The documentation supports three primary perspectives. Each path highlights
+what matters most for that audience and keeps lower-level detail available
+without making the starting path noisy.
 
 <div class="grid cards" markdown>
 
--   __Why Kast__
+-   __Path 1: Capability overview (most readers)__
 
     ---
 
-    See where Kast fits between text search, IDE workflows, and automation.
+    Use this path when you want to understand what Kast can do and how to run
+    the commands people use most often.
 
-    [Open the guide](why-kast.md)
+    Start here:
 
--   __What you can do__
+    - [Why Kast](why-kast.md)
+    - [What you can do](what-you-can-do.md)
+    - [Get started](get-started.md)
+    - [Run analysis commands](run-analysis-commands.md)
 
-    ---
-
-    Learn the questions Kast can answer before you think about commands or
-    request payloads.
-
-    [Open the guide](what-you-can-do.md)
-
--   __How Kast works__
+-   __Path 2: Advanced architecture and module depth__
 
     ---
 
-    Understand the high-level flow from the CLI to the daemon and into the K2
-    analysis engine.
+    Use this path when you need module-by-module understanding, architectural
+    tradeoffs, and reasoning behind system boundaries.
 
-    [Open the guide](how-it-works.md)
+    Start here:
 
--   __Things to know__
+    - [How Kast works](how-it-works.md)
+    - [Architecture deep dive](architecture-deep-dive.md)
+    - [Things to know](things-to-know.md)
+    - [Command reference](command-reference.md)
 
-    ---
-
-    Read the behavioral model and result boundaries that matter when you
-    interpret Kast output.
-
-    [Open the guide](things-to-know.md)
-
--   __Get started__
+-   __Path 3: LLM integration and agent workflows__
 
     ---
 
-    Install Kast, attach it to a workspace, and verify that the runtime is
-    ready.
+    Use this path when your main question is how an LLM agent can leverage
+    Kast safely and repeatably.
 
-    [Open the guide](get-started.md)
+    Start here:
 
--   __Use Kast from an LLM agent__
-
-    ---
-
-    Start from a human description of a symbol and let the packaged skill
-    bridge the lookup.
-
-    [Open the guide](use-kast-from-an-llm-agent.md)
+    - [Use Kast from an LLM agent](use-kast-from-an-llm-agent.md)
+    - [Run analysis commands](run-analysis-commands.md)
+    - [LLM scaffolding reference](llm-scaffolding-reference.md)
+    - [Things to know](things-to-know.md)
 
 </div>
 
-If you already know the flow and need the operational surface, move to
-[Run analysis commands](run-analysis-commands.md),
-[Command reference](command-reference.md), or the
-[LLM scaffolding reference](llm-scaffolding-reference.md).
+## Command surface model
+
+Most teams only need a compact command set day to day:
+
+- `workspace ensure`, `workspace status`, `workspace stop`
+- `capabilities`
+- `resolve`, `references`, `diagnostics`
+- `rename` and `apply-edits` for controlled mutation
+
+Kast also exposes advanced primitives such as `call-hierarchy`, `outline`,
+`workspace-symbol`, `type-hierarchy`, and `insertion-point`. Those stay fully
+supported, but they live behind the core path because they are most useful in
+power-user or agent-driven workflows.
+
+## System model at a glance
+
+At runtime, Kast follows the same high-level flow for CLI users and agent
+integrations.
+
+```mermaid
+flowchart LR
+    A[Operator or LLM agent] --> B[kast CLI]
+    B --> C[analysis-server JSON-RPC layer]
+    C --> D[backend-standalone or IntelliJ backend]
+    D --> E[K2 analysis session + workspace model + indexes]
+    E --> F[Structured JSON result]
+```
+
+This model keeps semantic state warm in a long-lived backend while preserving a
+small CLI surface for common operations.
+
+## Next steps
+
+Pick one perspective path above, then continue into deeper pages only when you
+need more granularity for automation or architecture work.

--- a/docs/run-analysis-commands.md
+++ b/docs/run-analysis-commands.md
@@ -1,268 +1,107 @@
 ---
 title: Run analysis commands
-description: Use the supported read and mutation commands once a workspace
-  runtime is live.
+description: Use the most common CLI workflows first, then add advanced
+  primitives when your use case needs deeper control.
 icon: lucide/search
 ---
 
-Once `kast workspace ensure` has prewarmed a daemon, or the first
-runtime-dependent command has auto-started one, you can run the supported
-analysis commands through the same CLI. This page focuses on the common tasks
-people reach for during normal workspace analysis. If you are starting from a
-human description of a class or property instead of a known file position, move
-to the [human-first agent guide](use-kast-from-an-llm-agent.md) first.
+This page presents Kast commands in two layers. First, you get the core command
+set most teams use every day. Then you get advanced primitives that expose more
+granularity for power users and agent workflows.
 
-Note: If you use the packaged `kast` skill or the repo-local launcher resolver,
-you can bring local builds or explicit paths into the discovery cascade with
-`KAST_CLI_PATH` (point at a specific executable) and `KAST_SOURCE_ROOT` (use
-local build outputs or trigger `:kast:writeWrapperScript` when Java 21+ is
-available). See the Get started guide for examples.
+## Use the core workflow first
 
-> **Note:** Analysis and refresh commands can attach while the daemon reports
-> `INDEXING`. Early semantic results can still be partial or empty until the
-> daemon reaches `READY`.
+For most usage, this sequence is enough:
 
-## Control startup behavior
-
-Use the startup mode that matches the level of control you need before the
-first semantic query.
-
-- Run `kast workspace ensure --workspace-root=/absolute/path/to/workspace` when
-  you want an explicit prewarm step that waits for `READY`.
-- Add `--accept-indexing=true` to `workspace ensure` when a servable
-  `INDEXING` daemon is enough for the next step.
-- Add `--no-auto-start=true` to any runtime-dependent command when automation
-  must fail instead of starting a daemon implicitly.
-
-## Choose inline options or a request file
-
-Most analysis commands support two ways to provide input. Inline flags are
-fast for ad hoc work. Request files are better when the payload is richer or
-you want to save it for repeatable automation.
-
-| Command | Inline input | Request file input | Notes |
-| --- | --- | --- | --- |
-| `resolve` | `--file-path` and `--offset` | `--request-file` | Use the inline form for a single lookup |
-| `references` | `--file-path`, `--offset`, and optional `--include-declaration=true` | `--request-file` | Keep `--include-declaration` off unless you need the declaration in the result |
-| `call-hierarchy` | `--file-path`, `--offset`, `--direction`, and optional bound flags | `--request-file` | Use inline input when you want to tune depth or truncation limits directly |
-| `diagnostics` | `--file-paths=/absolute/A.kt,/absolute/B.kt` | `--request-file` | Inline input is easiest for a small list of files |
-| `outline` | `--file-path` | Not supported | Use the inline form for a single file |
-| `workspace-symbol` | `--pattern`, optional `--regex`, `--kind`, `--max-results` | Not supported | Use the inline form for name-based search |
-| `rename` | `--file-path`, `--offset`, `--new-name`, and optional `--dry-run=true` | `--request-file` | Rename stays in planning mode unless you change `dryRun` in the query |
-| `apply-edits` | Not supported | `--request-file` | The request file must include edits plus expected file hashes |
-
-## Check capabilities before you rely on a feature
-
-Capabilities are the contract for what the current runtime is willing to do.
-Check them first when you switch workspaces or when automation depends on a
-specific operation being available.
+1. Ensure the workspace runtime is ready.
+2. Confirm capabilities if automation depends on specific features.
+3. Resolve and inspect symbols with read commands.
+4. Plan and apply mutations through the guarded edit path.
+5. Stop the daemon when you are done.
 
 ```bash
-kast \
-  capabilities \
-  --workspace-root=/absolute/path/to/workspace
+kast workspace ensure --workspace-root=/absolute/path/to/workspace
+kast capabilities --workspace-root=/absolute/path/to/workspace
+kast resolve --workspace-root=/absolute/path/to/workspace --file-path=/absolute/path/to/src/main/kotlin/com/example/App.kt --offset=123
+kast references --workspace-root=/absolute/path/to/workspace --file-path=/absolute/path/to/src/main/kotlin/com/example/App.kt --offset=123
+kast diagnostics --workspace-root=/absolute/path/to/workspace --file-paths=/absolute/path/to/src/main/kotlin/com/example/App.kt
 ```
 
-If a capability is missing, Kast rejects the command instead of pretending the
-runtime supports it.
-
-## Resolve a symbol
-
-Use `resolve` when you know a file position and want the symbol details
-at that exact offset.
+If you need explicit daemon control, use:
 
 ```bash
-kast \
-  resolve \
-  --workspace-root=/absolute/path/to/workspace \
-  --file-path=/absolute/path/to/src/main/kotlin/com/example/App.kt \
-  --offset=123
+kast workspace status --workspace-root=/absolute/path/to/workspace
+kast workspace stop --workspace-root=/absolute/path/to/workspace
 ```
 
-Use a request file when the calling code already knows how to serialize a
-`SymbolQuery` payload.
+## Core commands and when to use them
 
-## Find references
+These commands are the primary operator surface.
 
-Use `references` when you want usage sites for the symbol at a specific file
-position.
+| Command | Use it when | Key inputs |
+| --- | --- | --- |
+| `workspace ensure` | You want explicit prewarm before semantic queries | `--workspace-root` |
+| `workspace status` | You need liveness and readiness details | `--workspace-root` |
+| `capabilities` | You must verify runtime support before a workflow | `--workspace-root` |
+| `resolve` | You need the exact symbol identity at a file position | `--workspace-root`, `--file-path`, `--offset` |
+| `references` | You need semantic usages of the resolved symbol | `--workspace-root`, `--file-path`, `--offset` |
+| `diagnostics` | You need current analysis diagnostics for one or more files | `--workspace-root`, `--file-paths` |
+| `rename` | You want a safe rename plan before writing edits | `--workspace-root`, `--file-path`, `--offset`, `--new-name` |
+| `apply-edits` | You are ready to apply a prepared plan with hashes | `--workspace-root`, `--request-file` |
+| `workspace stop` | You want to stop a standalone daemon instance | `--workspace-root` |
 
-```bash
-kast \
-  references \
-  --workspace-root=/absolute/path/to/workspace \
-  --file-path=/absolute/path/to/src/main/kotlin/com/example/App.kt \
-  --offset=123 \
-  --include-declaration=true
-```
+## Understand startup behavior
 
-Keep `--include-declaration=true` for the cases where your consumer wants the
-declaration returned alongside the reference list.
+Kast can auto-start a standalone daemon for runtime-dependent commands.
 
-The result includes a `searchScope` object. Read `searchScope.exhaustive`
-before treating the reference list as complete. Kast searches only the files
-visible to the resolved symbol's visibility: private and local symbols produce
-a `FILE`-scoped result, internal symbols produce a `MODULE`-scoped result, and
-public or protected symbols produce a `DEPENDENT_MODULES`-scoped result using
-the identifier index. When `searchScope.exhaustive` is `false`, results may
-miss usages outside the searched scope.
+- Use `workspace ensure` when you want explicit startup control.
+- Add `--accept-indexing=true` to return when the daemon is servable in
+  `INDEXING`.
+- Add `--no-auto-start=true` to force failure instead of auto-start.
 
-## Expand a call hierarchy
+> **Note:** Commands can attach during `INDEXING`, but early semantic results
+> can still be partial while background enrichment continues.
 
-Use `call-hierarchy` when you want incoming callers or outgoing callees for the
-declaration at a specific file position.
+## Use mutation through a guarded flow
 
-```bash
-kast \
-  call-hierarchy \
-  --workspace-root=/absolute/path/to/workspace \
-  --file-path=/absolute/path/to/src/main/kotlin/com/example/App.kt \
-  --offset=123 \
-  --direction=incoming \
-  --depth=2
-```
+When changing code, keep this order:
 
-`--direction` is required. Add `--max-total-calls`,
-`--max-children-per-node`, or `--timeout-millis` when you need tighter
-control over result shape.
+1. Run `rename` to generate a plan.
+2. Review the returned edits and expected file hashes.
+3. Run `apply-edits` with the generated request payload.
+4. Re-run read commands to validate resulting symbol state.
 
-Read the returned `stats` object and any per-node `truncation` metadata when
-automation needs to know whether Kast cut the tree short.
+This flow keeps edits conflict-aware and reviewable.
 
-## Run diagnostics
+## Add advanced primitives only when needed
 
-Use `diagnostics` when you want current diagnostics for one or more files in
-the workspace.
+These operations are fully supported and important for advanced use cases, but
+they are not required in most day-to-day CLI usage.
 
-```bash
-kast \
-  diagnostics \
-  --workspace-root=/absolute/path/to/workspace \
-  --file-paths=/absolute/path/to/src/main/kotlin/com/example/App.kt
-```
+| Command | Primary use case | Boundary to read |
+| --- | --- | --- |
+| `call-hierarchy` | Incoming and outgoing call graph slices | `stats` and node `truncation` |
+| `outline` | File-level declaration tree | Excludes parameters, anonymous elements, and local declarations |
+| `workspace-symbol` | Name-based symbol discovery across workspace | `page.truncated` for result caps |
+| `type-hierarchy` | Supertypes and subtypes rooted at a symbol | Capability availability by backend |
+| `insertion-point` | Semantic insertion location for new declarations | Best-fit location, not a rewrite plan |
+| `workspace refresh` | Manual recovery after missed filesystem updates | `fullRefresh` and refreshed file lists |
+| `optimize-imports` | Import cleanup for selected files | Scope is limited to provided files |
 
-Move to `--request-file` when you want the calling side to control the payload
-shape directly.
+If you rely on these commands in automation, check `capabilities` before
+execution and report bounded results honestly.
 
-## Get a file outline
+## Choose inline flags or request files
 
-Use `outline` when you want a hierarchical view of the named declarations in a
-Kotlin file.
+For `resolve`, `references`, `diagnostics`, `call-hierarchy`, `rename`,
+`type-hierarchy`, and `insertion-point`, you can use inline flags for ad hoc
+work or `--request-file` for repeatable automation payloads.
 
-```bash
-kast \
-  outline \
-  --workspace-root=/absolute/path/to/workspace \
-  --file-path=/absolute/path/to/src/main/kotlin/com/example/App.kt
-```
-
-The result is a nested tree. Top-level classes contain their member functions
-and properties as children. The outline includes classes, objects, named
-functions, and named properties. It excludes parameters, anonymous elements,
-and local declarations.
-
-## Search for symbols by name
-
-Use `workspace-symbol` when you want to find declarations across the workspace
-by name instead of by file position.
-
-```bash
-kast \
-  workspace-symbol \
-  --workspace-root=/absolute/path/to/workspace \
-  --pattern=HealthCheck
-```
-
-The default match is a case-insensitive substring search. Add `--regex=true`
-when you need pattern-based matching. Filter by kind with `--kind=CLASS`,
-`--kind=FUNCTION`, or `--kind=PROPERTY`.
-
-```bash
-kast \
-  workspace-symbol \
-  --workspace-root=/absolute/path/to/workspace \
-  --pattern=Service$ \
-  --regex=true \
-  --kind=CLASS
-```
-
-Read `page.truncated` in the result before you treat the list as complete.
-The default limit is 100 results.
-
-## Plan a rename
-
-Use `rename` when you want an edit plan for a symbol rename. The inline form is
-usually enough for ad hoc work.
-
-```bash
-kast \
-  rename \
-  --workspace-root=/absolute/path/to/workspace \
-  --file-path=/absolute/path/to/src/main/kotlin/com/example/App.kt \
-  --offset=123 \
-  --new-name=RenamedSymbol
-```
-
-The inline command defaults to `--dry-run=true`, so the result stays in
-planning mode unless your request payload says otherwise.
-
-## Apply a prepared edit plan
-
-Use `apply-edits` only after you already have a prepared edit plan that
-includes the edits and expected file hashes.
-
-```bash
-kast \
-  apply-edits \
-  --workspace-root=/absolute/path/to/workspace \
-  --request-file=/absolute/path/to/query.json
-```
-
-This command does not support inline flags for the payload. It must read the
-request from a file.
-
-## Refresh workspace state manually
-
-Kast refreshes `apply-edits` results immediately and watches source roots for
-most external `.kt` file changes. Use `workspace refresh` when you need the
-manual recovery path.
-
-1. Refresh the full workspace:
-
-   ```bash
-   kast \
-     workspace refresh \
-     --workspace-root=/absolute/path/to/workspace
-   ```
-
-2. Optional: Refresh only the files you know changed:
-
-   ```bash
-   kast \
-     workspace refresh \
-     --workspace-root=/absolute/path/to/workspace \
-     --file-paths=/absolute/path/to/src/main/kotlin/com/example/App.kt,/absolute/path/to/src/main/kotlin/com/example/Use.kt
-   ```
-
-3. Inspect `refreshedFiles`, `removedFiles`, and `fullRefresh` in the JSON
-   result when your calling code needs to react to the refresh scope.
-
-## Understand bounded results
-
-`call-hierarchy`, `outline`, and `workspace-symbol` are part of the supported
-CLI, but each is intentionally bounded. When you summarize `call-hierarchy`
-results, report the direction you used and surface truncation honestly if
-`stats` or node metadata show that Kast hit a limit. `outline` covers named
-declarations but excludes parameters, anonymous elements, and local
-declarations. `workspace-symbol` defaults to 100 results; read
-`page.truncated` before treating the list as complete.
+`apply-edits` is request-file only because it needs a structured edit plan.
+`outline` and `workspace-symbol` are inline-only in the current CLI surface.
 
 ## Next steps
-
-Keep the reference page nearby when you want a smaller lookup-oriented summary
-of the public commands.
 
 - [Command reference](command-reference.md)
 - [Use Kast from an LLM agent](use-kast-from-an-llm-agent.md)
 - [LLM scaffolding reference](llm-scaffolding-reference.md)
-- [Get started](get-started.md)

--- a/zensical.toml
+++ b/zensical.toml
@@ -18,6 +18,7 @@ nav = [
   { "Why Kast" = "why-kast.md" },
   { "What you can do" = "what-you-can-do.md" },
   { "How Kast works" = "how-it-works.md" },
+  { "Architecture deep dive" = "architecture-deep-dive.md" },
   { "Things to know" = "things-to-know.md" },
   { "Get started" = "get-started.md" },
   { "Run analysis commands" = "run-analysis-commands.md" },


### PR DESCRIPTION
### Motivation

- Make the documentation approachable for three distinct audiences (capability-first users, advanced developers, and LLM integrators) so readers can follow a focused path without losing access to deeper material.
- Surface the most usable CLI commands for day-to-day workflows while preserving advanced primitives as clearly labeled building blocks for power users and agents.
- Preserve and synthesize high-value architectural and workflow insights from the existing docs and the compiled `.agents/wiki` notes into a defensible module-level view.

### Description

- Rewrote the docs landing page (`docs/index.md`) to present three explicit perspective-based paths and a compact command-surface model for typical users.
- Added `docs/architecture-deep-dive.md` containing high-level diagrams, a module ownership map, design rationales (JSON-RPC contract, stateful daemon, bounded traversals, planned mutation), a command granularity model, and an end-to-end request lifecycle diagram.
- Rewrote `docs/run-analysis-commands.md` to emphasize a Tier 1 core workflow for most users and to collect advanced operations into a Tier 2 "advanced primitives" section for power-user and agent flows.
- Updated `zensical.toml` navigation to include the new Architecture deep dive page and kept links to existing deeper references; content was synthesized from the current docs and `.agents/wiki` to avoid losing existing insights.

### Testing

- Ran `git diff --check` to validate there are no whitespace or diff issues, and it passed. 
- Attempted `zensical build --clean` to verify the site build, but the command is not available in this environment so the site build could not be completed here (tooling missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e179dc25e4832495aa602bd5e62c71)