### PR TITLE
Bound workspace file listing scope

### DIFF
--- a/.agents/skills/kast/fixtures/maintenance/references/wrapper-openapi.yaml
+++ b/.agents/skills/kast/fixtures/maintenance/references/wrapper-openapi.yaml
@@ -458,6 +458,13 @@ components:
               type: null
         includeFiles:
           type: boolean
+        maxFilesPerModule:
+          anyOf:
+            -
+              type: integer
+              format: int32
+            -
+              type: null
       additionalProperties: false
     KastWriteAndValidateCreateFileRequest:
       type: object
@@ -1995,6 +2002,13 @@ components:
               type: null
         includeFiles:
           type: boolean
+        maxFilesPerModule:
+          anyOf:
+            -
+              type: integer
+              format: int32
+            -
+              type: null
       additionalProperties: false
       required:
         - workspaceRoot
@@ -2015,6 +2029,8 @@ components:
           type: array
           items:
             type: string
+        filesTruncated:
+          type: boolean
         fileCount:
           type: integer
           format: int32

--- a/.agents/skills/kast/references/quickstart.md
+++ b/.agents/skills/kast/references/quickstart.md
@@ -51,8 +51,12 @@ instead of switching to non-semantic Kotlin search.
 ### List workspace files
 
 ```bash
-"$KAST_CLI_PATH" skill workspace-files '{"includeFiles":true}'
+"$KAST_CLI_PATH" skill workspace-files '{"includeFiles":true,"maxFilesPerModule":500}'
 ```
+
+`includeFiles` returns a capped file list for each module. If a module has more
+files than the cap, the response marks that module with `filesTruncated:true`
+while keeping `fileCount` as the total discovered source file count.
 
 ### Resolve an ambiguous property
 

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/query/WorkspaceFilesQuery.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/query/WorkspaceFilesQuery.kt
@@ -13,4 +13,9 @@ data class WorkspaceFilesQuery(
     val moduleName: String? = null,
     @DocField(description = "When true, includes individual file paths for each module.", defaultValue = "false")
     val includeFiles: Boolean = false,
+    @DocField(
+        description = "Maximum file paths to return per module when includeFiles is true. Omit to use the server maxResults limit.",
+        defaultValue = "null",
+    )
+    val maxFilesPerModule: Int? = null,
 )

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceFilesResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceFilesResult.kt
@@ -26,6 +26,8 @@ data class WorkspaceModule(
     val dependencyModuleNames: List<String>,
     @DocField(description = "Individual source file paths, populated when includeFiles is true.", defaultValue = "emptyList()")
     val files: List<String> = emptyList(),
+    @DocField(description = "True when the files list was capped before every source file path could be returned.", defaultValue = "false")
+    val filesTruncated: Boolean = false,
     @DocField(description = "Total number of source files in this module.")
     val fileCount: Int,
 )

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/wrapper/WrapperContracts.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/wrapper/WrapperContracts.kt
@@ -187,6 +187,7 @@ data class KastWorkspaceFilesRequest(
     val workspaceRoot: String? = null,
     val moduleName: String? = null,
     val includeFiles: Boolean = false,
+    val maxFilesPerModule: Int? = null,
 )
 
 @Serializable
@@ -313,6 +314,7 @@ data class KastWorkspaceFilesQuery(
     val workspaceRoot: String,
     val moduleName: String? = null,
     val includeFiles: Boolean = false,
+    val maxFilesPerModule: Int? = null,
 )
 
 @Serializable

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
@@ -315,7 +315,20 @@ class AnalysisDispatcher(
             "workspace/files" -> encode(
                 WorkspaceFilesResult.serializer(),
                 backend.workspaceFiles(
-                    decodeParams(WorkspaceFilesQuery.serializer(), params).also {
+                    decodeParams(WorkspaceFilesQuery.serializer(), params).also { query ->
+                        val moduleName = query.moduleName
+                        val maxFilesPerModule = query.maxFilesPerModule
+                        if (moduleName != null && moduleName.isBlank()) {
+                            throw ValidationException("Workspace files moduleName must not be blank when provided")
+                        }
+                        if (maxFilesPerModule != null && maxFilesPerModule < 1) {
+                            throw ValidationException("Workspace files maxFilesPerModule must be greater than zero")
+                        }
+                        if (maxFilesPerModule != null && maxFilesPerModule > config.maxResults) {
+                            throw ValidationException(
+                                "Workspace files maxFilesPerModule must be less than or equal to server maxResults (${config.maxResults})",
+                            )
+                        }
                         requireReadCapability(ReadCapability.WORKSPACE_FILES)
                     },
                 ),

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
@@ -413,6 +413,57 @@ class AnalysisDispatcherTest {
     }
 
     @Test
+    fun `workspace files rejects blank module name`() {
+        val response = dispatchRaw(
+            method = "workspace/files",
+            params = json.encodeToJsonElement(
+                WorkspaceFilesQuery.serializer(),
+                WorkspaceFilesQuery(moduleName = "  "),
+            ),
+        )
+
+        val error = json.decodeFromJsonElement(
+            JsonRpcErrorResponse.serializer(),
+            response,
+        )
+        assertEquals("VALIDATION_ERROR", error.error.data?.code)
+    }
+
+    @Test
+    fun `workspace files rejects non positive file cap`() {
+        val response = dispatchRaw(
+            method = "workspace/files",
+            params = json.encodeToJsonElement(
+                WorkspaceFilesQuery.serializer(),
+                WorkspaceFilesQuery(includeFiles = true, maxFilesPerModule = 0),
+            ),
+        )
+
+        val error = json.decodeFromJsonElement(
+            JsonRpcErrorResponse.serializer(),
+            response,
+        )
+        assertEquals("VALIDATION_ERROR", error.error.data?.code)
+    }
+
+    @Test
+    fun `workspace files rejects file cap above server max results`() {
+        val response = dispatchRaw(
+            method = "workspace/files",
+            params = json.encodeToJsonElement(
+                WorkspaceFilesQuery.serializer(),
+                WorkspaceFilesQuery(includeFiles = true, maxFilesPerModule = 501),
+            ),
+        )
+
+        val error = json.decodeFromJsonElement(
+            JsonRpcErrorResponse.serializer(),
+            response,
+        )
+        assertEquals("VALIDATION_ERROR", error.error.data?.code)
+    }
+
+    @Test
     fun `workspace symbol dispatches without HTTP`() {
         val result = dispatchSuccess<WorkspaceSymbolResult>(
             method = "workspace-symbol",

--- a/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastPluginBackend.kt
+++ b/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastPluginBackend.kt
@@ -405,7 +405,16 @@ internal class KastPluginBackend(
     }
 
     override suspend fun workspaceFiles(query: WorkspaceFilesQuery): WorkspaceFilesResult = withContext(readDispatcher) {
-        telemetry.inSpan(IntelliJTelemetryScope.WORKSPACE_FILES, "kast.intellij.workspaceFiles") {
+        val fileLimit = query.maxFilesPerModule ?: limits.maxResults
+        telemetry.inSpan(
+            IntelliJTelemetryScope.WORKSPACE_FILES,
+            "kast.intellij.workspaceFiles",
+            attributes = mapOf(
+                "kast.workspaceFiles.moduleName" to query.moduleName,
+                "kast.workspaceFiles.includeFiles" to query.includeFiles,
+                "kast.workspaceFiles.maxFilesPerModule" to fileLimit,
+            ),
+        ) { span ->
             val allModules = timedReadAction(telemetry, IntelliJTelemetryScope.WORKSPACE_FILES, "kast.intellij.workspaceFiles.listModules") {
                 ModuleManager.getInstance(project).modules.toList()
             }
@@ -423,27 +432,31 @@ internal class KastPluginBackend(
                 val depNames = rootManager.dependencies.map { it.name }
                 val moduleScope = GlobalSearchScope.moduleScope(module)
                 val kotlinFiles = FileTypeIndex.getFiles(KotlinFileType.INSTANCE, moduleScope)
-                val filteredPaths = if (query.includeFiles) {
-                    kotlinFiles
-                        .map { it.path }
-                        .filter { it.startsWith(workspacePrefix) }
-                        .sorted()
-                } else {
-                    emptyList()
+                val filteredPaths = mutableListOf<String>()
+                var fileCount = 0
+                kotlinFiles.forEach { file ->
+                    val path = file.path
+                    if (path.startsWith(workspacePrefix)) {
+                        fileCount += 1
+                        if (query.includeFiles && filteredPaths.size < fileLimit) {
+                            filteredPaths += path
+                        }
+                    }
                 }
                 WorkspaceModule(
                     name = module.name,
                     sourceRoots = sourceRoots,
                     dependencyModuleNames = depNames,
-                    files = filteredPaths,
-                    fileCount = if (query.includeFiles) {
-                        filteredPaths.size
-                    } else {
-                        kotlinFiles.count { it.path.startsWith(workspacePrefix) }
-                    },
+                    files = filteredPaths.sorted(),
+                    filesTruncated = query.includeFiles && fileCount > filteredPaths.size,
+                    fileCount = fileCount,
                 )
             }
             }
+            span.setAttribute("kast.workspaceFiles.moduleCount", modules.size)
+            span.setAttribute("kast.workspaceFiles.totalFileCount", modules.sumOf { it.fileCount })
+            span.setAttribute("kast.workspaceFiles.returnedFileCount", modules.sumOf { it.files.size })
+            span.setAttribute("kast.workspaceFiles.truncatedModuleCount", modules.count { it.filesTruncated })
             WorkspaceFilesResult(modules = modules)
         }
     }

--- a/backend-intellij/src/test/kotlin/io/github/amichne/kast/intellij/KastPluginBackendContractTest.kt
+++ b/backend-intellij/src/test/kotlin/io/github/amichne/kast/intellij/KastPluginBackendContractTest.kt
@@ -22,6 +22,7 @@ import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.contract.query.SymbolQuery
 import io.github.amichne.kast.api.contract.TypeHierarchyDirection
 import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
+import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -130,6 +131,28 @@ class KastPluginBackendContractTest {
         val status = backend().runtimeStatus()
 
         assertEquals(listOf("main", "secondary"), status.sourceModuleNames)
+    }
+
+    @Test
+    fun `workspace files caps included files per module and reports truncation`() = runBlocking {
+        ensureProjectReady()
+        val workspaceRoot = readAction {
+            commonWorkspaceRoot(sampleFile.virtualFile.path, hierarchyFile.virtualFile.path)
+        }
+
+        val result = backend(workspaceRoot).workspaceFiles(
+            WorkspaceFilesQuery(
+                moduleName = "main",
+                includeFiles = true,
+                maxFilesPerModule = 1,
+            ),
+        )
+
+        val module = result.modules.single()
+        assertEquals("main", module.name)
+        assertEquals(1, module.files.size)
+        assertTrue(module.fileCount > module.files.size)
+        assertTrue(module.filesTruncated)
     }
 
     @Test

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -781,50 +781,44 @@ internal class StandaloneAnalysisBackend internal constructor(
     }
 
     override suspend fun workspaceFiles(query: WorkspaceFilesQuery): WorkspaceFilesResult = withContext(readDispatcher) {
-        session.withReadAccess {
-            val specs = session.moduleSpecs()
-            val filtered = if (query.moduleName != null) {
-                specs.filter { it.name.value == query.moduleName }
-            } else {
-                specs
-            }
-            val modules = filtered.map { spec ->
-                val sourceRootStrings = spec.sourceRoots.map { it.toString() }
-                val files = if (query.includeFiles) {
-                    spec.sourceRoots
-                        .flatMap { root ->
-                            Files.walk(root).use { stream ->
-                                stream
-                                    .filter { Files.isRegularFile(it) && it.toString().endsWith(".kt") }
-                                    .map { it.toRealPath().toString() }
-                                    .toList()
-                            }
-                        }
-                        .sorted()
+        val fileLimit = query.maxFilesPerModule ?: limits.maxResults
+        telemetry.inSpan(
+            scope = StandaloneTelemetryScope.WORKSPACE_FILES,
+            name = "kast.workspaceFiles",
+            attributes = mapOf(
+                "kast.workspaceFiles.moduleName" to query.moduleName,
+                "kast.workspaceFiles.includeFiles" to query.includeFiles,
+                "kast.workspaceFiles.maxFilesPerModule" to fileLimit,
+            ),
+        ) { span ->
+            session.withReadAccess {
+                val specs = session.moduleSpecs()
+                val filtered = if (query.moduleName != null) {
+                    specs.filter { it.name.value == query.moduleName }
                 } else {
-                    emptyList()
+                    specs
                 }
-                val fileCount = if (query.includeFiles) {
-                    files.size
-                } else {
-                    spec.sourceRoots.sumOf { root ->
-                        Files.walk(root).use { stream ->
-                            stream
-                                .filter { Files.isRegularFile(it) && it.toString().endsWith(".kt") }
-                                .count()
-                                .toInt()
-                        }
-                    }
+                val modules = filtered.map { spec ->
+                    val listing = collectWorkspaceFiles(
+                        sourceRoots = spec.sourceRoots,
+                        includeFiles = query.includeFiles,
+                        maxFiles = fileLimit,
+                    )
+                    WorkspaceModule(
+                        name = spec.name.value,
+                        sourceRoots = spec.sourceRoots.map { it.toString() },
+                        dependencyModuleNames = spec.dependencyModuleNames.map { it.value },
+                        files = listing.files,
+                        filesTruncated = listing.filesTruncated,
+                        fileCount = listing.fileCount,
+                    )
                 }
-                WorkspaceModule(
-                    name = spec.name.value,
-                    sourceRoots = sourceRootStrings,
-                    dependencyModuleNames = spec.dependencyModuleNames.map { it.value },
-                    files = files,
-                    fileCount = fileCount,
-                )
+                span.setAttribute("kast.workspaceFiles.moduleCount", modules.size)
+                span.setAttribute("kast.workspaceFiles.totalFileCount", modules.sumOf { it.fileCount })
+                span.setAttribute("kast.workspaceFiles.returnedFileCount", modules.sumOf { it.files.size })
+                span.setAttribute("kast.workspaceFiles.truncatedModuleCount", modules.count { it.filesTruncated })
+                WorkspaceFilesResult(modules = modules)
             }
-            WorkspaceFilesResult(modules = modules)
         }
     }
 
@@ -834,6 +828,38 @@ internal class StandaloneAnalysisBackend internal constructor(
                 .getResource("/kast-backend-version.txt")
                 ?.readText()?.trim()
                 ?: "unknown"
+    }
+
+    private data class WorkspaceFileListing(
+        val files: List<String>,
+        val fileCount: Int,
+        val filesTruncated: Boolean,
+    )
+
+    private fun collectWorkspaceFiles(
+        sourceRoots: List<Path>,
+        includeFiles: Boolean,
+        maxFiles: Int,
+    ): WorkspaceFileListing {
+        val files = mutableListOf<String>()
+        var fileCount = 0
+        sourceRoots.forEach { root ->
+            Files.walk(root).use { stream ->
+                stream
+                    .filter { Files.isRegularFile(it) && it.toString().endsWith(".kt") }
+                    .forEach { file ->
+                        fileCount += 1
+                        if (includeFiles && files.size < maxFiles) {
+                            files += file.toRealPath().toString()
+                        }
+                    }
+            }
+        }
+        return WorkspaceFileListing(
+            files = files.sorted(),
+            fileCount = fileCount,
+            filesTruncated = includeFiles && fileCount > files.size,
+        )
     }
 
     private fun isConcreteType(type: PsiElement): Boolean = when (type) {

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/telemetry/StandaloneTelemetry.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/telemetry/StandaloneTelemetry.kt
@@ -1,7 +1,7 @@
 package io.github.amichne.kast.standalone.telemetry
 
 import io.github.amichne.kast.api.client.KastConfig
-import io.github.amichne.kast.api.client.workspaceDataDirectory
+import io.github.amichne.kast.api.client.kastConfigHome
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -90,6 +90,7 @@ internal class StandaloneTelemetry private constructor(
         fun fromConfig(
             workspaceRoot: Path,
             config: KastConfig = KastConfig.load(workspaceRoot),
+            configHome: () -> Path = { kastConfigHome() },
         ): StandaloneTelemetry {
             if (!config.telemetry.enabled) {
                 return disabled()
@@ -104,6 +105,7 @@ internal class StandaloneTelemetry private constructor(
             val outputFile = resolveOutputFile(
                 rawValue = config.telemetry.outputFile,
                 workspaceRoot = workspaceRoot,
+                configHome = configHome,
             )
 
             return create(
@@ -127,13 +129,17 @@ internal class StandaloneTelemetry private constructor(
             return scopes.ifEmpty { null }
         }
 
-        private fun resolveOutputFile(rawValue: String?, workspaceRoot: Path): Path {
+        private fun resolveOutputFile(
+            rawValue: String?,
+            workspaceRoot: Path,
+            configHome: () -> Path,
+        ): Path {
             val configuredPath = rawValue
                 ?.takeIf(String::isNotBlank)
                 ?.let(Path::of)
                 ?.let { path -> if (path.isAbsolute) path else workspaceRoot.resolve(path) }
 
-            return (configuredPath ?: workspaceDataDirectory(workspaceRoot).resolve("telemetry/standalone-spans.jsonl"))
+            return (configuredPath ?: configHome().resolve("telemetry/standalone-spans.jsonl"))
                 .toAbsolutePath()
                 .normalize()
         }

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/telemetry/StandaloneTelemetryScope.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/telemetry/StandaloneTelemetryScope.kt
@@ -7,6 +7,7 @@ internal enum class StandaloneTelemetryScope {
     SYMBOL_RESOLVE,
     FILE_OUTLINE,
     WORKSPACE_SYMBOL_SEARCH,
+    WORKSPACE_FILES,
     WORKSPACE_DISCOVERY,
     SESSION_LOCK,
     SESSION_LIFECYCLE,
@@ -21,6 +22,7 @@ internal enum class StandaloneTelemetryScope {
             "symbol-resolve", "symbol_resolve", "symbolresolve", "resolve" -> SYMBOL_RESOLVE
             "file-outline", "file_outline", "fileoutline", "outline" -> FILE_OUTLINE
             "workspace-symbol", "workspace_symbol", "workspacesymbol" -> WORKSPACE_SYMBOL_SEARCH
+            "workspace-files", "workspace_files", "workspacefiles" -> WORKSPACE_FILES
             "workspace-discovery", "workspace_discovery", "workspacediscovery", "discovery" -> WORKSPACE_DISCOVERY
             "session-lock", "session_lock", "sessionlock", "lock" -> SESSION_LOCK
             "session-lifecycle", "session_lifecycle", "sessionlifecycle", "lifecycle" -> SESSION_LIFECYCLE

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendTelemetryTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendTelemetryTest.kt
@@ -7,6 +7,7 @@ import io.github.amichne.kast.api.contract.query.ReferencesQuery
 import io.github.amichne.kast.api.contract.query.RenameQuery
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.contract.query.SymbolQuery
+import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
 import io.github.amichne.kast.standalone.telemetry.StandaloneTelemetry
 import io.github.amichne.kast.standalone.telemetry.StandaloneTelemetryConfig
 import io.github.amichne.kast.standalone.telemetry.StandaloneTelemetryDetail
@@ -182,8 +183,45 @@ class StandaloneAnalysisBackendTelemetryTest {
         )
     }
 
+    @Test
+    fun `workspaceFiles emits WORKSPACE_FILES span with scope and truncation counts`() = runTest {
+        writeFile("src/main/kotlin/sample/A.kt", "package sample\n")
+        writeFile("src/main/kotlin/sample/B.kt", "package sample\n")
+        val telemetryFile = workspaceRoot.resolve("build/telemetry/workspace-files-spans.jsonl")
+        val telemetry = StandaloneTelemetry.create(
+            StandaloneTelemetryConfig(
+                enabled = true,
+                scopes = setOf(StandaloneTelemetryScope.WORKSPACE_FILES),
+                detail = StandaloneTelemetryDetail.BASIC,
+                outputFile = telemetryFile,
+            ),
+        )
+
+        withBackend(telemetry, maxResults = 1) { backend ->
+            backend.workspaceFiles(WorkspaceFilesQuery(includeFiles = true))
+        }
+
+        val exportedSpans = telemetryFile.readText()
+            .lineSequence()
+            .filter(String::isNotBlank)
+            .map { line -> Json.parseToJsonElement(line).jsonObject }
+            .toList()
+
+        val workspaceFilesSpan = exportedSpans.find { span -> span["name"]?.toString() == "\"kast.workspaceFiles\"" }
+        assertTrue(
+            workspaceFilesSpan != null,
+            "Expected a kast.workspaceFiles span but found: ${exportedSpans.map { it["name"] }}",
+        )
+        val attributes = workspaceFilesSpan!!["attributes"]?.jsonObject
+        assertTrue(
+            attributes?.containsKey("kast.workspaceFiles.truncatedModuleCount") == true,
+            "Expected truncatedModuleCount attribute in span attributes: $attributes",
+        )
+    }
+
     private suspend fun withBackend(
         telemetry: StandaloneTelemetry,
+        maxResults: Int = 100,
         block: suspend (StandaloneAnalysisBackend) -> Unit,
     ) {
         val session = StandaloneAnalysisSession(
@@ -196,7 +234,7 @@ class StandaloneAnalysisBackendTelemetryTest {
             val backend = StandaloneAnalysisBackend(
                 workspaceRoot = workspaceRoot,
                 limits = ServerLimits(
-                    maxResults = 100,
+                    maxResults = maxResults,
                     requestTimeoutMillis = 30_000,
                     maxConcurrentRequests = 4,
                 ),

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendWorkspaceFilesTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackendWorkspaceFilesTest.kt
@@ -68,6 +68,43 @@ class StandaloneAnalysisBackendWorkspaceFilesTest {
     }
 
     @Test
+    fun `workspace files caps included files per module and reports truncation`() = runTest {
+        writeFile("src/main/kotlin/sample/A.kt", "package sample\n")
+        writeFile("src/main/kotlin/sample/B.kt", "package sample\n")
+        writeFile("src/main/kotlin/sample/C.kt", "package sample\n")
+
+        withBackend { backend ->
+            val result = backend.workspaceFiles(
+                WorkspaceFilesQuery(
+                    includeFiles = true,
+                    maxFilesPerModule = 2,
+                ),
+            )
+            val module = result.modules.first()
+
+            assertEquals(3, module.fileCount)
+            assertEquals(2, module.files.size)
+            assertTrue(module.filesTruncated)
+        }
+    }
+
+    @Test
+    fun `workspace files defaults included file cap to server max results`() = runTest {
+        writeFile("src/main/kotlin/sample/A.kt", "package sample\n")
+        writeFile("src/main/kotlin/sample/B.kt", "package sample\n")
+        writeFile("src/main/kotlin/sample/C.kt", "package sample\n")
+
+        withBackend(maxResults = 2) { backend ->
+            val result = backend.workspaceFiles(WorkspaceFilesQuery(includeFiles = true))
+            val module = result.modules.first()
+
+            assertEquals(3, module.fileCount)
+            assertEquals(2, module.files.size)
+            assertTrue(module.filesTruncated)
+        }
+    }
+
+    @Test
     fun `workspace files filtered by existing module name returns that module`() = runTest {
         writeFile("src/main/kotlin/sample/A.kt", "package sample\n")
         withBackend { backend ->
@@ -86,7 +123,10 @@ class StandaloneAnalysisBackendWorkspaceFilesTest {
         }
     }
 
-    private suspend fun withBackend(block: suspend (StandaloneAnalysisBackend) -> Unit) {
+    private suspend fun withBackend(
+        maxResults: Int = 100,
+        block: suspend (StandaloneAnalysisBackend) -> Unit,
+    ) {
         val session = StandaloneAnalysisSession(
             workspaceRoot = workspaceRoot,
             sourceRoots = emptyList(),
@@ -97,7 +137,7 @@ class StandaloneAnalysisBackendWorkspaceFilesTest {
             val backend = StandaloneAnalysisBackend(
                 workspaceRoot = workspaceRoot,
                 limits = ServerLimits(
-                    maxResults = 100,
+                    maxResults = maxResults,
                     requestTimeoutMillis = 30_000,
                     maxConcurrentRequests = 4,
                 ),

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneTelemetryConfigTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/StandaloneTelemetryConfigTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
 import java.nio.file.Path
 
 class StandaloneTelemetryConfigTest {
@@ -52,6 +53,13 @@ class StandaloneTelemetryConfigTest {
         assertEquals(StandaloneTelemetryScope.WORKSPACE_DISCOVERY, StandaloneTelemetryScope.parse("workspace_discovery"))
         assertEquals(StandaloneTelemetryScope.WORKSPACE_DISCOVERY, StandaloneTelemetryScope.parse("workspacediscovery"))
         assertEquals(StandaloneTelemetryScope.WORKSPACE_DISCOVERY, StandaloneTelemetryScope.parse("discovery"))
+    }
+
+    @Test
+    fun `parse recognizes workspace-files scope variants`() {
+        assertEquals(StandaloneTelemetryScope.WORKSPACE_FILES, StandaloneTelemetryScope.parse("workspace-files"))
+        assertEquals(StandaloneTelemetryScope.WORKSPACE_FILES, StandaloneTelemetryScope.parse("workspace_files"))
+        assertEquals(StandaloneTelemetryScope.WORKSPACE_FILES, StandaloneTelemetryScope.parse("workspacefiles"))
     }
 
     @Test
@@ -140,6 +148,26 @@ class StandaloneTelemetryConfigTest {
         assertFalse(telemetry.isEnabled(StandaloneTelemetryScope.CALL_HIERARCHY))
         assertFalse(telemetry.isEnabled(StandaloneTelemetryScope.SYMBOL_RESOLVE))
         assertFalse(telemetry.isEnabled(StandaloneTelemetryScope.WORKSPACE_DISCOVERY))
+    }
+
+    @Test
+    fun `fromConfig writes default telemetry output under config directory`() {
+        val configHome = workspaceRoot.resolve("config-home")
+        val telemetry = StandaloneTelemetry.fromConfig(
+            workspaceRoot = workspaceRoot,
+            config = KastConfig.defaults().copy(
+                telemetry = KastConfig.defaults().telemetry.copy(
+                    enabled = true,
+                    scopes = "workspace-files",
+                ),
+            ),
+            configHome = { configHome },
+        )
+
+        telemetry.inSpan(StandaloneTelemetryScope.WORKSPACE_FILES, "kast.workspaceFiles") {}
+
+        val telemetryFile = configHome.resolve("telemetry/standalone-spans.jsonl")
+        assertTrue(Files.isRegularFile(telemetryFile), "Expected telemetry at $telemetryFile")
     }
 
     // --- Detail parsing ---

--- a/docs/examples/workspaceFiles-response.json
+++ b/docs/examples/workspaceFiles-response.json
@@ -8,6 +8,7 @@
                 ],
                 "dependencyModuleNames": [],
                 "files": [],
+                "filesTruncated": false,
                 "fileCount": 2
             }
         ],

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -999,6 +999,8 @@ components:
           type: array
           items:
             type: string
+        filesTruncated:
+          type: boolean
         fileCount:
           type: integer
           format: int32
@@ -1421,6 +1423,11 @@ components:
             - type: "null"
         includeFiles:
           type: boolean
+        maxFilesPerModule:
+          anyOf:
+            - type: integer
+              format: int32
+            - type: "null"
       additionalProperties: false
     WorkspaceFilesResult:
       type: object

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -958,6 +958,7 @@ daemon, including input/output schemas, examples, and behavioral notes.
             |-----------|-------------|
             | `#!kotlin moduleName: String?` | Filter to a single module by name. Omit to list all modules. |
             | `#!kotlin includeFiles: Boolean` :material-information-outline:{ title="Default: false" } | When true, includes individual file paths for each module. |
+            | `#!kotlin maxFilesPerModule: Int?` :material-information-outline:{ title="Default: null" } | Maximum file paths to return per module when includeFiles is true. Omit to use the server maxResults limit. |
         === "Output: WorkspaceFilesResult"
 
             | Signature | Description |
@@ -994,6 +995,7 @@ daemon, including input/output schemas, examples, and behavioral notes.
                             ],
                             "dependencyModuleNames": [],
                             "files": [],
+                            "filesTruncated": false,
                             "fileCount": 2
                         }
                     ],

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -239,6 +239,7 @@ category. Expand any operation to see its input and output schemas.
             |-----------|-------------|
             | `#!kotlin moduleName: String?` | Filter to a single module by name. Omit to list all modules. |
             | `#!kotlin includeFiles: Boolean` :material-information-outline:{ title="Default: false" } | When true, includes individual file paths for each module. |
+            | `#!kotlin maxFilesPerModule: Int?` :material-information-outline:{ title="Default: null" } | Maximum file paths to return per module when includeFiles is true. Omit to use the server maxResults limit. |
         === "Output: WorkspaceFilesResult"
 
             | Signature | Description |

--- a/docs/what-can-kast-do/manage-workspaces.md
+++ b/docs/what-can-kast-do/manage-workspaces.md
@@ -110,15 +110,18 @@ kast workspace refresh \
 
 ## Inspect workspace files
 
-Use `workspace/files` to see the modules, source roots, and files the
-daemon discovered. This is useful for verifying that the daemon sees the
-structure you expect.
+Use `workspace/files` to see the modules and source roots the daemon
+discovered. File-path enumeration is capped per module so large workspaces
+can inspect scope without forcing the daemon to materialize every path in
+one response.
 
 === "CLI"
 
     ```console title="List workspace files"
-    kast workspace-files \
-      --workspace-root=/absolute/path/to/workspace
+    kast workspace files \
+      --workspace-root=/absolute/path/to/workspace \
+      --include-files=true \
+      --max-files-per-module=500
     ```
 
 === "JSON-RPC"
@@ -126,22 +129,27 @@ structure you expect.
     ```json title="JSON-RPC request"
     {
       "method": "workspace/files",
-      "params": {},
+      "params": {
+        "includeFiles": true,
+        "maxFilesPerModule": 500
+      },
       "id": 1, "jsonrpc": "2.0"
     }
     ```
 
-```json hl_lines="2-3" title="Response — module structure"
+```json hl_lines="6-8" title="Response — module structure"
 {
-  "sourceModuleNames": ["app", "lib-core", "lib-api"],
-  "dependentModuleNamesBySourceModuleName": {
-    "app": ["lib-core", "lib-api"],
-    "lib-api": ["lib-core"]
-  },
-  "files": [
-    "/workspace/app/src/main/kotlin/com/example/App.kt",
-    "/workspace/lib-core/src/main/kotlin/com/example/Core.kt"
-  ]
+  "modules": [
+    {
+      "name": "app",
+      "sourceRoots": ["/workspace/app/src/main/kotlin"],
+      "dependencyModuleNames": ["lib-core", "lib-api"],
+      "files": ["/workspace/app/src/main/kotlin/com/example/App.kt"],
+      "filesTruncated": false,
+      "fileCount": 1
+    }
+  ],
+  "schemaVersion": 3
 }
 ```
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -216,6 +216,11 @@ internal object CliCommandCatalog {
         description = "Enumerate individual file paths per module. Defaults to false.",
         completionKind = CliOptionCompletionKind.BOOLEAN,
     )
+    private val maxFilesPerModuleOption = CliOptionMetadata(
+        key = "max-files-per-module",
+        usage = "--max-files-per-module=500",
+        description = "Maximum file paths to return per module when --include-files=true. Defaults to the daemon maxResults limit.",
+    )
     private val dryRunOption = CliOptionMetadata(
         key = "dry-run",
         usage = "--dry-run=true",
@@ -406,16 +411,25 @@ internal object CliCommandCatalog {
             group = CliCommandGroup.WORKSPACE_LIFECYCLE,
             summary = "List workspace modules and their Kotlin source files.",
             description = "Returns the module layout discovered by the backend, including source roots and " +
-                "dependency relationships. Pass --include-files to enumerate individual .kt file paths per module.",
+                "dependency relationships. Pass --include-files to enumerate capped individual .kt file paths per module.",
             usages = listOf(
                 "$CLI_EXECUTABLE_NAME workspace files --workspace-root=/absolute/path/to/workspace",
-                "$CLI_EXECUTABLE_NAME workspace files --workspace-root=/absolute/path/to/workspace --include-files=true [--module-name=app]",
+                "$CLI_EXECUTABLE_NAME workspace files --workspace-root=/absolute/path/to/workspace --include-files=true [--module-name=app] [--max-files-per-module=500]",
             ),
-            options = listOf(workspaceRootOption, backendNameOption, waitTimeoutOption, noAutoStartOption, requestFileOption, moduleNameOption, includeFilesOption),
+            options = listOf(
+                workspaceRootOption,
+                backendNameOption,
+                waitTimeoutOption,
+                noAutoStartOption,
+                requestFileOption,
+                moduleNameOption,
+                includeFilesOption,
+                maxFilesPerModuleOption,
+            ),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME workspace files --workspace-root=/absolute/path/to/workspace",
                 "$CLI_EXECUTABLE_NAME workspace files --workspace-root=/absolute/path/to/workspace --include-files=true",
-                "$CLI_EXECUTABLE_NAME workspace files --workspace-root=/absolute/path/to/workspace --module-name=app --include-files=true",
+                "$CLI_EXECUTABLE_NAME workspace files --workspace-root=/absolute/path/to/workspace --module-name=app --include-files=true --max-files-per-module=200",
             ),
         ),
         CliCommandMetadata(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
@@ -400,6 +400,7 @@ internal data class ParsedArguments(
         WorkspaceFilesQuery(
             moduleName = options["module-name"],
             includeFiles = optionalBoolean("include-files", false),
+            maxFilesPerModule = options["max-files-per-module"]?.toIntOrNull(),
         )
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt
@@ -108,6 +108,7 @@ internal class SkillWrapperExecutor(
         val query = WorkspaceFilesQuery(
             moduleName = request.moduleName,
             includeFiles = request.includeFiles,
+            maxFilesPerModule = request.maxFilesPerModule,
         )
         val result = cliService.workspaceFiles(options, query)
         return KastWorkspaceFilesSuccessResponse(
@@ -116,6 +117,7 @@ internal class SkillWrapperExecutor(
                 workspaceRoot = workspaceRoot,
                 moduleName = request.moduleName,
                 includeFiles = request.includeFiles,
+                maxFilesPerModule = request.maxFilesPerModule,
             ),
             modules = result.payload.modules,
             schemaVersion = result.payload.schemaVersion,

--- a/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
+++ b/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
@@ -347,16 +347,20 @@ class FakeAnalysisBackend private constructor(
     }
 
     override suspend fun workspaceFiles(query: WorkspaceFilesQuery): WorkspaceFilesResult {
+        val allFiles = availableFiles.filter { it.endsWith(".kt") }.sorted()
+        val fileLimit = query.maxFilesPerModule ?: allFiles.size
+        val files = if (query.includeFiles) {
+            allFiles.take(fileLimit)
+        } else {
+            emptyList()
+        }
         val module = WorkspaceModule(
             name = "fake-module",
             sourceRoots = listOf(workspaceRoot.resolve("src").toString()),
             dependencyModuleNames = emptyList(),
-            files = if (query.includeFiles) {
-                availableFiles.filter { it.endsWith(".kt") }.sorted()
-            } else {
-                emptyList()
-            },
-            fileCount = availableFiles.count { it.endsWith(".kt") },
+            files = files,
+            filesTruncated = query.includeFiles && allFiles.size > files.size,
+            fileCount = allFiles.size,
         )
         val modules = if (query.moduleName == null || query.moduleName == "fake-module") {
             listOf(module)


### PR DESCRIPTION
This pull request enhances the workspace file listing API by adding support for capping the number of files returned per module and improves validation, documentation, and telemetry around this feature. It also ensures that clients are informed when the file list is truncated and provides comprehensive test coverage for these behaviors.

**Workspace file listing improvements:**

* Added a new `maxFilesPerModule` parameter to `WorkspaceFilesQuery` (and related request/response types and OpenAPI schema) to allow clients to specify a cap on the number of file paths returned per module. If not provided, the server's default maximum is used. [[1]](diffhunk://#diff-5ceb1a388a52db980e4f3b7a2f55714391a122fcd2c1bec88d7b06130b32e426R16-R20) [[2]](diffhunk://#diff-2e9af9f55784a5c1e7e547fca45507801aad892384a58436b21191f14060af9dR190) [[3]](diffhunk://#diff-2e9af9f55784a5c1e7e547fca45507801aad892384a58436b21191f14060af9dR317) [[4]](diffhunk://#diff-386ad59bfd6f7c5b5b16ecbe0cd3f1fc9c6e0d2d783b7c9333b3d6fa1f606ed7R461-R467) [[5]](diffhunk://#diff-386ad59bfd6f7c5b5b16ecbe0cd3f1fc9c6e0d2d783b7c9333b3d6fa1f606ed7R2005-R2011)
* The response now includes a `filesTruncated` boolean for each module, indicating if the file list was capped, and retains the full `fileCount` for transparency. [[1]](diffhunk://#diff-ff7aa2c8ffd2190647c9b138fdee79f43af148c6ed0a66b7a4053d45f7c04566R29-R30) [[2]](diffhunk://#diff-386ad59bfd6f7c5b5b16ecbe0cd3f1fc9c6e0d2d783b7c9333b3d6fa1f606ed7R2032-R2033)
* Both IntelliJ and standalone backends have been updated to enforce the file cap, populate the new fields, and track related telemetry. [[1]](diffhunk://#diff-5c5fd4fd5b775e8091cb42af726aeb55730719d2d80d739088fcf8efacb181c5L408-R417) [[2]](diffhunk://#diff-5c5fd4fd5b775e8091cb42af726aeb55730719d2d80d739088fcf8efacb181c5L426-R459) [[3]](diffhunk://#diff-62487a4f22891ba2e9d3c29f9b50aed6ae30f48cf94324d66950a3a187f6beabR784-R793) [[4]](diffhunk://#diff-62487a4f22891ba2e9d3c29f9b50aed6ae30f48cf94324d66950a3a187f6beabL792-R823) [[5]](diffhunk://#diff-62487a4f22891ba2e9d3c29f9b50aed6ae30f48cf94324d66950a3a187f6beabR833-R864)

**Validation and error handling:**

* Added validation to reject blank module names, non-positive file caps, and caps exceeding the server's configured maximum.
* Comprehensive tests were added to verify validation errors and correct truncation reporting. [[1]](diffhunk://#diff-acafec0b35328b0ae2be1dd3b0a2714b609f6947036a74f95565e74b4bddfd87R415-R465) [[2]](diffhunk://#diff-6060412f9dc0c68da7a00527df328c00bd79c36b428373969fc280e8f0a499f1R136-R157)

**Documentation and developer experience:**

* Updated the OpenAPI schema and quickstart documentation to describe the new parameters and response fields, improving clarity for API consumers. [[1]](diffhunk://#diff-386ad59bfd6f7c5b5b16ecbe0cd3f1fc9c6e0d2d783b7c9333b3d6fa1f606ed7R461-R467) [[2]](diffhunk://#diff-386ad59bfd6f7c5b5b16ecbe0cd3f1fc9c6e0d2d783b7c9333b3d6fa1f606ed7R2005-R2011) [[3]](diffhunk://#diff-386ad59bfd6f7c5b5b16ecbe0cd3f1fc9c6e0d2d783b7c9333b3d6fa1f606ed7R2032-R2033) [[4]](diffhunk://#diff-248170c16db3cd92a313ecccfd26122636dba67335b55951d75c38ae9a8d89efL54-R60)

**Telemetry and configuration:**

* Enhanced telemetry in both backends to record file cap usage and truncation statistics.
* Refactored standalone telemetry output file resolution to use `kastConfigHome` instead of `workspaceDataDirectory` for consistency. [[1]](diffhunk://#diff-85e927e195fe1d206ad56a5765095f15f67edae309e3c982054421d38f6f6a28L4-R4) [[2]](diffhunk://#diff-85e927e195fe1d206ad56a5765095f15f67edae309e3c982054421d38f6f6a28R93) [[3]](diffhunk://#diff-85e927e195fe1d206ad56a5765095f15f67edae309e3c982054421d38f6f6a28R108) [[4]](diffhunk://#diff-85e927e195fe1d206ad56a5765095f15f67edae309e3c982054421d38f6f6a28L130-R142)