### PR TITLE
Standardizing naming throughout API surface

### DIFF
--- a/.agents/skills/kast/SKILL.md
+++ b/.agents/skills/kast/SKILL.md
@@ -35,21 +35,20 @@ projection, or edit attempt is imperfect.
 ## JSON shape rules
 
 - Request JSON uses camelCase.
-- Top-level wrapper responses use snake_case for wrapper metadata such as
-  `log_file`, `error_text`, `file_path`, `applied_edits`, and
-  `import_changes`.
-- Nested API models can keep their model casing. For example, symbols use
-  `fqName` and locations use `location.filePath`, `startOffset`, and
+- Wrapper responses also use camelCase. Examples include `logFile`,
+  `errorText`, `filePath`, `appliedEdits`, and `importChanges`.
+- Nested API models keep the same camelCase field names. For example, symbols
+  use `fqName` and locations use `location.filePath`, `startOffset`, and
   `startLine`.
 - Check `ok` and `type` before projecting a response. Failure responses carry
-  `stage`, `message`, optional `error` or `error_text`, and `log_file`.
+  `stage`, `message`, optional `error` or `errorText`, and `logFile`.
 - `rename` and `write-and-validate` requests require a `type` discriminator
   such as `RENAME_BY_SYMBOL_REQUEST` or `REPLACE_RANGE_REQUEST`.
 - Any request field ending in `filePath`, `filePaths`, or `contentFile` should
   use an absolute path.
 - `scaffold` uses `targetFile` (singular absolute path) as the required field,
-  not `filePaths`. Always include `workspaceRoot` in the request body. Run one
-  `scaffold` call per file; there is no batch variant.
+  not `filePaths`. `workspaceRoot` defaults to the current working directory
+  when omitted. Run one `scaffold` call per file; there is no batch variant.
 
 ## Recovery rules
 

--- a/.agents/skills/kast/fixtures/maintenance/eval-baseline.json
+++ b/.agents/skills/kast/fixtures/maintenance/eval-baseline.json
@@ -1,0 +1,210 @@
+{
+    "schemaVersion": 1,
+    "target": {
+        "kind": "skill",
+        "name": "kast",
+        "path": "/Users/amichne/code/kast/.agents/skills/kast"
+    },
+    "summary": {
+        "score": 99,
+        "grade": "A",
+        "deductions": [
+            {
+                "checkId": "completeness-wrapper-metrics",
+                "points": 1,
+                "reason": "Wrapper metrics: skillMd=false, openApi=false"
+            }
+        ],
+        "checkCounts": {
+            "pass": 16,
+            "fail": 0,
+            "warn": 1,
+            "total": 17
+        },
+        "whyBullets": [
+            "16 checks passed"
+        ],
+        "fixFirst": "completeness-wrapper-metrics: Wrapper metrics: skillMd=false, openApi=false",
+        "watchNext": "completeness-wrapper-metrics: Wrapper metrics: skillMd=false, openApi=false"
+    },
+    "budgets": {
+        "triggerTokens": 987,
+        "triggerBand": "FAIR",
+        "invokeTokens": 0,
+        "invokeBand": "GOOD",
+        "deferredTokens": 1116,
+        "deferredBand": "GOOD"
+    },
+    "checks": [
+        {
+            "id": "structural-skill-md-exists",
+            "category": "structural",
+            "severity": "ERROR",
+            "status": "PASS",
+            "message": "SKILL.md found"
+        },
+        {
+            "id": "structural-legacy-artifacts-removed",
+            "category": "structural",
+            "severity": "WARNING",
+            "status": "PASS",
+            "message": "Legacy shell-wrapper and sub-agent artifacts are absent"
+        },
+        {
+            "id": "structural-trigger-phrases",
+            "category": "structural",
+            "severity": "WARNING",
+            "status": "PASS",
+            "message": "SKILL.md contains trigger/description metadata"
+        },
+        {
+            "id": "structural-openapi-exists",
+            "category": "structural",
+            "severity": "WARNING",
+            "status": "PASS",
+            "message": "wrapper-openapi.yaml found"
+        },
+        {
+            "id": "structural-routing-improvement-assets",
+            "category": "structural",
+            "severity": "WARNING",
+            "status": "PASS",
+            "message": "behavior-evals=true, routing-evals=true, routing-script=true, routing-reference=true"
+        },
+        {
+            "id": "corpus-behavior-evals-valid",
+            "category": "corpus",
+            "severity": "ERROR",
+            "status": "PASS",
+            "message": "behavior eval corpus valid (17 cases)"
+        },
+        {
+            "id": "corpus-routing-evals-valid",
+            "category": "corpus",
+            "severity": "ERROR",
+            "status": "PASS",
+            "message": "routing eval corpus valid (22 cases)"
+        },
+        {
+            "id": "corpus-failure-mode-coverage",
+            "category": "corpus",
+            "severity": "WARNING",
+            "status": "PASS",
+            "message": "Failure-mode coverage spans 10/10 required categories"
+        },
+        {
+            "id": "completeness-wrapper-resolve",
+            "category": "completeness",
+            "severity": "INFO",
+            "status": "PASS",
+            "message": "Wrapper resolve: skillMd=true, openApi=true"
+        },
+        {
+            "id": "completeness-wrapper-references",
+            "category": "completeness",
+            "severity": "INFO",
+            "status": "PASS",
+            "message": "Wrapper references: skillMd=true, openApi=true"
+        },
+        {
+            "id": "completeness-wrapper-callers",
+            "category": "completeness",
+            "severity": "INFO",
+            "status": "PASS",
+            "message": "Wrapper callers: skillMd=true, openApi=true"
+        },
+        {
+            "id": "completeness-wrapper-diagnostics",
+            "category": "completeness",
+            "severity": "INFO",
+            "status": "PASS",
+            "message": "Wrapper diagnostics: skillMd=true, openApi=true"
+        },
+        {
+            "id": "completeness-wrapper-rename",
+            "category": "completeness",
+            "severity": "INFO",
+            "status": "PASS",
+            "message": "Wrapper rename: skillMd=true, openApi=true"
+        },
+        {
+            "id": "completeness-wrapper-scaffold",
+            "category": "completeness",
+            "severity": "INFO",
+            "status": "PASS",
+            "message": "Wrapper scaffold: skillMd=true, openApi=true"
+        },
+        {
+            "id": "completeness-wrapper-write-and-validate",
+            "category": "completeness",
+            "severity": "INFO",
+            "status": "PASS",
+            "message": "Wrapper write-and-validate: skillMd=true, openApi=true"
+        },
+        {
+            "id": "completeness-wrapper-workspace-files",
+            "category": "completeness",
+            "severity": "INFO",
+            "status": "PASS",
+            "message": "Wrapper workspace-files: skillMd=true, openApi=true"
+        },
+        {
+            "id": "completeness-wrapper-metrics",
+            "category": "completeness",
+            "severity": "INFO",
+            "status": "WARN",
+            "message": "Wrapper metrics: skillMd=false, openApi=false",
+            "remediation": "Document `kast skill metrics` in both SKILL.md and fixtures/maintenance/references/wrapper-openapi.yaml"
+        }
+    ],
+    "metrics": [
+        {
+            "id": "budget-trigger-tokens",
+            "category": "budget",
+            "value": 987.0,
+            "unit": "tokens"
+        },
+        {
+            "id": "budget-invoke-tokens",
+            "category": "budget",
+            "value": 0.0,
+            "unit": "tokens"
+        },
+        {
+            "id": "budget-deferred-tokens",
+            "category": "budget",
+            "value": 1116.0,
+            "unit": "tokens"
+        },
+        {
+            "id": "corpus-behavior-eval-count",
+            "category": "corpus",
+            "value": 17.0,
+            "unit": "cases"
+        },
+        {
+            "id": "corpus-routing-eval-count",
+            "category": "corpus",
+            "value": 22.0,
+            "unit": "cases"
+        },
+        {
+            "id": "corpus-failure-mode-count",
+            "category": "corpus",
+            "value": 10.0,
+            "unit": "categories"
+        }
+    ],
+    "improvementBrief": {
+        "findings": [
+            "completeness-wrapper-metrics: Wrapper metrics: skillMd=false, openApi=false (-1)"
+        ],
+        "suggestedPrompt": "Fix 1 issue(s): completeness-wrapper-metrics: Wrapper metrics: skillMd=false, openApi=false"
+    },
+    "measurementPlan": {
+        "steps": [
+            "Run kast eval skill --compare=baseline.json to track regression",
+            "Verify CI passes with updated score"
+        ]
+    }
+}

--- a/.agents/skills/kast/fixtures/maintenance/evals/evals.json
+++ b/.agents/skills/kast/fixtures/maintenance/evals/evals.json
@@ -89,14 +89,14 @@
     },
     {
       "id": 8,
-      "prompt": "A Kast `references` response parsed oddly: top-level fields like `log_file` are snake_case, but my jq query for `.references[].file_path` was empty. Inspect the response shape and continue finding the Kotlin usages semantically.",
-      "expected_output": "A schema-recovery flow that distinguishes wrapper metadata from nested API model fields and resumes semantic traversal.",
+      "prompt": "A Kast `references` response parsed oddly and my jq query for `.references[].filePath` was empty. Inspect the response shape and continue finding the Kotlin usages semantically.",
+      "expected_output": "A schema-recovery flow that inspects the real response shape and resumes semantic traversal.",
       "files": [],
       "expectations": [
         "Checks top-level `ok` and `type` before assuming the command failed.",
-        "Recognizes that nested symbol/location fields can be camelCase, such as `location.filePath` or `symbol.fqName`.",
+        "Recognizes fields such as `location.filePath` or `symbol.fqName` after inspecting the response shape.",
         "Continues with `references`, `resolve`, `callers`, or `scaffold` after fixing the projection.",
-        "Does not fall back to grep/rg because a snake_case projection was wrong."
+        "Does not fall back to grep/rg because an initial projection was wrong."
       ],
       "failure_mode": "schema_response"
     },
@@ -128,7 +128,7 @@
     },
     {
       "id": 11,
-      "prompt": "A Kast command returned a failure response with `ok:false`, `stage`, `message`, `error_text`, and `log_file`. Use that output to decide the next step without abandoning Kast.",
+      "prompt": "A Kast command returned a failure response with `ok:false`, `stage`, `message`, `errorText`, and `logFile`. Use that output to decide the next step without abandoning Kast.",
       "expected_output": "A response-handling flow that surfaces the failure stage/message, retries or narrows only when appropriate, and does not ignore `ok:false`.",
       "files": [],
       "expectations": [
@@ -164,6 +164,54 @@
         "Does not use grep/rg to trace the interaction between files."
       ],
       "failure_mode": "schema_request"
+    },
+    {
+      "id": 14,
+      "prompt": "Rename the Kotlin symbol `DescriptorRegistry` to `WorkspaceDescriptorRegistry` with Kast. The request must use the wrapper schema the first time instead of trial-and-error.",
+      "expected_output": "A rename flow that includes the required request discriminator up front and keeps the request in the documented wrapper shape.",
+      "files": [],
+      "expectations": [
+        "Uses `kast skill rename` with `\"type\":\"RENAME_BY_SYMBOL_REQUEST\"` in the request body.",
+        "Keeps request field names camelCase, including `workspaceRoot`, `newName`, `fileHint`, and `containingType` when used.",
+        "Does not probe the schema by sending `{}` or omitting the discriminator to learn what the wrapper accepts."
+      ],
+      "failure_mode": "schema_request"
+    },
+    {
+      "id": 15,
+      "prompt": "Use `kast skill write-and-validate` to replace a Kotlin function body in `/abs/path/src/Main.kt`. Send the documented request shape on the first try.",
+      "expected_output": "A write-and-validate flow that supplies the correct request discriminator and documented camelCase request keys without schema probing.",
+      "files": [],
+      "expectations": [
+        "Uses `kast skill write-and-validate` with `\"type\":\"REPLACE_RANGE_REQUEST\"` in the request body.",
+        "Uses camelCase request fields such as `workspaceRoot`, `filePath`, `startOffset`, `endOffset`, and `content`.",
+        "Does not omit the discriminator or send placeholder `{}` requests to discover the schema."
+      ],
+      "failure_mode": "schema_request"
+    },
+    {
+      "id": 16,
+      "prompt": "I only know the file as `src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt`. Use Kast to scaffold it and then run diagnostics on that file, but make sure every request field that carries a path is absolute.",
+      "expected_output": "A schema-correct flow that normalizes relative paths to absolute ones before passing them to Kast skill requests.",
+      "files": [],
+      "expectations": [
+        "Converts the relative file path to an absolute path before using it as `targetFile` or `filePath`.",
+        "Keeps `workspaceRoot` and all `filePath`/`targetFile` request fields absolute.",
+        "Does not pass the relative path directly through to `kast skill scaffold` or `kast skill diagnostics`."
+      ],
+      "failure_mode": "relative_path"
+    },
+    {
+      "id": 17,
+      "prompt": "Trace callers of the Kotlin symbol `process` with Kast. If there are multiple candidates, disambiguate the request before treating one as the answer.",
+      "expected_output": "A disambiguated caller-tracing flow that narrows an ambiguous symbol with resolver hints before continuing.",
+      "files": [],
+      "expectations": [
+        "Treats a broad symbol like `process` as potentially ambiguous and resolves it with `kind`, `containingType`, or `fileHint` before tracing callers.",
+        "Uses the ambiguity signal from Kast responses when multiple candidates remain.",
+        "Does not silently choose one ambiguous candidate and continue without disambiguation."
+      ],
+      "failure_mode": "ambiguous_symbol"
     }
   ]
 }

--- a/.agents/skills/kast/fixtures/maintenance/evals/routing.json
+++ b/.agents/skills/kast/fixtures/maintenance/evals/routing.json
@@ -192,7 +192,7 @@
     },
     {
       "id": "parse-nested-response-shape",
-      "prompt": "A Kast `references` response has snake_case wrapper fields, but `.references[].file_path` is empty. Inspect the shape and keep tracing the Kotlin usages semantically.",
+      "prompt": "A Kast `references` response parsed oddly and `.references[].filePath` is empty. Inspect the shape and keep tracing the Kotlin usages semantically.",
       "expected_skill": "kast",
       "expected_route": "@kast",
       "allowed_ops": [
@@ -246,7 +246,7 @@
     },
     {
       "id": "respect-failure-response",
-      "prompt": "A Kast command returned `ok:false` with `stage`, `message`, `error_text`, and `log_file`. Use that response to decide the next step without abandoning Kast.",
+      "prompt": "A Kast command returned `ok:false` with `stage`, `message`, `errorText`, and `logFile`. Use that response to decide the next step without abandoning Kast.",
       "expected_skill": "kast",
       "expected_route": "@kast",
       "allowed_ops": [
@@ -295,6 +295,90 @@
         "rg"
       ],
       "failure_mode": "routing_bypass"
+    },
+    {
+      "id": "scaffold-multiple-files-individually",
+      "prompt": "Scaffold `DescriptorRegistry.kt`, `WorkspaceRuntimeManager.kt`, and `KastFileOperations.kt` so I can compare them before a Kotlin refactor.",
+      "expected_skill": "kast",
+      "expected_route": "@kast",
+      "allowed_ops": [
+        "kast skill scaffold"
+      ],
+      "forbidden_ops": [
+        "filePaths",
+        "grep",
+        "rg"
+      ],
+      "failure_mode": "schema_request"
+    },
+    {
+      "id": "write-new-code-via-wrapper",
+      "prompt": "Write new Kotlin code for this file and validate it. Use the supported Kast mutation path instead of editing by hand.",
+      "expected_skill": "kast",
+      "expected_route": "@kast",
+      "allowed_ops": [
+        "kast skill write-and-validate",
+        "kast skill diagnostics"
+      ],
+      "forbidden_ops": [
+        "apply_patch",
+        "sed",
+        "grep",
+        "rg"
+      ],
+      "failure_mode": "mutation_abandonment"
+    },
+    {
+      "id": "unknown-key-consults-quickstart",
+      "prompt": "My first Kast request failed with `Encountered an unknown key`. Recover by consulting the documented request shape instead of probing the wrapper.",
+      "expected_skill": "kast",
+      "expected_route": "@kast",
+      "allowed_ops": [
+        "references/quickstart.md",
+        "kast skill resolve",
+        "kast skill scaffold",
+        "kast skill rename",
+        "kast skill write-and-validate"
+      ],
+      "forbidden_ops": [
+        "{}",
+        "--help",
+        "grep",
+        "rg"
+      ],
+      "failure_mode": "schema_request"
+    },
+    {
+      "id": "absolute-path-wrapper-requests",
+      "prompt": "The Kotlin file is `src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt`. Use Kast on it, but normalize the path before you call the wrapper.",
+      "expected_skill": "kast",
+      "expected_route": "@kast",
+      "allowed_ops": [
+        "kast skill scaffold",
+        "kast skill diagnostics"
+      ],
+      "forbidden_ops": [
+        "\"targetFile\":\"src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt\"",
+        "\"filePath\":\"src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt\"",
+        "grep",
+        "rg"
+      ],
+      "failure_mode": "relative_path"
+    },
+    {
+      "id": "disambiguate-ambiguous-symbol-before-tracing",
+      "prompt": "Trace callers for the Kotlin symbol `handle`. If multiple candidates exist, do not guess which one I meant.",
+      "expected_skill": "kast",
+      "expected_route": "@kast",
+      "allowed_ops": [
+        "kast skill resolve",
+        "kast skill callers"
+      ],
+      "forbidden_ops": [
+        "grep",
+        "rg"
+      ],
+      "failure_mode": "ambiguous_symbol"
     }
   ]
 }

--- a/.agents/skills/kast/fixtures/maintenance/phoenix/README.md
+++ b/.agents/skills/kast/fixtures/maintenance/phoenix/README.md
@@ -14,7 +14,7 @@ history failures.
 | `acknowledges_ok_false` | code | failure_response_ignored, mutation_abandonment |
 | `routing_correct` | LLM | trigger_miss, routing_bypass |
 | `recovery_quality` | LLM | initialization_friction |
-| `schema_correct` | LLM | schema_request (filePaths→targetFile, workspaceRoot) |
+| `schema_correct` | LLM | schema_request, relative_path, ambiguous_symbol |
 | `failure_handling_correct` | LLM | failure_response_ignored, mutation_abandonment |
 
 ## Failure taxonomy (from session history)
@@ -26,15 +26,17 @@ Derived from sessions `803057da`, `dbda65ca`, `fe3aa9ad`, `431e7b1e`:
 - **initialization_friction** — `KAST_CLI_PATH` empty; agent searches filesystem instead of running bootstrap
 - **maintenance_thrash** — agent reads `.kast-version` / `fixtures/maintenance/` / `wrapper-openapi.yaml` before any useful work
 - **schema_request** — wrong request fields: `filePaths` instead of `targetFile`, missing `workspaceRoot`, probes `{}`
-- **schema_response** — abandons kast after jq projection fails (snake_case wrapper vs camelCase nested model)
+- **relative_path** — agent passes relative paths where wrapper request fields require absolute paths
+- **ambiguous_symbol** — agent keeps moving after a broad symbol lookup without using `kind`, `containingType`, or `fileHint` to disambiguate
+- **schema_response** — abandons kast after a bad jq projection instead of inspecting the actual response shape
 - **mutation_abandonment** — falls back to `sed`/manual edit after `write-and-validate` returns `ok=false`
 - **failure_response_ignored** — treats `ok=false` as success or abandons kast entirely
 
 ## Dataset
 
-30 examples total:
-- 13 from `evals/evals.json` (behavior evals)
-- 17 from `evals/routing.json` (routing evals)
+39 examples total:
+- 17 from `evals/evals.json` (behavior evals)
+- 22 from `evals/routing.json` (routing evals)
 
 The checked-in native corpora are now the source of truth for both `kast eval skill`
 and the Phoenix experiment. The Phoenix script no longer carries a separate

--- a/.agents/skills/kast/fixtures/maintenance/phoenix/kast_evals.py
+++ b/.agents/skills/kast/fixtures/maintenance/phoenix/kast_evals.py
@@ -62,8 +62,10 @@ QUICKSTART_MD = _SKILL_ROOT / "references" / "quickstart.md"
 #   routing_bypass        - kast loaded, agent uses grep/rg for Kotlin identity
 #   initialization_friction - KAST_CLI_PATH empty, wrong recovery path
 #   maintenance_thrash    - reads .kast-version / fixtures/maintenance / wrapper-openapi first
-#   schema_request        - wrong request fields (filePaths, no workspaceRoot, probes {})
-#   schema_response       - abandons kast after jq/snake_case/camelCase confusion
+#   schema_request        - wrong request fields (filePaths, no workspaceRoot, missing type, probes {})
+#   relative_path         - passes relative paths where wrapper requests require absolute paths
+#   ambiguous_symbol      - keeps going after a broad lookup without resolver disambiguation
+#   schema_response       - abandons kast after a bad jq projection
 #   mutation_abandonment  - falls back to sed/manual edit after write-and-validate ok=false
 #   failure_response_ignored - treats ok=false as success or abandons kast entirely
 
@@ -73,6 +75,8 @@ _REQUIRED_FAILURE_MODES = {
     "initialization_friction",
     "maintenance_thrash",
     "schema_request",
+    "relative_path",
+    "ambiguous_symbol",
     "schema_response",
     "mutation_abandonment",
     "failure_response_ignored",
@@ -269,10 +273,10 @@ You are evaluating whether a developer assistant used correct kast JSON shapes.
 
 Rules:
 - scaffold uses `targetFile` (singular absolute path), NOT `filePaths` array
-- Always include `workspaceRoot` in scaffold requests
+- `workspaceRoot` defaults to the current working directory when omitted
 - One scaffold call per file; no batch variant
 - Request JSON is camelCase
-- Top-level wrapper response metadata is snake_case
+- Wrapper responses are camelCase, including `logFile` and `errorText`
 - Nested API model fields are camelCase (e.g. symbol.fqName, location.filePath)
 - Never probe schema with empty `{}` or `--help`
 - Paths ending in filePath/filePaths/contentFile must be absolute
@@ -281,8 +285,7 @@ Rules:
 <response>{{output}}</response>
 
 "correct"        – all kast request/response handling follows the rules
-"incorrect"      – wrong field names, batched scaffold, omitted workspaceRoot,
-                   or misinterpreted snake_case/camelCase boundaries
+"incorrect"      – wrong field names, batched scaffold, or misread response shape
 "not_applicable" – no kast request JSON shown or constructed
 
 Answer (correct/incorrect/not_applicable):""",
@@ -296,7 +299,7 @@ failure_handling_evaluator = ClassificationEvaluator(
 You are evaluating how a developer assistant handled a kast failure response.
 
 kast failure responses carry: ok=false, type (e.g. WRITE_AND_VALIDATE_FAILURE),
-stage, message, optional error_text and log_file.
+stage, message, optional errorText and logFile.
 
 Correct behavior:
 1. Check `ok` and `type` BEFORE presenting results

--- a/.agents/skills/kast/fixtures/maintenance/references/wrapper-openapi.yaml
+++ b/.agents/skills/kast/fixtures/maintenance/references/wrapper-openapi.yaml
@@ -578,13 +578,13 @@ components:
     KastRenameBySymbolQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
         symbol:
           type: string
-        new_name:
+        newName:
           type: string
-        file_hint:
+        fileHint:
           anyOf:
             -
               type: string
@@ -596,13 +596,13 @@ components:
               $ref: "#/components/schemas/WrapperNamedSymbolKind"
             -
               type: null
-        containing_type:
+        containingType:
           anyOf:
             -
               type: string
             -
               type: null
-        file_path:
+        filePath:
           type: string
         offset:
           type: integer
@@ -612,55 +612,55 @@ components:
           const: RENAME_BY_SYMBOL_REQUEST
       additionalProperties: false
       required:
-        - workspace_root
+        - workspaceRoot
         - symbol
-        - new_name
-        - file_path
+        - newName
+        - filePath
         - offset
         - type
     KastRenameByOffsetQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
-        file_path:
+        filePath:
           type: string
         offset:
           type: integer
           format: int32
-        new_name:
+        newName:
           type: string
         type:
           type: string
           const: RENAME_BY_OFFSET_REQUEST
       additionalProperties: false
       required:
-        - workspace_root
-        - file_path
+        - workspaceRoot
+        - filePath
         - offset
-        - new_name
+        - newName
         - type
     KastWriteAndValidateCreateFileQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
-        file_path:
+        filePath:
           type: string
         type:
           type: string
           const: CREATE_FILE_REQUEST
       additionalProperties: false
       required:
-        - workspace_root
-        - file_path
+        - workspaceRoot
+        - filePath
         - type
     KastWriteAndValidateInsertAtOffsetQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
-        file_path:
+        filePath:
           type: string
         offset:
           type: integer
@@ -670,21 +670,21 @@ components:
           const: INSERT_AT_OFFSET_REQUEST
       additionalProperties: false
       required:
-        - workspace_root
-        - file_path
+        - workspaceRoot
+        - filePath
         - offset
         - type
     KastWriteAndValidateReplaceRangeQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
-        file_path:
+        filePath:
           type: string
-        start_offset:
+        startOffset:
           type: integer
           format: int32
-        end_offset:
+        endOffset:
           type: integer
           format: int32
         type:
@@ -692,10 +692,10 @@ components:
           const: REPLACE_RANGE_REQUEST
       additionalProperties: false
       required:
-        - workspace_root
-        - file_path
-        - start_offset
-        - end_offset
+        - workspaceRoot
+        - filePath
+        - startOffset
+        - endOffset
         - type
     KastResolveSuccessResponse:
       type: object
@@ -706,14 +706,29 @@ components:
           $ref: "#/components/schemas/KastResolveQuery"
         symbol:
           $ref: "#/components/schemas/Symbol"
-        file_path:
+        filePath:
           type: string
         offset:
           type: integer
           format: int32
         candidate:
           $ref: "#/components/schemas/KastCandidate"
-        log_file:
+        candidateCount:
+          anyOf:
+            -
+              type: integer
+              format: int32
+            -
+              type: null
+        alternatives:
+          anyOf:
+            -
+              type: array
+              items:
+                type: string
+            -
+              type: null
+        logFile:
           type: string
         type:
           type: string
@@ -722,19 +737,19 @@ components:
       required:
         - query
         - symbol
-        - file_path
+        - filePath
         - offset
         - candidate
-        - log_file
+        - logFile
         - type
     KastResolveQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
         symbol:
           type: string
-        file_hint:
+        fileHint:
           anyOf:
             -
               type: string
@@ -746,7 +761,7 @@ components:
               $ref: "#/components/schemas/WrapperNamedSymbolKind"
             -
               type: null
-        containing_type:
+        containingType:
           anyOf:
             -
               type: string
@@ -754,7 +769,7 @@ components:
               type: null
       additionalProperties: false
       required:
-        - workspace_root
+        - workspaceRoot
         - symbol
     Symbol:
       type: object
@@ -941,7 +956,7 @@ components:
           type: string
         query:
           $ref: "#/components/schemas/KastResolveQuery"
-        log_file:
+        logFile:
           type: string
         error:
           anyOf:
@@ -949,7 +964,7 @@ components:
               $ref: "#/components/schemas/ApiErrorResponse"
             -
               type: null
-        error_text:
+        errorText:
           anyOf:
             -
               type: string
@@ -963,7 +978,7 @@ components:
         - stage
         - message
         - query
-        - log_file
+        - logFile
         - type
     KastResolveResponse:
       oneOf:
@@ -985,7 +1000,7 @@ components:
           $ref: "#/components/schemas/KastReferencesQuery"
         symbol:
           $ref: "#/components/schemas/Symbol"
-        file_path:
+        filePath:
           type: string
         offset:
           type: integer
@@ -994,7 +1009,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Location"
-        search_scope:
+        searchScope:
           anyOf:
             -
               $ref: "#/components/schemas/SearchScope"
@@ -1006,7 +1021,22 @@ components:
               $ref: "#/components/schemas/Symbol"
             -
               type: null
-        log_file:
+        candidateCount:
+          anyOf:
+            -
+              type: integer
+              format: int32
+            -
+              type: null
+        alternatives:
+          anyOf:
+            -
+              type: array
+              items:
+                type: string
+            -
+              type: null
+        logFile:
           type: string
         type:
           type: string
@@ -1015,19 +1045,19 @@ components:
       required:
         - query
         - symbol
-        - file_path
+        - filePath
         - offset
         - references
-        - log_file
+        - logFile
         - type
     KastReferencesQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
         symbol:
           type: string
-        file_hint:
+        fileHint:
           anyOf:
             -
               type: string
@@ -1039,17 +1069,17 @@ components:
               $ref: "#/components/schemas/WrapperNamedSymbolKind"
             -
               type: null
-        containing_type:
+        containingType:
           anyOf:
             -
               type: string
             -
               type: null
-        include_declaration:
+        includeDeclaration:
           type: boolean
       additionalProperties: false
       required:
-        - workspace_root
+        - workspaceRoot
         - symbol
     SearchScope:
       type: object
@@ -1090,7 +1120,7 @@ components:
           type: string
         query:
           $ref: "#/components/schemas/KastReferencesQuery"
-        log_file:
+        logFile:
           type: string
         error:
           anyOf:
@@ -1098,7 +1128,7 @@ components:
               $ref: "#/components/schemas/ApiErrorResponse"
             -
               type: null
-        error_text:
+        errorText:
           anyOf:
             -
               type: string
@@ -1112,7 +1142,7 @@ components:
         - stage
         - message
         - query
-        - log_file
+        - logFile
         - type
     KastReferencesResponse:
       oneOf:
@@ -1134,7 +1164,7 @@ components:
           $ref: "#/components/schemas/KastCallersQuery"
         symbol:
           $ref: "#/components/schemas/Symbol"
-        file_path:
+        filePath:
           type: string
         offset:
           type: integer
@@ -1143,7 +1173,22 @@ components:
           $ref: "#/components/schemas/CallNode"
         stats:
           $ref: "#/components/schemas/CallHierarchyStats"
-        log_file:
+        candidateCount:
+          anyOf:
+            -
+              type: integer
+              format: int32
+            -
+              type: null
+        alternatives:
+          anyOf:
+            -
+              type: array
+              items:
+                type: string
+            -
+              type: null
+        logFile:
           type: string
         type:
           type: string
@@ -1152,20 +1197,20 @@ components:
       required:
         - query
         - symbol
-        - file_path
+        - filePath
         - offset
         - root
         - stats
-        - log_file
+        - logFile
         - type
     KastCallersQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
         symbol:
           type: string
-        file_hint:
+        fileHint:
           anyOf:
             -
               type: string
@@ -1177,7 +1222,7 @@ components:
               $ref: "#/components/schemas/WrapperNamedSymbolKind"
             -
               type: null
-        containing_type:
+        containingType:
           anyOf:
             -
               type: string
@@ -1188,21 +1233,21 @@ components:
         depth:
           type: integer
           format: int32
-        max_total_calls:
+        maxTotalCalls:
           anyOf:
             -
               type: integer
               format: int32
             -
               type: null
-        max_children_per_node:
+        maxChildrenPerNode:
           anyOf:
             -
               type: integer
               format: int32
             -
               type: null
-        timeout_millis:
+        timeoutMillis:
           anyOf:
             -
               type: integer
@@ -1211,7 +1256,7 @@ components:
               type: null
       additionalProperties: false
       required:
-        - workspace_root
+        - workspaceRoot
         - symbol
     CallNode:
       type: object
@@ -1304,7 +1349,7 @@ components:
           type: string
         query:
           $ref: "#/components/schemas/KastCallersQuery"
-        log_file:
+        logFile:
           type: string
         error:
           anyOf:
@@ -1312,7 +1357,7 @@ components:
               $ref: "#/components/schemas/ApiErrorResponse"
             -
               type: null
-        error_text:
+        errorText:
           anyOf:
             -
               type: string
@@ -1326,7 +1371,7 @@ components:
         - stage
         - message
         - query
-        - log_file
+        - logFile
         - type
     KastCallersResponse:
       oneOf:
@@ -1348,20 +1393,20 @@ components:
           $ref: "#/components/schemas/KastDiagnosticsQuery"
         clean:
           type: boolean
-        error_count:
+        errorCount:
           type: integer
           format: int32
-        warning_count:
+        warningCount:
           type: integer
           format: int32
-        info_count:
+        infoCount:
           type: integer
           format: int32
         diagnostics:
           type: array
           items:
             $ref: "#/components/schemas/Diagnostic"
-        log_file:
+        logFile:
           type: string
         type:
           type: string
@@ -1370,25 +1415,25 @@ components:
       required:
         - query
         - clean
-        - error_count
-        - warning_count
-        - info_count
+        - errorCount
+        - warningCount
+        - infoCount
         - diagnostics
-        - log_file
+        - logFile
         - type
     KastDiagnosticsQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
-        file_paths:
+        filePaths:
           type: array
           items:
             type: string
       additionalProperties: false
       required:
-        - workspace_root
-        - file_paths
+        - workspaceRoot
+        - filePaths
     Diagnostic:
       type: object
       properties:
@@ -1426,7 +1471,7 @@ components:
           type: string
         query:
           $ref: "#/components/schemas/KastDiagnosticsQuery"
-        log_file:
+        logFile:
           type: string
         error:
           anyOf:
@@ -1434,7 +1479,7 @@ components:
               $ref: "#/components/schemas/ApiErrorResponse"
             -
               type: null
-        error_text:
+        errorText:
           anyOf:
             -
               type: string
@@ -1448,7 +1493,7 @@ components:
         - stage
         - message
         - query
-        - log_file
+        - logFile
         - type
     KastDiagnosticsResponse:
       oneOf:
@@ -1468,18 +1513,18 @@ components:
           type: boolean
         query:
           $ref: "#/components/schemas/KastRenameQuery"
-        edit_count:
+        editCount:
           type: integer
           format: int32
-        affected_files:
+        affectedFiles:
           type: array
           items:
             type: string
-        apply_result:
+        applyResult:
           $ref: "#/components/schemas/ApplyEditsResult"
         diagnostics:
           $ref: "#/components/schemas/KastDiagnosticsSummary"
-        log_file:
+        logFile:
           type: string
         type:
           type: string
@@ -1488,11 +1533,11 @@ components:
       required:
         - ok
         - query
-        - edit_count
-        - affected_files
-        - apply_result
+        - editCount
+        - affectedFiles
+        - applyResult
         - diagnostics
-        - log_file
+        - logFile
         - type
     KastRenameQuery:
       oneOf:
@@ -1555,10 +1600,10 @@ components:
       properties:
         clean:
           type: boolean
-        error_count:
+        errorCount:
           type: integer
           format: int32
-        warning_count:
+        warningCount:
           type: integer
           format: int32
         errors:
@@ -1568,8 +1613,8 @@ components:
       additionalProperties: false
       required:
         - clean
-        - error_count
-        - warning_count
+        - errorCount
+        - warningCount
     KastRenameFailureResponse:
       type: object
       properties:
@@ -1581,7 +1626,7 @@ components:
           type: string
         query:
           $ref: "#/components/schemas/KastRenameFailureQuery"
-        log_file:
+        logFile:
           type: string
         error:
           anyOf:
@@ -1589,7 +1634,7 @@ components:
               $ref: "#/components/schemas/ApiErrorResponse"
             -
               type: null
-        error_text:
+        errorText:
           anyOf:
             -
               type: string
@@ -1603,7 +1648,7 @@ components:
         - stage
         - message
         - query
-        - log_file
+        - logFile
         - type
     KastRenameFailureQuery:
       type: object
@@ -1614,7 +1659,7 @@ components:
               type: string
             -
               type: null
-        workspace_root:
+        workspaceRoot:
           type: string
         symbol:
           anyOf:
@@ -1622,7 +1667,7 @@ components:
               type: string
             -
               type: null
-        file_hint:
+        fileHint:
           anyOf:
             -
               type: string
@@ -1634,13 +1679,13 @@ components:
               $ref: "#/components/schemas/WrapperNamedSymbolKind"
             -
               type: null
-        containing_type:
+        containingType:
           anyOf:
             -
               type: string
             -
               type: null
-        file_path:
+        filePath:
           anyOf:
             -
               type: string
@@ -1653,12 +1698,12 @@ components:
               format: int32
             -
               type: null
-        new_name:
+        newName:
           type: string
       additionalProperties: false
       required:
-        - workspace_root
-        - new_name
+        - workspaceRoot
+        - newName
     KastRenameResponse:
       oneOf:
         -
@@ -1681,7 +1726,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/OutlineSymbol"
-        file_content:
+        fileContent:
           anyOf:
             -
               type: string
@@ -1699,19 +1744,19 @@ components:
               $ref: "#/components/schemas/KastScaffoldReferences"
             -
               type: null
-        type_hierarchy:
+        typeHierarchy:
           anyOf:
             -
               $ref: "#/components/schemas/KastScaffoldTypeHierarchy"
             -
               type: null
-        insertion_point:
+        insertionPoint:
           anyOf:
             -
               $ref: "#/components/schemas/SemanticInsertionResult"
             -
               type: null
-        log_file:
+        logFile:
           type: string
         type:
           type: string
@@ -1720,16 +1765,16 @@ components:
       required:
         - query
         - outline
-        - log_file
+        - logFile
         - type
     KastScaffoldQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
-        target_file:
+        targetFile:
           type: string
-        target_symbol:
+        targetSymbol:
           anyOf:
             -
               type: string
@@ -1745,8 +1790,8 @@ components:
               type: null
       additionalProperties: false
       required:
-        - workspace_root
-        - target_file
+        - workspaceRoot
+        - targetFile
     OutlineSymbol:
       type: object
       properties:
@@ -1769,7 +1814,7 @@ components:
         count:
           type: integer
           format: int32
-        search_scope:
+        searchScope:
           anyOf:
             -
               $ref: "#/components/schemas/SearchScope"
@@ -1876,7 +1921,7 @@ components:
           type: string
         query:
           $ref: "#/components/schemas/KastScaffoldQuery"
-        log_file:
+        logFile:
           type: string
         error:
           anyOf:
@@ -1884,7 +1929,7 @@ components:
               $ref: "#/components/schemas/ApiErrorResponse"
             -
               type: null
-        error_text:
+        errorText:
           anyOf:
             -
               type: string
@@ -1898,7 +1943,7 @@ components:
         - stage
         - message
         - query
-        - log_file
+        - logFile
         - type
     KastScaffoldResponse:
       oneOf:
@@ -1922,10 +1967,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/WorkspaceModule"
-        schema_version:
+        schemaVersion:
           type: integer
           format: int32
-        log_file:
+        logFile:
           type: string
         type:
           type: string
@@ -1934,25 +1979,25 @@ components:
       required:
         - query
         - modules
-        - schema_version
-        - log_file
+        - schemaVersion
+        - logFile
         - type
     KastWorkspaceFilesQuery:
       type: object
       properties:
-        workspace_root:
+        workspaceRoot:
           type: string
-        module_name:
+        moduleName:
           anyOf:
             -
               type: string
             -
               type: null
-        include_files:
+        includeFiles:
           type: boolean
       additionalProperties: false
       required:
-        - workspace_root
+        - workspaceRoot
     WorkspaceModule:
       type: object
       properties:
@@ -1990,7 +2035,7 @@ components:
           type: string
         query:
           $ref: "#/components/schemas/KastWorkspaceFilesQuery"
-        log_file:
+        logFile:
           type: string
         error:
           anyOf:
@@ -1998,7 +2043,7 @@ components:
               $ref: "#/components/schemas/ApiErrorResponse"
             -
               type: null
-        error_text:
+        errorText:
           anyOf:
             -
               type: string
@@ -2012,7 +2057,7 @@ components:
         - stage
         - message
         - query
-        - log_file
+        - logFile
         - type
     KastWorkspaceFilesResponse:
       oneOf:
@@ -2032,10 +2077,10 @@ components:
           type: boolean
         query:
           $ref: "#/components/schemas/KastWriteAndValidateQuery"
-        applied_edits:
+        appliedEdits:
           type: integer
           format: int32
-        import_changes:
+        importChanges:
           type: integer
           format: int32
         diagnostics:
@@ -2046,7 +2091,7 @@ components:
               type: string
             -
               type: null
-        log_file:
+        logFile:
           type: string
         type:
           type: string
@@ -2055,10 +2100,10 @@ components:
       required:
         - ok
         - query
-        - applied_edits
-        - import_changes
+        - appliedEdits
+        - importChanges
         - diagnostics
-        - log_file
+        - logFile
         - type
     KastWriteAndValidateQuery:
       oneOf:
@@ -2085,7 +2130,7 @@ components:
           type: string
         query:
           $ref: "#/components/schemas/KastWriteAndValidateFailureQuery"
-        log_file:
+        logFile:
           type: string
         error:
           anyOf:
@@ -2093,7 +2138,7 @@ components:
               $ref: "#/components/schemas/ApiErrorResponse"
             -
               type: null
-        error_text:
+        errorText:
           anyOf:
             -
               type: string
@@ -2107,7 +2152,7 @@ components:
         - stage
         - message
         - query
-        - log_file
+        - logFile
         - type
     KastWriteAndValidateFailureQuery:
       type: object
@@ -2118,14 +2163,14 @@ components:
               type: string
             -
               type: null
-        workspace_root:
+        workspaceRoot:
           type: string
-        file_path:
+        filePath:
           type: string
       additionalProperties: false
       required:
-        - workspace_root
-        - file_path
+        - workspaceRoot
+        - filePath
     KastWriteAndValidateResponse:
       oneOf:
         -

--- a/.agents/skills/kast/references/quickstart.md
+++ b/.agents/skills/kast/references/quickstart.md
@@ -32,18 +32,19 @@ instead of switching to non-semantic Kotlin search.
 ## Request and response shape
 
 - Request JSON uses camelCase.
-- Top-level wrapper response metadata uses snake_case.
-- Nested API model fields may keep camelCase. Common examples are
+- Wrapper responses also use camelCase.
+- Nested API model fields use the same camelCase names. Common examples are
   `symbol.fqName`, `symbol.location.filePath`, `symbol.location.startOffset`,
   and `references[].location.filePath`.
 - Any field ending in `filePath`, `filePaths`, or `contentFile` should be an
   absolute path.
 - Check `ok` and `type` first. Failure responses include `stage`, `message`,
-  optional `error` or `error_text`, and `log_file`.
+  optional `error` or `errorText`, and `logFile`.
 - `rename` and `write-and-validate` requests require a `type` discriminator:
   `RENAME_BY_SYMBOL_REQUEST`, `RENAME_BY_OFFSET_REQUEST`,
   `CREATE_FILE_REQUEST`, `INSERT_AT_OFFSET_REQUEST`, or
   `REPLACE_RANGE_REQUEST`.
+- `workspaceRoot` defaults to the current working directory when omitted.
 
 ## Common requests
 
@@ -74,16 +75,16 @@ instead of switching to non-semantic Kotlin search.
 }'
 ```
 
-If a projection such as `.references[].file_path` returns nothing, inspect one
+If a projection such as `.references[].location.filePath` returns nothing, inspect one
 item before assuming the command failed:
 
 ```bash
 "$KAST_CLI_PATH" skill references '{"symbol":"EventBean","includeDeclaration":true}' \
-  | jq '{ok,type,first_reference:.references[0]}'
+  | jq '{ok,type,firstReference:.references[0]}'
 ```
 
-Wrapper metadata is snake_case, but nested locations use fields such as
-`location.filePath`.
+Wrapper metadata and nested API fields both use camelCase, including
+`logFile`, `filePath`, and `location.filePath`.
 
 ### Trace callers
 
@@ -108,8 +109,9 @@ Wrapper metadata is snake_case, but nested locations use fields such as
 }'
 ```
 
-`targetFile` is singular (not `filePaths`). Always include `workspaceRoot` in
-the request body. Run one `scaffold` call per file; there is no batch variant.
+`targetFile` is singular (not `filePaths`). `workspaceRoot` defaults to the
+current working directory when omitted. Run one `scaffold` call per file; there
+is no batch variant.
 
 ### Rename
 
@@ -150,8 +152,7 @@ than applying a manual edit.
 ## Recovery
 
 - If a `jq` projection is wrong, inspect one item first, for example
-  `.references[0]`, before assuming field names. Remember that nested API model
-  fields may be camelCase even when wrapper metadata is snake_case.
+  `.references[0]`, before assuming field names.
 - If a symbol name is broad, add `kind`, `containingType`, or `fileHint`.
 - For large result sets, narrow the query before post-processing.
 - Never pivot to `grep` or `rg` for Kotlin identity.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,14 +173,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          "$KAST_BIN" eval skill --skill-dir="$GITHUB_WORKSPACE/.agents/skills/kast" > "$RUNNER_TEMP/eval-result.json"
+          "$KAST_BIN" eval skill --skill-dir="$GITHUB_WORKSPACE/.agents/skills/kast" --format=json > "$RUNNER_TEMP/eval-result.json"
           echo "=== Eval Result ==="
           cat "$RUNNER_TEMP/eval-result.json" | python3 -c "import sys, json; d=json.load(sys.stdin); print(f'Score: {d[\"summary\"][\"score\"]}/100 ({d[\"summary\"][\"grade\"]})')"
+
+      - name: Compare skill evaluation baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$KAST_BIN" eval skill \
+            --skill-dir="$GITHUB_WORKSPACE/.agents/skills/kast" \
+            --compare="$GITHUB_WORKSPACE/.agents/skills/kast/fixtures/maintenance/eval-baseline.json" \
+            --format=json > "$RUNNER_TEMP/eval-compare.json"
 
       - name: Upload eval result
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: skill-eval-result
-          path: ${{ runner.temp }}/eval-result.json
+          path: |
+            ${{ runner.temp }}/eval-result.json
+            ${{ runner.temp }}/eval-compare.json
           retention-days: 30

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/FileOperation.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/FileOperation.kt
@@ -13,7 +13,7 @@ sealed interface FileOperation {
     val filePath: String
 
     @Serializable
-    @SerialName("create")
+    @SerialName("CREATE_FILE")
     data class CreateFile(
         @DocField(description = "Absolute path of the file to create.")
         override val filePath: String,
@@ -22,7 +22,7 @@ sealed interface FileOperation {
     ) : FileOperation
 
     @Serializable
-    @SerialName("delete")
+    @SerialName("DELETE_FILE")
     data class DeleteFile(
         @DocField(description = "Absolute path of the file to delete.")
         override val filePath: String,

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/OpenApiDocument.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/OpenApiDocument.kt
@@ -551,16 +551,16 @@ internal class SchemaRegistry {
     private fun manualUnionSchema(componentName: String): Map<String, Any?>? =
         when (componentName) {
             "FileOperation" -> discriminatedUnion(
-                "create" to "FileOperation.CreateFile",
-                "delete" to "FileOperation.DeleteFile",
+                "CREATE_FILE" to "FileOperation.CreateFile",
+                "DELETE_FILE" to "FileOperation.DeleteFile",
             )
             "FileOperation.CreateFile" -> subtypeWithDiscriminator(
                 FileOperation.CreateFile.serializer(),
-                discriminatorValue = "create",
+                discriminatorValue = "CREATE_FILE",
             )
             "FileOperation.DeleteFile" -> subtypeWithDiscriminator(
                 FileOperation.DeleteFile.serializer(),
-                discriminatorValue = "delete",
+                discriminatorValue = "DELETE_FILE",
             )
             else -> null
         }

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/wrapper/WrapperContracts.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/wrapper/WrapperContracts.kt
@@ -50,16 +50,16 @@ enum class WrapperScaffoldMode {
 
 @Serializable
 enum class WrapperMetric {
-    @SerialName("fan-in")
+    @SerialName("fanIn")
     FAN_IN,
 
-    @SerialName("fan-out")
+    @SerialName("fanOut")
     FAN_OUT,
 
     @SerialName("coupling")
     COUPLING,
 
-    @SerialName("dead-code")
+    @SerialName("deadCode")
     DEAD_CODE,
 
     @SerialName("impact")
@@ -77,7 +77,6 @@ data class KastMetricsRequest(
 
 @Serializable
 data class KastMetricsQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
     val metric: WrapperMetric,
     val limit: Int = 50,
@@ -94,7 +93,6 @@ data class KastMetricsSuccessResponse(
     val ok: Boolean = true,
     val query: KastMetricsQuery,
     val results: kotlinx.serialization.json.JsonElement,
-    @SerialName("log_file")
     val logFile: String,
 ) : KastMetricsResponse
 
@@ -105,7 +103,6 @@ data class KastMetricsFailureResponse(
     val stage: String,
     val message: String,
     val query: KastMetricsQuery,
-    @SerialName("log_file")
     val logFile: String,
 ) : KastMetricsResponse
 
@@ -222,73 +219,53 @@ data class KastWriteAndValidateReplaceRangeRequest(
 
 @Serializable
 data class KastResolveQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
     val symbol: String,
-    @SerialName("file_hint")
     val fileHint: String? = null,
     val kind: WrapperNamedSymbolKind? = null,
-    @SerialName("containing_type")
     val containingType: String? = null,
 )
 
 @Serializable
 data class KastReferencesQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
     val symbol: String,
-    @SerialName("file_hint")
     val fileHint: String? = null,
     val kind: WrapperNamedSymbolKind? = null,
-    @SerialName("containing_type")
     val containingType: String? = null,
-    @SerialName("include_declaration")
     val includeDeclaration: Boolean = true,
 )
 
 @Serializable
 data class KastCallersQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
     val symbol: String,
-    @SerialName("file_hint")
     val fileHint: String? = null,
     val kind: WrapperNamedSymbolKind? = null,
-    @SerialName("containing_type")
     val containingType: String? = null,
     val direction: WrapperCallDirection = WrapperCallDirection.INCOMING,
     val depth: Int = 2,
-    @SerialName("max_total_calls")
     val maxTotalCalls: Int? = null,
-    @SerialName("max_children_per_node")
     val maxChildrenPerNode: Int? = null,
-    @SerialName("timeout_millis")
     val timeoutMillis: Int? = null,
 )
 
 @Serializable
 data class KastDiagnosticsQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
-    @SerialName("file_paths")
     val filePaths: List<String>,
 )
 
 @Serializable
 data class KastRenameFailureQuery(
     val type: String? = null,
-    @SerialName("workspace_root")
     val workspaceRoot: String,
     val symbol: String? = null,
-    @SerialName("file_hint")
     val fileHint: String? = null,
     val kind: WrapperNamedSymbolKind? = null,
-    @SerialName("containing_type")
     val containingType: String? = null,
-    @SerialName("file_path")
     val filePath: String? = null,
     val offset: Int? = null,
-    @SerialName("new_name")
     val newName: String,
 )
 
@@ -298,17 +275,12 @@ sealed interface KastRenameQuery
 @Serializable
 @SerialName("RENAME_BY_SYMBOL_REQUEST")
 data class KastRenameBySymbolQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
     val symbol: String,
-    @SerialName("new_name")
     val newName: String,
-    @SerialName("file_hint")
     val fileHint: String? = null,
     val kind: WrapperNamedSymbolKind? = null,
-    @SerialName("containing_type")
     val containingType: String? = null,
-    @SerialName("file_path")
     val filePath: String,
     val offset: Int,
 ) : KastRenameQuery
@@ -316,22 +288,16 @@ data class KastRenameBySymbolQuery(
 @Serializable
 @SerialName("RENAME_BY_OFFSET_REQUEST")
 data class KastRenameByOffsetQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
-    @SerialName("file_path")
     val filePath: String,
     val offset: Int,
-    @SerialName("new_name")
     val newName: String,
 ) : KastRenameQuery
 
 @Serializable
 data class KastScaffoldQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
-    @SerialName("target_file")
     val targetFile: String,
-    @SerialName("target_symbol")
     val targetSymbol: String? = null,
     val mode: WrapperScaffoldMode = WrapperScaffoldMode.IMPLEMENT,
     val kind: WrapperNamedSymbolKind? = null,
@@ -339,20 +305,15 @@ data class KastScaffoldQuery(
 
 @Serializable
 data class KastWorkspaceFilesQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
-    @SerialName("module_name")
     val moduleName: String? = null,
-    @SerialName("include_files")
     val includeFiles: Boolean = false,
 )
 
 @Serializable
 data class KastWriteAndValidateFailureQuery(
     val type: String? = null,
-    @SerialName("workspace_root")
     val workspaceRoot: String,
-    @SerialName("file_path")
     val filePath: String,
 )
 
@@ -362,18 +323,14 @@ sealed interface KastWriteAndValidateQuery
 @Serializable
 @SerialName("CREATE_FILE_REQUEST")
 data class KastWriteAndValidateCreateFileQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
-    @SerialName("file_path")
     val filePath: String,
 ) : KastWriteAndValidateQuery
 
 @Serializable
 @SerialName("INSERT_AT_OFFSET_REQUEST")
 data class KastWriteAndValidateInsertAtOffsetQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
-    @SerialName("file_path")
     val filePath: String,
     val offset: Int,
 ) : KastWriteAndValidateQuery
@@ -381,13 +338,9 @@ data class KastWriteAndValidateInsertAtOffsetQuery(
 @Serializable
 @SerialName("REPLACE_RANGE_REQUEST")
 data class KastWriteAndValidateReplaceRangeQuery(
-    @SerialName("workspace_root")
     val workspaceRoot: String,
-    @SerialName("file_path")
     val filePath: String,
-    @SerialName("start_offset")
     val startOffset: Int,
-    @SerialName("end_offset")
     val endOffset: Int,
 ) : KastWriteAndValidateQuery
 
@@ -402,7 +355,6 @@ data class KastCandidate(
 data class KastScaffoldReferences(
     val locations: List<Location>,
     val count: Int,
-    @SerialName("search_scope")
     val searchScope: SearchScope? = null,
     val declaration: Symbol? = null,
 )
@@ -416,9 +368,7 @@ data class KastScaffoldTypeHierarchy(
 @Serializable
 data class KastDiagnosticsSummary(
     val clean: Boolean,
-    @SerialName("error_count")
     val errorCount: Int,
-    @SerialName("warning_count")
     val warningCount: Int,
     val errors: List<Diagnostic> = emptyList(),
 )
@@ -432,11 +382,11 @@ data class KastResolveSuccessResponse(
     val ok: Boolean = true,
     val query: KastResolveQuery,
     val symbol: Symbol,
-    @SerialName("file_path")
     val filePath: String,
     val offset: Int,
     val candidate: KastCandidate,
-    @SerialName("log_file")
+    val candidateCount: Int? = null,
+    val alternatives: List<String>? = null,
     val logFile: String,
 ) : KastResolveResponse
 
@@ -447,10 +397,8 @@ data class KastResolveFailureResponse(
     val stage: String,
     val message: String,
     val query: KastResolveQuery,
-    @SerialName("log_file")
     val logFile: String,
     val error: ApiErrorResponse? = null,
-    @SerialName("error_text")
     val errorText: String? = null,
 ) : KastResolveResponse
 
@@ -463,14 +411,13 @@ data class KastReferencesSuccessResponse(
     val ok: Boolean = true,
     val query: KastReferencesQuery,
     val symbol: Symbol,
-    @SerialName("file_path")
     val filePath: String,
     val offset: Int,
     val references: List<Location>,
-    @SerialName("search_scope")
     val searchScope: SearchScope? = null,
     val declaration: Symbol? = null,
-    @SerialName("log_file")
+    val candidateCount: Int? = null,
+    val alternatives: List<String>? = null,
     val logFile: String,
 ) : KastReferencesResponse
 
@@ -481,10 +428,8 @@ data class KastReferencesFailureResponse(
     val stage: String,
     val message: String,
     val query: KastReferencesQuery,
-    @SerialName("log_file")
     val logFile: String,
     val error: ApiErrorResponse? = null,
-    @SerialName("error_text")
     val errorText: String? = null,
 ) : KastReferencesResponse
 
@@ -497,12 +442,12 @@ data class KastCallersSuccessResponse(
     val ok: Boolean = true,
     val query: KastCallersQuery,
     val symbol: Symbol,
-    @SerialName("file_path")
     val filePath: String,
     val offset: Int,
     val root: CallNode,
     val stats: CallHierarchyStats,
-    @SerialName("log_file")
+    val candidateCount: Int? = null,
+    val alternatives: List<String>? = null,
     val logFile: String,
 ) : KastCallersResponse
 
@@ -513,10 +458,8 @@ data class KastCallersFailureResponse(
     val stage: String,
     val message: String,
     val query: KastCallersQuery,
-    @SerialName("log_file")
     val logFile: String,
     val error: ApiErrorResponse? = null,
-    @SerialName("error_text")
     val errorText: String? = null,
 ) : KastCallersResponse
 
@@ -529,14 +472,10 @@ data class KastDiagnosticsSuccessResponse(
     val ok: Boolean = true,
     val query: KastDiagnosticsQuery,
     val clean: Boolean,
-    @SerialName("error_count")
     val errorCount: Int,
-    @SerialName("warning_count")
     val warningCount: Int,
-    @SerialName("info_count")
     val infoCount: Int,
     val diagnostics: List<Diagnostic>,
-    @SerialName("log_file")
     val logFile: String,
 ) : KastDiagnosticsResponse
 
@@ -547,10 +486,8 @@ data class KastDiagnosticsFailureResponse(
     val stage: String,
     val message: String,
     val query: KastDiagnosticsQuery,
-    @SerialName("log_file")
     val logFile: String,
     val error: ApiErrorResponse? = null,
-    @SerialName("error_text")
     val errorText: String? = null,
 ) : KastDiagnosticsResponse
 
@@ -562,14 +499,10 @@ sealed interface KastRenameResponse
 data class KastRenameSuccessResponse(
     val ok: Boolean,
     val query: KastRenameQuery,
-    @SerialName("edit_count")
     val editCount: Int,
-    @SerialName("affected_files")
     val affectedFiles: List<String>,
-    @SerialName("apply_result")
     val applyResult: ApplyEditsResult,
     val diagnostics: KastDiagnosticsSummary,
-    @SerialName("log_file")
     val logFile: String,
 ) : KastRenameResponse
 
@@ -580,10 +513,8 @@ data class KastRenameFailureResponse(
     val stage: String,
     val message: String,
     val query: KastRenameFailureQuery,
-    @SerialName("log_file")
     val logFile: String,
     val error: ApiErrorResponse? = null,
-    @SerialName("error_text")
     val errorText: String? = null,
 ) : KastRenameResponse
 
@@ -596,15 +527,11 @@ data class KastScaffoldSuccessResponse(
     val ok: Boolean = true,
     val query: KastScaffoldQuery,
     val outline: List<OutlineSymbol>,
-    @SerialName("file_content")
     val fileContent: String? = null,
     val symbol: Symbol? = null,
     val references: KastScaffoldReferences? = null,
-    @SerialName("type_hierarchy")
     val typeHierarchy: KastScaffoldTypeHierarchy? = null,
-    @SerialName("insertion_point")
     val insertionPoint: SemanticInsertionResult? = null,
-    @SerialName("log_file")
     val logFile: String,
 ) : KastScaffoldResponse
 
@@ -615,10 +542,8 @@ data class KastScaffoldFailureResponse(
     val stage: String,
     val message: String,
     val query: KastScaffoldQuery,
-    @SerialName("log_file")
     val logFile: String,
     val error: ApiErrorResponse? = null,
-    @SerialName("error_text")
     val errorText: String? = null,
 ) : KastScaffoldResponse
 
@@ -631,9 +556,7 @@ data class KastWorkspaceFilesSuccessResponse(
     val ok: Boolean = true,
     val query: KastWorkspaceFilesQuery,
     val modules: List<WorkspaceModule>,
-    @SerialName("schema_version")
     val schemaVersion: Int,
-    @SerialName("log_file")
     val logFile: String,
 ) : KastWorkspaceFilesResponse
 
@@ -644,10 +567,8 @@ data class KastWorkspaceFilesFailureResponse(
     val stage: String,
     val message: String,
     val query: KastWorkspaceFilesQuery,
-    @SerialName("log_file")
     val logFile: String,
     val error: ApiErrorResponse? = null,
-    @SerialName("error_text")
     val errorText: String? = null,
 ) : KastWorkspaceFilesResponse
 
@@ -659,13 +580,10 @@ sealed interface KastWriteAndValidateResponse
 data class KastWriteAndValidateSuccessResponse(
     val ok: Boolean,
     val query: KastWriteAndValidateQuery,
-    @SerialName("applied_edits")
     val appliedEdits: Int,
-    @SerialName("import_changes")
     val importChanges: Int,
     val diagnostics: KastDiagnosticsSummary,
     val message: String? = null,
-    @SerialName("log_file")
     val logFile: String,
 ) : KastWriteAndValidateResponse
 
@@ -676,9 +594,7 @@ data class KastWriteAndValidateFailureResponse(
     val stage: String,
     val message: String,
     val query: KastWriteAndValidateFailureQuery,
-    @SerialName("log_file")
     val logFile: String,
     val error: ApiErrorResponse? = null,
-    @SerialName("error_text")
     val errorText: String? = null,
 ) : KastWriteAndValidateResponse

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/FileOperationTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/FileOperationTest.kt
@@ -24,7 +24,7 @@ class FileOperationTest {
             ),
         )
 
-        assertTrue(encoded.contains(""""type":"create""""))
+        assertTrue(encoded.contains(""""type":"CREATE_FILE""""))
     }
 
     @Test
@@ -36,7 +36,7 @@ class FileOperationTest {
             ),
         )
 
-        assertTrue(encoded.contains(""""type":"delete""""))
+        assertTrue(encoded.contains(""""type":"DELETE_FILE""""))
     }
 
     @Test

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WrapperContractModelTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WrapperContractModelTest.kt
@@ -1,5 +1,8 @@
 package io.github.amichne.kast.api.wrapper
 
+import io.github.amichne.kast.api.contract.Location
+import io.github.amichne.kast.api.contract.Symbol
+import io.github.amichne.kast.api.contract.SymbolKind
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -39,5 +42,35 @@ class WrapperContractModelTest {
         )
 
         assertTrue(encoded.contains(""""type":"REPLACE_RANGE_REQUEST""""))
+    }
+
+    @Test
+    fun `resolve success response serializes candidate count with camelCase`() {
+        val encoded = json.encodeToString<KastResolveResponse>(
+            KastResolveSuccessResponse(
+                query = KastResolveQuery(workspaceRoot = "/workspace", symbol = "sample.greet"),
+                symbol = Symbol(
+                    fqName = "sample.Greeter",
+                    kind = SymbolKind.CLASS,
+                    location = Location(
+                        filePath = "/workspace/src/main/kotlin/sample/Greeter.kt",
+                        startOffset = 10,
+                        endOffset = 17,
+                        startLine = 1,
+                        startColumn = 7,
+                        preview = "class Greeter",
+                    ),
+                ),
+                filePath = "/workspace/src/main/kotlin/sample/Greeter.kt",
+                offset = 10,
+                candidate = KastCandidate(line = 1, column = 7, context = "class Greeter"),
+                candidateCount = 3,
+                alternatives = listOf("sample.OtherGreeter"),
+                logFile = "/tmp/log.txt",
+            ),
+        )
+
+        assertTrue(encoded.contains(""""candidateCount":3"""))
+        assertTrue(encoded.contains(""""alternatives":["sample.OtherGreeter"]"""))
     }
 }

--- a/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastPluginBackend.kt
+++ b/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastPluginBackend.kt
@@ -470,7 +470,8 @@ internal class KastPluginBackend(
                                 val file = findKtFile(filePath)
                                 analyze(file) {
                                     file.collectDiagnostics(KaDiagnosticCheckerFilter.EXTENDED_AND_COMMON_CHECKERS)
-                                }.flatMap { diagnostic -> diagnostic.toApiDiagnostics() }
+                                        .flatMap { diagnostic -> diagnostic.toApiDiagnostics() }
+                                }
                             }
                         }.getOrElse { ex ->
                             listOf(

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -397,7 +397,8 @@ internal class StandaloneAnalysisBackend internal constructor(
                             val file = session.findKtFile(filePath)
                             analyze(file) {
                                 file.collectDiagnostics(KaDiagnosticCheckerFilter.EXTENDED_AND_COMMON_CHECKERS)
-                            }.flatMap { diagnostic -> diagnostic.toApiDiagnostics() }
+                                    .flatMap { diagnostic -> diagnostic.toApiDiagnostics() }
+                            }
                         }.getOrElse { ex ->
                             listOf(
                                 Diagnostic(

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1670,8 +1670,8 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          create: "#/components/schemas/FileOperation.CreateFile"
-          delete: "#/components/schemas/FileOperation.DeleteFile"
+          CREATE_FILE: "#/components/schemas/FileOperation.CreateFile"
+          DELETE_FILE: "#/components/schemas/FileOperation.DeleteFile"
     ApplyEditsResult:
       type: object
       properties:
@@ -1731,7 +1731,7 @@ components:
       properties:
         type:
           type: string
-          const: create
+          const: CREATE_FILE
         filePath:
           type: string
         content:
@@ -1746,7 +1746,7 @@ components:
       properties:
         type:
           type: string
-          const: delete
+          const: DELETE_FILE
         filePath:
           type: string
         expectedHash:

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -847,7 +847,7 @@ internal object CliCommandCatalog {
             group = CliCommandGroup.ANALYSIS,
             summary = "Skill wrapper: resolve a named symbol to a file position.",
             description = "Hidden native skill command. Accepts one JSON request argument.",
-            usages = listOf("$CLI_EXECUTABLE_NAME skill resolve '{\"workspace_root\":\"/ws\",\"symbol\":\"MyClass\"}'"),
+            usages = listOf("$CLI_EXECUTABLE_NAME skill resolve '{\"workspaceRoot\":\"/ws\",\"symbol\":\"MyClass\"}'"),
             visible = false,
         ),
         CliCommandMetadata(
@@ -855,7 +855,7 @@ internal object CliCommandCatalog {
             group = CliCommandGroup.ANALYSIS,
             summary = "Skill wrapper: find references to a named symbol.",
             description = "Hidden native skill command. Accepts one JSON request argument.",
-            usages = listOf("$CLI_EXECUTABLE_NAME skill references '{\"workspace_root\":\"/ws\",\"symbol\":\"myFun\"}'"),
+            usages = listOf("$CLI_EXECUTABLE_NAME skill references '{\"workspaceRoot\":\"/ws\",\"symbol\":\"myFun\"}'"),
             visible = false,
         ),
         CliCommandMetadata(
@@ -863,7 +863,7 @@ internal object CliCommandCatalog {
             group = CliCommandGroup.ANALYSIS,
             summary = "Skill wrapper: find callers of a named symbol.",
             description = "Hidden native skill command. Accepts one JSON request argument.",
-            usages = listOf("$CLI_EXECUTABLE_NAME skill callers '{\"workspace_root\":\"/ws\",\"symbol\":\"myFun\"}'"),
+            usages = listOf("$CLI_EXECUTABLE_NAME skill callers '{\"workspaceRoot\":\"/ws\",\"symbol\":\"myFun\"}'"),
             visible = false,
         ),
         CliCommandMetadata(
@@ -871,7 +871,7 @@ internal object CliCommandCatalog {
             group = CliCommandGroup.ANALYSIS,
             summary = "Skill wrapper: run diagnostics on specified files.",
             description = "Hidden native skill command. Accepts one JSON request argument.",
-            usages = listOf("$CLI_EXECUTABLE_NAME skill diagnostics '{\"workspace_root\":\"/ws\",\"file_paths\":[\"src/Main.kt\"]}'"),
+            usages = listOf("$CLI_EXECUTABLE_NAME skill diagnostics '{\"workspaceRoot\":\"/ws\",\"filePaths\":[\"/ws/src/Main.kt\"]}'"),
             visible = false,
         ),
         CliCommandMetadata(
@@ -879,7 +879,7 @@ internal object CliCommandCatalog {
             group = CliCommandGroup.MUTATION_FLOW,
             summary = "Skill wrapper: rename a symbol with validation.",
             description = "Hidden native skill command. Accepts one JSON request argument.",
-            usages = listOf("$CLI_EXECUTABLE_NAME skill rename '{\"workspace_root\":\"/ws\",\"symbol\":\"old\",\"new_name\":\"new\"}'"),
+            usages = listOf("$CLI_EXECUTABLE_NAME skill rename '{\"workspaceRoot\":\"/ws\",\"type\":\"RENAME_BY_SYMBOL_REQUEST\",\"symbol\":\"old\",\"newName\":\"new\"}'"),
             visible = false,
         ),
         CliCommandMetadata(
@@ -887,7 +887,7 @@ internal object CliCommandCatalog {
             group = CliCommandGroup.ANALYSIS,
             summary = "Skill wrapper: scaffold context for a target file.",
             description = "Hidden native skill command. Accepts one JSON request argument.",
-            usages = listOf("$CLI_EXECUTABLE_NAME skill scaffold '{\"workspace_root\":\"/ws\",\"target_file\":\"/ws/src/Foo.kt\"}'"),
+            usages = listOf("$CLI_EXECUTABLE_NAME skill scaffold '{\"workspaceRoot\":\"/ws\",\"targetFile\":\"/ws/src/Foo.kt\"}'"),
             visible = false,
         ),
         CliCommandMetadata(
@@ -895,7 +895,7 @@ internal object CliCommandCatalog {
             group = CliCommandGroup.MUTATION_FLOW,
             summary = "Skill wrapper: write code and validate with diagnostics.",
             description = "Hidden native skill command. Accepts one JSON request argument.",
-            usages = listOf("$CLI_EXECUTABLE_NAME skill write-and-validate '{\"workspace_root\":\"/ws\",\"file_path\":\"/ws/src/New.kt\"}'"),
+            usages = listOf("$CLI_EXECUTABLE_NAME skill write-and-validate '{\"workspaceRoot\":\"/ws\",\"type\":\"CREATE_FILE_REQUEST\",\"filePath\":\"/ws/src/New.kt\"}'"),
             visible = false,
         ),
         CliCommandMetadata(
@@ -903,7 +903,7 @@ internal object CliCommandCatalog {
             group = CliCommandGroup.ANALYSIS,
             summary = "Skill wrapper: list workspace modules and source files.",
             description = "Hidden native skill command. Accepts one JSON request argument.",
-            usages = listOf("$CLI_EXECUTABLE_NAME skill workspace-files '{\"workspace_root\":\"/ws\"}'"),
+            usages = listOf("$CLI_EXECUTABLE_NAME skill workspace-files '{\"workspaceRoot\":\"/ws\"}'"),
             visible = false,
         ),
         CliCommandMetadata(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/eval/EvalModels.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/eval/EvalModels.kt
@@ -37,19 +37,19 @@ data class EvalMetric(
 
 @Serializable
 data class RawBudget(
-    @SerialName("trigger_tokens") val triggerTokens: Int,
-    @SerialName("invoke_tokens") val invokeTokens: Int,
-    @SerialName("deferred_tokens") val deferredTokens: Int,
+    val triggerTokens: Int,
+    val invokeTokens: Int,
+    val deferredTokens: Int,
 )
 
 @Serializable
 data class BandedBudget(
-    @SerialName("trigger_tokens") val triggerTokens: Int,
-    @SerialName("trigger_band") val triggerBand: BudgetBand,
-    @SerialName("invoke_tokens") val invokeTokens: Int,
-    @SerialName("invoke_band") val invokeBand: BudgetBand,
-    @SerialName("deferred_tokens") val deferredTokens: Int,
-    @SerialName("deferred_band") val deferredBand: BudgetBand,
+    val triggerTokens: Int,
+    val triggerBand: BudgetBand,
+    val invokeTokens: Int,
+    val invokeBand: BudgetBand,
+    val deferredTokens: Int,
+    val deferredBand: BudgetBand,
 )
 
 @Serializable
@@ -72,15 +72,15 @@ data class EvalSummary(
     val score: Int,
     val grade: EvalGrade,
     val deductions: List<Deduction>,
-    @SerialName("check_counts") val checkCounts: CheckCounts,
-    @SerialName("why_bullets") val whyBullets: List<String> = emptyList(),
-    @SerialName("fix_first") val fixFirst: String? = null,
-    @SerialName("watch_next") val watchNext: String? = null,
+    val checkCounts: CheckCounts,
+    val whyBullets: List<String> = emptyList(),
+    val fixFirst: String? = null,
+    val watchNext: String? = null,
 )
 
 @Serializable
 data class Deduction(
-    @SerialName("check_id") val checkId: String,
+    val checkId: String,
     val points: Int,
     val reason: String,
 )
@@ -96,7 +96,7 @@ data class CheckCounts(
 @Serializable
 data class ImprovementBrief(
     val findings: List<String>,
-    @SerialName("suggested_prompt") val suggestedPrompt: String,
+    val suggestedPrompt: String,
 )
 
 @Serializable
@@ -106,29 +106,29 @@ data class MeasurementPlan(
 
 @Serializable
 data class EvalResult(
-    @SerialName("schema_version") val schemaVersion: Int = 1,
+    val schemaVersion: Int = 1,
     val target: SkillTarget,
     val summary: EvalSummary,
     val budgets: BandedBudget,
     val checks: List<EvalCheck>,
     val metrics: List<EvalMetric>,
-    @SerialName("improvement_brief") val improvementBrief: ImprovementBrief,
-    @SerialName("measurement_plan") val measurementPlan: MeasurementPlan,
+    val improvementBrief: ImprovementBrief,
+    val measurementPlan: MeasurementPlan,
 )
 
 @Serializable
 data class ComparisonResult(
-    @SerialName("score_delta") val scoreDelta: Int,
-    @SerialName("grade_before") val gradeBefore: EvalGrade,
-    @SerialName("grade_after") val gradeAfter: EvalGrade,
-    @SerialName("resolved_failures") val resolvedFailures: List<String>,
-    @SerialName("new_failures") val newFailures: List<String>,
-    @SerialName("budget_delta") val budgetDelta: BudgetDelta,
+    val scoreDelta: Int,
+    val gradeBefore: EvalGrade,
+    val gradeAfter: EvalGrade,
+    val resolvedFailures: List<String>,
+    val newFailures: List<String>,
+    val budgetDelta: BudgetDelta,
 )
 
 @Serializable
 data class BudgetDelta(
-    @SerialName("trigger_delta") val triggerDelta: Int,
-    @SerialName("invoke_delta") val invokeDelta: Int,
-    @SerialName("deferred_delta") val deferredDelta: Int,
+    val triggerDelta: Int,
+    val invokeDelta: Int,
+    val deferredDelta: Int,
 )

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/eval/adapter/SkillAdapter.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/eval/adapter/SkillAdapter.kt
@@ -448,6 +448,8 @@ internal class SkillAdapter(private val skillDir: Path) {
             "initialization_friction",
             "maintenance_thrash",
             "schema_request",
+            "relative_path",
+            "ambiguous_symbol",
             "schema_response",
             "mutation_abandonment",
             "failure_response_ignored",

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/NamedSymbolResolver.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/NamedSymbolResolver.kt
@@ -24,6 +24,8 @@ internal class NamedSymbolResolver(
         val symbol: Symbol,
         val filePath: String,
         val offset: Int,
+        val candidateCount: Int = 1,
+        val alternativeFqNames: List<String> = emptyList(),
     )
 
     /**
@@ -80,7 +82,15 @@ internal class NamedSymbolResolver(
         }
         if (exactMatches.isNotEmpty()) candidates = exactMatches
 
+        val candidateCount = candidates.size
         val best = candidates.firstOrNull() ?: return null
+        val alternativeFqNames = candidates
+            .asSequence()
+            .map(Symbol::fqName)
+            .filter { it != best.fqName }
+            .distinct()
+            .take(3)
+            .toList()
 
         // Confirm via resolve to get enriched symbol info
         val position = FilePosition(
@@ -96,6 +106,8 @@ internal class NamedSymbolResolver(
             symbol = resolveResult.payload.symbol,
             filePath = best.location.filePath,
             offset = best.location.startOffset,
+            candidateCount = candidateCount,
+            alternativeFqNames = alternativeFqNames,
         )
     }
 }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt
@@ -193,6 +193,8 @@ internal class SkillWrapperExecutor(
                 column = resolved.symbol.location.startColumn,
                 context = resolved.symbol.location.preview,
             ),
+            candidateCount = resolved.candidateCount.takeIf { it > 1 },
+            alternatives = resolved.alternativeFqNames.takeIf { it.isNotEmpty() },
             logFile = SkillLogFile.placeholder(),
         )
     }
@@ -244,6 +246,8 @@ internal class SkillWrapperExecutor(
             references = refsResult.references,
             searchScope = refsResult.searchScope,
             declaration = refsResult.declaration,
+            candidateCount = resolved.candidateCount.takeIf { it > 1 },
+            alternatives = resolved.alternativeFqNames.takeIf { it.isNotEmpty() },
             logFile = SkillLogFile.placeholder(),
         )
     }
@@ -307,6 +311,8 @@ internal class SkillWrapperExecutor(
             offset = resolved.offset,
             root = hierarchyResult.root,
             stats = hierarchyResult.stats,
+            candidateCount = resolved.candidateCount.takeIf { it > 1 },
+            alternatives = resolved.alternativeFqNames.takeIf { it.isNotEmpty() },
             logFile = SkillLogFile.placeholder(),
         )
     }
@@ -751,23 +757,23 @@ internal class SkillWrapperExecutor(
         val resultsJson = MetricsEngine(Path.of(workspaceRoot)).use { engine ->
             when (request.metric) {
                 WrapperMetric.FAN_IN -> json.encodeToJsonElement(
-                    kotlinx.serialization.builtins.ListSerializer(io.github.amichne.kast.indexstore.FanInMetric.serializer()),
+                    kotlinx.serialization.serializer<List<io.github.amichne.kast.indexstore.FanInMetric>>(),
                     engine.fanInRanking(request.limit),
                 )
                 WrapperMetric.FAN_OUT -> json.encodeToJsonElement(
-                    kotlinx.serialization.builtins.ListSerializer(io.github.amichne.kast.indexstore.FanOutMetric.serializer()),
+                    kotlinx.serialization.serializer<List<io.github.amichne.kast.indexstore.FanOutMetric>>(),
                     engine.fanOutRanking(request.limit),
                 )
                 WrapperMetric.COUPLING -> json.encodeToJsonElement(
-                    kotlinx.serialization.builtins.ListSerializer(io.github.amichne.kast.indexstore.ModuleCouplingMetric.serializer()),
+                    kotlinx.serialization.serializer<List<io.github.amichne.kast.indexstore.ModuleCouplingMetric>>(),
                     engine.moduleCouplingMatrix(),
                 )
                 WrapperMetric.DEAD_CODE -> json.encodeToJsonElement(
-                    kotlinx.serialization.builtins.ListSerializer(io.github.amichne.kast.indexstore.DeadCodeCandidate.serializer()),
+                    kotlinx.serialization.serializer<List<io.github.amichne.kast.indexstore.DeadCodeCandidate>>(),
                     engine.deadCodeCandidates(),
                 )
                 WrapperMetric.IMPACT -> json.encodeToJsonElement(
-                    kotlinx.serialization.builtins.ListSerializer(io.github.amichne.kast.indexstore.ChangeImpactNode.serializer()),
+                    kotlinx.serialization.serializer<List<io.github.amichne.kast.indexstore.ChangeImpactNode>>(),
                     engine.changeImpactRadius(
                         fqName = request.symbol ?: throw CliFailure(
                             code = "SKILL_VALIDATION",
@@ -790,16 +796,7 @@ internal class SkillWrapperExecutor(
 
     // region shared
 
-    private fun requireWorkspaceRoot(explicit: String?): String {
-        val resolved = SkillWrapperInput.resolveWorkspaceRoot(explicit)
-        if (resolved.isEmpty()) {
-            throw CliFailure(
-                code = "SKILL_VALIDATION",
-                message = "workspaceRoot is required: set it in the request body or export KAST_WORKSPACE_ROOT.",
-            )
-        }
-        return resolved
-    }
+    private fun requireWorkspaceRoot(explicit: String?): String = SkillWrapperInput.resolveWorkspaceRoot(explicit)
 
     private fun runtimeOptionsFor(workspaceRoot: String): RuntimeCommandOptions = RuntimeCommandOptions(
         workspaceRoot = Path.of(workspaceRoot).toAbsolutePath().normalize(),

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperInput.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperInput.kt
@@ -17,10 +17,13 @@ internal object SkillWrapperInput {
     fun resolveWorkspaceRoot(
         explicit: String?,
         env: Map<String, String> = System.getenv(),
+        currentWorkingDirectory: Path = Path.of("").toAbsolutePath().normalize(),
     ): String {
         val trimmed = explicit?.trim()?.takeIf(String::isNotEmpty)
-        if (trimmed != null) return trimmed
-        return env["KAST_WORKSPACE_ROOT"]?.trim()?.takeIf(String::isNotEmpty) ?: ""
+        if (trimmed != null) return Path.of(trimmed).toAbsolutePath().normalize().toString()
+        val envRoot = env["KAST_WORKSPACE_ROOT"]?.trim()?.takeIf(String::isNotEmpty)
+        if (envRoot != null) return Path.of(envRoot).toAbsolutePath().normalize().toString()
+        return currentWorkingDirectory.toString()
     }
 
     /**

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/PackagedSkillJsonContractTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/PackagedSkillJsonContractTest.kt
@@ -143,6 +143,70 @@ class PackagedSkillJsonContractTest {
         }
     }
 
+    @Test
+    fun `diagnostics stay clean for repo wrapper executor file`() {
+        val repoRoot = findRepoRoot(Path.of("").toAbsolutePath())
+        val targetFile = repoRoot.resolve(
+            "kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt",
+        )
+        val kastBinary = checkNotNull(System.getProperty("kast.wrapper")) {
+            "kast.wrapper system property is missing"
+        }
+        val configHome = tempDir.resolve("kast-config-repo")
+        val wrapperEnv = mapOf(
+            "KAST_CLI_PATH" to kastBinary,
+            "KAST_CONFIG_HOME" to configHome.toString(),
+            "KAST_WORKSPACE_ROOT" to repoRoot.toString(),
+        )
+
+        val daemon = startRealBackend(repoRoot, wrapperEnv)
+        try {
+            val ensureResult = runCommand(
+                command = listOf(kastBinary, "workspace", "ensure", "--workspace-root=$repoRoot"),
+                env = wrapperEnv,
+            )
+            assertEquals(0, ensureResult.exitCode, "stderr: ${ensureResult.stderr}")
+
+            val diagnosticsRequest = buildJsonObject {
+                put("workspaceRoot", repoRoot.toString())
+                put(
+                    "filePaths",
+                    buildJsonArray {
+                        add(JsonPrimitive(targetFile.toString()))
+                    },
+                )
+            }
+
+            val diagnosticsResult = runCommand(
+                command = listOf(
+                    kastBinary,
+                    "skill",
+                    "diagnostics",
+                    defaultCliJson().encodeToString(JsonObject.serializer(), diagnosticsRequest),
+                ),
+                env = wrapperEnv,
+            )
+
+            assertEquals(0, diagnosticsResult.exitCode, "stderr: ${diagnosticsResult.stderr}")
+            val diagnosticsPayload = defaultCliJson()
+                .parseToJsonElement(diagnosticsResult.stdout)
+                .jsonObject
+            assertEquals(true, diagnosticsPayload["ok"]?.toString()?.toBooleanStrictOrNull())
+            assertEquals("DIAGNOSTICS_SUCCESS", diagnosticsPayload["type"]?.jsonPrimitive?.content)
+            assertEquals(true, diagnosticsPayload["clean"]?.toString()?.toBooleanStrictOrNull(), diagnosticsResult.stdout)
+            assertEquals(0, diagnosticsPayload["errorCount"]?.jsonPrimitive?.content?.toInt())
+            assertEquals(0, diagnosticsPayload["warningCount"]?.jsonPrimitive?.content?.toInt())
+            assertEquals(0, diagnosticsPayload["infoCount"]?.jsonPrimitive?.content?.toInt())
+            assertTrue(diagnosticsPayload["diagnostics"]?.toString() == "[]")
+        } finally {
+            runCommand(
+                command = listOf(kastBinary, "workspace", "stop", "--workspace-root=$repoRoot"),
+                env = wrapperEnv,
+            )
+            daemon.destroyForcibly()
+        }
+    }
+
     private fun startRealBackend(
         workspace: Path,
         env: Map<String, String>,
@@ -195,6 +259,10 @@ class PackagedSkillJsonContractTest {
         val stdout: String,
         val stderr: String,
     )
+
+    private fun findRepoRoot(start: Path): Path = generateSequence(start.normalize()) { it.parent }
+        .firstOrNull { candidate -> Files.isRegularFile(candidate.resolve(".github/hooks/session-end.sh")) }
+        ?: error("Could not locate repo root from $start")
 
     private fun Path.createDirectoriesForParent(): Path {
         Files.createDirectories(checkNotNull(parent))

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/EvalSkillCommandTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/EvalSkillCommandTest.kt
@@ -23,12 +23,12 @@ class EvalSkillCommandTest {
     private val json = defaultCliJson()
 
     @Test
-    fun `eval skill produces JSON with schema_version`() {
+    fun `eval skill produces JSON with schemaVersion`() {
         val skillDir = createMinimalSkill()
         val executor = EvalSkillExecutor(json)
         val output = executor.execute(EvalSkillOptions(skillDir = skillDir))
         val text = (output as CliOutput.Text).value
-        assertTrue(text.contains("schema_version"))
+        assertTrue(text.contains("schemaVersion"))
         assertTrue(text.contains("summary"))
         assertTrue(text.contains("budgets"))
     }
@@ -186,6 +186,8 @@ class EvalSkillCommandTest {
             "initialization_friction",
             "maintenance_thrash",
             "schema_request",
+            "relative_path",
+            "ambiguous_symbol",
             "schema_response",
             "mutation_abandonment",
             "failure_response_ignored",

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/SkillEvalEngineTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/SkillEvalEngineTest.kt
@@ -263,12 +263,12 @@ class SkillEvalEngineTest {
     // --- JSON serialization ---
 
     @Test
-    fun `EvalResult serializes with schema version`() {
+    fun `EvalResult serializes with schemaVersion`() {
         val descriptor = descriptorWith(checks = listOf(passingCheck("c1")))
         val result = SkillEvalEngine.evaluate(descriptor)
         val json = io.github.amichne.kast.cli.defaultCliJson()
         val encoded = json.encodeToString(EvalResult.serializer(), result)
-        assertTrue(encoded.contains("schema_version"))
+        assertTrue(encoded.contains("schemaVersion"))
         assertTrue(encoded.contains("summary"))
         assertTrue(encoded.contains("budgets"))
     }

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/adapter/SkillAdapterTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/adapter/SkillAdapterTest.kt
@@ -293,6 +293,8 @@ class SkillAdapterTest {
             "initialization_friction",
             "maintenance_thrash",
             "schema_request",
+            "relative_path",
+            "ambiguous_symbol",
             "schema_response",
             "mutation_abandonment",
             "failure_response_ignored",

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperContractTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperContractTest.kt
@@ -91,10 +91,10 @@ class SkillWrapperContractTest {
         assertTrue(parsed["ok"]?.jsonPrimitive?.boolean ?: false)
         assertNotNull(parsed["query"])
         val query = parsed["query"] as JsonObject
-        assertEquals("/tmp/ws", query["workspace_root"]?.jsonPrimitive?.content)
+        assertEquals("/tmp/ws", query["workspaceRoot"]?.jsonPrimitive?.content)
         assertNotNull(parsed["modules"]?.jsonArray)
-        assertEquals(1, parsed["schema_version"]?.jsonPrimitive?.int)
-        assertEquals("/tmp/log.txt", parsed["log_file"]?.jsonPrimitive?.content)
+        assertEquals(1, parsed["schemaVersion"]?.jsonPrimitive?.int)
+        assertEquals("/tmp/log.txt", parsed["logFile"]?.jsonPrimitive?.content)
     }
 
     @Test
@@ -118,7 +118,7 @@ class SkillWrapperContractTest {
         assertEquals("resolve", parsed["stage"]?.jsonPrimitive?.content)
         assertEquals("Symbol not found", parsed["message"]?.jsonPrimitive?.content)
         assertNotNull(parsed["query"])
-        assertEquals("/tmp/log.txt", parsed["log_file"]?.jsonPrimitive?.content)
+        assertEquals("/tmp/log.txt", parsed["logFile"]?.jsonPrimitive?.content)
     }
 
     @Test
@@ -143,8 +143,8 @@ class SkillWrapperContractTest {
         assertEquals("DIAGNOSTICS_SUCCESS", parsed["type"]?.jsonPrimitive?.content)
         assertTrue(parsed["ok"]?.jsonPrimitive?.boolean ?: false)
         assertTrue(parsed["clean"]?.jsonPrimitive?.boolean ?: false)
-        assertEquals(0, parsed["error_count"]?.jsonPrimitive?.int)
-        assertEquals(0, parsed["warning_count"]?.jsonPrimitive?.int)
+        assertEquals(0, parsed["errorCount"]?.jsonPrimitive?.int)
+        assertEquals(0, parsed["warningCount"]?.jsonPrimitive?.int)
     }
 
     @Test
@@ -166,10 +166,10 @@ class SkillWrapperContractTest {
         assertTrue(parsed["ok"]?.jsonPrimitive?.boolean ?: false)
         assertNotNull(parsed["symbol"])
         assertNotNull(parsed["query"])
-        assertNotNull(parsed["file_path"])
+        assertNotNull(parsed["filePath"])
         assertNotNull(parsed["offset"])
         assertNotNull(parsed["candidate"])
-        assertEquals("/tmp/log.txt", parsed["log_file"]?.jsonPrimitive?.content)
+        assertEquals("/tmp/log.txt", parsed["logFile"]?.jsonPrimitive?.content)
     }
 
     @Test
@@ -254,10 +254,10 @@ class SkillWrapperContractTest {
 
         assertEquals("RENAME_SUCCESS", parsed["type"]?.jsonPrimitive?.content)
         assertTrue(parsed["ok"]?.jsonPrimitive?.boolean ?: false)
-        assertEquals(2, parsed["edit_count"]?.jsonPrimitive?.int)
-        assertNotNull(parsed["affected_files"]?.jsonArray)
+        assertEquals(2, parsed["editCount"]?.jsonPrimitive?.int)
+        assertNotNull(parsed["affectedFiles"]?.jsonArray)
         assertNotNull(parsed["diagnostics"])
-        assertNotNull(parsed["apply_result"])
+        assertNotNull(parsed["applyResult"])
     }
 
     @Test
@@ -297,8 +297,8 @@ class SkillWrapperContractTest {
 
         assertEquals("WRITE_AND_VALIDATE_SUCCESS", parsed["type"]?.jsonPrimitive?.content)
         assertTrue(parsed["ok"]?.jsonPrimitive?.boolean ?: false)
-        assertEquals(1, parsed["applied_edits"]?.jsonPrimitive?.int)
-        assertEquals(0, parsed["import_changes"]?.jsonPrimitive?.int)
+        assertEquals(1, parsed["appliedEdits"]?.jsonPrimitive?.int)
+        assertEquals(0, parsed["importChanges"]?.jsonPrimitive?.int)
         assertNotNull(parsed["diagnostics"])
     }
 }

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperDiscriminatorTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperDiscriminatorTest.kt
@@ -1,0 +1,38 @@
+package io.github.amichne.kast.cli.skill
+
+import io.github.amichne.kast.api.wrapper.KastRenameRequest
+import io.github.amichne.kast.api.wrapper.KastWriteAndValidateRequest
+import kotlinx.serialization.KSerializer
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+
+class SkillWrapperDiscriminatorTest {
+    @Test
+    fun `quickstart documents every request discriminator`() {
+        val quickstart = repoRoot()
+            .resolve(".agents/skills/kast/references/quickstart.md")
+            .readText()
+        val discriminators = discriminatorValues(KastRenameRequest.serializer()) +
+            discriminatorValues(KastWriteAndValidateRequest.serializer())
+
+        discriminators.forEach { discriminator ->
+            assertTrue(
+                quickstart.contains(discriminator),
+                "quickstart.md is missing $discriminator",
+            )
+        }
+    }
+
+    private fun discriminatorValues(serializer: KSerializer<*>): Set<String> =
+        (0 until serializer.descriptor.elementsCount)
+            .map(serializer.descriptor::getElementName)
+            .filter { it.endsWith("_REQUEST") }
+            .toSet()
+
+    private fun repoRoot(): Path =
+        generateSequence(Path.of("").toAbsolutePath()) { current -> current.parent }
+            .first { candidate -> Files.isDirectory(candidate.resolve(".agents")) }
+}

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperInputTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperInputTest.kt
@@ -15,7 +15,7 @@ class SkillWrapperInputTest {
             explicit = "/explicit/ws",
             env = mapOf("KAST_WORKSPACE_ROOT" to "/env/ws"),
         )
-        assertEquals("/explicit/ws", result)
+        assertEquals(Path.of("/explicit/ws").toAbsolutePath().normalize().toString(), result)
     }
 
     @Test
@@ -24,16 +24,17 @@ class SkillWrapperInputTest {
             explicit = null,
             env = mapOf("KAST_WORKSPACE_ROOT" to "/env/ws"),
         )
-        assertEquals("/env/ws", result)
+        assertEquals(Path.of("/env/ws").toAbsolutePath().normalize().toString(), result)
     }
 
     @Test
-    fun `resolveWorkspaceRoot falls back to empty string when env absent`() {
+    fun `resolveWorkspaceRoot falls back to current working directory when env absent`(@TempDir tempDir: Path) {
         val result = SkillWrapperInput.resolveWorkspaceRoot(
             explicit = null,
             env = emptyMap(),
+            currentWorkingDirectory = tempDir,
         )
-        assertEquals("", result)
+        assertEquals(tempDir.toAbsolutePath().normalize().toString(), result)
     }
 
     @Test
@@ -42,7 +43,7 @@ class SkillWrapperInputTest {
             explicit = "  ",
             env = mapOf("KAST_WORKSPACE_ROOT" to "/env/ws"),
         )
-        assertEquals("/env/ws", result)
+        assertEquals(Path.of("/env/ws").toAbsolutePath().normalize().toString(), result)
     }
 
     @Test

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperRequestCasingTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperRequestCasingTest.kt
@@ -1,0 +1,97 @@
+package io.github.amichne.kast.cli.skill
+
+import io.github.amichne.kast.api.wrapper.KastCallersRequest
+import io.github.amichne.kast.api.wrapper.KastDiagnosticsRequest
+import io.github.amichne.kast.api.wrapper.KastMetricsRequest
+import io.github.amichne.kast.api.wrapper.KastReferencesRequest
+import io.github.amichne.kast.api.wrapper.KastRenameByOffsetRequest
+import io.github.amichne.kast.api.wrapper.KastRenameBySymbolRequest
+import io.github.amichne.kast.api.wrapper.KastRenameRequest
+import io.github.amichne.kast.api.wrapper.KastResolveRequest
+import io.github.amichne.kast.api.wrapper.KastScaffoldRequest
+import io.github.amichne.kast.api.wrapper.KastWorkspaceFilesRequest
+import io.github.amichne.kast.api.wrapper.KastWriteAndValidateCreateFileRequest
+import io.github.amichne.kast.api.wrapper.KastWriteAndValidateInsertAtOffsetRequest
+import io.github.amichne.kast.api.wrapper.KastWriteAndValidateReplaceRangeRequest
+import io.github.amichne.kast.api.wrapper.KastWriteAndValidateRequest
+import io.github.amichne.kast.cli.CliCommandCatalog
+import io.github.amichne.kast.cli.CliCommandMetadata
+import io.github.amichne.kast.cli.defaultCliJson
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalSerializationApi::class)
+class SkillWrapperRequestCasingTest {
+    private val json: Json = defaultCliJson()
+
+    @Test
+    fun `skill usage examples use valid serialized request keys`() {
+        skillCommands().forEach { command ->
+            val name = SkillWrapperName.fromCliName(command.path[1])
+                ?: error("Unknown skill wrapper ${command.path[1]}")
+            val usageKeys = command.usages
+                .map(::extractJson)
+                .flatMap { usage -> json.parseToJsonElement(usage).jsonObject.keys }
+                .toSet()
+            val validKeys = requestKeyMapping(name)
+            val invalidKeys = usageKeys - validKeys
+            assertTrue(
+                invalidKeys.isEmpty(),
+                "Invalid serialized request keys for ${command.commandText}: ${invalidKeys.joinToString()} not in ${validKeys.sorted()}",
+            )
+        }
+    }
+
+    private fun skillCommands(): List<CliCommandMetadata> {
+        val field = CliCommandCatalog::class.java.getDeclaredField("commands")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val commands = field.get(CliCommandCatalog) as List<CliCommandMetadata>
+        return commands.filter { it.path.firstOrNull() == "skill" }
+    }
+
+    private fun extractJson(usage: String): String = usage.substringAfter('\'').substringBeforeLast('\'')
+
+    private fun requestKeyMapping(name: SkillWrapperName): Set<String> = when (name) {
+        SkillWrapperName.RESOLVE -> serializedKeys(KastResolveRequest.serializer())
+        SkillWrapperName.REFERENCES -> serializedKeys(KastReferencesRequest.serializer())
+        SkillWrapperName.CALLERS -> serializedKeys(KastCallersRequest.serializer())
+        SkillWrapperName.DIAGNOSTICS -> serializedKeys(KastDiagnosticsRequest.serializer())
+        SkillWrapperName.RENAME -> serializedKeys(
+            KastRenameRequest.serializer(),
+            KastRenameBySymbolRequest.serializer(),
+            KastRenameByOffsetRequest.serializer(),
+        )
+        SkillWrapperName.SCAFFOLD -> serializedKeys(KastScaffoldRequest.serializer())
+        SkillWrapperName.WRITE_AND_VALIDATE -> serializedKeys(
+            KastWriteAndValidateRequest.serializer(),
+            KastWriteAndValidateCreateFileRequest.serializer(),
+            KastWriteAndValidateInsertAtOffsetRequest.serializer(),
+            KastWriteAndValidateReplaceRangeRequest.serializer(),
+        )
+        SkillWrapperName.WORKSPACE_FILES -> serializedKeys(KastWorkspaceFilesRequest.serializer())
+        SkillWrapperName.METRICS -> serializedKeys(KastMetricsRequest.serializer())
+    }
+
+    private fun serializedKeys(
+        root: KSerializer<*>,
+        vararg concrete: KSerializer<*>,
+    ): Set<String> = buildSet {
+        addAll(descriptorKeys(root.descriptor))
+        concrete.forEach { addAll(descriptorKeys(it.descriptor)) }
+        if (root.descriptor.kind == PolymorphicKind.SEALED) {
+            add("type")
+        }
+    }
+
+    private fun descriptorKeys(descriptor: SerialDescriptor): Set<String> =
+        (0 until descriptor.elementsCount)
+            .map(descriptor::getElementName)
+            .toSet()
+}

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperSerializerTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperSerializerTest.kt
@@ -1,0 +1,445 @@
+package io.github.amichne.kast.cli.skill
+
+import io.github.amichne.kast.api.contract.ApplyEditsResult
+import io.github.amichne.kast.api.contract.CallHierarchyStats
+import io.github.amichne.kast.api.contract.CallNode
+import io.github.amichne.kast.api.contract.Diagnostic
+import io.github.amichne.kast.api.contract.DiagnosticSeverity
+import io.github.amichne.kast.api.contract.Location
+import io.github.amichne.kast.api.contract.Symbol
+import io.github.amichne.kast.api.contract.SymbolKind
+import io.github.amichne.kast.api.contract.WorkspaceModule
+import io.github.amichne.kast.api.protocol.ApiErrorResponse
+import io.github.amichne.kast.api.wrapper.KastCallersFailureResponse
+import io.github.amichne.kast.api.wrapper.KastCallersQuery
+import io.github.amichne.kast.api.wrapper.KastCallersResponse
+import io.github.amichne.kast.api.wrapper.KastCallersSuccessResponse
+import io.github.amichne.kast.api.wrapper.KastCandidate
+import io.github.amichne.kast.api.wrapper.KastDiagnosticsFailureResponse
+import io.github.amichne.kast.api.wrapper.KastDiagnosticsQuery
+import io.github.amichne.kast.api.wrapper.KastDiagnosticsResponse
+import io.github.amichne.kast.api.wrapper.KastDiagnosticsSuccessResponse
+import io.github.amichne.kast.api.wrapper.KastDiagnosticsSummary
+import io.github.amichne.kast.api.wrapper.KastMetricsFailureResponse
+import io.github.amichne.kast.api.wrapper.KastMetricsQuery
+import io.github.amichne.kast.api.wrapper.KastMetricsResponse
+import io.github.amichne.kast.api.wrapper.KastMetricsSuccessResponse
+import io.github.amichne.kast.api.wrapper.KastReferencesFailureResponse
+import io.github.amichne.kast.api.wrapper.KastReferencesQuery
+import io.github.amichne.kast.api.wrapper.KastReferencesResponse
+import io.github.amichne.kast.api.wrapper.KastReferencesSuccessResponse
+import io.github.amichne.kast.api.wrapper.KastRenameBySymbolQuery
+import io.github.amichne.kast.api.wrapper.KastRenameFailureQuery
+import io.github.amichne.kast.api.wrapper.KastRenameFailureResponse
+import io.github.amichne.kast.api.wrapper.KastRenameResponse
+import io.github.amichne.kast.api.wrapper.KastRenameSuccessResponse
+import io.github.amichne.kast.api.wrapper.KastResolveFailureResponse
+import io.github.amichne.kast.api.wrapper.KastResolveQuery
+import io.github.amichne.kast.api.wrapper.KastResolveResponse
+import io.github.amichne.kast.api.wrapper.KastResolveSuccessResponse
+import io.github.amichne.kast.api.wrapper.KastScaffoldFailureResponse
+import io.github.amichne.kast.api.wrapper.KastScaffoldQuery
+import io.github.amichne.kast.api.wrapper.KastScaffoldResponse
+import io.github.amichne.kast.api.wrapper.KastScaffoldSuccessResponse
+import io.github.amichne.kast.api.wrapper.KastWorkspaceFilesFailureResponse
+import io.github.amichne.kast.api.wrapper.KastWorkspaceFilesQuery
+import io.github.amichne.kast.api.wrapper.KastWorkspaceFilesResponse
+import io.github.amichne.kast.api.wrapper.KastWorkspaceFilesSuccessResponse
+import io.github.amichne.kast.api.wrapper.KastWriteAndValidateCreateFileQuery
+import io.github.amichne.kast.api.wrapper.KastWriteAndValidateFailureQuery
+import io.github.amichne.kast.api.wrapper.KastWriteAndValidateFailureResponse
+import io.github.amichne.kast.api.wrapper.KastWriteAndValidateResponse
+import io.github.amichne.kast.api.wrapper.KastWriteAndValidateSuccessResponse
+import io.github.amichne.kast.api.wrapper.WrapperCallDirection
+import io.github.amichne.kast.api.wrapper.WrapperMetric
+import io.github.amichne.kast.cli.defaultCliJson
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SkillWrapperSerializerTest {
+    private val json: Json = defaultCliJson()
+
+    @Test
+    fun `wrapper responses round-trip with documented casing`() {
+        wrapperCases().forEach { case ->
+            assertResponse(case.name, case.success, case.successType, case.successAssertions)
+            assertResponse(case.name, case.failure, case.failureType, case.failureAssertions)
+        }
+    }
+
+    private fun assertResponse(
+        name: SkillWrapperName,
+        response: Any,
+        expectedType: String,
+        extraAssertions: (JsonObject) -> Unit,
+    ) {
+        val parsed = json.parseToJsonElement(
+            SkillWrapperSerializer.encode(json, name, response),
+        ).jsonObject
+
+        assertNotNull(parsed["ok"], "missing ok for $name")
+        assertEquals(expectedType, parsed["type"]?.jsonPrimitive?.content, "wrong type for $name")
+        assertNotNull(parsed["query"], "missing query for $name")
+        assertNotNull(parsed["logFile"], "missing logFile for $name")
+        extraAssertions(parsed)
+    }
+
+    private fun wrapperCases(): List<WrapperCase> = listOf(
+        WrapperCase(
+            name = SkillWrapperName.RESOLVE,
+            success = KastResolveSuccessResponse(
+                query = KastResolveQuery(workspaceRoot = "/tmp/ws", symbol = "Foo"),
+                symbol = testSymbol(),
+                filePath = "/tmp/ws/src/Foo.kt",
+                offset = 10,
+                candidate = KastCandidate(line = 1, column = 7, context = "class Foo"),
+                candidateCount = 2,
+                alternatives = listOf("com.example.OtherFoo"),
+                logFile = "/tmp/log.txt",
+            ),
+            failure = KastResolveFailureResponse(
+                stage = "resolve",
+                message = "missing",
+                query = KastResolveQuery(workspaceRoot = "/tmp/ws", symbol = "Missing"),
+                logFile = "/tmp/log.txt",
+                error = apiError(),
+                errorText = "boom",
+            ),
+            successType = "RESOLVE_SUCCESS",
+            failureType = "RESOLVE_FAILURE",
+            successAssertions = { parsed ->
+                assertEquals(2, parsed["candidateCount"]?.jsonPrimitive?.content?.toInt())
+                assertEquals("com.example.Foo", parsed["symbol"]?.jsonObject?.get("fqName")?.jsonPrimitive?.content)
+                assertEquals(
+                    "/tmp/ws/src/Foo.kt",
+                    parsed["symbol"]?.jsonObject?.get("location")?.jsonObject?.get("filePath")?.jsonPrimitive?.content,
+                )
+            },
+            failureAssertions = { parsed ->
+                assertEquals("boom", parsed["errorText"]?.jsonPrimitive?.content)
+                assertEquals("REQUEST_FAILED", parsed["error"]?.jsonObject?.get("code")?.jsonPrimitive?.content)
+            },
+        ),
+        WrapperCase(
+            name = SkillWrapperName.REFERENCES,
+            success = KastReferencesSuccessResponse(
+                query = KastReferencesQuery(workspaceRoot = "/tmp/ws", symbol = "Foo"),
+                symbol = testSymbol(),
+                filePath = "/tmp/ws/src/Foo.kt",
+                offset = 10,
+                references = listOf(testLocation("/tmp/ws/src/Bar.kt", "Foo()")),
+                declaration = testSymbol("com.example.FooDeclaration"),
+                candidateCount = 2,
+                alternatives = listOf("com.example.OtherFoo"),
+                logFile = "/tmp/log.txt",
+            ),
+            failure = KastReferencesFailureResponse(
+                stage = "resolve",
+                message = "missing",
+                query = KastReferencesQuery(workspaceRoot = "/tmp/ws", symbol = "Missing"),
+                logFile = "/tmp/log.txt",
+            ),
+            successType = "REFERENCES_SUCCESS",
+            failureType = "REFERENCES_FAILURE",
+            successAssertions = { parsed ->
+                assertEquals(
+                    "/tmp/ws/src/Bar.kt",
+                    parsed["references"]?.jsonArray?.firstOrNull()?.jsonObject?.get("filePath")?.jsonPrimitive?.content,
+                )
+                assertEquals(
+                    "com.example.FooDeclaration",
+                    parsed["declaration"]?.jsonObject?.get("fqName")?.jsonPrimitive?.content,
+                )
+            },
+        ),
+        WrapperCase(
+            name = SkillWrapperName.CALLERS,
+            success = KastCallersSuccessResponse(
+                query = KastCallersQuery(
+                    workspaceRoot = "/tmp/ws",
+                    symbol = "process",
+                    direction = WrapperCallDirection.INCOMING,
+                ),
+                symbol = testSymbol(),
+                filePath = "/tmp/ws/src/Foo.kt",
+                offset = 10,
+                root = CallNode(
+                    symbol = testSymbol("com.example.CallRoot"),
+                    callSite = testLocation("/tmp/ws/src/Caller.kt", "process()"),
+                    children = emptyList(),
+                ),
+                stats = CallHierarchyStats(
+                    totalNodes = 1,
+                    totalEdges = 0,
+                    truncatedNodes = 0,
+                    maxDepthReached = 0,
+                    timeoutReached = false,
+                    maxTotalCallsReached = false,
+                    maxChildrenPerNodeReached = false,
+                    filesVisited = 1,
+                ),
+                candidateCount = 3,
+                alternatives = listOf("com.example.Handler.process"),
+                logFile = "/tmp/log.txt",
+            ),
+            failure = KastCallersFailureResponse(
+                stage = "resolve",
+                message = "missing",
+                query = KastCallersQuery(workspaceRoot = "/tmp/ws", symbol = "Missing"),
+                logFile = "/tmp/log.txt",
+            ),
+            successType = "CALLERS_SUCCESS",
+            failureType = "CALLERS_FAILURE",
+            successAssertions = { parsed ->
+                assertEquals(
+                    "com.example.CallRoot",
+                    parsed["root"]?.jsonObject?.get("symbol")?.jsonObject?.get("fqName")?.jsonPrimitive?.content,
+                )
+                assertEquals(
+                    "/tmp/ws/src/Caller.kt",
+                    parsed["root"]?.jsonObject?.get("callSite")?.jsonObject?.get("filePath")?.jsonPrimitive?.content,
+                )
+            },
+        ),
+        WrapperCase(
+            name = SkillWrapperName.DIAGNOSTICS,
+            success = KastDiagnosticsSuccessResponse(
+                query = KastDiagnosticsQuery(
+                    workspaceRoot = "/tmp/ws",
+                    filePaths = listOf("/tmp/ws/src/Foo.kt"),
+                ),
+                clean = false,
+                errorCount = 1,
+                warningCount = 0,
+                infoCount = 0,
+                diagnostics = listOf(
+                    Diagnostic(
+                        location = testLocation(),
+                        severity = DiagnosticSeverity.ERROR,
+                        message = "broken",
+                    ),
+                ),
+                logFile = "/tmp/log.txt",
+            ),
+            failure = KastDiagnosticsFailureResponse(
+                stage = "diagnostics",
+                message = "failed",
+                query = KastDiagnosticsQuery(
+                    workspaceRoot = "/tmp/ws",
+                    filePaths = listOf("/tmp/ws/src/Foo.kt"),
+                ),
+                logFile = "/tmp/log.txt",
+            ),
+            successType = "DIAGNOSTICS_SUCCESS",
+            failureType = "DIAGNOSTICS_FAILURE",
+            successAssertions = { parsed ->
+                assertEquals(
+                    "/tmp/ws/src/Foo.kt",
+                    parsed["diagnostics"]?.jsonArray?.firstOrNull()?.jsonObject
+                        ?.get("location")?.jsonObject?.get("filePath")?.jsonPrimitive?.content,
+                )
+            },
+        ),
+        WrapperCase(
+            name = SkillWrapperName.RENAME,
+            success = KastRenameSuccessResponse(
+                ok = true,
+                query = KastRenameBySymbolQuery(
+                    workspaceRoot = "/tmp/ws",
+                    symbol = "oldName",
+                    newName = "newName",
+                    filePath = "/tmp/ws/src/Foo.kt",
+                    offset = 10,
+                ),
+                editCount = 1,
+                affectedFiles = listOf("/tmp/ws/src/Foo.kt"),
+                applyResult = ApplyEditsResult(
+                    applied = emptyList(),
+                    affectedFiles = listOf("/tmp/ws/src/Foo.kt"),
+                ),
+                diagnostics = KastDiagnosticsSummary(clean = true, errorCount = 0, warningCount = 0, errors = emptyList()),
+                logFile = "/tmp/log.txt",
+            ),
+            failure = KastRenameFailureResponse(
+                stage = "resolve",
+                message = "missing",
+                query = KastRenameFailureQuery(
+                    type = "RENAME_BY_SYMBOL_REQUEST",
+                    workspaceRoot = "/tmp/ws",
+                    symbol = "oldName",
+                    newName = "newName",
+                ),
+                logFile = "/tmp/log.txt",
+            ),
+            successType = "RENAME_SUCCESS",
+            failureType = "RENAME_FAILURE",
+            successAssertions = { parsed ->
+                assertEquals(
+                    listOf("/tmp/ws/src/Foo.kt"),
+                    parsed["applyResult"]?.jsonObject?.get("affectedFiles")?.jsonArray?.map { it.jsonPrimitive.content },
+                )
+            },
+        ),
+        WrapperCase(
+            name = SkillWrapperName.SCAFFOLD,
+            success = KastScaffoldSuccessResponse(
+                query = KastScaffoldQuery(workspaceRoot = "/tmp/ws", targetFile = "/tmp/ws/src/Foo.kt"),
+                outline = emptyList(),
+                symbol = testSymbol(),
+                logFile = "/tmp/log.txt",
+            ),
+            failure = KastScaffoldFailureResponse(
+                stage = "scaffold",
+                message = "failed",
+                query = KastScaffoldQuery(workspaceRoot = "/tmp/ws", targetFile = "/tmp/ws/src/Foo.kt"),
+                logFile = "/tmp/log.txt",
+            ),
+            successType = "SCAFFOLD_SUCCESS",
+            failureType = "SCAFFOLD_FAILURE",
+            successAssertions = { parsed ->
+                assertEquals("com.example.Foo", parsed["symbol"]?.jsonObject?.get("fqName")?.jsonPrimitive?.content)
+            },
+        ),
+        WrapperCase(
+            name = SkillWrapperName.WORKSPACE_FILES,
+            success = KastWorkspaceFilesSuccessResponse(
+                query = KastWorkspaceFilesQuery(workspaceRoot = "/tmp/ws"),
+                modules = listOf(
+                    WorkspaceModule(
+                        name = ":app",
+                        sourceRoots = listOf("/tmp/ws/src"),
+                        dependencyModuleNames = listOf(":core"),
+                        fileCount = 1,
+                    ),
+                ),
+                schemaVersion = 1,
+                logFile = "/tmp/log.txt",
+            ),
+            failure = KastWorkspaceFilesFailureResponse(
+                stage = "workspace-files",
+                message = "failed",
+                query = KastWorkspaceFilesQuery(workspaceRoot = "/tmp/ws"),
+                logFile = "/tmp/log.txt",
+            ),
+            successType = "WORKSPACE_FILES_SUCCESS",
+            failureType = "WORKSPACE_FILES_FAILURE",
+            successAssertions = { parsed ->
+                assertEquals(
+                    listOf(":core"),
+                    parsed["modules"]?.jsonArray?.firstOrNull()?.jsonObject
+                        ?.get("dependencyModuleNames")?.jsonArray?.map { it.jsonPrimitive.content },
+                )
+            },
+        ),
+        WrapperCase(
+            name = SkillWrapperName.WRITE_AND_VALIDATE,
+            success = KastWriteAndValidateSuccessResponse(
+                ok = true,
+                query = KastWriteAndValidateCreateFileQuery(
+                    workspaceRoot = "/tmp/ws",
+                    filePath = "/tmp/ws/src/New.kt",
+                ),
+                appliedEdits = 1,
+                importChanges = 0,
+                diagnostics = KastDiagnosticsSummary(
+                    clean = false,
+                    errorCount = 1,
+                    warningCount = 0,
+                    errors = listOf(
+                        Diagnostic(
+                            location = testLocation("/tmp/ws/src/New.kt", "class New"),
+                            severity = DiagnosticSeverity.ERROR,
+                            message = "broken",
+                        ),
+                    ),
+                ),
+                message = "created",
+                logFile = "/tmp/log.txt",
+            ),
+            failure = KastWriteAndValidateFailureResponse(
+                stage = "validate",
+                message = "failed",
+                query = KastWriteAndValidateFailureQuery(
+                    type = "CREATE_FILE_REQUEST",
+                    workspaceRoot = "/tmp/ws",
+                    filePath = "/tmp/ws/src/New.kt",
+                ),
+                logFile = "/tmp/log.txt",
+            ),
+            successType = "WRITE_AND_VALIDATE_SUCCESS",
+            failureType = "WRITE_AND_VALIDATE_FAILURE",
+            successAssertions = { parsed ->
+                assertEquals(
+                    "/tmp/ws/src/New.kt",
+                    parsed["diagnostics"]?.jsonObject?.get("errors")?.jsonArray?.firstOrNull()?.jsonObject
+                        ?.get("location")?.jsonObject?.get("filePath")?.jsonPrimitive?.content,
+                )
+            },
+        ),
+        WrapperCase(
+            name = SkillWrapperName.METRICS,
+            success = KastMetricsSuccessResponse(
+                query = KastMetricsQuery(workspaceRoot = "/tmp/ws", metric = WrapperMetric.FAN_IN),
+                results = buildJsonObject {
+                    put("topSymbol", JsonPrimitive("com.example.Foo"))
+                },
+                logFile = "/tmp/log.txt",
+            ),
+            failure = KastMetricsFailureResponse(
+                stage = "metrics",
+                message = "failed",
+                query = KastMetricsQuery(workspaceRoot = "/tmp/ws", metric = WrapperMetric.FAN_IN),
+                logFile = "/tmp/log.txt",
+            ),
+            successType = "METRICS_SUCCESS",
+            failureType = "METRICS_FAILURE",
+            successAssertions = { parsed ->
+                assertEquals("com.example.Foo", parsed["results"]?.jsonObject?.get("topSymbol")?.jsonPrimitive?.content)
+            },
+        ),
+    )
+
+    private fun testLocation(
+        filePath: String = "/tmp/ws/src/Foo.kt",
+        preview: String = "class Foo",
+    ) = Location(
+        filePath = filePath,
+        startOffset = 10,
+        endOffset = 17,
+        startLine = 1,
+        startColumn = 7,
+        preview = preview,
+    )
+
+    private fun testSymbol(fqName: String = "com.example.Foo") = Symbol(
+        fqName = fqName,
+        kind = SymbolKind.CLASS,
+        location = testLocation(),
+    )
+
+    private fun apiError() = ApiErrorResponse(
+        requestId = "req-1",
+        code = "REQUEST_FAILED",
+        message = "broken",
+        retryable = false,
+    )
+
+    private data class WrapperCase(
+        val name: SkillWrapperName,
+        val success: Any,
+        val failure: Any,
+        val successType: String,
+        val failureType: String,
+        val successAssertions: (JsonObject) -> Unit = {},
+        val failureAssertions: (JsonObject) -> Unit = {},
+    )
+}


### PR DESCRIPTION
This pull request updates the documentation, evaluation datasets, and supporting scripts for the Kast skill to clarify schema conventions, expand the evaluation corpus, and refine the taxonomy of failure modes. The changes ensure consistent use of camelCase in request and response fields, add new test cases for schema correctness, and enhance the documentation and scripts to reflect these updates.

**Schema conventions and documentation updates:**

- Updated `.agents/skills/kast/SKILL.md` to clarify that both request and wrapper response fields use camelCase (e.g., `logFile`, `errorText`), and that `workspaceRoot` defaults to the current working directory if omitted. Also updated example field names for consistency.
- Revised inline documentation in `.agents/skills/kast/fixtures/maintenance/phoenix/kast_evals.py` to reflect new schema conventions, including camelCase for all fields and the behavior of `workspaceRoot`.

**Evaluation dataset expansion and improvements:**

- Added new evaluation cases to `.agents/skills/kast/fixtures/maintenance/evals/evals.json` for scenarios such as correct request discriminators, camelCase request fields, absolute path enforcement, and ambiguity handling.
- Added new routing evaluation scenarios to `.agents/skills/kast/fixtures/maintenance/evals/routing.json`, including multi-file scaffolding, mutation via wrapper, absolute path normalization, and ambiguous symbol disambiguation.
- Included a new baseline evaluation fixture `.agents/skills/kast/fixtures/maintenance/eval-baseline.json` summarizing evaluation results and checks.

**Failure taxonomy and dataset documentation:**

- Expanded the failure taxonomy in `.agents/skills/kast/fixtures/maintenance/phoenix/README.md` to include new categories: `relative_path` and `ambiguous_symbol`, and updated the dataset summary to reflect the increased number of evaluation examples. [[1]](diffhunk://#diff-19537545ebd8265ed32af40fb258ed3f590548f0911b82b0666c373da956fcd2L17-R17) [[2]](diffhunk://#diff-19537545ebd8265ed32af40fb258ed3f590548f0911b82b0666c373da956fcd2L29-R39)
- Updated the list of failure modes and categories in `.agents/skills/kast/fixtures/maintenance/phoenix/kast_evals.py` to match the expanded taxonomy. [[1]](diffhunk://#diff-1a6d7d8655a737e1fc2d3500c17c2abce061761db0b2196fde35451abdbe0e9bL65-R68) [[2]](diffhunk://#diff-1a6d7d8655a737e1fc2d3500c17c2abce061761db0b2196fde35451abdbe0e9bR78-R79)

**Evaluation prompt and expectation refinements:**

- Revised evaluation prompts and expectations throughout the evals and routing datasets to use camelCase field names (e.g., `filePath`, `logFile`, `errorText`) and to clarify the expected schema-correct behaviors. [[1]](diffhunk://#diff-c8891a0979e67953539409506d2c7915c92ce87f314939dae57aad5e3a6661acL92-R99) [[2]](diffhunk://#diff-c8891a0979e67953539409506d2c7915c92ce87f314939dae57aad5e3a6661acL131-R131) [[3]](diffhunk://#diff-09da808ad960d7ad64db11eff36027a6276bbeeed994c355fbb40e0389be1b8fL195-R195) [[4]](diffhunk://#diff-09da808ad960d7ad64db11eff36027a6276bbeeed994c355fbb40e0389be1b8fL249-R249)

These updates improve clarity, consistency, and coverage for both the documentation and the evaluation of the Kast skill.