### PR TITLE
fix: serialize Phase 2 FIR resolution with foreground operations

### DIFF
--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisSession.kt
@@ -65,6 +65,7 @@ internal class StandaloneAnalysisSession(
     private val analysisSessionLock: SessionLock = ReentrantSessionLock(),
     private val identifierIndexWaitMillis: Long = defaultIdentifierIndexWaitMillis,
     internal val telemetry: StandaloneTelemetry = StandaloneTelemetry.disabled(),
+    private val enablePhase2Indexing: Boolean = true,
 ) : AutoCloseable {
     private val normalizedWorkspaceRoot = normalizeStandalonePath(workspaceRoot)
     private val disposable: Disposable = Disposer.newDisposable("kast-standalone")
@@ -893,9 +894,11 @@ internal class StandaloneAnalysisSession(
             // clean starting point that watcher-driven partial refreshes cannot corrupt.
             checkpointKnownPaths = builtIndex.knownPaths()
         }
-        backgroundIndexer.identifierIndexReady.thenRun {
-            if (closed || sourceIndexGeneration.get() != generation) return@thenRun
-            backgroundIndexer.startPhase2(::scanFileReferences)
+        if (enablePhase2Indexing) {
+            backgroundIndexer.identifierIndexReady.thenRun {
+                if (closed || sourceIndexGeneration.get() != generation) return@thenRun
+                backgroundIndexer.startPhase2(::scanFileReferences)
+            }
         }
     }
 
@@ -909,8 +912,8 @@ internal class StandaloneAnalysisSession(
      */
     private fun scanFileReferences(filePath: String): List<SymbolReferenceRow> {
         val rows = mutableListOf<SymbolReferenceRow>()
-        withReadAccess {
-            val ktFile = runCatching { findKtFile(filePath) }.getOrNull() ?: return@withReadAccess
+        analysisSessionLock.write {
+            val ktFile = runCatching { findKtFile(filePath) }.getOrNull() ?: return@write
             val sourceFilePath = runCatching { ktFile.resolvedFilePath().value }.getOrElse { filePath }
 
             ktFile.accept(

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendFindReferencesTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendFindReferencesTest.kt
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import io.github.amichne.kast.standalone.cache.SourceIndexCache
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.writeText
@@ -970,6 +969,7 @@ class StandaloneAnalysisBackendFindReferencesTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { s ->
             s.awaitInitialSourceIndex()
@@ -1048,24 +1048,14 @@ class StandaloneAnalysisBackendFindReferencesTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { s ->
             s.awaitInitialSourceIndex()
 
-            // Phase 2 auto-starts after Phase 1; replace the backgroundIndexer with a fresh
-            // instance whose referenceIndexReady is not completed, to test the fallback path.
-            val indexerField = StandaloneAnalysisSession::class.java.getDeclaredField("backgroundIndexer")
-            indexerField.isAccessible = true
-            val dummyCache = SourceIndexCache(workspaceRoot, enabled = false)
-            val freshIndexer = BackgroundIndexer(
-                sourceRoots = emptyList(),
-                sourceIndexFileReader = { "" },
-                sourceModuleNameResolver = { null },
-                sourceIndexCache = dummyCache,
-                store = s.sqliteStore,
-            )
-            indexerField.set(s, freshIndexer)
-            assertFalse(s.isReferenceIndexReady(), "Fresh indexer should not be ready")
+            // Phase 2 is disabled; the backgroundIndexer's referenceIndexReady
+            // is not completed, which is exactly the state we want to test.
+            assertFalse(s.isReferenceIndexReady(), "Phase 2 disabled; indexer should not be ready")
 
             val backend = StandaloneAnalysisBackend(
                 workspaceRoot = workspaceRoot,
@@ -1120,11 +1110,12 @@ class StandaloneAnalysisBackendFindReferencesTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { s ->
             s.awaitInitialSourceIndex()
 
-            // Complete Phase 2 but don't insert any symbol_reference rows
+            // Complete Phase 2 future without inserting any symbol_reference rows
             s.sqliteStore.ensureSchema()
             val indexerField = StandaloneAnalysisSession::class.java.getDeclaredField("backgroundIndexer")
             indexerField.isAccessible = true

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendRenameTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendRenameTest.kt
@@ -57,6 +57,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             val backend = StandaloneAnalysisBackend(
@@ -118,6 +119,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             val backend = StandaloneAnalysisBackend(
@@ -178,6 +180,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             val backend = StandaloneAnalysisBackend(
@@ -230,6 +233,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             val backend = StandaloneAnalysisBackend(
@@ -318,6 +322,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             val backend = StandaloneAnalysisBackend(
@@ -406,6 +411,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             val backend = StandaloneAnalysisBackend(
@@ -476,6 +482,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             session.awaitInitialSourceIndex()
@@ -550,6 +557,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             session.awaitInitialSourceIndex()
@@ -618,6 +626,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             val backend = StandaloneAnalysisBackend(
@@ -674,6 +683,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             val backend = StandaloneAnalysisBackend(
@@ -737,6 +747,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             val backend = StandaloneAnalysisBackend(
@@ -791,6 +802,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { session ->
             val backend = StandaloneAnalysisBackend(
@@ -847,6 +859,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { s ->
             val backend = StandaloneAnalysisBackend(
@@ -902,6 +915,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { s ->
             val backend = StandaloneAnalysisBackend(
@@ -958,6 +972,7 @@ class StandaloneAnalysisBackendRenameTest {
             sourceRoots = emptyList(),
             classpathRoots = emptyList(),
             moduleName = "sources",
+            enablePhase2Indexing = false,
         )
         session.use { s ->
             val backend = StandaloneAnalysisBackend(


### PR DESCRIPTION
## Summary

Phase 2 background indexing (`scanFileReferences`) triggers K2/FIR resolution on a daemon thread concurrently with foreground analysis operations (rename, findReferences, etc.). Both previously acquired read locks, allowing concurrent execution. But the K2 FIR lazy declaration resolver is not thread-safe for concurrent resolution of the same declarations within a single standalone analysis session, causing spurious `KotlinIllegalArgumentExceptionWithAttachments` failures in CI.

Two complementary fixes:

1. **`enablePhase2Indexing` flag** — new constructor parameter on `StandaloneAnalysisSession` (default `true`). When `false`, the `thenRun` that calls `startPhase2` is skipped entirely. Tests that don't exercise the reference cache pass this flag to eliminate the race.

2. **Write lock in `scanFileReferences`** — changed from `withReadAccess` (read lock) to `analysisSessionLock.write` (write lock). This ensures Phase 2 resolution is exclusive with foreground read operations. The write lock is held only for the duration of resolving one file's references (not the entire Phase 2 run), so Phase 2 yields to foreground readers between files and foreground latency impact is bounded.

3. **Test updates** — all 15 rename test sessions and the 3 Phase 2 cache-hit/fallback tests in `StandaloneAnalysisBackendFindReferencesTest` now pass `enablePhase2Indexing = false`. The fallback test was simplified to rely on the flag instead of reflection-based `BackgroundIndexer` replacement.

## Review & Testing Checklist for Human

- [ ] Verify `scanFileReferences` write lock doesn't introduce unacceptable foreground latency — the lock is per-file so impact should be bounded, but worth checking with a large workspace
- [ ] Run `./gradlew :backend-standalone:test` multiple times to confirm no spurious failures
- [ ] Run the full CI matrix: `./gradlew :analysis-api:test :analysis-server:test :backend-standalone:test :kast-cli:test :kast-cli:portableDistZip`
- [ ] Verify the Phase 2 cache-hit tests in `StandaloneAnalysisBackendFindReferencesTest` still correctly exercise the cache path (they manually complete `referenceIndexReady` via reflection)

### Notes

- The `enablePhase2Indexing` parameter defaults to `true` so production behavior is unchanged
- The `findReferences falls back to CandidateFileResolver when phase 2 is not ready` test was failing with `IOException: Failed to delete temp directory` due to the Phase 2 background thread holding file references during cleanup — this is exactly the class of race condition being fixed


Link to Devin session: https://app.devin.ai/sessions/8f5b9b03586b40fdbfc679d7f4c4e1cd
Requested by: @amichne