### PR TITLE
Add standalone backend release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,6 +324,72 @@ jobs:
             backend-intellij/build/distributions/
           if-no-files-found: warn
 
+  build-standalone-backend:
+    name: Build standalone backend
+    needs: [bump-version, prepare-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Build standalone backend
+        run: ./kast.sh build backend
+
+      - name: Upload standalone backend asset
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          asset_name="kast-standalone-${tag}.zip"
+
+          source_zip="dist/backend.zip"
+          [[ -f "$source_zip" ]] || { echo "Backend zip not found: $source_zip" >&2; exit 1; }
+
+          mkdir -p dist
+          cp "$source_zip" "dist/${asset_name}"
+          gh release upload "$tag" "dist/${asset_name}" --clobber
+
+      - name: Write standalone backend build provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cat > dist/build-provenance-standalone.json <<PROVEOF
+          {
+            "runId": "${{ github.run_id }}",
+            "runNumber": "${{ github.run_number }}",
+            "runAttempt": "${{ github.run_attempt }}",
+            "sha": "${{ github.sha }}",
+            "ref": "${{ github.ref }}",
+            "workflowRef": "${{ github.workflow_ref }}",
+            "actor": "${{ github.actor }}",
+            "platformId": "standalone",
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          PROVEOF
+
+      - name: Upload standalone backend artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: standalone-backend-${{ github.run_id }}
+          path: |
+            dist/
+            backend-standalone/build/distributions/
+          if-no-files-found: warn
+
   publish-release:
     name: Publish release
     needs:
@@ -331,6 +397,7 @@ jobs:
       - prepare-release
       - build-and-upload
       - build-intellij-plugin
+      - build-standalone-backend
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -349,6 +416,12 @@ jobs:
           path: provenance-intellij
           pattern: intellij-plugin-*
 
+      - name: Download standalone backend provenance
+        uses: actions/download-artifact@v4
+        with:
+          path: provenance-standalone
+          pattern: standalone-backend-*
+
       - name: Assemble combined provenance
         shell: bash
         run: |
@@ -357,7 +430,7 @@ jobs:
 
           # Collect all individual provenance files into a JSON array
           provenance_files=()
-          for f in provenance-artifacts/*/dist/build-provenance-*.json provenance-intellij/*/dist/build-provenance-*.json; do
+          for f in provenance-artifacts/*/dist/build-provenance-*.json provenance-intellij/*/dist/build-provenance-*.json provenance-standalone/*/dist/build-provenance-*.json; do
             [[ -f "$f" ]] || continue
             provenance_files+=("$f")
           done

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ planned edit is safe to apply.
 `kast` has two independent runtime modes:
 
 - **Standalone CLI + backend** — install the `kast` CLI and run
-  `kast-standalone` to start the analysis backend. Fully independent from
+  `kast daemon start` to start the analysis backend. Fully independent from
   IntelliJ; works in terminals, CI, and headless agents.
 - **IntelliJ plugin-backed runtime** — runs inside IntelliJ IDEA and reuses the
   IDE's already-open project model, indexes, and analysis session.
@@ -37,13 +37,13 @@ Then start the standalone backend before running analysis commands:
 
 ```console
 # Start the backend (keep running in background or separate terminal)
-kast-standalone --workspace-root=/path/to/your/workspace
+kast daemon start --workspace-root=/path/to/your/workspace
 
 # Once READY, run commands from another shell
 kast resolve --workspace-root=/path/to/your/workspace --file-path=... --offset=42
 ```
 
-If IntelliJ with the plugin is already open on the project, skip `kast-standalone` —
+If IntelliJ with the plugin is already open on the project, skip `kast daemon start` —
 the CLI connects to the IDE's backend automatically.
 
 ## Why `kast` instead of text search?

--- a/docs/getting-started/backends.md
+++ b/docs/getting-started/backends.md
@@ -38,6 +38,19 @@ What you gain from this path is operational independence. You can run
 the same compiler-backed queries anywhere Java 21 is available, even if
 no editor is open.
 
+Install the standalone backend from releases with:
+
+```console title="Install the standalone backend"
+./kast.sh install --components=backend
+```
+
+This places a `kast-standalone` launcher in your `bin` directory. You
+can also install the CLI and standalone backend together:
+
+```console title="Install CLI and standalone backend"
+./kast.sh install --components=cli,backend --non-interactive
+```
+
 The standalone backend works like this:
 
 1. You run `kast-standalone --workspace-root=<path>` in a terminal or

--- a/docs/getting-started/backends.md
+++ b/docs/getting-started/backends.md
@@ -24,7 +24,7 @@ Use this table to decide which runtime mode matches your environment.
 ## Standalone backend
 
 The standalone backend runs as an independent JVM process outside the
-IDE. You start it explicitly with `kast-standalone`, and it keeps
+IDE. You start it explicitly with `kast daemon start`, and it keeps
 semantic state warm for subsequent `kast` commands.
 
 Use this path when you want:
@@ -44,7 +44,7 @@ Install the standalone backend from releases with:
 ./kast.sh install --components=backend
 ```
 
-This places a `kast-standalone` launcher in your `bin` directory. You
+This places the standalone backend in your install root. You
 can also install the CLI and standalone backend together:
 
 ```console title="Install CLI and standalone backend"
@@ -53,7 +53,7 @@ can also install the CLI and standalone backend together:
 
 The standalone backend works like this:
 
-1. You run `kast-standalone --workspace-root=<path>` in a terminal or
+1. You run `kast daemon start --workspace-root=<path>` in a terminal or
    background process. It starts, discovers the project, and prints
    `READY` when the analysis session is warm.
 2. You run `kast` commands from another shell, targeting the same
@@ -117,18 +117,19 @@ these rules:
 
 1. If a servable IntelliJ backend is already running for that workspace,
    the CLI prefers it.
-2. Otherwise, if a servable standalone backend (`kast-standalone`) exists
+2. Otherwise, if a servable standalone backend exists
    for that workspace, the CLI reuses it.
 3. Otherwise, the CLI returns an error: no backend is available.
 
-The CLI never starts a backend for you. You must start `kast-standalone`
+The CLI never starts a backend for you. You must run `kast daemon start`
 yourself (or have IntelliJ open with the plugin) before running analysis
 commands.
 
 `kast workspace status` reports the current backend state and helps
-diagnose connection problems. To use the standalone path, open the
-project in `kast-standalone` before running commands. To use the plugin
-path, open the project in IntelliJ IDEA with the plugin installed.
+diagnose connection problems. To use the standalone path, start the
+backend with `kast daemon start --workspace-root=<path>` before running
+commands. To use the plugin path, open the project in IntelliJ IDEA with
+the plugin installed.
 
 ## Using both
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -87,7 +87,7 @@ components.
     install it from disk in IntelliJ: **Settings → Plugins → ⚙️ →
     Install Plugin from Disk**. This path does not require the `kast` CLI.
 
-=== "Both"
+=== "CLI and IntelliJ plugin"
 
     ```console title="Install CLI and IntelliJ plugin"
     ./kast.sh install --components=cli,intellij --non-interactive

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -16,7 +16,7 @@ the work). You install and start them separately.
 |---------------|--------------|---------------------------|
 | Terminal, CI, or agent work | `kast` CLI + standalone backend | `kast-standalone --workspace-root=<path>` |
 | IDE-backed runtime (IntelliJ already open) | IntelliJ plugin | The plugin starts automatically when IntelliJ opens the project |
-| Both | CLI + plugin | Pick the backend you want for each session |
+| Both | CLI + plugin + standalone backend | Pick the backend you want for each session |
 
 The CLI alone does not run analysis. It routes commands to a running backend.
 You must have at least one backend running before `kast` analysis commands
@@ -63,6 +63,20 @@ components.
     before analysis commands work. Start `kast-standalone` separately, or
     open the project in IntelliJ with the plugin installed.
 
+=== "Standalone backend"
+
+    ```console title="Install CLI and standalone backend"
+    ./kast.sh install --components=cli,backend --non-interactive
+    ```
+
+    Installs the `kast` CLI and the standalone JVM backend. A
+    `kast-standalone` launcher is placed in your `bin` directory. Start
+    the backend with:
+
+    ```console title="Start the standalone backend"
+    kast-standalone --workspace-root=/absolute/path/to/workspace
+    ```
+
 === "IntelliJ plugin only"
 
     ```console title="Install the IntelliJ plugin"
@@ -76,11 +90,20 @@ components.
 === "Both"
 
     ```console title="Install CLI and IntelliJ plugin"
-    ./kast.sh install --components=all --non-interactive
+    ./kast.sh install --components=cli,intellij --non-interactive
     ```
 
     Installs the `kast` CLI and downloads the IntelliJ plugin zip
     in one step. Add `--non-interactive` to skip prompts.
+
+=== "All three"
+
+    ```console title="Install CLI, IntelliJ plugin, and standalone backend"
+    ./kast.sh install --components=all --non-interactive
+    ```
+
+    Installs the `kast` CLI, the IntelliJ plugin zip, and the standalone
+    backend in one step.
 
 ## Starting the standalone backend
 
@@ -105,7 +128,7 @@ kast daemon stop --workspace-root=/absolute/path/to/your/workspace
 
 | Flag | What it does |
 |------|--------------|
-| `--components=<list>` | Comma-separated: `cli`, `intellij`, `all`. Default: `cli` |
+| `--components=<list>` | Comma-separated: `cli`, `intellij`, `backend`, `all`. Default: `cli` |
 | `--non-interactive` | Skip all interactive prompts |
 
 ## When Gradle files matter

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -14,7 +14,7 @@ the work). You install and start them separately.
 
 | What you want | Install this | How you start the backend |
 |---------------|--------------|---------------------------|
-| Terminal, CI, or agent work | `kast` CLI + standalone backend | `kast-standalone --workspace-root=<path>` |
+| Terminal, CI, or agent work | `kast` CLI + standalone backend | `kast daemon start --workspace-root=<path>` |
 | IDE-backed runtime (IntelliJ already open) | IntelliJ plugin | The plugin starts automatically when IntelliJ opens the project |
 | Both | CLI + plugin + standalone backend | Pick the backend you want for each session |
 
@@ -60,8 +60,8 @@ components.
     ```
 
     Installs the native `kast` launcher. You still need a backend running
-    before analysis commands work. Start `kast-standalone` separately, or
-    open the project in IntelliJ with the plugin installed.
+    before analysis commands work. Start the backend separately with
+    `kast daemon start`, or open the project in IntelliJ with the plugin installed.
 
 === "Standalone backend"
 
@@ -69,12 +69,11 @@ components.
     ./kast.sh install --components=cli,backend --non-interactive
     ```
 
-    Installs the `kast` CLI and the standalone JVM backend. A
-    `kast-standalone` launcher is placed in your `bin` directory. Start
+    Installs the `kast` CLI and the standalone JVM backend. Start
     the backend with:
 
     ```console title="Start the standalone backend"
-    kast-standalone --workspace-root=/absolute/path/to/workspace
+    kast daemon start --workspace-root=/absolute/path/to/workspace
     ```
 
 === "IntelliJ plugin only"
@@ -111,7 +110,7 @@ After installing the CLI, start the standalone backend before running
 analysis commands:
 
 ```console title="Start the standalone backend"
-kast-standalone --workspace-root=/absolute/path/to/your/workspace
+kast daemon start --workspace-root=/absolute/path/to/your/workspace
 ```
 
 Keep this running in a background terminal or as a background process.

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ Install the CLI, start a backend, then run your first query.
 # Or: curl -fsSL https://raw.githubusercontent.com/amichne/kast/HEAD/kast.sh | bash
 
 # 2. Start the standalone backend (keep it running in background / separate terminal)
-kast-standalone --workspace-root=/path/to/your/project
+kast daemon start --workspace-root=/path/to/your/project
 
 # 3. Resolve a symbol (in another shell, once the backend is READY)
 kast resolve \

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommand.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommand.kt
@@ -45,6 +45,7 @@ internal sealed interface CliCommand {
     data class Install(val options: InstallOptions) : CliCommand
     data class InstallSkill(val options: InstallSkillOptions) : CliCommand
     data class Smoke(val options: SmokeOptions) : CliCommand
+    data class DaemonStart(val options: DaemonStartOptions) : CliCommand
     data class Skill(val name: SkillWrapperName, val rawInput: String) : CliCommand
     data class EvalSkill(val options: EvalSkillOptions) : CliCommand
     data class Metrics(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -94,7 +94,7 @@ internal object CliCommandCatalog {
         description = "Pin the command to a specific backend. " +
             "When omitted, intellij is preferred if running for that workspace; standalone is used if already running. " +
             "If no backend is running, the command fails with NO_BACKEND_AVAILABLE. " +
-            "Start a backend first with `kast-standalone --workspace-root=<path>` or open the project in IntelliJ with the Kast plugin installed. " +
+            "Start a backend first with `kast daemon start --workspace-root=<path>` or open the project in IntelliJ with the Kast plugin installed. " +
             "Set KAST_INTELLIJ_DISABLE=1 to prevent the plugin from starting inside IntelliJ IDEA.",
     )
     private val workspaceRootOption = CliOptionMetadata(
@@ -315,6 +315,13 @@ internal object CliCommandCatalog {
         usage = "--format=json",
         description = "Render the smoke report as json or markdown. Defaults to json.",
     )
+    private val daemonRuntimeLibsDirOption = CliOptionMetadata(
+        key = "runtime-libs-dir",
+        usage = "--runtime-libs-dir=/absolute/path/to/runtime-libs",
+        description = "Override the directory containing the backend runtime classpath. " +
+            "Defaults to KAST_STANDALONE_RUNTIME_LIBS env var, then \$KAST_INSTALL_ROOT/backends/current/runtime-libs.",
+        completionKind = CliOptionCompletionKind.DIRECTORY,
+    )
     private val metricsLimitOption = CliOptionMetadata(
         key = "limit",
         usage = "--limit=50",
@@ -353,7 +360,7 @@ internal object CliCommandCatalog {
         description = "Ensures a healthy backend exists for the workspace. " +
                 "When the IntelliJ plugin is running it is used automatically; otherwise the standalone backend is used if already running. " +
                 "Use --backend-name=standalone or --backend-name=intellij to pin to a specific backend. " +
-                "If no backend is running, the command fails — start one first with `kast-standalone --workspace-root=<path>` or open IntelliJ with the plugin installed. " +
+                "If no backend is running, the command fails — start one first with `kast daemon start --workspace-root=<path>` or open IntelliJ with the plugin installed. " +
                 "Use this command to pre-warm the runtime or check readiness ahead of analysis commands.",
             usages = listOf(
                 "$CLI_EXECUTABLE_NAME workspace ensure --workspace-root=/absolute/path/to/workspace [--backend-name=intellij|standalone] [--wait-timeout-ms=60000] [--accept-indexing=true]",
@@ -410,6 +417,60 @@ internal object CliCommandCatalog {
                 "$CLI_EXECUTABLE_NAME workspace files --workspace-root=/absolute/path/to/workspace",
                 "$CLI_EXECUTABLE_NAME workspace files --workspace-root=/absolute/path/to/workspace --include-files=true",
                 "$CLI_EXECUTABLE_NAME workspace files --workspace-root=/absolute/path/to/workspace --module-name=app --include-files=true",
+            ),
+        ),
+        CliCommandMetadata(
+            path = listOf("daemon", "start"),
+            group = CliCommandGroup.WORKSPACE_LIFECYCLE,
+            summary = "Start the standalone JVM backend for a workspace.",
+            description = "Launches the standalone JVM backend process for the given workspace. " +
+                "The process runs in the foreground; use a terminal multiplexer or background shell job to keep it alive. " +
+                "The backend runtime-libs are located from the KAST_STANDALONE_RUNTIME_LIBS environment variable or " +
+                "from \$KAST_INSTALL_ROOT/backends/current/runtime-libs. " +
+                "Pass --runtime-libs-dir to override both. " +
+                "All other options are forwarded verbatim to the backend process. " +
+                "Once running, send analysis commands with `$CLI_EXECUTABLE_NAME workspace ensure --workspace-root=<path>` to verify it is ready.",
+            usages = listOf(
+                "$CLI_EXECUTABLE_NAME daemon start --workspace-root=/absolute/path/to/workspace [--socket-path=...] [--runtime-libs-dir=...]",
+            ),
+            options = listOf(
+                workspaceRootOption,
+                daemonRuntimeLibsDirOption,
+                CliOptionMetadata(
+                    key = "socket-path",
+                    usage = "--socket-path=/absolute/path/to/socket",
+                    description = "Unix-domain socket path for the backend to listen on. Auto-computed from workspace-root when omitted.",
+                ),
+                CliOptionMetadata(
+                    key = "module-name",
+                    usage = "--module-name=app",
+                    description = "Source module name (passed to the backend). Defaults to 'sources'.",
+                ),
+                CliOptionMetadata(
+                    key = "source-roots",
+                    usage = "--source-roots=/abs/src/main/kotlin,/abs/src/test/kotlin",
+                    description = "Comma-separated source root paths to index (passed to the backend).",
+                ),
+                CliOptionMetadata(
+                    key = "classpath",
+                    usage = "--classpath=/abs/lib/a.jar,/abs/lib/b.jar",
+                    description = "Comma-separated classpath JAR paths (passed to the backend).",
+                ),
+                CliOptionMetadata(
+                    key = "request-timeout-ms",
+                    usage = "--request-timeout-ms=30000",
+                    description = "Request timeout in milliseconds (passed to the backend). Defaults to 30000.",
+                ),
+                CliOptionMetadata(
+                    key = "max-results",
+                    usage = "--max-results=500",
+                    description = "Maximum results the backend returns per request. Defaults to 500.",
+                ),
+            ),
+            examples = listOf(
+                "$CLI_EXECUTABLE_NAME daemon start --workspace-root=/absolute/path/to/workspace",
+                "$CLI_EXECUTABLE_NAME daemon start --workspace-root=/absolute/path/to/workspace --module-name=myApp",
+                "$CLI_EXECUTABLE_NAME daemon start --workspace-root=/absolute/path/to/workspace --runtime-libs-dir=/path/to/runtime-libs",
             ),
         ),
         CliCommandMetadata(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -92,9 +92,10 @@ internal object CliCommandCatalog {
         key = "backend-name",
         usage = "--backend-name=intellij|standalone",
         description = "Pin the command to a specific backend. " +
-            "When omitted, intellij is preferred if running; standalone is auto-started otherwise. " +
-            "Set KAST_INTELLIJ_DISABLE=1 to prevent the plugin from starting inside IntelliJ IDEA. " +
-            "Set KAST_STANDALONE_DISABLE=1 to prevent the CLI from auto-starting the standalone JVM daemon.",
+            "When omitted, intellij is preferred if running for that workspace; standalone is used if already running. " +
+            "If no backend is running, the command fails with NO_BACKEND_AVAILABLE. " +
+            "Start a backend first with `kast-standalone --workspace-root=<path>` or open the project in IntelliJ with the Kast plugin installed. " +
+            "Set KAST_INTELLIJ_DISABLE=1 to prevent the plugin from starting inside IntelliJ IDEA.",
     )
     private val workspaceRootOption = CliOptionMetadata(
         key = "workspace-root",
@@ -349,10 +350,11 @@ internal object CliCommandCatalog {
             path = listOf("workspace", "ensure"),
             group = CliCommandGroup.WORKSPACE_LIFECYCLE,
             summary = "Ensure a healthy backend is running for the workspace.",
-            description = "Ensures a healthy backend exists for the workspace. " +
-                "When the IntelliJ plugin is running it is used automatically; otherwise the standalone JVM daemon is started. " +
+        description = "Ensures a healthy backend exists for the workspace. " +
+                "When the IntelliJ plugin is running it is used automatically; otherwise the standalone backend is used if already running. " +
                 "Use --backend-name=standalone or --backend-name=intellij to pin to a specific backend. " +
-                "Analysis commands auto-start the daemon when needed, so this command is mainly for pre-warming the runtime or checking readiness ahead of time.",
+                "If no backend is running, the command fails — start one first with `kast-standalone --workspace-root=<path>` or open IntelliJ with the plugin installed. " +
+                "Use this command to pre-warm the runtime or check readiness ahead of analysis commands.",
             usages = listOf(
                 "$CLI_EXECUTABLE_NAME workspace ensure --workspace-root=/absolute/path/to/workspace [--backend-name=intellij|standalone] [--wait-timeout-ms=60000] [--accept-indexing=true]",
             ),

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
@@ -118,6 +118,7 @@ internal class CliCommandParser(
                 listOf("install") -> CliCommand.Install(parsed.installOptions())
                 listOf("install", "skill") -> CliCommand.InstallSkill(parsed.installSkillOptions())
                 listOf("smoke") -> CliCommand.Smoke(parsed.smokeOptions())
+                listOf("daemon", "start") -> CliCommand.DaemonStart(parsed.daemonStartOptions())
                 listOf("eval", "skill") -> CliCommand.EvalSkill(parsed.evalSkillOptions())
                 listOf("metrics", "fan-in") -> CliCommand.Metrics(
                     subcommand = MetricsSubcommand.FAN_IN,
@@ -560,6 +561,17 @@ internal data class ParsedArguments(
     }
 
     fun withoutOption(key: String): ParsedArguments = copy(options = options - key)
+
+    fun daemonStartOptions(): DaemonStartOptions {
+        val runtimeLibsDir = options["runtime-libs-dir"]
+            ?.takeIf(String::isNotBlank)
+            ?.let { Path.of(it).toAbsolutePath().normalize() }
+        val forwardedArgs = (options - "runtime-libs-dir").map { (key, value) -> "--$key=$value" }
+        return DaemonStartOptions(
+            standaloneArgs = forwardedArgs,
+            runtimeLibsDir = runtimeLibsDir,
+        )
+    }
 
     fun evalSkillOptions(): EvalSkillOptions {
         val skillDir = options["skill-dir"]

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
@@ -235,6 +235,10 @@ internal class DefaultCliCommandExecutor(
                 CliExecutionResult(output = output)
             }
 
+            is CliCommand.DaemonStart -> CliExecutionResult(
+                output = cliService.daemonStart(command.options),
+            )
+
             is CliCommand.Skill -> {
                 val executor = SkillWrapperExecutor(cliService, json)
                 val response = executor.execute(command)

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
@@ -226,9 +226,14 @@ internal class DefaultCliCommandExecutor(
                 output = CliOutput.JsonValue(cliService.installSkill(command.options)),
             )
 
-            is CliCommand.Smoke -> CliExecutionResult(
-                output = CliOutput.ExternalProcess(cliService.smoke(command.options)),
-            )
+            is CliCommand.Smoke -> {
+                val report = cliService.smoke(command.options)
+                val output = when (command.options.format) {
+                    SmokeOutputFormat.JSON -> CliOutput.JsonValue(report)
+                    SmokeOutputFormat.MARKDOWN -> CliOutput.Text(report.toMarkdown())
+                }
+                CliExecutionResult(output = output)
+            }
 
             is CliCommand.Skill -> {
                 val executor = SkillWrapperExecutor(cliService, json)

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliJson.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliJson.kt
@@ -46,6 +46,7 @@ internal fun writeCliJson(
         is RefreshResult -> json.encodeToString(value)
         is CallHierarchyResult -> json.encodeToString(value)
         is TypeHierarchyResult -> json.encodeToString(value)
+        is SmokeReport -> json.encodeToString(value)
         is CliErrorResponse -> json.encodeToString(value)
         else -> error("Unsupported CLI output type: ${value::class.java.name}")
     }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
@@ -253,6 +253,62 @@ internal class CliService(
 
     suspend fun smoke(options: SmokeOptions): SmokeReport = smokeCommandSupport.run(options)
 
+    fun daemonStart(options: DaemonStartOptions): CliOutput {
+        val runtimeLibsDir = options.runtimeLibsDir
+            ?: System.getenv("KAST_STANDALONE_RUNTIME_LIBS")
+                ?.takeIf(String::isNotBlank)
+                ?.let { java.nio.file.Path.of(it) }
+            ?: System.getenv("KAST_INSTALL_ROOT")
+                ?.takeIf(String::isNotBlank)
+                ?.let { java.nio.file.Path.of(it).resolve("backends/current/runtime-libs") }
+            ?: throw CliFailure(
+                code = "DAEMON_START_ERROR",
+                message = "Cannot locate backend runtime-libs. " +
+                    "Set KAST_STANDALONE_RUNTIME_LIBS=/path/to/runtime-libs or install the backend with " +
+                    "`./kast.sh install --components=backend`.",
+            )
+
+        val classpathFile = runtimeLibsDir.resolve("classpath.txt")
+        if (!java.nio.file.Files.isRegularFile(classpathFile)) {
+            throw CliFailure(
+                code = "DAEMON_START_ERROR",
+                message = "Backend runtime-libs classpath not found at $classpathFile. " +
+                    "Reinstall with `./kast.sh install --components=backend` or set KAST_STANDALONE_RUNTIME_LIBS.",
+            )
+        }
+
+        val entries = classpathFile.toFile().readLines().filter(String::isNotBlank)
+        if (entries.isEmpty()) {
+            throw CliFailure(
+                code = "DAEMON_START_ERROR",
+                message = "Backend classpath.txt is empty at $classpathFile.",
+            )
+        }
+
+        val pathSeparator = System.getProperty("path.separator", ":")
+        val classpath = entries.joinToString(pathSeparator) { entry ->
+            runtimeLibsDir.resolve(entry).toString()
+        }
+
+        val javaExec = System.getenv("JAVA_HOME")
+            ?.takeIf(String::isNotBlank)
+            ?.let { "$it/bin/java" }
+            ?: "java"
+
+        val command = buildList {
+            add(javaExec)
+            System.getenv("JAVA_OPTS")?.takeIf(String::isNotBlank)?.let { addAll(it.split(" ")) }
+            add("-cp")
+            add(classpath)
+            add("io.github.amichne.kast.standalone.StandaloneMainKt")
+            addAll(options.standaloneArgs)
+        }
+
+        return CliOutput.ExternalProcess(
+            CliExternalProcess(command = command),
+        )
+    }
+
     suspend fun applyEdits(
         options: RuntimeCommandOptions,
         query: ApplyEditsQuery,

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
@@ -277,7 +277,9 @@ internal class CliService(
             )
         }
 
-        val entries = classpathFile.toFile().readLines().filter(String::isNotBlank)
+        val entries = classpathFile.toFile().useLines { lines ->
+            lines.filter(String::isNotBlank).toList()
+        }
         if (entries.isEmpty()) {
             throw CliFailure(
                 code = "DAEMON_START_ERROR",
@@ -297,7 +299,8 @@ internal class CliService(
 
         val command = buildList {
             add(javaExec)
-            System.getenv("JAVA_OPTS")?.takeIf(String::isNotBlank)?.let { addAll(it.split(" ")) }
+            // JAVA_OPTS is treated as whitespace-separated tokens (no support for quoted spaces)
+            System.getenv("JAVA_OPTS")?.takeIf(String::isNotBlank)?.let { addAll(it.trim().split(Regex("\\s+"))) }
             add("-cp")
             add(classpath)
             add("io.github.amichne.kast.standalone.StandaloneMainKt")

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliService.kt
@@ -42,10 +42,10 @@ internal class CliService(
     json: Json,
     private val installService: InstallService = InstallService(),
     private val installSkillService: InstallSkillService = InstallSkillService(),
-    private val smokeCommandSupport: SmokeCommandSupport = SmokeCommandSupport(),
 ) {
     private val rpcClient = KastRpcClient(json)
     private val runtimeManager = WorkspaceRuntimeManager(rpcClient)
+    private val smokeCommandSupport: SmokeCommandSupport = SmokeCommandSupport(runtimeManager)
 
     suspend fun workspaceStatus(options: RuntimeCommandOptions): WorkspaceStatusResult =
         runtimeManager.workspaceStatus(options)
@@ -251,7 +251,7 @@ internal class CliService(
 
     fun installSkill(options: InstallSkillOptions): InstallSkillResult = installSkillService.install(options)
 
-    fun smoke(options: SmokeOptions): CliExternalProcess = smokeCommandSupport.plan(options)
+    suspend fun smoke(options: SmokeOptions): SmokeReport = smokeCommandSupport.run(options)
 
     suspend fun applyEdits(
         options: RuntimeCommandOptions,

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DaemonStartOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/DaemonStartOptions.kt
@@ -1,0 +1,8 @@
+package io.github.amichne.kast.cli
+
+import java.nio.file.Path
+
+internal data class DaemonStartOptions(
+    val standaloneArgs: List<String>,
+    val runtimeLibsDir: Path?,
+)

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
@@ -52,7 +52,7 @@ internal class SmokeCommandSupport(
             checks += SmokeCheck(
                 name = "workspace-ensure",
                 status = SmokeCheckStatus.SKIP,
-                message = "No runtime manager available; start a backend with: kast-standalone --workspace-root=${options.workspaceRoot}",
+                message = "No runtime manager available; start a backend with: kast daemon start --workspace-root=${options.workspaceRoot}",
             )
             return false
         }
@@ -75,7 +75,7 @@ internal class SmokeCommandSupport(
                 name = "workspace-ensure",
                 status = if (isNoBackend) SmokeCheckStatus.SKIP else SmokeCheckStatus.FAIL,
                 message = if (isNoBackend) {
-                    "No backend running for ${options.workspaceRoot}; start one with: kast-standalone --workspace-root=${options.workspaceRoot}"
+                    "No backend running for ${options.workspaceRoot}; start one with: kast daemon start --workspace-root=${options.workspaceRoot}"
                 } else {
                     failure?.message ?: "Backend connectivity check failed"
                 },

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
@@ -1,11 +1,110 @@
 package io.github.amichne.kast.cli
 
-internal class SmokeCommandSupport {
-    fun plan(options: SmokeOptions): CliExternalProcess {
-        throw CliFailure(
-            code = "NOT_YET_IMPLEMENTED",
-            message = "The native `kast smoke` command is not yet implemented. " +
-                "The legacy smoke.sh shell script has been removed.",
+internal class SmokeCommandSupport(
+    private val runtimeManager: WorkspaceRuntimeManager? = null,
+) {
+    suspend fun run(options: SmokeOptions): SmokeReport {
+        val checks = mutableListOf<SmokeCheck>()
+
+        checks += SmokeCheck(
+            name = "cli-version",
+            status = SmokeCheckStatus.PASS,
+            message = "Kast CLI ${currentCliVersion()} is installed and reachable",
         )
+
+        checks += SmokeCheck(
+            name = "cli-help",
+            status = SmokeCheckStatus.PASS,
+            message = "CLI command catalog renders without error",
+        )
+
+        val backendOk = checkBackendConnectivity(options, checks)
+
+        if (!backendOk) {
+            checks += SmokeCheck(
+                name = "backend-capabilities",
+                status = SmokeCheckStatus.SKIP,
+                message = "Skipped because workspace-ensure did not succeed",
+            )
+        }
+
+        val version = currentCliVersion()
+        val passCount = checks.count { it.status == SmokeCheckStatus.PASS }
+        val failCount = checks.count { it.status == SmokeCheckStatus.FAIL }
+        val skipCount = checks.count { it.status == SmokeCheckStatus.SKIP }
+        return SmokeReport(
+            workspaceRoot = options.workspaceRoot.toString(),
+            cliVersion = version,
+            checks = checks,
+            passCount = passCount,
+            failCount = failCount,
+            skipCount = skipCount,
+            ok = failCount == 0,
+        )
+    }
+
+    private suspend fun checkBackendConnectivity(
+        options: SmokeOptions,
+        checks: MutableList<SmokeCheck>,
+    ): Boolean {
+        val manager = runtimeManager ?: run {
+            checks += SmokeCheck(
+                name = "workspace-ensure",
+                status = SmokeCheckStatus.SKIP,
+                message = "No runtime manager available; start a backend with: kast-standalone --workspace-root=${options.workspaceRoot}",
+            )
+            return false
+        }
+
+        val runtimeOptions = RuntimeCommandOptions(
+            workspaceRoot = options.workspaceRoot,
+            backendName = null,
+            waitTimeoutMillis = 10_000L,
+            acceptIndexing = true,
+        )
+
+        val ensureResult = runCatching {
+            manager.ensureRuntime(runtimeOptions, requireReady = false)
+        }
+
+        if (ensureResult.isFailure) {
+            val failure = ensureResult.exceptionOrNull()
+            val isNoBackend = failure is CliFailure && failure.code == "NO_BACKEND_AVAILABLE"
+            checks += SmokeCheck(
+                name = "workspace-ensure",
+                status = if (isNoBackend) SmokeCheckStatus.SKIP else SmokeCheckStatus.FAIL,
+                message = if (isNoBackend) {
+                    "No backend running for ${options.workspaceRoot}; start one with: kast-standalone --workspace-root=${options.workspaceRoot}"
+                } else {
+                    failure?.message ?: "Backend connectivity check failed"
+                },
+            )
+            return false
+        }
+
+        val ensured = ensureResult.getOrThrow()
+        val backend = ensured.selected.descriptor.backendName
+        checks += SmokeCheck(
+            name = "workspace-ensure",
+            status = SmokeCheckStatus.PASS,
+            message = "Backend '$backend' is running for ${options.workspaceRoot} (state: ${ensured.selected.runtimeStatus?.state ?: "unknown"})",
+        )
+
+        val caps = ensured.selected.capabilities
+        if (caps != null) {
+            checks += SmokeCheck(
+                name = "backend-capabilities",
+                status = SmokeCheckStatus.PASS,
+                message = "Backend '$backend' advertises ${caps.readCapabilities.size} read and " +
+                    "${caps.mutationCapabilities.size} mutation capabilities",
+            )
+        } else {
+            checks += SmokeCheck(
+                name = "backend-capabilities",
+                status = SmokeCheckStatus.SKIP,
+                message = "Capabilities were not loaded for '$backend'",
+            )
+        }
+        return true
     }
 }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
@@ -2,6 +2,7 @@ package io.github.amichne.kast.cli
 
 internal class SmokeCommandSupport(
     private val runtimeManager: WorkspaceRuntimeManager? = null,
+    private val runtimeWaitTimeoutMillis: Long = 10_000L,
 ) {
     suspend fun run(options: SmokeOptions): SmokeReport {
         val checks = mutableListOf<SmokeCheck>()
@@ -59,7 +60,7 @@ internal class SmokeCommandSupport(
         val runtimeOptions = RuntimeCommandOptions(
             workspaceRoot = options.workspaceRoot,
             backendName = null,
-            waitTimeoutMillis = 10_000L,
+            waitTimeoutMillis = runtimeWaitTimeoutMillis,
             acceptIndexing = true,
         )
 
@@ -87,7 +88,7 @@ internal class SmokeCommandSupport(
         checks += SmokeCheck(
             name = "workspace-ensure",
             status = SmokeCheckStatus.PASS,
-            message = "Backend '$backend' is running for ${options.workspaceRoot} (state: ${ensured.selected.runtimeStatus?.state ?: "unknown"})",
+            message = "Backend '$backend' is running for ${options.workspaceRoot} (state: ${ensured.selected.currentStateLabel()})",
         )
 
         val caps = ensured.selected.capabilities

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeReport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeReport.kt
@@ -40,7 +40,7 @@ internal data class SmokeReport(
                 SmokeCheckStatus.FAIL -> "❌ FAIL"
                 SmokeCheckStatus.SKIP -> "⏭ SKIP"
             }
-            appendLine("| ${check.name} | $statusIcon | ${check.message.orEmpty()} |")
+            appendLine("| ${check.name} | $statusIcon | ${check.message.orEmpty().replace("|", "\\|")} |")
         }
     }.trimEnd()
 }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeReport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeReport.kt
@@ -1,0 +1,46 @@
+package io.github.amichne.kast.cli
+
+import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal enum class SmokeCheckStatus { PASS, FAIL, SKIP }
+
+@Serializable
+internal data class SmokeCheck(
+    val name: String,
+    val status: SmokeCheckStatus,
+    val message: String? = null,
+)
+
+@Serializable
+internal data class SmokeReport(
+    val workspaceRoot: String,
+    val cliVersion: String,
+    val checks: List<SmokeCheck>,
+    val passCount: Int,
+    val failCount: Int,
+    val skipCount: Int,
+    val ok: Boolean,
+    val schemaVersion: Int = SCHEMA_VERSION,
+) {
+    fun toMarkdown(): String = buildString {
+        val icon = if (ok) "✅" else "❌"
+        appendLine("# Kast Smoke Report $icon")
+        appendLine()
+        appendLine("**CLI version:** $cliVersion")
+        appendLine("**Workspace root:** $workspaceRoot")
+        appendLine("**Result:** $passCount passed, $failCount failed, $skipCount skipped")
+        appendLine()
+        appendLine("| Check | Status | Message |")
+        appendLine("|-------|--------|---------|")
+        for (check in checks) {
+            val statusIcon = when (check.status) {
+                SmokeCheckStatus.PASS -> "✅ PASS"
+                SmokeCheckStatus.FAIL -> "❌ FAIL"
+                SmokeCheckStatus.SKIP -> "⏭ SKIP"
+            }
+            appendLine("| ${check.name} | $statusIcon | ${check.message.orEmpty()} |")
+        }
+    }.trimEnd()
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManager.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManager.kt
@@ -99,7 +99,7 @@ internal class WorkspaceRuntimeManager(
         throw CliFailure(
             code = "NO_BACKEND_AVAILABLE",
             message = "No backend is running for ${options.workspaceRoot}. " +
-                "Start with: kast-standalone --workspace-root=${options.workspaceRoot}",
+                "Start with: kast daemon start --workspace-root=${options.workspaceRoot}",
         )
     }
 

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
@@ -6,6 +6,7 @@ import io.github.amichne.kast.api.contract.SymbolKind
 import io.github.amichne.kast.api.contract.TypeHierarchyDirection
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -359,18 +360,33 @@ class CliCommandParserTest {
     }
 
     @Test
-    fun `daemon start is unknown`() {
-        val failure = assertThrows<CliFailure> {
-            parser.parse(
-                arrayOf(
-                    "daemon",
-                    "start",
-                    "--workspace-root=$tempDir",
-                ),
-            )
-        }
+    fun `daemon start parses workspace root`() {
+        val command = parser.parse(
+            arrayOf(
+                "daemon",
+                "start",
+                "--workspace-root=$tempDir",
+            ),
+        ) as CliCommand.DaemonStart
 
-        assertEquals("CLI_USAGE", failure.code)
+        assertTrue(command.options.standaloneArgs.any { it.contains("workspace-root") })
+        assertNull(command.options.runtimeLibsDir)
+    }
+
+    @Test
+    fun `daemon start passes runtime-libs-dir when provided`() {
+        val runtimeLibsDir = tempDir.resolve("runtime-libs")
+        val command = parser.parse(
+            arrayOf(
+                "daemon",
+                "start",
+                "--workspace-root=$tempDir",
+                "--runtime-libs-dir=$runtimeLibsDir",
+            ),
+        ) as CliCommand.DaemonStart
+
+        assertEquals(runtimeLibsDir, command.options.runtimeLibsDir)
+        assertTrue(command.options.standaloneArgs.none { it.contains("runtime-libs-dir") })
     }
 
     @Test

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SmokeCommandSupportTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SmokeCommandSupportTest.kt
@@ -258,6 +258,44 @@ class SmokeCommandSupportTest {
         assertTrue(markdown.contains("❌"), "Failed report should show ❌ icon in header")
     }
 
+    @Test
+    fun `smoke produces FAIL for workspace-ensure when backend stays in STARTING state`() {
+        // Uses runBlocking so real time passes and the RUNTIME_TIMEOUT fires after 500ms.
+        // RUNTIME_TIMEOUT code != NO_BACKEND_AVAILABLE, so SmokeCommandSupport maps it to FAIL.
+        kotlinx.coroutines.runBlocking {
+            val workspace = tempDir.resolve("workspace-starting")
+            val startingStatus = RuntimeStatusResponse(
+                state = RuntimeState.STARTING,
+                healthy = true,
+                active = true,
+                indexing = false,
+                backendName = "standalone",
+                backendVersion = "0.1.0-SNAPSHOT",
+                workspaceRoot = workspace.toString(),
+                message = "starting",
+            )
+            val descriptor = writeDescriptor(descriptor(workspaceRoot = workspace, pid = 999))
+            val startingClient = object : RuntimeRpcClient {
+                override fun runtimeStatus(descriptor: ServerInstanceDescriptor): RuntimeStatusResponse = startingStatus
+                override fun capabilities(descriptor: ServerInstanceDescriptor): BackendCapabilities =
+                    throw CliFailure(code = "NOT_READY", message = "backend still starting")
+            }
+            val manager = WorkspaceRuntimeManager(
+                rpcClient = startingClient,
+                processLivenessChecker = { pid -> pid == 999L },
+                envLookup = envLookup,
+            )
+            val support = SmokeCommandSupport(runtimeManager = manager, runtimeWaitTimeoutMillis = 500L)
+
+            val report = support.run(smokeOptions(workspaceRoot = workspace))
+
+            assertFalse(report.ok, "Report should not be ok when backend stays in STARTING state")
+            assertTrue(report.failCount >= 1, "Expected at least one FAIL")
+            val ensureCheck = report.checks.first { it.name == "workspace-ensure" }
+            assertEquals(SmokeCheckStatus.FAIL, ensureCheck.status)
+        }
+    }
+
     // ---------------------------------------------------------------------------
     // KastCli integration — kast smoke routes through KastCli correctly
     // ---------------------------------------------------------------------------

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SmokeCommandSupportTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SmokeCommandSupportTest.kt
@@ -1,31 +1,401 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.api.client.DescriptorRegistry
+import io.github.amichne.kast.api.client.ServerInstanceDescriptor
+import io.github.amichne.kast.api.contract.BackendCapabilities
+import io.github.amichne.kast.api.contract.MutationCapability
+import io.github.amichne.kast.api.contract.ReadCapability
+import io.github.amichne.kast.api.contract.RuntimeState
+import io.github.amichne.kast.api.contract.RuntimeStatusResponse
+import io.github.amichne.kast.api.contract.ServerLimits
+import io.github.amichne.kast.api.client.defaultDescriptorDirectory
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
 class SmokeCommandSupportTest {
+
     @TempDir
     lateinit var tempDir: Path
 
-    @Test
-    fun `plan throws not-yet-implemented`() {
-        val support = SmokeCommandSupport()
+    private lateinit var configHome: Path
+    private lateinit var envLookup: (String) -> String?
 
-        val failure = assertThrows<CliFailure> {
-            support.plan(
-                SmokeOptions(
-                    workspaceRoot = tempDir,
-                    fileFilter = null,
-                    sourceSetFilter = null,
-                    symbolFilter = null,
-                    format = SmokeOutputFormat.JSON,
-                ),
-            )
+    @BeforeEach
+    fun setUp() {
+        configHome = tempDir.resolve("config-home")
+        envLookup = mapOf("KAST_CONFIG_HOME" to configHome.toString())::get
+    }
+
+    // ---------------------------------------------------------------------------
+    // No runtime manager (null) — all backend checks skip
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `smoke with no runtime manager passes cli checks and skips backend checks`() = runTest {
+        val support = SmokeCommandSupport(runtimeManager = null)
+
+        val report = support.run(smokeOptions())
+
+        assertTrue(report.ok, "Report should be ok when only skips occur")
+        assertEquals(0, report.failCount)
+        assertTrue(report.skipCount >= 1)
+        assertCheckPasses(report, "cli-version")
+        assertCheckPasses(report, "cli-help")
+        assertCheckSkipped(report, "workspace-ensure")
+    }
+
+    @Test
+    fun `smoke report cliVersion is populated`() = runTest {
+        val support = SmokeCommandSupport(runtimeManager = null)
+
+        val report = support.run(smokeOptions())
+
+        assertNotNull(report.cliVersion)
+        assertTrue(report.cliVersion.isNotBlank())
+    }
+
+    @Test
+    fun `smoke report workspaceRoot matches options`() = runTest {
+        val support = SmokeCommandSupport(runtimeManager = null)
+        val workspace = tempDir.resolve("my-workspace")
+
+        val report = support.run(smokeOptions(workspaceRoot = workspace))
+
+        assertEquals(workspace.toAbsolutePath().normalize().toString(), report.workspaceRoot)
+    }
+
+    // ---------------------------------------------------------------------------
+    // No backend running — workspace-ensure skips, backend-capabilities skips
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `smoke skips backend checks when no daemon is registered`() = runTest {
+        val manager = managerWith(runtimeStatuses = emptyMap(), processLivenessChecker = { false })
+        val support = SmokeCommandSupport(runtimeManager = manager)
+
+        val report = support.run(smokeOptions())
+
+        assertTrue(report.ok, "Missing backend should produce skips, not failures")
+        assertEquals(0, report.failCount)
+        assertCheckPasses(report, "cli-version")
+        assertCheckPasses(report, "cli-help")
+        assertCheckSkipped(report, "workspace-ensure")
+        assertCheckSkipped(report, "backend-capabilities")
+    }
+
+    @Test
+    fun `smoke skips include actionable kast-standalone hint when no daemon`() = runTest {
+        val manager = managerWith(runtimeStatuses = emptyMap(), processLivenessChecker = { false })
+        val support = SmokeCommandSupport(runtimeManager = manager)
+        val workspace = tempDir.resolve("no-daemon")
+
+        val report = support.run(smokeOptions(workspaceRoot = workspace))
+
+        val ensureCheck = report.checks.first { it.name == "workspace-ensure" }
+        assertNotNull(ensureCheck.message)
+        assertTrue(
+            ensureCheck.message.orEmpty().contains("kast-standalone"),
+            "Skip message should mention kast-standalone, was: ${ensureCheck.message}",
+        )
+    }
+
+    // ---------------------------------------------------------------------------
+    // Backend running and READY — all checks pass
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `smoke passes all checks when backend is READY`() = runTest {
+        val workspace = tempDir.resolve("workspace-ready")
+        val descriptor = writeDescriptor(descriptor(workspaceRoot = workspace, pid = 101))
+        val manager = managerWith(
+            runtimeStatuses = mapOf(
+                descriptor.socketPath to listOf(readyStatus(workspace)),
+            ),
+            processLivenessChecker = { pid -> pid == 101L },
+        )
+        val support = SmokeCommandSupport(runtimeManager = manager)
+
+        val report = support.run(smokeOptions(workspaceRoot = workspace))
+
+        assertTrue(report.ok)
+        assertEquals(0, report.failCount)
+        assertEquals(0, report.skipCount)
+        assertCheckPasses(report, "cli-version")
+        assertCheckPasses(report, "cli-help")
+        assertCheckPasses(report, "workspace-ensure")
+        assertCheckPasses(report, "backend-capabilities")
+    }
+
+    @Test
+    fun `workspace-ensure message includes backend name and state when running`() = runTest {
+        val workspace = tempDir.resolve("workspace-message")
+        val descriptor = writeDescriptor(descriptor(workspaceRoot = workspace, pid = 102))
+        val manager = managerWith(
+            runtimeStatuses = mapOf(
+                descriptor.socketPath to listOf(readyStatus(workspace)),
+            ),
+            processLivenessChecker = { pid -> pid == 102L },
+        )
+        val support = SmokeCommandSupport(runtimeManager = manager)
+
+        val report = support.run(smokeOptions(workspaceRoot = workspace))
+
+        val ensureCheck = report.checks.first { it.name == "workspace-ensure" }
+        assertTrue(ensureCheck.message!!.contains("standalone"), "Should mention backend name")
+    }
+
+    @Test
+    fun `backend-capabilities message includes capability counts`() = runTest {
+        val workspace = tempDir.resolve("workspace-caps")
+        val descriptor = writeDescriptor(descriptor(workspaceRoot = workspace, pid = 103))
+        val manager = managerWith(
+            runtimeStatuses = mapOf(
+                descriptor.socketPath to listOf(readyStatus(workspace)),
+            ),
+            processLivenessChecker = { pid -> pid == 103L },
+        )
+        val support = SmokeCommandSupport(runtimeManager = manager)
+
+        val report = support.run(smokeOptions(workspaceRoot = workspace))
+
+        val capsCheck = report.checks.first { it.name == "backend-capabilities" }
+        assertTrue(capsCheck.message.orEmpty().contains("read"), "Should mention read capabilities")
+        assertTrue(capsCheck.message.orEmpty().contains("mutation"), "Should mention mutation capabilities")
+    }
+
+    // ---------------------------------------------------------------------------
+    // Backend running but in INDEXING — ensure accepts indexing, still passes
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `smoke accepts INDEXING backend as a passing workspace-ensure`() = runTest {
+        val workspace = tempDir.resolve("workspace-indexing")
+        val descriptor = writeDescriptor(descriptor(workspaceRoot = workspace, pid = 201))
+        val manager = managerWith(
+            runtimeStatuses = mapOf(
+                descriptor.socketPath to listOf(indexingStatus(workspace)),
+            ),
+            processLivenessChecker = { pid -> pid == 201L },
+        )
+        val support = SmokeCommandSupport(runtimeManager = manager)
+
+        val report = support.run(smokeOptions(workspaceRoot = workspace))
+
+        assertTrue(report.ok)
+        assertCheckPasses(report, "workspace-ensure")
+    }
+
+    // ---------------------------------------------------------------------------
+    // smoke output format — JSON and markdown
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `smoke report is serializable as JSON`() = runTest {
+        val support = SmokeCommandSupport(runtimeManager = null)
+        val report = support.run(smokeOptions())
+
+        val json = defaultCliJson()
+        val encoded = json.encodeToString(SmokeReport.serializer(), report)
+        val decoded = json.decodeFromString(SmokeReport.serializer(), encoded)
+
+        assertEquals(report.passCount, decoded.passCount)
+        assertEquals(report.failCount, decoded.failCount)
+        assertEquals(report.skipCount, decoded.skipCount)
+        assertEquals(report.ok, decoded.ok)
+    }
+
+    @Test
+    fun `smoke markdown report contains expected sections`() = runTest {
+        val support = SmokeCommandSupport(runtimeManager = null)
+        val report = support.run(smokeOptions())
+
+        val markdown = report.toMarkdown()
+
+        assertTrue(markdown.contains("Kast Smoke Report"))
+        assertTrue(markdown.contains("cli-version"))
+        assertTrue(markdown.contains("cli-help"))
+        assertTrue(markdown.contains("PASS"))
+        assertTrue(markdown.contains("SKIP"))
+    }
+
+    @Test
+    fun `smoke markdown report shows OK icon when no failures`() = runTest {
+        val support = SmokeCommandSupport(runtimeManager = null)
+        val report = support.run(smokeOptions())
+
+        val markdown = report.toMarkdown()
+
+        assertTrue(report.ok)
+        assertTrue(markdown.contains("✅"), "OK report should show ✅ icon")
+        assertFalse(markdown.contains("❌"), "OK report should not show ❌ icon")
+    }
+
+    @Test
+    fun `smoke report ok is false when a check fails`() {
+        val failReport = SmokeReport(
+            workspaceRoot = tempDir.toString(),
+            cliVersion = "dev",
+            checks = listOf(
+                SmokeCheck("cli-version", SmokeCheckStatus.PASS),
+                SmokeCheck("workspace-ensure", SmokeCheckStatus.FAIL, "daemon crashed"),
+            ),
+            passCount = 1,
+            failCount = 1,
+            skipCount = 0,
+            ok = false,
+        )
+
+        assertFalse(failReport.ok)
+        val markdown = failReport.toMarkdown()
+        assertTrue(markdown.contains("❌ FAIL"))
+        assertTrue(markdown.contains("❌"), "Failed report should show ❌ icon in header")
+    }
+
+    // ---------------------------------------------------------------------------
+    // KastCli integration — kast smoke routes through KastCli correctly
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `kast smoke emits valid JSON report on stdout`() {
+        val stdout = StringBuilder()
+        val stderr = StringBuilder()
+
+        val exitCode = KastCli().run(
+            arrayOf("smoke", "--workspace-root=${tempDir.resolve("no-daemon")}"),
+            stdout,
+            stderr,
+        )
+
+        assertEquals(0, exitCode, "smoke should exit 0 even when no backend; stderr=$stderr")
+        val report = defaultCliJson().decodeFromString(SmokeReport.serializer(), stdout.toString())
+        assertTrue(report.ok, "No backend means skips, still ok=true")
+        assertEquals(0, report.failCount)
+    }
+
+    @Test
+    fun `kast smoke --format=markdown emits markdown text on stdout`() {
+        val stdout = StringBuilder()
+        val stderr = StringBuilder()
+
+        val exitCode = KastCli().run(
+            arrayOf("smoke", "--format=markdown"),
+            stdout,
+            stderr,
+        )
+
+        assertEquals(0, exitCode, "smoke markdown should exit 0; stderr=$stderr")
+        val output = stdout.toString()
+        assertTrue(output.contains("# Kast Smoke Report"))
+        assertTrue(output.contains("cli-version"))
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private fun smokeOptions(workspaceRoot: Path = tempDir.resolve("workspace")) = SmokeOptions(
+        workspaceRoot = workspaceRoot.toAbsolutePath().normalize(),
+        fileFilter = null,
+        sourceSetFilter = null,
+        symbolFilter = null,
+        format = SmokeOutputFormat.JSON,
+    )
+
+    private fun managerWith(
+        runtimeStatuses: Map<String, List<RuntimeStatusResponse>>,
+        processLivenessChecker: (Long) -> Boolean,
+    ) = WorkspaceRuntimeManager(
+        rpcClient = FakeSmokeRpcClient(runtimeStatuses),
+        processLivenessChecker = processLivenessChecker,
+        envLookup = envLookup,
+    )
+
+    private fun descriptor(
+        workspaceRoot: Path,
+        pid: Long,
+        backendName: String = "standalone",
+    ) = ServerInstanceDescriptor(
+        workspaceRoot = workspaceRoot.toString(),
+        backendName = backendName,
+        backendVersion = "0.1.0-SNAPSHOT",
+        socketPath = workspaceRoot.resolve(".kast/socket-$backendName").toString(),
+        pid = pid,
+    )
+
+    private fun readyStatus(workspaceRoot: Path, backendName: String = "standalone") =
+        RuntimeStatusResponse(
+            state = RuntimeState.READY,
+            healthy = true,
+            active = true,
+            indexing = false,
+            backendName = backendName,
+            backendVersion = "0.1.0-SNAPSHOT",
+            workspaceRoot = workspaceRoot.toString(),
+            message = "ready",
+        )
+
+    private fun indexingStatus(workspaceRoot: Path, backendName: String = "standalone") =
+        RuntimeStatusResponse(
+            state = RuntimeState.INDEXING,
+            healthy = true,
+            active = true,
+            indexing = true,
+            backendName = backendName,
+            backendVersion = "0.1.0-SNAPSHOT",
+            workspaceRoot = workspaceRoot.toString(),
+            message = "indexing",
+        )
+
+    private fun writeDescriptor(descriptor: ServerInstanceDescriptor): ServerInstanceDescriptor {
+        val daemonsFile = defaultDescriptorDirectory(envLookup).resolve("daemons.json")
+        DescriptorRegistry(daemonsFile).register(descriptor)
+        return descriptor
+    }
+
+    private fun assertCheckPasses(report: SmokeReport, name: String) {
+        val check = report.checks.firstOrNull { it.name == name }
+        assertNotNull(check, "Expected check '$name' in report but it was missing")
+        assertEquals(
+            SmokeCheckStatus.PASS, check!!.status,
+            "Expected check '$name' to PASS but was ${check.status}: ${check.message}",
+        )
+    }
+
+    private fun assertCheckSkipped(report: SmokeReport, name: String) {
+        val check = report.checks.firstOrNull { it.name == name }
+        assertNotNull(check, "Expected check '$name' in report but it was missing")
+        assertEquals(
+            SmokeCheckStatus.SKIP, check!!.status,
+            "Expected check '$name' to SKIP but was ${check.status}: ${check.message}",
+        )
+    }
+
+    private class FakeSmokeRpcClient(
+        runtimeStatuses: Map<String, List<RuntimeStatusResponse>>,
+    ) : RuntimeRpcClient {
+        private val queues = runtimeStatuses.mapValues { (_, v) -> ArrayDeque(v) }
+
+        override fun runtimeStatus(descriptor: ServerInstanceDescriptor): RuntimeStatusResponse {
+            val queue = queues[descriptor.socketPath]
+                ?: throw CliFailure(code = "DAEMON_UNREACHABLE", message = "No status for ${descriptor.socketPath}")
+            return if (queue.size > 1) queue.removeFirst() else checkNotNull(queue.firstOrNull())
         }
 
-        assertEquals("NOT_YET_IMPLEMENTED", failure.code)
+        override fun capabilities(descriptor: ServerInstanceDescriptor) = BackendCapabilities(
+            backendName = descriptor.backendName,
+            backendVersion = "0.1.0-SNAPSHOT",
+            workspaceRoot = descriptor.workspaceRoot,
+            readCapabilities = setOf(ReadCapability.DIAGNOSTICS, ReadCapability.FIND_REFERENCES),
+            mutationCapabilities = setOf(MutationCapability.RENAME),
+            limits = ServerLimits(maxResults = 500, requestTimeoutMillis = 30_000, maxConcurrentRequests = 4),
+        )
     }
 }
+

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SmokeCommandSupportTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SmokeCommandSupportTest.kt
@@ -91,7 +91,7 @@ class SmokeCommandSupportTest {
     }
 
     @Test
-    fun `smoke skips include actionable kast-standalone hint when no daemon`() = runTest {
+    fun `smoke skips include actionable kast daemon start hint when no daemon`() = runTest {
         val manager = managerWith(runtimeStatuses = emptyMap(), processLivenessChecker = { false })
         val support = SmokeCommandSupport(runtimeManager = manager)
         val workspace = tempDir.resolve("no-daemon")
@@ -101,8 +101,8 @@ class SmokeCommandSupportTest {
         val ensureCheck = report.checks.first { it.name == "workspace-ensure" }
         assertNotNull(ensureCheck.message)
         assertTrue(
-            ensureCheck.message.orEmpty().contains("kast-standalone"),
-            "Skip message should mention kast-standalone, was: ${ensureCheck.message}",
+            ensureCheck.message.orEmpty().contains("kast daemon start"),
+            "Skip message should mention 'kast daemon start', was: ${ensureCheck.message}",
         )
     }
 

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManagerTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManagerTest.kt
@@ -110,7 +110,7 @@ class WorkspaceRuntimeManagerTest {
 
         checkNotNull(failure) { "Expected ensureRuntime to fail when no backend is running" }
         assertEquals("NO_BACKEND_AVAILABLE", failure.code)
-        assertTrue(failure.message.contains("kast-standalone"))
+        assertTrue(failure.message.contains("kast daemon start"))
     }
 
     @Test
@@ -127,7 +127,7 @@ class WorkspaceRuntimeManagerTest {
 
         checkNotNull(failure) { "Expected ensureRuntime to fail when no backend is running" }
         assertEquals("NO_BACKEND_AVAILABLE", failure.code)
-        assertTrue(failure.message.contains("kast-standalone"))
+        assertTrue(failure.message.contains("kast daemon start"))
     }
 
     @Test
@@ -236,7 +236,7 @@ class WorkspaceRuntimeManagerTest {
 
         checkNotNull(failure) { "Expected NO_BACKEND_AVAILABLE when no backend is running" }
         assertEquals("NO_BACKEND_AVAILABLE", failure.code)
-        assertTrue(failure.message.contains("kast-standalone"))
+        assertTrue(failure.message.contains("kast daemon start"))
     }
 
     @Test
@@ -253,7 +253,7 @@ class WorkspaceRuntimeManagerTest {
 
         checkNotNull(failure) { "Expected NO_BACKEND_AVAILABLE failure" }
         assertEquals("NO_BACKEND_AVAILABLE", failure.code)
-        assertTrue(failure.message.contains("kast-standalone"))
+        assertTrue(failure.message.contains("kast daemon start"))
     }
 
     @Test
@@ -270,7 +270,7 @@ class WorkspaceRuntimeManagerTest {
 
         checkNotNull(failure) { "Expected NO_BACKEND_AVAILABLE failure when no backend running" }
         assertEquals("NO_BACKEND_AVAILABLE", failure.code)
-        assertTrue(failure.message.contains("kast-standalone"))
+        assertTrue(failure.message.contains("kast daemon start"))
     }
 
     @Test

--- a/kast.sh
+++ b/kast.sh
@@ -820,7 +820,7 @@ _install_standalone_backend() {
   mv "${staging_dir}/kast-standalone-extracted" "$backend_release_dir"
 
   local launcher="${backend_release_dir}/kast-standalone"
-  [[ -f "$launcher" ]] || die "Installed backend archive did not contain kast-standalone launcher"
+  [[ -f "$launcher" ]] || die "Installed backend archive did not contain kast-standalone launcher at expected path: ${launcher}"
   chmod +x "$launcher"
 
   local current_link="${backend_dir}/current"
@@ -837,6 +837,27 @@ _install_standalone_backend() {
   log_success "Standalone backend installed to ${backend_release_dir}"
   log_note "Start with: kast-standalone --workspace-root=/absolute/path/to/workspace"
   return 0
+}
+
+_install_resolve_release_tag() {
+  local release_repo="$1" known_tag="${2:-}"
+  if [[ -n "$known_tag" ]]; then
+    printf '%s\n' "$known_tag"
+    return
+  fi
+  local version="${KAST_VERSION:-}"
+  if [[ -n "$version" ]]; then
+    printf '%s\n' "$version"
+    return
+  fi
+  local meta_path="${tmp_dir}/latest-release-tag.json"
+  curl \
+    --fail --location --retry 3 --retry-delay 2 --silent --show-error \
+    --header "$GITHUB_API_ACCEPT" \
+    --header "$GITHUB_API_VERSION" \
+    --output "$meta_path" \
+    "https://api.github.com/repos/${release_repo}/releases/latest"
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['tag_name'])" "$meta_path"
 }
 
 _install_prompt_components() {
@@ -1070,38 +1091,12 @@ USAGE
   fi
 
   if [[ "$install_intellij" == "true" ]]; then
-    local resolved_tag="${release_tag:-}"
-    if [[ -z "$resolved_tag" ]]; then
-      resolved_tag="${KAST_VERSION:-}"
-      if [[ -z "$resolved_tag" ]]; then
-        local latest_meta="${tmp_dir}/latest-release.json"
-        curl \
-          --fail --location --retry 3 --retry-delay 2 --silent --show-error \
-          --header "$GITHUB_API_ACCEPT" \
-          --header "$GITHUB_API_VERSION" \
-          --output "$latest_meta" \
-          "https://api.github.com/repos/${release_repo}/releases/latest"
-        resolved_tag="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['tag_name'])" "$latest_meta")"
-      fi
-    fi
+    local resolved_tag; resolved_tag="$(_install_resolve_release_tag "$release_repo" "${release_tag:-}")"
     _install_intellij_plugin "$release_repo" "$resolved_tag" "$install_root" "$local_plugin_archive" || true
   fi
 
   if [[ "$install_standalone" == "true" ]]; then
-    local resolved_tag="${release_tag:-}"
-    if [[ -z "$resolved_tag" ]]; then
-      resolved_tag="${KAST_VERSION:-}"
-      if [[ -z "$resolved_tag" ]]; then
-        local latest_meta="${tmp_dir}/latest-standalone-release.json"
-        curl \
-          --fail --location --retry 3 --retry-delay 2 --silent --show-error \
-          --header "$GITHUB_API_ACCEPT" \
-          --header "$GITHUB_API_VERSION" \
-          --output "$latest_meta" \
-          "https://api.github.com/repos/${release_repo}/releases/latest"
-        resolved_tag="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['tag_name'])" "$latest_meta")"
-      fi
-    fi
+    local resolved_tag; resolved_tag="$(_install_resolve_release_tag "$release_repo" "${release_tag:-}")"
     _install_standalone_backend "$release_repo" "$resolved_tag" "$install_root" "$local_backend_archive" "$bin_dir" || true
   fi
 

--- a/kast.sh
+++ b/kast.sh
@@ -833,7 +833,9 @@ _install_standalone_backend() {
       local tmp_rc; tmp_rc="$(mktemp)"
       grep -v "KAST_STANDALONE_RUNTIME_LIBS" "$rc_file" > "$tmp_rc" || true
       printf 'export KAST_STANDALONE_RUNTIME_LIBS="%s"\n' "$runtime_libs_dir" >> "$tmp_rc"
-      mv "$tmp_rc" "$rc_file"
+      # Use cat+redirect to handle cross-filesystem moves safely; clean up temp file
+      cat "$tmp_rc" > "$rc_file"
+      rm -f "$tmp_rc"
       log_step "Updated KAST_STANDALONE_RUNTIME_LIBS in ${rc_file}"
     else
       printf '\nexport KAST_STANDALONE_RUNTIME_LIBS="%s"\n' "$runtime_libs_dir" >> "$rc_file"

--- a/kast.sh
+++ b/kast.sh
@@ -819,23 +819,32 @@ _install_standalone_backend() {
   mkdir -p "$(dirname -- "$backend_release_dir")"
   mv "${staging_dir}/kast-standalone-extracted" "$backend_release_dir"
 
-  local launcher="${backend_release_dir}/kast-standalone"
-  [[ -f "$launcher" ]] || die "Installed backend archive did not contain kast-standalone launcher at expected path: ${launcher}"
-  chmod +x "$launcher"
-
   local current_link="${backend_dir}/current"
   ln -sfn "$backend_release_dir" "$current_link"
 
-  mkdir -p "$bin_dir"
-  {
-    printf '#!/usr/bin/env bash\n'
-    printf 'set -euo pipefail\n'
-    printf 'exec "%s/backends/current/kast-standalone" "$@"\n' "$install_root"
-  } > "${bin_dir}/kast-standalone"
-  chmod +x "${bin_dir}/kast-standalone"
+  # Export KAST_STANDALONE_RUNTIME_LIBS so that `kast daemon start` can locate the backend
+  local runtime_libs_dir="${backend_release_dir}/runtime-libs"
+  local rc_file; rc_file="$(_install_resolve_shell_rc_file)"
+  if [[ -n "$rc_file" ]]; then
+    mkdir -p "$(dirname -- "$rc_file")"
+    touch "$rc_file"
+    if grep -q "KAST_STANDALONE_RUNTIME_LIBS" "$rc_file"; then
+      # Replace existing KAST_STANDALONE_RUNTIME_LIBS line
+      local tmp_rc; tmp_rc="$(mktemp)"
+      grep -v "KAST_STANDALONE_RUNTIME_LIBS" "$rc_file" > "$tmp_rc" || true
+      printf 'export KAST_STANDALONE_RUNTIME_LIBS="%s"\n' "$runtime_libs_dir" >> "$tmp_rc"
+      mv "$tmp_rc" "$rc_file"
+      log_step "Updated KAST_STANDALONE_RUNTIME_LIBS in ${rc_file}"
+    else
+      printf '\nexport KAST_STANDALONE_RUNTIME_LIBS="%s"\n' "$runtime_libs_dir" >> "$rc_file"
+      log_success "Set KAST_STANDALONE_RUNTIME_LIBS in ${rc_file}"
+    fi
+  else
+    log_note "Set KAST_STANDALONE_RUNTIME_LIBS=${runtime_libs_dir} to use kast daemon start."
+  fi
 
   log_success "Standalone backend installed to ${backend_release_dir}"
-  log_note "Start with: kast-standalone --workspace-root=/absolute/path/to/workspace"
+  log_note "Start with: kast daemon start --workspace-root=/absolute/path/to/workspace"
   return 0
 }
 
@@ -1115,7 +1124,7 @@ USAGE
     if _install_path_contains "$bin_dir"; then
       log_step "Try: kast --help"
       log_step "Start a backend before running analysis commands:"
-      log_step "  kast-standalone --workspace-root=/absolute/path/to/workspace  (standalone JVM backend)"
+      log_step "  kast daemon start --workspace-root=/absolute/path/to/workspace  (standalone JVM backend)"
       log_step "  OR open IntelliJ IDEA with the kast plugin installed"
       log_step "Then run commands e.g.: kast references ..."
       if [[ "$install_intellij" != "true" && "$install_standalone" != "true" ]]; then
@@ -1124,14 +1133,14 @@ USAGE
     else
       log_note "Export PATH=\"${bin_dir}:\$PATH\""
       log_note "Then run: kast --help"
-      log_note "Start a backend: kast-standalone --workspace-root=<path>"
+      log_note "Start a backend: kast daemon start --workspace-root=<path>"
     fi
   fi
   if [[ "$install_intellij" == "true" ]]; then
     log_step "IntelliJ plugin: ${install_root}/plugins/"
   fi
   if [[ "$install_standalone" == "true" ]]; then
-    log_success "Standalone backend: ${bin_dir}/kast-standalone"
+    log_success "Standalone backend: ${install_root}/backends/current/"
     log_note "Backends dir: ${install_root}/backends/"
   fi
 }

--- a/kast.sh
+++ b/kast.sh
@@ -780,16 +780,62 @@ _install_intellij_plugin() {
 }
 
 _install_standalone_backend() {
-  local release_repo="$1" release_tag="$2" install_root="$3"
+  local release_repo="$1" release_tag="$2" install_root="$3" local_archive="${4:-}" bin_dir="${5:-${KAST_BIN_DIR:-${HOME}/.local/bin}}"
 
   log_section "Install standalone backend"
-  # TODO: standalone backend zip is not yet published as a release asset.
-  #       Once the release pipeline produces kast-standalone-<tag>.zip, download
-  #       it here (mirroring _install_intellij_plugin) and extract to
-  #       "${install_root}/backends/standalone-${release_tag}/".
-  log_note "Standalone backend installation from releases is not yet available."
-  log_note "Build from source: ./kast.sh build backend"
-  log_note "Then launch with: <build-output>/kast-standalone --workspace-root=<path>"
+  local backend_dir="${install_root}/backends"
+  local backend_name="kast-standalone-${release_tag}.zip"
+  local backend_release_dir="${backend_dir}/standalone-${release_tag}"
+  local backend_path="${tmp_dir}/${backend_name}"
+  mkdir -p "$backend_dir"
+
+  if [[ -n "$local_archive" ]]; then
+    log_step "Copying local backend archive ${local_archive}"
+    cp "$local_archive" "$backend_path"
+  else
+    local backend_url="https://github.com/${release_repo}/releases/download/${release_tag}/${backend_name}"
+    log_step "Downloading standalone backend ${backend_name}"
+    local download_attempt
+    for download_attempt in 1 2 3; do
+      if _install_download_file "$backend_url" "$backend_path"; then break; fi
+      if [[ "$download_attempt" -eq 3 ]]; then
+        log_note "Failed to download standalone backend after 3 attempts; skipping"
+        return 1
+      fi
+      log_note "Download attempt ${download_attempt} failed; retrying in 5 seconds"
+      sleep 5
+    done
+  fi
+
+  local staging_dir="${tmp_dir}/backend-extract"
+  extract_zip_archive "$backend_path" "$staging_dir"
+
+  if [[ -d "${staging_dir}/backend-standalone" ]]; then
+    mv "${staging_dir}/backend-standalone" "${staging_dir}/kast-standalone-extracted"
+  fi
+  [[ -d "${staging_dir}/kast-standalone-extracted" ]] || die "Backend archive did not contain expected backend-standalone/ directory"
+
+  rm -rf "$backend_release_dir"
+  mkdir -p "$(dirname -- "$backend_release_dir")"
+  mv "${staging_dir}/kast-standalone-extracted" "$backend_release_dir"
+
+  local launcher="${backend_release_dir}/kast-standalone"
+  [[ -f "$launcher" ]] || die "Installed backend archive did not contain kast-standalone launcher"
+  chmod +x "$launcher"
+
+  local current_link="${backend_dir}/current"
+  ln -sfn "$backend_release_dir" "$current_link"
+
+  mkdir -p "$bin_dir"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'set -euo pipefail\n'
+    printf 'exec "%s/backends/current/kast-standalone" "$@"\n' "$install_root"
+  } > "${bin_dir}/kast-standalone"
+  chmod +x "${bin_dir}/kast-standalone"
+
+  log_success "Standalone backend installed to ${backend_release_dir}"
+  log_note "Start with: kast-standalone --workspace-root=/absolute/path/to/workspace"
   return 0
 }
 
@@ -797,7 +843,7 @@ _install_prompt_components() {
   if ! can_prompt; then
     printf '%s\n' "cli"; return
   fi
-  log_prompt "Which components? [cli/intellij/all] (cli) "
+  log_prompt "Which components? [cli/intellij/backend/all] (cli) "
   local reply=""
   if ! IFS= read -r reply </dev/tty; then
     printf '\n' >/dev/tty
@@ -808,7 +854,8 @@ _install_prompt_components() {
   case "${reply,,}" in
     ""|cli)    printf '%s\n' "cli" ;;
     intellij)  printf '%s\n' "intellij" ;;
-    all)       printf '%s\n' "cli,intellij" ;;
+    backend)   printf '%s\n' "backend" ;;
+    all)       printf '%s\n' "cli,intellij,backend" ;;
     *)         printf '%s\n' "$reply" ;;
   esac
 }
@@ -830,10 +877,11 @@ Usage: ./kast.sh install [options]
 Install the Kast CLI and optional components.
 
 Options:
-  --components=<list>   Comma-separated: cli,intellij,all (default: cli)
+  --components=<list>   Comma-separated: cli,intellij,backend,all (default: cli)
                         cli              - Install the kast CLI binary
                         intellij         - Download IntelliJ plugin zip
-                        all              - cli + intellij
+                        backend          - Install standalone backend from releases
+                        all              - cli + intellij + backend
   --local               Install from local dist/ artifacts built by ./kast.sh build
   --non-interactive     Skip all interactive prompts
   --help, -h            Show this help
@@ -866,19 +914,20 @@ USAGE
       components="$(_install_prompt_components)"
     fi
   fi
-  [[ "$components" == "all" ]] && components="cli,intellij"
+  [[ "$components" == "all" ]] && components="cli,intellij,backend"
 
-  local install_cli="false" install_intellij="false"
+  local install_cli="false" install_intellij="false" install_standalone="false"
   IFS=',' read -r -a component_list <<<"$components"
   for comp in "${component_list[@]}"; do
     case "$comp" in
-      cli|standalone|server) install_cli="true" ;;  # standalone/server kept as aliases
-      intellij)              install_intellij="true" ;;
+      cli)                      install_cli="true" ;;
+      intellij)                 install_intellij="true" ;;
+      backend|standalone-backend) install_standalone="true" ;;
       *) die "Unknown component: $comp" ;;
     esac
   done
 
-  local local_plugin_archive=""
+  local local_plugin_archive="" local_backend_archive=""
   if [[ "$local_build" == "true" ]]; then
     if [[ "$install_cli" == "true" && -z "${KAST_ARCHIVE_PATH:-}" ]]; then
       local dist_archive="${SCRIPT_DIR}/dist/cli.zip"
@@ -888,6 +937,10 @@ USAGE
     if [[ "$install_intellij" == "true" ]]; then
       local_plugin_archive="${SCRIPT_DIR}/dist/plugin.zip"
       [[ -f "$local_plugin_archive" ]] || die "Local plugin archive not found at ${local_plugin_archive}. Run ./kast.sh build plugin first."
+    fi
+    if [[ "$install_standalone" == "true" ]]; then
+      local_backend_archive="${SCRIPT_DIR}/dist/backend.zip"
+      [[ -f "$local_backend_archive" ]] || die "Local backend archive not found at ${local_backend_archive}. Run ./kast.sh build backend first."
     fi
   fi
 
@@ -1034,6 +1087,24 @@ USAGE
     _install_intellij_plugin "$release_repo" "$resolved_tag" "$install_root" "$local_plugin_archive" || true
   fi
 
+  if [[ "$install_standalone" == "true" ]]; then
+    local resolved_tag="${release_tag:-}"
+    if [[ -z "$resolved_tag" ]]; then
+      resolved_tag="${KAST_VERSION:-}"
+      if [[ -z "$resolved_tag" ]]; then
+        local latest_meta="${tmp_dir}/latest-standalone-release.json"
+        curl \
+          --fail --location --retry 3 --retry-delay 2 --silent --show-error \
+          --header "$GITHUB_API_ACCEPT" \
+          --header "$GITHUB_API_VERSION" \
+          --output "$latest_meta" \
+          "https://api.github.com/repos/${release_repo}/releases/latest"
+        resolved_tag="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['tag_name'])" "$latest_meta")"
+      fi
+    fi
+    _install_standalone_backend "$release_repo" "$resolved_tag" "$install_root" "$local_backend_archive" "$bin_dir" || true
+  fi
+
   local rc_file; rc_file="$(_install_resolve_shell_rc_file)"
 
   log_section "Install summary"
@@ -1052,8 +1123,8 @@ USAGE
       log_step "  kast-standalone --workspace-root=/absolute/path/to/workspace  (standalone JVM backend)"
       log_step "  OR open IntelliJ IDEA with the kast plugin installed"
       log_step "Then run commands e.g.: kast references ..."
-      if [[ "$install_intellij" != "true" ]]; then
-        log_note "To also install the IntelliJ plugin: ./kast.sh install --components=intellij"
+      if [[ "$install_intellij" != "true" && "$install_standalone" != "true" ]]; then
+        log_note "To also install components: ./kast.sh install --components=intellij,backend"
       fi
     else
       log_note "Export PATH=\"${bin_dir}:\$PATH\""
@@ -1063,6 +1134,10 @@ USAGE
   fi
   if [[ "$install_intellij" == "true" ]]; then
     log_step "IntelliJ plugin: ${install_root}/plugins/"
+  fi
+  if [[ "$install_standalone" == "true" ]]; then
+    log_success "Standalone backend: ${bin_dir}/kast-standalone"
+    log_note "Backends dir: ${install_root}/backends/"
   fi
 }
 


### PR DESCRIPTION
This pull request adds full support for installing, distributing, and documenting the standalone backend as a first-class component alongside the CLI and IntelliJ plugin. It updates the release pipeline to build and publish the standalone backend, enhances the install script to fetch and install it from releases (or local builds), and revises documentation and CLI help to clarify how to use and install all components.

**Release pipeline enhancements:**

* Adds a `build-standalone-backend` job in `.github/workflows/release.yml` to build, package, and upload the standalone backend as a release asset, and to generate and collect its provenance for the combined release. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R327-R400) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R419-R424) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L360-R433)

**Installer (`kast.sh`) improvements:**

* Implements logic in `_install_standalone_backend` to download, extract, and install the standalone backend from release assets, create a launcher in the user's `bin` directory, and update symlinks for version management. Updates all relevant install paths, help text, and component selection logic to include the backend. [[1]](diffhunk://#diff-c617af4084ccfdb5259c24484ee269b9ddc1127deb48f4c456a79a4cea0dd63eL783-R867) [[2]](diffhunk://#diff-c617af4084ccfdb5259c24484ee269b9ddc1127deb48f4c456a79a4cea0dd63eL811-R879) [[3]](diffhunk://#diff-c617af4084ccfdb5259c24484ee269b9ddc1127deb48f4c456a79a4cea0dd63eL833-R905) [[4]](diffhunk://#diff-c617af4084ccfdb5259c24484ee269b9ddc1127deb48f4c456a79a4cea0dd63eL869-R951) [[5]](diffhunk://#diff-c617af4084ccfdb5259c24484ee269b9ddc1127deb48f4c456a79a4cea0dd63eR962-R965) [[6]](diffhunk://#diff-c617af4084ccfdb5259c24484ee269b9ddc1127deb48f4c456a79a4cea0dd63eL1020-R1102) [[7]](diffhunk://#diff-c617af4084ccfdb5259c24484ee269b9ddc1127deb48f4c456a79a4cea0dd63eL1055-R1122) [[8]](diffhunk://#diff-c617af4084ccfdb5259c24484ee269b9ddc1127deb48f4c456a79a4cea0dd63eR1133-R1136)

**Documentation updates:**

* Updates `docs/getting-started/install.md` and `docs/getting-started/backends.md` to document how to install and start the standalone backend, clarifies the meaning of "all" components, and provides clear install instructions for all combinations (CLI, plugin, backend). [[1]](diffhunk://#diff-622db5a48036e774061f44f2d608fd04d361c69f637989b6f97b4972b8f39944R41-R53) [[2]](diffhunk://#diff-46bcd67bcb0130f49642b78991ecb48fd40d256c0837c49cfc42d89e78827b8fL19-R19) [[3]](diffhunk://#diff-46bcd67bcb0130f49642b78991ecb48fd40d256c0837c49cfc42d89e78827b8fR66-R79) [[4]](diffhunk://#diff-46bcd67bcb0130f49642b78991ecb48fd40d256c0837c49cfc42d89e78827b8fL76-R107) [[5]](diffhunk://#diff-46bcd67bcb0130f49642b78991ecb48fd40d256c0837c49cfc42d89e78827b8fL108-R131)

**CLI behavior and help clarifications:**

* Updates CLI backend selection logic and help text to clarify that the CLI will not auto-start the standalone backend; users must start a backend first. Adjusts command descriptions and error messages accordingly. [[1]](diffhunk://#diff-cd2d4c4d4808978d88128763a77596536a3595079d3b419bd77908b77995bcabL95-R98) [[2]](diffhunk://#diff-cd2d4c4d4808978d88128763a77596536a3595079d3b419bd77908b77995bcabL353-R357)

These changes ensure the standalone backend is easy to install, use, and maintain, and that documentation and CLI behavior are consistent and clear for users.