### PR TITLE
Start IntelliJ project-open source indexing

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/KastConfig.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/KastConfig.kt
@@ -32,6 +32,10 @@ data class KastConfig(
                 phase2BatchSize = 50,
                 identifierIndexWaitMillis = 10_000L,
                 referenceBatchSize = 50,
+                remote = RemoteIndexConfig(
+                    enabled = false,
+                    sourceIndexUrl = null,
+                ),
             ),
             cache = CacheConfig(
                 enabled = true,
@@ -97,6 +101,12 @@ data class IndexingConfig(
     val phase2BatchSize: Int,
     val identifierIndexWaitMillis: Long,
     val referenceBatchSize: Int,
+    val remote: RemoteIndexConfig,
+)
+
+data class RemoteIndexConfig(
+    val enabled: Boolean,
+    val sourceIndexUrl: String?,
 )
 
 data class CacheConfig(
@@ -156,6 +166,12 @@ data class IndexingConfigOverride(
     val phase2BatchSize: Int? = null,
     val identifierIndexWaitMillis: Long? = null,
     val referenceBatchSize: Int? = null,
+    val remote: RemoteIndexConfigOverride? = null,
+)
+
+data class RemoteIndexConfigOverride(
+    val enabled: Boolean? = null,
+    val sourceIndexUrl: String? = null,
 )
 
 data class CacheConfigOverride(
@@ -215,6 +231,12 @@ private fun IndexingConfig.merge(override: IndexingConfigOverride?): IndexingCon
     phase2BatchSize = override?.phase2BatchSize ?: phase2BatchSize,
     identifierIndexWaitMillis = override?.identifierIndexWaitMillis ?: identifierIndexWaitMillis,
     referenceBatchSize = override?.referenceBatchSize ?: referenceBatchSize,
+    remote = remote.merge(override?.remote),
+)
+
+private fun RemoteIndexConfig.merge(override: RemoteIndexConfigOverride?): RemoteIndexConfig = copy(
+    enabled = override?.enabled ?: enabled,
+    sourceIndexUrl = override?.sourceIndexUrl ?: sourceIndexUrl,
 )
 
 private fun CacheConfig.merge(override: CacheConfigOverride?): CacheConfig = copy(

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastConfigTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastConfigTest.kt
@@ -94,6 +94,10 @@ class KastConfigTest {
 
                 [cache]
                 enabled = false
+
+                [indexing.remote]
+                enabled = true
+                source-index-url = "file:///tmp/kast/source-index.db"
                 """.trimIndent(),
             )
         }
@@ -108,6 +112,8 @@ class KastConfigTest {
         assertEquals(45_000L, config.server.requestTimeoutMillis)
         assertEquals(KastConfig.defaults().server.maxConcurrentRequests, config.server.maxConcurrentRequests)
         assertEquals(false, config.cache.enabled)
+        assertEquals(true, config.indexing.remote.enabled)
+        assertEquals("file:///tmp/kast/source-index.db", config.indexing.remote.sourceIndexUrl)
         assertEquals(true, config.telemetry.enabled)
         assertEquals("references,rename", config.telemetry.scopes)
         assertEquals(config.server.maxResults, config.toServerLimits().maxResults)

--- a/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/IntelliJProjectIndexer.kt
+++ b/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/IntelliJProjectIndexer.kt
@@ -1,0 +1,86 @@
+package io.github.amichne.kast.intellij
+
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiFile
+import io.github.amichne.kast.api.client.KastConfig
+import io.github.amichne.kast.indexstore.ReferenceIndexer
+import io.github.amichne.kast.indexstore.SqliteSourceIndexStore
+import io.github.amichne.kast.shared.analysis.PsiReferenceScanner
+import io.github.amichne.kast.shared.analysis.PsiSourceIndexScanner
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal class IntelliJProjectIndexer(
+    private val project: Project,
+    private val workspaceRoot: Path,
+    private val store: SqliteSourceIndexStore,
+    private val cancelled: () -> Boolean,
+) {
+    private val environment = IntelliJReferenceIndexEnvironment(
+        project = project,
+        workspaceRoot = workspaceRoot,
+        cancelled = cancelled,
+    )
+
+    fun indexProject(config: KastConfig) {
+        store.ensureSchema()
+        val currentFilePaths = indexSourceIdentifiers()
+        if (config.indexing.phase2Enabled && !environment.isCancelled()) {
+            indexReferences(currentFilePaths, config.indexing.referenceBatchSize)
+        }
+    }
+
+    fun indexSourceIdentifiers(): Collection<String> {
+        store.ensureSchema()
+        val scanner = PsiSourceIndexScanner(
+            environment = environment,
+            moduleNameForFile = ::moduleNameForFile,
+        )
+        val updates = environment.allFilePaths().mapNotNull(scanner::scanFile)
+        val manifest = updates.associate { update ->
+            update.path to lastModifiedMillis(update.path)
+        }
+        store.saveFullIndex(updates = updates, manifest = manifest)
+        return manifest.keys
+    }
+
+    private fun indexReferences(
+        currentFilePaths: Collection<String>,
+        referenceBatchSize: Int,
+    ) {
+        store.removeReferencesOutsideSources(currentFilePaths)
+        ReferenceIndexer(store, batchSize = referenceBatchSize).indexReferences(
+            filePaths = currentFilePaths,
+            referenceScanner = PsiReferenceScanner(environment)::scanFileReferences,
+            isCancelled = environment::isCancelled,
+        )
+    }
+
+    private fun moduleNameForFile(psiFile: PsiFile): String? {
+        val virtualFile = psiFile.virtualFile
+        val module = ModuleUtilCore.findModuleForFile(virtualFile, project) ?: return null
+        val sourceSet = sourceSetForFile(virtualFile.path)
+        return if (sourceSet == null) module.name else "${module.name}[$sourceSet]"
+    }
+
+    private fun sourceSetForFile(path: String): String? {
+        val normalizedPath = path.replace('\\', '/')
+        return when {
+            "/src/main/" in normalizedPath -> "main"
+            "/src/testFixtures/" in normalizedPath -> "testFixtures"
+            "/src/test/" in normalizedPath -> "test"
+            else -> {
+                val virtualFile = LocalFileSystem.getInstance().findFileByNioFile(Path.of(path)) ?: return null
+                ProjectFileIndex.getInstance(project).getSourceRootForFile(virtualFile)?.name
+            }
+        }
+    }
+
+    private fun lastModifiedMillis(filePath: String): Long {
+        val path = Path.of(filePath)
+        return if (Files.isRegularFile(path)) Files.getLastModifiedTime(path).toMillis() else 0L
+    }
+}

--- a/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastPluginService.kt
+++ b/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastPluginService.kt
@@ -10,12 +10,10 @@ import io.github.amichne.kast.api.client.KastConfig
 import io.github.amichne.kast.api.client.defaultSocketPath
 import io.github.amichne.kast.api.contract.AnalysisTransport
 import io.github.amichne.kast.api.contract.ServerLimits
-import io.github.amichne.kast.indexstore.ReferenceIndexer
 import io.github.amichne.kast.indexstore.SqliteSourceIndexStore
 import io.github.amichne.kast.server.AnalysisServer
 import io.github.amichne.kast.server.AnalysisServerConfig
 import io.github.amichne.kast.server.RunningAnalysisServer
-import io.github.amichne.kast.shared.analysis.PsiReferenceScanner
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
@@ -63,13 +61,13 @@ internal class KastPluginService(
 
         val server = AnalysisServer(backend, config)
         runningServer = server.start()
-        startReferenceIndexing(workspaceRoot)
+        startProjectIndexing(workspaceRoot, kastConfig)
 
         LOG.info("Kast intellij backend started on socket: $socketPath")
     }
 
     override fun dispose() {
-        cancelReferenceIndexing()
+        cancelProjectIndexing()
         runningServer?.let { server ->
             LOG.info("Shutting down kast intellij backend")
             runCatching { server.close() }
@@ -78,46 +76,47 @@ internal class KastPluginService(
         }
     }
 
-    private fun startReferenceIndexing(workspaceRoot: Path) {
+    private fun startProjectIndexing(
+        workspaceRoot: Path,
+        kastConfig: KastConfig,
+    ) {
         if (indexingThread != null) return
         indexingCancelled.set(false)
-        val store = SqliteSourceIndexStore(workspaceRoot)
-        indexStore = store
         DumbService.getInstance(project).runWhenSmart {
             if (indexingCancelled.get() || project.isDisposed) return@runWhenSmart
             indexingThread = thread(
                 start = true,
                 isDaemon = true,
-                name = "kast-intellij-reference-indexer",
+                name = "kast-intellij-project-indexer",
             ) {
-                val environment = IntelliJReferenceIndexEnvironment(
-                    project = project,
-                    workspaceRoot = workspaceRoot,
-                    cancelled = { indexingCancelled.get() || Thread.currentThread().isInterrupted || project.isDisposed },
-                )
                 runCatching {
-                    store.ensureSchema()
-                    val currentFilePaths = environment.allFilePaths()
-                    store.removeReferencesOutsideSources(currentFilePaths)
-                    ReferenceIndexer(store).indexReferences(
-                        filePaths = currentFilePaths,
-                        referenceScanner = PsiReferenceScanner(environment)::scanFileReferences,
-                        isCancelled = environment::isCancelled,
-                    )
+                    runCatching {
+                        SourceIndexHydrator().hydrate(workspaceRoot, kastConfig.indexing.remote)
+                    }.onFailure { error ->
+                        LOG.warn("Kast IntelliJ remote source index hydration failed", error)
+                    }
+                    val store = SqliteSourceIndexStore(workspaceRoot)
+                    indexStore = store
+                    IntelliJProjectIndexer(
+                        project = project,
+                        workspaceRoot = workspaceRoot,
+                        store = store,
+                        cancelled = { indexingCancelled.get() || Thread.currentThread().isInterrupted || project.isDisposed },
+                    ).indexProject(kastConfig)
                 }.onSuccess {
                     if (!indexingCancelled.get()) {
-                        LOG.info("Kast IntelliJ reference index completed")
+                        LOG.info("Kast IntelliJ project index completed")
                     }
                 }.onFailure { error ->
                     if (!indexingCancelled.get()) {
-                        LOG.warn("Kast IntelliJ reference index failed", error)
+                        LOG.warn("Kast IntelliJ project index failed", error)
                     }
                 }
             }
         }
     }
 
-    private fun cancelReferenceIndexing() {
+    private fun cancelProjectIndexing() {
         indexingCancelled.set(true)
         indexingThread?.interrupt()
         if (!ApplicationManager.getApplication().isDispatchThread) {
@@ -126,7 +125,7 @@ internal class KastPluginService(
         indexingThread = null
         indexStore?.let { store ->
             runCatching { store.close() }
-                .onFailure { LOG.warn("Error closing kast reference index store", it) }
+                .onFailure { LOG.warn("Error closing kast project index store", it) }
         }
         indexStore = null
     }

--- a/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastProjectOpenAutoIndexing.kt
+++ b/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastProjectOpenAutoIndexing.kt
@@ -1,0 +1,32 @@
+package io.github.amichne.kast.intellij
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import io.github.amichne.kast.api.client.KastConfig
+import java.nio.file.Path
+
+internal object KastProjectOpenAutoIndexing {
+    fun execute(
+        project: Project,
+        loadConfig: (Path) -> KastConfig = KastConfig::load,
+        startBackendAndIndexReferences: (Project) -> Unit,
+    ): Boolean {
+        val workspaceRoot = project.basePath?.let { Path.of(it).toAbsolutePath().normalize() }
+        if (workspaceRoot == null) {
+            LOG.info("Kast intellij backend skipped because project has no base path")
+            return false
+        }
+
+        val config = loadConfig(workspaceRoot)
+        if (!config.backends.intellij.enabled) {
+            LOG.info("Kast intellij backend disabled by config")
+            return false
+        }
+
+        LOG.info("Kast startup activity triggered for project: ${project.name}")
+        startBackendAndIndexReferences(project)
+        return true
+    }
+
+    private val LOG = Logger.getInstance(KastProjectOpenAutoIndexing::class.java)
+}

--- a/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastStartupActivity.kt
+++ b/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastStartupActivity.kt
@@ -1,24 +1,13 @@
 package io.github.amichne.kast.intellij
 
 import com.intellij.openapi.components.service
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
-import io.github.amichne.kast.api.client.KastConfig
-import java.nio.file.Path
 
 internal class KastStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
-        val workspaceRoot = project.basePath?.let { Path.of(it).toAbsolutePath().normalize() }
-        if (workspaceRoot != null && !KastConfig.load(workspaceRoot).backends.intellij.enabled) {
-            LOG.info("Kast intellij backend disabled by config")
-            return
+        KastProjectOpenAutoIndexing.execute(project) { startupProject ->
+            startupProject.service<KastPluginService>().startServer()
         }
-        LOG.info("Kast startup activity triggered for project: ${project.name}")
-        project.service<KastPluginService>().startServer()
-    }
-
-    companion object {
-        private val LOG = Logger.getInstance(KastStartupActivity::class.java)
     }
 }

--- a/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/SourceIndexHydrator.kt
+++ b/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/SourceIndexHydrator.kt
@@ -1,0 +1,46 @@
+package io.github.amichne.kast.intellij
+
+import io.github.amichne.kast.api.client.RemoteIndexConfig
+import io.github.amichne.kast.indexstore.sourceIndexDatabasePath
+import java.net.URI
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+internal class SourceIndexHydrator(
+    private val openRemote: (URI) -> java.io.InputStream = { uri ->
+        when (uri.scheme?.lowercase()) {
+            null, "", "file" -> Files.newInputStream(Path.of(uri))
+            "http", "https" -> uri.toURL().openStream()
+            else -> error("Unsupported remote source index URI scheme: ${uri.scheme}")
+        }
+    },
+) {
+    fun hydrate(
+        workspaceRoot: Path,
+        remote: RemoteIndexConfig,
+    ): Boolean {
+        val remoteUrl = remote.sourceIndexUrl?.takeIf(String::isNotBlank) ?: return false
+        if (!remote.enabled) return false
+
+        val target = sourceIndexDatabasePath(workspaceRoot)
+        if (Files.isRegularFile(target)) return false
+
+        Files.createDirectories(target.parent)
+        val temp = Files.createTempFile(target.parent, "${target.fileName}.hydrate-", ".tmp")
+        try {
+            openRemote(URI(remoteUrl)).use { input ->
+                Files.copy(input, temp, StandardCopyOption.REPLACE_EXISTING)
+            }
+            try {
+                Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING)
+            }
+            return true
+        } finally {
+            Files.deleteIfExists(temp)
+        }
+    }
+}

--- a/backend-intellij/src/test/kotlin/io/github/amichne/kast/intellij/KastProjectOpenAutoIndexingTest.kt
+++ b/backend-intellij/src/test/kotlin/io/github/amichne/kast/intellij/KastProjectOpenAutoIndexingTest.kt
@@ -1,0 +1,173 @@
+package io.github.amichne.kast.intellij
+
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.IndexingTestUtil
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.fixture.TestFixture
+import com.intellij.testFramework.junit5.fixture.moduleFixture
+import com.intellij.testFramework.junit5.fixture.projectFixture
+import com.intellij.testFramework.junit5.fixture.psiFileFixture
+import com.intellij.testFramework.junit5.fixture.sourceRootFixture
+import io.github.amichne.kast.api.client.KastConfig
+import io.github.amichne.kast.api.client.RemoteIndexConfig
+import io.github.amichne.kast.indexstore.FileIndexUpdate
+import io.github.amichne.kast.indexstore.SqliteSourceIndexStore
+import io.github.amichne.kast.indexstore.sourceIndexDatabasePath
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+@TestApplication
+class KastProjectOpenAutoIndexingTest {
+    companion object {
+        private val projectFixture: TestFixture<Project> = projectFixture()
+
+        private const val targetSource = """
+            package demo
+
+            fun target(): String = "ok"
+        """
+
+        private const val callerSource = """
+            package demo
+
+            import demo.target
+
+            fun caller(): String = target()
+        """
+    }
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private val moduleFixture = projectFixture.moduleFixture("main")
+    private val sourceRootFixture = moduleFixture.sourceRootFixture()
+    private val targetFileFixture = sourceRootFixture.psiFileFixture("Target.kt", targetSource)
+    private val callerFileFixture = sourceRootFixture.psiFileFixture("Caller.kt", callerSource)
+
+    @Test
+    fun `project open starts backend and reference indexing when intellij backend is enabled`() {
+        val project = projectFixture.get()
+        var loadedWorkspaceRoot: Path? = null
+        var startedProject: Project? = null
+
+        val started = KastProjectOpenAutoIndexing.execute(
+            project = project,
+            loadConfig = { workspaceRoot ->
+                loadedWorkspaceRoot = workspaceRoot
+                KastConfig.defaults()
+            },
+            startBackendAndIndexReferences = { startedProject = it },
+        )
+
+        assertTrue(started)
+        assertSame(project, startedProject)
+        assertNotNull(loadedWorkspaceRoot)
+        assertEquals(loadedWorkspaceRoot, loadedWorkspaceRoot?.toAbsolutePath()?.normalize())
+    }
+
+    @Test
+    fun `project open skips backend and reference indexing when intellij backend is disabled`() {
+        val project = projectFixture.get()
+        var started = false
+        val disabledConfig = KastConfig.defaults().let { config ->
+            config.copy(
+                backends = config.backends.copy(
+                    intellij = config.backends.intellij.copy(enabled = false),
+                ),
+            )
+        }
+
+        val requestedStart = KastProjectOpenAutoIndexing.execute(
+            project = project,
+            loadConfig = { disabledConfig },
+            startBackendAndIndexReferences = { started = true },
+        )
+
+        assertFalse(requestedStart)
+        assertFalse(started)
+    }
+
+    @Test
+    fun `project indexer prepopulates SQLite source identifiers and references from IntelliJ PSI files`() {
+        val project = projectFixture.get()
+        val targetFile = targetFileFixture.get()
+        val callerFile = callerFileFixture.get()
+        IndexingTestUtil.waitUntilIndexesAreReady(project)
+        val workspaceRoot = Path.of(callerFile.virtualFile.path).parent.toAbsolutePath().normalize()
+        val callerPath = Path.of(callerFile.virtualFile.path).toAbsolutePath().normalize().toString()
+        val targetPath = Path.of(targetFile.virtualFile.path).toAbsolutePath().normalize().toString()
+
+        SqliteSourceIndexStore(workspaceRoot).use { store ->
+            IntelliJProjectIndexer(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                store = store,
+                cancelled = { false },
+            ).indexProject(KastConfig.defaults())
+
+            val snapshot = store.loadSourceIndexSnapshot()
+            assertEquals(listOf(callerPath), snapshot.candidatePathsByIdentifier.getValue("caller"))
+            assertTrue(snapshot.candidatePathsByIdentifier.getValue("target").contains(targetPath))
+            assertEquals("demo", snapshot.packageByPath.getValue(callerPath))
+            assertEquals(listOf("demo.target"), snapshot.importsByPath.getValue(callerPath))
+            assertTrue(store.loadManifest().orEmpty().keys.containsAll(setOf(callerPath, targetPath)))
+            assertTrue(store.referencesToSymbol("demo.target").any { row -> row.sourcePath == callerPath })
+        }
+    }
+
+    @Test
+    fun `remote source index hydration copies configured snapshot before local indexing opens the store`() {
+        val remoteWorkspaceRoot = tempDir.resolve("remote-workspace")
+        val localWorkspaceRoot = tempDir.resolve("local-workspace")
+        val remoteFile = remoteWorkspaceRoot.resolve("src/Remote.kt").toAbsolutePath().normalize().toString()
+        val remoteDbPath = sourceIndexDatabasePath(remoteWorkspaceRoot)
+        SqliteSourceIndexStore(remoteWorkspaceRoot).use { store ->
+            store.ensureSchema()
+            store.saveFullIndex(
+                updates = listOf(
+                    FileIndexUpdate(
+                        path = remoteFile,
+                        identifiers = setOf("RemoteIndexed"),
+                        packageName = "remote",
+                        modulePath = ":remote",
+                        sourceSet = "main",
+                        imports = emptySet(),
+                        wildcardImports = emptySet(),
+                    ),
+                ),
+                manifest = mapOf(remoteFile to 1L),
+            )
+        }
+        checkpointSqliteDatabase(remoteDbPath)
+
+        val hydrated = SourceIndexHydrator().hydrate(
+            workspaceRoot = localWorkspaceRoot,
+            remote = RemoteIndexConfig(
+                enabled = true,
+                sourceIndexUrl = remoteDbPath.toUri().toString(),
+            ),
+        )
+
+        assertTrue(hydrated)
+        SqliteSourceIndexStore(localWorkspaceRoot).use { store ->
+            val snapshot = store.loadSourceIndexSnapshot()
+            val hydratedFile = localWorkspaceRoot.resolve("src/Remote.kt").toAbsolutePath().normalize().toString()
+            assertEquals(listOf(hydratedFile), snapshot.candidatePathsByIdentifier.getValue("RemoteIndexed"))
+        }
+    }
+
+    private fun checkpointSqliteDatabase(dbPath: Path) {
+        java.sql.DriverManager.getConnection("jdbc:sqlite:$dbPath").use { connection ->
+            connection.createStatement().use { statement -> statement.execute("PRAGMA wal_checkpoint(FULL)") }
+        }
+        Files.deleteIfExists(Path.of("$dbPath-wal"))
+        Files.deleteIfExists(Path.of("$dbPath-shm"))
+    }
+}

--- a/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiSourceIndexScanner.kt
+++ b/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiSourceIndexScanner.kt
@@ -1,0 +1,23 @@
+package io.github.amichne.kast.shared.analysis
+
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.psi.PsiFile
+import io.github.amichne.kast.indexstore.FileIndexUpdate
+import io.github.amichne.kast.indexstore.parseSourceFileIndex
+
+class PsiSourceIndexScanner(
+    private val environment: ReferenceIndexEnvironment,
+    private val moduleNameForFile: (PsiFile) -> String? = { null },
+) {
+    fun scanFile(filePath: String): FileIndexUpdate? = environment.withReadAccess {
+        if (environment.isCancelled()) return@withReadAccess null
+        ProgressManager.checkCanceled()
+        val psiFile = environment.findPsiFile(filePath) ?: return@withReadAccess null
+        val sourcePath = runCatching { psiFile.resolvedFilePath().value }.getOrElse { filePath }
+        parseSourceFileIndex(
+            path = sourcePath,
+            content = psiFile.text,
+            moduleName = moduleNameForFile(psiFile),
+        )
+    }
+}

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/MutableSourceIdentifierIndex.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/MutableSourceIdentifierIndex.kt
@@ -8,7 +8,7 @@ import io.github.amichne.kast.api.contract.PackageName
 import io.github.amichne.kast.indexstore.FileIndexUpdate
 import io.github.amichne.kast.indexstore.SourceIndexSnapshot
 import io.github.amichne.kast.indexstore.SourceIndexWriter
-import io.github.amichne.kast.indexstore.splitModuleName
+import io.github.amichne.kast.indexstore.parseSourceFileIndex
 import java.util.concurrent.ConcurrentHashMap
 
 internal class MutableSourceIdentifierIndex(
@@ -99,23 +99,19 @@ internal class MutableSourceIdentifierIndex(
         moduleName: ModuleName? = null,
     ) {
         val path = NormalizedPath.ofNormalized(normalizedPath)
-        val identifiers = identifierRegex.findAll(newContent).map { match -> KotlinIdentifier(match.value) }.toSet()
+        val fileIndex = parseSourceFileIndex(
+            path = normalizedPath,
+            content = newContent,
+            moduleName = moduleName?.value,
+        )
+        val identifiers = fileIndex.identifiers.mapTo(mutableSetOf()) { KotlinIdentifier(it) }
         replaceIdentifiers(normalizedPath = path, identifiers = identifiers)
-        extractFileMetadata(path, newContent, moduleName)
+        replaceFileMetadata(path, fileIndex, moduleName)
 
         backingStore?.let { store ->
             runCatching {
-                val (modPath, srcSet) = splitModuleName(moduleName?.value)
                 store.saveFileIndex(
-                    FileIndexUpdate(
-                        path = normalizedPath,
-                        identifiers = identifiers.mapTo(mutableSetOf()) { it.value },
-                        packageName = packageByPath[path]?.value,
-                        modulePath = modPath,
-                        sourceSet = srcSet,
-                        imports = importsByPath[path]?.mapTo(mutableSetOf()) { it.value }.orEmpty(),
-                        wildcardImports = wildcardImportPackagesByPath[path]?.mapTo(mutableSetOf()) { it.value }.orEmpty(),
-                    ),
+                    fileIndex,
                 )
             }
         }
@@ -150,12 +146,20 @@ internal class MutableSourceIdentifierIndex(
         content: String,
         moduleName: ModuleName? = null,
     ) {
-        extractFileMetadata(NormalizedPath.ofNormalized(normalizedPath), content, moduleName)
+        replaceFileMetadata(
+            normalizedPath = NormalizedPath.ofNormalized(normalizedPath),
+            fileIndex = parseSourceFileIndex(
+                path = normalizedPath,
+                content = content,
+                moduleName = moduleName?.value,
+            ),
+            moduleName = moduleName,
+        )
     }
 
-    private fun extractFileMetadata(
+    private fun replaceFileMetadata(
         normalizedPath: NormalizedPath,
-        content: String,
+        fileIndex: FileIndexUpdate,
         moduleName: ModuleName?,
     ) {
         if (moduleName != null) {
@@ -163,20 +167,12 @@ internal class MutableSourceIdentifierIndex(
         } else {
             moduleNameByPath.remove(normalizedPath)
         }
-        packageRegex.find(content)?.groupValues?.getOrNull(1)
+        fileIndex.packageName
             ?.let { packageByPath[normalizedPath] = PackageName(it) }
         ?: packageByPath.remove(normalizedPath)
 
-        val imports = mutableSetOf<FqName>()
-        val wildcardPackages = mutableSetOf<PackageName>()
-        importRegex.findAll(content).forEach { match ->
-            val fqn = match.groupValues[1]
-            if (match.groupValues[2] == ".*") {
-                wildcardPackages += PackageName(fqn)
-            } else {
-                imports += FqName(fqn)
-            }
-        }
+        val imports = fileIndex.imports.mapTo(mutableSetOf()) { FqName(it) }
+        val wildcardPackages = fileIndex.wildcardImports.mapTo(mutableSetOf()) { PackageName(it) }
 
         if (imports.isNotEmpty()) importsByPath[normalizedPath] = imports
         else importsByPath.remove(normalizedPath)
@@ -222,9 +218,6 @@ internal class MutableSourceIdentifierIndex(
     }
 
     companion object {
-        private val packageRegex = Regex("""^package\s+([\w]+(?:\.[\w]+)*)""", RegexOption.MULTILINE)
-        private val importRegex = Regex("""^import\s+([\w]+(?:\.[\w]+)*)(\.\*)?""", RegexOption.MULTILINE)
-
         /**
          * Computes intermediate FQ name prefixes between [targetPackage] (exclusive)
          * and [targetFqName] (exclusive). For example, given

--- a/docs/getting-started/backends.md
+++ b/docs/getting-started/backends.md
@@ -80,12 +80,25 @@ How a session unfolds:
 
 1. You open the project in IntelliJ.
 2. The plugin starts a `kast` server on a Unix domain socket.
-3. It drops a descriptor file so other tools can find the socket.
-4. External tools connect and speak the same JSON-RPC.
+3. It hydrates a configured remote source index when one is available.
+4. It prepopulates the local SQLite source index from IntelliJ PSI files.
+5. It indexes resolved references while the IDE is in smart mode.
+6. It drops a descriptor file so other tools can find the socket.
+7. External tools connect and speak the same JSON-RPC.
 
 !!! tip
     Set `backends.intellij.enabled = false` in `config.toml` to disable
     the plugin without uninstalling it.
+
+To hydrate a remote SQLite source index before local indexing starts, add an
+`indexing.remote` block. `sourceIndexUrl` accepts `file://`, `http://`, and
+`https://` URLs that point to a `source-index.db` snapshot:
+
+```toml
+[indexing.remote]
+enabled = true
+sourceIndexUrl = "file:///absolute/path/to/source-index.db"
+```
 
 ## Capability surface
 

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/SourceFileIndexParser.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/SourceFileIndexParser.kt
@@ -1,0 +1,36 @@
+package io.github.amichne.kast.indexstore
+
+private val sourceIdentifierRegex = Regex("""\b[A-Za-z_][A-Za-z0-9_]*\b""")
+private val packageRegex = Regex("""^\s*package\s+([\w]+(?:\.[\w]+)*)""", RegexOption.MULTILINE)
+private val importRegex = Regex("""^\s*import\s+([\w]+(?:\.[\w]+)*)(\.\*)?""", RegexOption.MULTILINE)
+
+/**
+ * Parses the lightweight per-file data persisted in the source identifier index.
+ */
+fun parseSourceFileIndex(
+    path: String,
+    content: String,
+    moduleName: String? = null,
+): FileIndexUpdate {
+    val (modulePath, sourceSet) = splitModuleName(moduleName)
+    val imports = linkedSetOf<String>()
+    val wildcardImports = linkedSetOf<String>()
+    importRegex.findAll(content).forEach { match ->
+        val fqName = match.groupValues[1]
+        if (match.groupValues[2] == ".*") {
+            wildcardImports += fqName
+        } else {
+            imports += fqName
+        }
+    }
+
+    return FileIndexUpdate(
+        path = path,
+        identifiers = sourceIdentifierRegex.findAll(content).mapTo(linkedSetOf()) { match -> match.value },
+        packageName = packageRegex.find(content)?.groupValues?.getOrNull(1),
+        modulePath = modulePath,
+        sourceSet = sourceSet,
+        imports = imports,
+        wildcardImports = wildcardImports,
+    )
+}

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliService.kt
@@ -414,6 +414,10 @@ private fun defaultConfigTemplate(): String = """
     # phase2BatchSize = 50
     # identifierIndexWaitMillis = 10000
     # referenceBatchSize = 50
+    #
+    # [indexing.remote]
+    # enabled = false
+    # sourceIndexUrl = "file:///absolute/path/to/source-index.db"
 
     # [cache]
     # enabled = true


### PR DESCRIPTION
## Summary
- start IntelliJ project-open indexing through a coordinator that respects backend config
- hydrate a configured remote source-index DB before local indexing
- prepopulate SQLite source identifiers from IntelliJ PSI files and keep the existing resolved reference pass
- document the new remote index config and add it to the generated config template

## Validation
- :analysis-api:test --tests io.github.amichne.kast.api.client.KastConfigTest --offline
- :backend-intellij:test --tests io.github.amichne.kast.intellij.KastProjectOpenAutoIndexingTest --offline
- :backend-standalone:test --tests io.github.amichne.kast.standalone.SourceIndexCacheTest --offline
- :index-store:test :backend-shared:compileKotlin :backend-intellij:compileKotlin :backend-intellij:compileTestKotlin :analysis-api:compileKotlin :backend-standalone:compileKotlin --offline
- :analysis-server:test --offline
- :kast-cli:test --offline
- :backend-intellij:test --offline
- kast skill diagnostics on touched Kotlin files