### PR TITLE
feat: add metrics graph visualizer

### DIFF
--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
@@ -266,6 +266,70 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
         )
     }
 
+    /**
+     * Fuzzy search the source index for symbol fully-qualified names that match [query].
+     *
+     * The matcher is case-insensitive and substring-based against `fq_names.fq_name`. Results
+     * are ordered so that exact matches and short, simple-name matches rank first; remaining
+     * matches are returned alphabetically. An empty or blank [query] returns the most-frequently
+     * referenced symbols up to [limit].
+     *
+     * Returns an empty list when the workspace has not been indexed yet or the schema is stale,
+     * mirroring the safe defaults used by the metrics queries.
+     */
+    fun searchSymbols(query: String, limit: Int = 25): List<String> {
+        require(limit >= 0) { "limit must be non-negative" }
+        if (limit == 0) return emptyList()
+        val trimmed = query.trim()
+        return readMetric(emptyList()) { conn ->
+            val sql = if (trimmed.isEmpty()) {
+                """
+                SELECT names.fq_name
+                FROM fq_names names
+                JOIN symbol_references refs ON refs.target_fq_id = names.fq_id
+                GROUP BY names.fq_id
+                ORDER BY COUNT(*) DESC, names.fq_name ASC
+                LIMIT ?
+                """.trimIndent()
+            } else {
+                """
+                SELECT names.fq_name
+                FROM fq_names names
+                WHERE LOWER(names.fq_name) LIKE ?
+                ORDER BY
+                    CASE
+                        WHEN LOWER(names.fq_name) = ? THEN 0
+                        WHEN LOWER(names.fq_name) LIKE ? THEN 1
+                        WHEN LOWER(names.fq_name) LIKE ? THEN 2
+                        ELSE 3
+                    END,
+                    LENGTH(names.fq_name) ASC,
+                    names.fq_name ASC
+                LIMIT ?
+                """.trimIndent()
+            }
+            conn.prepareStatement(sql).use { stmt ->
+                if (trimmed.isEmpty()) {
+                    stmt.setInt(1, limit)
+                } else {
+                    val needle = trimmed.lowercase()
+                    stmt.setString(1, "%$needle%")
+                    stmt.setString(2, needle)
+                    stmt.setString(3, "%.$needle")
+                    stmt.setString(4, "$needle%")
+                    stmt.setInt(5, limit)
+                }
+                stmt.executeQuery().use { rs ->
+                    buildList {
+                        while (rs.next()) {
+                            add(rs.getString(1))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     fun graph(fqName: String, depth: Int): MetricsGraph {
         require(depth >= 0) { "depth must be non-negative" }
 

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
@@ -266,6 +266,65 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
         )
     }
 
+    fun graph(fqName: String, depth: Int): MetricsGraph {
+        require(depth >= 0) { "depth must be non-negative" }
+
+        val focal = fanInMetric(fqName)
+        val impact = changeImpactRadius(fqName = fqName, depth = depth)
+        val directReferences = impact.filter { it.depth == 1 && it.viaTargetFqName == fqName }
+        val childIdsByParent = buildChildIdsByParent(focal, impact)
+        val nodes = buildList {
+            add(focalSymbolNode(fqName, focal, directReferences, childIdsByParent))
+            focal?.targetPath?.let { targetPath ->
+                add(targetFileNode(targetPath, focal, childIdsByParent))
+            }
+            impact.forEach { node ->
+                add(sourceFileNode(node, childIdsByParent, parentIdFor(node, impact, fqName)))
+                add(referenceEdgeNode(node))
+            }
+        }
+        val edges = buildList {
+            focal?.targetPath?.let { targetPath ->
+                add(
+                    MetricsGraphEdge(
+                        from = fileNodeId(targetPath),
+                        to = symbolNodeId(fqName),
+                        edgeType = MetricsGraphEdgeType.CONTAINS,
+                    ),
+                )
+            }
+            impact.forEach { node ->
+                add(
+                    MetricsGraphEdge(
+                        from = parentIdFor(node, impact, fqName),
+                        to = sourceFileNodeId(node.sourcePath),
+                        edgeType = MetricsGraphEdgeType.REFERENCED_BY,
+                        weight = node.occurrenceCount,
+                    ),
+                )
+                add(
+                    MetricsGraphEdge(
+                        from = sourceFileNodeId(node.sourcePath),
+                        to = referenceEdgeNodeId(node),
+                        edgeType = MetricsGraphEdgeType.REFERENCES,
+                        weight = node.occurrenceCount,
+                    ),
+                )
+            }
+        }
+        return MetricsGraph(
+            focalNodeId = symbolNodeId(fqName),
+            nodes = nodes,
+            edges = edges,
+            index = MetricsGraphIndex(
+                symbolCount = 1 + impact.map(ChangeImpactNode::viaTargetFqName).filterNot { it == fqName }.distinct().size,
+                fileCount = listOfNotNull(focal?.targetPath).plus(impact.map(ChangeImpactNode::sourcePath)).distinct().size,
+                referenceCount = impact.sumOf(ChangeImpactNode::occurrenceCount),
+                maxDepth = impact.maxOfOrNull(ChangeImpactNode::depth) ?: 0,
+            ),
+        )
+    }
+
     override fun close() {
         cachedConnection?.let { conn ->
             if (!conn.isClosed) conn.close()
@@ -294,6 +353,162 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
                 }
             }
         }
+
+    private fun fanInMetric(fqName: String): FanInMetric? =
+        readMetric(null) { conn ->
+            conn.prepareStatement(
+                """
+                    SELECT target_name.fq_name,
+                           target_prefix.dir_path,
+                           refs.tgt_filename,
+                           target_meta.module_path,
+                           target_meta.source_set,
+                           COUNT(*) AS occurrence_count,
+                           COUNT(DISTINCT refs.src_prefix_id || ':' || refs.src_filename) AS source_file_count,
+                           COUNT(DISTINCT source_meta.module_path) AS source_module_count
+                    FROM symbol_references refs
+                    LEFT JOIN file_metadata source_meta
+                      ON source_meta.prefix_id = refs.src_prefix_id
+                     AND source_meta.filename = refs.src_filename
+                    LEFT JOIN file_metadata target_meta
+                      ON target_meta.prefix_id = refs.tgt_prefix_id
+                     AND target_meta.filename = refs.tgt_filename
+                    JOIN fq_names target_name ON target_name.fq_id = refs.target_fq_id
+                    LEFT JOIN path_prefixes target_prefix ON target_prefix.prefix_id = refs.tgt_prefix_id
+                    WHERE target_name.fq_name = ?
+                    GROUP BY refs.target_fq_id, refs.tgt_prefix_id, refs.tgt_filename, target_meta.module_path, target_meta.source_set
+                """.trimIndent(),
+            ).use { stmt ->
+                stmt.setString(1, fqName)
+                stmt.executeQuery().use { rs ->
+                    val row = MetricResultRow(resultSet = rs, fields = FanInField.entries)
+                    if (!rs.next()) {
+                        null
+                    } else {
+                        FanInMetric(
+                            targetFqName = row.string(FanInField.TARGET_FQ_NAME),
+                            targetPath = row.nullablePath(FanInField.TARGET_DIR, FanInField.TARGET_FILENAME),
+                            targetModulePath = row.nullableString(FanInField.TARGET_MODULE_PATH),
+                            targetSourceSet = row.nullableString(FanInField.TARGET_SOURCE_SET),
+                            occurrenceCount = row.int(FanInField.OCCURRENCE_COUNT),
+                            sourceFileCount = row.int(FanInField.SOURCE_FILE_COUNT),
+                            sourceModuleCount = row.int(FanInField.SOURCE_MODULE_COUNT),
+                        )
+                    }
+                }
+            }
+        }
+
+    private fun buildChildIdsByParent(
+        focal: FanInMetric?,
+        impact: List<ChangeImpactNode>,
+    ): Map<String, List<String>> =
+        buildMap {
+            focal?.targetPath?.let { targetPath ->
+                put(fileNodeId(targetPath), listOf(symbolNodeId(focal.targetFqName)))
+            }
+            impact.groupBy { parentIdFor(it, impact, focal?.targetFqName ?: it.viaTargetFqName) }
+                .forEach { (parentId, children) ->
+                    put(parentId, children.map { sourceFileNodeId(it.sourcePath) }.distinct())
+                }
+            impact.forEach { node ->
+                put(sourceFileNodeId(node.sourcePath), listOf(referenceEdgeNodeId(node)))
+            }
+        }
+
+    private fun focalSymbolNode(
+        fqName: String,
+        focal: FanInMetric?,
+        directReferences: List<ChangeImpactNode>,
+        childIdsByParent: Map<String, List<String>>,
+    ): MetricsGraphNode {
+        val attributes = buildList {
+            focal?.targetPath?.let { add("path=$it") }
+            focal?.targetModulePath?.let { add("module=$it") }
+            focal?.targetSourceSet?.let { add("sourceSet=$it") }
+            add("incomingReferences=${focal?.occurrenceCount ?: directReferences.sumOf(ChangeImpactNode::occurrenceCount)}")
+            add("sourceFiles=${focal?.sourceFileCount ?: directReferences.map(ChangeImpactNode::sourcePath).distinct().size}")
+            focal?.sourceModuleCount?.let { add("sourceModules=$it") }
+        }
+        return MetricsGraphNode(
+            id = symbolNodeId(fqName),
+            name = fqName,
+            type = MetricsGraphNodeType.SYMBOL,
+            parentId = focal?.targetPath?.let(::fileNodeId),
+            children = childIdsByParent[symbolNodeId(fqName)].orEmpty(),
+            attributes = attributes,
+        )
+    }
+
+    private fun targetFileNode(
+        targetPath: String,
+        focal: FanInMetric,
+        childIdsByParent: Map<String, List<String>>,
+    ): MetricsGraphNode =
+        MetricsGraphNode(
+            id = fileNodeId(targetPath),
+            name = targetPath,
+            type = MetricsGraphNodeType.FILE,
+            children = childIdsByParent[fileNodeId(targetPath)].orEmpty(),
+            attributes = listOfNotNull(
+                "role=target",
+                focal.targetModulePath?.let { "module=$it" },
+                focal.targetSourceSet?.let { "sourceSet=$it" },
+            ),
+        )
+
+    private fun sourceFileNode(
+        node: ChangeImpactNode,
+        childIdsByParent: Map<String, List<String>>,
+        parentId: String,
+    ): MetricsGraphNode =
+        MetricsGraphNode(
+            id = sourceFileNodeId(node.sourcePath),
+            name = node.sourcePath,
+            type = MetricsGraphNodeType.FILE,
+            parentId = parentId,
+            children = childIdsByParent[sourceFileNodeId(node.sourcePath)].orEmpty(),
+            attributes = listOf(
+                "incomingDepth=${node.depth}",
+                "references=${node.occurrenceCount}",
+                "via=${node.viaTargetFqName}",
+            ),
+        )
+
+    private fun referenceEdgeNode(node: ChangeImpactNode): MetricsGraphNode =
+        MetricsGraphNode(
+            id = referenceEdgeNodeId(node),
+            name = node.viaTargetFqName,
+            type = MetricsGraphNodeType.REFERENCE_EDGE,
+            parentId = sourceFileNodeId(node.sourcePath),
+            attributes = listOf(
+                "from=${node.sourcePath}",
+                "to=${node.viaTargetFqName}",
+                "references=${node.occurrenceCount}",
+            ),
+        )
+
+    private fun parentIdFor(
+        node: ChangeImpactNode,
+        impact: List<ChangeImpactNode>,
+        fqName: String,
+    ): String =
+        impact
+            .firstOrNull { candidate ->
+                candidate.depth == node.depth - 1 &&
+                    node.viaTargetFqName.endsWith(candidate.sourcePath.substringAfterLast('/').removeSuffix(".kt"))
+            }
+            ?.sourcePath
+            ?.let(::sourceFileNodeId)
+            ?: symbolNodeId(fqName)
+
+    private fun symbolNodeId(fqName: String): String = "symbol:$fqName"
+
+    private fun fileNodeId(path: String): String = "file:$path"
+
+    private fun sourceFileNodeId(path: String): String = "source-file:$path"
+
+    private fun referenceEdgeNodeId(node: ChangeImpactNode): String = "via:${node.viaTargetFqName}:${node.sourcePath}"
 
     private fun schemaIsCurrent(conn: Connection): Boolean = try {
         val version = conn.prepareStatement("SELECT version FROM schema_version LIMIT 1").use { stmt ->

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
@@ -344,7 +344,7 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
                 add(targetFileNode(targetPath, focal, childIdsByParent))
             }
             impactBySourcePath.forEach { (_, nodesForPath) ->
-                val representative = nodesForPath.minByOrNull { it.depth } ?: nodesForPath.first()
+                val representative = nodesForPath.minBy { it.depth }
                 add(sourceFileNode(nodesForPath, childIdsByParent, parentIdFor(representative, impact, fqName)))
                 nodesForPath.forEach { node -> add(referenceEdgeNode(node)) }
             }
@@ -360,7 +360,7 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
                 )
             }
             impactBySourcePath.forEach { (_, nodesForPath) ->
-                val representative = nodesForPath.minByOrNull { it.depth } ?: nodesForPath.first()
+                val representative = nodesForPath.minBy { it.depth }
                 add(
                     MetricsGraphEdge(
                         from = parentIdFor(representative, impact, fqName),
@@ -532,7 +532,7 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
         childIdsByParent: Map<String, List<String>>,
         parentId: String,
     ): MetricsGraphNode {
-        val representative = nodes.minByOrNull { it.depth } ?: nodes.first()
+        val representative = nodes.minBy { it.depth }
         return MetricsGraphNode(
             id = sourceFileNodeId(representative.sourcePath),
             name = representative.sourcePath,

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
@@ -412,7 +412,8 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
                     put(parentId, children.map { sourceFileNodeId(it.sourcePath) }.distinct())
                 }
             impact.forEach { node ->
-                put(sourceFileNodeId(node.sourcePath), listOf(referenceEdgeNodeId(node)))
+                val parentId = sourceFileNodeId(node.sourcePath)
+                put(parentId, getOrDefault(parentId, emptyList()) + referenceEdgeNodeId(node))
             }
         }
 

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
@@ -312,9 +312,9 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
                 if (trimmed.isEmpty()) {
                     stmt.setInt(1, limit)
                 } else {
-                    val needle = trimmed.lowercase()
+                    val needle = trimmed.lowercase().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
                     stmt.setString(1, "%$needle%")
-                    stmt.setString(2, needle)
+                    stmt.setString(2, trimmed.lowercase())
                     stmt.setString(3, "%.$needle")
                     stmt.setString(4, "$needle%")
                     stmt.setInt(5, limit)

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
@@ -476,7 +476,7 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
             focal?.targetPath?.let { targetPath ->
                 put(fileNodeId(targetPath), listOf(symbolNodeId(focal.targetFqName)))
             }
-            impact.groupBy { parentIdFor(it, impact, focal?.targetFqName ?: it.viaTargetFqName) }
+            impact.groupBy { parentIdFor(it, impact, focal?.targetFqName ?: focalFqNameFallback) }
                 .forEach { (parentId, children) ->
                     put(parentId, children.map { sourceFileNodeId(it.sourcePath) }.distinct())
                 }

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsEngine.kt
@@ -337,14 +337,16 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
         val impact = changeImpactRadius(fqName = fqName, depth = depth)
         val directReferences = impact.filter { it.depth == 1 && it.viaTargetFqName == fqName }
         val childIdsByParent = buildChildIdsByParent(focal, impact)
+        val impactBySourcePath = impact.groupBy { it.sourcePath }
         val nodes = buildList {
             add(focalSymbolNode(fqName, focal, directReferences, childIdsByParent))
             focal?.targetPath?.let { targetPath ->
                 add(targetFileNode(targetPath, focal, childIdsByParent))
             }
-            impact.forEach { node ->
-                add(sourceFileNode(node, childIdsByParent, parentIdFor(node, impact, fqName)))
-                add(referenceEdgeNode(node))
+            impactBySourcePath.forEach { (_, nodesForPath) ->
+                val representative = nodesForPath.minByOrNull { it.depth } ?: nodesForPath.first()
+                add(sourceFileNode(nodesForPath, childIdsByParent, parentIdFor(representative, impact, fqName)))
+                nodesForPath.forEach { node -> add(referenceEdgeNode(node)) }
             }
         }
         val edges = buildList {
@@ -357,23 +359,26 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
                     ),
                 )
             }
-            impact.forEach { node ->
+            impactBySourcePath.forEach { (_, nodesForPath) ->
+                val representative = nodesForPath.minByOrNull { it.depth } ?: nodesForPath.first()
                 add(
                     MetricsGraphEdge(
-                        from = parentIdFor(node, impact, fqName),
-                        to = sourceFileNodeId(node.sourcePath),
+                        from = parentIdFor(representative, impact, fqName),
+                        to = sourceFileNodeId(representative.sourcePath),
                         edgeType = MetricsGraphEdgeType.REFERENCED_BY,
-                        weight = node.occurrenceCount,
+                        weight = nodesForPath.sumOf(ChangeImpactNode::occurrenceCount),
                     ),
                 )
-                add(
-                    MetricsGraphEdge(
-                        from = sourceFileNodeId(node.sourcePath),
-                        to = referenceEdgeNodeId(node),
-                        edgeType = MetricsGraphEdgeType.REFERENCES,
-                        weight = node.occurrenceCount,
-                    ),
-                )
+                nodesForPath.forEach { node ->
+                    add(
+                        MetricsGraphEdge(
+                            from = sourceFileNodeId(node.sourcePath),
+                            to = referenceEdgeNodeId(node),
+                            edgeType = MetricsGraphEdgeType.REFERENCES,
+                            weight = node.occurrenceCount,
+                        ),
+                    )
+                }
             }
         }
         return MetricsGraph(
@@ -523,22 +528,24 @@ class MetricsEngine(workspaceRoot: Path) : AutoCloseable {
         )
 
     private fun sourceFileNode(
-        node: ChangeImpactNode,
+        nodes: List<ChangeImpactNode>,
         childIdsByParent: Map<String, List<String>>,
         parentId: String,
-    ): MetricsGraphNode =
-        MetricsGraphNode(
-            id = sourceFileNodeId(node.sourcePath),
-            name = node.sourcePath,
+    ): MetricsGraphNode {
+        val representative = nodes.minByOrNull { it.depth } ?: nodes.first()
+        return MetricsGraphNode(
+            id = sourceFileNodeId(representative.sourcePath),
+            name = representative.sourcePath,
             type = MetricsGraphNodeType.FILE,
             parentId = parentId,
-            children = childIdsByParent[sourceFileNodeId(node.sourcePath)].orEmpty(),
+            children = childIdsByParent[sourceFileNodeId(representative.sourcePath)].orEmpty(),
             attributes = listOf(
-                "incomingDepth=${node.depth}",
-                "references=${node.occurrenceCount}",
-                "via=${node.viaTargetFqName}",
+                "incomingDepth=${representative.depth}",
+                "references=${nodes.sumOf(ChangeImpactNode::occurrenceCount)}",
+                "via=${representative.viaTargetFqName}",
             ),
         )
+    }
 
     private fun referenceEdgeNode(node: ChangeImpactNode): MetricsGraphNode =
         MetricsGraphNode(

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsModels.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/MetricsModels.kt
@@ -55,6 +55,54 @@ data class ChangeImpactNode(
 )
 
 @Serializable
+data class MetricsGraph(
+    val focalNodeId: String,
+    val nodes: List<MetricsGraphNode>,
+    val edges: List<MetricsGraphEdge>,
+    val index: MetricsGraphIndex,
+)
+
+@Serializable
+data class MetricsGraphNode(
+    val id: String,
+    val name: String,
+    val type: MetricsGraphNodeType,
+    val parentId: String? = null,
+    val children: List<String> = emptyList(),
+    val attributes: List<String> = emptyList(),
+)
+
+@Serializable
+data class MetricsGraphEdge(
+    val from: String,
+    val to: String,
+    val edgeType: MetricsGraphEdgeType,
+    val weight: Int = 1,
+)
+
+@Serializable
+data class MetricsGraphIndex(
+    val symbolCount: Int,
+    val fileCount: Int,
+    val referenceCount: Int,
+    val maxDepth: Int,
+)
+
+@Serializable
+enum class MetricsGraphNodeType {
+    SYMBOL,
+    FILE,
+    REFERENCE_EDGE,
+}
+
+@Serializable
+enum class MetricsGraphEdgeType {
+    CONTAINS,
+    REFERENCED_BY,
+    REFERENCES,
+}
+
+@Serializable
 enum class MetricsConfidence {
     LOW,
 }

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
@@ -364,6 +364,62 @@ class MetricsEngineTest {
         }
     }
 
+    @Test
+    fun `graph deduplicates sourceFileNodes when same path appears with multiple viaTargetFqNames`() {
+        val root = workspaceRoot.toAbsolutePath().normalize()
+        SqliteSourceIndexStore(root).use { store ->
+            store.ensureSchema()
+            store.saveFullIndex(
+                updates = listOf(
+                    fileUpdate("/lib/Root.kt", identifiers = setOf("Root"), packageName = "lib", modulePath = ":lib", sourceSet = "main"),
+                    fileUpdate("/app/A.kt", identifiers = setOf("A"), packageName = "app", modulePath = ":app", sourceSet = "main"),
+                    fileUpdate("/app/B.kt", identifiers = setOf("B"), packageName = "app", modulePath = ":app", sourceSet = "main"),
+                    fileUpdate("/app/D.kt", identifiers = setOf("D"), packageName = "app", modulePath = ":app", sourceSet = "main"),
+                ),
+                manifest = mapOf(
+                    "/lib/Root.kt" to 1L,
+                    "/app/A.kt" to 1L,
+                    "/app/B.kt" to 1L,
+                    "/app/D.kt" to 1L,
+                ),
+            )
+            // A.kt and B.kt each reference lib.Root (depth=1 callers)
+            store.upsertSymbolReference("/app/A.kt", 10, "lib.Root", "/lib/Root.kt", 1)
+            store.upsertSymbolReference("/app/B.kt", 10, "lib.Root", "/lib/Root.kt", 1)
+            // D.kt references both A.kt and B.kt symbols — two different viaTargetFqNames at depth=2
+            store.upsertSymbolReference("/app/D.kt", 10, "app.A", "/app/A.kt", 1)
+            store.upsertSymbolReference("/app/D.kt", 20, "app.B", "/app/B.kt", 1)
+        }
+
+        MetricsEngine(root).use { metrics ->
+            val graph = metrics.graph(fqName = "lib.Root", depth = 2)
+
+            val nodeIds = graph.nodes.map { it.id }
+            // Each sourcePath must appear exactly once as a source-file node
+            assertEquals(nodeIds.distinct(), nodeIds, "graph must not contain duplicate node IDs")
+
+            val sourceFileNodes = graph.nodes.filter { it.type == MetricsGraphNodeType.FILE && it.id.startsWith("source-file:") }
+            val sourceFilePaths = sourceFileNodes.map { it.name }
+            assertEquals(sourceFilePaths.distinct(), sourceFilePaths, "duplicate sourceFileNodes found for same path")
+
+            // /app/D.kt appears via both app.A and app.B — must produce exactly one source-file node
+            assertEquals(1, sourceFileNodes.count { it.name == "/app/D.kt" })
+
+            // both reference edge nodes for D.kt must still be present
+            val dReferenceEdges = graph.nodes.filter { it.type == MetricsGraphNodeType.REFERENCE_EDGE && it.parentId == "source-file:/app/D.kt" }
+            assertEquals(2, dReferenceEdges.size)
+            assertTrue(dReferenceEdges.any { it.id == "via:app.A:/app/D.kt" })
+            assertTrue(dReferenceEdges.any { it.id == "via:app.B:/app/D.kt" })
+
+            // aggregated REFERENCED_BY edge weight for D.kt must be sum of both occurrences (1+1=2)
+            val referencedByDEdge = graph.edges.filter {
+                it.edgeType == MetricsGraphEdgeType.REFERENCED_BY && it.to == "source-file:/app/D.kt"
+            }
+            assertEquals(1, referencedByDEdge.size)
+            assertEquals(2, referencedByDEdge.single().weight)
+        }
+    }
+
     private fun seededWorkspace(): Path {
         val root = workspaceRoot.toAbsolutePath().normalize()
         SqliteSourceIndexStore(root).use { store ->

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
@@ -302,6 +302,48 @@ class MetricsEngineTest {
     }
 
     @Test
+    fun `searchSymbols returns empty when database is missing`() {
+        val root = workspaceRoot.toAbsolutePath().normalize()
+        MetricsEngine(root).use { metrics ->
+            assertTrue(metrics.searchSymbols("foo").isEmpty())
+        }
+    }
+
+    @Test
+    fun `searchSymbols ranks popular symbols when query is blank`() {
+        val root = seededWorkspace()
+        MetricsEngine(root).use { metrics ->
+            val results = metrics.searchSymbols(query = "  ", limit = 5)
+            assertEquals("lib.Foo", results.first())
+            assertTrue(results.contains("lib.Bar"))
+            assertTrue(results.contains("app.A"))
+        }
+    }
+
+    @Test
+    fun `searchSymbols matches case-insensitively and ranks exact match first`() {
+        val root = seededWorkspace()
+        MetricsEngine(root).use { metrics ->
+            val results = metrics.searchSymbols(query = "FOO", limit = 5)
+            assertEquals("lib.Foo", results.first())
+        }
+    }
+
+    @Test
+    fun `searchSymbols rejects negative limit and returns empty for zero`() {
+        val root = seededWorkspace()
+        MetricsEngine(root).use { metrics ->
+            assertTrue(metrics.searchSymbols("foo", limit = 0).isEmpty())
+            try {
+                metrics.searchSymbols("foo", limit = -1)
+                assertTrue(false, "expected IllegalArgumentException")
+            } catch (_: IllegalArgumentException) {
+                // expected
+            }
+        }
+    }
+
+    @Test
     fun `returns empty metrics when database schema is not current`() {
         val root = workspaceRoot.toAbsolutePath().normalize()
         val dbPath = sourceIndexDatabasePath(root)

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
@@ -228,7 +228,7 @@ class MetricsEngineTest {
                             name = "/app/B.kt",
                             type = MetricsGraphNodeType.FILE,
                             parentId = "symbol:lib.Foo",
-                            children = listOf("via:lib.Foo:/app/B.kt"),
+                            children = listOf("source-file:/app/C.kt", "via:lib.Foo:/app/B.kt"),
                             attributes = listOf("incomingDepth=1", "references=1", "via=lib.Foo"),
                         ),
                         MetricsGraphNode(

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/MetricsEngineTest.kt
@@ -3,6 +3,7 @@ package io.github.amichne.kast.indexstore
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
@@ -173,6 +174,117 @@ class MetricsEngineTest {
                 ),
                 metrics.changeImpactRadius(fqName = "lib.Foo", depth = 2),
             )
+        }
+    }
+
+    @Test
+    fun `builds visual graph around focal indexed symbol`() {
+        val root = seededWorkspace()
+
+        MetricsEngine(root).use { metrics ->
+            assertEquals(
+                MetricsGraph(
+                    focalNodeId = "symbol:lib.Foo",
+                    nodes = listOf(
+                        MetricsGraphNode(
+                            id = "symbol:lib.Foo",
+                            name = "lib.Foo",
+                            type = MetricsGraphNodeType.SYMBOL,
+                            parentId = "file:/lib/Foo.kt",
+                            children = listOf("source-file:/app/A.kt", "source-file:/app/B.kt"),
+                            attributes = listOf(
+                                "path=/lib/Foo.kt",
+                                "module=:lib",
+                                "sourceSet=main",
+                                "incomingReferences=3",
+                                "sourceFiles=2",
+                                "sourceModules=1",
+                            ),
+                        ),
+                        MetricsGraphNode(
+                            id = "file:/lib/Foo.kt",
+                            name = "/lib/Foo.kt",
+                            type = MetricsGraphNodeType.FILE,
+                            children = listOf("symbol:lib.Foo"),
+                            attributes = listOf("role=target", "module=:lib", "sourceSet=main"),
+                        ),
+                        MetricsGraphNode(
+                            id = "source-file:/app/A.kt",
+                            name = "/app/A.kt",
+                            type = MetricsGraphNodeType.FILE,
+                            parentId = "symbol:lib.Foo",
+                            children = listOf("via:lib.Foo:/app/A.kt"),
+                            attributes = listOf("incomingDepth=1", "references=2", "via=lib.Foo"),
+                        ),
+                        MetricsGraphNode(
+                            id = "via:lib.Foo:/app/A.kt",
+                            name = "lib.Foo",
+                            type = MetricsGraphNodeType.REFERENCE_EDGE,
+                            parentId = "source-file:/app/A.kt",
+                            attributes = listOf("from=/app/A.kt", "to=lib.Foo", "references=2"),
+                        ),
+                        MetricsGraphNode(
+                            id = "source-file:/app/B.kt",
+                            name = "/app/B.kt",
+                            type = MetricsGraphNodeType.FILE,
+                            parentId = "symbol:lib.Foo",
+                            children = listOf("via:lib.Foo:/app/B.kt"),
+                            attributes = listOf("incomingDepth=1", "references=1", "via=lib.Foo"),
+                        ),
+                        MetricsGraphNode(
+                            id = "via:lib.Foo:/app/B.kt",
+                            name = "lib.Foo",
+                            type = MetricsGraphNodeType.REFERENCE_EDGE,
+                            parentId = "source-file:/app/B.kt",
+                            attributes = listOf("from=/app/B.kt", "to=lib.Foo", "references=1"),
+                        ),
+                        MetricsGraphNode(
+                            id = "source-file:/app/C.kt",
+                            name = "/app/C.kt",
+                            type = MetricsGraphNodeType.FILE,
+                            parentId = "source-file:/app/B.kt",
+                            children = listOf("via:app.B:/app/C.kt"),
+                            attributes = listOf("incomingDepth=2", "references=1", "via=app.B"),
+                        ),
+                        MetricsGraphNode(
+                            id = "via:app.B:/app/C.kt",
+                            name = "app.B",
+                            type = MetricsGraphNodeType.REFERENCE_EDGE,
+                            parentId = "source-file:/app/C.kt",
+                            attributes = listOf("from=/app/C.kt", "to=app.B", "references=1"),
+                        ),
+                    ),
+                    edges = listOf(
+                        MetricsGraphEdge("file:/lib/Foo.kt", "symbol:lib.Foo", MetricsGraphEdgeType.CONTAINS),
+                        MetricsGraphEdge("symbol:lib.Foo", "source-file:/app/A.kt", MetricsGraphEdgeType.REFERENCED_BY, 2),
+                        MetricsGraphEdge("source-file:/app/A.kt", "via:lib.Foo:/app/A.kt", MetricsGraphEdgeType.REFERENCES, 2),
+                        MetricsGraphEdge("symbol:lib.Foo", "source-file:/app/B.kt", MetricsGraphEdgeType.REFERENCED_BY, 1),
+                        MetricsGraphEdge("source-file:/app/B.kt", "via:lib.Foo:/app/B.kt", MetricsGraphEdgeType.REFERENCES, 1),
+                        MetricsGraphEdge("source-file:/app/B.kt", "source-file:/app/C.kt", MetricsGraphEdgeType.REFERENCED_BY, 1),
+                        MetricsGraphEdge("source-file:/app/C.kt", "via:app.B:/app/C.kt", MetricsGraphEdgeType.REFERENCES, 1),
+                    ),
+                    index = MetricsGraphIndex(
+                        symbolCount = 2,
+                        fileCount = 4,
+                        referenceCount = 4,
+                        maxDepth = 2,
+                    ),
+                ),
+                metrics.graph(fqName = "lib.Foo", depth = 2),
+            )
+        }
+    }
+
+    @Test
+    fun `serializes graph with stable node type names`() {
+        val root = seededWorkspace()
+
+        MetricsEngine(root).use { metrics ->
+            val encoded = Json.encodeToString(MetricsGraph.serializer(), metrics.graph(fqName = "lib.Foo", depth = 1))
+
+            assertTrue(encoded.contains("\"type\":\"SYMBOL\""))
+            assertTrue(encoded.contains("\"edgeType\":\"REFERENCED_BY\""))
+            assertTrue(encoded.contains("\"focalNodeId\":\"symbol:lib.Foo\""))
         }
     }
 

--- a/kast-cli/build.gradle.kts
+++ b/kast-cli/build.gradle.kts
@@ -20,7 +20,7 @@ val embeddedSkillFiles = listOf(
 )
 
 application {
-    mainClass = "io.github.amichne.kast.cli.CliMainKt"
+    mainClass = "io.github.amichne.kast.cli.tty.CliMainKt"
 }
 
 dependencies {
@@ -38,12 +38,13 @@ graalvmNative {
     binaries {
         named("main") {
             imageName.set("kast")
-            mainClass.set("io.github.amichne.kast.cli.CliMainKt")
+            mainClass.set("io.github.amichne.kast.cli.tty.CliMainKt")
             sharedLibrary.set(false)
             configurationFileDirectories.from(nativeConfigDir)
             buildArgs.addAll(
                 "--no-fallback",
                 "--initialize-at-build-time=kotlin.DeprecationLevel",
+                "--enable-native-access=ALL-UNNAMED",
                 "-H:+ReportExceptionStackTraces",
             )
         }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommand.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommand.kt
@@ -55,6 +55,7 @@ internal sealed interface CliCommand {
         val limit: Int = 50,
         val symbol: String? = null,
         val depth: Int = 3,
+        val interactive: Boolean = false,
     ) : CliCommand
 }
 
@@ -64,6 +65,7 @@ internal enum class MetricsSubcommand {
     COUPLING,
     DEAD_CODE,
     IMPACT,
+    GRAPH,
 }
 
 internal data class EvalSkillOptions(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandCatalog.kt
@@ -341,6 +341,11 @@ internal object CliCommandCatalog {
         usage = "--depth=3",
         description = "Maximum edge depth for impact traversal. Defaults to 3.",
     )
+    private val metricsInteractiveOption = CliOptionMetadata(
+        key = "interactive",
+        usage = "--interactive=true",
+        description = "Render an interactive shell graph view instead of JSON.",
+    )
 
     private val commands: List<CliCommandMetadata> = listOf(
         CliCommandMetadata(
@@ -996,6 +1001,20 @@ internal object CliCommandCatalog {
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME metrics impact --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass",
                 "$CLI_EXECUTABLE_NAME metrics impact --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass --depth=5",
+            ),
+        ),
+        CliCommandMetadata(
+            path = listOf("metrics", "graph"),
+            group = CliCommandGroup.METRICS,
+            summary = "Show a navigable symbol graph from the local reference index.",
+            description = "Queries the local SQLite reference index without a running daemon. Builds a focal symbol graph with target file, incoming source files, reference edges, and index summary. Add --interactive=true for a keyboard-navigable shell view.",
+            usages = listOf(
+                "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass [--depth=3] [--interactive=true]",
+            ),
+            options = listOf(workspaceRootOption, metricsSymbolOption, metricsDepthOption, metricsInteractiveOption),
+            examples = listOf(
+                "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass",
+                "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass --depth=5 --interactive=true",
             ),
         ),
         // Skill wrapper: metrics — hidden, called by agent shell scripts

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliCommandParser.kt
@@ -148,6 +148,16 @@ internal class CliCommandParser(
                     ),
                     depth = parsed.optionalInt("depth") ?: 3,
                 )
+                listOf("metrics", "graph") -> CliCommand.Metrics(
+                    subcommand = MetricsSubcommand.GRAPH,
+                    workspaceRoot = parsed.requireWorkspaceRootPath(),
+                    symbol = parsed.options["symbol"] ?: throw CliFailure(
+                        code = "CLI_USAGE",
+                        message = "--symbol is required for metrics graph",
+                    ),
+                    depth = parsed.optionalInt("depth") ?: 3,
+                    interactive = parsed.parseBool("interactive"),
+                )
                 else -> throw CliFailure(
                     code = "CLI_USAGE",
                     message = "Unknown command: ${metadata.commandText}",
@@ -679,15 +689,16 @@ internal data class ParsedArguments(
     }
 
     fun optionalInt(key: String): Int? = options[key]?.toIntOrNull()
-}
 
-private fun ParsedArguments.parseBool(key: String): Boolean = when (options[key]?.lowercase()) {
-    null, "", "true", "on", "yes", "1" -> options.containsKey(key)
-    "false", "off", "no", "0" -> false
-    else -> throw CliFailure(
-        code = "CLI_USAGE",
-        message = "Unknown value for --$key: ${options[key]}. Valid values: true, false.",
-    )
+    fun parseBool(key: String): Boolean = when (options[key]?.lowercase()) {
+        null -> false
+        "", "true", "on", "yes", "1" -> true
+        "false", "off", "no", "0" -> false
+        else -> throw CliFailure(
+            code = "CLI_USAGE",
+            message = "Unknown value for --$key: ${options[key]}. Valid values: true, false.",
+        )
+    }
 }
 
 private val VALID_BACKEND_NAMES = setOf("standalone", "intellij")

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/CliExecution.kt
@@ -6,6 +6,7 @@ import io.github.amichne.kast.indexstore.ChangeImpactNode
 import io.github.amichne.kast.indexstore.DeadCodeCandidate
 import io.github.amichne.kast.indexstore.FanInMetric
 import io.github.amichne.kast.indexstore.FanOutMetric
+import io.github.amichne.kast.indexstore.MetricsGraph
 import io.github.amichne.kast.indexstore.MetricsEngine
 import io.github.amichne.kast.indexstore.ModuleCouplingMetric
 import kotlinx.serialization.builtins.ListSerializer
@@ -15,6 +16,7 @@ import java.nio.file.Path
 internal sealed interface CliOutput {
     data class JsonValue(val value: Any) : CliOutput
     data class Text(val value: String) : CliOutput
+    data class InteractiveGraph(val graph: MetricsGraph) : CliOutput
     data class ExternalProcess(val process: CliExternalProcess) : CliOutput
     data object None : CliOutput
 }
@@ -258,6 +260,15 @@ internal class DefaultCliCommandExecutor(
             }
 
             is CliCommand.Metrics -> {
+                if (command.subcommand == MetricsSubcommand.GRAPH && command.interactive) {
+                    val graph = MetricsEngine(command.workspaceRoot).use { engine ->
+                        engine.graph(
+                            fqName = requireNotNull(command.symbol) { "--symbol is required for graph" },
+                            depth = command.depth,
+                        )
+                    }
+                    return CliExecutionResult(output = CliOutput.InteractiveGraph(graph))
+                }
                 val encoded = MetricsEngine(command.workspaceRoot).use { engine ->
                     when (command.subcommand) {
                         MetricsSubcommand.FAN_IN -> json.encodeToString(
@@ -276,6 +287,13 @@ internal class DefaultCliCommandExecutor(
                             ListSerializer(ChangeImpactNode.serializer()),
                             engine.changeImpactRadius(
                                 fqName = requireNotNull(command.symbol) { "--symbol is required for impact" },
+                                depth = command.depth,
+                            ),
+                        )
+                        MetricsSubcommand.GRAPH -> json.encodeToString(
+                            MetricsGraph.serializer(),
+                            engine.graph(
+                                fqName = requireNotNull(command.symbol) { "--symbol is required for graph" },
                                 depth = command.depth,
                             ),
                         )

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/EmbeddedSkillResources.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/EmbeddedSkillResources.kt
@@ -1,5 +1,7 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.cli.tty.CliFailure
+import io.github.amichne.kast.cli.tty.currentCliVersion
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/EvalSkillExecutor.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/EvalSkillExecutor.kt
@@ -4,6 +4,10 @@ import io.github.amichne.kast.cli.eval.ComparisonResult
 import io.github.amichne.kast.cli.eval.EvalResult
 import io.github.amichne.kast.cli.eval.SkillEvalEngine
 import io.github.amichne.kast.cli.eval.adapter.SkillAdapter
+import io.github.amichne.kast.cli.tty.CliFailure
+import io.github.amichne.kast.cli.tty.CliOutput
+import io.github.amichne.kast.cli.tty.EvalOutputFormat
+import io.github.amichne.kast.cli.tty.EvalSkillOptions
 import kotlinx.serialization.json.Json
 import kotlin.io.path.readText
 
@@ -59,8 +63,8 @@ internal class EvalSkillExecutor(private val json: Json) {
             throw CliFailure(
                 code = "EVAL_SKILL_REGRESSION",
                 message = "Score regressed by ${-comparison.scoreDelta} points " +
-                    "(${baseline.summary.grade} → ${result.summary.grade}). " +
-                    "New failures: ${comparison.newFailures.joinToString()}",
+                          "(${baseline.summary.grade} → ${result.summary.grade}). " +
+                          "New failures: ${comparison.newFailures.joinToString()}",
             )
         }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/InstallService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/InstallService.kt
@@ -1,5 +1,8 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.cli.options.InstallOptions
+import io.github.amichne.kast.cli.results.InstallResult
+import io.github.amichne.kast.cli.tty.CliFailure
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/InstallSkillService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/InstallSkillService.kt
@@ -1,5 +1,8 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.cli.options.InstallSkillOptions
+import io.github.amichne.kast.cli.skill.InstallSkillResult
+import io.github.amichne.kast.cli.tty.CliFailure
 import java.io.IOException
 import java.nio.file.FileVisitResult
 import java.nio.file.Files

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastCli.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastCli.kt
@@ -1,5 +1,14 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.cli.tty.CliCommandExecutor
+import io.github.amichne.kast.cli.tty.CliCommandParser
+import io.github.amichne.kast.cli.tty.CliExternalProcess
+import io.github.amichne.kast.cli.tty.CliOutput
+import io.github.amichne.kast.cli.tty.CliService
+import io.github.amichne.kast.cli.tty.DefaultCliCommandExecutor
+import io.github.amichne.kast.cli.tty.cliErrorFromThrowable
+import io.github.amichne.kast.cli.tty.defaultCliJson
+import io.github.amichne.kast.cli.tty.writeCliJson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastCli.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastCli.kt
@@ -86,6 +86,7 @@ class KastCli private constructor(
             }
 
             is CliOutput.InteractiveGraph -> writeInteractiveGraph(output.graph, stdout)
+            is CliOutput.InteractiveGraphPicker -> writeInteractiveGraphPicker(output, stdout, stderr)
             is CliOutput.ExternalProcess -> runExternalProcess(output.process, stdout, stderr)
             CliOutput.None -> 0
         }
@@ -104,7 +105,27 @@ class KastCli private constructor(
             return 0
         }
         return withContext(Dispatchers.IO) {
-            MetricsGraphTerminal(graph).run(System.`in`, System.out)
+            MetricsGraphTerminal(graph).run()
+        }
+    }
+
+    private suspend fun writeInteractiveGraphPicker(
+        spec: CliOutput.InteractiveGraphPicker,
+        stdout: Appendable,
+        stderr: Appendable,
+    ): Int {
+        if (stdout !== System.out) {
+            stderr.append(
+                "Interactive symbol picker requires a TTY. Pass --symbol=<fqName> to render the graph as JSON.\n",
+            )
+            return 2
+        }
+        return withContext(Dispatchers.IO) {
+            MetricsGraphPicker(
+                workspaceRoot = spec.workspaceRoot,
+                depth = spec.depth,
+                initialQuery = spec.initialQuery.orEmpty(),
+            ).run()
         }
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastCli.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastCli.kt
@@ -76,8 +76,26 @@ class KastCli private constructor(
                 0
             }
 
+            is CliOutput.InteractiveGraph -> writeInteractiveGraph(output.graph, stdout)
             is CliOutput.ExternalProcess -> runExternalProcess(output.process, stdout, stderr)
             CliOutput.None -> 0
+        }
+    }
+
+    private suspend fun writeInteractiveGraph(
+        graph: io.github.amichne.kast.indexstore.MetricsGraph,
+        stdout: Appendable,
+    ): Int {
+        if (stdout !== System.out) {
+            val rendered = MetricsGraphShell.render(graph)
+            stdout.append(rendered)
+            if (!rendered.endsWith('\n')) {
+                stdout.append('\n')
+            }
+            return 0
+        }
+        return withContext(Dispatchers.IO) {
+            MetricsGraphTerminal(graph).run(System.`in`, System.out)
         }
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastHttpClient.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/KastHttpClient.kt
@@ -7,6 +7,7 @@ import io.github.amichne.kast.api.protocol.JsonRpcRequest
 import io.github.amichne.kast.api.protocol.JsonRpcSuccessResponse
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.client.ServerInstanceDescriptor
+import io.github.amichne.kast.cli.tty.CliFailure
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphMordantView.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphMordantView.kt
@@ -1,0 +1,219 @@
+package io.github.amichne.kast.cli
+
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.TextStyle
+import com.github.ajalt.mordant.rendering.TextStyles
+import com.github.ajalt.mordant.rendering.Widget
+import com.github.ajalt.mordant.table.verticalLayout
+import com.github.ajalt.mordant.widgets.Panel
+import io.github.amichne.kast.indexstore.MetricsGraph
+import io.github.amichne.kast.indexstore.MetricsGraphEdge
+import io.github.amichne.kast.indexstore.MetricsGraphEdgeType
+import io.github.amichne.kast.indexstore.MetricsGraphNode
+import io.github.amichne.kast.indexstore.MetricsGraphNodeType
+
+internal object MetricsGraphMordantView {
+    fun render(
+        graph: MetricsGraph,
+        cursor: MetricsGraphCursor,
+    ): Widget {
+        val context = MetricsGraphDashboardContext(graph, cursor)
+        return verticalLayout {
+            spacing = 1
+            cell(headerPanel(graph))
+            cell(section("Path", TextColors.brightBlue, context.pathBlock()))
+            cell(section("Current", TextColors.brightGreen, context.currentBlock()))
+            cell(section("Neighborhood", TextColors.brightCyan, context.neighborhoodBlock()))
+            cell(section("Children", TextColors.brightYellow, context.childrenBlock()))
+            cell(section("Relations", TextColors.brightMagenta, context.relationsBlock()))
+        }
+    }
+
+    private fun headerPanel(graph: MetricsGraph): Widget {
+        val statsLine = listOf(
+            "${graph.index.symbolCount} symbols",
+            "${graph.index.fileCount} files",
+            "${graph.index.referenceCount} refs",
+            "depth ${graph.index.maxDepth}",
+        ).joinToString("  ") { TextColors.brightWhite(it) }
+
+        val keys = sequenceOf(
+            "U/↑" to "parent",
+            "D/↓/Enter" to "child",
+            "←/→" to "sibling",
+            "A" to "members",
+            "Q" to "quit",
+        ).joinToString("  ") { (key, label) ->
+            TextStyles.bold(TextColors.brightYellow(key)) + " " + TextColors.gray(label)
+        }
+
+        return Panel(
+            content = statsLine + "\n" + keys,
+            title = TextStyles.bold(TextColors.brightCyan("Kast graph visualizer")),
+            expand = true,
+            borderStyle = TextColors.brightCyan,
+        )
+    }
+
+    private fun section(title: String, accent: TextStyle, body: String): Widget =
+        Panel(
+            content = body,
+            title = TextStyles.bold(accent(title)),
+            expand = true,
+            borderStyle = accent,
+        )
+}
+
+private class MetricsGraphDashboardContext(
+    graph: MetricsGraph,
+    cursor: MetricsGraphCursor,
+) {
+    private val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+    private val current = nodesById.getValue(cursor.currentNodeId)
+    private val parent = current.parentId?.let(nodesById::get)
+    private val siblings = parent
+        ?.children
+        ?.mapNotNull(nodesById::get)
+        .orEmpty()
+    private val currentSiblingIndex = siblings.indexOfFirst { it.id == current.id }
+    private val children = current.children.mapNotNull(nodesById::get)
+    private val relatedEdges = graph.edges.filter { edge -> edge.from == current.id || edge.to == current.id }
+    private val showAttributes = cursor.showAttributes
+
+    fun pathBlock(): String {
+        val crumbs = generateSequence(current) { node -> node.parentId?.let(nodesById::get) }
+            .toList()
+            .asReversed()
+        if (crumbs.isEmpty()) return TextColors.gray(EMPTY)
+        return crumbs.joinToString(TextColors.gray("  →  ")) { node ->
+            val isCurrent = node.id == current.id
+            val name = displayName(node)
+            if (isCurrent) {
+                TextStyles.bold(typeStyle(node.type)(name))
+            } else {
+                typeStyle(node.type)(name)
+            }
+        }
+    }
+
+    fun currentBlock(): String {
+        val arrow = TextStyles.bold(TextColors.brightGreen("▶ "))
+        val name = TextStyles.bold(TextColors.brightWhite(displayName(current)))
+        val typeLabel = typeStyle(current.type)(current.type.name.lowercase())
+        val parentLabel = parent?.let(::displayName)?.let(TextColors.cyan::invoke) ?: TextColors.gray(EMPTY)
+        val summary = listOf(
+            typeLabel,
+            "parent " + parentLabel,
+            TextColors.yellow("${children.size} children"),
+            TextColors.magenta("${current.attributes.size} attrs"),
+        ).joinToString(TextColors.gray(" · "))
+
+        val lines = mutableListOf(
+            "$arrow$name",
+            "  $summary",
+            "  ${TextColors.gray("id ")}${TextColors.white(current.id)}",
+        )
+        if (current.name != current.id && current.name != displayName(current)) {
+            lines += "  ${TextColors.gray("label ")}${TextColors.white(current.name)}"
+        }
+        if (showAttributes && current.attributes.isNotEmpty()) {
+            lines += "  ${TextColors.gray("attrs:")}"
+            current.attributes.forEach { attr ->
+                lines += "    ${TextColors.brightCyan("•")} ${TextColors.white(attr)}"
+            }
+        } else if (!showAttributes) {
+            lines += "  " + TextColors.gray("(attributes hidden — press A)")
+        }
+        return lines.joinToString("\n")
+    }
+
+    fun neighborhoodBlock(): String {
+        val parentName = parent?.let(::displayName)?.let(TextColors.cyan::invoke) ?: TextColors.gray(EMPTY)
+        val prevName = siblingAt(-1)?.let(::displayName)?.let(TextColors.gray::invoke)
+            ?: TextColors.gray(EMPTY)
+        val nextName = siblingAt(1)?.let(::displayName)?.let(TextColors.gray::invoke)
+            ?: TextColors.gray(EMPTY)
+        val firstChildName = children.firstOrNull()?.let(::displayName)?.let(TextColors.yellow::invoke)
+            ?: TextColors.gray(EMPTY)
+        val curr = TextStyles.bold(TextColors.brightGreen(displayName(current)))
+        val pipe = TextColors.gray("│")
+        val arrowLeft = TextColors.gray("←")
+        val arrowRight = TextColors.gray("→")
+        return buildString {
+            appendLine("        $parentName")
+            appendLine("          $pipe")
+            appendLine("  $prevName  $arrowLeft  $curr  $arrowRight  $nextName")
+            appendLine("          $pipe")
+            append("        $firstChildName")
+        }
+    }
+
+    fun childrenBlock(): String {
+        if (children.isEmpty()) return TextColors.gray(EMPTY)
+        return children.mapIndexed { index, child ->
+            val number = TextColors.gray("${(index + 1).toString().padStart(2)}.")
+            val name = TextColors.white(displayName(child))
+            val typeLabel = typeStyle(child.type)(child.type.name.lowercase())
+            "$number $name  $typeLabel"
+        }.joinToString("\n")
+    }
+
+    fun relationsBlock(): String {
+        if (relatedEdges.isEmpty()) return TextColors.gray(EMPTY)
+        val lines = relatedEdges.take(MAX_RELATIONS).map { edge -> describeEdge(edge) }
+        val overflow = (relatedEdges.size - MAX_RELATIONS).takeIf { it > 0 }
+            ?.let { TextColors.gray("… $it more") }
+        return (lines + listOfNotNull(overflow)).joinToString("\n")
+    }
+
+    private fun siblingAt(offset: Int): MetricsGraphNode? {
+        if (currentSiblingIndex == -1 || siblings.size < 2) return null
+        val index = (currentSiblingIndex + offset + siblings.size) % siblings.size
+        return siblings[index]
+    }
+
+    private fun describeEdge(edge: MetricsGraphEdge): String {
+        val outbound = edge.from == current.id
+        val otherId = if (outbound) edge.to else edge.from
+        val other = nodesById[otherId]
+        val relation = if (outbound) edge.edgeType.forwardLabel() else edge.edgeType.inverseLabel()
+        val styledRelation = edgeStyle(edge.edgeType)(relation.padEnd(14))
+        val target = other?.let { TextColors.white(displayName(it)) } ?: TextColors.gray(otherId)
+        val weight = edge.weight.takeIf { it > 1 }?.let {
+            "  " + TextColors.gray("weight ") + TextColors.brightWhite(it.toString())
+        }.orEmpty()
+        return "$styledRelation $target$weight"
+    }
+
+    private fun displayName(node: MetricsGraphNode): String =
+        node.name.substringAfterLast('/').substringAfterLast(':').substringAfterLast('.')
+
+    private fun typeStyle(type: MetricsGraphNodeType): TextStyle = when (type) {
+        MetricsGraphNodeType.SYMBOL -> TextColors.brightCyan
+        MetricsGraphNodeType.FILE -> TextColors.brightBlue
+        MetricsGraphNodeType.REFERENCE_EDGE -> TextColors.brightMagenta
+    }
+
+    private fun edgeStyle(type: MetricsGraphEdgeType): TextStyle = when (type) {
+        MetricsGraphEdgeType.CONTAINS -> TextColors.brightCyan
+        MetricsGraphEdgeType.REFERENCES -> TextColors.brightYellow
+        MetricsGraphEdgeType.REFERENCED_BY -> TextColors.brightMagenta
+    }
+
+    companion object {
+        private const val EMPTY = "∅"
+        private const val MAX_RELATIONS = 8
+    }
+}
+
+private fun MetricsGraphEdgeType.forwardLabel(): String = when (this) {
+    MetricsGraphEdgeType.CONTAINS -> "contains"
+    MetricsGraphEdgeType.REFERENCED_BY -> "referenced by"
+    MetricsGraphEdgeType.REFERENCES -> "references"
+}
+
+private fun MetricsGraphEdgeType.inverseLabel(): String = when (this) {
+    MetricsGraphEdgeType.CONTAINS -> "contained by"
+    MetricsGraphEdgeType.REFERENCED_BY -> "references"
+    MetricsGraphEdgeType.REFERENCES -> "referenced by"
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphPicker.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphPicker.kt
@@ -1,0 +1,184 @@
+package io.github.amichne.kast.cli
+
+import com.github.ajalt.mordant.animation.animation
+import com.github.ajalt.mordant.input.InputReceiver
+import com.github.ajalt.mordant.input.KeyboardEvent
+import com.github.ajalt.mordant.input.isCtrlC
+import com.github.ajalt.mordant.input.receiveKeyEvents
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.TextStyles
+import com.github.ajalt.mordant.rendering.Widget
+import com.github.ajalt.mordant.table.verticalLayout
+import com.github.ajalt.mordant.terminal.Terminal
+import com.github.ajalt.mordant.widgets.Panel
+import io.github.amichne.kast.indexstore.MetricsEngine
+import java.nio.file.Path
+
+internal class MetricsGraphPicker(
+    private val workspaceRoot: Path,
+    private val depth: Int,
+    initialQuery: String = "",
+    private val terminal: Terminal = Terminal(),
+    private val engineFactory: () -> MetricsEngine = { MetricsEngine(workspaceRoot) },
+    private val graphRunner: (io.github.amichne.kast.indexstore.MetricsGraph) -> Int = { graph ->
+        MetricsGraphTerminal(graph).run()
+    },
+) {
+    private val state = PickerState(query = initialQuery)
+
+    fun run(): Int {
+        engineFactory().use { engine ->
+            refreshResults(engine)
+            val animation = terminal.animation<PickerState> { snapshot -> render(snapshot) }
+            terminal.cursor.hide(showOnExit = true)
+            animation.update(state)
+
+            var resolved: String? = null
+            terminal.receiveKeyEvents { event ->
+                if (event.isCtrlC) return@receiveKeyEvents InputReceiver.Status.Finished
+                when (val action = event.toPickerAction()) {
+                    PickerAction.Quit -> return@receiveKeyEvents InputReceiver.Status.Finished
+                    PickerAction.Confirm -> {
+                        val pick = state.results.getOrNull(state.selection)
+                        if (pick != null) {
+                            resolved = pick
+                            return@receiveKeyEvents InputReceiver.Status.Finished
+                        }
+                    }
+
+                    PickerAction.Up -> state.selection = (state.selection - 1).coerceAtLeast(0)
+                    PickerAction.Down -> state.selection =
+                        (state.selection + 1).coerceAtMost((state.results.size - 1).coerceAtLeast(0))
+
+                    PickerAction.Backspace -> {
+                        if (state.query.isNotEmpty()) {
+                            state.query = state.query.dropLast(1)
+                            refreshResults(engine)
+                        }
+                    }
+
+                    is PickerAction.Type -> {
+                        state.query += action.char
+                        refreshResults(engine)
+                    }
+
+                    null -> Unit
+                }
+                animation.update(state)
+                InputReceiver.Status.Continue
+            }
+
+            animation.clear()
+
+            val pick = resolved ?: return 0
+            val graph = engine.graph(fqName = pick, depth = depth)
+            return graphRunner(graph)
+        }
+    }
+
+    private fun refreshResults(engine: MetricsEngine) {
+        state.results = engine.searchSymbols(state.query, limit = MAX_RESULTS)
+        state.selection = state.selection.coerceIn(0, (state.results.size - 1).coerceAtLeast(0))
+    }
+
+    private fun render(snapshot: PickerState): Widget {
+        val header = Panel(
+            content = buildString {
+                append(TextStyles.bold(TextColors.brightCyan("Pick a symbol")))
+                append("  ")
+                append(TextColors.gray("type to filter · ↑/↓ select · Enter open · Esc/Ctrl-C cancel"))
+            },
+            title = TextStyles.bold(TextColors.brightCyan("Kast graph picker")),
+            expand = true,
+            borderStyle = TextColors.brightCyan,
+        )
+        val prompt = Panel(
+            content = buildString {
+                append(TextColors.brightYellow("› "))
+                append(snapshot.query)
+                append(TextStyles.dim("▏"))
+            },
+            title = TextColors.brightBlue("Query"),
+            expand = true,
+            borderStyle = TextColors.brightBlue,
+        )
+        val resultsBody = if (snapshot.results.isEmpty()) {
+            TextColors.gray(
+                if (snapshot.query.isBlank()) {
+                    "No indexed symbols. Run `kast metrics fan-in` once to populate the index."
+                } else {
+                    "No matches for \"${snapshot.query}\"."
+                },
+            )
+        } else {
+            snapshot.results.mapIndexed { index, fqName ->
+                val displayName = simpleName(fqName)
+                val qualifier = fqName.substringBeforeLast('.', missingDelimiterValue = "")
+                val styled = if (index == snapshot.selection) {
+                    val arrow = TextStyles.bold(TextColors.brightGreen("▶ "))
+                    val name = TextStyles.bold(TextColors.brightWhite(displayName))
+                    val tail = if (qualifier.isNotEmpty()) " " + TextColors.gray(qualifier) else ""
+                    "$arrow$name$tail"
+                } else {
+                    val name = TextColors.white(displayName)
+                    val tail = if (qualifier.isNotEmpty()) " " + TextColors.gray(qualifier) else ""
+                    "  $name$tail"
+                }
+                styled
+            }.joinToString("\n")
+        }
+        val results = Panel(
+            content = resultsBody,
+            title = TextColors.brightMagenta("Matches (${snapshot.results.size})"),
+            expand = true,
+            borderStyle = TextColors.brightMagenta,
+        )
+        return verticalLayout {
+            spacing = 1
+            cell(header)
+            cell(prompt)
+            cell(results)
+        }
+    }
+
+    private fun simpleName(fqName: String): String =
+        fqName.substringAfterLast('.').ifBlank { fqName }
+
+    private data class PickerState(
+        var query: String = "",
+        var results: List<String> = emptyList(),
+        var selection: Int = 0,
+    )
+
+    private sealed interface PickerAction {
+        data object Up : PickerAction
+        data object Down : PickerAction
+        data object Confirm : PickerAction
+        data object Quit : PickerAction
+        data object Backspace : PickerAction
+        data class Type(val char: Char) : PickerAction
+    }
+
+    private fun KeyboardEvent.toPickerAction(): PickerAction? {
+        return when (key) {
+            "ArrowUp" -> PickerAction.Up
+            "ArrowDown" -> PickerAction.Down
+            "Enter" -> PickerAction.Confirm
+            "Escape" -> PickerAction.Quit
+            "Backspace" -> PickerAction.Backspace
+            else -> {
+                if (key.length == 1) {
+                    val ch = key[0]
+                    if (ch.isLetterOrDigit() || ch in PRINTABLE_PICKER_CHARS) PickerAction.Type(ch) else null
+                } else {
+                    null
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val MAX_RESULTS = 25
+        private val PRINTABLE_PICKER_CHARS = setOf('.', '_', '-', '$', ':', '/', '<', '>')
+    }
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphShell.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphShell.kt
@@ -1,0 +1,73 @@
+package io.github.amichne.kast.cli
+
+import io.github.amichne.kast.indexstore.MetricsGraph
+import io.github.amichne.kast.indexstore.MetricsGraphNode
+
+internal object MetricsGraphShell {
+    fun render(graph: MetricsGraph): String {
+        val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+        val focal = nodesById.getValue(graph.focalNodeId)
+        return buildString {
+            appendLine("Kast graph visualizer")
+            appendLine("Keys: U parent · D/Enter first child · ←/→ sibling · A attributes/members")
+            appendLine("Index: ${graph.index.symbolCount} symbols · ${graph.index.fileCount} files · ${graph.index.referenceCount} refs · depth ${graph.index.maxDepth}")
+            appendLine()
+            append(renderNode(graph = graph, current = focal, showAttributes = true))
+        }
+    }
+
+    private fun renderNode(
+        graph: MetricsGraph,
+        current: MetricsGraphNode,
+        showAttributes: Boolean,
+    ): String {
+        val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+        val parent = current.parentId?.let(nodesById::get)
+        val children = current.children.mapNotNull(nodesById::get)
+        val siblings = siblingNodes(graph = graph, current = current)
+        return buildString {
+            appendLine("▶ ${current.name}")
+            appendLine("  type: ${current.type}")
+            appendLine("  node: ${current.id}")
+            appendLine("  parent: ${parent?.name ?: "∅"}")
+            appendLine("  siblings: ${siblings.joinToString { it.name }.ifBlank { "∅" }}")
+            appendLine("  children:")
+            if (children.isEmpty()) {
+                appendLine("    ∅")
+            } else {
+                children.forEachIndexed { index, child ->
+                    appendLine("    ${index + 1}. ${child.name} [${child.type}]")
+                }
+            }
+            if (showAttributes) {
+                appendLine("  attributes:")
+                if (current.attributes.isEmpty()) {
+                    appendLine("    ∅")
+                } else {
+                    current.attributes.forEach { attribute ->
+                        appendLine("    - $attribute")
+                    }
+                }
+            }
+            appendLine()
+            appendLine("Graph edges from here:")
+            graph.edges
+                .filter { edge -> edge.from == current.id || edge.to == current.id }
+                .forEach { edge ->
+                    appendLine("  ${edge.from} -${edge.edgeType}/${edge.weight}-> ${edge.to}")
+                }
+        }
+    }
+
+    private fun siblingNodes(
+        graph: MetricsGraph,
+        current: MetricsGraphNode,
+    ): List<MetricsGraphNode> {
+        val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+        val parentId = current.parentId ?: return emptyList()
+        val parent = nodesById[parentId] ?: return emptyList()
+        return parent.children
+            .filterNot { it == current.id }
+            .mapNotNull(nodesById::get)
+    }
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt
@@ -23,9 +23,10 @@ internal class MetricsGraphTerminal(private val graph: MetricsGraph) {
         animation.update(cursor)
 
         terminal.receiveKeyEvents { event ->
+            if (event.isCtrlC) return@receiveKeyEvents InputReceiver.Status.Finished
             val action = event.toGraphAction() ?: return@receiveKeyEvents InputReceiver.Status.Continue
 
-            if (action == GraphAction.Quit || event.isCtrlC) {
+            if (action == GraphAction.Quit) {
                 return@receiveKeyEvents InputReceiver.Status.Finished
             }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt
@@ -1,147 +1,103 @@
 package io.github.amichne.kast.cli
 
+import com.github.ajalt.mordant.animation.animation
+import com.github.ajalt.mordant.input.InputReceiver
+import com.github.ajalt.mordant.input.KeyboardEvent
+import com.github.ajalt.mordant.input.isCtrlC
+import com.github.ajalt.mordant.input.receiveKeyEvents
+import com.github.ajalt.mordant.terminal.Terminal
 import io.github.amichne.kast.indexstore.MetricsGraph
 import io.github.amichne.kast.indexstore.MetricsGraphNode
-import java.io.InputStream
-import java.io.PrintStream
 
 internal class MetricsGraphTerminal(private val graph: MetricsGraph) {
-    private val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+    fun run(): Int {
+        val terminal = Terminal()
+        val navigator = MetricsGraphNavigator(graph)
+        var cursor = MetricsGraphCursor(graph.focalNodeId)
 
-    fun run(
-        input: InputStream,
-        output: PrintStream,
-    ): Int {
-        val rawMode = TerminalRawMode.enter()
-        rawMode.use { rawMode ->
-            var current = nodesById.getValue(graph.focalNodeId)
-            var showAttributes = true
-            render(output, current, showAttributes)
-            while (true) {
-                val key = readKey(input)
-                when (key) {
-                    TerminalKey.QUIT -> return 0
-                    TerminalKey.PARENT -> current.parentId?.let(nodesById::get)?.let { current = it }
-                    TerminalKey.FIRST_CHILD -> current.children.firstOrNull()?.let(nodesById::get)?.let { current = it }
-                    TerminalKey.PREVIOUS_SIBLING -> sibling(current, -1)?.let { current = it }
-                    TerminalKey.NEXT_SIBLING -> sibling(current, 1)?.let { current = it }
-                    TerminalKey.ATTRIBUTES -> showAttributes = !showAttributes
-                    TerminalKey.IGNORED -> Unit
-                }
-                if (key != TerminalKey.IGNORED) {
-                    render(output, current, showAttributes)
-                }
-            }
+        val animation = terminal.animation<MetricsGraphCursor> { frame ->
+            MetricsGraphMordantView.render(graph, frame)
         }
+
+        terminal.cursor.hide(showOnExit = true)
+        animation.update(cursor)
+
+        terminal.receiveKeyEvents { event ->
+            val action = event.toGraphAction() ?: return@receiveKeyEvents InputReceiver.Status.Continue
+
+            if (action == GraphAction.Quit || event.isCtrlC) {
+                return@receiveKeyEvents InputReceiver.Status.Finished
+            }
+
+            cursor = navigator.reduce(cursor, action)
+            animation.update(cursor)
+            InputReceiver.Status.Continue
+        }
+
         return 0
     }
+}
 
-    private fun render(
-        output: PrintStream,
-        current: MetricsGraphNode,
-        showAttributes: Boolean,
-    ) {
-        val parent = current.parentId?.let(nodesById::get)
-        val children = current.children.mapNotNull(nodesById::get)
-        val siblings = siblingList(current)
-        output.print("\u001b[2J\u001b[H")
-        output.println("Kast graph visualizer")
-        output.println("U parent · D/Enter child · ←/→ sibling · A attributes · Q quit")
-        output.println("${graph.index.symbolCount} symbols · ${graph.index.fileCount} files · ${graph.index.referenceCount} refs · depth ${graph.index.maxDepth}")
-        output.println()
-        output.println("▶ ${current.name}")
-        output.println("  type: ${current.type}")
-        output.println("  node: ${current.id}")
-        output.println("  parent: ${parent?.name ?: "∅"}")
-        output.println("  peers: ${siblings.joinToString { if (it.id == current.id) "[${it.name}]" else it.name }.ifBlank { "∅" }}")
-        output.println()
-        output.println("children")
-        if (children.isEmpty()) {
-            output.println("  ∅")
-        } else {
-            children.forEachIndexed { index, child ->
-                output.println("  ${index + 1}. ${child.name} [${child.type}]")
-            }
+internal data class MetricsGraphCursor(
+    val currentNodeId: String,
+    val showAttributes: Boolean = true,
+)
+
+internal enum class GraphAction {
+    Parent,
+    FirstChild,
+    PreviousSibling,
+    NextSibling,
+    ToggleAttributes,
+    Quit,
+}
+
+internal class MetricsGraphNavigator(private val graph: MetricsGraph) {
+    private val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+
+    fun reduce(cursor: MetricsGraphCursor, action: GraphAction): MetricsGraphCursor {
+        val current = nodesById.getValue(cursor.currentNodeId)
+        return when (action) {
+            GraphAction.Parent ->
+                current.parentId?.let { cursor.copy(currentNodeId = it) } ?: cursor
+
+            GraphAction.FirstChild ->
+                current.children.firstOrNull()?.let { cursor.copy(currentNodeId = it) } ?: cursor
+
+            GraphAction.PreviousSibling ->
+                sibling(current, -1)?.let { cursor.copy(currentNodeId = it.id) } ?: cursor
+
+            GraphAction.NextSibling ->
+                sibling(current, 1)?.let { cursor.copy(currentNodeId = it.id) } ?: cursor
+
+            GraphAction.ToggleAttributes ->
+                cursor.copy(showAttributes = !cursor.showAttributes)
+
+            GraphAction.Quit -> cursor
         }
-        output.println()
-        if (showAttributes) {
-            output.println("attributes / members")
-            if (current.attributes.isEmpty()) {
-                output.println("  ∅")
-            } else {
-                current.attributes.forEach { output.println("  - $it") }
-            }
-            output.println()
-        }
-        output.println("relational context")
-        val visibleEdges = graph.edges.filter { edge -> edge.from == current.id || edge.to == current.id }
-        if (visibleEdges.isEmpty()) {
-            output.println("  ∅")
-        } else {
-            visibleEdges.forEach { edge -> output.println("  ${edge.from} -${edge.edgeType}/${edge.weight}-> ${edge.to}") }
-        }
-        output.flush()
     }
 
-    private fun sibling(
-        current: MetricsGraphNode,
-        direction: Int,
-    ): MetricsGraphNode? {
-        val siblings = siblingList(current)
+    private fun sibling(current: MetricsGraphNode, direction: Int): MetricsGraphNode? {
+        val parent = current.parentId?.let(nodesById::get) ?: return null
+        val siblings = parent.children.mapNotNull(nodesById::get)
         val index = siblings.indexOfFirst { it.id == current.id }
         if (index == -1 || siblings.size < 2) return null
         return siblings[(index + direction + siblings.size) % siblings.size]
     }
-
-    private fun siblingList(current: MetricsGraphNode): List<MetricsGraphNode> {
-        val parent = current.parentId?.let(nodesById::get) ?: return listOf(current)
-        return parent.children.mapNotNull(nodesById::get)
-    }
-
-    private fun readKey(input: InputStream): TerminalKey {
-        return when (val first = input.read()) {
-            -1, 'q'.code, 'Q'.code -> TerminalKey.QUIT
-            'u'.code, 'U'.code -> TerminalKey.PARENT
-            'd'.code, 'D'.code, '\n'.code, '\r'.code -> TerminalKey.FIRST_CHILD
-            'a'.code, 'A'.code -> TerminalKey.ATTRIBUTES
-            27 -> readEscape(input)
-            else -> TerminalKey.IGNORED
-        }
-    }
-
-    private fun readEscape(input: InputStream): TerminalKey {
-        if (input.read() != '['.code) return TerminalKey.IGNORED
-        return when (input.read()) {
-            'D'.code -> TerminalKey.PREVIOUS_SIBLING
-            'C'.code -> TerminalKey.NEXT_SIBLING
-            else -> TerminalKey.IGNORED
-        }
-    }
 }
 
-private enum class TerminalKey {
-    PARENT,
-    FIRST_CHILD,
-    PREVIOUS_SIBLING,
-    NEXT_SIBLING,
-    ATTRIBUTES,
-    QUIT,
-    IGNORED,
-}
-
-private class TerminalRawMode private constructor(private val active: Boolean) : AutoCloseable {
-    override fun close() {
-        if (active) {
-            runCatching { ProcessBuilder("sh", "-c", "stty sane < /dev/tty").start().waitFor() }
-        }
-    }
-
-    companion object {
-        fun enter(): TerminalRawMode {
-            val exitCode = runCatching {
-                ProcessBuilder("sh", "-c", "stty raw -echo < /dev/tty").start().waitFor()
-            }.getOrDefault(1)
-            return TerminalRawMode(exitCode == 0)
+private fun KeyboardEvent.toGraphAction(): GraphAction? {
+    return when (key) {
+        "ArrowUp" -> GraphAction.Parent
+        "ArrowDown", "Enter" -> GraphAction.FirstChild
+        "ArrowLeft" -> GraphAction.PreviousSibling
+        "ArrowRight" -> GraphAction.NextSibling
+        else -> when (key.lowercase()) {
+            "u" -> GraphAction.Parent
+            "d" -> GraphAction.FirstChild
+            "a" -> GraphAction.ToggleAttributes
+            "q" -> GraphAction.Quit
+            else -> null
         }
     }
 }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt
@@ -1,0 +1,149 @@
+package io.github.amichne.kast.cli
+
+import io.github.amichne.kast.indexstore.MetricsGraph
+import io.github.amichne.kast.indexstore.MetricsGraphNode
+import java.io.InputStream
+import java.io.PrintStream
+
+internal class MetricsGraphTerminal(private val graph: MetricsGraph) {
+    private val nodesById = graph.nodes.associateBy(MetricsGraphNode::id)
+
+    fun run(
+        input: InputStream,
+        output: PrintStream,
+    ): Int {
+        val rawMode = TerminalRawMode.enter()
+        try {
+            var current = nodesById.getValue(graph.focalNodeId)
+            var showAttributes = true
+            render(output, current, showAttributes)
+            while (true) {
+                val key = readKey(input)
+                when (key) {
+                    TerminalKey.QUIT -> return 0
+                    TerminalKey.PARENT -> current.parentId?.let(nodesById::get)?.let { current = it }
+                    TerminalKey.FIRST_CHILD -> current.children.firstOrNull()?.let(nodesById::get)?.let { current = it }
+                    TerminalKey.PREVIOUS_SIBLING -> sibling(current, -1)?.let { current = it }
+                    TerminalKey.NEXT_SIBLING -> sibling(current, 1)?.let { current = it }
+                    TerminalKey.ATTRIBUTES -> showAttributes = !showAttributes
+                    TerminalKey.IGNORED -> Unit
+                }
+                if (key != TerminalKey.IGNORED) {
+                    render(output, current, showAttributes)
+                }
+            }
+        } finally {
+            rawMode.close()
+        }
+        return 0
+    }
+
+    private fun render(
+        output: PrintStream,
+        current: MetricsGraphNode,
+        showAttributes: Boolean,
+    ) {
+        val parent = current.parentId?.let(nodesById::get)
+        val children = current.children.mapNotNull(nodesById::get)
+        val siblings = siblingList(current)
+        output.print("\u001b[2J\u001b[H")
+        output.println("Kast graph visualizer")
+        output.println("U parent · D/Enter child · ←/→ sibling · A attributes · Q quit")
+        output.println("${graph.index.symbolCount} symbols · ${graph.index.fileCount} files · ${graph.index.referenceCount} refs · depth ${graph.index.maxDepth}")
+        output.println()
+        output.println("▶ ${current.name}")
+        output.println("  type: ${current.type}")
+        output.println("  node: ${current.id}")
+        output.println("  parent: ${parent?.name ?: "∅"}")
+        output.println("  peers: ${siblings.joinToString { if (it.id == current.id) "[${it.name}]" else it.name }.ifBlank { "∅" }}")
+        output.println()
+        output.println("children")
+        if (children.isEmpty()) {
+            output.println("  ∅")
+        } else {
+            children.forEachIndexed { index, child ->
+                output.println("  ${index + 1}. ${child.name} [${child.type}]")
+            }
+        }
+        output.println()
+        if (showAttributes) {
+            output.println("attributes / members")
+            if (current.attributes.isEmpty()) {
+                output.println("  ∅")
+            } else {
+                current.attributes.forEach { output.println("  - $it") }
+            }
+            output.println()
+        }
+        output.println("relational context")
+        val visibleEdges = graph.edges.filter { edge -> edge.from == current.id || edge.to == current.id }
+        if (visibleEdges.isEmpty()) {
+            output.println("  ∅")
+        } else {
+            visibleEdges.forEach { edge -> output.println("  ${edge.from} -${edge.edgeType}/${edge.weight}-> ${edge.to}") }
+        }
+        output.flush()
+    }
+
+    private fun sibling(
+        current: MetricsGraphNode,
+        direction: Int,
+    ): MetricsGraphNode? {
+        val siblings = siblingList(current)
+        val index = siblings.indexOfFirst { it.id == current.id }
+        if (index == -1 || siblings.size < 2) return null
+        return siblings[(index + direction + siblings.size) % siblings.size]
+    }
+
+    private fun siblingList(current: MetricsGraphNode): List<MetricsGraphNode> {
+        val parent = current.parentId?.let(nodesById::get) ?: return listOf(current)
+        return parent.children.mapNotNull(nodesById::get)
+    }
+
+    private fun readKey(input: InputStream): TerminalKey {
+        return when (val first = input.read()) {
+            -1, 'q'.code, 'Q'.code -> TerminalKey.QUIT
+            'u'.code, 'U'.code -> TerminalKey.PARENT
+            'd'.code, 'D'.code, '\n'.code, '\r'.code -> TerminalKey.FIRST_CHILD
+            'a'.code, 'A'.code -> TerminalKey.ATTRIBUTES
+            27 -> readEscape(input)
+            else -> TerminalKey.IGNORED
+        }
+    }
+
+    private fun readEscape(input: InputStream): TerminalKey {
+        if (input.read() != '['.code) return TerminalKey.IGNORED
+        return when (input.read()) {
+            'D'.code -> TerminalKey.PREVIOUS_SIBLING
+            'C'.code -> TerminalKey.NEXT_SIBLING
+            else -> TerminalKey.IGNORED
+        }
+    }
+}
+
+private enum class TerminalKey {
+    PARENT,
+    FIRST_CHILD,
+    PREVIOUS_SIBLING,
+    NEXT_SIBLING,
+    ATTRIBUTES,
+    QUIT,
+    IGNORED,
+}
+
+private class TerminalRawMode private constructor(private val active: Boolean) : AutoCloseable {
+    override fun close() {
+        if (active) {
+            runCatching { ProcessBuilder("sh", "-c", "stty sane < /dev/tty").start().waitFor() }
+        }
+    }
+
+    companion object {
+        fun enter(): TerminalRawMode {
+            val exitCode = runCatching {
+                ProcessBuilder("sh", "-c", "stty raw -echo < /dev/tty").start().waitFor()
+            }.getOrDefault(1)
+            return TerminalRawMode(exitCode == 0)
+        }
+    }
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt
@@ -13,7 +13,7 @@ internal class MetricsGraphTerminal(private val graph: MetricsGraph) {
         output: PrintStream,
     ): Int {
         val rawMode = TerminalRawMode.enter()
-        try {
+        rawMode.use { rawMode ->
             var current = nodesById.getValue(graph.focalNodeId)
             var showAttributes = true
             render(output, current, showAttributes)
@@ -32,8 +32,6 @@ internal class MetricsGraphTerminal(private val graph: MetricsGraph) {
                     render(output, current, showAttributes)
                 }
             }
-        } finally {
-            rawMode.close()
         }
         return 0
     }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
@@ -1,5 +1,10 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.cli.options.RuntimeCommandOptions
+import io.github.amichne.kast.cli.options.SmokeOptions
+import io.github.amichne.kast.cli.tty.CliFailure
+import io.github.amichne.kast.cli.tty.currentCliVersion
+
 internal class SmokeCommandSupport(
     private val runtimeManager: WorkspaceRuntimeManager? = null,
     private val runtimeWaitTimeoutMillis: Long = 10_000L,

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManager.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManager.kt
@@ -5,6 +5,11 @@ import io.github.amichne.kast.api.client.RegisteredDescriptor
 import io.github.amichne.kast.api.contract.RuntimeState
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.client.defaultDescriptorDirectory
+import io.github.amichne.kast.cli.options.RuntimeCommandOptions
+import io.github.amichne.kast.cli.results.DaemonStopResult
+import io.github.amichne.kast.cli.results.WorkspaceEnsureResult
+import io.github.amichne.kast.cli.results.WorkspaceStatusResult
+import io.github.amichne.kast.cli.tty.CliFailure
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -75,7 +80,7 @@ internal class WorkspaceRuntimeManager(
             throw CliFailure(
                 code = "INTELLIJ_NOT_RUNNING",
                 message = "No IntelliJ backend is available for ${options.workspaceRoot}. " +
-                    "Open the project in IntelliJ IDEA with the Kast plugin installed.",
+                          "Open the project in IntelliJ IDEA with the Kast plugin installed.",
             )
         }
 
@@ -99,7 +104,7 @@ internal class WorkspaceRuntimeManager(
         throw CliFailure(
             code = "NO_BACKEND_AVAILABLE",
             message = "No backend is running for ${options.workspaceRoot}. " +
-                "Start with: kast daemon start --workspace-root=${options.workspaceRoot}",
+                      "Start with: kast daemon start --workspace-root=${options.workspaceRoot}",
         )
     }
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/DaemonStartOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/DaemonStartOptions.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.options
 
 import java.nio.file.Path
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/InstallOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/InstallOptions.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.options
 
 import java.nio.file.Path
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/InstallSkillOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/InstallSkillOptions.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.options
 
 import java.nio.file.Path
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/RuntimeCommandOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/RuntimeCommandOptions.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.options
 
 import io.github.amichne.kast.api.client.StandaloneServerOptions
 import java.nio.file.Path

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/SmokeOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/SmokeOptions.kt
@@ -1,5 +1,6 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.options
 
+import io.github.amichne.kast.cli.SmokeOutputFormat
 import java.nio.file.Path
 
 internal data class SmokeOptions(

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/results/DaemonStopResult.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/results/DaemonStopResult.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.results
 
 import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
 import kotlinx.serialization.Serializable

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/results/InstallResult.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/results/InstallResult.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.results
 
 import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
 import kotlinx.serialization.Serializable

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/results/WorkspaceEnsureResult.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/results/WorkspaceEnsureResult.kt
@@ -1,6 +1,7 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.results
 
 import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
+import io.github.amichne.kast.cli.RuntimeCandidateStatus
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/results/WorkspaceStatusResult.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/results/WorkspaceStatusResult.kt
@@ -1,6 +1,7 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.results
 
 import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
+import io.github.amichne.kast.cli.RuntimeCandidateStatus
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/InstallSkillResult.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/InstallSkillResult.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.skill
 
 import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
 import kotlinx.serialization.Serializable

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/NamedSymbolResolver.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/NamedSymbolResolver.kt
@@ -6,8 +6,8 @@ import io.github.amichne.kast.api.contract.SymbolKind
 import io.github.amichne.kast.api.contract.query.SymbolQuery
 import io.github.amichne.kast.api.wrapper.WrapperNamedSymbolKind
 import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
-import io.github.amichne.kast.cli.CliService
-import io.github.amichne.kast.cli.RuntimeCommandOptions
+import io.github.amichne.kast.cli.tty.CliService
+import io.github.amichne.kast.cli.options.RuntimeCommandOptions
 
 /**
  * Resolves a named symbol (e.g. "MyClass", "doStuff") to a [FilePosition] + [Symbol]

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt
@@ -66,10 +66,10 @@ import io.github.amichne.kast.api.wrapper.KastWriteAndValidateSuccessResponse
 import io.github.amichne.kast.api.wrapper.WrapperCallDirection
 import io.github.amichne.kast.api.wrapper.WrapperMetric
 import io.github.amichne.kast.api.wrapper.WrapperScaffoldMode
-import io.github.amichne.kast.cli.CliCommand
-import io.github.amichne.kast.cli.CliFailure
-import io.github.amichne.kast.cli.CliService
-import io.github.amichne.kast.cli.RuntimeCommandOptions
+import io.github.amichne.kast.cli.tty.CliCommand
+import io.github.amichne.kast.cli.tty.CliFailure
+import io.github.amichne.kast.cli.tty.CliService
+import io.github.amichne.kast.cli.options.RuntimeCommandOptions
 import io.github.amichne.kast.indexstore.MetricsEngine
 import kotlinx.serialization.json.Json
 import java.nio.file.Path

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommand.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommand.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
 
 import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
 import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
@@ -16,7 +16,13 @@ import io.github.amichne.kast.api.contract.query.SymbolQuery
 import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
+import io.github.amichne.kast.cli.options.DaemonStartOptions
+import io.github.amichne.kast.cli.options.InstallOptions
+import io.github.amichne.kast.cli.options.InstallSkillOptions
+import io.github.amichne.kast.cli.options.RuntimeCommandOptions
+import io.github.amichne.kast.cli.options.SmokeOptions
 import io.github.amichne.kast.cli.skill.SkillWrapperName
+import java.nio.file.Path
 
 internal sealed interface CliCommand {
     data class Help(val topic: List<String> = emptyList()) : CliCommand
@@ -51,7 +57,7 @@ internal sealed interface CliCommand {
     data class EvalSkill(val options: EvalSkillOptions) : CliCommand
     data class Metrics(
         val subcommand: MetricsSubcommand,
-        val workspaceRoot: java.nio.file.Path,
+        val workspaceRoot: Path,
         val limit: Int = 50,
         val symbol: String? = null,
         val depth: Int = 3,
@@ -69,8 +75,8 @@ internal enum class MetricsSubcommand {
 }
 
 internal data class EvalSkillOptions(
-    val skillDir: java.nio.file.Path,
-    val compareBaseline: java.nio.file.Path? = null,
+    val skillDir: Path,
+    val compareBaseline: Path? = null,
     val format: EvalOutputFormat = EvalOutputFormat.JSON,
 )
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandCatalog.kt
@@ -1009,14 +1009,16 @@ internal object CliCommandCatalog {
             path = listOf("metrics", "graph"),
             group = CliCommandGroup.METRICS,
             summary = "Show a navigable symbol graph from the local reference index.",
-            description = "Queries the local SQLite reference index without a running daemon. Builds a focal symbol graph with target file, incoming source files, reference edges, and index summary. Add --interactive=true for a keyboard-navigable shell view.",
+            description = "Queries the local SQLite reference index without a running daemon. Builds a focal symbol graph with target file, incoming source files, reference edges, and index summary. Add --interactive=true for a keyboard-navigable shell view; with --interactive you may omit --symbol to fuzzy-pick one from the index.",
             usages = listOf(
                 "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass [--depth=3] [--interactive=true]",
+                "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --interactive=true",
             ),
             options = listOf(workspaceRootOption, metricsSymbolOption, metricsDepthOption, metricsInteractiveOption),
             examples = listOf(
                 "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass",
                 "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --symbol=com.example.MyClass --depth=5 --interactive=true",
+                "$CLI_EXECUTABLE_NAME metrics graph --workspace-root=/absolute/path/to/workspace --interactive=true",
             ),
         ),
         // Skill wrapper: metrics — hidden, called by agent shell scripts

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandCatalog.kt
@@ -1,4 +1,6 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
+
+import io.github.amichne.kast.cli.KastCli
 
 internal const val CLI_EXECUTABLE_NAME = "kast"
 
@@ -1317,8 +1319,8 @@ internal object CliCommandCatalog {
 
 internal fun currentCliVersion(): String {
     return KastCli::class.java.`package`.implementationVersion
-        ?: System.getProperty("io.github.amichne.kast.version")
-        ?: "dev"
+           ?: System.getProperty("io.github.amichne.kast.version")
+           ?: "dev"
 }
 
 private fun List<String>.isPrefixOf(other: List<String>): Boolean {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandParser.kt
@@ -154,16 +154,23 @@ internal class CliCommandParser(
                     ),
                     depth = parsed.optionalInt("depth") ?: 3,
                 )
-                listOf("metrics", "graph") -> CliCommand.Metrics(
-                    subcommand = MetricsSubcommand.GRAPH,
-                    workspaceRoot = parsed.requireWorkspaceRootPath(),
-                    symbol = parsed.options["symbol"] ?: throw CliFailure(
-                        code = "CLI_USAGE",
-                        message = "--symbol is required for metrics graph",
-                    ),
-                    depth = parsed.optionalInt("depth") ?: 3,
-                    interactive = parsed.parseBool("interactive"),
-                )
+                listOf("metrics", "graph") -> {
+                    val symbol = parsed.options["symbol"]
+                    val interactive = parsed.parseBool("interactive")
+                    if (symbol == null && !interactive) {
+                        throw CliFailure(
+                            code = "CLI_USAGE",
+                            message = "--symbol is required for metrics graph (or pass --interactive=true to pick one)",
+                        )
+                    }
+                    CliCommand.Metrics(
+                        subcommand = MetricsSubcommand.GRAPH,
+                        workspaceRoot = parsed.requireWorkspaceRootPath(),
+                        symbol = symbol,
+                        depth = parsed.optionalInt("depth") ?: 3,
+                        interactive = interactive,
+                    )
+                }
                 else -> throw CliFailure(
                     code = "CLI_USAGE",
                     message = "Unknown command: ${metadata.commandText}",

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandParser.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
 
 import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
 import io.github.amichne.kast.api.contract.CallDirection
@@ -22,6 +22,12 @@ import io.github.amichne.kast.api.contract.TypeHierarchyDirection
 import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
+import io.github.amichne.kast.cli.options.DaemonStartOptions
+import io.github.amichne.kast.cli.options.InstallOptions
+import io.github.amichne.kast.cli.options.InstallSkillOptions
+import io.github.amichne.kast.cli.options.RuntimeCommandOptions
+import io.github.amichne.kast.cli.options.SmokeOptions
+import io.github.amichne.kast.cli.SmokeOutputFormat
 import io.github.amichne.kast.cli.skill.SkillWrapperName
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
@@ -518,8 +524,8 @@ internal data class ParsedArguments(
     fun installSkillOptions(): InstallSkillOptions = InstallSkillOptions(
         targetDir = options["target-dir"]?.let { Path.of(it).toAbsolutePath().normalize() },
         name = options["name"]?.takeIf(String::isNotEmpty)
-            ?: options["link-name"]?.takeIf(String::isNotEmpty)
-            ?: "kast",
+               ?: options["link-name"]?.takeIf(String::isNotEmpty)
+               ?: "kast",
         force = optionalBoolean("yes", false),
     )
 
@@ -529,11 +535,11 @@ internal data class ParsedArguments(
             archivePath = Path.of(requireOption("archive")).toAbsolutePath().normalize(),
             instanceName = options["instance"]?.takeIf(String::isNotEmpty),
             instancesRoot = options["instances-root"]
-                ?.let { Path.of(it).toAbsolutePath().normalize() }
-                ?: home.resolve(".local/share/kast/instances"),
+                                ?.let { Path.of(it).toAbsolutePath().normalize() }
+                            ?: home.resolve(".local/share/kast/instances"),
             binDir = options["bin-dir"]
-                ?.let { Path.of(it).toAbsolutePath().normalize() }
-                ?: home.resolve(".local/bin"),
+                         ?.let { Path.of(it).toAbsolutePath().normalize() }
+                     ?: home.resolve(".local/bin"),
         )
     }
 
@@ -552,8 +558,8 @@ internal data class ParsedArguments(
         }
         val format = options["format"]
             ?.takeIf(String::isNotBlank)
-            ?.let(SmokeOutputFormat::fromCliValue)
-            ?: SmokeOutputFormat.JSON
+            ?.let(SmokeOutputFormat.Companion::fromCliValue)
+                     ?: SmokeOutputFormat.JSON
         if (options["format"] != null && SmokeOutputFormat.fromCliValue(checkNotNull(options["format"])) == null) {
             throw CliFailure(
                 code = "CLI_USAGE",
@@ -562,9 +568,9 @@ internal data class ParsedArguments(
         }
         return SmokeOptions(
             workspaceRoot = options["workspace-root"]
-                ?.takeIf(String::isNotBlank)
-                ?.let { Path.of(it).toAbsolutePath().normalize() }
-                ?: Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize(),
+                                ?.takeIf(String::isNotBlank)
+                                ?.let { Path.of(it).toAbsolutePath().normalize() }
+                            ?: Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize(),
             fileFilter = options["file"]?.takeIf(String::isNotBlank),
             sourceSetFilter = options["source-set"]?.takeIf(String::isNotBlank),
             symbolFilter = options["symbol"]?.takeIf(String::isNotBlank),
@@ -582,9 +588,9 @@ internal data class ParsedArguments(
         return DaemonStartOptions(
             standaloneArgs = forwardedArgs,
             workspaceRoot = options["workspace-root"]
-                ?.takeIf(String::isNotBlank)
-                ?.let { Path.of(it).toAbsolutePath().normalize() }
-                ?: Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize(),
+                                ?.takeIf(String::isNotBlank)
+                                ?.let { Path.of(it).toAbsolutePath().normalize() }
+                            ?: Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize(),
             runtimeLibsDir = runtimeLibsDir,
         )
     }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCompletionScripts.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCompletionScripts.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
 
 internal enum class CliCompletionShell {
     BASH,

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliDaemonStatusNotes.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliDaemonStatusNotes.kt
@@ -1,4 +1,9 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
+
+import io.github.amichne.kast.cli.results.DaemonStopResult
+import io.github.amichne.kast.cli.RuntimeCandidateStatus
+import io.github.amichne.kast.cli.results.WorkspaceEnsureResult
+import io.github.amichne.kast.cli.results.WorkspaceStatusResult
 
 internal fun daemonNoteFor(result: WorkspaceStatusResult): String? {
     if (result.candidates.isEmpty()) {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliErrorResponse.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliErrorResponse.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
 
 import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
 import kotlinx.serialization.Serializable

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliExecution.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliExecution.kt
@@ -1,5 +1,8 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
 
+import io.github.amichne.kast.cli.EvalSkillExecutor
+import io.github.amichne.kast.cli.RuntimeCandidateStatus
+import io.github.amichne.kast.cli.SmokeOutputFormat
 import io.github.amichne.kast.cli.skill.SkillWrapperExecutor
 import io.github.amichne.kast.cli.skill.SkillWrapperSerializer
 import io.github.amichne.kast.indexstore.ChangeImpactNode

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliExecution.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliExecution.kt
@@ -20,6 +20,11 @@ internal sealed interface CliOutput {
     data class JsonValue(val value: Any) : CliOutput
     data class Text(val value: String) : CliOutput
     data class InteractiveGraph(val graph: MetricsGraph) : CliOutput
+    data class InteractiveGraphPicker(
+        val workspaceRoot: Path,
+        val depth: Int,
+        val initialQuery: String? = null,
+    ) : CliOutput
     data class ExternalProcess(val process: CliExternalProcess) : CliOutput
     data object None : CliOutput
 }
@@ -264,9 +269,17 @@ internal class DefaultCliCommandExecutor(
 
             is CliCommand.Metrics -> {
                 if (command.subcommand == MetricsSubcommand.GRAPH && command.interactive) {
+                    if (command.symbol == null) {
+                        return CliExecutionResult(
+                            output = CliOutput.InteractiveGraphPicker(
+                                workspaceRoot = command.workspaceRoot,
+                                depth = command.depth,
+                            ),
+                        )
+                    }
                     val graph = MetricsEngine(command.workspaceRoot).use { engine ->
                         engine.graph(
-                            fqName = requireNotNull(command.symbol) { "--symbol is required for graph" },
+                            fqName = command.symbol,
                             depth = command.depth,
                         )
                     }

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliFailure.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliFailure.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
 
 internal class CliFailure(
     val code: String,

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliJson.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliJson.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
 
 import io.github.amichne.kast.api.protocol.AnalysisException
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
@@ -14,6 +14,12 @@ import io.github.amichne.kast.api.contract.SemanticInsertionResult
 import io.github.amichne.kast.api.contract.result.SymbolResult
 import io.github.amichne.kast.api.contract.result.TypeHierarchyResult
 import io.github.amichne.kast.api.contract.result.WorkspaceSymbolResult
+import io.github.amichne.kast.cli.results.DaemonStopResult
+import io.github.amichne.kast.cli.results.InstallResult
+import io.github.amichne.kast.cli.skill.InstallSkillResult
+import io.github.amichne.kast.cli.SmokeReport
+import io.github.amichne.kast.cli.results.WorkspaceEnsureResult
+import io.github.amichne.kast.cli.results.WorkspaceStatusResult
 import kotlinx.serialization.json.Json
 
 internal fun defaultCliJson(): Json = Json {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliMain.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliMain.kt
@@ -1,5 +1,6 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
 
+import io.github.amichne.kast.cli.KastCli
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliService.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
 
 import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
@@ -38,14 +38,32 @@ import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
 import io.github.amichne.kast.api.contract.result.WorkspaceSymbolResult
 import io.github.amichne.kast.api.client.KastConfig
 import io.github.amichne.kast.api.client.kastConfigHome
+import io.github.amichne.kast.cli.options.DaemonStartOptions
+import io.github.amichne.kast.cli.results.DaemonStopResult
+import io.github.amichne.kast.cli.options.InstallOptions
+import io.github.amichne.kast.cli.results.InstallResult
+import io.github.amichne.kast.cli.InstallService
+import io.github.amichne.kast.cli.options.InstallSkillOptions
+import io.github.amichne.kast.cli.skill.InstallSkillResult
+import io.github.amichne.kast.cli.InstallSkillService
+import io.github.amichne.kast.cli.KastRpcClient
+import io.github.amichne.kast.cli.RuntimeCandidateStatus
+import io.github.amichne.kast.cli.options.RuntimeCommandOptions
+import io.github.amichne.kast.cli.SmokeCommandSupport
+import io.github.amichne.kast.cli.options.SmokeOptions
+import io.github.amichne.kast.cli.SmokeReport
+import io.github.amichne.kast.cli.results.WorkspaceEnsureResult
+import io.github.amichne.kast.cli.WorkspaceRuntimeManager
+import io.github.amichne.kast.cli.results.WorkspaceStatusResult
 import kotlinx.serialization.json.Json
 import java.nio.file.Files
+import java.nio.file.Path
 
 internal class CliService(
     json: Json,
     private val installService: InstallService = InstallService(),
     private val installSkillService: InstallSkillService = InstallSkillService(),
-    private val configLoader: (java.nio.file.Path) -> KastConfig = KastConfig::load,
+    private val configLoader: (Path) -> KastConfig = KastConfig::load,
 ) {
     private val rpcClient = KastRpcClient(json)
     private val runtimeManager = WorkspaceRuntimeManager(rpcClient)
@@ -262,7 +280,7 @@ internal class CliService(
         val runtimeLibsDir = options.runtimeLibsDir
             ?: config.backends.standalone.runtimeLibsDir
                 ?.takeIf(String::isNotBlank)
-                ?.let { java.nio.file.Path.of(it).toAbsolutePath().normalize() }
+                ?.let { Path.of(it).toAbsolutePath().normalize() }
             ?: throw CliFailure(
                 code = "DAEMON_START_ERROR",
                 message = "Cannot locate backend runtime-libs. " +
@@ -270,7 +288,7 @@ internal class CliService(
             )
 
         val classpathFile = runtimeLibsDir.resolve("classpath.txt")
-        if (!java.nio.file.Files.isRegularFile(classpathFile)) {
+        if (!Files.isRegularFile(classpathFile)) {
             throw CliFailure(
                 code = "DAEMON_START_ERROR",
                 message = "Backend runtime-libs classpath not found at $classpathFile. " +

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliTextTheme.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliTextTheme.kt
@@ -1,4 +1,4 @@
-package io.github.amichne.kast.cli
+package io.github.amichne.kast.cli.tty
 
 import io.github.amichne.kast.api.contract.SymbolKind
 

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
@@ -670,6 +670,20 @@ class CliCommandParserTest {
     }
 
     @Test
+    fun `metrics graph parses interactive option`() {
+        val command = parser.parse(
+            arrayOf("metrics", "graph", "--workspace-root=$tempDir", "--symbol=com.example.Foo", "--depth=2", "--interactive=true"),
+        )
+
+        assertTrue(command is CliCommand.Metrics)
+        val metrics = command as CliCommand.Metrics
+        assertEquals(MetricsSubcommand.GRAPH, metrics.subcommand)
+        assertEquals("com.example.Foo", metrics.symbol)
+        assertEquals(2, metrics.depth)
+        assertTrue(metrics.interactive)
+    }
+
+    @Test
     fun `metrics impact fails without symbol`() {
         assertThrows<CliFailure> {
             parser.parse(

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
@@ -4,6 +4,12 @@ import io.github.amichne.kast.api.contract.query.RefreshQuery
 import io.github.amichne.kast.api.contract.SemanticInsertionTarget
 import io.github.amichne.kast.api.contract.SymbolKind
 import io.github.amichne.kast.api.contract.TypeHierarchyDirection
+import io.github.amichne.kast.cli.tty.CliCommand
+import io.github.amichne.kast.cli.tty.CliCommandParser
+import io.github.amichne.kast.cli.tty.CliCompletionShell
+import io.github.amichne.kast.cli.tty.CliFailure
+import io.github.amichne.kast.cli.tty.MetricsSubcommand
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliDaemonStatusNotesTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliDaemonStatusNotesTest.kt
@@ -3,6 +3,9 @@ package io.github.amichne.kast.cli
 import io.github.amichne.kast.api.contract.RuntimeState
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.client.ServerInstanceDescriptor
+import io.github.amichne.kast.cli.results.WorkspaceEnsureResult
+import io.github.amichne.kast.cli.results.WorkspaceStatusResult
+import io.github.amichne.kast.cli.tty.daemonNoteFor
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliJsonTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliJsonTest.kt
@@ -9,6 +9,10 @@ import io.github.amichne.kast.api.contract.result.TypeHierarchyNode
 import io.github.amichne.kast.api.contract.result.TypeHierarchyResult
 import io.github.amichne.kast.api.contract.result.TypeHierarchyStats
 import io.github.amichne.kast.api.contract.TextEdit
+import io.github.amichne.kast.cli.results.InstallResult
+import io.github.amichne.kast.cli.skill.InstallSkillResult
+import io.github.amichne.kast.cli.tty.defaultCliJson
+import io.github.amichne.kast.cli.tty.writeCliJson
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/InstallServiceTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/InstallServiceTest.kt
@@ -1,5 +1,12 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.cli.options.InstallOptions
+import io.github.amichne.kast.cli.results.InstallResult
+import io.github.amichne.kast.cli.tty.CliCommand
+import io.github.amichne.kast.cli.tty.CliCommandExecutor
+import io.github.amichne.kast.cli.tty.CliExecutionResult
+import io.github.amichne.kast.cli.tty.CliFailure
+import io.github.amichne.kast.cli.tty.CliOutput
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/InstallSkillServiceTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/InstallSkillServiceTest.kt
@@ -1,5 +1,7 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.cli.options.InstallSkillOptions
+import io.github.amichne.kast.cli.tty.CliFailure
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/KastCliTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/KastCliTest.kt
@@ -173,6 +173,30 @@ class KastCliTest {
         assertEquals("shell stderr\n", stderr.toString())
     }
 
+    @Test
+    fun `interactive graph falls back to shell rendering when stdout is redirected`() {
+        val stdout = StringBuilder()
+        val stderr = StringBuilder()
+        val graph = sampleMetricsGraph()
+        val cli = KastCli.testInstance(
+            commandExecutorFactory = { _ ->
+                object : CliCommandExecutor {
+                    override suspend fun execute(command: CliCommand): CliExecutionResult {
+                        return CliExecutionResult(
+                            output = CliOutput.InteractiveGraph(graph),
+                        )
+                    }
+                }
+            },
+        )
+
+        val exitCode = cli.run(arrayOf("--help"), stdout, stderr)
+
+        assertEquals(0, exitCode)
+        assertEquals(MetricsGraphShell.render(graph), stdout.toString())
+        assertEquals("", stderr.toString())
+    }
+
     private fun sampleCapabilities(): BackendCapabilities {
         return BackendCapabilities(
             backendName = "standalone",

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/KastCliTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/KastCliTest.kt
@@ -4,8 +4,16 @@ import io.github.amichne.kast.api.contract.BackendCapabilities
 import io.github.amichne.kast.api.contract.MutationCapability
 import io.github.amichne.kast.api.contract.ReadCapability
 import io.github.amichne.kast.api.contract.ServerLimits
+import io.github.amichne.kast.cli.tty.CliCommand
+import io.github.amichne.kast.cli.tty.CliCommandCatalog
+import io.github.amichne.kast.cli.tty.CliCommandExecutor
+import io.github.amichne.kast.cli.tty.CliErrorResponse
+import io.github.amichne.kast.cli.tty.CliExecutionResult
+import io.github.amichne.kast.cli.tty.CliExternalProcess
+import io.github.amichne.kast.cli.tty.CliOutput
+import io.github.amichne.kast.cli.tty.CliTextTheme
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/KastWrapperTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/KastWrapperTest.kt
@@ -11,6 +11,9 @@ import io.github.amichne.kast.api.contract.RuntimeState
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.client.ServerInstanceDescriptor
 import io.github.amichne.kast.api.contract.ServerLimits
+import io.github.amichne.kast.cli.results.WorkspaceEnsureResult
+import io.github.amichne.kast.cli.results.WorkspaceStatusResult
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/MetricsGraphNavigatorTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/MetricsGraphNavigatorTest.kt
@@ -1,0 +1,69 @@
+package io.github.amichne.kast.cli
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MetricsGraphNavigatorTest {
+    @Test
+    fun `reduce navigates parent child and siblings`() {
+        val navigator = MetricsGraphNavigator(sampleMetricsGraph())
+        val childCursor = MetricsGraphCursor(currentNodeId = "child-2")
+
+        assertEquals(
+            MetricsGraphCursor(currentNodeId = "root"),
+            navigator.reduce(childCursor, GraphAction.Parent),
+        )
+        assertEquals(
+            MetricsGraphCursor(currentNodeId = "leaf"),
+            navigator.reduce(MetricsGraphCursor(currentNodeId = "child-3"), GraphAction.FirstChild),
+        )
+        assertEquals(
+            MetricsGraphCursor(currentNodeId = "child-1"),
+            navigator.reduce(childCursor, GraphAction.PreviousSibling),
+        )
+        assertEquals(
+            MetricsGraphCursor(currentNodeId = "child-3"),
+            navigator.reduce(childCursor, GraphAction.NextSibling),
+        )
+    }
+
+    @Test
+    fun `reduce wraps siblings and keeps cursor on root and leaf boundaries`() {
+        val navigator = MetricsGraphNavigator(sampleMetricsGraph())
+
+        assertEquals(
+            MetricsGraphCursor(currentNodeId = "child-3"),
+            navigator.reduce(MetricsGraphCursor(currentNodeId = "child-1"), GraphAction.PreviousSibling),
+        )
+        assertEquals(
+            MetricsGraphCursor(currentNodeId = "child-1"),
+            navigator.reduce(MetricsGraphCursor(currentNodeId = "child-3"), GraphAction.NextSibling),
+        )
+        assertEquals(
+            MetricsGraphCursor(currentNodeId = "root"),
+            navigator.reduce(MetricsGraphCursor(currentNodeId = "root"), GraphAction.Parent),
+        )
+        assertEquals(
+            MetricsGraphCursor(currentNodeId = "leaf"),
+            navigator.reduce(MetricsGraphCursor(currentNodeId = "leaf"), GraphAction.FirstChild),
+        )
+    }
+
+    @Test
+    fun `reduce toggles attribute visibility without moving`() {
+        val navigator = MetricsGraphNavigator(sampleMetricsGraph())
+
+        assertEquals(
+            MetricsGraphCursor(currentNodeId = "child-2", showAttributes = false),
+            navigator.reduce(MetricsGraphCursor(currentNodeId = "child-2"), GraphAction.ToggleAttributes),
+        )
+        assertEquals(
+            MetricsGraphCursor(currentNodeId = "child-2", showAttributes = true),
+            navigator.reduce(
+                MetricsGraphCursor(currentNodeId = "child-2", showAttributes = false),
+                GraphAction.ToggleAttributes,
+            ),
+        )
+    }
+
+}

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/MetricsGraphTestFixtures.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/MetricsGraphTestFixtures.kt
@@ -1,0 +1,63 @@
+package io.github.amichne.kast.cli
+
+import io.github.amichne.kast.indexstore.MetricsGraph
+import io.github.amichne.kast.indexstore.MetricsGraphEdge
+import io.github.amichne.kast.indexstore.MetricsGraphEdgeType
+import io.github.amichne.kast.indexstore.MetricsGraphIndex
+import io.github.amichne.kast.indexstore.MetricsGraphNode
+import io.github.amichne.kast.indexstore.MetricsGraphNodeType
+
+internal fun sampleMetricsGraph(): MetricsGraph {
+    return MetricsGraph(
+        focalNodeId = "root",
+        nodes = listOf(
+            MetricsGraphNode(
+                id = "root",
+                name = "io.github.amichne.kast.Root",
+                type = MetricsGraphNodeType.SYMBOL,
+                children = listOf("child-1", "child-2", "child-3"),
+                attributes = listOf("root attr"),
+            ),
+            MetricsGraphNode(
+                id = "child-1",
+                name = "firstChild",
+                type = MetricsGraphNodeType.SYMBOL,
+                parentId = "root",
+                attributes = listOf("first attr"),
+            ),
+            MetricsGraphNode(
+                id = "child-2",
+                name = "secondChild",
+                type = MetricsGraphNodeType.SYMBOL,
+                parentId = "root",
+                attributes = listOf("second attr"),
+            ),
+            MetricsGraphNode(
+                id = "child-3",
+                name = "thirdChild",
+                type = MetricsGraphNodeType.SYMBOL,
+                parentId = "root",
+                children = listOf("leaf"),
+            ),
+            MetricsGraphNode(
+                id = "leaf",
+                name = "leaf",
+                type = MetricsGraphNodeType.FILE,
+                parentId = "child-3",
+            ),
+        ),
+        edges = listOf(
+            MetricsGraphEdge("root", "child-1", MetricsGraphEdgeType.CONTAINS),
+            MetricsGraphEdge("root", "child-2", MetricsGraphEdgeType.CONTAINS),
+            MetricsGraphEdge("root", "child-3", MetricsGraphEdgeType.CONTAINS),
+            MetricsGraphEdge("child-3", "leaf", MetricsGraphEdgeType.CONTAINS),
+            MetricsGraphEdge("root", "child-2", MetricsGraphEdgeType.REFERENCED_BY, weight = 2),
+        ),
+        index = MetricsGraphIndex(
+            symbolCount = 4,
+            fileCount = 1,
+            referenceCount = 2,
+            maxDepth = 2,
+        ),
+    )
+}

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/PackagedSkillJsonContractTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/PackagedSkillJsonContractTest.kt
@@ -1,5 +1,8 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.cli.options.InstallSkillOptions
+import io.github.amichne.kast.cli.results.WorkspaceStatusResult
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SmokeCommandSupportTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SmokeCommandSupportTest.kt
@@ -9,6 +9,9 @@ import io.github.amichne.kast.api.contract.RuntimeState
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.client.defaultDescriptorDirectory
+import io.github.amichne.kast.cli.options.SmokeOptions
+import io.github.amichne.kast.cli.tty.CliFailure
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -436,4 +439,3 @@ class SmokeCommandSupportTest {
         )
     }
 }
-

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManagerTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManagerTest.kt
@@ -9,6 +9,8 @@ import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.client.ServerInstanceDescriptor
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.client.defaultDescriptorDirectory
+import io.github.amichne.kast.cli.options.RuntimeCommandOptions
+import io.github.amichne.kast.cli.tty.CliFailure
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -357,7 +359,10 @@ class WorkspaceRuntimeManagerTest {
 
         override fun runtimeStatus(descriptor: ServerInstanceDescriptor): RuntimeStatusResponse {
             val queue = statusQueues[descriptor.socketPath]
-                ?: throw CliFailure(code = "DAEMON_UNREACHABLE", message = "No runtime status for ${descriptor.socketPath}")
+                ?: throw CliFailure(
+                    code = "DAEMON_UNREACHABLE",
+                    message = "No runtime status for ${descriptor.socketPath}"
+                )
             if (queue.size > 1) {
                 return queue.removeFirst()
             }
@@ -380,4 +385,3 @@ class WorkspaceRuntimeManagerTest {
     }
 
 }
-

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/EvalSkillCommandTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/EvalSkillCommandTest.kt
@@ -1,11 +1,11 @@
 package io.github.amichne.kast.cli.eval
 
-import io.github.amichne.kast.cli.CliFailure
-import io.github.amichne.kast.cli.CliOutput
-import io.github.amichne.kast.cli.EvalOutputFormat
+import io.github.amichne.kast.cli.tty.CliFailure
+import io.github.amichne.kast.cli.tty.CliOutput
+import io.github.amichne.kast.cli.tty.EvalOutputFormat
 import io.github.amichne.kast.cli.EvalSkillExecutor
-import io.github.amichne.kast.cli.EvalSkillOptions
-import io.github.amichne.kast.cli.defaultCliJson
+import io.github.amichne.kast.cli.tty.EvalSkillOptions
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/SkillEvalEngineTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/eval/SkillEvalEngineTest.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.cli.eval
 
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -266,7 +267,7 @@ class SkillEvalEngineTest {
     fun `EvalResult serializes with schemaVersion`() {
         val descriptor = descriptorWith(checks = listOf(passingCheck("c1")))
         val result = SkillEvalEngine.evaluate(descriptor)
-        val json = io.github.amichne.kast.cli.defaultCliJson()
+        val json = defaultCliJson()
         val encoded = json.encodeToString(EvalResult.serializer(), result)
         assertTrue(encoded.contains("schemaVersion"))
         assertTrue(encoded.contains("summary"))

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillCommandParsingTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillCommandParsingTest.kt
@@ -1,9 +1,9 @@
 package io.github.amichne.kast.cli.skill
 
-import io.github.amichne.kast.cli.CliCommand
-import io.github.amichne.kast.cli.CliCommandParser
-import io.github.amichne.kast.cli.CliFailure
-import io.github.amichne.kast.cli.defaultCliJson
+import io.github.amichne.kast.cli.tty.CliCommand
+import io.github.amichne.kast.cli.tty.CliCommandParser
+import io.github.amichne.kast.cli.tty.CliFailure
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperContractTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperContractTest.kt
@@ -26,7 +26,7 @@ import io.github.amichne.kast.api.contract.Location
 import io.github.amichne.kast.api.contract.Symbol
 import io.github.amichne.kast.api.contract.SymbolKind
 import io.github.amichne.kast.api.contract.result.WorkspaceModule
-import io.github.amichne.kast.cli.defaultCliJson
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperRequestCasingTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperRequestCasingTest.kt
@@ -14,9 +14,9 @@ import io.github.amichne.kast.api.wrapper.KastWriteAndValidateCreateFileRequest
 import io.github.amichne.kast.api.wrapper.KastWriteAndValidateInsertAtOffsetRequest
 import io.github.amichne.kast.api.wrapper.KastWriteAndValidateReplaceRangeRequest
 import io.github.amichne.kast.api.wrapper.KastWriteAndValidateRequest
-import io.github.amichne.kast.cli.CliCommandCatalog
-import io.github.amichne.kast.cli.CliCommandMetadata
-import io.github.amichne.kast.cli.defaultCliJson
+import io.github.amichne.kast.cli.tty.CliCommandCatalog
+import io.github.amichne.kast.cli.tty.CliCommandMetadata
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.descriptors.PolymorphicKind

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperSerializerTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperSerializerTest.kt
@@ -43,7 +43,7 @@ import io.github.amichne.kast.api.wrapper.KastWriteAndValidateFailureResponse
 import io.github.amichne.kast.api.wrapper.KastWriteAndValidateSuccessResponse
 import io.github.amichne.kast.api.wrapper.WrapperCallDirection
 import io.github.amichne.kast.api.wrapper.WrapperMetric
-import io.github.amichne.kast.cli.defaultCliJson
+import io.github.amichne.kast.cli.tty.defaultCliJson
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive

--- a/plan.md
+++ b/plan.md
@@ -1,182 +1,45 @@
-Repository: amichne/kast
 
-## Overview
-Restructure the published documentation rooted at `docs/index.md` to optimize for quick onboarding, seamless usage, and clear "user-not-contributor" separation. The changes span the nav structure in `zensical.toml`, content edits to existing pages, and two new pages.
+The important design move is that rendering should no longer be a transcript. It should be a **spatial dashboard**:
 
-## 1. Update nav structure in `zensical.toml`
+```text
+┌ Kast graph visualizer ───────────────────────────────────────────────┐
+│ 12,484 symbols  1,218 files  88,210 refs  depth 4                    │
+│ U parent  D/Enter child  ←/→ sibling  A members  Q quit              │
+└──────────────────────────────────────────────────────────────────────┘
 
-Change the `nav` array (lines 16–48) to this order:
-```toml
-nav = [
-  { "Overview" = "index.md" },
-  { "Getting started" = [
-    { "Install" = "getting-started/install.md" },
-    { "Quickstart" = "getting-started/quickstart.md" },
-  ]},
-  { "For agents" = [
-    { "Overview" = "for-agents/index.md" },
-    { "Talk to your agent" = "for-agents/talk-to-your-agent.md" },
-    { "Install the skill" = "for-agents/install-the-skill.md" },
-    { "Direct CLI usage" = "for-agents/direct-cli.md" },
-  ]},
-  { "Recipes" = "recipes.md" },
-  { "What can Kast do?" = [
-    { "Understand symbols" = "what-can-kast-do/understand-symbols.md" },
-    { "Trace usage" = "what-can-kast-do/trace-usage.md" },
-    { "Refactor safely" = "what-can-kast-do/refactor-safely.md" },
-    { "Validate code" = "what-can-kast-do/validate-code.md" },
-    { "Manage workspaces" = "what-can-kast-do/manage-workspaces.md" },
-  ]},
-  { "CLI cheat sheet" = "cli-cheat-sheet.md" },
-  { "Backends" = "getting-started/backends.md" },
-  { "Kast vs LSP" = "architecture/kast-vs-lsp.md" },
-  { "Reference" = [
-    { "API reference" = "reference/api-reference.md" },
-    { "API specification" = "reference/api-specification.md" },
-    { "Error codes" = "reference/error-codes.md" },
-  ]},
-  { "Troubleshooting" = "troubleshooting.md" },
-  { "Architecture" = [
-    { "How Kast works" = "architecture/how-it-works.md" },
-    { "Behavioral model" = "architecture/behavioral-model.md" },
-  ]},
-  { "Changelog" = "changelog.md" },
-]
+Path
+source file → focal class → selected member/reference
+
+Current
+▶ io.github.amichne.kast.cli.MetricsGraphTerminal
+  SYMBOL · parent MetricsGraphTerminal.kt · 4 children · 7 attrs
+
+Neighborhood
+        parent
+          │
+  prev ← current → next
+          │
+      first child
+
+Children
+  1. run(...)                         FUNCTION
+  2. render(...)                      FUNCTION
+  3. sibling(...)                     FUNCTION
+
+Relations
+  referenced by  KastCli.writeInteractiveGraph       weight 1
+  contains       TerminalRawMode                     weight 1
 ```
 
-Key changes: "For agents" promoted up, "Backends" moved to top-level, "Kast vs LSP" promoted to top-level, "Architecture" demoted to bottom, two new pages added (recipes.md, cli-cheat-sheet.md).
+For demo quality, the conversion should emphasize these details:
 
-## 2. Edit `docs/index.md`
+- Show **names as simple names first**, with FQNs/path detail secondary.
+- Show a **breadcrumb/path** every frame so the viewer knows where they are.
+- Show **parent/current/children/siblings** in fixed regions, not as a vertical dump.
+- Show edge labels as human language: `contains`, `references`, `referenced by`.
+- Keep the reducer pure and test it with tracer bullets before polishing the view.
+- Keep a non-interactive fallback via `MetricsGraphShell.render(graph)` for redirected stdout/tests.
 
-### 2a. Fix the 60-second snippet (lines 78–93)
-Replace `kast daemon start --workspace-root=/path/to/your/project` with `kast workspace ensure --backend-name=standalone --workspace-root=$(pwd)`. Replace `kast resolve --workspace-root=/path/to/your/project ...` with `kast resolve --workspace-root=$(pwd) ...`. Add a prerequisite line above the code block: "Run from the root of any Kotlin project. Requires Java 21+."
+If you choose Kotter instead, the reducer/view split stays the same, but the loop becomes `session { var cursor by liveVarOf(...); section { render(cursor) }.runUntilKeyPressed(Keys.Q) { onKeyPressed { cursor = reduce(...) } } }`. That is elegant, but I do not think it outweighs Mordant’s existing dependency and lower integration risk here.
 
-### 2b. Restructure "Next steps" grid (lines 99–134)
-Remove the "Dive into the architecture" card. Replace it with a "Common recipes" card linking to `recipes.md`. The four cards should be: Get started, See what kast can do, Use kast from an agent, Common recipes.
-
-### 2c. Shorten "Two independent runtime modes" section (lines 38–49)
-Replace the table with two sentences and a link: "kast runs as a standalone daemon or inside IntelliJ. Both expose the same JSON-RPC contract. Compare backends →"
-
-## 3. Edit `docs/getting-started/install.md`
-
-### 3a. Reorder: move "Choose your setup" table (lines 15–20) below the one-line install section
-The first thing after the intro should be the install command, not a decision table.
-
-### 3b. Wrap the wizard walkthrough (lines 52–69) in a collapsible admonition
-Use `??? info "What the wizard does"` so it doesn't dominate the page.
-
-### 3c. Remove "Starting the standalone backend" section (lines 138–155)
-This duplicates quickstart.md. The install page should end with "Verify the install" and link to quickstart.
-
-### 3d. Wrap the config file section (lines 114–136) in a collapsible
-Use `??? info "Where kast stores configuration"`.
-
-## 4. Edit `docs/getting-started/quickstart.md`
-
-### 4a. Replace placeholder paths with $(pwd)
-Change `--workspace-root=/absolute/path/to/workspace` to `--workspace-root=$(pwd)` in all commands. Add a callout: "Run these commands from the root of your Kotlin project."
-
-### 4b. Add an offset hint after the resolve command (around line 89)
-Add a tip: "Open any .kt file, find a function name, and count the byte offset from the start of the file. Or use `grep -bo 'functionName' file.kt` to find it."
-
-## 5. Edit `docs/for-agents/index.md`
-
-### 5a. Add a quick-start block after the intro paragraph (after line 14)
-Add a 3-command block: `kast install skill`, `kast workspace ensure --workspace-root=$(pwd)`, and a comment "Agent can now use kast".
-
-## 6. Edit `docs/for-agents/install-the-skill.md`
-
-### 6a. Wrap "What the skill contains" (lines 53–82) in a collapsible
-Use `??? info "What the skill directory contains"`.
-
-### 6b. Wrap "How agents locate the Kast binary" (lines 84–105) in a collapsible
-Use `??? info "How agents locate the kast binary"`.
-
-## 7. Create `docs/recipes.md` (NEW)
-
-Create a new page with task-oriented, copy-paste recipes. Each recipe should be a collapsible section (`??? example`) with:
-- A task-oriented title
-- 2–4 copy-pasteable commands using $(pwd)
-- A one-sentence explanation of the output
-- A link to the relevant deep-dive page
-
-Include these recipes:
-1. Find all usages of a function (resolve → references)
-2. See who calls a function (resolve → call-hierarchy --direction=INCOMING)
-3. Rename a symbol safely (rename → review → apply-edits)
-4. Check if code compiles (diagnostics)
-5. Find all implementations of an interface (implementations)
-6. Explore a file's structure (outline)
-7. Find a class by name (workspace-symbol)
-8. Clean up imports (optimize-imports → apply-edits)
-
-Use frontmatter: title "Recipes", description "Task-oriented copy-paste examples for common kast workflows", icon "lucide/book-open".
-
-## 8. Create `docs/cli-cheat-sheet.md` (NEW)
-
-Create a new page with scannable tables of every CLI command grouped by category. No JSON-RPC, no example responses — just command syntax and one-line descriptions.
-
-Categories:
-- Workspace lifecycle (ensure, status, stop, refresh)
-- Read operations (resolve, references, call-hierarchy, type-hierarchy, outline, workspace-symbol, workspace-files, implementations, diagnostics, code-actions, completions, capabilities, health, insertion-point)
-- Mutations (rename, apply-edits, optimize-imports)
-- Setup (install skill)
-
-Include the Tier 1 / Tier 2 distinction from architecture/how-it-works.md lines 201–228.
-
-Use frontmatter: title "CLI cheat sheet", description "Every kast command at a glance", icon "lucide/list".
-
-## 9. Edit `docs/getting-started/backends.md`
-
-### 9a. Fix line 128-130
-Replace "The CLI never starts a backend for you. You must run `kast daemon start` yourself..." with "The CLI does not implicitly start a backend when you run an analysis command like `resolve` or `references`. Use `workspace ensure` to explicitly start a backend before running queries."
-
-### 9b. Update "Next steps" (lines 148–151)
-Replace the link to how-it-works.md with links to quickstart and manage-workspaces.
-
-## 10. Edit `docs/what-can-kast-do/refactor-safely.md`
-
-### 10a. Add a "Verify the result" section after "Apply edits" (after line 204)
-Show `kast resolve` or `kast diagnostics` as a verification step after applying edits.
-
-### 10b. Replace the "Next steps" link to behavioral-model.md (line 249)
-Replace with a link to troubleshooting for the conflict error case.
-
-## 11. Edit `docs/what-can-kast-do/validate-code.md`
-
-### 11a. Add a CI gate callout after the diagnostics section
-Show a minimal 3-command CI script (ensure → diagnostics → stop).
-
-### 11b. Promote the "Refresh before diagnosing" tip (line 69) to a warning admonition
-Change from `!!! tip` to `!!! warning`.
-
-## 12. Edit `docs/what-can-kast-do/manage-workspaces.md`
-
-### 12a. Update "Next steps" (lines 169–172)
-Replace the link to how-it-works.md with a link to troubleshooting.
-
-## 13. Edit `docs/troubleshooting.md`
-
-### 13a. Remove the "Development and CI" section (lines 143–163)
-This is contributor-only content about drift tests and model regeneration.
-
-### 13b. Add a "Diagnostics return stale results" entry under "Analysis results"
-Symptom: diagnostics don't reflect recent file changes. Fix: run `kast workspace refresh`.
-
-## 14. Edit `docs/reference/api-specification.md`
-
-### 14a. Wrap "Regenerating the spec" (lines 64–72) in a collapsible
-Use `??? info "For contributors: regenerating the spec"`.
-
-## 15. Edit `docs/architecture/how-it-works.md`
-
-### 15a. Add a banner at the top (after frontmatter)
-Add: "This page explains how Kast works internally. You don't need to read it to use Kast. For usage documentation, start with the [Quickstart](../getting-started/quickstart.md)."
-
-### 15b. Wrap the module ownership table (lines 68–83) in a collapsible
-Use `??? info "Module ownership (for contributors)"`.
-
-## 16. Edit `docs/architecture/behavioral-model.md`
-
-### 16a. Add a banner at the top
-Add: "This page explains the rules behind Kast results. Read it when you need to understand why a result looks the way it does."
+One caveat: the file path in the current `/Users/amichne/.codex/worktrees/790c/kast` checkout does not exist; I inspected the existing file at `/Users/amichne/code/kast/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/MetricsGraphTerminal.kt`.


### PR DESCRIPTION
## Summary
- Add `MetricsGraph` models and `MetricsEngine.graph(...)` to turn reference-index metrics into a navigable focal-symbol graph.
- Add `kast metrics graph --workspace-root=... --symbol=... [--depth=...]` JSON output and `--interactive=true` shell mode with U/D/Enter/arrow/A/Q navigation.
- Cover graph construction, serialization, and CLI parsing with focused tests.

## Review & Testing Checklist for Human
- [ ] Run `kast metrics graph --workspace-root=<indexed workspace> --symbol=<fqName> --interactive=true` against a workspace with non-empty reference-index rows and verify navigation feels demo-ready.
- [ ] Check whether the graph parent heuristic for transitive impact edges matches the desired mental model before extending this beyond proof-of-concept usage.
- [ ] Confirm JSON payload shape is acceptable for future browser visualizer reuse.

### Notes
Local validation run:
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew :kast-cli:test :kast-cli:compileKotlin`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew :kast-cli:run --args='metrics graph --workspace-root=/home/ubuntu/repos/kast --symbol=io.github.amichne.kast.indexstore.MetricsEngine --depth=2 --interactive=true' --quiet`

I installed the latest released Kast CLI via `gh` for semantic tooling, per request. The live repo index in this VM currently produced an empty inbound graph for `MetricsEngine`; seeded tests exercise the non-empty evidentiary graph shape.
