### PR TITLE
kast-cli: rewrite `kast demo` in Kotlin with an interactive symbol-graph walker

### DIFF
--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -775,16 +775,18 @@ internal object CliCommandCatalog {
             path = listOf("demo"),
             group = CliCommandGroup.VALIDATION,
             summary = "Interactive comparison of grep vs kast semantic analysis on your workspace.",
-            description = "Picks a symbol from your workspace — via --symbol or the built-in terminal chooser — and runs grep-style text search alongside standalone kast resolve, references, rename, and call-hierarchy so you can see the difference side by side.",
+            description = "Picks a symbol from your workspace — via --symbol or the built-in terminal chooser — and runs grep-style text search alongside kast resolve, references, rename, and call-hierarchy so you can see the difference side by side. " +
+                "Uses the live IntelliJ plugin backend when one is available and auto-starts the standalone JVM daemon otherwise; pin with --backend-name=intellij|standalone.",
             usages = listOf(
-                "$CLI_EXECUTABLE_NAME demo [--workspace-root=/absolute/path/to/workspace] [--symbol=CliService] [--walk=auto|true|false]",
+                "$CLI_EXECUTABLE_NAME demo [--workspace-root=/absolute/path/to/workspace] [--symbol=CliService] [--walk=auto|true|false] [--backend-name=intellij|standalone]",
             ),
-            options = listOf(workspaceRootOption, demoSymbolOption, demoWalkOption),
+            options = listOf(workspaceRootOption, demoSymbolOption, demoWalkOption, backendNameOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME demo",
                 "$CLI_EXECUTABLE_NAME demo --workspace-root=/absolute/path/to/workspace",
                 "$CLI_EXECUTABLE_NAME demo --workspace-root=/absolute/path/to/workspace --symbol=CliService",
                 "$CLI_EXECUTABLE_NAME demo --walk=true  # always runs the interactive symbol-graph walker",
+                "$CLI_EXECUTABLE_NAME demo --backend-name=intellij  # target a running IntelliJ IDEA plugin backend",
             ),
         ),
         CliCommandMetadata(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -317,6 +317,12 @@ internal object CliCommandCatalog {
         description = "Skip the interactive picker and use the first symbol matching this text.",
     )
 
+    private val demoWalkOption = CliOptionMetadata(
+        key = "walk",
+        usage = "--walk=auto|true|false",
+        description = "Run the interactive symbol-graph walker after Act 2. Defaults to auto: on when stdin is a TTY and --symbol is not set.",
+    )
+
     private val commands: List<CliCommandMetadata> = listOf(
         CliCommandMetadata(
             path = listOf("workspace", "status"),
@@ -771,13 +777,14 @@ internal object CliCommandCatalog {
             summary = "Interactive comparison of grep vs kast semantic analysis on your workspace.",
             description = "Picks a symbol from your workspace — via --symbol or the built-in terminal chooser — and runs grep-style text search alongside standalone kast resolve, references, rename, and call-hierarchy so you can see the difference side by side.",
             usages = listOf(
-                "$CLI_EXECUTABLE_NAME demo [--workspace-root=/absolute/path/to/workspace] [--symbol=CliService]",
+                "$CLI_EXECUTABLE_NAME demo [--workspace-root=/absolute/path/to/workspace] [--symbol=CliService] [--walk=auto|true|false]",
             ),
-            options = listOf(workspaceRootOption, demoSymbolOption),
+            options = listOf(workspaceRootOption, demoSymbolOption, demoWalkOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME demo",
                 "$CLI_EXECUTABLE_NAME demo --workspace-root=/absolute/path/to/workspace",
                 "$CLI_EXECUTABLE_NAME demo --workspace-root=/absolute/path/to/workspace --symbol=CliService",
+                "$CLI_EXECUTABLE_NAME demo --walk=true  # always runs the interactive symbol-graph walker",
             ),
         ),
         CliCommandMetadata(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
@@ -544,12 +544,22 @@ internal data class ParsedArguments(
                 message = "`kast demo` does not accept --kast; invoke demo.sh directly if you need to override the launcher",
             )
         }
+        val walkMode = when (options["walk"]?.lowercase()) {
+            null, "", "auto" -> DemoWalkMode.AUTO
+            "true", "on", "yes", "1" -> DemoWalkMode.ENABLED
+            "false", "off", "no", "0" -> DemoWalkMode.DISABLED
+            else -> throw CliFailure(
+                code = "CLI_USAGE",
+                message = "Unknown value for --walk: ${options["walk"]}. Valid values: auto, true, false.",
+            )
+        }
         return DemoOptions(
             workspaceRoot = options["workspace-root"]
                 ?.takeIf(String::isNotBlank)
                 ?.let { Path.of(it).toAbsolutePath().normalize() }
                 ?: Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize(),
             symbolFilter = options["symbol"]?.takeIf(String::isNotBlank),
+            walkMode = walkMode,
         )
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
@@ -553,6 +553,14 @@ internal data class ParsedArguments(
                 message = "Unknown value for --walk: ${options["walk"]}. Valid values: auto, true, false.",
             )
         }
+        val backend = when (val raw = options["backend-name"]?.trim()?.lowercase()?.takeIf(String::isNotEmpty)) {
+            null, "auto" -> null
+            "standalone", "intellij" -> raw
+            else -> throw CliFailure(
+                code = "CLI_USAGE",
+                message = "Unknown value for --backend-name: ${options["backend-name"]}. Valid values: auto, standalone, intellij.",
+            )
+        }
         return DemoOptions(
             workspaceRoot = options["workspace-root"]
                 ?.takeIf(String::isNotBlank)
@@ -560,6 +568,7 @@ internal data class ParsedArguments(
                 ?: Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize(),
             symbolFilter = options["symbol"]?.takeIf(String::isNotBlank),
             walkMode = walkMode,
+            backend = backend,
         )
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
@@ -257,66 +257,35 @@ internal class CliService(
 
     fun smoke(options: SmokeOptions): CliExternalProcess = smokeCommandSupport.plan(options)
 
-    suspend fun demo(options: DemoOptions): RuntimeAttachedResult<String> {
-        val runtimeOptions = RuntimeCommandOptions(
-            workspaceRoot = options.workspaceRoot,
-            backendName = "standalone",
-            waitTimeoutMillis = 180_000L,
+    suspend fun demo(
+        options: DemoOptions,
+        sink: (String) -> Unit = { text -> System.err.print(text) },
+        reader: java.io.BufferedReader? = defaultDemoReader(),
+        consoleProvider: () -> java.io.Console? = System::console,
+    ): RuntimeAttachedResult<String> {
+        val walkerEnabled = when (options.walkMode) {
+            DemoWalkMode.DISABLED -> false
+            DemoWalkMode.ENABLED -> true
+            DemoWalkMode.AUTO -> consoleProvider() != null && options.symbolFilter == null
+        }
+        demoCommandSupport.runInteractive(
+            options = options,
+            cliService = this,
+            sink = sink,
+            reader = reader,
+            walkerEnabled = walkerEnabled,
         )
-        val ensured = workspaceEnsure(runtimeOptions)
-        val symbolSearch = workspaceSymbolSearch(
-            runtimeOptions,
-            WorkspaceSymbolQuery(
-                pattern = options.symbolFilter ?: ".",
-                maxResults = 500,
-                regex = options.symbolFilter == null,
+        val runtime = runtimeManager.workspaceEnsure(
+            RuntimeCommandOptions(
+                workspaceRoot = options.workspaceRoot,
+                backendName = "standalone",
+                waitTimeoutMillis = 180_000L,
             ),
-        )
-        val selectedSymbol = demoCommandSupport.selectSymbol(options, symbolSearch.payload.symbols)
-        val symbolPosition = FilePosition(
-            filePath = selectedSymbol.location.filePath,
-            offset = selectedSymbol.location.startOffset,
-        )
-        val resolvedSymbol = resolveSymbol(
-            runtimeOptions,
-            SymbolQuery(position = symbolPosition),
-        ).payload.symbol
-        val references = findReferences(
-            runtimeOptions,
-            ReferencesQuery(
-                position = symbolPosition,
-                includeDeclaration = true,
-            ),
-        ).payload
-        val rename = rename(
-            runtimeOptions,
-            RenameQuery(
-                position = symbolPosition,
-                newName = "${resolvedSymbol.fqName.substringAfterLast('.')}Renamed",
-                dryRun = true,
-            ),
-        ).payload
-        val callHierarchy = callHierarchy(
-            runtimeOptions,
-            CallHierarchyQuery(
-                position = symbolPosition,
-                direction = CallDirection.INCOMING,
-                depth = 2,
-            ),
-        ).payload
-        val report = DemoReport(
-            workspaceRoot = options.workspaceRoot,
-            selectedSymbol = selectedSymbol,
-            textSearch = demoCommandSupport.analyzeTextSearch(options.workspaceRoot, resolvedSymbol),
-            resolvedSymbol = resolvedSymbol,
-            references = references,
-            rename = rename,
-            callHierarchy = callHierarchy,
         )
         return RuntimeAttachedResult(
-            payload = demoCommandSupport.render(report),
-            runtime = ensured.selected,
-            daemonNote = ensured.note,
+            payload = "",
+            runtime = runtime.selected,
+            daemonNote = runtime.note,
         )
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
@@ -278,7 +278,7 @@ internal class CliService(
         val runtime = runtimeManager.workspaceEnsure(
             RuntimeCommandOptions(
                 workspaceRoot = options.workspaceRoot,
-                backendName = "standalone",
+                backendName = options.backend,
                 waitTimeoutMillis = 180_000L,
             ),
         )

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoCommandSupport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoCommandSupport.kt
@@ -172,7 +172,7 @@ internal class DemoCommandSupport(
 
         val runtimeOptions = RuntimeCommandOptions(
             workspaceRoot = options.workspaceRoot,
-            backendName = "standalone",
+            backendName = options.backend,
             waitTimeoutMillis = 180_000L,
         )
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoCommandSupport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoCommandSupport.kt
@@ -1,18 +1,40 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.api.contract.CallDirection
+import io.github.amichne.kast.api.contract.CallHierarchyQuery
 import io.github.amichne.kast.api.contract.CallHierarchyResult
-import io.github.amichne.kast.api.contract.CallNode
-import io.github.amichne.kast.api.contract.Location
+import io.github.amichne.kast.api.contract.FilePosition
+import io.github.amichne.kast.api.contract.ReferencesQuery
 import io.github.amichne.kast.api.contract.ReferencesResult
+import io.github.amichne.kast.api.contract.RenameQuery
 import io.github.amichne.kast.api.contract.RenameResult
 import io.github.amichne.kast.api.contract.Symbol
+import io.github.amichne.kast.api.contract.SymbolQuery
+import io.github.amichne.kast.api.contract.WorkspaceSymbolQuery
+import io.github.amichne.kast.cli.demo.CliServiceSymbolGraph
+import io.github.amichne.kast.cli.demo.DemoActs.act1TextSearchBaseline
+import io.github.amichne.kast.cli.demo.DemoActs.act2Semantic
+import io.github.amichne.kast.cli.demo.DemoActs.closingPanel
+import io.github.amichne.kast.cli.demo.DemoActs.comparisonSummary
+import io.github.amichne.kast.cli.demo.DemoActs.openingBanner
+import io.github.amichne.kast.cli.demo.DemoActs.targetPanel
+import io.github.amichne.kast.cli.demo.DemoRenderer
+import io.github.amichne.kast.cli.demo.DemoScript
+import io.github.amichne.kast.cli.demo.LineEmphasis
+import io.github.amichne.kast.cli.demo.StreamWalkerIO
+import io.github.amichne.kast.cli.demo.SymbolWalker
+import io.github.amichne.kast.cli.demo.Timed
+import io.github.amichne.kast.cli.demo.demoScript
+import io.github.amichne.kast.cli.demo.timed
+import java.io.BufferedReader
 import java.io.Console
+import java.io.InputStreamReader
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.name
 import kotlin.io.path.readLines
-import kotlin.math.max
 
+/** Shared entry points used by [CliService.demo] and directly by unit tests. */
 internal class DemoCommandSupport(
     private val symbolChooser: DemoSymbolChooser = TerminalDemoSymbolChooser(),
     private val themeProvider: () -> CliTextTheme = CliTextTheme::detect,
@@ -101,165 +123,197 @@ internal class DemoCommandSupport(
         )
     }
 
+    /**
+     * Batch rendering used when the caller wants a complete transcript in
+     * one shot (older callers + unit tests). Builds the full scene tree,
+     * then renders it in a single pass.
+     */
     fun render(report: DemoReport): String {
-        val theme = themeProvider()
-        val symbolName = report.selectedSymbol.fqName.substringAfterLast('.')
-        return buildString {
-            appendLine(theme.title("kast demo"))
-            appendLine("Workspace  ${report.workspaceRoot}")
-            appendLine("Selected   ${report.resolvedSymbol.fqName}")
-            appendLine()
-
-            appendLine(theme.heading("Act 1 · text search baseline"))
-            appendLine("grep found ${report.textSearch.totalMatches} matches for \"$symbolName\"")
-            appendLine("- likely true: ${report.textSearch.likelyCorrect}")
-            appendLine("- ambiguous: ${report.textSearch.ambiguous}")
-            appendLine("- likely false positives: ${report.textSearch.falsePositives}")
-            appendLine("- blind rename would touch ${report.textSearch.filesTouched} files")
-            report.textSearch.sampleMatches.forEach { match ->
-                appendLine(
-                    "  ${relativeToWorkspace(report.workspaceRoot, match.filePath)}:${match.lineNumber}  " +
-                        "${match.preview} ${match.category.renderHint(theme)}",
-                )
-            }
-            appendLine()
-
-            appendLine(theme.heading("Act 2 · semantic analysis"))
-            appendLine("resolve")
-            appendLine("- fqName: ${report.resolvedSymbol.fqName}")
-            appendLine("- kind: ${report.resolvedSymbol.kind}")
-            report.resolvedSymbol.visibility?.let { appendLine("- visibility: $it") }
-            appendLine("- location: ${renderLocation(report.workspaceRoot, report.resolvedSymbol.location)}")
-            report.resolvedSymbol.containingDeclaration?.let { appendLine("- container: $it") }
-            appendLine()
-
-            appendLine("references")
-            appendLine("- semantic references: ${report.references.references.size}")
-            report.references.searchScope?.let { scope ->
-                appendLine("- exhaustive: ${scope.exhaustive}")
-                appendLine("- searched: ${scope.searchedFileCount}/${scope.candidateFileCount} files (${scope.scope})")
-            }
-            report.references.references.take(REFERENCE_PREVIEW_LIMIT).forEach { reference ->
-                appendLine("  ${renderLocation(report.workspaceRoot, reference)}  ${reference.preview.trim()}")
-            }
-            appendLine()
-
-            appendLine("rename --dry-run")
-            appendLine("- edits: ${report.rename.edits.size}")
-            appendLine("- affected files: ${report.rename.affectedFiles.size}")
-            appendLine("- file hashes: ${report.rename.fileHashes.size}")
-            report.rename.affectedFiles.take(FILE_PREVIEW_LIMIT).forEach { filePath ->
-                appendLine("  ${relativeToWorkspace(report.workspaceRoot, filePath)}")
-            }
-            appendLine()
-
-            appendLine("call-hierarchy (incoming, depth=2)")
-            appendLine("- incoming callers: ${report.callHierarchy.stats.totalNodes}")
-            appendLine("- max depth: ${report.callHierarchy.stats.maxDepthReached}")
-            appendLine("- files visited: ${report.callHierarchy.stats.filesVisited}")
-            renderCallTree(report.workspaceRoot, report.callHierarchy.root).forEach(::appendLine)
-            appendLine()
-
-            appendLine(theme.heading("Side-by-side summary"))
-            append(renderComparisonTable(report, theme))
-            appendLine()
-            appendLine()
-
-            appendLine(theme.heading("why the semantic pass wins"))
-            appendLine("grep only sees text, so it mixes real usages with imports, comments, strings, and substring collisions.")
-            appendLine("kast resolves the exact declaration, returns true semantic references, previews a safe rename, and maps incoming callers before you edit anything.")
+        val renderer = newRenderer()
+        val script = demoScript {
+            openingBanner(report.workspaceRoot)
+            targetPanel(report.workspaceRoot, report.resolvedSymbol)
+            act1TextSearchBaseline(
+                workspaceRoot = report.workspaceRoot,
+                symbolName = report.resolvedSymbol.fqName.substringAfterLast('.'),
+                summary = report.textSearch,
+            )
+            act2Semantic(
+                workspaceRoot = report.workspaceRoot,
+                resolvedSymbol = report.resolvedSymbol,
+                references = report.references,
+                rename = report.rename,
+                callHierarchy = report.callHierarchy,
+            )
+            comparisonSummary(report)
+            closingPanel()
         }
+        return renderer.render(script)
     }
 
-    private fun renderCallTree(
-        workspaceRoot: Path,
-        root: CallNode,
-    ): List<String> {
-        val lines = mutableListOf<String>()
-        val remaining = ArrayDeque<Int>().apply { add(CALL_TREE_LIMIT) }
+    /**
+     * Streaming orchestrator. Gathers the analysis payload piece by piece,
+     * emits each scene to [sink] as it completes, optionally runs the
+     * interactive symbol-graph walker, and finally prints the comparison
+     * summary and closing panel. Returns the populated [DemoReport] so the
+     * caller can attach it to a runtime-aware result.
+     */
+    suspend fun runInteractive(
+        options: DemoOptions,
+        cliService: CliService,
+        sink: (String) -> Unit,
+        reader: BufferedReader?,
+        walkerEnabled: Boolean,
+    ): DemoReport {
+        val renderer = newRenderer()
+        fun emit(script: DemoScript) = sink(renderer.render(script))
 
-        fun walk(node: CallNode, depth: Int) {
-            val left = remaining.removeFirst()
-            if (left <= 0) {
-                remaining.addFirst(0)
-                return
-            }
-            remaining.addFirst(left - 1)
-            val symbol = node.symbol
-            val indent = "  ".repeat(max(0, depth))
-            lines += buildString {
-                append(indent)
-                append("- ")
-                append(symbol.fqName.substringAfterLast('.'))
-                append(" (")
-                append(symbol.kind)
-                append(") ")
-                append(renderLocation(workspaceRoot, symbol.location))
-            }
-            node.children.forEach { child -> walk(child, depth + 1) }
-        }
+        emit(demoScript { openingBanner(options.workspaceRoot) })
 
-        walk(root, depth = 0)
-        return lines
-    }
-
-    private fun renderComparisonTable(
-        report: DemoReport,
-        theme: CliTextTheme,
-    ): String {
-        val rows = listOf(
-            Triple(
-                "Matches found",
-                "${report.textSearch.totalMatches} total / ${report.textSearch.likelyCorrect} likely true / ${report.textSearch.ambiguous} ambiguous",
-                "${report.references.references.size} semantic references",
-            ),
-            Triple("Symbol identity", "text only", "exact symbol identity"),
-            Triple("Kind awareness", "none", "knows the declaration kind"),
-            Triple("Call graph", "none", "${report.callHierarchy.stats.totalNodes} incoming callers"),
-            Triple("Rename plan", "blind sed across ${report.textSearch.filesTouched} files", "${report.rename.edits.size} edits across ${report.rename.affectedFiles.size} files"),
-            Triple("Conflict detection", "none", "${report.rename.fileHashes.size} file hashes"),
-            Triple(
-                "Coverage signal",
-                "none",
-                report.references.searchScope?.let { "exhaustive=${it.exhaustive} over ${it.searchedFileCount}/${it.candidateFileCount} files" } ?: "scope unavailable",
-            ),
-            Triple("Post-edit checks", "manual", "kast diagnostics"),
+        val runtimeOptions = RuntimeCommandOptions(
+            workspaceRoot = options.workspaceRoot,
+            backendName = "standalone",
+            waitTimeoutMillis = 180_000L,
         )
-        val metricWidth = max("metric".length, rows.maxOf { it.first.length })
-        val grepWidth = max("grep + sed".length, rows.maxOf { it.second.length })
-        val kastWidth = max("kast".length, rows.maxOf { it.third.length })
-        val separator = "${"-".repeat(metricWidth)}-+-${"-".repeat(grepWidth)}-+-${"-".repeat(kastWidth)}"
-        return buildString {
-            appendLine("metric".padEnd(metricWidth) + " | " + "grep + sed".padEnd(grepWidth) + " | " + theme.command("kast").padEnd(kastWidth))
-            appendLine(separator)
-            rows.forEachIndexed { index, row ->
-                append(row.first.padEnd(metricWidth))
-                append(" | ")
-                append(row.second.padEnd(grepWidth))
-                append(" | ")
-                append(row.third.padEnd(kastWidth))
-                if (index < rows.lastIndex) {
-                    appendLine()
+
+        emit(demoScript { progress("Warming workspace daemon (kast workspace ensure)...") })
+        val warm = timed { cliService.workspaceEnsure(runtimeOptions) }
+        emit(stepOutcomeScript("workspace ensure", warm))
+        warm.value.getOrThrow()
+
+        emit(demoScript { progress("Discovering workspace symbols (kast workspace-symbol)...") })
+        val symbolSearch = timed {
+            cliService.workspaceSymbolSearch(
+                runtimeOptions,
+                WorkspaceSymbolQuery(
+                    pattern = options.symbolFilter ?: ".",
+                    maxResults = 500,
+                    regex = options.symbolFilter == null,
+                ),
+            )
+        }
+        emit(stepOutcomeScript("workspace symbol search", symbolSearch))
+        val symbolPayload = symbolSearch.value.getOrThrow().payload
+
+        val selectedSymbol = selectSymbol(options, symbolPayload.symbols)
+        val symbolPosition = FilePosition(
+            filePath = selectedSymbol.location.filePath,
+            offset = selectedSymbol.location.startOffset,
+        )
+
+        emit(demoScript { targetPanel(options.workspaceRoot, selectedSymbol) })
+
+        emit(demoScript { progress("Classifying grep matches for ${selectedSymbol.fqName.substringAfterLast('.')}...") })
+        val textSearch = analyzeTextSearch(options.workspaceRoot, selectedSymbol)
+        emit(demoScript {
+            act1TextSearchBaseline(
+                workspaceRoot = options.workspaceRoot,
+                symbolName = selectedSymbol.fqName.substringAfterLast('.'),
+                summary = textSearch,
+            )
+        })
+
+        val resolved = timed {
+            cliService.resolveSymbol(runtimeOptions, SymbolQuery(position = symbolPosition))
+        }
+        val resolvedSymbol = resolved.value.getOrThrow().payload.symbol
+
+        val references = timed {
+            cliService.findReferences(
+                runtimeOptions,
+                ReferencesQuery(position = symbolPosition, includeDeclaration = true),
+            )
+        }
+        val referencesPayload = references.value.getOrThrow().payload
+
+        val rename = timed {
+            cliService.rename(
+                runtimeOptions,
+                RenameQuery(
+                    position = symbolPosition,
+                    newName = "${resolvedSymbol.fqName.substringAfterLast('.')}Renamed",
+                    dryRun = true,
+                ),
+            )
+        }
+        val renamePayload = rename.value.getOrThrow().payload
+
+        val callHierarchy = timed {
+            cliService.callHierarchy(
+                runtimeOptions,
+                CallHierarchyQuery(
+                    position = symbolPosition,
+                    direction = CallDirection.INCOMING,
+                    depth = 2,
+                ),
+            )
+        }
+        val callHierarchyPayload = callHierarchy.value.getOrThrow().payload
+
+        emit(demoScript {
+            act2Semantic(
+                workspaceRoot = options.workspaceRoot,
+                resolvedSymbol = resolvedSymbol,
+                references = referencesPayload,
+                rename = renamePayload,
+                callHierarchy = callHierarchyPayload,
+            )
+        })
+
+        if (walkerEnabled && reader != null) {
+            val walker = SymbolWalker(
+                workspaceRoot = options.workspaceRoot,
+                graph = CliServiceSymbolGraph(cliService, runtimeOptions),
+                io = StreamWalkerIO(reader = reader, output = sink),
+                renderer = renderer,
+            )
+            walker.run(resolvedSymbol)
+        } else {
+            emit(demoScript {
+                section("Act 3 · walk the symbol graph")
+                panel("interactive walker · skipped") {
+                    line(
+                        text = "pass --walk=true with a real terminal to hop between references, callers, and callees.",
+                        emphasis = LineEmphasis.DIM,
+                    )
+                }
+                blank()
+            })
+        }
+
+        val report = DemoReport(
+            workspaceRoot = options.workspaceRoot,
+            selectedSymbol = selectedSymbol,
+            textSearch = textSearch,
+            resolvedSymbol = resolvedSymbol,
+            references = referencesPayload,
+            rename = renamePayload,
+            callHierarchy = callHierarchyPayload,
+        )
+
+        emit(demoScript {
+            comparisonSummary(report)
+            closingPanel()
+        })
+
+        return report
+    }
+
+    private fun newRenderer(): DemoRenderer = DemoRenderer(theme = themeProvider())
+
+    private fun stepOutcomeScript(message: String, outcome: Timed<Result<*>>): DemoScript = demoScript {
+        step(message) {
+            if (outcome.value.isSuccess) success(outcome.elapsed) else failure(outcome.elapsed)
+            if (outcome.value.isFailure) {
+                body {
+                    line(
+                        text = outcome.value.exceptionOrNull()?.message ?: "unknown failure",
+                        emphasis = LineEmphasis.ERROR,
+                    )
                 }
             }
         }
     }
-
-    private fun relativeToWorkspace(
-        workspaceRoot: Path,
-        filePath: String,
-    ): String {
-        val absolutePath = Path.of(filePath).toAbsolutePath().normalize()
-        return absolutePath
-            .takeIf { it.startsWith(workspaceRoot.toAbsolutePath().normalize()) }
-            ?.let { workspaceRoot.toAbsolutePath().normalize().relativize(it).toString() }
-            ?: absolutePath.toString()
-    }
-
-    private fun renderLocation(
-        workspaceRoot: Path,
-        location: Location,
-    ): String = "${relativeToWorkspace(workspaceRoot, location.filePath)}:${location.startLine}"
 
     private fun symbolMatchesFilter(
         symbol: Symbol,
@@ -311,14 +365,6 @@ internal class DemoCommandSupport(
         segmentName.startsWith(".") || segmentName in IGNORED_DIRECTORIES
     }
 
-    private fun DemoTextMatchCategory.renderHint(theme: CliTextTheme): String = when (this) {
-        DemoTextMatchCategory.LIKELY_CORRECT -> ""
-        DemoTextMatchCategory.IMPORT -> theme.muted("← import")
-        DemoTextMatchCategory.COMMENT -> theme.muted("← comment")
-        DemoTextMatchCategory.STRING -> theme.muted("← string")
-        DemoTextMatchCategory.SUBSTRING -> theme.muted("← substring")
-    }
-
     private companion object {
         val IGNORED_DIRECTORIES = setOf(
             ".git",
@@ -332,9 +378,6 @@ internal class DemoCommandSupport(
             "buildSrc",
         )
         const val SAMPLE_MATCH_LIMIT = 12
-        const val REFERENCE_PREVIEW_LIMIT = 8
-        const val FILE_PREVIEW_LIMIT = 6
-        const val CALL_TREE_LIMIT = 12
     }
 }
 
@@ -402,3 +445,7 @@ internal data class DemoReport(
     val rename: RenameResult,
     val callHierarchy: CallHierarchyResult,
 )
+
+/** Convenience reader for CLI plumbing. */
+internal fun defaultDemoReader(): BufferedReader =
+    BufferedReader(InputStreamReader(System.`in`, Charsets.UTF_8))

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoOptions.kt
@@ -5,4 +5,21 @@ import java.nio.file.Path
 internal data class DemoOptions(
     val workspaceRoot: Path,
     val symbolFilter: String?,
+    val walkMode: DemoWalkMode = DemoWalkMode.AUTO,
 )
+
+/**
+ * Whether the interactive symbol-graph walker (Act 3) should run.
+ *
+ * - [AUTO] runs the walker only when stdin is a TTY and `--symbol` was not
+ *   supplied, matching the "take me through it" default for a terminal demo.
+ * - [ENABLED] forces the walker to run even without a TTY — useful when
+ *   driving the CLI over a scripted transport.
+ * - [DISABLED] skips the walker entirely, restoring the non-interactive
+ *   rendered report used by CI and older call sites.
+ */
+internal enum class DemoWalkMode {
+    AUTO,
+    ENABLED,
+    DISABLED,
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoOptions.kt
@@ -6,6 +6,16 @@ internal data class DemoOptions(
     val workspaceRoot: Path,
     val symbolFilter: String?,
     val walkMode: DemoWalkMode = DemoWalkMode.AUTO,
+    /**
+     * Backend the demo should talk to.
+     *  - `null` — auto-select: prefer a live IntelliJ plugin backend when one
+     *    is discoverable, otherwise fall back to (and auto-start if needed)
+     *    the standalone JVM daemon.
+     *  - `"standalone"` — force the standalone JVM daemon.
+     *  - `"intellij"` — require a running IntelliJ IDEA instance with the
+     *    Kast plugin; fails fast when no IntelliJ runtime is available.
+     */
+    val backend: String? = null,
 )
 
 /**

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoActs.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoActs.kt
@@ -1,0 +1,260 @@
+package io.github.amichne.kast.cli.demo
+
+import io.github.amichne.kast.api.contract.CallHierarchyResult
+import io.github.amichne.kast.api.contract.CallNode
+import io.github.amichne.kast.api.contract.Location
+import io.github.amichne.kast.api.contract.ReferencesResult
+import io.github.amichne.kast.api.contract.RenameResult
+import io.github.amichne.kast.api.contract.Symbol
+import io.github.amichne.kast.cli.DemoReport
+import io.github.amichne.kast.cli.DemoTextMatch
+import io.github.amichne.kast.cli.DemoTextMatchCategory
+import io.github.amichne.kast.cli.DemoTextSearchSummary
+import java.nio.file.Path
+
+/** Pure functions that turn analysis payloads into scene-builder calls. */
+internal object DemoActs {
+    const val REFERENCE_PREVIEW_LIMIT: Int = 8
+    const val FILE_PREVIEW_LIMIT: Int = 6
+    const val CALL_TREE_LIMIT: Int = 12
+    const val SAMPLE_MATCH_LIMIT: Int = 12
+
+    fun DemoScriptBuilder.openingBanner(workspaceRoot: Path) {
+        banner("kast demo") {
+            line("semantic analysis vs text search", emphasis = LineEmphasis.STRONG)
+            blank()
+            line("Workspace  $workspaceRoot")
+        }
+        blank()
+    }
+
+    fun DemoScriptBuilder.targetPanel(
+        workspaceRoot: Path,
+        symbol: Symbol,
+    ) {
+        val simpleName = symbol.fqName.substringAfterLast('.')
+        val relFile = Paths.relative(workspaceRoot, symbol.location.filePath)
+        banner("demo target") {
+            line("Symbol  ${symbol.fqName}", emphasis = LineEmphasis.STRONG)
+            line("Kind    ${symbol.kind}")
+            line("File    $relFile")
+            line("Offset  ${symbol.location.startOffset}")
+            blank()
+            line("> Find semantic references without comment, import, or substring noise")
+            line("> Preview a safe rename before editing a single file")
+            line("> Trace incoming callers and compare that graph with grep output")
+            blank()
+            line("Walker tip (Act 3): hop the $simpleName graph — r/c/o for references, callers, callees.", emphasis = LineEmphasis.DIM)
+        }
+        blank()
+    }
+
+    fun DemoScriptBuilder.act1TextSearchBaseline(
+        workspaceRoot: Path,
+        symbolName: String,
+        summary: DemoTextSearchSummary,
+    ) {
+        section("Act 1 · text search baseline")
+        step("grep '$symbolName' --include='*.kt'") {
+            info()
+            body {
+                summary.sampleMatches.take(SAMPLE_MATCH_LIMIT).forEach { match ->
+                    val rel = Paths.relative(workspaceRoot, match.filePath)
+                    line(
+                        text = "$rel:${match.lineNumber}  ${match.preview.take(90)}",
+                        emphasis = match.emphasisForCategory(),
+                        tag = match.bodyTag(),
+                    )
+                }
+                if (summary.totalMatches > summary.sampleMatches.size) {
+                    val remaining = summary.totalMatches - summary.sampleMatches.size
+                    line("... and $remaining more matches", emphasis = LineEmphasis.DIM)
+                }
+                blank()
+                line("grep found ${summary.totalMatches} matches for \"$symbolName\"", emphasis = LineEmphasis.STRONG)
+                line("▸ ${summary.likelyCorrect} likely correct", emphasis = LineEmphasis.SUCCESS)
+                if (summary.ambiguous > 0) {
+                    line("▸ ${summary.ambiguous} ambiguous (imports)", emphasis = LineEmphasis.WARN)
+                }
+                if (summary.falsePositives > 0) {
+                    val parts = summary.categoryCounts
+                        .filterKeys { it != DemoTextMatchCategory.LIKELY_CORRECT }
+                        .filterValues { it > 0 }
+                        .entries
+                        .joinToString(", ") { (kind, count) -> "$count ${kind.name.lowercase()}" }
+                    line("▸ ${summary.falsePositives} likely false positives ($parts)", emphasis = LineEmphasis.ERROR)
+                }
+                blank()
+                line(
+                    text = "sed -i \"s/$symbolName/${symbolName}Renamed/g\" would touch ${summary.filesTouched} files — including ${summary.falsePositives} non-symbol matches",
+                    emphasis = LineEmphasis.DIM,
+                )
+            }
+        }
+        blank()
+    }
+
+    fun DemoScriptBuilder.act2Semantic(
+        workspaceRoot: Path,
+        resolvedSymbol: Symbol,
+        references: ReferencesResult,
+        rename: RenameResult,
+        callHierarchy: CallHierarchyResult,
+    ) {
+        section("Act 2 · semantic analysis")
+
+        step("resolve") {
+            success()
+            body {
+                line("fqName:     ${resolvedSymbol.fqName}", emphasis = LineEmphasis.STRONG)
+                line("kind:       ${resolvedSymbol.kind}")
+                resolvedSymbol.visibility?.let { line("visibility: $it") }
+                line("location:   ${Paths.locationLine(workspaceRoot, resolvedSymbol.location)}")
+                resolvedSymbol.containingDeclaration?.let { line("container:  $it") }
+            }
+        }
+        blank()
+
+        step("references") {
+            success()
+            body {
+                line("references:  ${references.references.size}", emphasis = LineEmphasis.SUCCESS)
+                references.searchScope?.let { scope ->
+                    line("exhaustive:  ${scope.exhaustive}")
+                    line("scope:       ${scope.scope}")
+                    line("searched:    ${scope.searchedFileCount} / ${scope.candidateFileCount} files")
+                }
+                references.references.take(REFERENCE_PREVIEW_LIMIT).forEach { reference ->
+                    line("  ${Paths.locationLine(workspaceRoot, reference)}  ${reference.preview.trim().take(80)}")
+                }
+                if (references.references.size > REFERENCE_PREVIEW_LIMIT) {
+                    line("... and ${references.references.size - REFERENCE_PREVIEW_LIMIT} more", emphasis = LineEmphasis.DIM)
+                }
+            }
+        }
+        blank()
+
+        val renameName = "${resolvedSymbol.fqName.substringAfterLast('.')}Renamed"
+        step("rename --dry-run  (${resolvedSymbol.fqName.substringAfterLast('.')} → $renameName)") {
+            success()
+            body {
+                line("edits:          ${rename.edits.size}", emphasis = LineEmphasis.SUCCESS)
+                line("affected files: ${rename.affectedFiles.size}", emphasis = LineEmphasis.SUCCESS)
+                line("file hashes:    ${rename.fileHashes.size} SHA-256 pre-images")
+                rename.affectedFiles.take(FILE_PREVIEW_LIMIT).forEach { filePath ->
+                    line("  ${Paths.relative(workspaceRoot, filePath)}")
+                }
+                if (rename.affectedFiles.size > FILE_PREVIEW_LIMIT) {
+                    line("... and ${rename.affectedFiles.size - FILE_PREVIEW_LIMIT} more", emphasis = LineEmphasis.DIM)
+                }
+            }
+        }
+        blank()
+
+        step("call-hierarchy (incoming, depth=2)") {
+            success()
+            body {
+                line("incoming callers: ${callHierarchy.stats.totalNodes}", emphasis = LineEmphasis.SUCCESS)
+                line("max depth:        ${callHierarchy.stats.maxDepthReached}")
+                line("files visited:    ${callHierarchy.stats.filesVisited}")
+                if (callHierarchy.stats.timeoutReached || callHierarchy.stats.maxTotalCallsReached) {
+                    line("⚠ results truncated", emphasis = LineEmphasis.WARN)
+                }
+                renderCallTree(workspaceRoot, callHierarchy.root).forEach { rendered ->
+                    line(rendered)
+                }
+            }
+        }
+        blank()
+    }
+
+    fun DemoScriptBuilder.comparisonSummary(report: DemoReport) {
+        section("Side-by-side summary")
+        comparisonTable {
+            header("metric", "grep + sed", "kast")
+            row(
+                metric = "Matches found",
+                left = "${report.textSearch.totalMatches} total / ${report.textSearch.likelyCorrect} likely true / ${report.textSearch.ambiguous} ambiguous",
+                right = "${report.references.references.size} semantic references",
+            )
+            row("Symbol identity", "text only", "exact symbol identity")
+            row("Kind awareness", "none", "knows the declaration kind")
+            row("Call graph", "none", "${report.callHierarchy.stats.totalNodes} incoming callers")
+            row(
+                metric = "Rename plan",
+                left = "blind sed across ${report.textSearch.filesTouched} files",
+                right = "${report.rename.edits.size} edits across ${report.rename.affectedFiles.size} files",
+            )
+            row("Conflict detection", "none", "${report.rename.fileHashes.size} file hashes")
+            val coverage = report.references.searchScope?.let {
+                "exhaustive=${it.exhaustive} over ${it.searchedFileCount}/${it.candidateFileCount} files"
+            } ?: "scope unavailable"
+            row("Coverage signal", "none", coverage)
+            row("Post-edit checks", "manual", "kast diagnostics")
+            row("Node-by-node walk", "impossible — no identity", "r/c/o hops across the symbol graph")
+        }
+        blank()
+    }
+
+    fun DemoScriptBuilder.closingPanel() {
+        banner("why the semantic pass wins") {
+            line("grep only sees text, so it mixes real usages with imports, comments, string literals, and substring collisions.")
+            line("kast resolves the exact declaration, returns true semantic references, previews a safe rename, and maps the incoming call graph before you edit anything.")
+            line("Act 3 turns that into a live graph walk — references, callers, and callees addressed by symbol identity, not by substring.", emphasis = LineEmphasis.DIM)
+            blank()
+            line("Docs  https://amichne.github.io/kast/")
+            line("Repo  https://github.com/amichne/kast")
+        }
+    }
+
+    internal fun renderCallTree(workspaceRoot: Path, root: CallNode): List<String> {
+        val lines = mutableListOf<String>()
+        val remaining = intArrayOf(CALL_TREE_LIMIT)
+
+        fun walk(node: CallNode, depth: Int) {
+            if (remaining[0] <= 0) return
+            remaining[0] -= 1
+            val indent = "  ".repeat(depth.coerceAtLeast(0))
+            val symbol = node.symbol
+            val prefix = if (depth > 0) "├─ " else ""
+            val location = Paths.locationLine(workspaceRoot, symbol.location)
+            lines += "$indent$prefix${symbol.fqName.substringAfterLast('.')} (${symbol.kind})  $location"
+            node.children.forEach { child -> walk(child, depth + 1) }
+        }
+
+        walk(root, depth = 0)
+        return lines
+    }
+
+    private fun DemoTextMatch.emphasisForCategory(): LineEmphasis = when (category) {
+        DemoTextMatchCategory.LIKELY_CORRECT -> LineEmphasis.SUCCESS
+        DemoTextMatchCategory.IMPORT -> LineEmphasis.WARN
+        DemoTextMatchCategory.COMMENT,
+        DemoTextMatchCategory.STRING,
+        DemoTextMatchCategory.SUBSTRING,
+        -> LineEmphasis.ERROR
+    }
+
+    private fun DemoTextMatch.bodyTag(): BodyLineTag = when (category) {
+        DemoTextMatchCategory.LIKELY_CORRECT -> BodyLineTag.CORRECT
+        DemoTextMatchCategory.COMMENT -> BodyLineTag.COMMENT
+        DemoTextMatchCategory.STRING -> BodyLineTag.STRING
+        DemoTextMatchCategory.IMPORT -> BodyLineTag.IMPORT
+        DemoTextMatchCategory.SUBSTRING -> BodyLineTag.SUBSTRING
+    }
+}
+
+internal object Paths {
+    fun relative(workspaceRoot: Path, filePath: String): String {
+        val absolute = Path.of(filePath).toAbsolutePath().normalize()
+        val normalizedRoot = workspaceRoot.toAbsolutePath().normalize()
+        return if (absolute.startsWith(normalizedRoot)) {
+            normalizedRoot.relativize(absolute).toString()
+        } else {
+            absolute.toString()
+        }
+    }
+
+    fun locationLine(workspaceRoot: Path, location: Location): String =
+        "${relative(workspaceRoot, location.filePath)}:${location.startLine}"
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoRenderer.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoRenderer.kt
@@ -1,0 +1,143 @@
+package io.github.amichne.kast.cli.demo
+
+import io.github.amichne.kast.cli.CliTextTheme
+import kotlin.math.max
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+
+/**
+ * Pure rendering of a [DemoScript] into an ANSI (or plain-text) transcript.
+ * Kept host-free so tests can assert against the exact string output.
+ */
+internal class DemoRenderer(
+    private val theme: CliTextTheme,
+    private val width: Int = DEFAULT_WIDTH,
+    private val ansiEnabled: Boolean = true,
+) {
+    fun render(script: DemoScript): String = buildString {
+        script.scenes.forEach { scene -> renderScene(scene) }
+    }
+
+    private fun StringBuilder.renderScene(scene: DemoScene) {
+        when (scene) {
+            is DemoScene.Panel -> renderPanel(scene)
+            is DemoScene.SectionHeading -> renderSectionHeading(scene)
+            is DemoScene.StepProgress -> appendLine("${styleIcon("›", "1;34")} ${scene.message}")
+            is DemoScene.StepOutcome -> renderStepOutcome(scene)
+            is DemoScene.StepBody -> renderStepBody(scene)
+            is DemoScene.ComparisonTable -> renderComparisonTable(scene)
+            is DemoScene.BlankLine -> appendLine()
+        }
+    }
+
+    private fun StringBuilder.renderPanel(panel: DemoScene.Panel) {
+        val inner = max(MIN_PANEL_WIDTH, width - 2)
+        val border = styleAnsi("1;36", "─".repeat(inner))
+        val titleText = styleAnsi("1;37", panel.title)
+        val topRule = "${styleAnsi("1;36", "┌")}$border${styleAnsi("1;36", "┐")}"
+        val bottomRule = "${styleAnsi("1;36", "└")}$border${styleAnsi("1;36", "┘")}"
+        val titleBar = "${styleAnsi("1;36", "│ ")}$titleText${padTo(panel.title.length, inner - 2)}${styleAnsi("1;36", " │")}"
+        val separator = "${styleAnsi("1;36", "├")}$border${styleAnsi("1;36", "┤")}"
+        appendLine(topRule)
+        appendLine(titleBar)
+        appendLine(separator)
+        panel.lines.forEach { line ->
+            val text = emphasise(line.emphasis, line.text)
+            val pad = padTo(line.text.length, inner - 2)
+            appendLine("${styleAnsi("1;36", "│ ")}$text$pad${styleAnsi("1;36", " │")}")
+        }
+        appendLine(bottomRule)
+    }
+
+    private fun StringBuilder.renderSectionHeading(heading: DemoScene.SectionHeading) {
+        val title = heading.title
+        val fill = max(0, width - title.length - 4)
+        appendLine()
+        appendLine("${styleAnsi("1;36", "──")} ${styleAnsi("1;37", title)} ${styleAnsi("2", "─".repeat(fill))}")
+        appendLine()
+    }
+
+    private fun StringBuilder.renderStepOutcome(outcome: DemoScene.StepOutcome) {
+        val icon = when (outcome.outcome) {
+            StepResult.SUCCESS -> styleIcon("✓", "1;32")
+            StepResult.FAILURE -> styleIcon("✕", "1;31")
+            StepResult.INFO -> styleIcon("•", "33")
+        }
+        val elapsed = outcome.elapsed?.let { " ${styleAnsi("2", "(${formatDuration(it)})")}" } ?: ""
+        appendLine("$icon ${outcome.message}$elapsed")
+    }
+
+    private fun StringBuilder.renderStepBody(body: DemoScene.StepBody) {
+        body.lines.forEach { line ->
+            val tag = when (line.tag) {
+                BodyLineTag.NONE -> ""
+                BodyLineTag.COMMENT -> " ${styleAnsi("2", "← comment")}"
+                BodyLineTag.STRING -> " ${styleAnsi("2", "← string")}"
+                BodyLineTag.IMPORT -> " ${styleAnsi("2", "← import")}"
+                BodyLineTag.SUBSTRING -> " ${styleAnsi("2", "← substring")}"
+                BodyLineTag.CORRECT -> ""
+            }
+            if (line.text.isEmpty() && line.tag == BodyLineTag.NONE) {
+                appendLine()
+                return@forEach
+            }
+            val prefix = styleAnsi("2", "  │ ")
+            appendLine("$prefix${emphasise(line.emphasis, line.text)}$tag")
+        }
+    }
+
+    private fun StringBuilder.renderComparisonTable(table: DemoScene.ComparisonTable) {
+        val allRows = listOf(table.header) + table.rows
+        val metricWidth = max(table.header.first.length, table.rows.maxOfOrNull { it.first.length } ?: 0)
+        val leftWidth = max(table.header.second.length, table.rows.maxOfOrNull { it.second.length } ?: 0)
+        val rightWidth = max(table.header.third.length, table.rows.maxOfOrNull { it.third.length } ?: 0)
+        val top = "${styleAnsi("1;36", "┌")}${styleAnsi("1;36", "─".repeat(metricWidth + 2))}${styleAnsi("1;36", "┬")}${styleAnsi("1;36", "─".repeat(leftWidth + 2))}${styleAnsi("1;36", "┬")}${styleAnsi("1;36", "─".repeat(rightWidth + 2))}${styleAnsi("1;36", "┐")}"
+        val mid = "${styleAnsi("1;36", "├")}${styleAnsi("1;36", "─".repeat(metricWidth + 2))}${styleAnsi("1;36", "┼")}${styleAnsi("1;36", "─".repeat(leftWidth + 2))}${styleAnsi("1;36", "┼")}${styleAnsi("1;36", "─".repeat(rightWidth + 2))}${styleAnsi("1;36", "┤")}"
+        val bottom = "${styleAnsi("1;36", "└")}${styleAnsi("1;36", "─".repeat(metricWidth + 2))}${styleAnsi("1;36", "┴")}${styleAnsi("1;36", "─".repeat(leftWidth + 2))}${styleAnsi("1;36", "┴")}${styleAnsi("1;36", "─".repeat(rightWidth + 2))}${styleAnsi("1;36", "┘")}"
+        val pipe = styleAnsi("1;36", "│")
+        fun renderRow(row: Triple<String, String, String>, strongRight: Boolean): String {
+            val metric = row.first.padEnd(metricWidth)
+            val left = row.second.padEnd(leftWidth)
+            val right = if (strongRight) styleAnsi("1;37", row.third.padEnd(rightWidth)) else row.third.padEnd(rightWidth)
+            return "$pipe $metric $pipe $left $pipe $right $pipe"
+        }
+        appendLine(top)
+        appendLine(renderRow(table.header, strongRight = true))
+        appendLine(mid)
+        allRows.drop(1).forEachIndexed { index, row ->
+            appendLine(renderRow(row, strongRight = true))
+            if (index < table.rows.size - 1) appendLine(mid)
+        }
+        appendLine(bottom)
+    }
+
+    private fun emphasise(emphasis: LineEmphasis, text: String): String = when (emphasis) {
+        LineEmphasis.NORMAL -> text
+        LineEmphasis.DIM -> styleAnsi("2", text)
+        LineEmphasis.STRONG -> styleAnsi("1;37", text)
+        LineEmphasis.SUCCESS -> styleAnsi("1;32", text)
+        LineEmphasis.WARN -> styleAnsi("33", text)
+        LineEmphasis.ERROR -> styleAnsi("1;31", text)
+    }
+
+    private fun styleAnsi(code: String, text: String): String =
+        if (ansiEnabled) "\u001B[${code}m$text\u001B[0m" else text
+
+    private fun styleIcon(icon: String, code: String): String = styleAnsi(code, icon)
+
+    private fun padTo(current: Int, target: Int): String =
+        if (current >= target) "" else " ".repeat(target - current)
+
+    @Suppress("UNUSED_PARAMETER")
+    private fun themeTitle(text: String): String = theme.title(text)
+
+    private fun formatDuration(duration: Duration): String {
+        val ms = duration.toDouble(DurationUnit.MILLISECONDS)
+        return if (ms < 1_000) "${ms.toInt()}ms" else "%.2fs".format(ms / 1_000)
+    }
+
+    companion object {
+        const val DEFAULT_WIDTH: Int = 96
+        const val MIN_PANEL_WIDTH: Int = 58
+    }
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoScene.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoScene.kt
@@ -1,0 +1,242 @@
+package io.github.amichne.kast.cli.demo
+
+import kotlin.time.Duration
+
+/**
+ * Declarative description of a `kast demo` scene. A [DemoScript] is a flat,
+ * ordered list of [DemoScene] nodes built through [demoScript]. The renderer
+ * walks the tree once and produces an ANSI/markdown string; the DSL lets the
+ * command flow stay declarative and lets tests assert on the tree before any
+ * text is produced.
+ */
+internal data class DemoScript(
+    val scenes: List<DemoScene>,
+)
+
+/**
+ * A single scene in the demo. Sealed so the renderer exhausts every case and
+ * new scene kinds cannot silently slip through.
+ */
+internal sealed interface DemoScene {
+    /** Top or closing banner rendered as a boxed panel. */
+    data class Panel(
+        val title: String,
+        val lines: List<PanelLine>,
+    ) : DemoScene
+
+    /** Section heading, e.g. `── Act 1 · text search baseline ──`. */
+    data class SectionHeading(
+        val title: String,
+    ) : DemoScene
+
+    /** One-line step progress indicator, e.g. `› Warming workspace daemon...`. */
+    data class StepProgress(
+        val message: String,
+    ) : DemoScene
+
+    /** Step outcome with elapsed wall-clock time. */
+    data class StepOutcome(
+        val message: String,
+        val outcome: StepResult,
+        val elapsed: Duration?,
+    ) : DemoScene
+
+    /** Indented body of a rendered step (e.g. resolved symbol, ref list). */
+    data class StepBody(
+        val lines: List<BodyLine>,
+    ) : DemoScene
+
+    /** Side-by-side comparison table. */
+    data class ComparisonTable(
+        val header: Triple<String, String, String>,
+        val rows: List<Triple<String, String, String>>,
+    ) : DemoScene
+
+    /** Arbitrary blank line. */
+    data object BlankLine : DemoScene
+}
+
+internal enum class StepResult { SUCCESS, FAILURE, INFO }
+
+/** A line inside a [DemoScene.Panel]. */
+internal data class PanelLine(
+    val text: String,
+    val emphasis: LineEmphasis = LineEmphasis.NORMAL,
+)
+
+/** A line inside a [DemoScene.StepBody] — carries enough classification for the renderer to colour it. */
+internal data class BodyLine(
+    val text: String,
+    val emphasis: LineEmphasis = LineEmphasis.NORMAL,
+    val tag: BodyLineTag = BodyLineTag.NONE,
+)
+
+internal enum class LineEmphasis { NORMAL, DIM, STRONG, SUCCESS, WARN, ERROR }
+
+/** Tag attached to individual body lines; used by the renderer to append trailing hints like `← comment`. */
+internal enum class BodyLineTag {
+    NONE,
+    COMMENT,
+    STRING,
+    IMPORT,
+    SUBSTRING,
+    CORRECT,
+}
+
+/**
+ * Entry point DSL. Returns a fully-built [DemoScript].
+ *
+ * ```
+ * val script = demoScript {
+ *     banner("kast demo") {
+ *         line("semantic analysis vs text search")
+ *         blank()
+ *         line("Workspace  $workspaceRoot")
+ *     }
+ *     section("Act 1 · text search baseline")
+ *     step("grep") {
+ *         success(elapsed)
+ *         body {
+ *             line("grep found 128 matches", emphasis = LineEmphasis.STRONG)
+ *         }
+ *     }
+ * }
+ * ```
+ */
+internal fun demoScript(block: DemoScriptBuilder.() -> Unit): DemoScript {
+    val builder = DemoScriptBuilder()
+    builder.block()
+    return DemoScript(builder.build())
+}
+
+@DslMarker
+internal annotation class DemoDsl
+
+@DemoDsl
+internal class DemoScriptBuilder internal constructor() {
+    private val scenes = mutableListOf<DemoScene>()
+
+    fun banner(title: String, block: PanelBuilder.() -> Unit) {
+        val builder = PanelBuilder()
+        builder.block()
+        scenes += DemoScene.Panel(title = title, lines = builder.build())
+    }
+
+    fun panel(title: String, block: PanelBuilder.() -> Unit) = banner(title, block)
+
+    fun section(title: String) {
+        scenes += DemoScene.SectionHeading(title)
+    }
+
+    fun blank() {
+        scenes += DemoScene.BlankLine
+    }
+
+    fun progress(message: String) {
+        scenes += DemoScene.StepProgress(message)
+    }
+
+    fun step(message: String, block: StepBuilder.() -> Unit) {
+        val builder = StepBuilder(message)
+        builder.block()
+        scenes += builder.outcomeScene()
+        builder.bodyScene()?.let { scenes += it }
+    }
+
+    fun comparisonTable(block: ComparisonTableBuilder.() -> Unit) {
+        val builder = ComparisonTableBuilder()
+        builder.block()
+        scenes += DemoScene.ComparisonTable(
+            header = builder.headerOrDefault(),
+            rows = builder.rows(),
+        )
+    }
+
+    fun build(): List<DemoScene> = scenes.toList()
+}
+
+@DemoDsl
+internal class PanelBuilder internal constructor() {
+    private val lines = mutableListOf<PanelLine>()
+
+    fun line(text: String, emphasis: LineEmphasis = LineEmphasis.NORMAL) {
+        lines += PanelLine(text, emphasis)
+    }
+
+    fun blank() {
+        lines += PanelLine("", LineEmphasis.NORMAL)
+    }
+
+    internal fun build(): List<PanelLine> = lines.toList()
+}
+
+@DemoDsl
+internal class StepBuilder internal constructor(val message: String) {
+    private var outcome: StepResult = StepResult.SUCCESS
+    private var elapsed: Duration? = null
+    private var body: List<BodyLine>? = null
+
+    fun success(elapsed: Duration? = null) {
+        outcome = StepResult.SUCCESS
+        this.elapsed = elapsed
+    }
+
+    fun failure(elapsed: Duration? = null) {
+        outcome = StepResult.FAILURE
+        this.elapsed = elapsed
+    }
+
+    fun info(elapsed: Duration? = null) {
+        outcome = StepResult.INFO
+        this.elapsed = elapsed
+    }
+
+    fun body(block: BodyBuilder.() -> Unit) {
+        val builder = BodyBuilder()
+        builder.block()
+        body = builder.build()
+    }
+
+    internal fun outcomeScene(): DemoScene.StepOutcome =
+        DemoScene.StepOutcome(message = message, outcome = outcome, elapsed = elapsed)
+
+    internal fun bodyScene(): DemoScene.StepBody? = body?.let { DemoScene.StepBody(it) }
+}
+
+@DemoDsl
+internal class BodyBuilder internal constructor() {
+    private val lines = mutableListOf<BodyLine>()
+
+    fun line(
+        text: String,
+        emphasis: LineEmphasis = LineEmphasis.NORMAL,
+        tag: BodyLineTag = BodyLineTag.NONE,
+    ) {
+        lines += BodyLine(text = text, emphasis = emphasis, tag = tag)
+    }
+
+    fun blank() {
+        lines += BodyLine("", LineEmphasis.NORMAL)
+    }
+
+    internal fun build(): List<BodyLine> = lines.toList()
+}
+
+@DemoDsl
+internal class ComparisonTableBuilder internal constructor() {
+    private var header: Triple<String, String, String>? = null
+    private val rows = mutableListOf<Triple<String, String, String>>()
+
+    fun header(metric: String, left: String, right: String) {
+        header = Triple(metric, left, right)
+    }
+
+    fun row(metric: String, left: String, right: String) {
+        rows += Triple(metric, left, right)
+    }
+
+    internal fun rows(): List<Triple<String, String, String>> = rows.toList()
+
+    internal fun headerOrDefault(): Triple<String, String, String> =
+        header ?: Triple("metric", "grep + sed", "kast")
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoTimer.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoTimer.kt
@@ -1,0 +1,14 @@
+package io.github.amichne.kast.cli.demo
+
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+/** Result of a timed block. Carries a value plus the wall-clock duration. */
+internal data class Timed<out T>(val value: T, val elapsed: Duration)
+
+/** Run [block] and return its [Result] alongside the elapsed [Duration]. */
+internal suspend fun <T> timed(block: suspend () -> T): Timed<Result<T>> {
+    val mark = TimeSource.Monotonic.markNow()
+    val outcome = runCatching { block() }
+    return Timed(outcome, mark.elapsedNow())
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolWalker.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolWalker.kt
@@ -1,0 +1,332 @@
+package io.github.amichne.kast.cli.demo
+
+import io.github.amichne.kast.api.contract.CallDirection
+import io.github.amichne.kast.api.contract.CallHierarchyQuery
+import io.github.amichne.kast.api.contract.CallNode
+import io.github.amichne.kast.api.contract.FilePosition
+import io.github.amichne.kast.api.contract.Location
+import io.github.amichne.kast.api.contract.ReferencesQuery
+import io.github.amichne.kast.api.contract.Symbol
+import io.github.amichne.kast.api.contract.SymbolQuery
+import io.github.amichne.kast.cli.CliService
+import io.github.amichne.kast.cli.RuntimeCommandOptions
+import java.io.BufferedReader
+import java.nio.file.Files
+import java.nio.file.Path
+
+/** Snapshot of a symbol the walker is focused on. */
+internal data class SymbolCursor(
+    val symbol: Symbol,
+    val position: FilePosition,
+    val references: List<Location>,
+    val incomingCallers: List<Symbol>,
+    val outgoingCallees: List<Symbol>,
+) {
+    val simpleName: String get() = symbol.fqName.substringAfterLast('.')
+}
+
+/** Functional seam over [CliService] so the walker can be tested without a live daemon. */
+internal interface SymbolGraph {
+    suspend fun resolve(position: FilePosition): Result<Symbol>
+    suspend fun references(position: FilePosition): Result<List<Location>>
+    suspend fun callers(position: FilePosition): Result<List<Symbol>>
+    suspend fun callees(position: FilePosition): Result<List<Symbol>>
+}
+
+/** Default implementation backed by [CliService]. */
+internal class CliServiceSymbolGraph(
+    private val cliService: CliService,
+    private val runtimeOptions: RuntimeCommandOptions,
+) : SymbolGraph {
+    override suspend fun resolve(position: FilePosition): Result<Symbol> = runCatching {
+        cliService.resolveSymbol(runtimeOptions, SymbolQuery(position = position)).payload.symbol
+    }
+
+    override suspend fun references(position: FilePosition): Result<List<Location>> = runCatching {
+        cliService.findReferences(
+            runtimeOptions,
+            ReferencesQuery(position = position, includeDeclaration = false),
+        ).payload.references
+    }
+
+    override suspend fun callers(position: FilePosition): Result<List<Symbol>> = runCatching {
+        val root = cliService.callHierarchy(
+            runtimeOptions,
+            CallHierarchyQuery(position = position, direction = CallDirection.INCOMING, depth = 1),
+        ).payload.root
+        directChildren(root)
+    }
+
+    override suspend fun callees(position: FilePosition): Result<List<Symbol>> = runCatching {
+        val root = cliService.callHierarchy(
+            runtimeOptions,
+            CallHierarchyQuery(position = position, direction = CallDirection.OUTGOING, depth = 1),
+        ).payload.root
+        directChildren(root)
+    }
+
+    private fun directChildren(root: CallNode): List<Symbol> =
+        root.children.map { it.symbol }
+}
+
+/**
+ * Transport between the walker and the operator. [prompt] is called before
+ * every read; [emit] is called for every rendered line. Kept minimal so the
+ * walker can be driven by a real TTY or by a scripted test.
+ */
+internal interface WalkerIO {
+    fun emit(line: String)
+    fun prompt(): String?
+}
+
+internal class StreamWalkerIO(
+    private val reader: BufferedReader,
+    private val output: (String) -> Unit,
+) : WalkerIO {
+    override fun emit(line: String) = output(line)
+    override fun prompt(): String? = reader.readLine()
+}
+
+/** Runs the interactive symbol-graph walk and returns the number of successful hops made. */
+internal class SymbolWalker(
+    private val workspaceRoot: Path,
+    private val graph: SymbolGraph,
+    private val io: WalkerIO,
+    private val renderer: DemoRenderer,
+    private val grepRunner: GrepRunner = DefaultGrepRunner(workspaceRoot),
+) {
+    private val history: ArrayDeque<SymbolCursor> = ArrayDeque()
+
+    suspend fun run(initialSymbol: Symbol): WalkSummary {
+        io.emit(renderer.render(intro()))
+        var cursor = hydrate(initialSymbol).getOrElse {
+            io.emit("Could not hydrate starting symbol: ${it.message}")
+            return WalkSummary(hops = 0)
+        }
+        history.addLast(cursor)
+        var hops = 0
+        while (true) {
+            io.emit(renderer.render(cursorCard(cursor)))
+            io.emit(renderer.render(promptLine()))
+            when (val command = WalkerCommand.parse(io.prompt())) {
+                WalkerCommand.Help -> io.emit(renderer.render(helpCard()))
+                WalkerCommand.Quit, WalkerCommand.EndOfInput -> return WalkSummary(hops = hops)
+                WalkerCommand.Back -> {
+                    if (history.size <= 1) {
+                        io.emit(renderer.render(errorCard("Already at the starting symbol — nothing to pop.")))
+                    } else {
+                        history.removeLast()
+                        cursor = history.last()
+                    }
+                }
+                WalkerCommand.ShowDeclaration -> io.emit(renderer.render(declarationCard(cursor)))
+                is WalkerCommand.GrepComparison -> io.emit(renderer.render(grepCard(cursor, command.maxLines)))
+                is WalkerCommand.JumpReference -> {
+                    val target = cursor.references.getOrNull(command.oneBasedIndex - 1)
+                    cursor = hopTo(cursor, target?.asPosition())?.also { history.addLast(it); hops += 1 } ?: cursor
+                }
+                is WalkerCommand.JumpCaller -> {
+                    val target = cursor.incomingCallers.getOrNull(command.oneBasedIndex - 1)
+                    cursor = hopTo(cursor, target?.location?.asPosition())?.also { history.addLast(it); hops += 1 } ?: cursor
+                }
+                is WalkerCommand.JumpCallee -> {
+                    val target = cursor.outgoingCallees.getOrNull(command.oneBasedIndex - 1)
+                    cursor = hopTo(cursor, target?.location?.asPosition())?.also { history.addLast(it); hops += 1 } ?: cursor
+                }
+                is WalkerCommand.Unknown -> io.emit(
+                    renderer.render(errorCard("Unknown command: ${command.raw}. Type `h` for help."))
+                )
+            }
+        }
+    }
+
+    private suspend fun hopTo(
+        current: SymbolCursor,
+        target: FilePosition?,
+    ): SymbolCursor? {
+        if (target == null) {
+            io.emit(renderer.render(errorCard("That index is out of range for the current node.")))
+            return null
+        }
+        val resolved = graph.resolve(target)
+        val symbol = resolved.getOrElse {
+            io.emit(renderer.render(errorCard("resolve failed: ${it.message ?: "no message"}")))
+            return null
+        }
+        return hydrateAt(symbol, target)
+    }
+
+    private suspend fun hydrate(symbol: Symbol): Result<SymbolCursor> = runCatching {
+        hydrateAt(symbol, symbol.location.asPosition())
+    }
+
+    private suspend fun hydrateAt(symbol: Symbol, position: FilePosition): SymbolCursor {
+        val refs = graph.references(position).getOrElse { emptyList() }
+        val callers = graph.callers(position).getOrElse { emptyList() }
+        val callees = graph.callees(position).getOrElse { emptyList() }
+        return SymbolCursor(
+            symbol = symbol,
+            position = position,
+            references = refs,
+            incomingCallers = callers,
+            outgoingCallees = callees,
+        )
+    }
+
+    private fun intro(): DemoScript = demoScript {
+        section("Act 3 · walk the symbol graph")
+        panel("interactive walker") {
+            line("Hop between references, callers, and callees — every move is anchored to symbol identity.", emphasis = LineEmphasis.STRONG)
+            blank()
+            line("r <n>  jump to reference #n        c <n>  jump to incoming caller #n")
+            line("o <n>  jump to outgoing callee #n  g [n]  compare against grep (n lines)")
+            line("s      show current declaration    b      pop the last hop")
+            line("h      help                         q      finish the walker")
+        }
+        blank()
+    }
+
+    private fun cursorCard(cursor: SymbolCursor): DemoScript = demoScript {
+        val symbol = cursor.symbol
+        panel("current node") {
+            line("fqName   ${symbol.fqName}", emphasis = LineEmphasis.STRONG)
+            line("kind     ${symbol.kind}${symbol.visibility?.let { " · $it" } ?: ""}")
+            line("location ${Paths.locationLine(workspaceRoot, symbol.location)}")
+            symbol.containingDeclaration?.takeIf { it.isNotBlank() }?.let { line("inside   $it") }
+        }
+        step("references (${cursor.references.size})") {
+            info()
+            body {
+                if (cursor.references.isEmpty()) {
+                    line("no semantic references", emphasis = LineEmphasis.DIM)
+                } else {
+                    cursor.references.take(WALK_PREVIEW).forEachIndexed { index, ref ->
+                        line("[r ${index + 1}]  ${Paths.locationLine(workspaceRoot, ref)}  ${ref.preview.trim().take(70)}")
+                    }
+                    if (cursor.references.size > WALK_PREVIEW) {
+                        line("... and ${cursor.references.size - WALK_PREVIEW} more (use r <n> with larger n)", emphasis = LineEmphasis.DIM)
+                    }
+                }
+            }
+        }
+        step("incoming callers (${cursor.incomingCallers.size})") {
+            info()
+            body {
+                if (cursor.incomingCallers.isEmpty()) {
+                    line("no callers found at depth 1", emphasis = LineEmphasis.DIM)
+                } else {
+                    cursor.incomingCallers.take(WALK_PREVIEW).forEachIndexed { index, sym ->
+                        line("[c ${index + 1}]  ${sym.fqName.substringAfterLast('.')} (${sym.kind})  ${Paths.locationLine(workspaceRoot, sym.location)}")
+                    }
+                }
+            }
+        }
+        step("outgoing callees (${cursor.outgoingCallees.size})") {
+            info()
+            body {
+                if (cursor.outgoingCallees.isEmpty()) {
+                    line("no callees found at depth 1", emphasis = LineEmphasis.DIM)
+                } else {
+                    cursor.outgoingCallees.take(WALK_PREVIEW).forEachIndexed { index, sym ->
+                        line("[o ${index + 1}]  ${sym.fqName.substringAfterLast('.')} (${sym.kind})  ${Paths.locationLine(workspaceRoot, sym.location)}")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun promptLine(): DemoScript = demoScript {
+        step("walker›") { info() }
+    }
+
+    private fun helpCard(): DemoScript = demoScript {
+        panel("walker commands") {
+            line("r <n>  jump to reference #n")
+            line("c <n>  jump to incoming caller #n")
+            line("o <n>  jump to outgoing callee #n")
+            line("g [n]  run grep on the current simple name and show n lines (default 6)")
+            line("s      show the declaration line")
+            line("b      pop the last hop")
+            line("h ?    show this help")
+            line("q      end the walker and continue the demo")
+        }
+    }
+
+    private fun errorCard(message: String): DemoScript = demoScript {
+        panel("walker error") {
+            line(message, emphasis = LineEmphasis.ERROR)
+        }
+    }
+
+    private fun declarationCard(cursor: SymbolCursor): DemoScript = demoScript {
+        panel("declaration @ ${Paths.locationLine(workspaceRoot, cursor.symbol.location)}") {
+            val lines = readDeclarationContext(cursor.symbol.location)
+            if (lines.isEmpty()) {
+                line("(file unreadable from walker)", emphasis = LineEmphasis.DIM)
+            } else {
+                lines.forEach { line(it) }
+            }
+        }
+    }
+
+    private fun grepCard(cursor: SymbolCursor, maxLines: Int): DemoScript = demoScript {
+        panel("grep '${cursor.simpleName}' — the same question without identity") {
+            val outcome = grepRunner.grep(cursor.simpleName, maxLines)
+            outcome.onSuccess { lines ->
+                if (lines.isEmpty()) {
+                    line("(no text matches found)", emphasis = LineEmphasis.DIM)
+                } else {
+                    lines.forEach { line(it) }
+                    blank()
+                    line(
+                        text = "grep has no way to tell you which of these is the current node, which are imports, and which are strings. The walker above already did.",
+                        emphasis = LineEmphasis.DIM,
+                    )
+                }
+            }
+            outcome.onFailure {
+                line("grep unavailable: ${it.message}", emphasis = LineEmphasis.ERROR)
+            }
+        }
+    }
+
+    private fun readDeclarationContext(location: Location): List<String> {
+        val file = runCatching { Path.of(location.filePath) }.getOrNull() ?: return emptyList()
+        if (!Files.isRegularFile(file)) return emptyList()
+        val all = runCatching { Files.readAllLines(file) }.getOrElse { return emptyList() }
+        val centre = (location.startLine - 1).coerceIn(0, all.lastIndex.coerceAtLeast(0))
+        val start = (centre - DECLARATION_CONTEXT).coerceAtLeast(0)
+        val end = (centre + DECLARATION_CONTEXT).coerceAtMost(all.lastIndex)
+        return (start..end).map { index ->
+            val marker = if (index == centre) "▶" else " "
+            "$marker ${"%4d".format(index + 1)}  ${all[index]}"
+        }
+    }
+
+    private fun Location.asPosition(): FilePosition = FilePosition(filePath = filePath, offset = startOffset)
+
+    companion object {
+        const val WALK_PREVIEW: Int = 8
+        const val DECLARATION_CONTEXT: Int = 3
+    }
+}
+
+internal data class WalkSummary(val hops: Int)
+
+/** Abstract over grep invocations so tests can supply a canned result. */
+internal interface GrepRunner {
+    fun grep(pattern: String, maxLines: Int): Result<List<String>>
+}
+
+internal class DefaultGrepRunner(private val workspaceRoot: Path) : GrepRunner {
+    override fun grep(pattern: String, maxLines: Int): Result<List<String>> = runCatching {
+        val process = ProcessBuilder(
+            "grep", "-rn", "--include=*.kt", "--color=never", "-F", pattern, "."
+        ).directory(workspaceRoot.toFile())
+            .redirectErrorStream(true)
+            .start()
+        val lines = process.inputStream.bufferedReader().use { it.readLines() }
+        process.waitFor()
+        lines.take(maxLines)
+    }
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/WalkerCommand.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/WalkerCommand.kt
@@ -1,0 +1,49 @@
+package io.github.amichne.kast.cli.demo
+
+/** Parsed user input for the interactive symbol walker. */
+internal sealed interface WalkerCommand {
+    data object Help : WalkerCommand
+    data object Back : WalkerCommand
+    data object Quit : WalkerCommand
+    data object ShowDeclaration : WalkerCommand
+
+    /** Hop to the n-th reference (1-based as rendered to the user). */
+    data class JumpReference(val oneBasedIndex: Int) : WalkerCommand
+
+    /** Hop to the n-th incoming caller. */
+    data class JumpCaller(val oneBasedIndex: Int) : WalkerCommand
+
+    /** Hop to the n-th outgoing callee. */
+    data class JumpCallee(val oneBasedIndex: Int) : WalkerCommand
+
+    /** Run grep for the current symbol's simple name and print a few lines. */
+    data class GrepComparison(val maxLines: Int = 6) : WalkerCommand
+
+    /** Arbitrary text that does not parse; renderer shows a usage hint. */
+    data class Unknown(val raw: String) : WalkerCommand
+
+    /** End-of-stream (stdin closed). Treated like quit. */
+    data object EndOfInput : WalkerCommand
+
+    companion object {
+        fun parse(raw: String?): WalkerCommand {
+            if (raw == null) return EndOfInput
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty()) return Help
+            val parts = trimmed.split(Regex("\\s+"), limit = 2)
+            val head = parts[0].lowercase()
+            val arg = parts.getOrNull(1)?.trim().orEmpty()
+            return when (head) {
+                "q", "quit", "exit" -> Quit
+                "b", "back" -> Back
+                "h", "help", "?" -> Help
+                "s", "show" -> ShowDeclaration
+                "g", "grep" -> GrepComparison(maxLines = arg.toIntOrNull() ?: 6)
+                "r", "ref", "references" -> arg.toIntOrNull()?.let { JumpReference(it) } ?: Unknown(trimmed)
+                "c", "caller", "callers" -> arg.toIntOrNull()?.let { JumpCaller(it) } ?: Unknown(trimmed)
+                "o", "out", "callee", "callees" -> arg.toIntOrNull()?.let { JumpCallee(it) } ?: Unknown(trimmed)
+                else -> Unknown(trimmed)
+            }
+        }
+    }
+}

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/DemoSceneTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/DemoSceneTest.kt
@@ -1,0 +1,85 @@
+package io.github.amichne.kast.cli.demo
+
+import io.github.amichne.kast.cli.CliTextTheme
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DemoSceneTest {
+    @Test
+    fun `DSL preserves scene order and types`() {
+        val script = demoScript {
+            banner("title") {
+                line("hello")
+                blank()
+                line("world", emphasis = LineEmphasis.STRONG)
+            }
+            section("Act 1")
+            progress("running...")
+            step("resolve") {
+                success()
+                body { line("ok") }
+            }
+            comparisonTable {
+                header("metric", "grep", "kast")
+                row("m", "g", "k")
+            }
+            blank()
+        }
+
+        val kinds = script.scenes.map { it::class.simpleName }
+        assertEquals(
+            listOf("Panel", "SectionHeading", "StepProgress", "StepOutcome", "StepBody", "ComparisonTable", "BlankLine"),
+            kinds,
+        )
+    }
+
+    @Test
+    fun `panel lines are captured verbatim`() {
+        val script = demoScript {
+            panel("p") {
+                line("one", emphasis = LineEmphasis.SUCCESS)
+                blank()
+                line("two")
+            }
+        }
+        val panel = script.scenes.single() as DemoScene.Panel
+        assertEquals("p", panel.title)
+        assertEquals(listOf("one", "", "two"), panel.lines.map(PanelLine::text))
+        assertEquals(LineEmphasis.SUCCESS, panel.lines.first().emphasis)
+    }
+
+    @Test
+    fun `renderer emits the section heading, panel title, and table header in order`() {
+        val script = demoScript {
+            section("Act 1 · baseline")
+            panel("demo target") {
+                line("Symbol  Foo")
+            }
+            comparisonTable {
+                header("metric", "grep + sed", "kast")
+                row("Matches found", "5", "2")
+            }
+        }
+        val output = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false).render(script)
+        assertTrue(output.contains("Act 1 · baseline"), output)
+        assertTrue(output.contains("demo target"), output)
+        assertTrue(output.contains("grep + sed"), output)
+        assertTrue(output.contains("Symbol  Foo"), output)
+        val actIdx = output.indexOf("Act 1")
+        val panelIdx = output.indexOf("demo target")
+        val tableIdx = output.indexOf("grep + sed")
+        assertTrue(actIdx < panelIdx, "section before panel")
+        assertTrue(panelIdx < tableIdx, "panel before table")
+    }
+
+    @Test
+    fun `step with failure includes outcome icon in rendered text`() {
+        val script = demoScript {
+            step("references") { failure() }
+        }
+        val output = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false).render(script)
+        assertTrue(output.contains("references"), output)
+        assertTrue(output.contains("✕"), output)
+    }
+}

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/SymbolWalkerTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/SymbolWalkerTest.kt
@@ -1,0 +1,193 @@
+package io.github.amichne.kast.cli.demo
+
+import io.github.amichne.kast.api.contract.FilePosition
+import io.github.amichne.kast.api.contract.Location
+import io.github.amichne.kast.api.contract.Symbol
+import io.github.amichne.kast.api.contract.SymbolKind
+import io.github.amichne.kast.api.contract.SymbolVisibility
+import io.github.amichne.kast.cli.CliTextTheme
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class SymbolWalkerTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `walker emits intro and cursor card, exits on quit with zero hops`() {
+        val root = symbol("app.Root", tempDir.resolve("Root.kt"))
+        val graph = RecordingGraph(
+            resolves = mapOf(root.location.asKey() to Result.success(root)),
+            references = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callers = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callees = mapOf(root.location.asKey() to Result.success(emptyList())),
+        )
+        val io = ScriptedIO(inputs = listOf("q"))
+        val summary = runBlocking {
+            SymbolWalker(
+                workspaceRoot = tempDir,
+                graph = graph,
+                io = io,
+                renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false),
+                grepRunner = NoopGrepRunner,
+            ).run(root)
+        }
+        assertEquals(0, summary.hops)
+        val transcript = io.emitted.joinToString("\n")
+        assertTrue(transcript.contains("Act 3 · walk the symbol graph"), transcript)
+        assertTrue(transcript.contains("current node"), transcript)
+        assertTrue(transcript.contains(root.fqName), transcript)
+    }
+
+    @Test
+    fun `jumping to a reference resolves the target and counts as a hop`() {
+        val root = symbol("app.Root", tempDir.resolve("Root.kt"))
+        val refTarget = symbol("app.Caller.useRoot", tempDir.resolve("Caller.kt"), kind = SymbolKind.FUNCTION)
+        val refLocation = Location(
+            filePath = refTarget.location.filePath,
+            startOffset = 50,
+            endOffset = 54,
+            startLine = 3,
+            startColumn = 1,
+            preview = "Root()",
+        )
+        val graph = RecordingGraph(
+            resolves = mapOf(
+                root.location.asKey() to Result.success(root),
+                refLocation.asKey() to Result.success(refTarget),
+            ),
+            references = mapOf(
+                root.location.asKey() to Result.success(listOf(refLocation)),
+                refTarget.location.asKey() to Result.success(emptyList()),
+            ),
+            callers = emptyMap(),
+            callees = emptyMap(),
+        )
+        val io = ScriptedIO(inputs = listOf("r 1", "q"))
+        val summary = runBlocking {
+            SymbolWalker(
+                workspaceRoot = tempDir,
+                graph = graph,
+                io = io,
+                renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false),
+                grepRunner = NoopGrepRunner,
+            ).run(root)
+        }
+        assertEquals(1, summary.hops)
+        val transcript = io.emitted.joinToString("\n")
+        assertTrue(transcript.contains(refTarget.fqName), transcript)
+    }
+
+    @Test
+    fun `out-of-range jump emits walker error and does not increment hops`() {
+        val root = symbol("app.Root", tempDir.resolve("Root.kt"))
+        val graph = RecordingGraph(
+            resolves = mapOf(root.location.asKey() to Result.success(root)),
+            references = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callers = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callees = mapOf(root.location.asKey() to Result.success(emptyList())),
+        )
+        val io = ScriptedIO(inputs = listOf("r 9", "q"))
+        val summary = runBlocking {
+            SymbolWalker(
+                workspaceRoot = tempDir,
+                graph = graph,
+                io = io,
+                renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false),
+                grepRunner = NoopGrepRunner,
+            ).run(root)
+        }
+        assertEquals(0, summary.hops)
+        assertTrue(io.emitted.joinToString("\n").contains("out of range"))
+    }
+
+    @Test
+    fun `grep comparison prints the canned grep lines and the disclaimer`() {
+        val root = symbol("app.Root", tempDir.resolve("Root.kt"))
+        val graph = RecordingGraph(
+            resolves = mapOf(root.location.asKey() to Result.success(root)),
+            references = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callers = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callees = mapOf(root.location.asKey() to Result.success(emptyList())),
+        )
+        val io = ScriptedIO(inputs = listOf("g 3", "q"))
+        val grep = StaticGrepRunner(Result.success(listOf("A.kt:1: class Root", "B.kt:2: // Root")))
+        runBlocking {
+            SymbolWalker(
+                workspaceRoot = tempDir,
+                graph = graph,
+                io = io,
+                renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false),
+                grepRunner = grep,
+            ).run(root)
+        }
+        val transcript = io.emitted.joinToString("\n")
+        assertTrue(transcript.contains("A.kt:1: class Root"), transcript)
+        assertTrue(transcript.contains("grep has no way"), transcript)
+    }
+
+    // ---- test helpers ----
+
+    private fun symbol(
+        fqName: String,
+        filePath: Path,
+        kind: SymbolKind = SymbolKind.CLASS,
+    ): Symbol = Symbol(
+        fqName = fqName,
+        kind = kind,
+        location = Location(
+            filePath = filePath.toString(),
+            startOffset = 0,
+            endOffset = 4,
+            startLine = 1,
+            startColumn = 1,
+            preview = "class ${fqName.substringAfterLast('.')}",
+        ),
+        visibility = SymbolVisibility.PUBLIC,
+        containingDeclaration = fqName.substringBeforeLast('.', ""),
+    )
+
+    private fun Location.asKey(): String = "$filePath@$startOffset"
+
+    private class RecordingGraph(
+        val resolves: Map<String, Result<Symbol>>,
+        val references: Map<String, Result<List<Location>>>,
+        val callers: Map<String, Result<List<Symbol>>>,
+        val callees: Map<String, Result<List<Symbol>>>,
+    ) : SymbolGraph {
+        override suspend fun resolve(position: FilePosition): Result<Symbol> =
+            resolves["${position.filePath}@${position.offset}"]
+                ?: Result.failure(IllegalStateException("unexpected resolve at ${position.filePath}@${position.offset}"))
+
+        override suspend fun references(position: FilePosition): Result<List<Location>> =
+            references["${position.filePath}@${position.offset}"] ?: Result.success(emptyList())
+
+        override suspend fun callers(position: FilePosition): Result<List<Symbol>> =
+            callers["${position.filePath}@${position.offset}"] ?: Result.success(emptyList())
+
+        override suspend fun callees(position: FilePosition): Result<List<Symbol>> =
+            callees["${position.filePath}@${position.offset}"] ?: Result.success(emptyList())
+    }
+
+    private class ScriptedIO(inputs: List<String>) : WalkerIO {
+        private val queue: ArrayDeque<String> = ArrayDeque(inputs)
+        val emitted: MutableList<String> = mutableListOf()
+        override fun emit(line: String) {
+            emitted += line
+        }
+
+        override fun prompt(): String? = queue.removeFirstOrNull()
+    }
+
+    private object NoopGrepRunner : GrepRunner {
+        override fun grep(pattern: String, maxLines: Int): Result<List<String>> = Result.success(emptyList())
+    }
+
+    private class StaticGrepRunner(private val outcome: Result<List<String>>) : GrepRunner {
+        override fun grep(pattern: String, maxLines: Int): Result<List<String>> = outcome
+    }
+}

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/WalkerCommandTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/WalkerCommandTest.kt
@@ -1,0 +1,53 @@
+package io.github.amichne.kast.cli.demo
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class WalkerCommandTest {
+    @Test
+    fun `null input is treated as end of stream`() {
+        assertEquals(WalkerCommand.EndOfInput, WalkerCommand.parse(null))
+    }
+
+    @Test
+    fun `blank input is treated as help`() {
+        assertEquals(WalkerCommand.Help, WalkerCommand.parse("   "))
+    }
+
+    @Test
+    fun `quit aliases all map to Quit`() {
+        listOf("q", "quit", "exit").forEach { raw ->
+            assertEquals(WalkerCommand.Quit, WalkerCommand.parse(raw), "parse($raw)")
+        }
+    }
+
+    @Test
+    fun `back aliases map to Back`() {
+        listOf("b", "back").forEach { raw ->
+            assertEquals(WalkerCommand.Back, WalkerCommand.parse(raw))
+        }
+    }
+
+    @Test
+    fun `jump commands parse a one-based index`() {
+        assertEquals(WalkerCommand.JumpReference(3), WalkerCommand.parse("r 3"))
+        assertEquals(WalkerCommand.JumpCaller(1), WalkerCommand.parse("c 1"))
+        assertEquals(WalkerCommand.JumpCallee(7), WalkerCommand.parse("o 7"))
+    }
+
+    @Test
+    fun `grep with explicit n overrides default`() {
+        assertEquals(WalkerCommand.GrepComparison(6), WalkerCommand.parse("g"))
+        assertEquals(WalkerCommand.GrepComparison(20), WalkerCommand.parse("grep 20"))
+    }
+
+    @Test
+    fun `unknown commands preserve the raw input`() {
+        assertEquals(WalkerCommand.Unknown("jump"), WalkerCommand.parse("jump"))
+    }
+
+    @Test
+    fun `jump without index is reported as unknown`() {
+        assertEquals(WalkerCommand.Unknown("r"), WalkerCommand.parse("r"))
+    }
+}


### PR DESCRIPTION
## Summary

Reimplements `kast demo` on top of a small, testable Kotlin DSL (replacing the 921-line bash reference from `feature/cli-interactive-demo`) and adds **Act 3 — an interactive symbol-graph walker** that hops through references, incoming callers, and outgoing callees *by symbol identity* — the thing grep structurally cannot do.

Everything lives in `kast-cli`. No changes to `analysis-api`, the JSON-RPC contract, or any backend.

### Recording

Full end-to-end cast of the Kotlin demo + walker (acts 1–2, then `s / r 1 / c 1 / g / b / b / q` across the symbol graph):

📽️ **https://asciinema.org/a/Ev2YdA4BmRr3cH7i**

> Uploaded anonymously — asciinema.org auto-deletes unauthenticated uploads 7 days after upload. Re-upload from your account (or grab the `.cast` attached in the session) to keep it permanently.

### What's new

**Declarative scene DSL (`io.github.amichne.kast.cli.demo`)**
- `DemoScene` sealed hierarchy (`Panel`, `SectionHeading`, `StepProgress`, `StepOutcome`, `StepBody`, `ComparisonTable`, `BlankLine`)
- `demoScript { ... }` entry-point builder with `@DslMarker`-guarded nested builders
- `DemoRenderer` — a pure scene-to-ANSI renderer (no I/O)
- `DemoActs` — declarative scene builders for the opening banner, target panel, Act 1 (grep baseline), Act 2 (semantic), comparison table, closing panel
- `DemoTimer.timed { ... }` for ergonomic step-outcome timing

**Act 3 · interactive symbol-graph walker**
- `--walk=auto|true|false` (default `auto` = on when stdin is a TTY and `--symbol` is not set)
- `r <n>` jump to reference, `c <n>` jump to caller, `o <n>` jump to callee, `g [n]` side-by-side grep, `s` show declaration, `b` pop the last hop, `h` help, `q` quit
- Every hop re-resolves at the target position so the user is always anchored to a real symbol — not a substring
- `SymbolGraph` / `WalkerIO` / `GrepRunner` abstractions keep the walker fully unit-testable without a live daemon

**Backend selection — both standalone and IntelliJ are first-class**
- `kast demo` now accepts `--backend-name=auto|standalone|intellij` (default `auto`)
- `auto` uses the live IntelliJ plugin backend when one is discoverable for the workspace, otherwise auto-starts the standalone JVM daemon — matching how the rest of the CLI behaves
- Previously the demo was pinned to `standalone`, which threw against IntelliJ-only workspaces; that pin is gone and the flag is plumbed through to `workspaceEnsure` and the in-demo runtime options

**Tests**
- `WalkerCommandTest` covers every parse branch
- `DemoSceneTest` asserts DSL ordering, panel line capture, and renderer output
- `SymbolWalkerTest` drives the state machine with scripted IO and a recording `SymbolGraph`

### Wiring changes

- `DemoOptions` gains `walkMode: DemoWalkMode` and `backend: String?`
- `CliCommandParser.demoOptions()` parses `--walk` and `--backend-name`
- `CliCommandCatalog` advertises both options + examples
- `DemoCommandSupport` exposes both `render(report)` (batch, backward-compatible) and `runInteractive(...)` (streaming) paths
- `CliService.demo` delegates entirely to `runInteractive`, streaming scenes to `System.err` and returning a runtime-attached empty payload

## Review & Testing Checklist for Human

- [ ] `./kast.sh demo` from a real terminal (no `--symbol`) — confirm Acts 1–2 render, the walker starts, and `r 1 / c 1 / o 1 / g / s / b / q` behave as expected
- [ ] `./kast.sh demo --backend-name=intellij` against a workspace open in IntelliJ with the Kast plugin — confirm it attaches to the live plugin backend instead of spawning the standalone daemon
- [ ] `./kast.sh demo --walk=false` skips Act 3 but still prints the comparison summary
- [ ] `./kast.sh demo --symbol=CliService` runs non-interactively (walker auto-disabled) — matches the old bash demo's non-interactive shape
- [ ] Skim `DemoScene.kt` / `DemoRenderer.kt` / `SymbolWalker.kt` for fit with the kotlin-standards DSL guidance

### Notes

- The batch `render(report)` path is preserved so existing tests and any non-interactive callers keep working.
- The walker only streams to the sink — no daemon contract changes, no new RPC methods.
- Happy to iterate on copy (panel titles, Act 3 intro text, walker command glossary) if you want it toned differently.


Link to Devin session: https://app.devin.ai/sessions/3b1b729af83f442aa57f46970b5f045b
Requested by: @amichne