### PR TITLE
fix: metrics CLI serialization crash and doc nullability for referenceIndexReady

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/RuntimeStatusResponse.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/RuntimeStatusResponse.kt
@@ -31,7 +31,7 @@ data class RuntimeStatusResponse(
     val sourceModuleNames: List<String> = emptyList(),
     @DocField(description = "Map from source module name to its dependency module names.", defaultValue = "emptyMap()")
     val dependentModuleNamesBySourceModuleName: Map<String, List<String>> = emptyMap(),
-    @DocField(description = "True when the symbol reference index is fully populated.")
+    @DocField(description = "True when the symbol reference index is fully populated.", defaultValue = "false")
     val referenceIndexReady: Boolean = false,
     @DocField(description = "Protocol schema version for forward compatibility.", serverManaged = true)
     val schemaVersion: Int = SCHEMA_VERSION,

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -83,7 +83,7 @@ daemon, including input/output schemas, examples, and behavioral notes.
             | `#!kotlin warnings: List<String>` :material-information-outline:{ title="Default: emptyList()" } | Active warning messages about the runtime environment. |
             | `#!kotlin sourceModuleNames: List<String>` :material-information-outline:{ title="Default: emptyList()" } | Names of source modules discovered in the workspace. |
             | `#!kotlin dependentModuleNamesBySourceModuleName: Map<String, List<String>>` :material-information-outline:{ title="Default: emptyMap()" } | Map from source module name to its dependency module names. |
-            | `#!kotlin referenceIndexReady: Boolean?` | True when the symbol reference index is fully populated. |
+            | `#!kotlin referenceIndexReady: Boolean` :material-information-outline:{ title="Default: false" } | True when the symbol reference index is fully populated. |
             | `#!kotlin schemaVersion: Int` | Protocol schema version for forward compatibility. |
         === "CLI"
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -51,7 +51,7 @@ category. Expand any operation to see its input and output schemas.
             | `#!kotlin warnings: List<String>` :material-information-outline:{ title="Default: emptyList()" } | Active warning messages about the runtime environment. |
             | `#!kotlin sourceModuleNames: List<String>` :material-information-outline:{ title="Default: emptyList()" } | Names of source modules discovered in the workspace. |
             | `#!kotlin dependentModuleNamesBySourceModuleName: Map<String, List<String>>` :material-information-outline:{ title="Default: emptyMap()" } | Map from source module name to its dependency module names. |
-            | `#!kotlin referenceIndexReady: Boolean?` | True when the symbol reference index is fully populated. |
+            | `#!kotlin referenceIndexReady: Boolean` :material-information-outline:{ title="Default: false" } | True when the symbol reference index is fully populated. |
             | `#!kotlin schemaVersion: Int` | Protocol schema version for forward compatibility. |
 
     ??? info "capabilities — Advertised read and mutation capabilities"

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
@@ -2,7 +2,13 @@ package io.github.amichne.kast.cli
 
 import io.github.amichne.kast.cli.skill.SkillWrapperExecutor
 import io.github.amichne.kast.cli.skill.SkillWrapperSerializer
+import io.github.amichne.kast.indexstore.ChangeImpactNode
+import io.github.amichne.kast.indexstore.DeadCodeCandidate
+import io.github.amichne.kast.indexstore.FanInMetric
+import io.github.amichne.kast.indexstore.FanOutMetric
 import io.github.amichne.kast.indexstore.MetricsEngine
+import io.github.amichne.kast.indexstore.ModuleCouplingMetric
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import java.nio.file.Path
 
@@ -239,19 +245,30 @@ internal class DefaultCliCommandExecutor(
             }
 
             is CliCommand.Metrics -> {
-                MetricsEngine(command.workspaceRoot).use { engine ->
-                    val result = when (command.subcommand) {
-                        MetricsSubcommand.FAN_IN -> engine.fanInRanking(command.limit)
-                        MetricsSubcommand.FAN_OUT -> engine.fanOutRanking(command.limit)
-                        MetricsSubcommand.COUPLING -> engine.moduleCouplingMatrix()
-                        MetricsSubcommand.DEAD_CODE -> engine.deadCodeCandidates()
-                        MetricsSubcommand.IMPACT -> engine.changeImpactRadius(
-                            fqName = requireNotNull(command.symbol) { "--symbol is required for impact" },
-                            depth = command.depth,
+                val encoded = MetricsEngine(command.workspaceRoot).use { engine ->
+                    when (command.subcommand) {
+                        MetricsSubcommand.FAN_IN -> json.encodeToString(
+                            ListSerializer(FanInMetric.serializer()), engine.fanInRanking(command.limit),
+                        )
+                        MetricsSubcommand.FAN_OUT -> json.encodeToString(
+                            ListSerializer(FanOutMetric.serializer()), engine.fanOutRanking(command.limit),
+                        )
+                        MetricsSubcommand.COUPLING -> json.encodeToString(
+                            ListSerializer(ModuleCouplingMetric.serializer()), engine.moduleCouplingMatrix(),
+                        )
+                        MetricsSubcommand.DEAD_CODE -> json.encodeToString(
+                            ListSerializer(DeadCodeCandidate.serializer()), engine.deadCodeCandidates(),
+                        )
+                        MetricsSubcommand.IMPACT -> json.encodeToString(
+                            ListSerializer(ChangeImpactNode.serializer()),
+                            engine.changeImpactRadius(
+                                fqName = requireNotNull(command.symbol) { "--symbol is required for impact" },
+                                depth = command.depth,
+                            ),
                         )
                     }
-                    CliExecutionResult(output = CliOutput.JsonValue(result))
                 }
+                CliExecutionResult(output = CliOutput.Text(encoded))
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes two issues identified by Devin Review on #111:

### 1. Metrics CLI crash (`CliExecution.kt`)
The `CliCommand.Metrics` handler wrapped raw `List<FanInMetric>`, `List<FanOutMetric>`, etc. in `CliOutput.JsonValue(result)`. The `writeCliJson` function in `CliJson.kt` has no branch for these types and falls through to `error("Unsupported CLI output type: ...")`, crashing every `kast metrics` subcommand.

**Fix:** Serialize each metrics result with an explicit `ListSerializer(T.serializer())` inside the handler (matching how the skill wrapper already works), then emit as `CliOutput.Text(encoded)` which bypasses `writeCliJson` entirely.

### 2. Doc nullability (`RuntimeStatusResponse`)
The `referenceIndexReady: Boolean = false` field was rendered as `Boolean?` in the generated docs (`api-reference.md`, `capabilities.md`) because the `@DocField` annotation lacked `defaultValue`. The doc generator treats optional fields without an explicit default annotation as nullable.

**Fix:** Added `defaultValue = "false"` to the `@DocField` annotation, which routes through the correct generator branch that renders `Boolean` with a `Default: false` tooltip.

## Review & Testing Checklist for Human
- [ ] Run `kast metrics fan-in --workspace-root=<path>` against a workspace with a populated `source-index.db` — should output valid JSON instead of crashing
- [ ] Verify `docs/reference/api-reference.md` shows `referenceIndexReady: Boolean` (not `Boolean?`)

### Notes
- The skill wrapper path (`kast skill metrics`) was already unaffected — it serializes via `json.encodeToJsonElement` with explicit serializers and emits `CliOutput.Text`.
- No new tests added; the existing parser tests validate argument handling, and the fix changes output serialization only. End-to-end validation requires a populated SQLite index.


Link to Devin session: https://app.devin.ai/sessions/99bb631bdec14e8b8974936a09db9de4
Requested by: @amichne