### PR TITLE
feat: add metrics graph visualizer

### DIFF
--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
@@ -266,6 +266,65 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
         )
     }
 
+    fun graph(fqName: String, depth: Int): MetricsGraph {
+        require(depth >= 0) { "depth must be non-negative" }
+
+        val focal = fanInMetric(fqName)
+        val impact = changeImpactRadius(fqName = fqName, depth = depth)
+        val directReferences = impact.filter { it.depth == 1 && it.viaTargetFqName == fqName }
+        val childIdsByParent = buildChildIdsByParent(focal, impact)
+        val nodes = buildList {
+            add(focalSymbolNode(fqName, focal, directReferences, childIdsByParent))
+            focal?.targetPath?.let { targetPath ->
+                add(targetFileNode(targetPath, focal, childIdsByParent))
+            }
+            impact.forEach { node ->
+                add(sourceFileNode(node, childIdsByParent, parentIdFor(node, impact, fqName)))
+                add(referenceEdgeNode(node))
+            }
+        }
+        val edges = buildList {
+            focal?.targetPath?.let { targetPath ->
+                add(
+                    MetricsGraphEdge(
+                        from = fileNodeId(targetPath),
+                        to = symbolNodeId(fqName),
+                        edgeType = MetricsGraphEdgeType.CONTAINS,
+                    ),
+                )
+            }
+            impact.forEach { node ->
+                add(
+                    MetricsGraphEdge(
+                        from = parentIdFor(node, impact, fqName),
+                        to = sourceFileNodeId(node.sourcePath),
+                        edgeType = MetricsGraphEdgeType.REFERENCED_BY,
+                        weight = node.occurrenceCount,
+                    ),
+                )
+                add(
+                    MetricsGraphEdge(
+                        from = sourceFileNodeId(node.sourcePath),
+                        to = referenceEdgeNodeId(node),
+                        edgeType = MetricsGraphEdgeType.REFERENCES,
+                        weight = node.occurrenceCount,
+                    ),
+                )
+            }
+        }
+        return MetricsGraph(
+            focalNodeId = symbolNodeId(fqName),
+            nodes = nodes,
+            edges = edges,
+            index = MetricsGraphIndex(
+                symbolCount = 1 + impact.map(ChangeImpactNode::viaTargetFqName).filterNot { it == fqName }.distinct().size,
+                fileCount = listOfNotNull(focal?.targetPath).plus(impact.map(ChangeImpactNode::sourcePath)).distinct().size,
+                referenceCount = impact.sumOf(ChangeImpactNode::occurrenceCount),
+                maxDepth = impact.maxOfOrNull(ChangeImpactNode::depth) ?: 0,
+            ),
+        )
+    }
+
     override fun close() {
         cachedConnection?.let { conn ->
             if (!conn.isClosed) conn.close()
@@ -294,6 +353,162 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
                 }
             }
         }
+
+    private fun fanInMetric(fqName: String): FanInMetric? =
+        readMetric(null) { conn ->
+            conn.prepareStatement(
+                """
+                    SELECT target_name.fq_name,
+                           target_prefix.dir_path,
+                           refs.tgt_filename,
+                           target_meta.module_path,
+                           target_meta.source_set,
+                           COUNT(*) AS occurrence_count,
+                           COUNT(DISTINCT refs.src_prefix_id || ':' || refs.src_filename) AS source_file_count,
+                           COUNT(DISTINCT source_meta.module_path) AS source_module_count
+                    FROM symbol_references refs
+                    LEFT JOIN file_metadata source_meta
+                      ON source_meta.prefix_id = refs.src_prefix_id
+                     AND source_meta.filename = refs.src_filename
+                    LEFT JOIN file_metadata target_meta
+                      ON target_meta.prefix_id = refs.tgt_prefix_id
+                     AND target_meta.filename = refs.tgt_filename
+                    JOIN fq_names target_name ON target_name.fq_id = refs.target_fq_id
+                    LEFT JOIN path_prefixes target_prefix ON target_prefix.prefix_id = refs.tgt_prefix_id
+                    WHERE target_name.fq_name = ?
+                    GROUP BY refs.target_fq_id, refs.tgt_prefix_id, refs.tgt_filename, target_meta.module_path, target_meta.source_set
+                """.trimIndent(),
+            ).use { stmt ->
+                stmt.setString(1, fqName)
+                stmt.executeQuery().use { rs ->
+                    val row = MetricResultRow(resultSet = rs, fields = FanInField.entries)
+                    if (!rs.next()) {
+                        null
+                    } else {
+                        FanInMetric(
+                            targetFqName = row.string(FanInField.TARGET_FQ_NAME),
+                            targetPath = row.nullablePath(FanInField.TARGET_DIR, FanInField.TARGET_FILENAME),
+                            targetModulePath = row.nullableString(FanInField.TARGET_MODULE_PATH),
+                            targetSourceSet = row.nullableString(FanInField.TARGET_SOURCE_SET),
+                            occurrenceCount = row.int(FanInField.OCCURRENCE_COUNT),
+                            sourceFileCount = row.int(FanInField.SOURCE_FILE_COUNT),
+                            sourceModuleCount = row.int(FanInField.SOURCE_MODULE_COUNT),
+                        )
+                    }
+                }
+            }
+        }
+
+    private fun buildChildIdsByParent(
+        focal: FanInMetric?,
+        impact: List<ChangeImpactNode>,
+    ): Map<String, List<String>> =
+        buildMap {
+            focal?.targetPath?.let { targetPath ->
+                put(fileNodeId(targetPath), listOf(symbolNodeId(focal.targetFqName)))
+            }
+            impact.groupBy { parentIdFor(it, impact, focal?.targetFqName ?: it.viaTargetFqName) }
+                .forEach { (parentId, children) ->
+                    put(parentId, children.map { sourceFileNodeId(it.sourcePath) }.distinct())
+                }
+            impact.forEach { node ->
+                put(sourceFileNodeId(node.sourcePath), listOf(referenceEdgeNodeId(node)))
+            }
+        }
+
+    private fun focalSymbolNode(
+        fqName: String,
+        focal: FanInMetric?,
+        directReferences: List<ChangeImpactNode>,
+        childIdsByParent: Map<String, List<String>>,
+    ): MetricsGraphNode {
+        val attributes = buildList {
+            focal?.targetPath?.let { add("path=$it") }
+            focal?.targetModulePath?.let { add("module=$it") }
+            focal?.targetSourceSet?.let { add("sourceSet=$it") }
+            add("incomingReferences=${focal?.occurrenceCount ?: directReferences.sumOf(ChangeImpactNode::occurrenceCount)}")
+            add("sourceFiles=${focal?.sourceFileCount ?: directReferences.map(ChangeImpactNode::sourcePath).distinct().size}")
+            focal?.sourceModuleCount?.let { add("sourceModules=$it") }
+        }
+        return MetricsGraphNode(
+            id = symbolNodeId(fqName),
+            name = fqName,
+            type = MetricsGraphNodeType.SYMBOL,
+            parentId = focal?.targetPath?.let(::fileNodeId),
+            children = childIdsByParent[symbolNodeId(fqName)].orEmpty(),
+            attributes = attributes,
+        )
+    }
+
+    private fun targetFileNode(
+        targetPath: String,
+        focal: FanInMetric,
+        childIdsByParent: Map<String, List<String>>,
+    ): MetricsGraphNode =
+        MetricsGraphNode(
+            id = fileNodeId(targetPath),
+            name = targetPath,
+            type = MetricsGraphNodeType.FILE,
+            children = childIdsByParent[fileNodeId(targetPath)].orEmpty(),
+            attributes = listOfNotNull(
+                "role=target",
+                focal.targetModulePath?.let { "module=$it" },
+                focal.targetSourceSet?.let { "sourceSet=$it" },
+            ),
+        )
+
+    private fun sourceFileNode(
+        node: ChangeImpactNode,
+        childIdsByParent: Map<String, List<String>>,
+        parentId: String,
+    ): MetricsGraphNode =
+        MetricsGraphNode(
+            id = sourceFileNodeId(node.sourcePath),
+            name = node.sourcePath,
+            type = MetricsGraphNodeType.FILE,
+            parentId = parentId,
+            children = childIdsByParent[sourceFileNodeId(node.sourcePath)].orEmpty(),
+            attributes = listOf(
+                "incomingDepth=${node.depth}",
+                "references=${node.occurrenceCount}",
+                "via=${node.viaTargetFqName}",
+            ),
+        )
+
+    private fun referenceEdgeNode(node: ChangeImpactNode): MetricsGraphNode =
+        MetricsGraphNode(
+            id = referenceEdgeNodeId(node),
+            name = node.viaTargetFqName,
+            type = MetricsGraphNodeType.REFERENCE_EDGE,
+            parentId = sourceFileNodeId(node.sourcePath),
+            attributes = listOf(
+                "from=${node.sourcePath}",
+                "to=${node.viaTargetFqName}",
+                "references=${node.occurrenceCount}",
+            ),
+        )
+
+    private fun parentIdFor(
+        node: ChangeImpactNode,
+        impact: List<ChangeImpactNode>,
+        fqName: String,
+    ): String =
+        impact
+            .firstOrNull { candidate ->
+                candidate.depth == node.depth - 1 &&
+                    node.viaTargetFqName.endsWith(candidate.sourcePath.substringAfterLast('/').removeSuffix(".kt"))
+            }
+            ?.sourcePath
+            ?.let(::sourceFileNodeId)
+            ?: symbolNodeId(fqName)
+
+    private fun symbolNodeId(fqName: String): String = "symbol:$fqName"
+
+    private fun fileNodeId(path: String): String = "file:$path"
+
+    private fun sourceFileNodeId(path: String): String = "source-file:$path"
+
+    private fun referenceEdgeNodeId(node: ChangeImpactNode): String = "via:${node.viaTargetFqName}:${node.sourcePath}"
 
     private fun schemaIsCurrent(conn: Connection): Boolean = try {
         val version = conn.prepareStatement("SELECT version FROM schema_version LIMIT 1").use { stmt ->

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
@@ -412,7 +412,8 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
                     put(parentId, children.map { sourceFileNodeId(it.sourcePath) }.distinct())
                 }
             impact.forEach { node ->
-                put(sourceFileNodeId(node.sourcePath), listOf(referenceEdgeNodeId(node)))
+                val parentId = sourceFileNodeId(node.sourcePath)
+                put(parentId, getOrDefault(parentId, emptyList()) + referenceEdgeNodeId(node))
             }
         }
 

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsModels.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsModels.kt
@@ -55,6 +55,54 @@ data class ChangeImpactNode(
 )
 
 @Serializable
+data class MetricsGraph(
+    val focalNodeId: String,
+    val nodes: List<MetricsGraphNode>,
+    val edges: List<MetricsGraphEdge>,
+    val index: MetricsGraphIndex,
+)
+
+@Serializable
+data class MetricsGraphNode(
+    val id: String,
+    val name: String,
+    val type: MetricsGraphNodeType,
+    val parentId: String? = null,
+    val children: List<String> = emptyList(),
+    val attributes: List<String> = emptyList(),
+)
+
+@Serializable
+data class MetricsGraphEdge(
+    val from: String,
+    val to: String,
+    val edgeType: MetricsGraphEdgeType,
+    val weight: Int = 1,
+)
+
+@Serializable
+data class MetricsGraphIndex(
+    val symbolCount: Int,
+    val fileCount: Int,
+    val referenceCount: Int,
+    val maxDepth: Int,
+)
+
+@Serializable
+enum class MetricsGraphNodeType {
+    SYMBOL,
+    FILE,
+    REFERENCE_EDGE,
+}
+
+@Serializable
+enum class MetricsGraphEdgeType {
+    CONTAINS,
+    REFERENCED_BY,
+    REFERENCES,
+}
+
+@Serializable
 enum class MetricsConfidence {
     LOW,
 }

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
@@ -228,7 +228,7 @@ class MetricsEngineTest {
                             name = "/app/B.kt",
                             type = MetricsGraphNodeType.FILE,
                             parentId = "symbol:lib.Foo",
-                            children = listOf("via:lib.Foo:/app/B.kt"),
+                            children = listOf("source-file:/app/C.kt", "via:lib.Foo:/app/B.kt"),
                             attributes = listOf("incomingDepth=1", "references=1", "via=lib.Foo"),
                         ),
                         MetricsGraphNode(

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
@@ -3,6 +3,7 @@ package io.github.amichne.kast.indexstore
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
@@ -173,6 +174,117 @@ class MetricsEngineTest {
                 ),
                 metrics.changeImpactRadius(fqName = "lib.Foo", depth = 2),
             )
+        }
+    }
+
+    @Test
+    fun `builds visual graph around focal indexed symbol`() {
+        val root = seededWorkspace()
+
+        MetricsEngine(root).use { metrics ->
+            assertEquals(
+                MetricsGraph(
+                    focalNodeId = "symbol:lib.Foo",
+                    nodes = listOf(
+                        MetricsGraphNode(
+                            id = "symbol:lib.Foo",
+                            name = "lib.Foo",
+                            type = MetricsGraphNodeType.SYMBOL,
+                            parentId = "file:/lib/Foo.kt",
+                            children = listOf("source-file:/app/A.kt", "source-file:/app/B.kt"),
+                            attributes = listOf(
+                                "path=/lib/Foo.kt",
+                                "module=:lib",
+                                "sourceSet=main",
+                                "incomingReferences=3",
+                                "sourceFiles=2",
+                                "sourceModules=1",
+                            ),
+                        ),
+                        MetricsGraphNode(
+                            id = "file:/lib/Foo.kt",
+                            name = "/lib/Foo.kt",
+                            type = MetricsGraphNodeType.FILE,
+                            children = listOf("symbol:lib.Foo"),
+                            attributes = listOf("role=target", "module=:lib", "sourceSet=main"),
+                        ),
+                        MetricsGraphNode(
+                            id = "source-file:/app/A.kt",
+                            name = "/app/A.kt",
+                            type = MetricsGraphNodeType.FILE,
+                            parentId = "symbol:lib.Foo",
+                            children = listOf("via:lib.Foo:/app/A.kt"),
+                            attributes = listOf("incomingDepth=1", "references=2", "via=lib.Foo"),
+                        ),
+                        MetricsGraphNode(
+                            id = "via:lib.Foo:/app/A.kt",
+                            name = "lib.Foo",
+                            type = MetricsGraphNodeType.REFERENCE_EDGE,
+                            parentId = "source-file:/app/A.kt",
+                            attributes = listOf("from=/app/A.kt", "to=lib.Foo", "references=2"),
+                        ),
+                        MetricsGraphNode(
+                            id = "source-file:/app/B.kt",
+                            name = "/app/B.kt",
+                            type = MetricsGraphNodeType.FILE,
+                            parentId = "symbol:lib.Foo",
+                            children = listOf("via:lib.Foo:/app/B.kt"),
+                            attributes = listOf("incomingDepth=1", "references=1", "via=lib.Foo"),
+                        ),
+                        MetricsGraphNode(
+                            id = "via:lib.Foo:/app/B.kt",
+                            name = "lib.Foo",
+                            type = MetricsGraphNodeType.REFERENCE_EDGE,
+                            parentId = "source-file:/app/B.kt",
+                            attributes = listOf("from=/app/B.kt", "to=lib.Foo", "references=1"),
+                        ),
+                        MetricsGraphNode(
+                            id = "source-file:/app/C.kt",
+                            name = "/app/C.kt",
+                            type = MetricsGraphNodeType.FILE,
+                            parentId = "source-file:/app/B.kt",
+                            children = listOf("via:app.B:/app/C.kt"),
+                            attributes = listOf("incomingDepth=2", "references=1", "via=app.B"),
+                        ),
+                        MetricsGraphNode(
+                            id = "via:app.B:/app/C.kt",
+                            name = "app.B",
+                            type = MetricsGraphNodeType.REFERENCE_EDGE,
+                            parentId = "source-file:/app/C.kt",
+                            attributes = listOf("from=/app/C.kt", "to=app.B", "references=1"),
+                        ),
+                    ),
+                    edges = listOf(
+                        MetricsGraphEdge("file:/lib/Foo.kt", "symbol:lib.Foo", MetricsGraphEdgeType.CONTAINS),
+                        MetricsGraphEdge("symbol:lib.Foo", "source-file:/app/A.kt", MetricsGraphEdgeType.REFERENCED_BY, 2),
+                        MetricsGraphEdge("source-file:/app/A.kt", "via:lib.Foo:/app/A.kt", MetricsGraphEdgeType.REFERENCES, 2),
+                        MetricsGraphEdge("symbol:lib.Foo", "source-file:/app/B.kt", MetricsGraphEdgeType.REFERENCED_BY, 1),
+                        MetricsGraphEdge("source-file:/app/B.kt", "via:lib.Foo:/app/B.kt", MetricsGraphEdgeType.REFERENCES, 1),
+                        MetricsGraphEdge("source-file:/app/B.kt", "source-file:/app/C.kt", MetricsGraphEdgeType.REFERENCED_BY, 1),
+                        MetricsGraphEdge("source-file:/app/C.kt", "via:app.B:/app/C.kt", MetricsGraphEdgeType.REFERENCES, 1),
+                    ),
+                    index = MetricsGraphIndex(
+                        symbolCount = 2,
+                        fileCount = 4,
+                        referenceCount = 4,
+                        maxDepth = 2,
+                    ),
+                ),
+                metrics.graph(fqName = "lib.Foo", depth = 2),
+            )
+        }
+    }
+
+    @Test
+    fun `serializes graph with stable node type names`() {
+        val root = seededWorkspace()
+
+        MetricsEngine(root).use { metrics ->
+            val encoded = Json.encodeToString(MetricsGraph.serializer(), metrics.graph(fqName = "lib.Foo", depth = 1))
+
+            assertTrue(encoded.contains("\"type\":\"SYMBOL\""))
+            assertTrue(encoded.contains("\"edgeType\":\"REFERENCED_BY\""))
+            assertTrue(encoded.contains("\"focalNodeId\":\"symbol:lib.Foo\""))
         }
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommand.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommand.kt
@@ -55,6 +55,7 @@ internal sealed interface CliCommand {
         val limit: Int = 50,
         val symbol: String? = null,
         val depth: Int = 3,
+        val interactive: Boolean = false,
     ) : CliCommand
 }
 
@@ -64,6 +65,7 @@ internal enum class MetricsSubcommand {
     COUPLING,
     DEAD_CODE,
     IMPACT,
+    GRAPH,
 }
 
 internal data class EvalSkillOptions(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -341,6 +341,11 @@ internal object CliCommandCatalog {
         usage = "--depth=3",
         description = "Maximum edge depth for impact traversal. Defaults to 3.",
     )
+    private val metricsInteractiveOption = CliOptionMetadata(
+        key = "interactive",
+        usage = "--interactive=true",
+        description = "Render an interactive shell graph view instead of JSON.",
+    )
 
     private val commands: List<CliCommandMetadata> = listOf(
         CliCommandMetadata(
@@ -996,6 +1001,20 @@ internal object CliCommandCatalog {
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME metrics impact --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass",
                 "$CLI_EXECUTABLE_NAME metrics impact --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass --depth=5",
+            ),
+        ),
+        CliCommandMetadata(
+            path = listOf("metrics", "graph"),
+            group = CliCommandGroup.METRICS,
+            summary = "Show a navigable symbol graph from the local reference index.",
+            description = "Queries the local SQLite reference index without a running daemon. Builds a focal symbol graph with target file, incoming source files, reference edges, and index summary. Add --interactive=true for a keyboard-navigable shell view.",
+            usages = listOf(
+                "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass [--depth=3] [--interactive=true]",
+            ),
+            options = listOf(workspaceRootOption, metricsSymbolOption, metricsDepthOption, metricsInteractiveOption),
+            examples = listOf(
+                "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass",
+                "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass --depth=5 --interactive=true",
             ),
         ),
         // Skill wrapper: metrics — hidden, called by agent shell scripts

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
@@ -148,6 +148,16 @@ internal class CliCommandParser(
                     ),
                     depth = parsed.optionalInt("depth") ?: 3,
                 )
+                listOf("metrics", "graph") -> CliCommand.Metrics(
+                    subcommand = MetricsSubcommand.GRAPH,
+                    workspaceRoot = parsed.requireWorkspaceRootPath(),
+                    symbol = parsed.options["symbol"] ?: throw CliFailure(
+                        code = "CLI_USAGE",
+                        message = "--symbol is required for metrics graph",
+                    ),
+                    depth = parsed.optionalInt("depth") ?: 3,
+                    interactive = parsed.parseBool("interactive"),
+                )
                 else -> throw CliFailure(
                     code = "CLI_USAGE",
                     message = "Unknown command: ${metadata.commandText}",
@@ -679,15 +689,16 @@ internal data class ParsedArguments(
     }
 
     fun optionalInt(key: String): Int? = options[key]?.toIntOrNull()
-}
 
-private fun ParsedArguments.parseBool(key: String): Boolean = when (options[key]?.lowercase()) {
-    null, "", "true", "on", "yes", "1" -> options.containsKey(key)
-    "false", "off", "no", "0" -> false
-    else -> throw CliFailure(
-        code = "CLI_USAGE",
-        message = "Unknown value for --$key: ${options[key]}. Valid values: true, false.",
-    )
+    fun parseBool(key: String): Boolean = when (options[key]?.lowercase()) {
+        null -> false
+        "", "true", "on", "yes", "1" -> true
+        "false", "off", "no", "0" -> false
+        else -> throw CliFailure(
+            code = "CLI_USAGE",
+            message = "Unknown value for --$key: ${options[key]}. Valid values: true, false.",
+        )
+    }
 }
 
 private val VALID_BACKEND_NAMES = setOf("standalone", "intellij")

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
@@ -6,6 +6,7 @@ import io.github.amichne.kast.indexstore.ChangeImpactNode
 import io.github.amichne.kast.indexstore.DeadCodeCandidate
 import io.github.amichne.kast.indexstore.FanInMetric
 import io.github.amichne.kast.indexstore.FanOutMetric
+import io.github.amichne.kast.indexstore.MetricsGraph
 import io.github.amichne.kast.indexstore.MetricsEngine
 import io.github.amichne.kast.indexstore.ModuleCouplingMetric
 import kotlinx.serialization.builtins.ListSerializer
@@ -15,6 +16,7 @@ import java.nio.file.Path
 internal sealed interface CliOutput {
     data class JsonValue(val value: Any) : CliOutput
     data class Text(val value: String) : CliOutput
+    data class InteractiveGraph(val graph: MetricsGraph) : CliOutput
     data class ExternalProcess(val process: CliExternalProcess) : CliOutput
     data object None : CliOutput
 }
@@ -258,6 +260,15 @@ internal class DefaultCliCommandExecutor(
             }
 
             is CliCommand.Metrics -> {
+                if (command.subcommand == MetricsSubcommand.GRAPH && command.interactive) {
+                    val graph = MetricsEngine(command.workspaceRoot).use { engine ->
+                        engine.graph(
+                            fqName = requireNotNull(command.symbol) { "--symbol is required for graph" },
+                            depth = command.depth,
+                        )
+                    }
+                    return CliExecutionResult(output = CliOutput.InteractiveGraph(graph))
+                }
                 val encoded = MetricsEngine(command.workspaceRoot).use { engine ->
                     when (command.subcommand) {
                         MetricsSubcommand.FAN_IN -> json.encodeToString(
@@ -276,6 +287,13 @@ internal class DefaultCliCommandExecutor(
                             ListSerializer(ChangeImpactNode.serializer()),
                             engine.changeImpactRadius(
                                 fqName = requireNotNull(command.symbol) { "--symbol is required for impact" },
+                                depth = command.depth,
+                            ),
+                        )
+                        MetricsSubcommand.GRAPH -> json.encodeToString(
+                            MetricsGraph.serializer(),
+                            engine.graph(
+                                fqName = requireNotNull(command.symbol) { "--symbol is required for graph" },
                                 depth = command.depth,
                             ),
                         )

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastCli.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastCli.kt
@@ -76,8 +76,26 @@ class KastCli private constructor(
                 0
             }
 
+            is CliOutput.InteractiveGraph -> writeInteractiveGraph(output.graph, stdout)
             is CliOutput.ExternalProcess -> runExternalProcess(output.process, stdout, stderr)
             CliOutput.None -> 0
+        }
+    }
+
+    private suspend fun writeInteractiveGraph(
+        graph: io.github.amichne.kast.indexstore.MetricsGraph,
+        stdout: Appendable,
+    ): Int {
+        if (stdout !== System.out) {
+            val rendered = MetricsGraphShell.render(graph)
+            stdout.append(rendered)
+            if (!rendered.endsWith('\n')) {
+                stdout.append('\n')
+            }
+            return 0
+        }
+        return withContext(Dispatchers.IO) {
+            MetricsGraphTerminal(graph).run(System.`in`, System.out)
         }
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphShell.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphShell.kt
@@ -1,0 +1,73 @@
+package io.github.amichne.kast.cli
+
+import io.github.amichne.kast.indexstore.MetricsGraph
+import io.github.amichne.kast.indexstore.MetricsGraphNode
+
+internal object MetricsGraphShell {
+    fun render(graph: MetricsGraph): String {
+        val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+        val focal = nodesById.getValue(graph.focalNodeId)
+        return buildString {
+            appendLine("Kast graph visualizer")
+            appendLine("Keys: U parent · D/Enter first child · ←/→ sibling · A attributes/members")
+            appendLine("Index: ${graph.index.symbolCount} symbols · ${graph.index.fileCount} files · ${graph.index.referenceCount} refs · depth ${graph.index.maxDepth}")
+            appendLine()
+            append(renderNode(graph = graph, current = focal, showAttributes = true))
+        }
+    }
+
+    private fun renderNode(
+        graph: MetricsGraph,
+        current: MetricsGraphNode,
+        showAttributes: Boolean,
+    ): String {
+        val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+        val parent = current.parentId?.let(nodesById::get)
+        val children = current.children.mapNotNull(nodesById::get)
+        val siblings = siblingNodes(graph = graph, current = current)
+        return buildString {
+            appendLine("▶ ${current.name}")
+            appendLine("  type: ${current.type}")
+            appendLine("  node: ${current.id}")
+            appendLine("  parent: ${parent?.name ?: "∅"}")
+            appendLine("  siblings: ${siblings.joinToString { it.name }.ifBlank { "∅" }}")
+            appendLine("  children:")
+            if (children.isEmpty()) {
+                appendLine("    ∅")
+            } else {
+                children.forEachIndexed { index, child ->
+                    appendLine("    ${index + 1}. ${child.name} [${child.type}]")
+                }
+            }
+            if (showAttributes) {
+                appendLine("  attributes:")
+                if (current.attributes.isEmpty()) {
+                    appendLine("    ∅")
+                } else {
+                    current.attributes.forEach { attribute ->
+                        appendLine("    - $attribute")
+                    }
+                }
+            }
+            appendLine()
+            appendLine("Graph edges from here:")
+            graph.edges
+                .filter { edge -> edge.from == current.id || edge.to == current.id }
+                .forEach { edge ->
+                    appendLine("  ${edge.from} -${edge.edgeType}/${edge.weight}-> ${edge.to}")
+                }
+        }
+    }
+
+    private fun siblingNodes(
+        graph: MetricsGraph,
+        current: MetricsGraphNode,
+    ): List<MetricsGraphNode> {
+        val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+        val parentId = current.parentId ?: return emptyList()
+        val parent = nodesById[parentId] ?: return emptyList()
+        return parent.children
+            .filterNot { it == current.id }
+            .mapNotNull(nodesById::get)
+    }
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt
@@ -1,0 +1,149 @@
+package io.github.amichne.kast.cli
+
+import io.github.amichne.kast.indexstore.MetricsGraph
+import io.github.amichne.kast.indexstore.MetricsGraphNode
+import java.io.InputStream
+import java.io.PrintStream
+
+internal class MetricsGraphTerminal(private val graph: MetricsGraph) {
+    private val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+
+    fun run(
+        input: InputStream,
+        output: PrintStream,
+    ): Int {
+        val rawMode = TerminalRawMode.enter()
+        try {
+            var current = nodesById.getValue(graph.focalNodeId)
+            var showAttributes = true
+            render(output, current, showAttributes)
+            while (true) {
+                val key = readKey(input)
+                when (key) {
+                    TerminalKey.QUIT -> return 0
+                    TerminalKey.PARENT -> current.parentId?.let(nodesById::get)?.let { current = it }
+                    TerminalKey.FIRST_CHILD -> current.children.firstOrNull()?.let(nodesById::get)?.let { current = it }
+                    TerminalKey.PREVIOUS_SIBLING -> sibling(current, -1)?.let { current = it }
+                    TerminalKey.NEXT_SIBLING -> sibling(current, 1)?.let { current = it }
+                    TerminalKey.ATTRIBUTES -> showAttributes = !showAttributes
+                    TerminalKey.IGNORED -> Unit
+                }
+                if (key != TerminalKey.IGNORED) {
+                    render(output, current, showAttributes)
+                }
+            }
+        } finally {
+            rawMode.close()
+        }
+        return 0
+    }
+
+    private fun render(
+        output: PrintStream,
+        current: MetricsGraphNode,
+        showAttributes: Boolean,
+    ) {
+        val parent = current.parentId?.let(nodesById::get)
+        val children = current.children.mapNotNull(nodesById::get)
+        val siblings = siblingList(current)
+        output.print("\u001b[2J\u001b[H")
+        output.println("Kast graph visualizer")
+        output.println("U parent · D/Enter child · ←/→ sibling · A attributes · Q quit")
+        output.println("${graph.index.symbolCount} symbols · ${graph.index.fileCount} files · ${graph.index.referenceCount} refs · depth ${graph.index.maxDepth}")
+        output.println()
+        output.println("▶ ${current.name}")
+        output.println("  type: ${current.type}")
+        output.println("  node: ${current.id}")
+        output.println("  parent: ${parent?.name ?: "∅"}")
+        output.println("  peers: ${siblings.joinToString { if (it.id == current.id) "[${it.name}]" else it.name }.ifBlank { "∅" }}")
+        output.println()
+        output.println("children")
+        if (children.isEmpty()) {
+            output.println("  ∅")
+        } else {
+            children.forEachIndexed { index, child ->
+                output.println("  ${index + 1}. ${child.name} [${child.type}]")
+            }
+        }
+        output.println()
+        if (showAttributes) {
+            output.println("attributes / members")
+            if (current.attributes.isEmpty()) {
+                output.println("  ∅")
+            } else {
+                current.attributes.forEach { output.println("  - $it") }
+            }
+            output.println()
+        }
+        output.println("relational context")
+        val visibleEdges = graph.edges.filter { edge -> edge.from == current.id || edge.to == current.id }
+        if (visibleEdges.isEmpty()) {
+            output.println("  ∅")
+        } else {
+            visibleEdges.forEach { edge -> output.println("  ${edge.from} -${edge.edgeType}/${edge.weight}-> ${edge.to}") }
+        }
+        output.flush()
+    }
+
+    private fun sibling(
+        current: MetricsGraphNode,
+        direction: Int,
+    ): MetricsGraphNode? {
+        val siblings = siblingList(current)
+        val index = siblings.indexOfFirst { it.id == current.id }
+        if (index == -1 || siblings.size < 2) return null
+        return siblings[(index + direction + siblings.size) % siblings.size]
+    }
+
+    private fun siblingList(current: MetricsGraphNode): List<MetricsGraphNode> {
+        val parent = current.parentId?.let(nodesById::get) ?: return listOf(current)
+        return parent.children.mapNotNull(nodesById::get)
+    }
+
+    private fun readKey(input: InputStream): TerminalKey {
+        return when (val first = input.read()) {
+            -1, 'q'.code, 'Q'.code -> TerminalKey.QUIT
+            'u'.code, 'U'.code -> TerminalKey.PARENT
+            'd'.code, 'D'.code, '\n'.code, '\r'.code -> TerminalKey.FIRST_CHILD
+            'a'.code, 'A'.code -> TerminalKey.ATTRIBUTES
+            27 -> readEscape(input)
+            else -> TerminalKey.IGNORED
+        }
+    }
+
+    private fun readEscape(input: InputStream): TerminalKey {
+        if (input.read() != '['.code) return TerminalKey.IGNORED
+        return when (input.read()) {
+            'D'.code -> TerminalKey.PREVIOUS_SIBLING
+            'C'.code -> TerminalKey.NEXT_SIBLING
+            else -> TerminalKey.IGNORED
+        }
+    }
+}
+
+private enum class TerminalKey {
+    PARENT,
+    FIRST_CHILD,
+    PREVIOUS_SIBLING,
+    NEXT_SIBLING,
+    ATTRIBUTES,
+    QUIT,
+    IGNORED,
+}
+
+private class TerminalRawMode private constructor(private val active: Boolean) : AutoCloseable {
+    override fun close() {
+        if (active) {
+            runCatching { ProcessBuilder("sh", "-c", "stty sane < /dev/tty").start().waitFor() }
+        }
+    }
+
+    companion object {
+        fun enter(): TerminalRawMode {
+            val exitCode = runCatching {
+                ProcessBuilder("sh", "-c", "stty raw -echo < /dev/tty").start().waitFor()
+            }.getOrDefault(1)
+            return TerminalRawMode(exitCode == 0)
+        }
+    }
+}

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
@@ -670,6 +670,20 @@ class CliCommandParserTest {
     }
 
     @Test
+    fun `metrics graph parses interactive option`() {
+        val command = parser.parse(
+            arrayOf("metrics", "graph", "--workspace-root=$tempDir", "--symbol=com.example.Foo", "--depth=2", "--interactive=true"),
+        )
+
+        assertTrue(command is CliCommand.Metrics)
+        val metrics = command as CliCommand.Metrics
+        assertEquals(MetricsSubcommand.GRAPH, metrics.subcommand)
+        assertEquals("com.example.Foo", metrics.symbol)
+        assertEquals(2, metrics.depth)
+        assertTrue(metrics.interactive)
+    }
+
+    @Test
     fun `metrics impact fails without symbol`() {
         assertThrows<CliFailure> {
             parser.parse(


### PR DESCRIPTION
## Summary
- Add `MetricsGraph` models and `MetricsEngine.graph(...)` to turn reference-index metrics into a navigable focal-symbol graph.
- Add `kast metrics graph --workspace-root=... --symbol=... [--depth=...]` JSON output and `--interactive=true` shell mode with U/D/Enter/arrow/A/Q navigation.
- Cover graph construction, serialization, and CLI parsing with focused tests.

## Review & Testing Checklist for Human
- [ ] Run `kast metrics graph --workspace-root=<indexed workspace> --symbol=<fqName> --interactive=true` against a workspace with non-empty reference-index rows and verify navigation feels demo-ready.
- [ ] Check whether the graph parent heuristic for transitive impact edges matches the desired mental model before extending this beyond proof-of-concept usage.
- [ ] Confirm JSON payload shape is acceptable for future browser visualizer reuse.

### Notes
Local validation run:
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew :kast-cli:test :kast-cli:compileKotlin`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew :kast-cli:run --args='metrics graph --workspace-root=/home/ubuntu/repos/kast --symbol=io.github.amichne.kast.indexstore.MetricsEngine --depth=2 --interactive=true' --quiet`

I installed the latest released Kast CLI via `gh` for semantic tooling, per request. The live repo index in this VM currently produced an empty inbound graph for `MetricsEngine`; seeded tests exercise the non-empty evidentiary graph shape.

Link to Devin session: https://app.devin.ai/sessions/8147f38c472149819f86d26a71e1290a
Requested by: @amichne