### PR TITLE
feat: MetricsEngine CLI, skill wrapper, incremental reindex, and status reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Agents must use native `kast skill ...` subcommands for Kotlin semantic operatio
 | Scaffold context      | `kast skill scaffold`                   | None     |
 | Write and validate    | `kast skill write-and-validate`         | None     |
 | List workspace files  | `kast skill workspace-files`            | None     |
+| Workspace metrics     | `kast skill metrics`                    | None     |
 
 **Prohibited substitutions:** `grep`, `rg`, `ast-grep`, `cat` + manual
 parsing must NOT be used for symbol identity, reference finding, or call

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/RuntimeStatusResponse.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/RuntimeStatusResponse.kt
@@ -31,6 +31,8 @@ data class RuntimeStatusResponse(
     val sourceModuleNames: List<String> = emptyList(),
     @DocField(description = "Map from source module name to its dependency module names.", defaultValue = "emptyMap()")
     val dependentModuleNamesBySourceModuleName: Map<String, List<String>> = emptyMap(),
+    @DocField(description = "True when the symbol reference index is fully populated.")
+    val referenceIndexReady: Boolean = false,
     @DocField(description = "Protocol schema version for forward compatibility.", serverManaged = true)
     val schemaVersion: Int = SCHEMA_VERSION,
 )

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/wrapper/WrapperContracts.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/wrapper/WrapperContracts.kt
@@ -49,6 +49,67 @@ enum class WrapperScaffoldMode {
 }
 
 @Serializable
+enum class WrapperMetric {
+    @SerialName("fan-in")
+    FAN_IN,
+
+    @SerialName("fan-out")
+    FAN_OUT,
+
+    @SerialName("coupling")
+    COUPLING,
+
+    @SerialName("dead-code")
+    DEAD_CODE,
+
+    @SerialName("impact")
+    IMPACT,
+}
+
+@Serializable
+data class KastMetricsRequest(
+    val workspaceRoot: String? = null,
+    val metric: WrapperMetric,
+    val limit: Int = 50,
+    val symbol: String? = null,
+    val depth: Int = 3,
+)
+
+@Serializable
+data class KastMetricsQuery(
+    @SerialName("workspace_root")
+    val workspaceRoot: String,
+    val metric: WrapperMetric,
+    val limit: Int = 50,
+    val symbol: String? = null,
+    val depth: Int = 3,
+)
+
+@Serializable
+sealed interface KastMetricsResponse
+
+@Serializable
+@SerialName("METRICS_SUCCESS")
+data class KastMetricsSuccessResponse(
+    val ok: Boolean = true,
+    val query: KastMetricsQuery,
+    val results: kotlinx.serialization.json.JsonElement,
+    @SerialName("log_file")
+    val logFile: String,
+) : KastMetricsResponse
+
+@Serializable
+@SerialName("METRICS_FAILURE")
+data class KastMetricsFailureResponse(
+    val ok: Boolean = false,
+    val stage: String,
+    val message: String,
+    val query: KastMetricsQuery,
+    @SerialName("log_file")
+    val logFile: String,
+) : KastMetricsResponse
+
+@Serializable
 data class KastResolveRequest(
     val workspaceRoot: String? = null,
     val symbol: String,

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/BackgroundIndexer.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/BackgroundIndexer.kt
@@ -140,10 +140,14 @@ internal class BackgroundIndexer(
     /**
      * Re-indexes a set of changed file paths incrementally. Skips files that
      * no longer exist on disk (deleted between discovery and read).
+     *
+     * When [referenceScanner] is provided, also triggers an incremental Phase 2
+     * re-scan for the same changed paths after the Phase 1 update completes.
      */
     fun reindexFiles(
         index: MutableSourceIdentifierIndex,
         paths: Set<NormalizedPath>,
+        referenceScanner: ((String) -> List<SymbolReferenceRow>)? = null,
     ) {
         paths.forEach { normalizedPath ->
             val filePath = normalizedPath.toJavaPath()
@@ -160,6 +164,14 @@ internal class BackgroundIndexer(
                 )
                 sourceIndexCache.saveFileIndex(index, normalizedPath)
             }
+        }
+        if (referenceScanner != null) {
+            val changedPathStrings = paths.map { it.value }.toSet()
+            ReferenceIndexer(store, batchSize = PHASE2_BATCH_SIZE).reindexFiles(
+                changedPaths = changedPathStrings,
+                referenceScanner = referenceScanner,
+                isCancelled = { cancelled || Thread.currentThread().isInterrupted },
+            )
         }
     }
 

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -176,6 +176,7 @@ internal class StandaloneAnalysisBackend internal constructor(
             dependentModuleNamesBySourceModuleName = moduleGraph.entries.associate { (module, dependents) ->
                 module.value to dependents.map { it.value }.sorted()
             },
+            referenceIndexReady = session.isReferenceIndexReady(),
         )
     }
 

--- a/docs/examples/runtimeStatus-response.json
+++ b/docs/examples/runtimeStatus-response.json
@@ -10,6 +10,7 @@
         "warnings": [],
         "sourceModuleNames": [],
         "dependentModuleNamesBySourceModuleName": {},
+        "referenceIndexReady": false,
         "schemaVersion": 3
     },
     "id": 1,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -659,6 +659,8 @@ components:
             type: array
             items:
               type: string
+        referenceIndexReady:
+          type: boolean
         schemaVersion:
           type: integer
           format: int32

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -83,6 +83,7 @@ daemon, including input/output schemas, examples, and behavioral notes.
             | `#!kotlin warnings: List<String>` :material-information-outline:{ title="Default: emptyList()" } | Active warning messages about the runtime environment. |
             | `#!kotlin sourceModuleNames: List<String>` :material-information-outline:{ title="Default: emptyList()" } | Names of source modules discovered in the workspace. |
             | `#!kotlin dependentModuleNamesBySourceModuleName: Map<String, List<String>>` :material-information-outline:{ title="Default: emptyMap()" } | Map from source module name to its dependency module names. |
+            | `#!kotlin referenceIndexReady: Boolean?` | True when the symbol reference index is fully populated. |
             | `#!kotlin schemaVersion: Int` | Protocol schema version for forward compatibility. |
         === "CLI"
 
@@ -113,6 +114,7 @@ daemon, including input/output schemas, examples, and behavioral notes.
                     "warnings": [],
                     "sourceModuleNames": [],
                     "dependentModuleNamesBySourceModuleName": {},
+                    "referenceIndexReady": false,
                     "schemaVersion": 3
                 },
                 "id": 1,

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -51,6 +51,7 @@ category. Expand any operation to see its input and output schemas.
             | `#!kotlin warnings: List<String>` :material-information-outline:{ title="Default: emptyList()" } | Active warning messages about the runtime environment. |
             | `#!kotlin sourceModuleNames: List<String>` :material-information-outline:{ title="Default: emptyList()" } | Names of source modules discovered in the workspace. |
             | `#!kotlin dependentModuleNamesBySourceModuleName: Map<String, List<String>>` :material-information-outline:{ title="Default: emptyMap()" } | Map from source module name to its dependency module names. |
+            | `#!kotlin referenceIndexReady: Boolean?` | True when the symbol reference index is fully populated. |
             | `#!kotlin schemaVersion: Int` | Protocol schema version for forward compatibility. |
 
     ??? info "capabilities — Advertised read and mutation capabilities"

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsModels.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsModels.kt
@@ -1,5 +1,8 @@
 package io.github.amichne.kast.indexstore
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class FanInMetric(
     val targetFqName: String,
     val targetPath: String?,
@@ -9,6 +12,7 @@ data class FanInMetric(
     val sourceModuleCount: Int,
 )
 
+@Serializable
 data class FanOutMetric(
     val sourcePath: String,
     val sourceModuleName: String?,
@@ -19,12 +23,14 @@ data class FanOutMetric(
     val externalTargetCount: Int,
 )
 
+@Serializable
 data class ModuleCouplingMetric(
     val sourceModuleName: String,
     val targetModuleName: String,
     val referenceCount: Int,
 )
 
+@Serializable
 data class DeadCodeCandidate(
     val identifier: String,
     val path: String,
@@ -34,6 +40,7 @@ data class DeadCodeCandidate(
     val reason: String,
 )
 
+@Serializable
 data class ChangeImpactNode(
     val sourcePath: String,
     val depth: Int,
@@ -42,10 +49,12 @@ data class ChangeImpactNode(
     val semantics: ImpactSemantics,
 )
 
+@Serializable
 enum class MetricsConfidence {
     LOW,
 }
 
+@Serializable
 enum class ImpactSemantics {
     FILE_LEVEL_APPROXIMATION,
 }

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/ReferenceIndexer.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/ReferenceIndexer.kt
@@ -40,6 +40,18 @@ class ReferenceIndexer(
         }
     }
 
+    fun reindexFiles(
+        changedPaths: Set<String>,
+        referenceScanner: (String) -> List<SymbolReferenceRow>,
+        isCancelled: () -> Boolean = { Thread.currentThread().isInterrupted },
+    ) {
+        indexReferences(
+            filePaths = changedPaths,
+            referenceScanner = referenceScanner,
+            isCancelled = isCancelled,
+        )
+    }
+
     private fun Throwable.isCancellation(): Boolean =
         this is CancellationException ||
             this is InterruptedException ||

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/ReferenceIndexerTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/ReferenceIndexerTest.kt
@@ -128,6 +128,45 @@ class ReferenceIndexerTest {
         }
     }
 
+    @Test
+    fun `reindexFiles replaces references for changed paths only`() {
+        val filePaths = listOf("/src/A.kt", "/src/B.kt")
+        storeWithManifest(*filePaths.toTypedArray()).use { store ->
+            ReferenceIndexer(store).indexReferences(filePaths, referenceScanner = { path ->
+                listOf(
+                    SymbolReferenceRow(
+                        sourcePath = path,
+                        sourceOffset = 0,
+                        targetFqName = "original.Target",
+                        targetPath = null,
+                        targetOffset = null,
+                    ),
+                )
+            })
+            assertEquals(2, store.referencesToSymbol("original.Target").size)
+
+            ReferenceIndexer(store).reindexFiles(
+                changedPaths = setOf("/src/A.kt"),
+                referenceScanner = { path ->
+                    listOf(
+                        SymbolReferenceRow(
+                            sourcePath = path,
+                            sourceOffset = 0,
+                            targetFqName = "updated.Target",
+                            targetPath = null,
+                            targetOffset = null,
+                        ),
+                    )
+                },
+            )
+
+            assertEquals(1, store.referencesToSymbol("original.Target").size)
+            assertEquals("/src/B.kt", store.referencesToSymbol("original.Target").single().sourcePath)
+            assertEquals(1, store.referencesToSymbol("updated.Target").size)
+            assertEquals("/src/A.kt", store.referencesToSymbol("updated.Target").single().sourcePath)
+        }
+    }
+
     private fun storeWithManifest(vararg filePaths: String): SqliteSourceIndexStore {
         val store = SqliteSourceIndexStore(workspaceRoot.toAbsolutePath().normalize())
         store.ensureSchema()

--- a/kast-cli/build.gradle.kts
+++ b/kast-cli/build.gradle.kts
@@ -25,6 +25,7 @@ application {
 
 dependencies {
     api(project(":analysis-api"))
+    implementation(project(":index-store"))
     implementation(libs.coroutines.core)
     implementation(libs.mordant)
     implementation(libs.serialization.json)

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommand.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommand.kt
@@ -47,6 +47,21 @@ internal sealed interface CliCommand {
     data class Smoke(val options: SmokeOptions) : CliCommand
     data class Skill(val name: SkillWrapperName, val rawInput: String) : CliCommand
     data class EvalSkill(val options: EvalSkillOptions) : CliCommand
+    data class Metrics(
+        val subcommand: MetricsSubcommand,
+        val workspaceRoot: java.nio.file.Path,
+        val limit: Int = 50,
+        val symbol: String? = null,
+        val depth: Int = 3,
+    ) : CliCommand
+}
+
+internal enum class MetricsSubcommand {
+    FAN_IN,
+    FAN_OUT,
+    COUPLING,
+    DEAD_CODE,
+    IMPACT,
 }
 
 internal data class EvalSkillOptions(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -30,6 +30,10 @@ internal enum class CliCommandGroup(
         title = "CLI management",
         overview = "Install and manage local Kast CLI instances.",
     ),
+    METRICS(
+        title = "Metrics",
+        overview = "Read-only workspace metrics computed directly from the local SQLite reference index — no running daemon required.",
+    ),
 }
 
 internal enum class CliOptionCompletionKind {
@@ -309,6 +313,21 @@ internal object CliCommandCatalog {
         key = "format",
         usage = "--format=json",
         description = "Render the smoke report as json or markdown. Defaults to json.",
+    )
+    private val metricsLimitOption = CliOptionMetadata(
+        key = "limit",
+        usage = "--limit=50",
+        description = "Maximum number of result rows. Defaults to 50.",
+    )
+    private val metricsSymbolOption = CliOptionMetadata(
+        key = "symbol",
+        usage = "--symbol=com.example.MyClass",
+        description = "Fully qualified symbol name for impact analysis.",
+    )
+    private val metricsDepthOption = CliOptionMetadata(
+        key = "depth",
+        usage = "--depth=3",
+        description = "Maximum edge depth for impact traversal. Defaults to 3.",
     )
 
     private val commands: List<CliCommandMetadata> = listOf(
@@ -822,6 +841,83 @@ internal object CliCommandCatalog {
             summary = "Skill wrapper: list workspace modules and source files.",
             description = "Hidden native skill command. Accepts one JSON request argument.",
             usages = listOf("$CLI_EXECUTABLE_NAME skill workspace-files '{\"workspace_root\":\"/ws\"}'"),
+            visible = false,
+        ),
+        CliCommandMetadata(
+            path = listOf("metrics", "fan-in"),
+            group = CliCommandGroup.METRICS,
+            summary = "Show symbols ranked by incoming reference count (coupling hotspots).",
+            description = "Queries the local SQLite reference index without a running daemon. Returns symbols with the highest inbound reference counts.",
+            usages = listOf(
+                "$CLI_EXECUTABLE_NAME metrics fan-in --workspace-root=/absolute/path/to/workspace [--limit=50]",
+            ),
+            options = listOf(workspaceRootOption, metricsLimitOption),
+            examples = listOf(
+                "$CLI_EXECUTABLE_NAME metrics fan-in --workspace-root=/absolute/path/to/workspace",
+                "$CLI_EXECUTABLE_NAME metrics fan-in --workspace-root=/absolute/path/to/workspace --limit=20",
+            ),
+        ),
+        CliCommandMetadata(
+            path = listOf("metrics", "fan-out"),
+            group = CliCommandGroup.METRICS,
+            summary = "Show files ranked by outgoing reference count (complexity hotspots).",
+            description = "Queries the local SQLite reference index without a running daemon. Returns files with the highest outbound reference counts.",
+            usages = listOf(
+                "$CLI_EXECUTABLE_NAME metrics fan-out --workspace-root=/absolute/path/to/workspace [--limit=50]",
+            ),
+            options = listOf(workspaceRootOption, metricsLimitOption),
+            examples = listOf(
+                "$CLI_EXECUTABLE_NAME metrics fan-out --workspace-root=/absolute/path/to/workspace",
+                "$CLI_EXECUTABLE_NAME metrics fan-out --workspace-root=/absolute/path/to/workspace --limit=20",
+            ),
+        ),
+        CliCommandMetadata(
+            path = listOf("metrics", "coupling"),
+            group = CliCommandGroup.METRICS,
+            summary = "Show cross-module reference counts.",
+            description = "Queries the local SQLite reference index without a running daemon. Returns module pairs with cross-module reference counts.",
+            usages = listOf(
+                "$CLI_EXECUTABLE_NAME metrics coupling --workspace-root=/absolute/path/to/workspace",
+            ),
+            options = listOf(workspaceRootOption),
+            examples = listOf(
+                "$CLI_EXECUTABLE_NAME metrics coupling --workspace-root=/absolute/path/to/workspace",
+            ),
+        ),
+        CliCommandMetadata(
+            path = listOf("metrics", "dead-code"),
+            group = CliCommandGroup.METRICS,
+            summary = "Show symbols with zero incoming references.",
+            description = "Queries the local SQLite reference index without a running daemon. Returns indexed identifiers that have no inbound symbol references.",
+            usages = listOf(
+                "$CLI_EXECUTABLE_NAME metrics dead-code --workspace-root=/absolute/path/to/workspace",
+            ),
+            options = listOf(workspaceRootOption),
+            examples = listOf(
+                "$CLI_EXECUTABLE_NAME metrics dead-code --workspace-root=/absolute/path/to/workspace",
+            ),
+        ),
+        CliCommandMetadata(
+            path = listOf("metrics", "impact"),
+            group = CliCommandGroup.METRICS,
+            summary = "Show transitive change impact radius for a symbol.",
+            description = "Queries the local SQLite reference index without a running daemon. Walks incoming reference edges up to --depth levels to estimate which files are transitively affected by a change to --symbol.",
+            usages = listOf(
+                "$CLI_EXECUTABLE_NAME metrics impact --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass [--depth=3]",
+            ),
+            options = listOf(workspaceRootOption, metricsSymbolOption, metricsDepthOption),
+            examples = listOf(
+                "$CLI_EXECUTABLE_NAME metrics impact --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass",
+                "$CLI_EXECUTABLE_NAME metrics impact --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass --depth=5",
+            ),
+        ),
+        // Skill wrapper: metrics — hidden, called by agent shell scripts
+        CliCommandMetadata(
+            path = listOf("skill", "metrics"),
+            group = CliCommandGroup.METRICS,
+            summary = "Skill wrapper: query workspace metrics from the local reference index.",
+            description = "Hidden native skill command. Accepts one JSON request argument.",
+            usages = listOf("$CLI_EXECUTABLE_NAME skill metrics '{\"workspaceRoot\":\"/ws\",\"metric\":\"fan-in\"}'"),
             visible = false,
         ),
         CliCommandMetadata(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
@@ -119,6 +119,33 @@ internal class CliCommandParser(
                 listOf("install", "skill") -> CliCommand.InstallSkill(parsed.installSkillOptions())
                 listOf("smoke") -> CliCommand.Smoke(parsed.smokeOptions())
                 listOf("eval", "skill") -> CliCommand.EvalSkill(parsed.evalSkillOptions())
+                listOf("metrics", "fan-in") -> CliCommand.Metrics(
+                    subcommand = MetricsSubcommand.FAN_IN,
+                    workspaceRoot = parsed.requireWorkspaceRootPath(),
+                    limit = parsed.optionalInt("limit") ?: 50,
+                )
+                listOf("metrics", "fan-out") -> CliCommand.Metrics(
+                    subcommand = MetricsSubcommand.FAN_OUT,
+                    workspaceRoot = parsed.requireWorkspaceRootPath(),
+                    limit = parsed.optionalInt("limit") ?: 50,
+                )
+                listOf("metrics", "coupling") -> CliCommand.Metrics(
+                    subcommand = MetricsSubcommand.COUPLING,
+                    workspaceRoot = parsed.requireWorkspaceRootPath(),
+                )
+                listOf("metrics", "dead-code") -> CliCommand.Metrics(
+                    subcommand = MetricsSubcommand.DEAD_CODE,
+                    workspaceRoot = parsed.requireWorkspaceRootPath(),
+                )
+                listOf("metrics", "impact") -> CliCommand.Metrics(
+                    subcommand = MetricsSubcommand.IMPACT,
+                    workspaceRoot = parsed.requireWorkspaceRootPath(),
+                    symbol = parsed.options["symbol"] ?: throw CliFailure(
+                        code = "CLI_USAGE",
+                        message = "--symbol is required for metrics impact",
+                    ),
+                    depth = parsed.optionalInt("depth") ?: 3,
+                )
                 else -> throw CliFailure(
                     code = "CLI_USAGE",
                     message = "Unknown command: ${metadata.commandText}",
@@ -623,6 +650,17 @@ internal data class ParsedArguments(
     ): Boolean = options[key]?.toBooleanStrictOrNull() ?: default
 
     private fun absoluteFilePath(value: String): String = Path.of(value).toAbsolutePath().normalize().toString()
+
+    fun requireWorkspaceRootPath(): Path {
+        val raw = options["workspace-root"]
+            ?: throw CliFailure(
+                code = "CLI_USAGE",
+                message = "Missing required option --workspace-root",
+            )
+        return Path.of(raw).toAbsolutePath().normalize()
+    }
+
+    fun optionalInt(key: String): Int? = options[key]?.toIntOrNull()
 }
 
 private fun ParsedArguments.parseBool(key: String): Boolean = when (options[key]?.lowercase()) {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
@@ -2,6 +2,7 @@ package io.github.amichne.kast.cli
 
 import io.github.amichne.kast.cli.skill.SkillWrapperExecutor
 import io.github.amichne.kast.cli.skill.SkillWrapperSerializer
+import io.github.amichne.kast.indexstore.MetricsEngine
 import kotlinx.serialization.json.Json
 import java.nio.file.Path
 
@@ -235,6 +236,22 @@ internal class DefaultCliCommandExecutor(
             is CliCommand.EvalSkill -> {
                 val result = EvalSkillExecutor(json).execute(command.options)
                 CliExecutionResult(output = result)
+            }
+
+            is CliCommand.Metrics -> {
+                MetricsEngine(command.workspaceRoot).use { engine ->
+                    val result = when (command.subcommand) {
+                        MetricsSubcommand.FAN_IN -> engine.fanInRanking(command.limit)
+                        MetricsSubcommand.FAN_OUT -> engine.fanOutRanking(command.limit)
+                        MetricsSubcommand.COUPLING -> engine.moduleCouplingMatrix()
+                        MetricsSubcommand.DEAD_CODE -> engine.deadCodeCandidates()
+                        MetricsSubcommand.IMPACT -> engine.changeImpactRadius(
+                            fqName = requireNotNull(command.symbol) { "--symbol is required for impact" },
+                            depth = command.depth,
+                        )
+                    }
+                    CliExecutionResult(output = CliOutput.JsonValue(result))
+                }
             }
         }
     }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt
@@ -54,7 +54,12 @@ import io.github.amichne.kast.api.wrapper.KastWriteAndValidateReplaceRangeReques
 import io.github.amichne.kast.api.wrapper.KastWriteAndValidateRequest
 import io.github.amichne.kast.api.wrapper.KastWriteAndValidateSuccessResponse
 import io.github.amichne.kast.api.wrapper.KastCandidate
+import io.github.amichne.kast.api.wrapper.KastMetricsQuery
+import io.github.amichne.kast.api.wrapper.KastMetricsRequest
+import io.github.amichne.kast.api.wrapper.KastMetricsSuccessResponse
+import io.github.amichne.kast.api.wrapper.WrapperMetric
 import io.github.amichne.kast.api.wrapper.WrapperScaffoldMode
+import io.github.amichne.kast.indexstore.MetricsEngine
 import io.github.amichne.kast.api.contract.ReferencesQuery
 import io.github.amichne.kast.api.contract.RenameQuery
 import io.github.amichne.kast.api.contract.SemanticInsertionQuery
@@ -93,6 +98,7 @@ internal class SkillWrapperExecutor(
             SkillWrapperName.RENAME -> executeRename(rawJson)
             SkillWrapperName.SCAFFOLD -> executeScaffold(rawJson)
             SkillWrapperName.WRITE_AND_VALIDATE -> executeWriteAndValidate(rawJson)
+            SkillWrapperName.METRICS -> executeMetrics(rawJson)
         }
     }
 
@@ -725,6 +731,58 @@ internal class SkillWrapperExecutor(
         throw CliFailure(
             code = "SKILL_VALIDATION",
             message = "Either 'content' or 'contentFile' must be provided",
+        )
+    }
+
+    // endregion
+
+    // region metrics
+
+    private fun executeMetrics(rawJson: String): Any {
+        val request = json.decodeFromString<KastMetricsRequest>(rawJson)
+        val workspaceRoot = requireWorkspaceRoot(request.workspaceRoot)
+        val query = KastMetricsQuery(
+            workspaceRoot = workspaceRoot,
+            metric = request.metric,
+            limit = request.limit,
+            symbol = request.symbol,
+            depth = request.depth,
+        )
+        val resultsJson = MetricsEngine(Path.of(workspaceRoot)).use { engine ->
+            when (request.metric) {
+                WrapperMetric.FAN_IN -> json.encodeToJsonElement(
+                    kotlinx.serialization.builtins.ListSerializer(io.github.amichne.kast.indexstore.FanInMetric.serializer()),
+                    engine.fanInRanking(request.limit),
+                )
+                WrapperMetric.FAN_OUT -> json.encodeToJsonElement(
+                    kotlinx.serialization.builtins.ListSerializer(io.github.amichne.kast.indexstore.FanOutMetric.serializer()),
+                    engine.fanOutRanking(request.limit),
+                )
+                WrapperMetric.COUPLING -> json.encodeToJsonElement(
+                    kotlinx.serialization.builtins.ListSerializer(io.github.amichne.kast.indexstore.ModuleCouplingMetric.serializer()),
+                    engine.moduleCouplingMatrix(),
+                )
+                WrapperMetric.DEAD_CODE -> json.encodeToJsonElement(
+                    kotlinx.serialization.builtins.ListSerializer(io.github.amichne.kast.indexstore.DeadCodeCandidate.serializer()),
+                    engine.deadCodeCandidates(),
+                )
+                WrapperMetric.IMPACT -> json.encodeToJsonElement(
+                    kotlinx.serialization.builtins.ListSerializer(io.github.amichne.kast.indexstore.ChangeImpactNode.serializer()),
+                    engine.changeImpactRadius(
+                        fqName = request.symbol ?: throw CliFailure(
+                            code = "SKILL_VALIDATION",
+                            message = "'symbol' is required for impact metric",
+                        ),
+                        depth = request.depth,
+                    ),
+                )
+            }
+        }
+        return KastMetricsSuccessResponse(
+            ok = true,
+            query = query,
+            results = resultsJson,
+            logFile = SkillLogFile.placeholder(),
         )
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperName.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperName.kt
@@ -13,6 +13,7 @@ internal enum class SkillWrapperName(val cliName: String) {
     SCAFFOLD("scaffold"),
     WRITE_AND_VALIDATE("write-and-validate"),
     WORKSPACE_FILES("workspace-files"),
+    METRICS("metrics"),
     ;
 
     companion object {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperSerializer.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperSerializer.kt
@@ -2,6 +2,7 @@ package io.github.amichne.kast.cli.skill
 
 import io.github.amichne.kast.api.wrapper.KastCallersResponse
 import io.github.amichne.kast.api.wrapper.KastDiagnosticsResponse
+import io.github.amichne.kast.api.wrapper.KastMetricsResponse
 import io.github.amichne.kast.api.wrapper.KastReferencesResponse
 import io.github.amichne.kast.api.wrapper.KastRenameResponse
 import io.github.amichne.kast.api.wrapper.KastResolveResponse
@@ -37,5 +38,7 @@ internal object SkillWrapperSerializer {
             json.encodeToString(KastWorkspaceFilesResponse.serializer(), response as KastWorkspaceFilesResponse)
         SkillWrapperName.WRITE_AND_VALIDATE ->
             json.encodeToString(KastWriteAndValidateResponse.serializer(), response as KastWriteAndValidateResponse)
+        SkillWrapperName.METRICS ->
+            json.encodeToString(KastMetricsResponse.serializer(), response as KastMetricsResponse)
     }
 }

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
@@ -577,4 +577,90 @@ class CliCommandParserTest {
         assertEquals(7, completionsCommand.query.maxResults)
         assertEquals(setOf(SymbolKind.FUNCTION, SymbolKind.CLASS), completionsCommand.query.kindFilter)
     }
+
+    @Test
+    fun `metrics fan-in parses with defaults`() {
+        val command = parser.parse(
+            arrayOf("metrics", "fan-in", "--workspace-root=$tempDir"),
+        )
+
+        assertTrue(command is CliCommand.Metrics)
+        val metrics = command as CliCommand.Metrics
+        assertEquals(MetricsSubcommand.FAN_IN, metrics.subcommand)
+        assertEquals(tempDir.toAbsolutePath().normalize(), metrics.workspaceRoot)
+        assertEquals(50, metrics.limit)
+    }
+
+    @Test
+    fun `metrics fan-out parses with custom limit`() {
+        val command = parser.parse(
+            arrayOf("metrics", "fan-out", "--workspace-root=$tempDir", "--limit=20"),
+        )
+
+        assertTrue(command is CliCommand.Metrics)
+        val metrics = command as CliCommand.Metrics
+        assertEquals(MetricsSubcommand.FAN_OUT, metrics.subcommand)
+        assertEquals(20, metrics.limit)
+    }
+
+    @Test
+    fun `metrics coupling parses`() {
+        val command = parser.parse(
+            arrayOf("metrics", "coupling", "--workspace-root=$tempDir"),
+        )
+
+        assertTrue(command is CliCommand.Metrics)
+        assertEquals(MetricsSubcommand.COUPLING, (command as CliCommand.Metrics).subcommand)
+    }
+
+    @Test
+    fun `metrics dead-code parses`() {
+        val command = parser.parse(
+            arrayOf("metrics", "dead-code", "--workspace-root=$tempDir"),
+        )
+
+        assertTrue(command is CliCommand.Metrics)
+        assertEquals(MetricsSubcommand.DEAD_CODE, (command as CliCommand.Metrics).subcommand)
+    }
+
+    @Test
+    fun `metrics impact parses with required symbol`() {
+        val command = parser.parse(
+            arrayOf("metrics", "impact", "--workspace-root=$tempDir", "--symbol=com.example.Foo"),
+        )
+
+        assertTrue(command is CliCommand.Metrics)
+        val metrics = command as CliCommand.Metrics
+        assertEquals(MetricsSubcommand.IMPACT, metrics.subcommand)
+        assertEquals("com.example.Foo", metrics.symbol)
+        assertEquals(3, metrics.depth)
+    }
+
+    @Test
+    fun `metrics impact with custom depth`() {
+        val command = parser.parse(
+            arrayOf("metrics", "impact", "--workspace-root=$tempDir", "--symbol=com.example.Foo", "--depth=5"),
+        )
+
+        val metrics = command as CliCommand.Metrics
+        assertEquals(5, metrics.depth)
+    }
+
+    @Test
+    fun `metrics impact fails without symbol`() {
+        assertThrows<CliFailure> {
+            parser.parse(
+                arrayOf("metrics", "impact", "--workspace-root=$tempDir"),
+            )
+        }
+    }
+
+    @Test
+    fun `metrics fails without workspace-root`() {
+        assertThrows<CliFailure> {
+            parser.parse(
+                arrayOf("metrics", "fan-in"),
+            )
+        }
+    }
 }

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/adapter/SkillAdapterTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/adapter/SkillAdapterTest.kt
@@ -185,7 +185,7 @@ class SkillAdapterTest {
         val skillDir = createMinimalSkill()
         val descriptor = SkillAdapter(skillDir).scan()
         val completenessChecks = descriptor.checks.filter { it.category == "completeness" }
-        assertEquals(8, completenessChecks.size, "Should have one completeness check per wrapper")
+        assertEquals(9, completenessChecks.size, "Should have one completeness check per wrapper")
         assertTrue(completenessChecks.all { it.status == EvalStatus.PASS })
     }
 
@@ -213,6 +213,7 @@ class SkillAdapterTest {
             kast skill scaffold
             kast skill write-and-validate
             kast skill workspace-files
+            kast skill metrics
             """.trimIndent(),
         )
 
@@ -236,6 +237,7 @@ class SkillAdapterTest {
             x-command: kast skill scaffold
             x-command: kast skill write-and-validate
             x-command: kast skill workspace-files
+            x-command: kast skill metrics
             """.trimIndent(),
         )
 


### PR DESCRIPTION
## Summary

Implements Phases 2–5 of the MetricsEngine workspace metrics plan. Phase 1 (MetricsEngine + data classes + tests) was already complete on `main`.

### Phase 2: CLI surface
- `kast-cli` now depends on `index-store`
- Five new CLI commands under `metrics` namespace: `fan-in`, `fan-out`, `coupling`, `dead-code`, `impact`
- `CliCommand.Metrics` variant with `MetricsSubcommand` enum
- Parser support for `--workspace-root` (required), `--limit`, `--symbol` (impact only), `--depth`
- Executor opens SQLite directly — no running daemon needed
- Parser tests for all metrics commands including error cases

### Phase 3: Skill wrapper for agents
- `METRICS("metrics")` added to `SkillWrapperName`
- `KastMetricsRequest` / `KastMetricsSuccessResponse` / `KastMetricsFailureResponse` wrapper types in `analysis-api`
- `WrapperMetric` enum for `fan-in|fan-out|coupling|dead-code|impact`
- `executeMetrics` in `SkillWrapperExecutor` — reads SQLite directly, serializes results as `JsonElement`
- Serialization support in `SkillWrapperSerializer`
- Hidden `skill metrics` catalog entry + AGENTS.md routing table entry

### Phase 4: Incremental reference updates
- `ReferenceIndexer.reindexFiles(changedPaths, scanner)` delegates to `indexReferences` for changed paths only
- `BackgroundIndexer.reindexFiles` accepts optional `referenceScanner` callback — when provided, triggers Phase 2 incremental re-scan after Phase 1 update
- Test verifying incremental reindex replaces only changed-path references

### Phase 5: Reference index readiness
- `referenceIndexReady: Boolean = false` added to `RuntimeStatusResponse` with `@DocField`
- Standalone backend wires `session.isReferenceIndexReady()`
- IntelliJ backend defaults to `false` (no Phase 2 indexer yet)
- Regenerated docs, OpenAPI spec, and doc examples

### Metrics model changes
- Added `@Serializable` to all metrics data classes and enums in `index-store` to support `json.encodeToJsonElement` in the skill wrapper

## Review & Testing Checklist for Human
- [ ] Verify `kast metrics fan-in --workspace-root=<path>` works against a workspace with a populated `source-index.db`
- [ ] Verify `kast skill metrics '{"workspaceRoot":"/ws","metric":"fan-in"}'` returns valid JSON
- [ ] Verify `kast workspace status` now includes `referenceIndexReady` in its output
- [ ] Confirm incremental reindex updates symbol_references correctly after file modifications
- [ ] Review the `WrapperMetric` enum values match the CLI subcommand names exactly

Recommended test plan: build the project, index a workspace (`kast workspace ensure`), then exercise each metrics subcommand and the skill wrapper against the populated index.

### Notes
- The `@Serializable` annotations on `MetricsModels.kt` are needed for the skill wrapper's `json.encodeToJsonElement` calls — `index-store` already had the serialization plugin and dependency.
- `BackgroundIndexer.reindexFiles` is backward-compatible: the new `referenceScanner` parameter defaults to `null`, preserving existing call sites.


Link to Devin session: https://app.devin.ai/sessions/99bb631bdec14e8b8974936a09db9de4
Requested by: @amichne