### PR TITLE
kast-cli: wrap demo panels, tree-shape walker, FQCN picker, fzf menu, color kinds

### DIFF
--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -325,8 +325,9 @@ internal object CliCommandCatalog {
 
     private val demoVerboseOption = CliOptionMetadata(
         key = "verbose",
-        usage = "--verbose",
+        usage = "--verbose=true",
         description = "Render fully-qualified names and workspace-relative paths everywhere. Default: simple names and bare file names.",
+        completionKind = CliOptionCompletionKind.BOOLEAN,
     )
 
     private val commands: List<CliCommandMetadata> = listOf(
@@ -784,7 +785,7 @@ internal object CliCommandCatalog {
             description = "Picks a symbol from your workspace — via --symbol or the built-in terminal chooser — and runs grep-style text search alongside kast resolve, references, rename, and call-hierarchy so you can see the difference side by side. " +
                 "Uses the live IntelliJ plugin backend when one is available and auto-starts the standalone JVM daemon otherwise; pin with --backend-name=intellij|standalone.",
             usages = listOf(
-                "$CLI_EXECUTABLE_NAME demo [--workspace-root=/absolute/path/to/workspace] [--symbol=CliService] [--walk=auto|true|false] [--backend-name=intellij|standalone] [--verbose]",
+                "$CLI_EXECUTABLE_NAME demo [--workspace-root=/absolute/path/to/workspace] [--symbol=CliService] [--walk=auto|true|false] [--backend-name=intellij|standalone] [--verbose=true]",
             ),
             options = listOf(workspaceRootOption, demoSymbolOption, demoWalkOption, backendNameOption, demoVerboseOption),
             examples = listOf(
@@ -793,7 +794,7 @@ internal object CliCommandCatalog {
                 "$CLI_EXECUTABLE_NAME demo --workspace-root=/absolute/path/to/workspace --symbol=CliService",
                 "$CLI_EXECUTABLE_NAME demo --walk=true  # always runs the interactive symbol-graph walker",
                 "$CLI_EXECUTABLE_NAME demo --backend-name=intellij  # target a running IntelliJ IDEA plugin backend",
-                "$CLI_EXECUTABLE_NAME demo --verbose  # render fully-qualified names and full paths",
+                "$CLI_EXECUTABLE_NAME demo --verbose=true  # render fully-qualified names and full paths",
             ),
         ),
         CliCommandMetadata(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -323,6 +323,12 @@ internal object CliCommandCatalog {
         description = "Run the interactive symbol-graph walker after Act 2. Defaults to auto: on when stdin is a TTY and --symbol is not set.",
     )
 
+    private val demoVerboseOption = CliOptionMetadata(
+        key = "verbose",
+        usage = "--verbose",
+        description = "Render fully-qualified names and workspace-relative paths everywhere. Default: simple names and bare file names.",
+    )
+
     private val commands: List<CliCommandMetadata> = listOf(
         CliCommandMetadata(
             path = listOf("workspace", "status"),
@@ -778,15 +784,16 @@ internal object CliCommandCatalog {
             description = "Picks a symbol from your workspace — via --symbol or the built-in terminal chooser — and runs grep-style text search alongside kast resolve, references, rename, and call-hierarchy so you can see the difference side by side. " +
                 "Uses the live IntelliJ plugin backend when one is available and auto-starts the standalone JVM daemon otherwise; pin with --backend-name=intellij|standalone.",
             usages = listOf(
-                "$CLI_EXECUTABLE_NAME demo [--workspace-root=/absolute/path/to/workspace] [--symbol=CliService] [--walk=auto|true|false] [--backend-name=intellij|standalone]",
+                "$CLI_EXECUTABLE_NAME demo [--workspace-root=/absolute/path/to/workspace] [--symbol=CliService] [--walk=auto|true|false] [--backend-name=intellij|standalone] [--verbose]",
             ),
-            options = listOf(workspaceRootOption, demoSymbolOption, demoWalkOption, backendNameOption),
+            options = listOf(workspaceRootOption, demoSymbolOption, demoWalkOption, backendNameOption, demoVerboseOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME demo",
                 "$CLI_EXECUTABLE_NAME demo --workspace-root=/absolute/path/to/workspace",
                 "$CLI_EXECUTABLE_NAME demo --workspace-root=/absolute/path/to/workspace --symbol=CliService",
                 "$CLI_EXECUTABLE_NAME demo --walk=true  # always runs the interactive symbol-graph walker",
                 "$CLI_EXECUTABLE_NAME demo --backend-name=intellij  # target a running IntelliJ IDEA plugin backend",
+                "$CLI_EXECUTABLE_NAME demo --verbose  # render fully-qualified names and full paths",
             ),
         ),
         CliCommandMetadata(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
@@ -561,6 +561,14 @@ internal data class ParsedArguments(
                 message = "Unknown value for --backend-name: ${options["backend-name"]}. Valid values: auto, standalone, intellij.",
             )
         }
+        val verbose = when (options["verbose"]?.lowercase()) {
+            null, "", "true", "on", "yes", "1" -> options.containsKey("verbose")
+            "false", "off", "no", "0" -> false
+            else -> throw CliFailure(
+                code = "CLI_USAGE",
+                message = "Unknown value for --verbose: ${options["verbose"]}. Valid values: true, false.",
+            )
+        }
         return DemoOptions(
             workspaceRoot = options["workspace-root"]
                 ?.takeIf(String::isNotBlank)
@@ -569,6 +577,7 @@ internal data class ParsedArguments(
             symbolFilter = options["symbol"]?.takeIf(String::isNotBlank),
             walkMode = walkMode,
             backend = backend,
+            verbose = verbose,
         )
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliTextTheme.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliTextTheme.kt
@@ -1,5 +1,7 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.api.contract.SymbolKind
+
 internal class CliTextTheme private constructor(
     private val ansiEnabled: Boolean,
 ) {
@@ -12,6 +14,25 @@ internal class CliTextTheme private constructor(
     fun option(text: String): String = style(text, "33")
 
     fun muted(text: String): String = style(text, "2")
+
+    /** Light-grey text. Used for file-name headers and other secondary metadata. */
+    fun fileHeader(text: String): String = style(text, "38;5;245")
+
+    /** Color a symbol-kind label (e.g. "class", "function") consistently across the walker. */
+    fun kind(kind: SymbolKind, text: String): String = style(text, kindCode(kind))
+
+    /**
+     * Return the raw SGR code for a [SymbolKind] so callers can inline the style.
+     * Palette keeps each category visually distinct without fighting the panel chrome:
+     * type declarations land on yellow / magenta, behavior on cyan, data on green.
+     */
+    fun kindCode(kind: SymbolKind): String = when (kind) {
+        SymbolKind.CLASS, SymbolKind.OBJECT -> "1;33"
+        SymbolKind.INTERFACE -> "1;35"
+        SymbolKind.FUNCTION -> "1;36"
+        SymbolKind.PROPERTY, SymbolKind.PARAMETER -> "1;32"
+        SymbolKind.UNKNOWN -> "37"
+    }
 
     private fun style(
         text: String,

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoCommandSupport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoCommandSupport.kt
@@ -21,8 +21,10 @@ import io.github.amichne.kast.cli.demo.DemoActs.targetPanel
 import io.github.amichne.kast.cli.demo.DemoRenderer
 import io.github.amichne.kast.cli.demo.DemoScript
 import io.github.amichne.kast.cli.demo.LineEmphasis
+import io.github.amichne.kast.cli.demo.FzfWalkerIO
 import io.github.amichne.kast.cli.demo.StreamWalkerIO
 import io.github.amichne.kast.cli.demo.SymbolWalker
+import io.github.amichne.kast.cli.demo.WalkerIO
 import io.github.amichne.kast.cli.demo.Timed
 import io.github.amichne.kast.cli.demo.demoScript
 import io.github.amichne.kast.cli.demo.timed
@@ -53,7 +55,42 @@ internal class DemoCommandSupport(
         return when {
             filter == null && symbols.size == 1 -> symbols.single()
             filter == null -> symbolChooser.choose(symbols)
-            else -> symbols.firstOrNull { symbolMatchesFilter(it, filter) } ?: symbols.first()
+            else -> pickBestMatch(symbols, filter) ?: symbols.first()
+        }
+    }
+
+    /**
+     * Choose the [Symbol] that best matches a user filter. Prefers an exact
+     * `fqName` match so callers can disambiguate overloaded simple names by
+     * passing a fully-qualified class name; falls back through suffix and
+     * substring matches in that order.
+     */
+    private fun pickBestMatch(symbols: List<Symbol>, filter: String): Symbol? {
+        val exact = symbols.firstOrNull { it.fqName == filter }
+        if (exact != null) return exact
+        val suffix = symbols.firstOrNull { it.fqName.endsWith(".$filter") }
+        if (suffix != null) return suffix
+        val simple = symbols.firstOrNull { it.fqName.substringAfterLast('.') == filter }
+        if (simple != null) return simple
+        return symbols.firstOrNull { symbolMatchesFilter(it, filter) }
+    }
+
+    /**
+     * Build the server-side query for a user-provided symbol filter. FQNs
+     * are split so the daemon can find the declaration by simple name — the
+     * client then re-filters by FQN exactness. Substring inputs flow through
+     * as-is with `regex=false`.
+     */
+    internal fun workspaceSymbolQueryFor(filter: String?): WorkspaceSymbolQuery {
+        val trimmed = filter?.takeIf(String::isNotBlank)
+        return when {
+            trimmed == null -> WorkspaceSymbolQuery(pattern = ".", maxResults = 500, regex = true)
+            trimmed.contains('.') -> WorkspaceSymbolQuery(
+                pattern = trimmed.substringAfterLast('.'),
+                maxResults = 500,
+                regex = false,
+            )
+            else -> WorkspaceSymbolQuery(pattern = trimmed, maxResults = 500, regex = false)
         }
     }
 
@@ -182,16 +219,8 @@ internal class DemoCommandSupport(
         warm.value.getOrThrow()
 
         emit(demoScript { progress("Discovering workspace symbols (kast workspace-symbol)...") })
-        val symbolSearch = timed {
-            cliService.workspaceSymbolSearch(
-                runtimeOptions,
-                WorkspaceSymbolQuery(
-                    pattern = options.symbolFilter ?: ".",
-                    maxResults = 500,
-                    regex = options.symbolFilter == null,
-                ),
-            )
-        }
+        val searchQuery = workspaceSymbolQueryFor(options.symbolFilter)
+        val symbolSearch = timed { cliService.workspaceSymbolSearch(runtimeOptions, searchQuery) }
         emit(stepOutcomeScript("workspace symbol search", symbolSearch))
         val symbolPayload = symbolSearch.value.getOrThrow().payload
 
@@ -261,10 +290,15 @@ internal class DemoCommandSupport(
         })
 
         if (walkerEnabled && reader != null) {
+            val base: WalkerIO = StreamWalkerIO(reader = reader, output = sink)
+            val io: WalkerIO = FzfWalkerIO.locateFzf()
+                ?.takeIf { System.console() != null }
+                ?.let { FzfWalkerIO(delegate = base, fzfPath = it) }
+                ?: base
             val walker = SymbolWalker(
                 workspaceRoot = options.workspaceRoot,
                 graph = CliServiceSymbolGraph(cliService, runtimeOptions),
-                io = StreamWalkerIO(reader = reader, output = sink),
+                io = io,
                 renderer = renderer,
             )
             walker.run(resolvedSymbol)

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoCommandSupport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoCommandSupport.kt
@@ -23,6 +23,7 @@ import io.github.amichne.kast.cli.demo.DemoScript
 import io.github.amichne.kast.cli.demo.LineEmphasis
 import io.github.amichne.kast.cli.demo.FzfWalkerIO
 import io.github.amichne.kast.cli.demo.StreamWalkerIO
+import io.github.amichne.kast.cli.demo.SymbolDisplay
 import io.github.amichne.kast.cli.demo.SymbolWalker
 import io.github.amichne.kast.cli.demo.WalkerIO
 import io.github.amichne.kast.cli.demo.Timed
@@ -300,6 +301,11 @@ internal class DemoCommandSupport(
                 graph = CliServiceSymbolGraph(cliService, runtimeOptions),
                 io = io,
                 renderer = renderer,
+                theme = themeProvider(),
+                display = SymbolDisplay(
+                    workspaceRoot = options.workspaceRoot,
+                    verbose = options.verbose,
+                ),
             )
             walker.run(resolvedSymbol)
         } else {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DemoOptions.kt
@@ -16,6 +16,13 @@ internal data class DemoOptions(
      *    Kast plugin; fails fast when no IntelliJ runtime is available.
      */
     val backend: String? = null,
+    /**
+     * When `true`, the demo renders fully-qualified names and workspace-
+     * relative paths everywhere (symbol identity, walker tree, declaration
+     * headers). When `false` (default), simple names and bare file names are
+     * used, keeping tree rows readable in a standard terminal width.
+     */
+    val verbose: Boolean = false,
 )
 
 /**

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoActs.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoActs.kt
@@ -255,6 +255,20 @@ internal object Paths {
         }
     }
 
+    /** Bare file name (last path segment), e.g. `DemoRenderer.kt`. */
+    fun fileName(filePath: String): String =
+        Path.of(filePath).fileName?.toString() ?: filePath
+
     fun locationLine(workspaceRoot: Path, location: Location): String =
         "${relative(workspaceRoot, location.filePath)}:${location.startLine}"
+
+    /** `<file>:<line>` where `<file>` is either the bare file name or the workspace-relative path. */
+    fun locationLine(
+        workspaceRoot: Path,
+        location: Location,
+        verbose: Boolean,
+    ): String {
+        val path = if (verbose) relative(workspaceRoot, location.filePath) else fileName(location.filePath)
+        return "$path:${location.startLine}"
+    }
 }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoRenderer.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoRenderer.kt
@@ -41,6 +41,19 @@ internal class DemoRenderer(
         appendLine(renderPanelRow(styleAnsi("1;37", truncate(panel.title, contentWidth)), truncate(panel.title, contentWidth).length, contentWidth))
         appendLine(separator)
         panel.lines.forEach { line ->
+            if (line.prerendered != null) {
+                // Pre-styled lines own their own ANSI / truncation. We still
+                // pad them out to contentWidth using the plain text length.
+                val rawLength = line.text.length.coerceAtMost(contentWidth)
+                val rendered = if (line.text.length > contentWidth) {
+                    // Caller gave us an oversize line. Fall back to a plain-text truncate so we don't overflow.
+                    emphasise(line.emphasis, truncate(line.text, contentWidth))
+                } else {
+                    line.prerendered
+                }
+                appendLine(renderPanelRow(rendered, rawLength, contentWidth))
+                return@forEach
+            }
             val segments = wrapForWidth(line.text, contentWidth)
             if (segments.isEmpty()) {
                 appendLine(renderPanelRow("", 0, contentWidth))
@@ -228,8 +241,25 @@ internal class DemoRenderer(
         return listOf(token.take(width - 1) + "…")
     }
 
+    /** Columns available inside a panel's borders (after the `│ ` / ` │` gutters). */
+    internal val panelContentWidth: Int
+        get() = max(MIN_PANEL_WIDTH, width - 2) - 2
+
     internal fun truncate(text: String, width: Int): String =
         if (text.length <= width) text else text.take(width - 1) + "…"
+
+    /**
+     * Right-biased truncation: keep the **tail** of [text] visible and
+     * replace the leading prefix with `…`. Use for file paths and similar
+     * strings where the rightmost segment (file name, line number) is the
+     * most useful part for the reader.
+     */
+    internal fun truncateLeft(text: String, width: Int): String = when {
+        width <= 0 -> ""
+        text.length <= width -> text
+        width == 1 -> "…"
+        else -> "…" + text.takeLast(width - 1)
+    }
 
     @Suppress("UNUSED_PARAMETER")
     private fun themeTitle(text: String): String = theme.title(text)

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoRenderer.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoRenderer.kt
@@ -32,21 +32,30 @@ internal class DemoRenderer(
 
     private fun StringBuilder.renderPanel(panel: DemoScene.Panel) {
         val inner = max(MIN_PANEL_WIDTH, width - 2)
+        val contentWidth = inner - 2
         val border = styleAnsi("1;36", "─".repeat(inner))
-        val titleText = styleAnsi("1;37", panel.title)
         val topRule = "${styleAnsi("1;36", "┌")}$border${styleAnsi("1;36", "┐")}"
         val bottomRule = "${styleAnsi("1;36", "└")}$border${styleAnsi("1;36", "┘")}"
-        val titleBar = "${styleAnsi("1;36", "│ ")}$titleText${padTo(panel.title.length, inner - 2)}${styleAnsi("1;36", " │")}"
         val separator = "${styleAnsi("1;36", "├")}$border${styleAnsi("1;36", "┤")}"
         appendLine(topRule)
-        appendLine(titleBar)
+        appendLine(renderPanelRow(styleAnsi("1;37", truncate(panel.title, contentWidth)), truncate(panel.title, contentWidth).length, contentWidth))
         appendLine(separator)
         panel.lines.forEach { line ->
-            val text = emphasise(line.emphasis, line.text)
-            val pad = padTo(line.text.length, inner - 2)
-            appendLine("${styleAnsi("1;36", "│ ")}$text$pad${styleAnsi("1;36", " │")}")
+            val segments = wrapForWidth(line.text, contentWidth)
+            if (segments.isEmpty()) {
+                appendLine(renderPanelRow("", 0, contentWidth))
+            } else {
+                segments.forEach { segment ->
+                    appendLine(renderPanelRow(emphasise(line.emphasis, segment), segment.length, contentWidth))
+                }
+            }
         }
         appendLine(bottomRule)
+    }
+
+    private fun renderPanelRow(rendered: String, rawLength: Int, contentWidth: Int): String {
+        val pad = padTo(rawLength, contentWidth)
+        return "${styleAnsi("1;36", "│ ")}$rendered$pad${styleAnsi("1;36", " │")}"
     }
 
     private fun StringBuilder.renderSectionHeading(heading: DemoScene.SectionHeading) {
@@ -87,28 +96,57 @@ internal class DemoRenderer(
     }
 
     private fun StringBuilder.renderComparisonTable(table: DemoScene.ComparisonTable) {
-        val allRows = listOf(table.header) + table.rows
-        val metricWidth = max(table.header.first.length, table.rows.maxOfOrNull { it.first.length } ?: 0)
-        val leftWidth = max(table.header.second.length, table.rows.maxOfOrNull { it.second.length } ?: 0)
-        val rightWidth = max(table.header.third.length, table.rows.maxOfOrNull { it.third.length } ?: 0)
-        val top = "${styleAnsi("1;36", "┌")}${styleAnsi("1;36", "─".repeat(metricWidth + 2))}${styleAnsi("1;36", "┬")}${styleAnsi("1;36", "─".repeat(leftWidth + 2))}${styleAnsi("1;36", "┬")}${styleAnsi("1;36", "─".repeat(rightWidth + 2))}${styleAnsi("1;36", "┐")}"
-        val mid = "${styleAnsi("1;36", "├")}${styleAnsi("1;36", "─".repeat(metricWidth + 2))}${styleAnsi("1;36", "┼")}${styleAnsi("1;36", "─".repeat(leftWidth + 2))}${styleAnsi("1;36", "┼")}${styleAnsi("1;36", "─".repeat(rightWidth + 2))}${styleAnsi("1;36", "┤")}"
-        val bottom = "${styleAnsi("1;36", "└")}${styleAnsi("1;36", "─".repeat(metricWidth + 2))}${styleAnsi("1;36", "┴")}${styleAnsi("1;36", "─".repeat(leftWidth + 2))}${styleAnsi("1;36", "┴")}${styleAnsi("1;36", "─".repeat(rightWidth + 2))}${styleAnsi("1;36", "┘")}"
+        val natMetric = max(table.header.first.length, table.rows.maxOfOrNull { it.first.length } ?: 0)
+        val natLeft = max(table.header.second.length, table.rows.maxOfOrNull { it.second.length } ?: 0)
+        val natRight = max(table.header.third.length, table.rows.maxOfOrNull { it.third.length } ?: 0)
+        // Budget: width - (4 vertical bars + 6 single-space pads) = width - 10.
+        val budget = max(natMetric + 12, width - 10)
+        val metricCap = natMetric.coerceAtMost((budget * 0.22).toInt().coerceAtLeast(12))
+        val remaining = (budget - metricCap).coerceAtLeast(24)
+        val (leftCap, rightCap) = splitProportional(remaining, natLeft, natRight)
+
         val pipe = styleAnsi("1;36", "│")
-        fun renderRow(row: Triple<String, String, String>, strongRight: Boolean): String {
-            val metric = row.first.padEnd(metricWidth)
-            val left = row.second.padEnd(leftWidth)
-            val right = if (strongRight) styleAnsi("1;37", row.third.padEnd(rightWidth)) else row.third.padEnd(rightWidth)
-            return "$pipe $metric $pipe $left $pipe $right $pipe"
+        fun ruler(left: String, mid: String, right: String): String =
+            "${styleAnsi("1;36", left)}${styleAnsi("1;36", "─".repeat(metricCap + 2))}${styleAnsi("1;36", mid)}${styleAnsi("1;36", "─".repeat(leftCap + 2))}${styleAnsi("1;36", mid)}${styleAnsi("1;36", "─".repeat(rightCap + 2))}${styleAnsi("1;36", right)}"
+
+        val top = ruler("┌", "┬", "┐")
+        val mid = ruler("├", "┼", "┤")
+        val bottom = ruler("└", "┴", "┘")
+
+        fun renderRow(row: Triple<String, String, String>, strongRight: Boolean) {
+            val metricSegs = wrapForWidth(row.first, metricCap)
+            val leftSegs = wrapForWidth(row.second, leftCap)
+            val rightSegs = wrapForWidth(row.third, rightCap)
+            val rows = maxOf(metricSegs.size, leftSegs.size, rightSegs.size)
+            for (r in 0 until rows) {
+                val metric = (metricSegs.getOrNull(r) ?: "").padEnd(metricCap)
+                val left = (leftSegs.getOrNull(r) ?: "").padEnd(leftCap)
+                val rightRaw = rightSegs.getOrNull(r) ?: ""
+                val right = if (strongRight) styleAnsi("1;37", rightRaw) else rightRaw
+                val rightPad = padTo(rightRaw.length, rightCap)
+                appendLine("$pipe $metric $pipe $left $pipe $right$rightPad $pipe")
+            }
         }
+
         appendLine(top)
-        appendLine(renderRow(table.header, strongRight = true))
+        renderRow(table.header, strongRight = true)
         appendLine(mid)
-        allRows.drop(1).forEachIndexed { index, row ->
-            appendLine(renderRow(row, strongRight = true))
+        table.rows.forEachIndexed { index, row ->
+            renderRow(row, strongRight = true)
             if (index < table.rows.size - 1) appendLine(mid)
         }
         appendLine(bottom)
+    }
+
+    /** Split [budget] between two natural widths, never shrinking either below [MIN_CELL]. */
+    private fun splitProportional(budget: Int, leftNatural: Int, rightNatural: Int): Pair<Int, Int> {
+        val total = (leftNatural + rightNatural).coerceAtLeast(1)
+        val leftShare = ((budget.toDouble() * leftNatural) / total).toInt().coerceAtLeast(MIN_CELL)
+        val rightShare = (budget - leftShare).coerceAtLeast(MIN_CELL)
+        // Don't blow past the natural size — leaves breathing room when the
+        // terminal is wider than the content.
+        return leftShare.coerceAtMost(leftNatural.coerceAtLeast(MIN_CELL)) to
+            rightShare.coerceAtMost(rightNatural.coerceAtLeast(MIN_CELL))
     }
 
     private fun emphasise(emphasis: LineEmphasis, text: String): String = when (emphasis) {
@@ -128,6 +166,71 @@ internal class DemoRenderer(
     private fun padTo(current: Int, target: Int): String =
         if (current >= target) "" else " ".repeat(target - current)
 
+    /**
+     * Word-wrap [text] to fit inside [width] columns. Tokens longer than
+     * [width] are broken with a trailing ellipsis so the right border never
+     * overflows. An empty input returns a single empty segment.
+     */
+    internal fun wrapForWidth(text: String, width: Int): List<String> {
+        if (width <= 0) return emptyList()
+        if (text.isEmpty()) return listOf("")
+        val out = mutableListOf<String>()
+        var current = StringBuilder()
+        fun flush() {
+            out += current.toString()
+            current = StringBuilder()
+        }
+        for (token in tokenizeForWrap(text)) {
+            val chunks = breakLongToken(token, width)
+            for (chunk in chunks) {
+                val candidateLength = current.length + chunk.length
+                when {
+                    candidateLength <= width -> current.append(chunk)
+                    current.isEmpty() -> {
+                        out += chunk
+                    }
+                    else -> {
+                        flush()
+                        // Don't carry leading whitespace onto a fresh line.
+                        val trimmed = chunk.trimStart()
+                        if (trimmed.length <= width) current.append(trimmed) else out += trimmed.take(width - 1) + "…"
+                    }
+                }
+            }
+        }
+        if (current.isNotEmpty()) flush()
+        return if (out.isEmpty()) listOf("") else out.map { it.trimEnd() }
+    }
+
+    /** Split [text] into alternating word / whitespace tokens, preserving both. */
+    private fun tokenizeForWrap(text: String): List<String> {
+        if (text.isEmpty()) return emptyList()
+        val tokens = mutableListOf<String>()
+        var i = 0
+        while (i < text.length) {
+            val isSpace = text[i].isWhitespace()
+            var j = i + 1
+            while (j < text.length && text[j].isWhitespace() == isSpace) j += 1
+            tokens += text.substring(i, j)
+            i = j
+        }
+        return tokens
+    }
+
+    /** Break a single token into [width]-sized chunks, ellipsising the first
+     *  chunk when the token cannot possibly fit. */
+    private fun breakLongToken(token: String, width: Int): List<String> {
+        if (token.length <= width) return listOf(token)
+        // For oversize whitespace-only tokens (unlikely but harmless) drop to
+        // a single space so we don't waste a wrapped line.
+        if (token.isBlank()) return listOf(" ")
+        // Hard truncation with a unicode ellipsis keeps the cell inside the box.
+        return listOf(token.take(width - 1) + "…")
+    }
+
+    internal fun truncate(text: String, width: Int): String =
+        if (text.length <= width) text else text.take(width - 1) + "…"
+
     @Suppress("UNUSED_PARAMETER")
     private fun themeTitle(text: String): String = theme.title(text)
 
@@ -139,5 +242,6 @@ internal class DemoRenderer(
     companion object {
         const val DEFAULT_WIDTH: Int = 96
         const val MIN_PANEL_WIDTH: Int = 58
+        const val MIN_CELL: Int = 10
     }
 }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoScene.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/DemoScene.kt
@@ -58,10 +58,19 @@ internal sealed interface DemoScene {
 
 internal enum class StepResult { SUCCESS, FAILURE, INFO }
 
-/** A line inside a [DemoScene.Panel]. */
+/**
+ * A line inside a [DemoScene.Panel].
+ *
+ * Width is always measured from [text] (plain, no ANSI). When [prerendered] is
+ * non-null the renderer emits that string verbatim instead of applying
+ * [emphasis]; this lets callers (e.g. the walker) hand the renderer an
+ * ANSI-styled composition while the renderer keeps ownership of padding and
+ * truncation using the plain [text].
+ */
 internal data class PanelLine(
     val text: String,
     val emphasis: LineEmphasis = LineEmphasis.NORMAL,
+    val prerendered: String? = null,
 )
 
 /** A line inside a [DemoScene.StepBody] — carries enough classification for the renderer to colour it. */
@@ -161,6 +170,16 @@ internal class PanelBuilder internal constructor() {
 
     fun line(text: String, emphasis: LineEmphasis = LineEmphasis.NORMAL) {
         lines += PanelLine(text, emphasis)
+    }
+
+    /**
+     * A panel line whose styling is owned by the caller. [plain] is used for
+     * width measurement and padding; [rendered] is emitted verbatim. The
+     * caller is responsible for pre-truncating [plain] / [rendered] to fit
+     * the panel's inner width (use [DemoRenderer.truncate] / [DemoRenderer.truncateLeft]).
+     */
+    fun styledLine(plain: String, rendered: String) {
+        lines += PanelLine(text = plain, prerendered = rendered)
     }
 
     fun blank() {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolDisplay.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolDisplay.kt
@@ -1,0 +1,47 @@
+package io.github.amichne.kast.cli.demo
+
+import io.github.amichne.kast.api.contract.Location
+import io.github.amichne.kast.api.contract.Symbol
+import io.github.amichne.kast.api.contract.SymbolKind
+import io.github.amichne.kast.cli.CliTextTheme
+import java.nio.file.Path
+
+/**
+ * Formats [Symbol]s and [Location]s for the demo presentation layer.
+ *
+ * Default (non-verbose) rendering collapses to the simple name + bare file
+ * name that fits a normal terminal. [verbose] mode re-expands to the fully-
+ * qualified name and workspace-relative path — handy when the operator is
+ * reviewing the walker transcript later and needs unambiguous anchors.
+ *
+ * Display is deliberately kept separate from [CliTextTheme] so tests can
+ * assert on plain-text output while the theme owns the ANSI styling.
+ */
+internal class SymbolDisplay(
+    private val workspaceRoot: Path,
+    val verbose: Boolean,
+) {
+    /** How the symbol is named in the walker UI. */
+    fun name(symbol: Symbol): String = if (verbose) symbol.fqName else simpleName(symbol)
+
+    /** Always the simple / short name, regardless of verbose. */
+    fun simpleName(symbol: Symbol): String = symbol.fqName.substringAfterLast('.')
+
+    /** How a location is rendered in walker rows (`file:line` by default, workspace-relative when verbose). */
+    fun locationLabel(location: Location): String = Paths.locationLine(workspaceRoot, location, verbose)
+
+    /** Human-readable kind label, e.g. `class`, `function`, `property`. */
+    fun kindLabel(kind: SymbolKind): String = when (kind) {
+        SymbolKind.CLASS -> "class"
+        SymbolKind.INTERFACE -> "interface"
+        SymbolKind.OBJECT -> "object"
+        SymbolKind.FUNCTION -> "function"
+        SymbolKind.PROPERTY -> "property"
+        SymbolKind.PARAMETER -> "parameter"
+        SymbolKind.UNKNOWN -> "symbol"
+    }
+
+    /** The header used when previewing a location in its own panel. */
+    fun fileHeaderLabel(location: Location): String =
+        if (verbose) Paths.relative(workspaceRoot, location.filePath) else Paths.fileName(location.filePath)
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolWalker.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolWalker.kt
@@ -116,7 +116,10 @@ internal class FzfWalkerIO(
 ) : WalkerIO by delegate {
     override fun choose(header: String, choices: List<WalkerMenuChoice>): String? {
         if (choices.isEmpty()) return null
-        val separator = "\u0000" // NUL is safe: no choice display ever contains it.
+        // Tab is safe: no walker token or choice display ever contains one, and unlike
+        // NUL it is accepted in ProcessBuilder argv (JDK 17+ throws `IOException: Invalid
+        // null character in command` when any arg contains U+0000).
+        val separator = "\t"
         val process = ProcessBuilder(
             fzfPath,
             "--prompt", "walker› ",
@@ -147,7 +150,10 @@ internal class FzfWalkerIO(
         if (code != 0) return null
         val lines = output.lineSequence().filter { it.isNotEmpty() }.toList()
         // With --expect, fzf prints the key line first (empty when Enter was used).
-        val payload = lines.dropWhile { it in CANCEL_KEYS }.firstOrNull() ?: return null
+        // If the first non-empty line is a cancel key the user dismissed the picker —
+        // treat it as a cancel and do NOT execute the highlighted item.
+        if (lines.firstOrNull() in CANCEL_KEYS) return null
+        val payload = lines.firstOrNull { it !in CANCEL_KEYS } ?: return null
         return payload.substringBefore(separator).takeIf { it.isNotBlank() }
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolWalker.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolWalker.kt
@@ -7,8 +7,10 @@ import io.github.amichne.kast.api.contract.FilePosition
 import io.github.amichne.kast.api.contract.Location
 import io.github.amichne.kast.api.contract.ReferencesQuery
 import io.github.amichne.kast.api.contract.Symbol
+import io.github.amichne.kast.api.contract.SymbolKind
 import io.github.amichne.kast.api.contract.SymbolQuery
 import io.github.amichne.kast.cli.CliService
+import io.github.amichne.kast.cli.CliTextTheme
 import io.github.amichne.kast.cli.RuntimeCommandOptions
 import java.io.BufferedReader
 import java.nio.file.Files
@@ -175,6 +177,8 @@ internal class SymbolWalker(
     private val graph: SymbolGraph,
     private val io: WalkerIO,
     private val renderer: DemoRenderer,
+    private val theme: CliTextTheme = CliTextTheme.detect(),
+    private val display: SymbolDisplay = SymbolDisplay(workspaceRoot = workspaceRoot, verbose = false),
     private val grepRunner: GrepRunner = DefaultGrepRunner(workspaceRoot),
 ) {
     private val history: ArrayDeque<SymbolCursor> = ArrayDeque()
@@ -237,35 +241,38 @@ internal class SymbolWalker(
     }
 
     private fun menuHeader(cursor: SymbolCursor): String =
-        "current: ${cursor.symbol.fqName}  ·  " +
+        "current: ${display.name(cursor.symbol)}  ·  " +
             "${cursor.references.size} refs · ${cursor.incomingCallers.size} callers · ${cursor.outgoingCallees.size} callees"
 
     /**
      * Build the fzf menu for the current cursor. Rows are grouped by action
      * (references → callers → callees → meta), each row carries a parser
-     * token identical to what the operator would type.
+     * token identical to what the operator would type. Kind is coloured so
+     * the operator can eyeball function-vs-property-vs-class at a glance.
      */
     private fun buildMenuChoices(cursor: SymbolCursor): List<WalkerMenuChoice> {
         val choices = mutableListOf<WalkerMenuChoice>()
         cursor.references.take(WALK_PREVIEW).forEachIndexed { index, ref ->
             val n = index + 1
+            val file = theme.fileHeader(display.locationLabel(ref))
+            val preview = theme.muted(ref.preview.trim().take(PREVIEW_MAX))
             choices += WalkerMenuChoice(
                 token = "r $n",
-                display = "[r $n] reference   ${Paths.locationLine(workspaceRoot, ref)}  ${ref.preview.trim().take(PREVIEW_MAX)}",
+                display = "[r $n] reference   $file  $preview",
             )
         }
         cursor.incomingCallers.take(WALK_PREVIEW).forEachIndexed { index, sym ->
             val n = index + 1
             choices += WalkerMenuChoice(
                 token = "c $n",
-                display = "[c $n] caller      ${sym.fqName.substringAfterLast('.')} · ${sym.kind}  ${Paths.locationLine(workspaceRoot, sym.location)}",
+                display = "[c $n] caller      ${styledSymbolLabel(sym)}  ${theme.fileHeader(display.locationLabel(sym.location))}",
             )
         }
         cursor.outgoingCallees.take(WALK_PREVIEW).forEachIndexed { index, sym ->
             val n = index + 1
             choices += WalkerMenuChoice(
                 token = "o $n",
-                display = "[o $n] callee      ${sym.fqName.substringAfterLast('.')} · ${sym.kind}  ${Paths.locationLine(workspaceRoot, sym.location)}",
+                display = "[o $n] callee      ${styledSymbolLabel(sym)}  ${theme.fileHeader(display.locationLabel(sym.location))}",
             )
         }
         choices += WalkerMenuChoice("s", "[s]   show current declaration")
@@ -276,6 +283,53 @@ internal class SymbolWalker(
         choices += WalkerMenuChoice("h", "[h]   help")
         choices += WalkerMenuChoice("q", "[q]   finish the walker")
         return choices
+    }
+
+    /** `<kind-coloured name> · <kind label>` — the small signature used inside menu rows. */
+    private fun styledSymbolLabel(symbol: Symbol): String =
+        "${theme.kind(symbol.kind, display.name(symbol))} ${theme.muted("·")} ${theme.kind(symbol.kind, display.kindLabel(symbol.kind))}"
+
+    /** Columns available inside a demo panel (`width - borders - padding`). */
+    private fun panelContentWidth(): Int = renderer.panelContentWidth
+
+    /**
+     * Fit `<location>  <preview>` into [availableWidth] columns. The file
+     * location is preserved in full whenever it fits; any remaining budget
+     * goes to the preview, which is right-truncated with `…`. If even the
+     * location doesn't fit, it's left-truncated so the file name stays
+     * visible.
+     */
+    private fun fitLocationAndPreview(
+        availableWidth: Int,
+        location: String,
+        preview: String,
+    ): Pair<String, String> {
+        if (availableWidth <= 0) return "" to ""
+        val maxLocation = (availableWidth * 2 / 3).coerceAtLeast(12)
+        val fittedLocation = renderer.truncateLeft(location, maxLocation)
+        val remaining = (availableWidth - fittedLocation.length - 2).coerceAtLeast(0)
+        val fittedPreview = if (remaining <= 0 || preview.isEmpty()) "" else renderer.truncate(preview, remaining)
+        return fittedLocation to fittedPreview
+    }
+
+    /**
+     * Fit `<name> · <kind>  <file>` into [availableWidth]. The identity
+     * segment (`name · kind`) stays as-is whenever possible; the file
+     * location is left-truncated to fit the remaining budget so the
+     * filename stays on the right edge.
+     */
+    private fun fitSignatureAndLocation(
+        availableWidth: Int,
+        name: String,
+        kindLabel: String,
+        location: String,
+    ): Pair<String, String> {
+        if (availableWidth <= 0) return "" to ""
+        val signature = "$name · $kindLabel"
+        val fittedSignature = renderer.truncate(signature, (availableWidth * 2 / 3).coerceAtLeast(12))
+        val remaining = (availableWidth - fittedSignature.length - 2).coerceAtLeast(0)
+        val fittedLocation = if (remaining <= 0) "" else renderer.truncateLeft(location, remaining)
+        return fittedSignature to fittedLocation
     }
 
     private suspend fun hopTo(
@@ -326,43 +380,43 @@ internal class SymbolWalker(
 
     private fun cursorCard(cursor: SymbolCursor): DemoScript = demoScript {
         val symbol = cursor.symbol
-        panel("current node · ${symbol.fqName}") {
-            line("fqName   ${symbol.fqName}", emphasis = LineEmphasis.STRONG)
-            line("kind     ${symbol.kind}${symbol.visibility?.let { " · $it" } ?: ""}")
-            line("location ${Paths.locationLine(workspaceRoot, symbol.location)}")
+        val title = "current node · ${display.name(symbol)}"
+        panel(title) {
+            line("name     ${display.name(symbol)}", emphasis = LineEmphasis.STRONG)
+            val kindSuffix = symbol.visibility?.let { " · $it" } ?: ""
+            val kindPlain = "kind     ${display.kindLabel(symbol.kind)}$kindSuffix"
+            styledLine(
+                plain = kindPlain,
+                rendered = "kind     ${theme.kind(symbol.kind, display.kindLabel(symbol.kind))}${theme.muted(kindSuffix)}",
+            )
+            val locationPlain = "file     ${display.locationLabel(symbol.location)}"
+            styledLine(
+                plain = locationPlain,
+                rendered = "file     ${theme.fileHeader(display.locationLabel(symbol.location))}",
+            )
             symbol.containingDeclaration?.takeIf { it.isNotBlank() }?.let { line("inside   $it") }
             blank()
-            renderSymbolBranch(
+            renderReferenceBranch(
                 header = "references (${cursor.references.size})",
-                emptyNote = "no semantic references",
-                tokenPrefix = "r",
-                entries = cursor.references.take(WALK_PREVIEW).mapIndexed { index, ref ->
-                    index + 1 to "${Paths.locationLine(workspaceRoot, ref)}  ${ref.preview.trim().take(PREVIEW_MAX)}"
-                },
+                references = cursor.references.take(WALK_PREVIEW),
                 truncatedNote = (cursor.references.size - WALK_PREVIEW)
                     .takeIf { it > 0 }
                     ?.let { "... and $it more (use r <n> with larger n)" },
             )
             blank()
-            renderSymbolBranch(
+            renderSymbolCallBranch(
                 header = "incoming callers (${cursor.incomingCallers.size})",
-                emptyNote = "no callers found at depth 1",
                 tokenPrefix = "c",
-                entries = cursor.incomingCallers.take(WALK_PREVIEW).mapIndexed { index, sym ->
-                    index + 1 to "${sym.fqName.substringAfterLast('.')} · ${sym.kind}  ${Paths.locationLine(workspaceRoot, sym.location)}"
-                },
+                symbols = cursor.incomingCallers.take(WALK_PREVIEW),
                 truncatedNote = (cursor.incomingCallers.size - WALK_PREVIEW)
                     .takeIf { it > 0 }
                     ?.let { "... and $it more" },
             )
             blank()
-            renderSymbolBranch(
+            renderSymbolCallBranch(
                 header = "outgoing callees (${cursor.outgoingCallees.size})",
-                emptyNote = "no callees found at depth 1",
                 tokenPrefix = "o",
-                entries = cursor.outgoingCallees.take(WALK_PREVIEW).mapIndexed { index, sym ->
-                    index + 1 to "${sym.fqName.substringAfterLast('.')} · ${sym.kind}  ${Paths.locationLine(workspaceRoot, sym.location)}"
-                },
+                symbols = cursor.outgoingCallees.take(WALK_PREVIEW),
                 truncatedNote = (cursor.outgoingCallees.size - WALK_PREVIEW)
                     .takeIf { it > 0 }
                     ?.let { "... and $it more" },
@@ -370,24 +424,74 @@ internal class SymbolWalker(
         }
     }
 
-    private fun PanelBuilder.renderSymbolBranch(
+    /** A reference row: `├── [r n]  <file:line>  <preview>`. Path is left-truncated, preview is right-truncated. */
+    private fun PanelBuilder.renderReferenceBranch(
         header: String,
-        emptyNote: String,
-        tokenPrefix: String,
-        entries: List<Pair<Int, String>>,
+        references: List<Location>,
         truncatedNote: String?,
     ) {
         line(header, emphasis = LineEmphasis.STRONG)
-        if (entries.isEmpty()) {
-            line("  └── $emptyNote", emphasis = LineEmphasis.DIM)
+        if (references.isEmpty()) {
+            line("  └── no semantic references", emphasis = LineEmphasis.DIM)
             return
         }
-        val lastIndex = entries.lastIndex
+        val contentWidth = panelContentWidth()
+        val lastIndex = references.lastIndex
         val hasTail = truncatedNote != null
-        entries.forEachIndexed { i, (number, text) ->
-            val isTerminal = i == lastIndex && !hasTail
-            val elbow = if (isTerminal) "└──" else "├──"
-            line("  $elbow [$tokenPrefix $number]  $text")
+        references.forEachIndexed { i, ref ->
+            val n = i + 1
+            val elbow = if (i == lastIndex && !hasTail) "└──" else "├──"
+            val prefix = "  $elbow [r $n]  "
+            val locationRaw = display.locationLabel(ref)
+            val previewRaw = ref.preview.trim().take(PREVIEW_MAX)
+            val (locationPlain, previewPlain) = fitLocationAndPreview(
+                availableWidth = (contentWidth - prefix.length).coerceAtLeast(8),
+                location = locationRaw,
+                preview = previewRaw,
+            )
+            val plain = "$prefix$locationPlain${if (previewPlain.isNotEmpty()) "  $previewPlain" else ""}"
+            val rendered = "$prefix${theme.fileHeader(locationPlain)}" +
+                if (previewPlain.isNotEmpty()) "  ${theme.muted(previewPlain)}" else ""
+            styledLine(plain = plain, rendered = rendered)
+        }
+        truncatedNote?.let { line("  └── $it", emphasis = LineEmphasis.DIM) }
+    }
+
+    /** A caller / callee row: `├── [c n]  <name> · <kind>  <file:line>`. */
+    private fun PanelBuilder.renderSymbolCallBranch(
+        header: String,
+        tokenPrefix: String,
+        symbols: List<Symbol>,
+        truncatedNote: String?,
+    ) {
+        line(header, emphasis = LineEmphasis.STRONG)
+        if (symbols.isEmpty()) {
+            line("  └── no ${if (tokenPrefix == "c") "callers" else "callees"} found at depth 1", emphasis = LineEmphasis.DIM)
+            return
+        }
+        val contentWidth = panelContentWidth()
+        val lastIndex = symbols.lastIndex
+        val hasTail = truncatedNote != null
+        symbols.forEachIndexed { i, sym ->
+            val n = i + 1
+            val elbow = if (i == lastIndex && !hasTail) "└──" else "├──"
+            val prefix = "  $elbow [$tokenPrefix $n]  "
+            val namePlain = display.name(sym)
+            val kindLabel = display.kindLabel(sym.kind)
+            val locationRaw = display.locationLabel(sym.location)
+            val available = (contentWidth - prefix.length).coerceAtLeast(8)
+            val (signaturePlain, locationPlain) = fitSignatureAndLocation(
+                availableWidth = available,
+                name = namePlain,
+                kindLabel = kindLabel,
+                location = locationRaw,
+            )
+            val plain = "$prefix$signaturePlain${if (locationPlain.isNotEmpty()) "  $locationPlain" else ""}"
+            val renderedSignature = signaturePlain.replace(namePlain, theme.kind(sym.kind, namePlain))
+                .replace("· $kindLabel", "${theme.muted("·")} ${theme.kind(sym.kind, kindLabel)}")
+            val rendered = "$prefix$renderedSignature" +
+                if (locationPlain.isNotEmpty()) "  ${theme.fileHeader(locationPlain)}" else ""
+            styledLine(plain = plain, rendered = rendered)
         }
         truncatedNote?.let { line("  └── $it", emphasis = LineEmphasis.DIM) }
     }
@@ -416,8 +520,15 @@ internal class SymbolWalker(
     }
 
     private fun declarationCard(cursor: SymbolCursor): DemoScript = demoScript {
-        panel("declaration @ ${Paths.locationLine(workspaceRoot, cursor.symbol.location)}") {
-            val lines = readDeclarationContext(cursor.symbol.location)
+        val location = cursor.symbol.location
+        panel("declaration @ ${display.locationLabel(location)}") {
+            val fileHeaderText = "file     ${display.locationLabel(location)}"
+            styledLine(
+                plain = fileHeaderText,
+                rendered = "file     ${theme.fileHeader(display.locationLabel(location))}",
+            )
+            blank()
+            val lines = readDeclarationContext(location)
             if (lines.isEmpty()) {
                 line("(file unreadable from walker)", emphasis = LineEmphasis.DIM)
             } else {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolWalker.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolWalker.kt
@@ -77,7 +77,22 @@ internal class CliServiceSymbolGraph(
 internal interface WalkerIO {
     fun emit(line: String)
     fun prompt(): String?
+
+    /**
+     * Offer the user a structured menu of [choices]. Return the selected
+     * choice's [WalkerMenuChoice.token], or `null` to fall back to reading a
+     * raw command line via [prompt]. Default: always fall back.
+     */
+    fun choose(header: String, choices: List<WalkerMenuChoice>): String? = null
 }
+
+/** One line offered to the walker's interactive picker. */
+internal data class WalkerMenuChoice(
+    /** The command string to feed into [WalkerCommand.parse], e.g. `"r 3"` or `"q"`. */
+    val token: String,
+    /** What the operator sees when selecting the choice. */
+    val display: String,
+)
 
 internal class StreamWalkerIO(
     private val reader: BufferedReader,
@@ -85,6 +100,73 @@ internal class StreamWalkerIO(
 ) : WalkerIO {
     override fun emit(line: String) = output(line)
     override fun prompt(): String? = reader.readLine()
+}
+
+/**
+ * [WalkerIO] that delegates emit/prompt to [delegate] but offers an fzf-backed
+ * [choose] when the `fzf` binary is available on `PATH`. Falls back cleanly
+ * when fzf is missing, the terminal is non-interactive, or fzf exits without a
+ * selection (e.g. the operator pressed Esc), letting the caller re-prompt.
+ */
+internal class FzfWalkerIO(
+    private val delegate: WalkerIO,
+    private val fzfPath: String,
+) : WalkerIO by delegate {
+    override fun choose(header: String, choices: List<WalkerMenuChoice>): String? {
+        if (choices.isEmpty()) return null
+        val separator = "\u0000" // NUL is safe: no choice display ever contains it.
+        val process = ProcessBuilder(
+            fzfPath,
+            "--prompt", "walker› ",
+            "--header", header,
+            "--layout=reverse",
+            "--height=~60%",
+            "--no-mouse",
+            "--ansi",
+            "--with-nth=2..",
+            "--delimiter=$separator",
+            "--expect=esc,ctrl-c,ctrl-d",
+        )
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectInput(ProcessBuilder.Redirect.PIPE)
+            .start()
+        process.outputStream.bufferedWriter().use { writer ->
+            choices.forEach { choice ->
+                writer.write(choice.token)
+                writer.write(separator)
+                writer.write(choice.display)
+                writer.newLine()
+            }
+        }
+        val output = process.inputStream.bufferedReader().readText()
+        val code = process.waitFor()
+        if (code == 130 || code == 1) return null // user cancelled or no match
+        if (code != 0) return null
+        val lines = output.lineSequence().filter { it.isNotEmpty() }.toList()
+        // With --expect, fzf prints the key line first (empty when Enter was used).
+        val payload = lines.dropWhile { it in CANCEL_KEYS }.firstOrNull() ?: return null
+        return payload.substringBefore(separator).takeIf { it.isNotBlank() }
+    }
+
+    companion object {
+        private val CANCEL_KEYS = setOf("esc", "ctrl-c", "ctrl-d")
+
+        /** Resolve an `fzf` executable on `PATH`; null if not found. */
+        fun locateFzf(): String? {
+            val path = System.getenv("PATH") ?: return null
+            val isWindows = System.getProperty("os.name").orEmpty().startsWith("Windows")
+            val exts = if (isWindows) listOf(".exe", ".bat", ".cmd") else listOf("")
+            for (dir in path.split(java.io.File.pathSeparatorChar)) {
+                if (dir.isBlank()) continue
+                for (ext in exts) {
+                    val candidate = java.io.File(dir, "fzf$ext")
+                    if (candidate.canExecute()) return candidate.absolutePath
+                }
+            }
+            return null
+        }
+    }
 }
 
 /** Runs the interactive symbol-graph walk and returns the number of successful hops made. */
@@ -107,8 +189,8 @@ internal class SymbolWalker(
         var hops = 0
         while (true) {
             io.emit(renderer.render(cursorCard(cursor)))
-            io.emit(renderer.render(promptLine()))
-            when (val command = WalkerCommand.parse(io.prompt())) {
+            val raw = readCommand(cursor)
+            when (val command = WalkerCommand.parse(raw)) {
                 WalkerCommand.Help -> io.emit(renderer.render(helpCard()))
                 WalkerCommand.Quit, WalkerCommand.EndOfInput -> return WalkSummary(hops = hops)
                 WalkerCommand.Back -> {
@@ -138,6 +220,62 @@ internal class SymbolWalker(
                 )
             }
         }
+    }
+
+    /**
+     * Read the next walker command. Prefers [WalkerIO.choose] so fzf-style
+     * transports can render a navigable menu; falls back to a plain `prompt`
+     * read when choose returns null (Esc, missing fzf, EOF from a script,
+     * etc.).
+     */
+    private fun readCommand(cursor: SymbolCursor): String? {
+        val choices = buildMenuChoices(cursor)
+        val picked = if (choices.isNotEmpty()) io.choose(menuHeader(cursor), choices) else null
+        if (picked != null) return picked
+        io.emit(renderer.render(promptLine()))
+        return io.prompt()
+    }
+
+    private fun menuHeader(cursor: SymbolCursor): String =
+        "current: ${cursor.symbol.fqName}  ·  " +
+            "${cursor.references.size} refs · ${cursor.incomingCallers.size} callers · ${cursor.outgoingCallees.size} callees"
+
+    /**
+     * Build the fzf menu for the current cursor. Rows are grouped by action
+     * (references → callers → callees → meta), each row carries a parser
+     * token identical to what the operator would type.
+     */
+    private fun buildMenuChoices(cursor: SymbolCursor): List<WalkerMenuChoice> {
+        val choices = mutableListOf<WalkerMenuChoice>()
+        cursor.references.take(WALK_PREVIEW).forEachIndexed { index, ref ->
+            val n = index + 1
+            choices += WalkerMenuChoice(
+                token = "r $n",
+                display = "[r $n] reference   ${Paths.locationLine(workspaceRoot, ref)}  ${ref.preview.trim().take(PREVIEW_MAX)}",
+            )
+        }
+        cursor.incomingCallers.take(WALK_PREVIEW).forEachIndexed { index, sym ->
+            val n = index + 1
+            choices += WalkerMenuChoice(
+                token = "c $n",
+                display = "[c $n] caller      ${sym.fqName.substringAfterLast('.')} · ${sym.kind}  ${Paths.locationLine(workspaceRoot, sym.location)}",
+            )
+        }
+        cursor.outgoingCallees.take(WALK_PREVIEW).forEachIndexed { index, sym ->
+            val n = index + 1
+            choices += WalkerMenuChoice(
+                token = "o $n",
+                display = "[o $n] callee      ${sym.fqName.substringAfterLast('.')} · ${sym.kind}  ${Paths.locationLine(workspaceRoot, sym.location)}",
+            )
+        }
+        choices += WalkerMenuChoice("s", "[s]   show current declaration")
+        choices += WalkerMenuChoice("g", "[g]   compare against grep (baseline)")
+        if (history.size > 1) {
+            choices += WalkerMenuChoice("b", "[b]   pop the last hop")
+        }
+        choices += WalkerMenuChoice("h", "[h]   help")
+        choices += WalkerMenuChoice("q", "[q]   finish the walker")
+        return choices
     }
 
     private suspend fun hopTo(
@@ -188,51 +326,70 @@ internal class SymbolWalker(
 
     private fun cursorCard(cursor: SymbolCursor): DemoScript = demoScript {
         val symbol = cursor.symbol
-        panel("current node") {
+        panel("current node · ${symbol.fqName}") {
             line("fqName   ${symbol.fqName}", emphasis = LineEmphasis.STRONG)
             line("kind     ${symbol.kind}${symbol.visibility?.let { " · $it" } ?: ""}")
             line("location ${Paths.locationLine(workspaceRoot, symbol.location)}")
             symbol.containingDeclaration?.takeIf { it.isNotBlank() }?.let { line("inside   $it") }
+            blank()
+            renderSymbolBranch(
+                header = "references (${cursor.references.size})",
+                emptyNote = "no semantic references",
+                tokenPrefix = "r",
+                entries = cursor.references.take(WALK_PREVIEW).mapIndexed { index, ref ->
+                    index + 1 to "${Paths.locationLine(workspaceRoot, ref)}  ${ref.preview.trim().take(PREVIEW_MAX)}"
+                },
+                truncatedNote = (cursor.references.size - WALK_PREVIEW)
+                    .takeIf { it > 0 }
+                    ?.let { "... and $it more (use r <n> with larger n)" },
+            )
+            blank()
+            renderSymbolBranch(
+                header = "incoming callers (${cursor.incomingCallers.size})",
+                emptyNote = "no callers found at depth 1",
+                tokenPrefix = "c",
+                entries = cursor.incomingCallers.take(WALK_PREVIEW).mapIndexed { index, sym ->
+                    index + 1 to "${sym.fqName.substringAfterLast('.')} · ${sym.kind}  ${Paths.locationLine(workspaceRoot, sym.location)}"
+                },
+                truncatedNote = (cursor.incomingCallers.size - WALK_PREVIEW)
+                    .takeIf { it > 0 }
+                    ?.let { "... and $it more" },
+            )
+            blank()
+            renderSymbolBranch(
+                header = "outgoing callees (${cursor.outgoingCallees.size})",
+                emptyNote = "no callees found at depth 1",
+                tokenPrefix = "o",
+                entries = cursor.outgoingCallees.take(WALK_PREVIEW).mapIndexed { index, sym ->
+                    index + 1 to "${sym.fqName.substringAfterLast('.')} · ${sym.kind}  ${Paths.locationLine(workspaceRoot, sym.location)}"
+                },
+                truncatedNote = (cursor.outgoingCallees.size - WALK_PREVIEW)
+                    .takeIf { it > 0 }
+                    ?.let { "... and $it more" },
+            )
         }
-        step("references (${cursor.references.size})") {
-            info()
-            body {
-                if (cursor.references.isEmpty()) {
-                    line("no semantic references", emphasis = LineEmphasis.DIM)
-                } else {
-                    cursor.references.take(WALK_PREVIEW).forEachIndexed { index, ref ->
-                        line("[r ${index + 1}]  ${Paths.locationLine(workspaceRoot, ref)}  ${ref.preview.trim().take(70)}")
-                    }
-                    if (cursor.references.size > WALK_PREVIEW) {
-                        line("... and ${cursor.references.size - WALK_PREVIEW} more (use r <n> with larger n)", emphasis = LineEmphasis.DIM)
-                    }
-                }
-            }
+    }
+
+    private fun PanelBuilder.renderSymbolBranch(
+        header: String,
+        emptyNote: String,
+        tokenPrefix: String,
+        entries: List<Pair<Int, String>>,
+        truncatedNote: String?,
+    ) {
+        line(header, emphasis = LineEmphasis.STRONG)
+        if (entries.isEmpty()) {
+            line("  └── $emptyNote", emphasis = LineEmphasis.DIM)
+            return
         }
-        step("incoming callers (${cursor.incomingCallers.size})") {
-            info()
-            body {
-                if (cursor.incomingCallers.isEmpty()) {
-                    line("no callers found at depth 1", emphasis = LineEmphasis.DIM)
-                } else {
-                    cursor.incomingCallers.take(WALK_PREVIEW).forEachIndexed { index, sym ->
-                        line("[c ${index + 1}]  ${sym.fqName.substringAfterLast('.')} (${sym.kind})  ${Paths.locationLine(workspaceRoot, sym.location)}")
-                    }
-                }
-            }
+        val lastIndex = entries.lastIndex
+        val hasTail = truncatedNote != null
+        entries.forEachIndexed { i, (number, text) ->
+            val isTerminal = i == lastIndex && !hasTail
+            val elbow = if (isTerminal) "└──" else "├──"
+            line("  $elbow [$tokenPrefix $number]  $text")
         }
-        step("outgoing callees (${cursor.outgoingCallees.size})") {
-            info()
-            body {
-                if (cursor.outgoingCallees.isEmpty()) {
-                    line("no callees found at depth 1", emphasis = LineEmphasis.DIM)
-                } else {
-                    cursor.outgoingCallees.take(WALK_PREVIEW).forEachIndexed { index, sym ->
-                        line("[o ${index + 1}]  ${sym.fqName.substringAfterLast('.')} (${sym.kind})  ${Paths.locationLine(workspaceRoot, sym.location)}")
-                    }
-                }
-            }
-        }
+        truncatedNote?.let { line("  └── $it", emphasis = LineEmphasis.DIM) }
     }
 
     private fun promptLine(): DemoScript = demoScript {
@@ -308,6 +465,8 @@ internal class SymbolWalker(
     companion object {
         const val WALK_PREVIEW: Int = 8
         const val DECLARATION_CONTEXT: Int = 3
+        /** Max characters of reference-line preview we carry into a row. */
+        const val PREVIEW_MAX: Int = 60
     }
 }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolWalker.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/demo/SymbolWalker.kt
@@ -487,8 +487,16 @@ internal class SymbolWalker(
                 location = locationRaw,
             )
             val plain = "$prefix$signaturePlain${if (locationPlain.isNotEmpty()) "  $locationPlain" else ""}"
-            val renderedSignature = signaturePlain.replace(namePlain, theme.kind(sym.kind, namePlain))
-                .replace("· $kindLabel", "${theme.muted("·")} ${theme.kind(sym.kind, kindLabel)}")
+            // Style each half of `name · kindLabel` by splitting on the separator once. Using
+            // String.replace here would corrupt rendering when the name is a substring of the
+            // kind label (e.g. `face` in `interface`).
+            val renderedSignature = if (signaturePlain.contains(" · ")) {
+                val styledName = theme.kind(sym.kind, signaturePlain.substringBefore(" · "))
+                val styledKind = theme.kind(sym.kind, signaturePlain.substringAfter(" · "))
+                "$styledName ${theme.muted("·")} $styledKind"
+            } else {
+                theme.kind(sym.kind, signaturePlain)
+            }
             val rendered = "$prefix$renderedSignature" +
                 if (locationPlain.isNotEmpty()) "  ${theme.fileHeader(locationPlain)}" else ""
             styledLine(plain = plain, rendered = rendered)

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/DemoSceneTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/DemoSceneTest.kt
@@ -82,4 +82,46 @@ class DemoSceneTest {
         assertTrue(output.contains("references"), output)
         assertTrue(output.contains("✕"), output)
     }
+
+    @Test
+    fun `panel lines longer than inner width are wrapped on whitespace`() {
+        // 60 is below MIN_PANEL_WIDTH (58) plus border; use 80 so the panel
+        // actually respects the requested terminal width.
+        val width = 80
+        val renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false, width = width)
+        val long = "grep only sees text, so it mixes real usages with imports, comments, string literals, and substring collisions that have nothing to do with the symbol."
+        val script = demoScript { panel("why the semantic pass wins") { line(long) } }
+
+        val lines = renderer.render(script).trimEnd().lines()
+        val bodyLines = lines.filter { it.startsWith("│ ") && !it.contains("why the semantic pass wins") }
+        assertTrue(bodyLines.size >= 2, "expected wrapped output across multiple rows, got:\n${lines.joinToString("\n")}")
+        // Every body line must fit the configured terminal width.
+        bodyLines.forEach { row ->
+            assertTrue(row.length <= width, "row overflows $width cols: '$row' (${row.length})")
+            assertTrue(row.endsWith(" │"), "row must end with right border: '$row'")
+        }
+    }
+
+    @Test
+    fun `panel tokens that cannot fit a single row are truncated with an ellipsis`() {
+        val width = 60
+        val renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false, width = width)
+        val giant = "io.github.amichne.kast.backend.standalone.CliServiceSymbolGraphThatIsLongerThanAnyBodyCellWouldEverTolerateInRealLife"
+        val script = demoScript { panel("p") { line(giant) } }
+
+        val lines = renderer.render(script).trimEnd().lines()
+        val bodyLines = lines.filter { it.startsWith("│ ") && !it.contains("│ p ") }
+        assertTrue(bodyLines.any { it.contains("…") }, "expected unicode ellipsis in:\n${lines.joinToString("\n")}")
+        bodyLines.forEach { assertTrue(it.length <= width, "row overflows $width cols: '$it' (${it.length})") }
+    }
+
+    @Test
+    fun `wrapForWidth keeps tokens intact when they fit and breaks oversized tokens with ellipsis`() {
+        val renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false, width = 80)
+        assertEquals(listOf("hello world"), renderer.wrapForWidth("hello world", 20))
+        assertEquals(listOf("short one", "bar baz"), renderer.wrapForWidth("short one bar baz", 10))
+        val chunks = renderer.wrapForWidth("longertokenthanwidthsoitmustbreak", 10)
+        assertEquals(listOf("longertok…"), chunks)
+        assertEquals(listOf(""), renderer.wrapForWidth("", 10))
+    }
 }

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/SymbolWalkerTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/SymbolWalkerTest.kt
@@ -40,7 +40,8 @@ class SymbolWalkerTest {
         val transcript = io.emitted.joinToString("\n")
         assertTrue(transcript.contains("Act 3 · walk the symbol graph"), transcript)
         assertTrue(transcript.contains("current node"), transcript)
-        assertTrue(transcript.contains(root.fqName), transcript)
+        // Default display is simple name + bare file name; verbose FQCN paths are gated behind --verbose.
+        assertTrue(transcript.contains(root.fqName.substringAfterLast('.')), transcript)
     }
 
     @Test
@@ -79,7 +80,8 @@ class SymbolWalkerTest {
         }
         assertEquals(1, summary.hops)
         val transcript = io.emitted.joinToString("\n")
-        assertTrue(transcript.contains(refTarget.fqName), transcript)
+        // Default renders the simple name; verbose renders the FQCN.
+        assertTrue(transcript.contains(refTarget.fqName.substringAfterLast('.')), transcript)
     }
 
     @Test
@@ -185,6 +187,31 @@ class SymbolWalkerTest {
         }
         assertEquals(1, io.chooseCalls)
         assertEquals(1, io.promptCalls)
+    }
+
+    @Test
+    fun `verbose display shows fully-qualified names and workspace-relative paths`() {
+        val root = symbol("app.nested.Root", tempDir.resolve("nested/Root.kt"))
+        val graph = RecordingGraph(
+            resolves = mapOf(root.location.asKey() to Result.success(root)),
+            references = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callers = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callees = mapOf(root.location.asKey() to Result.success(emptyList())),
+        )
+        val io = ScriptedIO(inputs = listOf("q"))
+        runBlocking {
+            SymbolWalker(
+                workspaceRoot = tempDir,
+                graph = graph,
+                io = io,
+                renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false),
+                display = SymbolDisplay(workspaceRoot = tempDir, verbose = true),
+                grepRunner = NoopGrepRunner,
+            ).run(root)
+        }
+        val transcript = io.emitted.joinToString("\n")
+        assertTrue(transcript.contains(root.fqName), transcript)
+        assertTrue(transcript.contains("nested/Root.kt") || transcript.contains("nested\\Root.kt"), transcript)
     }
 
     @Test

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/SymbolWalkerTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/demo/SymbolWalkerTest.kt
@@ -106,6 +106,88 @@ class SymbolWalkerTest {
     }
 
     @Test
+    fun `cursor card uses tree prefixes for references callers and callees`() {
+        val root = symbol("app.Root", tempDir.resolve("Root.kt"))
+        val refLoc = Location(
+            filePath = tempDir.resolve("Caller.kt").toString(),
+            startOffset = 10,
+            endOffset = 14,
+            startLine = 2,
+            startColumn = 3,
+            preview = "Root()",
+        )
+        val graph = RecordingGraph(
+            resolves = mapOf(root.location.asKey() to Result.success(root)),
+            references = mapOf(root.location.asKey() to Result.success(listOf(refLoc))),
+            callers = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callees = mapOf(root.location.asKey() to Result.success(emptyList())),
+        )
+        val io = ScriptedIO(inputs = listOf("q"))
+        runBlocking {
+            SymbolWalker(
+                workspaceRoot = tempDir,
+                graph = graph,
+                io = io,
+                renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false),
+                grepRunner = NoopGrepRunner,
+            ).run(root)
+        }
+        val transcript = io.emitted.joinToString("\n")
+        // Non-empty branch gets the tree elbow + token prefix.
+        assertTrue(transcript.contains("├── [r 1]") || transcript.contains("└── [r 1]"), transcript)
+        // Empty branches fall through to the terminal elbow.
+        assertTrue(transcript.contains("└── no callers found at depth 1"), transcript)
+        assertTrue(transcript.contains("└── no callees found at depth 1"), transcript)
+    }
+
+    @Test
+    fun `choose result takes priority over prompt input`() {
+        val root = symbol("app.Root", tempDir.resolve("Root.kt"))
+        val graph = RecordingGraph(
+            resolves = mapOf(root.location.asKey() to Result.success(root)),
+            references = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callers = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callees = mapOf(root.location.asKey() to Result.success(emptyList())),
+        )
+        // If choose returned "q" the walker must exit without ever reading from prompt.
+        val io = ChoosingIO(chooseReturns = listOf("q"), promptInputs = emptyList())
+        runBlocking {
+            SymbolWalker(
+                workspaceRoot = tempDir,
+                graph = graph,
+                io = io,
+                renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false),
+                grepRunner = NoopGrepRunner,
+            ).run(root)
+        }
+        assertEquals(0, io.promptCalls)
+        assertEquals(1, io.chooseCalls)
+    }
+
+    @Test
+    fun `walker falls back to prompt when choose returns null`() {
+        val root = symbol("app.Root", tempDir.resolve("Root.kt"))
+        val graph = RecordingGraph(
+            resolves = mapOf(root.location.asKey() to Result.success(root)),
+            references = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callers = mapOf(root.location.asKey() to Result.success(emptyList())),
+            callees = mapOf(root.location.asKey() to Result.success(emptyList())),
+        )
+        val io = ChoosingIO(chooseReturns = listOf<String?>(null), promptInputs = listOf("q"))
+        runBlocking {
+            SymbolWalker(
+                workspaceRoot = tempDir,
+                graph = graph,
+                io = io,
+                renderer = DemoRenderer(CliTextTheme.ansi(), ansiEnabled = false),
+                grepRunner = NoopGrepRunner,
+            ).run(root)
+        }
+        assertEquals(1, io.chooseCalls)
+        assertEquals(1, io.promptCalls)
+    }
+
+    @Test
     fun `grep comparison prints the canned grep lines and the disclaimer`() {
         val root = symbol("app.Root", tempDir.resolve("Root.kt"))
         val graph = RecordingGraph(
@@ -181,6 +263,34 @@ class SymbolWalkerTest {
         }
 
         override fun prompt(): String? = queue.removeFirstOrNull()
+    }
+
+    /**
+     * Records invocations of [choose] vs [prompt] so we can prove the walker
+     * prefers structured selection when available and only falls back to a
+     * raw prompt read when the picker returns null.
+     */
+    private class ChoosingIO(
+        chooseReturns: List<String?>,
+        promptInputs: List<String>,
+    ) : WalkerIO {
+        private val chooseQueue: ArrayDeque<String?> = ArrayDeque(chooseReturns)
+        private val promptQueue: ArrayDeque<String> = ArrayDeque(promptInputs)
+        var chooseCalls: Int = 0
+            private set
+        var promptCalls: Int = 0
+            private set
+
+        override fun emit(line: String) { /* discard */ }
+        override fun prompt(): String? {
+            promptCalls += 1
+            return promptQueue.removeFirstOrNull()
+        }
+
+        override fun choose(header: String, choices: List<WalkerMenuChoice>): String? {
+            chooseCalls += 1
+            return chooseQueue.removeFirstOrNull()
+        }
     }
 
     private object NoopGrepRunner : GrepRunner {


### PR DESCRIPTION
## Summary

Follow-up polish on top of #86's Kotlin rewrite of `kast demo`. Two batches of improvements, all isolated to `kast-cli` — no RPC contract or backend changes.

**Batch A — panel bounding, tree, FQCN, fzf:**
- `DemoRenderer` wraps panel bodies and comparison-table cells to the inner width and truncates oversized tokens with `…` (fixes the "why the semantic pass wins" / reference-preview overflow).
- Walker `current node` card is now a single panel with tree-shaped references / incoming callers / outgoing callees branches using `├──` / `└──`.
- FQCN-aware symbol picker: `--symbol=io.github.amichne.kast.cli.CliService` resolves to the exact declaration (exact → suffix → simple → substring) and the server-side workspace-symbol query splits dotted input on its last dot so the daemon returns candidates.
- `WalkerIO.choose(header, choices)` + `FzfWalkerIO` spawns `fzf` (NUL-delimited rows, `--expect=esc,ctrl-c,ctrl-d`) when fzf is on `PATH` and stdin is a real TTY; cancel / missing fzf / piped stdin fall back cleanly to the line reader.

**Batch B — color, concise-by-default, light-grey headers, right-biased truncation:**
- Per-`SymbolKind` colors via `CliTextTheme.kind(kind, text)` (class/object/interface → yellow family, function → cyan, property → green, parameter → magenta, unknown → dim). Applied to cursor-card tree rows and menu choices.
- Concise-by-default display: simple name + bare file name everywhere. New `SymbolDisplay(workspaceRoot, verbose)` formatter is the single source of truth. `--verbose` flag re-enables FQCN + workspace-relative paths.
- **Right-biased truncation** (`DemoRenderer.truncateLeft`) on location rows so the tail — filename and line number — stays visible; over-long leading path segments get replaced with `…`.
- Light-grey file-name headers (`theme.fileHeader`) on walker tree rows, menu choices, the cursor card's `file …` line, and the declaration card title.
- Styled pre-rendered line support in `PanelBuilder.styledLine()` / `DemoRenderer` so the walker can emit pre-coloured rows without fighting the wrap math.

Tests updated: default-display assertions use simple names; a new test pins `--verbose=true` behaviour (FQCN + workspace-relative path).

## Review & Testing Checklist for Human
- [ ] Run `./gradlew :kast-cli:test` — expect green.
- [ ] `./kast.sh build cli`, then in a real TTY: `./dist/cli/kast-cli demo --symbol=io.github.amichne.kast.cli.CliService --walk=true`. Verify kind colors on caller / callee rows, light-grey file headers, and `…` on the left of over-long paths (filenames on the right stay readable).
- [ ] Re-run with `--verbose=true` and verify FQCN + workspace-relative paths render in the walker.
- [ ] If `fzf` is on `PATH`, confirm the menu switches to fzf; pipe stdin instead and confirm the line-reader fallback.

## Asciinema

https://asciinema.org/a/EuNsctmAa2PqiDPH — drives `s → r 1 → c 1 → g → b → b → q` against `--symbol=io.github.amichne.kast.cli.CliService` (concise-by-default). Anonymous upload, auto-deletes in 7 days; the `.cast` is attached for permanent re-upload.

### Notes

Kotlin syntax highlighting on the declaration preview is deferred — it kept fighting the wrap / truncation math. The rest of the requested polish is in.


Link to Devin session: https://app.devin.ai/sessions/3b1b729af83f442aa57f46970b5f045b
Requested by: @amichne