### PR TITLE
Adding foundational type approach refactor

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/AnalysisBackend.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/AnalysisBackend.kt
@@ -1,20 +1,5 @@
 package io.github.amichne.kast.api.contract
 
-import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
-import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
-import io.github.amichne.kast.api.contract.query.CodeActionsQuery
-import io.github.amichne.kast.api.contract.query.CompletionsQuery
-import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
-import io.github.amichne.kast.api.contract.query.FileOutlineQuery
-import io.github.amichne.kast.api.contract.query.ImplementationsQuery
-import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
-import io.github.amichne.kast.api.contract.query.ReferencesQuery
-import io.github.amichne.kast.api.contract.query.RefreshQuery
-import io.github.amichne.kast.api.contract.query.RenameQuery
-import io.github.amichne.kast.api.contract.query.SymbolQuery
-import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
-import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
-import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
 import io.github.amichne.kast.api.contract.result.CallHierarchyResult
 import io.github.amichne.kast.api.contract.result.CodeActionsResult
@@ -31,6 +16,7 @@ import io.github.amichne.kast.api.contract.result.TypeHierarchyResult
 import io.github.amichne.kast.api.contract.result.WorkspaceFilesResult
 import io.github.amichne.kast.api.contract.result.WorkspaceSymbolResult
 import io.github.amichne.kast.api.protocol.*
+import io.github.amichne.kast.api.validation.*
 
 interface AnalysisBackend {
     suspend fun capabilities(): BackendCapabilities
@@ -57,87 +43,87 @@ interface AnalysisBackend {
         )
     }
 
-    suspend fun resolveSymbol(query: SymbolQuery): SymbolResult
+    suspend fun resolveSymbol(query: ParsedSymbolQuery): SymbolResult
 
-    suspend fun findReferences(query: ReferencesQuery): ReferencesResult
+    suspend fun findReferences(query: ParsedReferencesQuery): ReferencesResult
 
-    suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult {
+    suspend fun callHierarchy(query: ParsedCallHierarchyQuery): CallHierarchyResult {
         throw CapabilityNotSupportedException(
             capability = "CALL_HIERARCHY",
             message = "Call hierarchy is not available for this backend",
         )
     }
 
-    suspend fun typeHierarchy(query: TypeHierarchyQuery): TypeHierarchyResult {
+    suspend fun typeHierarchy(query: ParsedTypeHierarchyQuery): TypeHierarchyResult {
         throw CapabilityNotSupportedException(
             capability = "TYPE_HIERARCHY",
             message = "Type hierarchy is not available for this backend",
         )
     }
 
-    suspend fun semanticInsertionPoint(query: SemanticInsertionQuery): SemanticInsertionResult {
+    suspend fun semanticInsertionPoint(query: ParsedSemanticInsertionQuery): SemanticInsertionResult {
         throw CapabilityNotSupportedException(
             capability = "SEMANTIC_INSERTION_POINT",
             message = "Semantic insertion point lookup is not available for this backend",
         )
     }
 
-    suspend fun diagnostics(query: DiagnosticsQuery): DiagnosticsResult
+    suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult
 
-    suspend fun rename(query: RenameQuery): RenameResult
+    suspend fun rename(query: ParsedRenameQuery): RenameResult
 
-    suspend fun applyEdits(query: ApplyEditsQuery): ApplyEditsResult
+    suspend fun applyEdits(query: ParsedApplyEditsQuery): ApplyEditsResult
 
-    suspend fun optimizeImports(query: ImportOptimizeQuery): ImportOptimizeResult {
+    suspend fun optimizeImports(query: ParsedImportOptimizeQuery): ImportOptimizeResult {
         throw CapabilityNotSupportedException(
             capability = "OPTIMIZE_IMPORTS",
             message = "Import optimization is not available for this backend",
         )
     }
 
-    suspend fun refresh(query: RefreshQuery): RefreshResult {
+    suspend fun refresh(query: ParsedRefreshQuery): RefreshResult {
         throw CapabilityNotSupportedException(
             capability = "REFRESH_WORKSPACE",
             message = "Workspace refresh is not available for this backend",
         )
     }
 
-    suspend fun fileOutline(query: FileOutlineQuery): FileOutlineResult {
+    suspend fun fileOutline(query: ParsedFileOutlineQuery): FileOutlineResult {
         throw CapabilityNotSupportedException(
             capability = "FILE_OUTLINE",
             message = "File outline is not available for this backend",
         )
     }
 
-    suspend fun workspaceSymbolSearch(query: WorkspaceSymbolQuery): WorkspaceSymbolResult {
+    suspend fun workspaceSymbolSearch(query: ParsedWorkspaceSymbolQuery): WorkspaceSymbolResult {
         throw CapabilityNotSupportedException(
             capability = "WORKSPACE_SYMBOL_SEARCH",
             message = "Workspace symbol search is not available for this backend",
         )
     }
 
-    suspend fun workspaceFiles(query: WorkspaceFilesQuery): WorkspaceFilesResult {
+    suspend fun workspaceFiles(query: ParsedWorkspaceFilesQuery): WorkspaceFilesResult {
         throw CapabilityNotSupportedException(
             capability = "WORKSPACE_FILES",
             message = "Workspace file listing is not available for this backend",
         )
     }
 
-    suspend fun implementations(query: ImplementationsQuery): ImplementationsResult {
+    suspend fun implementations(query: ParsedImplementationsQuery): ImplementationsResult {
         throw CapabilityNotSupportedException(
             capability = "IMPLEMENTATIONS",
             message = "Go to implementation is not available for this backend",
         )
     }
 
-    suspend fun codeActions(query: CodeActionsQuery): CodeActionsResult {
+    suspend fun codeActions(query: ParsedCodeActionsQuery): CodeActionsResult {
         throw CapabilityNotSupportedException(
             capability = "CODE_ACTIONS",
             message = "Code actions are not available for this backend",
         )
     }
 
-    suspend fun completions(query: CompletionsQuery): CompletionsResult {
+    suspend fun completions(query: ParsedCompletionsQuery): CompletionsResult {
         throw CapabilityNotSupportedException(
             capability = "COMPLETIONS",
             message = "Completions are not available for this backend",

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/CoreTypes.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/CoreTypes.kt
@@ -174,6 +174,66 @@ value class ColumnNumber(val value: Int) {
 }
 
 /**
+ * An integer that must be at least one.
+ */
+@JvmInline
+value class PositiveInt(val value: Int) {
+    init {
+        require(value >= 1) { "PositiveInt must be >= 1, was $value" }
+    }
+
+    override fun toString(): String = value.toString()
+}
+
+/**
+ * An integer that may be zero but not negative.
+ */
+@JvmInline
+value class NonNegativeInt(val value: Int) {
+    init {
+        require(value >= 0) { "NonNegativeInt must be >= 0, was $value" }
+    }
+
+    override fun toString(): String = value.toString()
+}
+
+/**
+ * A long that must be at least one.
+ */
+@JvmInline
+value class PositiveLong(val value: Long) {
+    init {
+        require(value >= 1L) { "PositiveLong must be >= 1, was $value" }
+    }
+
+    override fun toString(): String = value.toString()
+}
+
+/**
+ * A string that must contain non-whitespace content.
+ */
+@JvmInline
+value class NonBlankString(val value: String) {
+    init {
+        require(value.isNotBlank()) { "NonBlankString must not be blank" }
+    }
+
+    override fun toString(): String = value
+}
+
+/**
+ * A list that must contain at least one element.
+ */
+@JvmInline
+value class NonEmptyList<T>(val value: List<T>) {
+    init {
+        require(value.isNotEmpty()) { "NonEmptyList must not be empty" }
+    }
+
+    override fun toString(): String = value.toString()
+}
+
+/**
  * A hex-encoded SHA-256 hash string.
  */
 @JvmInline

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/PageInfo.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/PageInfo.kt
@@ -14,3 +14,9 @@ data class PageInfo(
     @DocField(description = "Opaque token to pass in the next request for the next page of results.")
     val nextPageToken: String? = null,
 )
+
+interface PageableResult<T> {
+    val items: List<T>
+    val page: PageInfo?
+    fun withItems(items: List<T>, page: PageInfo?): PageableResult<T>
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/DiagnosticsResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/DiagnosticsResult.kt
@@ -4,6 +4,7 @@ package io.github.amichne.kast.api.contract.result
 
 import io.github.amichne.kast.api.contract.Diagnostic
 import io.github.amichne.kast.api.contract.PageInfo
+import io.github.amichne.kast.api.contract.PageableResult
 import io.github.amichne.kast.api.docs.DocField
 import io.github.amichne.kast.api.protocol.*
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -15,7 +16,15 @@ data class DiagnosticsResult(
     @DocField(description = "List of compilation diagnostics found in the requested files.")
     val diagnostics: List<Diagnostic>,
     @DocField(description = "Pagination metadata when results are truncated.")
-    val page: PageInfo? = null,
+    override val page: PageInfo? = null,
     @DocField(description = "Protocol schema version for forward compatibility.", serverManaged = true)
     val schemaVersion: Int = SCHEMA_VERSION,
-)
+) : PageableResult<Diagnostic> {
+    override val items: List<Diagnostic>
+        get() = diagnostics
+
+    override fun withItems(items: List<Diagnostic>, page: PageInfo?): PageableResult<Diagnostic> = copy(
+        diagnostics = items,
+        page = page,
+    )
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/ReferencesResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/ReferencesResult.kt
@@ -4,6 +4,7 @@ package io.github.amichne.kast.api.contract.result
 
 import io.github.amichne.kast.api.contract.Location
 import io.github.amichne.kast.api.contract.PageInfo
+import io.github.amichne.kast.api.contract.PageableResult
 import io.github.amichne.kast.api.contract.SearchScope
 import io.github.amichne.kast.api.contract.Symbol
 import io.github.amichne.kast.api.docs.DocField
@@ -19,9 +20,17 @@ data class ReferencesResult(
     @DocField(description = "List of source locations where the symbol is referenced.")
     val references: List<Location>,
     @DocField(description = "Pagination metadata when results are truncated.")
-    val page: PageInfo? = null,
+    override val page: PageInfo? = null,
     @DocField(description = "Describes the scope and exhaustiveness of the search.")
     val searchScope: SearchScope? = null,
     @DocField(description = "Protocol schema version for forward compatibility.", serverManaged = true)
     val schemaVersion: Int = SCHEMA_VERSION,
-)
+) : PageableResult<Location> {
+    override val items: List<Location>
+        get() = references
+
+    override fun withItems(items: List<Location>, page: PageInfo?): PageableResult<Location> = copy(
+        references = items,
+        page = page,
+    )
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceSymbolResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceSymbolResult.kt
@@ -3,6 +3,7 @@
 package io.github.amichne.kast.api.contract.result
 
 import io.github.amichne.kast.api.contract.PageInfo
+import io.github.amichne.kast.api.contract.PageableResult
 import io.github.amichne.kast.api.contract.Symbol
 import io.github.amichne.kast.api.docs.DocField
 import io.github.amichne.kast.api.protocol.*
@@ -15,7 +16,15 @@ data class WorkspaceSymbolResult(
     @DocField(description = "Symbols matching the search pattern.")
     val symbols: List<Symbol>,
     @DocField(description = "Pagination metadata when results are truncated.")
-    val page: PageInfo? = null,
+    override val page: PageInfo? = null,
     @DocField(description = "Protocol schema version for forward compatibility.", serverManaged = true)
     val schemaVersion: Int = SCHEMA_VERSION,
-)
+) : PageableResult<Symbol> {
+    override val items: List<Symbol>
+        get() = symbols
+
+    override fun withItems(items: List<Symbol>, page: PageInfo?): PageableResult<Symbol> = copy(
+        symbols = items,
+        page = page,
+    )
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedModels.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedModels.kt
@@ -1,7 +1,23 @@
 package io.github.amichne.kast.api.validation
 
 import io.github.amichne.kast.api.contract.*
+import io.github.amichne.kast.api.contract.query.*
 import io.github.amichne.kast.api.protocol.*
+
+/**
+ * Parsed query contract for requests anchored at a validated source position.
+ */
+interface PositionQuery { val position: ParsedFilePosition }
+
+/**
+ * Parsed query contract for requests whose result count is bounded by a positive limit.
+ */
+interface BoundedQuery { val maxResults: PositiveInt }
+
+/**
+ * Parsed query contract for traversal requests whose depth is zero or greater.
+ */
+interface DepthBoundedQuery { val depth: NonNegativeInt }
 
 /**
  * Validated internal representation of a [FilePosition].
@@ -36,6 +52,115 @@ data class ParsedTextEdit(
     val newText: String,
 )
 
+data class ParsedFileHash(
+    val filePath: NormalizedPath,
+    val hash: String,
+)
+
+sealed interface ParsedFileOperation {
+    val filePath: NormalizedPath
+
+    data class CreateFile(
+        override val filePath: NormalizedPath,
+        val content: String,
+    ) : ParsedFileOperation
+
+    data class DeleteFile(
+        override val filePath: NormalizedPath,
+        val expectedHash: String,
+    ) : ParsedFileOperation
+}
+
+data class ParsedSymbolQuery(
+    override val position: ParsedFilePosition,
+    val includeDeclarationScope: Boolean,
+    val includeDocumentation: Boolean,
+) : PositionQuery
+
+data class ParsedReferencesQuery(
+    override val position: ParsedFilePosition,
+    val includeDeclaration: Boolean,
+) : PositionQuery
+
+data class ParsedCallHierarchyQuery(
+    override val position: ParsedFilePosition,
+    val direction: CallDirection,
+    override val depth: NonNegativeInt,
+    val maxTotalCalls: PositiveInt,
+    val maxChildrenPerNode: PositiveInt,
+    val timeoutMillis: PositiveLong?,
+) : PositionQuery, DepthBoundedQuery
+
+data class ParsedTypeHierarchyQuery(
+    override val position: ParsedFilePosition,
+    val direction: TypeHierarchyDirection,
+    override val depth: NonNegativeInt,
+    override val maxResults: PositiveInt,
+) : PositionQuery, DepthBoundedQuery, BoundedQuery
+
+data class ParsedSemanticInsertionQuery(
+    override val position: ParsedFilePosition,
+    val target: SemanticInsertionTarget,
+) : PositionQuery
+
+data class ParsedDiagnosticsQuery(
+    val filePaths: NonEmptyList<NormalizedPath>,
+)
+
+data class ParsedRenameQuery(
+    override val position: ParsedFilePosition,
+    val newName: NonBlankString,
+    val dryRun: Boolean,
+) : PositionQuery
+
+data class ParsedImportOptimizeQuery(
+    val filePaths: NonEmptyList<NormalizedPath>,
+)
+
+data class ParsedApplyEditsQuery(
+    val edits: List<ParsedTextEdit>,
+    val fileHashes: List<ParsedFileHash>,
+    val fileOperations: List<ParsedFileOperation>,
+)
+
+data class ParsedRefreshQuery(
+    val filePaths: List<NormalizedPath>,
+)
+
+data class ParsedFileOutlineQuery(
+    val filePath: NormalizedPath,
+)
+
+data class ParsedWorkspaceSymbolQuery(
+    val pattern: NonBlankString,
+    val kind: SymbolKind?,
+    override val maxResults: PositiveInt,
+    val regex: Boolean,
+    val includeDeclarationScope: Boolean,
+) : BoundedQuery
+
+data class ParsedWorkspaceFilesQuery(
+    val moduleName: NonBlankString?,
+    val includeFiles: Boolean,
+    val maxFilesPerModule: PositiveInt?,
+)
+
+data class ParsedImplementationsQuery(
+    override val position: ParsedFilePosition,
+    override val maxResults: PositiveInt,
+) : PositionQuery, BoundedQuery
+
+data class ParsedCodeActionsQuery(
+    override val position: ParsedFilePosition,
+    val diagnosticCode: String?,
+) : PositionQuery
+
+data class ParsedCompletionsQuery(
+    override val position: ParsedFilePosition,
+    override val maxResults: PositiveInt,
+    val kindFilter: Set<SymbolKind>?,
+) : PositionQuery, BoundedQuery
+
 /**
  * Parse a wire-format [FilePosition] into a validated [ParsedFilePosition].
  * Throws [ValidationException] if the path is not absolute or the offset is negative.
@@ -66,3 +191,178 @@ fun TextEdit.parsed(): ParsedTextEdit = ParsedTextEdit(
     endOffset = ByteOffset(endOffset),
     newText = newText,
 )
+
+fun FileHash.parsed(): ParsedFileHash = ParsedFileHash(
+    filePath = NormalizedPath.parse(filePath),
+    hash = hash,
+)
+
+fun FileOperation.parsed(): ParsedFileOperation = when (this) {
+    is FileOperation.CreateFile -> ParsedFileOperation.CreateFile(
+        filePath = NormalizedPath.parse(filePath),
+        content = content,
+    )
+
+    is FileOperation.DeleteFile -> ParsedFileOperation.DeleteFile(
+        filePath = NormalizedPath.parse(filePath),
+        expectedHash = expectedHash,
+    )
+}
+
+fun SymbolQuery.parsed(): ParsedSymbolQuery = validationBoundary {
+    ParsedSymbolQuery(
+        position = position.parsed(),
+        includeDeclarationScope = includeDeclarationScope,
+        includeDocumentation = includeDocumentation,
+    )
+}
+
+fun ReferencesQuery.parsed(): ParsedReferencesQuery = validationBoundary {
+    ParsedReferencesQuery(
+        position = position.parsed(),
+        includeDeclaration = includeDeclaration,
+    )
+}
+
+fun CallHierarchyQuery.parsed(): ParsedCallHierarchyQuery = validationBoundary {
+    ParsedCallHierarchyQuery(
+        position = position.parsed(),
+        direction = direction,
+        depth = NonNegativeInt(depth),
+        maxTotalCalls = PositiveInt(maxTotalCalls),
+        maxChildrenPerNode = PositiveInt(maxChildrenPerNode),
+        timeoutMillis = timeoutMillis?.let(::PositiveLong),
+    )
+}
+
+fun TypeHierarchyQuery.parsed(): ParsedTypeHierarchyQuery = validationBoundary {
+    ParsedTypeHierarchyQuery(
+        position = position.parsed(),
+        direction = direction,
+        depth = NonNegativeInt(depth),
+        maxResults = PositiveInt(maxResults),
+    )
+}
+
+fun SemanticInsertionQuery.parsed(): ParsedSemanticInsertionQuery = validationBoundary {
+    ParsedSemanticInsertionQuery(
+        position = position.parsed(),
+        target = target,
+    )
+}
+
+fun DiagnosticsQuery.parsed(): ParsedDiagnosticsQuery = validationBoundary {
+    ParsedDiagnosticsQuery(
+        filePaths = NonEmptyList(filePaths.map(NormalizedPath::parse)),
+    )
+}
+
+fun RenameQuery.parsed(): ParsedRenameQuery = validationBoundary {
+    ParsedRenameQuery(
+        position = position.parsed(),
+        newName = NonBlankString(newName),
+        dryRun = dryRun,
+    )
+}
+
+fun ImportOptimizeQuery.parsed(): ParsedImportOptimizeQuery = validationBoundary {
+    ParsedImportOptimizeQuery(
+        filePaths = NonEmptyList(filePaths.map(NormalizedPath::parse)),
+    )
+}
+
+fun ApplyEditsQuery.parsed(): ParsedApplyEditsQuery = validationBoundary {
+    ParsedApplyEditsQuery(
+        edits = edits.map(TextEdit::parsed),
+        fileHashes = fileHashes.map(FileHash::parsed),
+        fileOperations = fileOperations.map(FileOperation::parsed),
+    )
+}
+
+fun RefreshQuery.parsed(): ParsedRefreshQuery = validationBoundary {
+    ParsedRefreshQuery(filePaths = filePaths.map(NormalizedPath::parse))
+}
+
+fun FileOutlineQuery.parsed(): ParsedFileOutlineQuery = validationBoundary {
+    ParsedFileOutlineQuery(filePath = NormalizedPath.parse(filePath))
+}
+
+fun WorkspaceSymbolQuery.parsed(): ParsedWorkspaceSymbolQuery = validationBoundary {
+    ParsedWorkspaceSymbolQuery(
+        pattern = NonBlankString(pattern),
+        kind = kind,
+        maxResults = PositiveInt(maxResults),
+        regex = regex,
+        includeDeclarationScope = includeDeclarationScope,
+    )
+}
+
+fun WorkspaceFilesQuery.parsed(): ParsedWorkspaceFilesQuery = validationBoundary {
+    ParsedWorkspaceFilesQuery(
+        moduleName = moduleName?.let(::NonBlankString),
+        includeFiles = includeFiles,
+        maxFilesPerModule = maxFilesPerModule?.let(::PositiveInt),
+    )
+}
+
+fun ImplementationsQuery.parsed(): ParsedImplementationsQuery = validationBoundary {
+    ParsedImplementationsQuery(
+        position = position.parsed(),
+        maxResults = PositiveInt(maxResults),
+    )
+}
+
+fun CodeActionsQuery.parsed(): ParsedCodeActionsQuery = validationBoundary {
+    ParsedCodeActionsQuery(
+        position = position.parsed(),
+        diagnosticCode = diagnosticCode,
+    )
+}
+
+fun CompletionsQuery.parsed(): ParsedCompletionsQuery = validationBoundary {
+    ParsedCompletionsQuery(
+        position = position.parsed(),
+        maxResults = PositiveInt(maxResults),
+        kindFilter = kindFilter,
+    )
+}
+
+fun ParsedTextEdit.toWire(): TextEdit = TextEdit(
+    filePath = filePath.value,
+    startOffset = startOffset.value,
+    endOffset = endOffset.value,
+    newText = newText,
+)
+
+fun ParsedFileHash.toWire(): FileHash = FileHash(
+    filePath = filePath.value,
+    hash = hash,
+)
+
+fun ParsedFileOperation.toWire(): FileOperation = when (this) {
+    is ParsedFileOperation.CreateFile -> FileOperation.CreateFile(
+        filePath = filePath.value,
+        content = content,
+    )
+
+    is ParsedFileOperation.DeleteFile -> FileOperation.DeleteFile(
+        filePath = filePath.value,
+        expectedHash = expectedHash,
+    )
+}
+
+fun ParsedApplyEditsQuery.toWire(): ApplyEditsQuery = ApplyEditsQuery(
+    edits = edits.map(ParsedTextEdit::toWire),
+    fileHashes = fileHashes.map(ParsedFileHash::toWire),
+    fileOperations = fileOperations.map(ParsedFileOperation::toWire),
+)
+
+private inline fun <T> validationBoundary(block: () -> T): T {
+    try {
+        return block()
+    } catch (exception: ValidationException) {
+        throw exception
+    } catch (exception: IllegalArgumentException) {
+        throw ValidationException(exception.message ?: "Invalid request")
+    }
+}

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/CoreTypesTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/CoreTypesTest.kt
@@ -225,6 +225,62 @@ class CoreTypesTest {
         }
     }
 
+    @Test
+    fun `PositiveInt accepts positive values`() {
+        assertEquals(1, PositiveInt(1).value)
+        assertEquals(42, PositiveInt(42).value)
+    }
+
+    @Test
+    fun `PositiveInt rejects zero and negative values`() {
+        assertThrows<IllegalArgumentException> { PositiveInt(0) }
+        assertThrows<IllegalArgumentException> { PositiveInt(-1) }
+    }
+
+    @Test
+    fun `NonNegativeInt accepts zero and positive values`() {
+        assertEquals(0, NonNegativeInt(0).value)
+        assertEquals(42, NonNegativeInt(42).value)
+    }
+
+    @Test
+    fun `NonNegativeInt rejects negative values`() {
+        assertThrows<IllegalArgumentException> { NonNegativeInt(-1) }
+    }
+
+    @Test
+    fun `PositiveLong accepts positive values`() {
+        assertEquals(1L, PositiveLong(1L).value)
+        assertEquals(42L, PositiveLong(42L).value)
+    }
+
+    @Test
+    fun `PositiveLong rejects zero and negative values`() {
+        assertThrows<IllegalArgumentException> { PositiveLong(0L) }
+        assertThrows<IllegalArgumentException> { PositiveLong(-1L) }
+    }
+
+    @Test
+    fun `NonBlankString accepts content`() {
+        assertEquals("name", NonBlankString("name").value)
+    }
+
+    @Test
+    fun `NonBlankString rejects blank content`() {
+        assertThrows<IllegalArgumentException> { NonBlankString("") }
+        assertThrows<IllegalArgumentException> { NonBlankString("   ") }
+    }
+
+    @Test
+    fun `NonEmptyList accepts non-empty list`() {
+        assertEquals(listOf("file.kt"), NonEmptyList(listOf("file.kt")).value)
+    }
+
+    @Test
+    fun `NonEmptyList rejects empty list`() {
+        assertThrows<IllegalArgumentException> { NonEmptyList(emptyList<String>()) }
+    }
+
     // --- ShaHash ---
 
     @Test

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/ParsedModelsTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/ParsedModelsTest.kt
@@ -1,9 +1,11 @@
 package io.github.amichne.kast.api.validation
 
 import io.github.amichne.kast.api.contract.*
+import io.github.amichne.kast.api.contract.query.*
 import io.github.amichne.kast.api.protocol.*
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -83,5 +85,117 @@ class ParsedModelsTest {
             newText = "x",
         )
         assertThrows<ValidationException> { edit.parsed() }
+    }
+
+    @Test
+    fun `query parsed happy paths create typed models`() {
+        val position = FilePosition("/workspace/src/Main.kt", 3)
+        val filePaths = listOf("/workspace/src/Main.kt")
+
+        val parsedQueries = listOf(
+            SymbolQuery(position).parsed(),
+            ReferencesQuery(position).parsed(),
+            CallHierarchyQuery(position, CallDirection.INCOMING).parsed(),
+            TypeHierarchyQuery(position).parsed(),
+            SemanticInsertionQuery(position, SemanticInsertionTarget.FILE_TOP).parsed(),
+            DiagnosticsQuery(filePaths).parsed(),
+            RenameQuery(position, "renamed").parsed(),
+            ImportOptimizeQuery(filePaths).parsed(),
+            ApplyEditsQuery(
+                edits = listOf(TextEdit("/workspace/src/Main.kt", 0, 1, "x")),
+                fileHashes = listOf(FileHash("/workspace/src/Main.kt", "hash")),
+                fileOperations = listOf(FileOperation.CreateFile("/workspace/src/New.kt", "class New")),
+            ).parsed(),
+            RefreshQuery(filePaths).parsed(),
+            FileOutlineQuery("/workspace/src/Main.kt").parsed(),
+            WorkspaceSymbolQuery("Main").parsed(),
+            WorkspaceFilesQuery(moduleName = "main", maxFilesPerModule = 1).parsed(),
+            ImplementationsQuery(position).parsed(),
+            CodeActionsQuery(position).parsed(),
+            CompletionsQuery(position).parsed(),
+        )
+
+        assertEquals(16, parsedQueries.size)
+        assertEquals(PositiveInt(100), (parsedQueries.last() as ParsedCompletionsQuery).maxResults)
+    }
+
+    @Test
+    fun `position query parsed rejects invalid position`() {
+        assertThrows<ValidationException> {
+            SymbolQuery(FilePosition("relative.kt", 0)).parsed()
+        }
+        assertThrows<ValidationException> {
+            ReferencesQuery(FilePosition("/workspace/src/Main.kt", -1)).parsed()
+        }
+    }
+
+    @Test
+    fun `bounded query parsed rejects non-positive limits`() {
+        val position = FilePosition("/workspace/src/Main.kt", 0)
+
+        assertThrows<ValidationException> { CompletionsQuery(position, maxResults = 0).parsed() }
+        assertThrows<ValidationException> { TypeHierarchyQuery(position, maxResults = 0).parsed() }
+        assertThrows<ValidationException> { ImplementationsQuery(position, maxResults = 0).parsed() }
+        assertThrows<ValidationException> { WorkspaceSymbolQuery("Main", maxResults = 0).parsed() }
+        assertThrows<ValidationException> { WorkspaceFilesQuery(maxFilesPerModule = 0).parsed() }
+    }
+
+    @Test
+    fun `depth bounded query parsed rejects negative depths`() {
+        val position = FilePosition("/workspace/src/Main.kt", 0)
+
+        assertThrows<ValidationException> { CallHierarchyQuery(position, CallDirection.INCOMING, depth = -1).parsed() }
+        assertThrows<ValidationException> { TypeHierarchyQuery(position, depth = -1).parsed() }
+    }
+
+    @Test
+    fun `call hierarchy parsed rejects invalid call limits and timeout`() {
+        val position = FilePosition("/workspace/src/Main.kt", 0)
+
+        assertThrows<ValidationException> {
+            CallHierarchyQuery(position, CallDirection.INCOMING, maxTotalCalls = 0).parsed()
+        }
+        assertThrows<ValidationException> {
+            CallHierarchyQuery(position, CallDirection.INCOMING, maxChildrenPerNode = 0).parsed()
+        }
+        assertThrows<ValidationException> {
+            CallHierarchyQuery(position, CallDirection.INCOMING, timeoutMillis = 0).parsed()
+        }
+    }
+
+    @Test
+    fun `file path list query parsed rejects empty or relative paths`() {
+        assertThrows<ValidationException> { DiagnosticsQuery(emptyList()).parsed() }
+        assertThrows<ValidationException> { DiagnosticsQuery(listOf("relative.kt")).parsed() }
+        assertThrows<ValidationException> { ImportOptimizeQuery(emptyList()).parsed() }
+        assertThrows<ValidationException> { ImportOptimizeQuery(listOf("relative.kt")).parsed() }
+        assertThrows<ValidationException> { RefreshQuery(listOf("relative.kt")).parsed() }
+    }
+
+    @Test
+    fun `blank string query parsed rejects blank values`() {
+        val position = FilePosition("/workspace/src/Main.kt", 0)
+
+        assertThrows<ValidationException> { RenameQuery(position, " ").parsed() }
+        assertThrows<ValidationException> { WorkspaceSymbolQuery(" ").parsed() }
+        assertThrows<ValidationException> { WorkspaceFilesQuery(moduleName = " ").parsed() }
+    }
+
+    @Test
+    fun `apply edits parsed validates nested paths and can convert back to wire query`() {
+        val parsed = ApplyEditsQuery(
+            edits = listOf(TextEdit("/workspace/src/Main.kt", 0, 1, "x")),
+            fileHashes = listOf(FileHash("/workspace/src/Main.kt", "hash")),
+            fileOperations = listOf(FileOperation.DeleteFile("/workspace/src/Old.kt", "oldHash")),
+        ).parsed()
+
+        assertInstanceOf(ParsedFileOperation.DeleteFile::class.java, parsed.fileOperations.single())
+        assertEquals("/workspace/src/Main.kt", parsed.toWire().edits.single().filePath)
+        assertThrows<ValidationException> {
+            ApplyEditsQuery(
+                edits = listOf(TextEdit("relative.kt", 0, 1, "x")),
+                fileHashes = emptyList(),
+            ).parsed()
+        }
     }
 }

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
@@ -34,6 +34,7 @@ import io.github.amichne.kast.api.protocol.JsonRpcRequest
 import io.github.amichne.kast.api.protocol.JsonRpcSuccessResponse
 import io.github.amichne.kast.api.contract.MutationCapability
 import io.github.amichne.kast.api.contract.PageInfo
+import io.github.amichne.kast.api.contract.PageableResult
 import io.github.amichne.kast.api.contract.ReadCapability
 import io.github.amichne.kast.api.contract.query.RefreshQuery
 import io.github.amichne.kast.api.contract.result.RefreshResult
@@ -58,8 +59,8 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
-import java.nio.file.Path
 import java.util.UUID
+import io.github.amichne.kast.api.validation.parsed
 
 class AnalysisDispatcher(
     private val backend: AnalysisBackend,
@@ -156,8 +157,7 @@ class AnalysisDispatcher(
             "symbol/resolve" -> encode(
                 SymbolResult.serializer(),
                 backend.resolveSymbol(
-                    decodeParams(SymbolQuery.serializer(), params).also { query ->
-                        validateFilePosition(query.position.filePath, query.position.offset)
+                    decodeParams(SymbolQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.RESOLVE_SYMBOL)
                     },
                 ),
@@ -166,31 +166,16 @@ class AnalysisDispatcher(
             "references" -> encode(
                 ReferencesResult.serializer(),
                 backend.findReferences(
-                    decodeParams(ReferencesQuery.serializer(), params).also { query ->
-                        validateFilePosition(query.position.filePath, query.position.offset)
+                    decodeParams(ReferencesQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.FIND_REFERENCES)
                     },
-                ).withLimit(config.maxResults),
+                ).withLimit(config.maxResults, ::referencePageToken),
             )
 
             "call-hierarchy" -> encode(
                 CallHierarchyResult.serializer(),
                 backend.callHierarchy(
-                    decodeParams(CallHierarchyQuery.serializer(), params).also { query ->
-                        validateFilePosition(query.position.filePath, query.position.offset)
-                        if (query.depth < 0) {
-                            throw ValidationException("Call hierarchy depth must be greater than or equal to zero")
-                        }
-                        if (query.maxTotalCalls < 1) {
-                            throw ValidationException("Call hierarchy maxTotalCalls must be greater than zero")
-                        }
-                        if (query.maxChildrenPerNode < 1) {
-                            throw ValidationException("Call hierarchy maxChildrenPerNode must be greater than zero")
-                        }
-                        val timeoutMillis = query.timeoutMillis
-                        if (timeoutMillis != null && timeoutMillis < 1) {
-                            throw ValidationException("Call hierarchy timeoutMillis must be greater than zero when provided")
-                        }
+                    decodeParams(CallHierarchyQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.CALL_HIERARCHY)
                     },
                 ),
@@ -199,14 +184,7 @@ class AnalysisDispatcher(
             "type-hierarchy" -> encode(
                 TypeHierarchyResult.serializer(),
                 backend.typeHierarchy(
-                    decodeParams(TypeHierarchyQuery.serializer(), params).also { query ->
-                        validateFilePosition(query.position.filePath, query.position.offset)
-                        if (query.depth < 0) {
-                            throw ValidationException("Type hierarchy depth must be greater than or equal to zero")
-                        }
-                        if (query.maxResults < 1) {
-                            throw ValidationException("Type hierarchy maxResults must be greater than zero")
-                        }
+                    decodeParams(TypeHierarchyQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.TYPE_HIERARCHY)
                     },
                 ),
@@ -215,8 +193,7 @@ class AnalysisDispatcher(
             "semantic-insertion-point" -> encode(
                 SemanticInsertionResult.serializer(),
                 backend.semanticInsertionPoint(
-                    decodeParams(SemanticInsertionQuery.serializer(), params).also { query ->
-                        validateFilePosition(query.position.filePath, query.position.offset)
+                    decodeParams(SemanticInsertionQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.SEMANTIC_INSERTION_POINT)
                     },
                 ),
@@ -225,24 +202,16 @@ class AnalysisDispatcher(
             "diagnostics" -> encode(
                 DiagnosticsResult.serializer(),
                 backend.diagnostics(
-                    decodeParams(DiagnosticsQuery.serializer(), params).also { query ->
-                        if (query.filePaths.isEmpty()) {
-                            throw ValidationException("At least one file path is required for diagnostics")
-                        }
-                        query.filePaths.forEach(::validateAbsoluteFilePath)
+                    decodeParams(DiagnosticsQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.DIAGNOSTICS)
                     },
-                ).withLimit(config.maxResults),
+                ).withLimit(config.maxResults, ::diagnosticPageToken),
             )
 
             "rename" -> encode(
                 RenameResult.serializer(),
                 backend.rename(
-                    decodeParams(RenameQuery.serializer(), params).also { query ->
-                        validateFilePosition(query.position.filePath, query.position.offset)
-                        if (query.newName.isBlank()) {
-                            throw ValidationException("The new symbol name must not be blank")
-                        }
+                    decodeParams(RenameQuery.serializer(), params).parsed().also {
                         requireMutationCapability(MutationCapability.RENAME)
                     },
                 ),
@@ -251,11 +220,7 @@ class AnalysisDispatcher(
             "imports/optimize" -> encode(
                 ImportOptimizeResult.serializer(),
                 backend.optimizeImports(
-                    decodeParams(ImportOptimizeQuery.serializer(), params).also { query ->
-                        if (query.filePaths.isEmpty()) {
-                            throw ValidationException("At least one file path is required for import optimization")
-                        }
-                        query.filePaths.forEach(::validateAbsoluteFilePath)
+                    decodeParams(ImportOptimizeQuery.serializer(), params).parsed().also {
                         requireMutationCapability(MutationCapability.OPTIMIZE_IMPORTS)
                     },
                 ),
@@ -264,10 +229,7 @@ class AnalysisDispatcher(
             "edits/apply" -> encode(
                 ApplyEditsResult.serializer(),
                 backend.applyEdits(
-                    decodeParams(ApplyEditsQuery.serializer(), params).also { query ->
-                        query.fileOperations.forEach { operation ->
-                            validateAbsoluteFilePath(operation.filePath)
-                        }
+                    decodeParams(ApplyEditsQuery.serializer(), params).parsed().also { query ->
                         requireMutationCapability(MutationCapability.APPLY_EDITS)
                         if (query.fileOperations.isNotEmpty()) {
                             requireMutationCapability(MutationCapability.FILE_OPERATIONS)
@@ -279,8 +241,7 @@ class AnalysisDispatcher(
             "workspace/refresh" -> encode(
                 RefreshResult.serializer(),
                 backend.refresh(
-                    decodeParams(RefreshQuery.serializer(), params).also { query ->
-                        query.filePaths.forEach(::validateAbsoluteFilePath)
+                    decodeParams(RefreshQuery.serializer(), params).parsed().also {
                         requireMutationCapability(MutationCapability.REFRESH_WORKSPACE)
                     },
                 ),
@@ -289,8 +250,7 @@ class AnalysisDispatcher(
             "file-outline" -> encode(
                 FileOutlineResult.serializer(),
                 backend.fileOutline(
-                    decodeParams(FileOutlineQuery.serializer(), params).also { query ->
-                        validateAbsoluteFilePath(query.filePath)
+                    decodeParams(FileOutlineQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.FILE_OUTLINE)
                     },
                 ),
@@ -299,48 +259,31 @@ class AnalysisDispatcher(
             "workspace-symbol" -> encode(
                 WorkspaceSymbolResult.serializer(),
                 backend.workspaceSymbolSearch(
-                    decodeParams(WorkspaceSymbolQuery.serializer(), params).also { query ->
-                        if (query.pattern.isBlank()) {
-                            throw ValidationException("Symbol search pattern must not be blank")
-                        }
-                        if (query.maxResults < 1) {
-                            throw ValidationException("Symbol search maxResults must be greater than zero")
-                        }
+                    decodeParams(WorkspaceSymbolQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.WORKSPACE_SYMBOL_SEARCH)
                     },
-                ).withLimit(config.maxResults),
+                ).withLimit(config.maxResults) { workspaceSymbolPageToken(config.maxResults) },
             )
 
             "workspace/files" -> encode(
                 WorkspaceFilesResult.serializer(),
                 backend.workspaceFiles(
                     decodeParams(WorkspaceFilesQuery.serializer(), params).also { query ->
-                        val moduleName = query.moduleName
                         val maxFilesPerModule = query.maxFilesPerModule
-                        if (moduleName != null && moduleName.isBlank()) {
-                            throw ValidationException("Workspace files moduleName must not be blank when provided")
-                        }
-                        if (maxFilesPerModule != null && maxFilesPerModule < 1) {
-                            throw ValidationException("Workspace files maxFilesPerModule must be greater than zero")
-                        }
                         if (maxFilesPerModule != null && maxFilesPerModule > config.maxResults) {
                             throw ValidationException(
                                 "Workspace files maxFilesPerModule must be less than or equal to server maxResults (${config.maxResults})",
                             )
                         }
                         requireReadCapability(ReadCapability.WORKSPACE_FILES)
-                    },
+                    }.parsed(),
                 ),
             )
 
             "implementations" -> encode(
                 ImplementationsResult.serializer(),
                 backend.implementations(
-                    decodeParams(ImplementationsQuery.serializer(), params).also { query ->
-                        validateFilePosition(query.position.filePath, query.position.offset)
-                        if (query.maxResults < 1) {
-                            throw ValidationException("Implementations maxResults must be greater than zero")
-                        }
+                    decodeParams(ImplementationsQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.IMPLEMENTATIONS)
                     },
                 ),
@@ -349,8 +292,7 @@ class AnalysisDispatcher(
             "code-actions" -> encode(
                 CodeActionsResult.serializer(),
                 backend.codeActions(
-                    decodeParams(CodeActionsQuery.serializer(), params).also { query ->
-                        validateFilePosition(query.position.filePath, query.position.offset)
+                    decodeParams(CodeActionsQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.CODE_ACTIONS)
                     },
                 ),
@@ -359,11 +301,7 @@ class AnalysisDispatcher(
             "completions" -> encode(
                 CompletionsResult.serializer(),
                 backend.completions(
-                    decodeParams(CompletionsQuery.serializer(), params).also { query ->
-                        validateFilePosition(query.position.filePath, query.position.offset)
-                        if (query.maxResults < 1) {
-                            throw ValidationException("Completions maxResults must be greater than zero")
-                        }
+                    decodeParams(CompletionsQuery.serializer(), params).parsed().also {
                         requireReadCapability(ReadCapability.COMPLETIONS)
                     },
                 ),
@@ -427,64 +365,28 @@ private fun requestId(id: JsonElement): String {
     } ?: UUID.randomUUID().toString()
 }
 
-private fun ReferencesResult.withLimit(limit: Int): ReferencesResult {
-    if (references.size <= limit) {
+private fun referencePageToken(location: io.github.amichne.kast.api.contract.Location): String =
+    location.startOffset.toString()
+
+private fun diagnosticPageToken(diagnostic: io.github.amichne.kast.api.contract.Diagnostic): String =
+    diagnostic.location.startOffset.toString()
+
+private fun workspaceSymbolPageToken(limit: Int): String = limit.toString()
+
+@Suppress("UNCHECKED_CAST")
+private fun <T, R : PageableResult<T>> R.withLimit(
+    limit: Int,
+    nextPageToken: (T) -> String,
+): R {
+    if (items.size <= limit) {
         return this
     }
 
-    return copy(
-        references = references.take(limit),
+    return withItems(
+        items = items.take(limit),
         page = PageInfo(
             truncated = true,
-            nextPageToken = references[limit - 1].startOffset.toString(),
+            nextPageToken = nextPageToken(items[limit - 1]),
         ),
-    )
-}
-
-private fun DiagnosticsResult.withLimit(limit: Int): DiagnosticsResult {
-    if (diagnostics.size <= limit) {
-        return this
-    }
-
-    return copy(
-        diagnostics = diagnostics.take(limit),
-        page = PageInfo(
-            truncated = true,
-            nextPageToken = diagnostics[limit - 1].location.startOffset.toString(),
-        ),
-    )
-}
-
-private fun WorkspaceSymbolResult.withLimit(limit: Int): WorkspaceSymbolResult {
-    if (symbols.size <= limit) {
-        return this
-    }
-
-    return copy(
-        symbols = symbols.take(limit),
-        page = PageInfo(
-            truncated = true,
-            nextPageToken = limit.toString(),
-        ),
-    )
-}
-
-private fun validateFilePosition(
-    filePath: String,
-    offset: Int,
-) {
-    validateAbsoluteFilePath(filePath)
-    if (offset < 0) {
-        throw ValidationException("Offsets must be greater than or equal to zero")
-    }
-}
-
-private fun validateAbsoluteFilePath(filePath: String) {
-    val path = Path.of(filePath)
-    if (!path.isAbsolute) {
-        throw ValidationException(
-            message = "File paths must be absolute",
-            details = mapOf("filePath" to filePath),
-        )
-    }
+    ) as R
 }

--- a/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastPluginBackend.kt
+++ b/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/KastPluginBackend.kt
@@ -19,56 +19,41 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiShortNamesCache
 import com.intellij.psi.search.searches.ReferencesSearch
 import io.github.amichne.kast.api.contract.AnalysisBackend
-import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
+import io.github.amichne.kast.api.validation.*
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
 import io.github.amichne.kast.api.contract.BackendCapabilities
-import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
 import io.github.amichne.kast.api.contract.result.CallHierarchyResult
-import io.github.amichne.kast.api.contract.query.CodeActionsQuery
 import io.github.amichne.kast.api.contract.result.CodeActionsResult
 import io.github.amichne.kast.api.contract.result.CompletionItem
-import io.github.amichne.kast.api.contract.query.CompletionsQuery
 import io.github.amichne.kast.api.contract.result.CompletionsResult
 import io.github.amichne.kast.api.contract.Diagnostic
 import io.github.amichne.kast.api.contract.DiagnosticSeverity
-import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
 import io.github.amichne.kast.api.contract.result.DiagnosticsResult
-import io.github.amichne.kast.api.contract.query.FileOutlineQuery
 import io.github.amichne.kast.api.contract.result.FileOutlineResult
 import io.github.amichne.kast.api.contract.HealthResponse
-import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
 import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
-import io.github.amichne.kast.api.contract.query.ImplementationsQuery
 import io.github.amichne.kast.api.contract.result.ImplementationsResult
 
 import io.github.amichne.kast.api.contract.Location
 import io.github.amichne.kast.api.contract.MutationCapability
 import io.github.amichne.kast.api.protocol.NotFoundException
 import io.github.amichne.kast.api.contract.ReadCapability
-import io.github.amichne.kast.api.contract.query.ReferencesQuery
 import io.github.amichne.kast.api.contract.result.ReferencesResult
-import io.github.amichne.kast.api.contract.query.RefreshQuery
 import io.github.amichne.kast.api.contract.result.RefreshResult
-import io.github.amichne.kast.api.contract.query.RenameQuery
 import io.github.amichne.kast.api.contract.result.RenameResult
 import io.github.amichne.kast.api.contract.RuntimeState
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.contract.SearchScope
 import io.github.amichne.kast.api.contract.SearchScopeKind
-import io.github.amichne.kast.api.contract.SemanticInsertionQuery
 import io.github.amichne.kast.api.contract.SemanticInsertionResult
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.contract.Symbol
-import io.github.amichne.kast.api.contract.query.SymbolQuery
 import io.github.amichne.kast.api.contract.result.SymbolResult
 import io.github.amichne.kast.api.contract.SymbolVisibility
 import io.github.amichne.kast.api.contract.TextEdit
-import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
 import io.github.amichne.kast.api.contract.result.TypeHierarchyResult
-import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
 import io.github.amichne.kast.api.contract.result.WorkspaceFilesResult
 import io.github.amichne.kast.api.contract.result.WorkspaceModule
-import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
 import io.github.amichne.kast.api.contract.result.WorkspaceSymbolResult
 import io.github.amichne.kast.shared.analysis.FileOutlineBuilder
 import io.github.amichne.kast.shared.analysis.ImportAnalysis
@@ -182,11 +167,11 @@ internal class KastPluginBackend(
         )
     }
 
-    override suspend fun resolveSymbol(query: SymbolQuery): SymbolResult = withContext(readDispatcher) {
+    override suspend fun resolveSymbol(query: ParsedSymbolQuery): SymbolResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.RESOLVE, "kast.intellij.resolveSymbol") {
             timedReadAction(telemetry, IntelliJTelemetryScope.RESOLVE, "kast.intellij.resolveSymbol.readAction") {
-                val file = findKtFile(query.position.filePath)
-                val target = resolveTarget(file, query.position.offset)
+                val file = findKtFile(query.position.filePath.value)
+                val target = resolveTarget(file, query.position.offset.value)
                 SymbolResult(
                     analyze(file) {
                         target.toSymbolModel(
@@ -201,12 +186,12 @@ internal class KastPluginBackend(
         }
     }
 
-    override suspend fun findReferences(query: ReferencesQuery): ReferencesResult = withContext(readDispatcher) {
+    override suspend fun findReferences(query: ParsedReferencesQuery): ReferencesResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.REFERENCES, "kast.intellij.findReferences") {
         val (snapshot, references) = collectInShortReadActions(
             collectSnapshot = {
-                val file = findKtFile(query.position.filePath)
-                val target = resolveTarget(file, query.position.offset)
+                val file = findKtFile(query.position.filePath.value)
+                val target = resolveTarget(file, query.position.offset.value)
                 val visibility = target.visibility()
                 val (searchScope, scopeKind) = visibilityScopedSearch(target, visibility)
                 val refs = mutableListOf<PsiReference>()
@@ -255,20 +240,20 @@ internal class KastPluginBackend(
         }
     }
 
-    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult = withContext(readDispatcher) {
+    override suspend fun callHierarchy(query: ParsedCallHierarchyQuery): CallHierarchyResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.CALL_HIERARCHY, "kast.intellij.callHierarchy") {
         // Resolve the root target under a short read lock; the recursive
         // traversal acquires per-level read locks inside the edge resolver
         // so the IDE write lock is not starved for the full duration.
         val rootTarget = timedReadAction(telemetry, IntelliJTelemetryScope.CALL_HIERARCHY, "kast.intellij.callHierarchy.resolveTarget") {
-            val file = findKtFile(query.position.filePath)
-            resolveTarget(file, query.position.offset)
+            val file = findKtFile(query.position.filePath.value)
+            resolveTarget(file, query.position.offset.value)
         }
 
         val budget = TraversalBudget(
-            maxTotalCalls = query.maxTotalCalls,
-            maxChildrenPerNode = query.maxChildrenPerNode,
-            timeoutMillis = query.timeoutMillis ?: limits.requestTimeoutMillis,
+            maxTotalCalls = query.maxTotalCalls.value,
+            maxChildrenPerNode = query.maxChildrenPerNode.value,
+            timeoutMillis = query.timeoutMillis?.value ?: limits.requestTimeoutMillis,
         )
         val resolver = IntelliJCallEdgeResolver(
             project = project,
@@ -279,7 +264,7 @@ internal class KastPluginBackend(
             target = rootTarget,
             parentCallSite = null,
             direction = query.direction,
-            depthRemaining = query.depth,
+            depthRemaining = query.depth.value,
             pathKeys = emptySet(),
             budget = budget,
             currentDepth = 0,
@@ -292,20 +277,20 @@ internal class KastPluginBackend(
         }
     }
 
-    override suspend fun typeHierarchy(query: TypeHierarchyQuery): TypeHierarchyResult = withContext(readDispatcher) {
+    override suspend fun typeHierarchy(query: ParsedTypeHierarchyQuery): TypeHierarchyResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.TYPE_HIERARCHY, "kast.intellij.typeHierarchy") {
         val rootTarget = readAction {
-            val file = findKtFile(query.position.filePath)
-            val resolved = resolveTarget(file, query.position.offset)
+            val file = findKtFile(query.position.filePath.value)
+            val resolved = resolveTarget(file, query.position.offset.value)
             resolved.typeHierarchyDeclaration() ?: resolved
         }
         val resolver = IntelliJTypeEdgeResolver(project = project)
         val engine = TypeHierarchyEngine(edgeResolver = resolver, readAccess = intellijReadAccess)
-        val budget = TypeHierarchyBudget(maxResults = query.maxResults.coerceAtLeast(1))
+        val budget = TypeHierarchyBudget(maxResults = query.maxResults.value)
         val root = engine.buildNode(
             target = rootTarget,
             direction = query.direction,
-            depthRemaining = query.depth.coerceAtLeast(0),
+            depthRemaining = query.depth.value,
             pathKeys = emptySet(),
             budget = budget,
             currentDepth = 0,
@@ -314,11 +299,11 @@ internal class KastPluginBackend(
         }
     }
 
-    override suspend fun implementations(query: ImplementationsQuery): ImplementationsResult = withContext(readDispatcher) {
+    override suspend fun implementations(query: ParsedImplementationsQuery): ImplementationsResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.IMPLEMENTATIONS, "kast.intellij.implementations") {
         val rootTarget = readAction {
-            val file = findKtFile(query.position.filePath)
-            val resolved = resolveTarget(file, query.position.offset)
+            val file = findKtFile(query.position.filePath.value)
+            val resolved = resolveTarget(file, query.position.offset.value)
             resolved.typeHierarchyDeclaration() ?: resolved
         }
         val resolver = IntelliJTypeEdgeResolver(project = project)
@@ -328,7 +313,7 @@ internal class KastPluginBackend(
         val implementations = mutableListOf<Symbol>()
         queue += rootTarget
         var exhaustive = true
-        val limit = query.maxResults.coerceAtLeast(1)
+        val limit = query.maxResults.value
 
         while (queue.isNotEmpty() && implementations.size < limit) {
             val current = queue.removeFirst()
@@ -358,17 +343,17 @@ internal class KastPluginBackend(
         }
     }
 
-    override suspend fun codeActions(query: CodeActionsQuery): CodeActionsResult = withContext(readDispatcher) {
+    override suspend fun codeActions(query: ParsedCodeActionsQuery): CodeActionsResult = withContext(readDispatcher) {
         readAction {
-            findKtFile(query.position.filePath)
+            findKtFile(query.position.filePath.value)
             CodeActionsResult(actions = emptyList())
         }
     }
 
-    override suspend fun completions(query: CompletionsQuery): CompletionsResult = withContext(readDispatcher) {
+    override suspend fun completions(query: ParsedCompletionsQuery): CompletionsResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.COMPLETIONS, "kast.intellij.completions") {
         readAction {
-            val file = findKtFile(query.position.filePath)
+            val file = findKtFile(query.position.filePath.value)
             val kindFilter = query.kindFilter
             val items = mutableListOf<CompletionItem>()
             file.accept(object : com.intellij.psi.PsiRecursiveElementWalkingVisitor() {
@@ -376,7 +361,7 @@ internal class KastPluginBackend(
                     if (element is KtNamedDeclaration &&
                         element !is KtParameter &&
                         element.name != null &&
-                        element.textOffset <= query.position.offset
+                        element.textOffset <= query.position.offset.value
                     ) {
                         val symbol = element.toSymbolModel(
                             containingDeclaration = null,
@@ -399,7 +384,7 @@ internal class KastPluginBackend(
             val deduped = items
                 .distinctBy { Triple(it.fqName, it.kind, it.name) }
                 .sortedWith(compareBy({ it.name }, { it.fqName }))
-            val capped = deduped.take(query.maxResults.coerceAtLeast(1))
+            val capped = deduped.take(query.maxResults.value)
             CompletionsResult(
                 items = capped,
                 exhaustive = deduped.size <= capped.size,
@@ -408,13 +393,13 @@ internal class KastPluginBackend(
         }
     }
 
-    override suspend fun workspaceFiles(query: WorkspaceFilesQuery): WorkspaceFilesResult = withContext(readDispatcher) {
-        val fileLimit = query.maxFilesPerModule ?: limits.maxResults
+    override suspend fun workspaceFiles(query: ParsedWorkspaceFilesQuery): WorkspaceFilesResult = withContext(readDispatcher) {
+        val fileLimit = query.maxFilesPerModule?.value ?: limits.maxResults
         telemetry.inSpan(
             IntelliJTelemetryScope.WORKSPACE_FILES,
             "kast.intellij.workspaceFiles",
             attributes = mapOf(
-                "kast.workspaceFiles.moduleName" to query.moduleName,
+                "kast.workspaceFiles.moduleName" to query.moduleName?.value,
                 "kast.workspaceFiles.includeFiles" to query.includeFiles,
                 "kast.workspaceFiles.maxFilesPerModule" to fileLimit,
             ),
@@ -422,8 +407,8 @@ internal class KastPluginBackend(
             val allModules = timedReadAction(telemetry, IntelliJTelemetryScope.WORKSPACE_FILES, "kast.intellij.workspaceFiles.listModules") {
                 ModuleManager.getInstance(project).modules.toList()
             }
-            val targetModules = if (query.moduleName != null) {
-                allModules.filter { timedReadAction(telemetry, IntelliJTelemetryScope.WORKSPACE_FILES, "kast.intellij.workspaceFiles.filterModule") { it.name } == query.moduleName }
+            val targetModules = if (query.moduleName?.value != null) {
+                allModules.filter { timedReadAction(telemetry, IntelliJTelemetryScope.WORKSPACE_FILES, "kast.intellij.workspaceFiles.filterModule") { it.name } == query.moduleName?.value }
             } else {
                 allModules
             }
@@ -466,20 +451,20 @@ internal class KastPluginBackend(
     }
 
     override suspend fun semanticInsertionPoint(
-        query: SemanticInsertionQuery,
+        query: ParsedSemanticInsertionQuery,
     ): SemanticInsertionResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.SEMANTIC_INSERTION_POINT, "kast.intellij.semanticInsertionPoint") {
         readAction {
-            val file = findKtFile(query.position.filePath)
+            val file = findKtFile(query.position.filePath.value)
             SemanticInsertionPointResolver.resolve(file, query)
         }
         }
     }
 
-    override suspend fun diagnostics(query: DiagnosticsQuery): DiagnosticsResult = withContext(readDispatcher) {
+    override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.DIAGNOSTICS, "kast.intellij.diagnostics") {
             val diagnostics = coroutineScope {
-                query.filePaths.sorted().map { filePath ->
+                query.filePaths.value.map { it.value }.sorted().map { filePath ->
                     async(readDispatcher) {
                         runCatching {
                             timedReadAction(telemetry, IntelliJTelemetryScope.DIAGNOSTICS, "kast.intellij.diagnostics.file") {
@@ -516,12 +501,12 @@ internal class KastPluginBackend(
 
     // Note: Unlike the standalone backend, IntelliJ's ReferencesSearch.search() resolves
     // import directives as reference sites, so explicit import FQN handling is not needed here.
-    override suspend fun rename(query: RenameQuery): RenameResult = withContext(readDispatcher) {
+    override suspend fun rename(query: ParsedRenameQuery): RenameResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.RENAME, "kast.intellij.rename") {
         val (snapshot, referenceEdits) = collectInShortReadActions(
             collectSnapshot = {
-                val file = findKtFile(query.position.filePath)
-                val target = resolveTarget(file, query.position.offset)
+                val file = findKtFile(query.position.filePath.value)
+                val target = resolveTarget(file, query.position.offset.value)
                 val visibility = target.visibility()
                 val (searchScope, scopeKind) = visibilityScopedSearch(target, visibility)
                 val candidateFileCount = FileTypeIndex.getFiles(KotlinFileType.INSTANCE, searchScope)
@@ -533,7 +518,7 @@ internal class KastPluginBackend(
                     true
                 }
                 RenameSnapshot(
-                    declarationEdit = target.declarationEdit(query.newName),
+                    declarationEdit = target.declarationEdit(query.newName.value),
                     visibility = visibility,
                     scopeKind = scopeKind,
                     candidateFileCount = candidateFileCount,
@@ -548,7 +533,7 @@ internal class KastPluginBackend(
                     filePath = refFilePath,
                     startOffset = ref.rangeInElement.startOffset + element.textRange.startOffset,
                     endOffset = ref.rangeInElement.endOffset + element.textRange.startOffset,
-                    newText = query.newName,
+                    newText = query.newName.value,
                 )
             },
             runInitialReadAction = { action -> runIntellijReadAction(action) },
@@ -577,17 +562,18 @@ internal class KastPluginBackend(
         }
     }
 
-    override suspend fun applyEdits(query: ApplyEditsQuery): ApplyEditsResult {
+    override suspend fun applyEdits(query: ParsedApplyEditsQuery): ApplyEditsResult {
         return telemetry.inSpan(IntelliJTelemetryScope.APPLY_EDITS, "kast.intellij.applyEdits") {
             val applier = IntelliJEditApplier(project)
-            applier.apply(query)
+            applier.apply(query.toWire())
             // No asyncRefresh needed - IntelliJ APIs handle VFS updates automatically
         }
     }
 
-    override suspend fun optimizeImports(query: ImportOptimizeQuery): ImportOptimizeResult = withContext(readDispatcher) {
+    override suspend fun optimizeImports(query: ParsedImportOptimizeQuery): ImportOptimizeResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.OPTIMIZE_IMPORTS, "kast.intellij.optimizeImports") {
-        val edits = query.filePaths
+        val edits = query.filePaths.value
+            .map { it.value }
             .distinct()
             .sorted()
             .flatMap { filePath ->
@@ -605,31 +591,32 @@ internal class KastPluginBackend(
         }
     }
 
-    override suspend fun refresh(query: RefreshQuery): RefreshResult {
+    override suspend fun refresh(query: ParsedRefreshQuery): RefreshResult {
         return telemetry.inSpan(IntelliJTelemetryScope.REFRESH, "kast.intellij.refresh") {
             ApplicationManager.getApplication().invokeLater {
                 VirtualFileManager.getInstance().asyncRefresh(null)
             }
-            if (query.filePaths.isEmpty()) {
+            val filePaths = query.filePaths.map { it.value }
+            if (filePaths.isEmpty()) {
                 RefreshResult(refreshedFiles = emptyList(), fullRefresh = true)
             } else {
-                RefreshResult(refreshedFiles = query.filePaths, fullRefresh = false)
+                RefreshResult(refreshedFiles = filePaths, fullRefresh = false)
             }
         }
     }
 
-    override suspend fun fileOutline(query: FileOutlineQuery): FileOutlineResult = withContext(readDispatcher) {
+    override suspend fun fileOutline(query: ParsedFileOutlineQuery): FileOutlineResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.FILE_OUTLINE, "kast.intellij.fileOutline") {
             timedReadAction(telemetry, IntelliJTelemetryScope.FILE_OUTLINE, "kast.intellij.fileOutline.readAction") {
-                val file = findKtFile(query.filePath)
+                val file = findKtFile(query.filePath.value)
                 FileOutlineResult(symbols = FileOutlineBuilder.build(file))
             }
         }
     }
 
-    override suspend fun workspaceSymbolSearch(query: WorkspaceSymbolQuery): WorkspaceSymbolResult = withContext(readDispatcher) {
+    override suspend fun workspaceSymbolSearch(query: ParsedWorkspaceSymbolQuery): WorkspaceSymbolResult = withContext(readDispatcher) {
         telemetry.inSpan(IntelliJTelemetryScope.WORKSPACE_SYMBOL_SEARCH, "kast.intellij.workspaceSymbolSearch") {
-        val matcher = SymbolSearchMatcher.create(query.pattern, query.regex)
+        val matcher = SymbolSearchMatcher.create(query.pattern.value, query.regex)
         val scope = GlobalSearchScope.projectScope(project)
         val cache = PsiShortNamesCache.getInstance(project)
         val symbols = mutableListOf<Symbol>()
@@ -668,16 +655,16 @@ internal class KastPluginBackend(
     private fun <T : PsiElement> collectMatchingSymbols(
         scope: GlobalSearchScope,
         matcher: SymbolSearchMatcher,
-        query: WorkspaceSymbolQuery,
+        query: ParsedWorkspaceSymbolQuery,
         symbols: MutableList<Symbol>,
         allNames: Array<String>,
         lookupByName: (String, GlobalSearchScope) -> Array<out T>,
     ) {
         for (name in allNames) {
-            if (symbols.size >= query.maxResults) break
+            if (symbols.size >= query.maxResults.value) break
             if (!matcher.matches(name)) continue
             for (element in lookupByName(name, scope)) {
-                if (symbols.size >= query.maxResults) break
+                if (symbols.size >= query.maxResults.value) break
                 val ktElement = element.navigationElement as? KtNamedDeclaration ?: continue
                 val filePath = ktElement.containingFile?.virtualFile?.path ?: continue
                 if (!isWorkspaceFile(filePath)) continue

--- a/backend-intellij/src/test/kotlin/io/github/amichne/kast/intellij/ParsedQueryTestAdapters.kt
+++ b/backend-intellij/src/test/kotlin/io/github/amichne/kast/intellij/ParsedQueryTestAdapters.kt
@@ -1,0 +1,36 @@
+package io.github.amichne.kast.intellij
+
+import io.github.amichne.kast.api.contract.SemanticInsertionQuery
+import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
+import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
+import io.github.amichne.kast.api.contract.query.CodeActionsQuery
+import io.github.amichne.kast.api.contract.query.CompletionsQuery
+import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
+import io.github.amichne.kast.api.contract.query.FileOutlineQuery
+import io.github.amichne.kast.api.contract.query.ImplementationsQuery
+import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
+import io.github.amichne.kast.api.contract.query.ReferencesQuery
+import io.github.amichne.kast.api.contract.query.RefreshQuery
+import io.github.amichne.kast.api.contract.query.RenameQuery
+import io.github.amichne.kast.api.contract.query.SymbolQuery
+import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
+import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
+import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
+import io.github.amichne.kast.api.validation.parsed
+
+internal suspend fun KastPluginBackend.resolveSymbol(query: SymbolQuery) = resolveSymbol(query.parsed())
+internal suspend fun KastPluginBackend.findReferences(query: ReferencesQuery) = findReferences(query.parsed())
+internal suspend fun KastPluginBackend.callHierarchy(query: CallHierarchyQuery) = callHierarchy(query.parsed())
+internal suspend fun KastPluginBackend.typeHierarchy(query: TypeHierarchyQuery) = typeHierarchy(query.parsed())
+internal suspend fun KastPluginBackend.semanticInsertionPoint(query: SemanticInsertionQuery) = semanticInsertionPoint(query.parsed())
+internal suspend fun KastPluginBackend.diagnostics(query: DiagnosticsQuery) = diagnostics(query.parsed())
+internal suspend fun KastPluginBackend.rename(query: RenameQuery) = rename(query.parsed())
+internal suspend fun KastPluginBackend.applyEdits(query: ApplyEditsQuery) = applyEdits(query.parsed())
+internal suspend fun KastPluginBackend.optimizeImports(query: ImportOptimizeQuery) = optimizeImports(query.parsed())
+internal suspend fun KastPluginBackend.refresh(query: RefreshQuery) = refresh(query.parsed())
+internal suspend fun KastPluginBackend.fileOutline(query: FileOutlineQuery) = fileOutline(query.parsed())
+internal suspend fun KastPluginBackend.workspaceSymbolSearch(query: WorkspaceSymbolQuery) = workspaceSymbolSearch(query.parsed())
+internal suspend fun KastPluginBackend.workspaceFiles(query: WorkspaceFilesQuery) = workspaceFiles(query.parsed())
+internal suspend fun KastPluginBackend.implementations(query: ImplementationsQuery) = implementations(query.parsed())
+internal suspend fun KastPluginBackend.codeActions(query: CodeActionsQuery) = codeActions(query.parsed())
+internal suspend fun KastPluginBackend.completions(query: CompletionsQuery) = completions(query.parsed())

--- a/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/SemanticInsertionPointResolver.kt
+++ b/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/SemanticInsertionPointResolver.kt
@@ -1,7 +1,7 @@
 package io.github.amichne.kast.shared.analysis
 
 import io.github.amichne.kast.api.protocol.NotFoundException
-import io.github.amichne.kast.api.contract.SemanticInsertionQuery
+import io.github.amichne.kast.api.validation.*
 import io.github.amichne.kast.api.contract.SemanticInsertionResult
 import io.github.amichne.kast.api.contract.SemanticInsertionTarget
 import org.jetbrains.kotlin.psi.KtClassBody
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.psi.KtFile
 object SemanticInsertionPointResolver {
     fun resolve(
         file: KtFile,
-        query: SemanticInsertionQuery,
+        query: ParsedSemanticInsertionQuery,
     ): SemanticInsertionResult {
         val insertionOffset = when (query.target) {
             SemanticInsertionTarget.CLASS_BODY_START -> classBody(file, query).lBrace?.textRange?.endOffset
@@ -22,7 +22,7 @@ object SemanticInsertionPointResolver {
         } ?: throw NotFoundException(
             message = "The requested semantic insertion point could not be resolved",
             details = mapOf(
-                "filePath" to query.position.filePath,
+                "filePath" to query.position.filePath.value,
                 "target" to query.target.name,
             ),
         )
@@ -35,14 +35,14 @@ object SemanticInsertionPointResolver {
 
     private fun classBody(
         file: KtFile,
-        query: SemanticInsertionQuery,
+        query: ParsedSemanticInsertionQuery,
     ): KtClassBody {
-        val target = resolveTarget(file, query.position.offset)
+        val target = resolveTarget(file, query.position.offset.value)
         val declaration = target.typeHierarchyDeclaration() as? KtClassOrObject
             ?: throw NotFoundException(
                 message = "The requested semantic insertion target requires a class or object declaration",
                 details = mapOf(
-                    "filePath" to query.position.filePath,
+                    "filePath" to query.position.filePath.value,
                     "target" to query.target.name,
                 ),
             )
@@ -50,7 +50,7 @@ object SemanticInsertionPointResolver {
             ?: throw NotFoundException(
                 message = "The requested class or object does not have a body",
                 details = mapOf(
-                    "filePath" to query.position.filePath,
+                    "filePath" to query.position.filePath.value,
                     "target" to query.target.name,
                 ),
             )

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/StandaloneAnalysisBackend.kt
@@ -3,56 +3,41 @@ package io.github.amichne.kast.standalone
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
 import io.github.amichne.kast.api.contract.AnalysisBackend
-import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
+import io.github.amichne.kast.api.validation.*
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
 import io.github.amichne.kast.api.contract.BackendCapabilities
-import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
 import io.github.amichne.kast.api.contract.result.CallHierarchyResult
-import io.github.amichne.kast.api.contract.query.CodeActionsQuery
 import io.github.amichne.kast.api.contract.result.CodeActionsResult
 import io.github.amichne.kast.api.contract.result.CompletionItem
-import io.github.amichne.kast.api.contract.query.CompletionsQuery
 import io.github.amichne.kast.api.contract.result.CompletionsResult
 import io.github.amichne.kast.api.contract.Diagnostic
 import io.github.amichne.kast.api.contract.DiagnosticSeverity
-import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
 import io.github.amichne.kast.api.contract.result.DiagnosticsResult
 import io.github.amichne.kast.api.contract.Location
 import io.github.amichne.kast.api.contract.FileHash
-import io.github.amichne.kast.api.contract.query.FileOutlineQuery
 import io.github.amichne.kast.api.contract.result.FileOutlineResult
 import io.github.amichne.kast.api.contract.HealthResponse
-import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
 import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
-import io.github.amichne.kast.api.contract.query.ImplementationsQuery
 import io.github.amichne.kast.api.contract.result.ImplementationsResult
 import io.github.amichne.kast.api.validation.LocalDiskEditApplier
 import io.github.amichne.kast.api.contract.MutationCapability
 import io.github.amichne.kast.api.contract.ReadCapability
-import io.github.amichne.kast.api.contract.query.ReferencesQuery
 import io.github.amichne.kast.api.contract.result.ReferencesResult
-import io.github.amichne.kast.api.contract.query.RefreshQuery
 import io.github.amichne.kast.api.contract.result.RefreshResult
-import io.github.amichne.kast.api.contract.query.RenameQuery
 import io.github.amichne.kast.api.contract.result.RenameResult
 import io.github.amichne.kast.api.contract.RuntimeState
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.contract.SearchScope
 import io.github.amichne.kast.api.contract.SearchScopeKind
-import io.github.amichne.kast.api.contract.SemanticInsertionQuery
 import io.github.amichne.kast.api.contract.SemanticInsertionResult
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.contract.Symbol
-import io.github.amichne.kast.api.contract.query.SymbolQuery
 import io.github.amichne.kast.api.contract.result.SymbolResult
 import io.github.amichne.kast.api.contract.SymbolVisibility
 import io.github.amichne.kast.api.contract.TextEdit
-import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
 import io.github.amichne.kast.api.contract.result.TypeHierarchyResult
-import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
 import io.github.amichne.kast.api.contract.result.WorkspaceFilesResult
 import io.github.amichne.kast.api.contract.result.WorkspaceModule
-import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
 import io.github.amichne.kast.api.contract.result.WorkspaceSymbolResult
 import io.github.amichne.kast.shared.analysis.FileOutlineBuilder
 import io.github.amichne.kast.shared.analysis.ImportAnalysis
@@ -188,18 +173,18 @@ internal class StandaloneAnalysisBackend internal constructor(
         )
     }
 
-    override suspend fun resolveSymbol(query: SymbolQuery): SymbolResult = withContext(readDispatcher) {
+    override suspend fun resolveSymbol(query: ParsedSymbolQuery): SymbolResult = withContext(readDispatcher) {
         session.withReadAccess {
             telemetry.inSpan(
                 scope = StandaloneTelemetryScope.SYMBOL_RESOLVE,
                 name = "kast.resolveSymbol",
                 attributes = mapOf(
-                    "kast.symbolResolve.filePath" to query.position.filePath,
-                    "kast.symbolResolve.offset" to query.position.offset,
+                    "kast.symbolResolve.filePath" to query.position.filePath.value,
+                    "kast.symbolResolve.offset" to query.position.offset.value,
                 ),
             ) {
-                val file = session.findKtFile(query.position.filePath)
-                val target = resolveTarget(file, query.position.offset)
+                val file = session.findKtFile(query.position.filePath.value)
+                val target = resolveTarget(file, query.position.offset.value)
                 SymbolResult(
                     analyze(file) {
                         target.toSymbolModel(
@@ -214,18 +199,18 @@ internal class StandaloneAnalysisBackend internal constructor(
         }
     }
 
-    override suspend fun findReferences(query: ReferencesQuery): ReferencesResult = withContext(readDispatcher) {
+    override suspend fun findReferences(query: ParsedReferencesQuery): ReferencesResult = withContext(readDispatcher) {
         session.withReadAccess {
             telemetry.inSpan(
                 scope = StandaloneTelemetryScope.REFERENCES,
                 name = "kast.findReferences",
                 attributes = mapOf(
-                    "kast.references.filePath" to query.position.filePath,
-                    "kast.references.offset" to query.position.offset,
+                    "kast.references.filePath" to query.position.filePath.value,
+                    "kast.references.offset" to query.position.offset.value,
                 ),
             ) { span ->
-                val file = session.findKtFile(query.position.filePath)
-                val target = resolveTarget(file, query.position.offset)
+                val file = session.findKtFile(query.position.filePath.value)
+                val target = resolveTarget(file, query.position.offset.value)
                 val (candidateFiles, searchScope) = resolveCandidateFilesForReferences(target, span)
                 span.setAttribute("kast.references.candidateFileCount", candidateFiles.size)
                 span.setAttribute("kast.references.searchScope", searchScope.scope.name)
@@ -244,20 +229,20 @@ internal class StandaloneAnalysisBackend internal constructor(
         }
     }
 
-    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult = withContext(readDispatcher) {
+    override suspend fun callHierarchy(query: ParsedCallHierarchyQuery): CallHierarchyResult = withContext(readDispatcher) {
         session.withReadAccess {
             callHierarchyTraversal.build(query)
         }
     }
 
-    override suspend fun typeHierarchy(query: TypeHierarchyQuery): TypeHierarchyResult = withContext(readDispatcher) {
+    override suspend fun typeHierarchy(query: ParsedTypeHierarchyQuery): TypeHierarchyResult = withContext(readDispatcher) {
         session.withReadAccess {
             telemetry.inSpan(
                 scope = StandaloneTelemetryScope.SYMBOL_RESOLVE,
                 name = "kast.typeHierarchy",
                 attributes = mapOf(
-                    "kast.typeHierarchy.filePath" to query.position.filePath,
-                    "kast.typeHierarchy.offset" to query.position.offset,
+                    "kast.typeHierarchy.filePath" to query.position.filePath.value,
+                    "kast.typeHierarchy.offset" to query.position.offset.value,
                 ),
             ) {
                 typeHierarchyTraversal.build(query)
@@ -265,10 +250,10 @@ internal class StandaloneAnalysisBackend internal constructor(
         }
     }
 
-    override suspend fun implementations(query: ImplementationsQuery): ImplementationsResult = withContext(readDispatcher) {
+    override suspend fun implementations(query: ParsedImplementationsQuery): ImplementationsResult = withContext(readDispatcher) {
         session.withReadAccess {
-            val file = session.findKtFile(query.position.filePath)
-            val resolvedTarget = resolveTarget(file, query.position.offset)
+            val file = session.findKtFile(query.position.filePath.value)
+            val resolvedTarget = resolveTarget(file, query.position.offset.value)
             val declaration = resolvedTarget.typeHierarchyDeclaration() ?: resolvedTarget
             val declarationSymbol = analyze(file) {
                 declaration.toSymbolModel(
@@ -308,7 +293,7 @@ internal class StandaloneAnalysisBackend internal constructor(
                     }
                 }
                 .sortedWith(compareBy({ it.fqName }, { it.location.filePath }, { it.location.startOffset }))
-            val capped = implementations.take(query.maxResults.coerceAtLeast(1))
+            val capped = implementations.take(query.maxResults.value)
             ImplementationsResult(
                 declaration = declarationSymbol,
                 implementations = capped,
@@ -317,16 +302,16 @@ internal class StandaloneAnalysisBackend internal constructor(
         }
     }
 
-    override suspend fun codeActions(query: CodeActionsQuery): CodeActionsResult = withContext(readDispatcher) {
+    override suspend fun codeActions(query: ParsedCodeActionsQuery): CodeActionsResult = withContext(readDispatcher) {
         session.withReadAccess {
-            session.findKtFile(query.position.filePath)
+            session.findKtFile(query.position.filePath.value)
             CodeActionsResult(actions = emptyList())
         }
     }
 
-    override suspend fun completions(query: CompletionsQuery): CompletionsResult = withContext(readDispatcher) {
+    override suspend fun completions(query: ParsedCompletionsQuery): CompletionsResult = withContext(readDispatcher) {
         session.withReadAccess {
-            val file = session.findKtFile(query.position.filePath)
+            val file = session.findKtFile(query.position.filePath.value)
             val kindFilter = query.kindFilter
             val symbols = mutableListOf<CompletionItem>()
             file.accept(object : PsiRecursiveElementWalkingVisitor() {
@@ -334,7 +319,7 @@ internal class StandaloneAnalysisBackend internal constructor(
                     if (element is KtNamedDeclaration &&
                         element !is KtParameter &&
                         element.name != null &&
-                        element.textOffset <= query.position.offset
+                        element.textOffset <= query.position.offset.value
                     ) {
                         val symbol = analyze(file) {
                             element.toSymbolModel(
@@ -359,7 +344,7 @@ internal class StandaloneAnalysisBackend internal constructor(
             val deduped = symbols
                 .distinctBy { Triple(it.fqName, it.kind, it.name) }
                 .sortedWith(compareBy({ it.name }, { it.fqName }))
-            val capped = deduped.take(query.maxResults.coerceAtLeast(1))
+            val capped = deduped.take(query.maxResults.value)
             CompletionsResult(
                 items = capped,
                 exhaustive = deduped.size <= capped.size,
@@ -368,28 +353,29 @@ internal class StandaloneAnalysisBackend internal constructor(
     }
 
     override suspend fun semanticInsertionPoint(
-        query: SemanticInsertionQuery,
+        query: ParsedSemanticInsertionQuery,
     ): SemanticInsertionResult = withContext(readDispatcher) {
         session.withReadAccess {
             telemetry.inSpan(
                 scope = StandaloneTelemetryScope.SYMBOL_RESOLVE,
                 name = "kast.semanticInsertionPoint",
-                attributes = mapOf("kast.insertionPoint.filePath" to query.position.filePath),
+                attributes = mapOf("kast.insertionPoint.filePath" to query.position.filePath.value),
             ) {
-                val file = session.findKtFile(query.position.filePath)
+                val file = session.findKtFile(query.position.filePath.value)
                 SemanticInsertionPointResolver.resolve(file, query)
             }
         }
     }
 
-    override suspend fun diagnostics(query: DiagnosticsQuery): DiagnosticsResult = withContext(readDispatcher) {
+    override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult = withContext(readDispatcher) {
         session.withReadAccess {
             telemetry.inSpan(
                 scope = StandaloneTelemetryScope.SYMBOL_RESOLVE,
                 name = "kast.diagnostics",
-                attributes = mapOf("kast.diagnostics.fileCount" to query.filePaths.size),
+                attributes = mapOf("kast.diagnostics.fileCount" to query.filePaths.value.size),
             ) {
-                val diagnostics = query.filePaths
+                val diagnostics = query.filePaths.value
+                    .map { it.value }
                     .sorted()
                     .flatMap { filePath ->
                         runCatching {
@@ -423,27 +409,27 @@ internal class StandaloneAnalysisBackend internal constructor(
         }
     }
 
-    override suspend fun rename(query: RenameQuery): RenameResult = withContext(readDispatcher) {
+    override suspend fun rename(query: ParsedRenameQuery): RenameResult = withContext(readDispatcher) {
         session.withReadAccess {
             telemetry.inSpan(
                 scope = StandaloneTelemetryScope.RENAME,
                 name = "kast.rename",
                 attributes = mapOf(
-                    "kast.rename.filePath" to query.position.filePath,
-                    "kast.rename.newName" to query.newName,
+                    "kast.rename.filePath" to query.position.filePath.value,
+                    "kast.rename.newName" to query.newName.value,
                 ),
             ) { renameSpan ->
                 val file = traceRenamePhase(
                     phaseName = "findKtFile",
-                    attributes = mapOf("kast.rename.filePath" to query.position.filePath),
+                    attributes = mapOf("kast.rename.filePath" to query.position.filePath.value),
                 ) {
-                    session.findKtFile(query.position.filePath)
+                    session.findKtFile(query.position.filePath.value)
                 }
                 val target = traceRenamePhase(
                     phaseName = "resolveTarget",
-                    attributes = mapOf("kast.rename.offset" to query.position.offset),
+                    attributes = mapOf("kast.rename.offset" to query.position.offset.value),
                 ) {
-                    resolveTarget(file, query.position.offset)
+                    resolveTarget(file, query.position.offset.value)
                 }
                 val searchIdentifier = target.referenceSearchIdentifier()
                 val candidateSearch = traceRenamePhase(
@@ -468,16 +454,16 @@ internal class StandaloneAnalysisBackend internal constructor(
                 )
 
                 val edits = traceRenamePhase("collectReferenceEdits") {
-                    val referenceEdits = (listOf(target.declarationEdit(query.newName)) + candidateFiles
+                    val referenceEdits = (listOf(target.declarationEdit(query.newName.value)) + candidateFiles
                         .parallelMapFlat { candidateFile ->
-                            candidateFile.referenceEdits(target, query.newName, searchIdentifier)
+                            candidateFile.referenceEdits(target, query.newName.value, searchIdentifier)
                         })
 
                     val importEdits = run {
                         val oldFqn = target.targetFqNameAndPackage()?.first?.value
                         if (oldFqn != null && oldFqn.isNotBlank()) {
                             val lastDot = oldFqn.lastIndexOf('.')
-                            val newFqn = if (lastDot < 0) query.newName else "${oldFqn.substring(0, lastDot)}.${query.newName}"
+                            val newFqn = if (lastDot < 0) query.newName.value else "${oldFqn.substring(0, lastDot)}.${query.newName.value}"
                             candidateFiles.flatMap { candidateFile ->
                                 candidateFile.importDirectives.mapNotNull { directive ->
                                     ImportAnalysis.renameImportFqnEdit(directive, oldFqn, newFqn)
@@ -507,14 +493,15 @@ internal class StandaloneAnalysisBackend internal constructor(
         }
     }
 
-    override suspend fun optimizeImports(query: ImportOptimizeQuery): ImportOptimizeResult = withContext(readDispatcher) {
+    override suspend fun optimizeImports(query: ParsedImportOptimizeQuery): ImportOptimizeResult = withContext(readDispatcher) {
         session.withReadAccess {
             telemetry.inSpan(
                 scope = StandaloneTelemetryScope.SYMBOL_RESOLVE,
                 name = "kast.optimizeImports",
-                attributes = mapOf("kast.imports.fileCount" to query.filePaths.size),
+                attributes = mapOf("kast.imports.fileCount" to query.filePaths.value.size),
             ) {
-                val edits = query.filePaths
+                val edits = query.filePaths.value
+                    .map { it.value }
                     .distinct()
                     .sorted()
                     .flatMap { filePath ->
@@ -531,12 +518,12 @@ internal class StandaloneAnalysisBackend internal constructor(
         }
     }
 
-    override suspend fun applyEdits(query: ApplyEditsQuery): ApplyEditsResult {
+    override suspend fun applyEdits(query: ParsedApplyEditsQuery): ApplyEditsResult {
         return telemetry.inSpan(
             scope = StandaloneTelemetryScope.SESSION_LIFECYCLE,
             name = "kast.applyEdits",
         ) {
-            val result = LocalDiskEditApplier.apply(query)
+            val result = LocalDiskEditApplier.apply(query.toWire())
             if (result.createdFiles.isNotEmpty() || result.deletedFiles.isNotEmpty()) {
                 session.refreshWorkspace()
             } else {
@@ -546,16 +533,17 @@ internal class StandaloneAnalysisBackend internal constructor(
         }
     }
 
-    override suspend fun refresh(query: RefreshQuery): RefreshResult {
+    override suspend fun refresh(query: ParsedRefreshQuery): RefreshResult {
         return telemetry.inSpan(
             scope = StandaloneTelemetryScope.SESSION_LIFECYCLE,
             name = "kast.refresh",
             attributes = mapOf("kast.refresh.fileCount" to query.filePaths.size),
         ) {
-            if (query.filePaths.isEmpty()) {
+            val filePaths = query.filePaths.map { it.value }
+            if (filePaths.isEmpty()) {
                 session.refreshWorkspace(invalidateCaches = true)
             } else {
-                session.refreshTargetedPaths(query.filePaths.toSet())
+                session.refreshTargetedPaths(filePaths.toSet())
             }
         }
     }
@@ -709,31 +697,31 @@ internal class StandaloneAnalysisBackend internal constructor(
         block = action,
     )
 
-    override suspend fun fileOutline(query: FileOutlineQuery): FileOutlineResult = withContext(readDispatcher) {
+    override suspend fun fileOutline(query: ParsedFileOutlineQuery): FileOutlineResult = withContext(readDispatcher) {
         session.withReadAccess {
             telemetry.inSpan(
                 scope = StandaloneTelemetryScope.FILE_OUTLINE,
                 name = "kast.fileOutline",
-                attributes = mapOf("kast.fileOutline.filePath" to query.filePath),
+                attributes = mapOf("kast.fileOutline.filePath" to query.filePath.value),
             ) {
-                val file = session.findKtFile(query.filePath)
+                val file = session.findKtFile(query.filePath.value)
                 FileOutlineResult(symbols = FileOutlineBuilder.build(file))
             }
         }
     }
 
-    override suspend fun workspaceSymbolSearch(query: WorkspaceSymbolQuery): WorkspaceSymbolResult = withContext(readDispatcher) {
+    override suspend fun workspaceSymbolSearch(query: ParsedWorkspaceSymbolQuery): WorkspaceSymbolResult = withContext(readDispatcher) {
         session.withReadAccess {
             telemetry.inSpan(
                 scope = StandaloneTelemetryScope.WORKSPACE_SYMBOL_SEARCH,
                 name = "kast.workspaceSymbolSearch",
                 attributes = mapOf(
-                    "kast.workspaceSymbol.pattern" to query.pattern,
+                    "kast.workspaceSymbol.pattern" to query.pattern.value,
                     "kast.workspaceSymbol.regex" to query.regex,
                     "kast.workspaceSymbol.kind" to (query.kind?.name ?: "ALL"),
                 ),
             ) { span ->
-                val matcher = SymbolSearchMatcher.create(query.pattern, query.regex)
+                val matcher = SymbolSearchMatcher.create(query.pattern.value, query.regex)
                 val files = session.allKtFiles()
                 span.setAttribute("kast.workspaceSymbol.fileCount", files.size)
 
@@ -741,7 +729,7 @@ internal class StandaloneAnalysisBackend internal constructor(
                 for (file in files) {
                     file.accept(object : PsiRecursiveElementWalkingVisitor() {
                         override fun visitElement(element: PsiElement) {
-                            if (symbols.size >= query.maxResults) {
+                            if (symbols.size >= query.maxResults.value) {
                                 stopWalking()
                                 return
                             }
@@ -763,7 +751,7 @@ internal class StandaloneAnalysisBackend internal constructor(
                             super.visitElement(element)
                         }
                     })
-                    if (symbols.size >= query.maxResults) break
+                    if (symbols.size >= query.maxResults.value) break
                 }
                 span.setAttribute("kast.workspaceSymbol.resultCount", symbols.size)
 
@@ -780,21 +768,21 @@ internal class StandaloneAnalysisBackend internal constructor(
         else -> false
     }
 
-    override suspend fun workspaceFiles(query: WorkspaceFilesQuery): WorkspaceFilesResult = withContext(readDispatcher) {
-        val fileLimit = query.maxFilesPerModule ?: limits.maxResults
+    override suspend fun workspaceFiles(query: ParsedWorkspaceFilesQuery): WorkspaceFilesResult = withContext(readDispatcher) {
+        val fileLimit = query.maxFilesPerModule?.value ?: limits.maxResults
         telemetry.inSpan(
             scope = StandaloneTelemetryScope.WORKSPACE_FILES,
             name = "kast.workspaceFiles",
             attributes = mapOf(
-                "kast.workspaceFiles.moduleName" to query.moduleName,
+                "kast.workspaceFiles.moduleName" to query.moduleName?.value,
                 "kast.workspaceFiles.includeFiles" to query.includeFiles,
                 "kast.workspaceFiles.maxFilesPerModule" to fileLimit,
             ),
         ) { span ->
             session.withReadAccess {
                 val specs = session.moduleSpecs()
-                val filtered = if (query.moduleName != null) {
-                    specs.filter { it.name.value == query.moduleName }
+                val filtered = if (query.moduleName?.value != null) {
+                    specs.filter { it.name.value == query.moduleName?.value }
                 } else {
                     specs
                 }

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/hierarchy/CallHierarchyTraversal.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/hierarchy/CallHierarchyTraversal.kt
@@ -1,7 +1,7 @@
 package io.github.amichne.kast.standalone.hierarchy
 
-import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
 import io.github.amichne.kast.api.contract.result.CallHierarchyResult
+import io.github.amichne.kast.api.validation.*
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.shared.analysis.resolveTarget
 import io.github.amichne.kast.shared.hierarchy.CallHierarchyEngine
@@ -22,25 +22,25 @@ internal class CallHierarchyTraversal(
     private val normalizedWorkspaceRoot = normalizeStandalonePath(workspaceRoot)
     private val candidateFileResolver = CandidateFileResolver(session = session)
 
-    fun build(query: CallHierarchyQuery): CallHierarchyResult {
-        val file = session.findKtFile(query.position.filePath)
-        val rootTarget = resolveTarget(file, query.position.offset)
+    fun build(query: ParsedCallHierarchyQuery): CallHierarchyResult {
+        val file = session.findKtFile(query.position.filePath.value)
+        val rootTarget = resolveTarget(file, query.position.offset.value)
 
         return telemetry.inSpan(
             scope = StandaloneTelemetryScope.CALL_HIERARCHY,
             name = "kast.callHierarchy",
             attributes = mapOf(
                 "kast.callHierarchy.direction" to query.direction.name,
-                "kast.callHierarchy.depth" to query.depth,
-                "kast.callHierarchy.maxTotalCalls" to query.maxTotalCalls,
-                "kast.callHierarchy.maxChildrenPerNode" to query.maxChildrenPerNode,
-                "kast.callHierarchy.timeoutMillis" to (query.timeoutMillis ?: limits.requestTimeoutMillis),
+                "kast.callHierarchy.depth" to query.depth.value,
+                "kast.callHierarchy.maxTotalCalls" to query.maxTotalCalls.value,
+                "kast.callHierarchy.maxChildrenPerNode" to query.maxChildrenPerNode.value,
+                "kast.callHierarchy.timeoutMillis" to (query.timeoutMillis?.value ?: limits.requestTimeoutMillis),
             ),
         ) { span ->
             val budget = TraversalBudget(
-                maxTotalCalls = query.maxTotalCalls,
-                maxChildrenPerNode = query.maxChildrenPerNode,
-                timeoutMillis = query.timeoutMillis ?: limits.requestTimeoutMillis,
+                maxTotalCalls = query.maxTotalCalls.value,
+                maxChildrenPerNode = query.maxChildrenPerNode.value,
+                timeoutMillis = query.timeoutMillis?.value ?: limits.requestTimeoutMillis,
             )
             val resolver = StandaloneCallEdgeResolver(
                 candidateFileResolver = candidateFileResolver,
@@ -51,7 +51,7 @@ internal class CallHierarchyTraversal(
                 target = rootTarget,
                 parentCallSite = null,
                 direction = query.direction,
-                depthRemaining = query.depth,
+                depthRemaining = query.depth.value,
                 pathKeys = emptySet(),
                 budget = budget,
                 currentDepth = 0,

--- a/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/hierarchy/TypeHierarchyTraversal.kt
+++ b/backend-standalone/src/main/kotlin/io/github/amichne/kast/standalone/hierarchy/TypeHierarchyTraversal.kt
@@ -1,7 +1,7 @@
 package io.github.amichne.kast.standalone.hierarchy
 
-import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
 import io.github.amichne.kast.api.contract.result.TypeHierarchyResult
+import io.github.amichne.kast.api.validation.*
 import io.github.amichne.kast.shared.analysis.resolveTarget
 import io.github.amichne.kast.shared.analysis.typeHierarchyDeclaration
 import io.github.amichne.kast.shared.hierarchy.ReadAccessScope
@@ -15,15 +15,15 @@ internal class TypeHierarchyTraversal(
     private val resolver = StandaloneTypeEdgeResolver(session)
     private val engine = TypeHierarchyEngine(edgeResolver = resolver, readAccess = ReadAccessScope.IDENTITY)
 
-    fun build(query: TypeHierarchyQuery): TypeHierarchyResult {
-        val file = session.findKtFile(query.position.filePath)
-        val resolvedTarget = resolveTarget(file, query.position.offset)
+    fun build(query: ParsedTypeHierarchyQuery): TypeHierarchyResult {
+        val file = session.findKtFile(query.position.filePath.value)
+        val resolvedTarget = resolveTarget(file, query.position.offset.value)
         val rootTarget = resolvedTarget.typeHierarchyDeclaration() ?: resolvedTarget
-        val budget = TypeHierarchyBudget(maxResults = query.maxResults.coerceAtLeast(1))
+        val budget = TypeHierarchyBudget(maxResults = query.maxResults.value)
         val root = engine.buildNode(
             target = rootTarget,
             direction = query.direction,
-            depthRemaining = query.depth.coerceAtLeast(0),
+            depthRemaining = query.depth.value,
             pathKeys = emptySet(),
             budget = budget,
             currentDepth = 0,

--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/ParsedQueryTestAdapters.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/ParsedQueryTestAdapters.kt
@@ -1,0 +1,36 @@
+package io.github.amichne.kast.standalone
+
+import io.github.amichne.kast.api.contract.SemanticInsertionQuery
+import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
+import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
+import io.github.amichne.kast.api.contract.query.CodeActionsQuery
+import io.github.amichne.kast.api.contract.query.CompletionsQuery
+import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
+import io.github.amichne.kast.api.contract.query.FileOutlineQuery
+import io.github.amichne.kast.api.contract.query.ImplementationsQuery
+import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
+import io.github.amichne.kast.api.contract.query.ReferencesQuery
+import io.github.amichne.kast.api.contract.query.RefreshQuery
+import io.github.amichne.kast.api.contract.query.RenameQuery
+import io.github.amichne.kast.api.contract.query.SymbolQuery
+import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
+import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
+import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
+import io.github.amichne.kast.api.validation.parsed
+
+internal suspend fun StandaloneAnalysisBackend.resolveSymbol(query: SymbolQuery) = resolveSymbol(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.findReferences(query: ReferencesQuery) = findReferences(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.callHierarchy(query: CallHierarchyQuery) = callHierarchy(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.typeHierarchy(query: TypeHierarchyQuery) = typeHierarchy(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.semanticInsertionPoint(query: SemanticInsertionQuery) = semanticInsertionPoint(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.diagnostics(query: DiagnosticsQuery) = diagnostics(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.rename(query: RenameQuery) = rename(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.applyEdits(query: ApplyEditsQuery) = applyEdits(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.optimizeImports(query: ImportOptimizeQuery) = optimizeImports(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.refresh(query: RefreshQuery) = refresh(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.fileOutline(query: FileOutlineQuery) = fileOutline(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.workspaceSymbolSearch(query: WorkspaceSymbolQuery) = workspaceSymbolSearch(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.workspaceFiles(query: WorkspaceFilesQuery) = workspaceFiles(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.implementations(query: ImplementationsQuery) = implementations(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.codeActions(query: CodeActionsQuery) = codeActions(query.parsed())
+internal suspend fun StandaloneAnalysisBackend.completions(query: CompletionsQuery) = completions(query.parsed())

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
@@ -1,5 +1,7 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.PositiveLong
 import io.github.amichne.kast.cli.options.RuntimeCommandOptions
 import io.github.amichne.kast.cli.options.SmokeOptions
 import io.github.amichne.kast.cli.tty.CliFailure
@@ -63,9 +65,9 @@ internal class SmokeCommandSupport(
         }
 
         val runtimeOptions = RuntimeCommandOptions(
-            workspaceRoot = options.workspaceRoot,
+            workspaceRoot = NormalizedPath.ofAbsolute(options.workspaceRoot),
             backendName = null,
-            waitTimeoutMillis = runtimeWaitTimeoutMillis,
+            waitTimeoutMillis = PositiveLong(runtimeWaitTimeoutMillis),
             acceptIndexing = true,
         )
 

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManager.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManager.kt
@@ -6,6 +6,7 @@ import io.github.amichne.kast.api.contract.RuntimeState
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.client.defaultDescriptorDirectory
 import io.github.amichne.kast.cli.options.RuntimeCommandOptions
+import io.github.amichne.kast.cli.options.BackendName
 import io.github.amichne.kast.cli.results.DaemonStopResult
 import io.github.amichne.kast.cli.results.WorkspaceEnsureResult
 import io.github.amichne.kast.cli.results.WorkspaceStatusResult
@@ -41,7 +42,7 @@ internal class WorkspaceRuntimeManager(
             options = options,
             pruneStaleDescriptors = true,
         )
-        val backendFilter = options.backendName
+        val backendFilter = options.backendName?.canonicalName
         val candidate = if (backendFilter != null) {
             inspection.candidates.firstOrNull { it.descriptor.backendName == backendFilter }
         } else {
@@ -75,7 +76,7 @@ internal class WorkspaceRuntimeManager(
             )
         }
 
-        if (options.backendName == "intellij") {
+        if (options.backendName == BackendName.INTELLIJ) {
             throw CliFailure(
                 code = "INTELLIJ_NOT_RUNNING",
                 message = "No IntelliJ backend is available for ${options.workspaceRoot}. " +
@@ -92,8 +93,8 @@ internal class WorkspaceRuntimeManager(
                     workspaceRoot = options.workspaceRoot.toString(),
                     started = false,
                     selected = waitForServable(
-                        options = options.copy(backendName = "standalone"),
-                        backendName = "standalone",
+                        options = options.copy(backendName = BackendName.STANDALONE),
+                        backendName = BackendName.STANDALONE,
                         acceptIndexing = !requireReady,
                     ),
                 )
@@ -109,10 +110,10 @@ internal class WorkspaceRuntimeManager(
 
     private suspend fun waitForServable(
         options: RuntimeCommandOptions,
-        backendName: String,
+        backendName: BackendName,
         acceptIndexing: Boolean,
     ): RuntimeCandidateStatus {
-        val deadline = System.nanoTime() + options.waitTimeoutMillis * 1_000_000
+        val deadline = System.nanoTime() + options.waitTimeoutMillis.value * 1_000_000
         while (System.nanoTime() < deadline) {
             val inspection = inspectWorkspace(options, pruneStaleDescriptors = true)
             selectServableCandidate(
@@ -127,7 +128,7 @@ internal class WorkspaceRuntimeManager(
         val targetState = if (acceptIndexing) "servable" else "ready"
         throw CliFailure(
             code = "RUNTIME_TIMEOUT",
-            message = "Timed out waiting for $backendName runtime to become $targetState for ${options.workspaceRoot}",
+            message = "Timed out waiting for ${backendName.canonicalName} runtime to become $targetState for ${options.workspaceRoot}",
         )
     }
 
@@ -137,7 +138,7 @@ internal class WorkspaceRuntimeManager(
     ): WorkspaceInspection {
         val descriptorDirectory = defaultDescriptorDirectory(envLookup)
         val registry = DescriptorRegistry(descriptorDirectory.resolve("daemons.json"))
-        val registeredDescriptors = registry.findByWorkspaceRoot(options.workspaceRoot)
+        val registeredDescriptors = registry.findByWorkspaceRoot(options.workspaceRoot.toJavaPath())
         val candidates = registeredDescriptors.map { registered ->
             inspectDescriptor(registry, registered, pruneStaleDescriptors)
         }
@@ -148,7 +149,7 @@ internal class WorkspaceRuntimeManager(
                 compareByDescending(RuntimeCandidateStatus::ready)
                     .thenBy(RuntimeCandidateStatus::descriptorPath),
             ),
-            selected = selectStatusCandidate(candidates, options.backendName),
+            selected = selectStatusCandidate(candidates, options.backendName?.canonicalName),
         )
     }
 
@@ -256,10 +257,10 @@ internal fun RuntimeStatusResponse?.isReady(): Boolean = this != null &&
 
 internal fun selectServableCandidate(
     candidates: List<RuntimeCandidateStatus>,
-    backendName: String?,
+    backendName: BackendName?,
     acceptIndexing: Boolean,
 ): RuntimeCandidateStatus? = candidates
-    .filter { candidate -> backendName == null || candidate.descriptor.backendName == backendName }
+    .filter { candidate -> backendName == null || candidate.descriptor.backendName == backendName.canonicalName }
     .filter { candidate ->
         if (acceptIndexing) {
             candidate.runtimeStatus.isServable()

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/RuntimeCommandOptions.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/options/RuntimeCommandOptions.kt
@@ -1,12 +1,21 @@
 package io.github.amichne.kast.cli.options
 
 import io.github.amichne.kast.api.client.StandaloneServerOptions
-import java.nio.file.Path
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.PositiveLong
+
+internal enum class BackendName {
+    STANDALONE,
+    INTELLIJ,
+    ;
+
+    val canonicalName: String = name.lowercase()
+}
 
 internal data class RuntimeCommandOptions(
-    val workspaceRoot: Path,
-    val backendName: String?,
-    val waitTimeoutMillis: Long,
+    val workspaceRoot: NormalizedPath,
+    val backendName: BackendName?,
+    val waitTimeoutMillis: PositiveLong,
     val standaloneOptions: StandaloneServerOptions? = null,
     val acceptIndexing: Boolean = false,
     val noAutoStart: Boolean = false,

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/skill/SkillWrapperExecutor.kt
@@ -8,6 +8,8 @@ import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
 import io.github.amichne.kast.api.contract.FileOperation
 import io.github.amichne.kast.api.contract.query.FileOutlineQuery
 import io.github.amichne.kast.api.contract.FilePosition
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.PositiveLong
 import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
 import io.github.amichne.kast.api.contract.query.ReferencesQuery
 import io.github.amichne.kast.api.contract.query.RenameQuery
@@ -797,9 +799,9 @@ internal class SkillWrapperExecutor(
     private fun requireWorkspaceRoot(explicit: String?): String = SkillWrapperInput.resolveWorkspaceRoot(explicit)
 
     private fun runtimeOptionsFor(workspaceRoot: String): RuntimeCommandOptions = RuntimeCommandOptions(
-        workspaceRoot = Path.of(workspaceRoot).toAbsolutePath().normalize(),
+        workspaceRoot = NormalizedPath.ofAbsolute(Path.of(workspaceRoot).toAbsolutePath().normalize()),
         backendName = null,
-        waitTimeoutMillis = 60_000L,
+        waitTimeoutMillis = PositiveLong(60_000L),
     )
 
     // endregion

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommand.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommand.kt
@@ -26,29 +26,34 @@ import io.github.amichne.kast.cli.skill.SkillWrapperName
 import java.nio.file.Path
 
 internal sealed interface CliCommand {
+    interface BackendQuery<Q> : CliCommand {
+        val options: RuntimeCommandOptions
+        val query: Q
+    }
+
     data class Help(val topic: List<String> = emptyList()) : CliCommand
     data object Version : CliCommand
     data class Completion(val shell: CliCompletionShell) : CliCommand
     data class WorkspaceStatus(val options: RuntimeCommandOptions) : CliCommand
     data class WorkspaceEnsure(val options: RuntimeCommandOptions) : CliCommand
-    data class WorkspaceRefresh(val options: RuntimeCommandOptions, val query: RefreshQuery) : CliCommand
+    data class WorkspaceRefresh(override val options: RuntimeCommandOptions, override val query: RefreshQuery) : BackendQuery<RefreshQuery>
     data class WorkspaceStop(val options: RuntimeCommandOptions) : CliCommand
     data class Capabilities(val options: RuntimeCommandOptions) : CliCommand
-    data class ResolveSymbol(val options: RuntimeCommandOptions, val query: SymbolQuery) : CliCommand
-    data class FindReferences(val options: RuntimeCommandOptions, val query: ReferencesQuery) : CliCommand
-    data class CallHierarchy(val options: RuntimeCommandOptions, val query: CallHierarchyQuery) : CliCommand
-    data class TypeHierarchy(val options: RuntimeCommandOptions, val query: TypeHierarchyQuery) : CliCommand
-    data class SemanticInsertionPoint(val options: RuntimeCommandOptions, val query: SemanticInsertionQuery) : CliCommand
-    data class Diagnostics(val options: RuntimeCommandOptions, val query: DiagnosticsQuery) : CliCommand
-    data class FileOutline(val options: RuntimeCommandOptions, val query: FileOutlineQuery) : CliCommand
-    data class WorkspaceSymbol(val options: RuntimeCommandOptions, val query: WorkspaceSymbolQuery) : CliCommand
-    data class WorkspaceFiles(val options: RuntimeCommandOptions, val query: WorkspaceFilesQuery) : CliCommand
-    data class Implementations(val options: RuntimeCommandOptions, val query: ImplementationsQuery) : CliCommand
-    data class CodeActions(val options: RuntimeCommandOptions, val query: CodeActionsQuery) : CliCommand
-    data class Completions(val options: RuntimeCommandOptions, val query: CompletionsQuery) : CliCommand
-    data class Rename(val options: RuntimeCommandOptions, val query: RenameQuery) : CliCommand
-    data class ImportOptimize(val options: RuntimeCommandOptions, val query: ImportOptimizeQuery) : CliCommand
-    data class ApplyEdits(val options: RuntimeCommandOptions, val query: ApplyEditsQuery) : CliCommand
+    data class ResolveSymbol(override val options: RuntimeCommandOptions, override val query: SymbolQuery) : BackendQuery<SymbolQuery>
+    data class FindReferences(override val options: RuntimeCommandOptions, override val query: ReferencesQuery) : BackendQuery<ReferencesQuery>
+    data class CallHierarchy(override val options: RuntimeCommandOptions, override val query: CallHierarchyQuery) : BackendQuery<CallHierarchyQuery>
+    data class TypeHierarchy(override val options: RuntimeCommandOptions, override val query: TypeHierarchyQuery) : BackendQuery<TypeHierarchyQuery>
+    data class SemanticInsertionPoint(override val options: RuntimeCommandOptions, override val query: SemanticInsertionQuery) : BackendQuery<SemanticInsertionQuery>
+    data class Diagnostics(override val options: RuntimeCommandOptions, override val query: DiagnosticsQuery) : BackendQuery<DiagnosticsQuery>
+    data class FileOutline(override val options: RuntimeCommandOptions, override val query: FileOutlineQuery) : BackendQuery<FileOutlineQuery>
+    data class WorkspaceSymbol(override val options: RuntimeCommandOptions, override val query: WorkspaceSymbolQuery) : BackendQuery<WorkspaceSymbolQuery>
+    data class WorkspaceFiles(override val options: RuntimeCommandOptions, override val query: WorkspaceFilesQuery) : BackendQuery<WorkspaceFilesQuery>
+    data class Implementations(override val options: RuntimeCommandOptions, override val query: ImplementationsQuery) : BackendQuery<ImplementationsQuery>
+    data class CodeActions(override val options: RuntimeCommandOptions, override val query: CodeActionsQuery) : BackendQuery<CodeActionsQuery>
+    data class Completions(override val options: RuntimeCommandOptions, override val query: CompletionsQuery) : BackendQuery<CompletionsQuery>
+    data class Rename(override val options: RuntimeCommandOptions, override val query: RenameQuery) : BackendQuery<RenameQuery>
+    data class ImportOptimize(override val options: RuntimeCommandOptions, override val query: ImportOptimizeQuery) : BackendQuery<ImportOptimizeQuery>
+    data class ApplyEdits(override val options: RuntimeCommandOptions, override val query: ApplyEditsQuery) : BackendQuery<ApplyEditsQuery>
     data class Install(val options: InstallOptions) : CliCommand
     data class InstallSkill(val options: InstallSkillOptions) : CliCommand
     data class InstallCopilotExtension(val options: InstallCopilotExtensionOptions) : CliCommand

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandParser.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandParser.kt
@@ -8,6 +8,8 @@ import io.github.amichne.kast.api.contract.query.CompletionsQuery
 import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
 import io.github.amichne.kast.api.contract.query.FileOutlineQuery
 import io.github.amichne.kast.api.contract.FilePosition
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.PositiveLong
 import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
 import io.github.amichne.kast.api.contract.query.ImplementationsQuery
 import io.github.amichne.kast.api.contract.query.ReferencesQuery
@@ -23,6 +25,7 @@ import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
 import io.github.amichne.kast.cli.options.DaemonStartOptions
+import io.github.amichne.kast.cli.options.BackendName
 import io.github.amichne.kast.cli.options.InstallCopilotExtensionOptions
 import io.github.amichne.kast.cli.options.InstallOptions
 import io.github.amichne.kast.cli.options.InstallSkillOptions
@@ -292,17 +295,11 @@ internal data class ParsedArguments(
         val requestedBackendName = backendName
             ?.trim()
             ?.takeIf(String::isNotEmpty)
-        if (requestedBackendName != null && requestedBackendName !in VALID_BACKEND_NAMES) {
-            throw CliFailure(
-                code = "CLI_USAGE",
-                message = "Unsupported --backend-name=$requestedBackendName. " +
-                    "Valid values: ${VALID_BACKEND_NAMES.joinToString()}",
-            )
-        }
+            ?.let(::parseBackendName)
         return RuntimeCommandOptions(
-            workspaceRoot = standaloneOptions.workspaceRoot,
+            workspaceRoot = NormalizedPath.ofAbsolute(standaloneOptions.workspaceRoot),
             backendName = requestedBackendName,
-            waitTimeoutMillis = options["wait-timeout-ms"]?.toLongOrNull() ?: 60_000L,
+            waitTimeoutMillis = PositiveLong(options["wait-timeout-ms"]?.toLongOrNull() ?: 60_000L),
             standaloneOptions = standaloneOptions,
             acceptIndexing = optionalBoolean("accept-indexing", false),
             noAutoStart = optionalBoolean("no-auto-start", false),
@@ -722,6 +719,16 @@ internal data class ParsedArguments(
 
     private fun absoluteFilePath(value: String): String = Path.of(value).toAbsolutePath().normalize().toString()
 
+    private fun parseBackendName(raw: String): BackendName = runCatching {
+        BackendName.valueOf(raw.uppercase())
+    }.getOrElse {
+        throw CliFailure(
+            code = "CLI_USAGE",
+            message = "Unsupported --backend-name=$raw. " +
+                "Valid values: ${BackendName.entries.joinToString { backend -> backend.canonicalName }}",
+        )
+    }
+
     fun requireWorkspaceRootPath(): Path {
         val raw = options["workspace-root"]
             ?: System.getProperty("user.dir", ".")
@@ -740,5 +747,3 @@ internal data class ParsedArguments(
         )
     }
 }
-
-private val VALID_BACKEND_NAMES = setOf("standalone", "intellij")

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliExecution.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliExecution.kt
@@ -19,6 +19,7 @@ import io.github.amichne.kast.indexstore.ModuleDepthMetric
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import java.nio.file.Path
+import kotlin.reflect.KClass
 
 internal sealed interface CliOutput {
     data class JsonValue(val value: Any) : CliOutput
@@ -58,6 +59,73 @@ internal class DefaultCliCommandExecutor(
     private val cliService: CliService,
     private val json: Json = defaultCliJson(),
 ) : CliCommandExecutor {
+    private val backendQueryHandlers: Map<KClass<out CliCommand.BackendQuery<*>>, suspend (CliCommand.BackendQuery<*>) -> RuntimeAttachedResult<*>> = mapOf(
+        CliCommand.WorkspaceRefresh::class to { command ->
+            command as CliCommand.WorkspaceRefresh
+            cliService.workspaceRefresh(command.options, command.query)
+        },
+        CliCommand.ResolveSymbol::class to { command ->
+            command as CliCommand.ResolveSymbol
+            cliService.resolveSymbol(command.options, command.query)
+        },
+        CliCommand.FindReferences::class to { command ->
+            command as CliCommand.FindReferences
+            cliService.findReferences(command.options, command.query)
+        },
+        CliCommand.CallHierarchy::class to { command ->
+            command as CliCommand.CallHierarchy
+            cliService.callHierarchy(command.options, command.query)
+        },
+        CliCommand.TypeHierarchy::class to { command ->
+            command as CliCommand.TypeHierarchy
+            cliService.typeHierarchy(command.options, command.query)
+        },
+        CliCommand.SemanticInsertionPoint::class to { command ->
+            command as CliCommand.SemanticInsertionPoint
+            cliService.semanticInsertionPoint(command.options, command.query)
+        },
+        CliCommand.Diagnostics::class to { command ->
+            command as CliCommand.Diagnostics
+            cliService.diagnostics(command.options, command.query)
+        },
+        CliCommand.FileOutline::class to { command ->
+            command as CliCommand.FileOutline
+            cliService.fileOutline(command.options, command.query)
+        },
+        CliCommand.WorkspaceSymbol::class to { command ->
+            command as CliCommand.WorkspaceSymbol
+            cliService.workspaceSymbolSearch(command.options, command.query)
+        },
+        CliCommand.WorkspaceFiles::class to { command ->
+            command as CliCommand.WorkspaceFiles
+            cliService.workspaceFiles(command.options, command.query)
+        },
+        CliCommand.Implementations::class to { command ->
+            command as CliCommand.Implementations
+            cliService.implementations(command.options, command.query)
+        },
+        CliCommand.CodeActions::class to { command ->
+            command as CliCommand.CodeActions
+            cliService.codeActions(command.options, command.query)
+        },
+        CliCommand.Completions::class to { command ->
+            command as CliCommand.Completions
+            cliService.completions(command.options, command.query)
+        },
+        CliCommand.Rename::class to { command ->
+            command as CliCommand.Rename
+            cliService.rename(command.options, command.query)
+        },
+        CliCommand.ImportOptimize::class to { command ->
+            command as CliCommand.ImportOptimize
+            cliService.optimizeImports(command.options, command.query)
+        },
+        CliCommand.ApplyEdits::class to { command ->
+            command as CliCommand.ApplyEdits
+            cliService.applyEdits(command.options, command.query)
+        },
+    )
+
     override suspend fun execute(command: CliCommand): CliExecutionResult {
         return when (command) {
             is CliCommand.Help -> CliExecutionResult(
@@ -88,13 +156,7 @@ internal class DefaultCliCommandExecutor(
                 )
             }
 
-            is CliCommand.WorkspaceRefresh -> {
-                val result = cliService.workspaceRefresh(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
+            is CliCommand.BackendQuery<*> -> executeBackendQuery(command)
 
             is CliCommand.WorkspaceStop -> {
                 val result = cliService.workspaceStop(command.options)
@@ -106,126 +168,6 @@ internal class DefaultCliCommandExecutor(
 
             is CliCommand.Capabilities -> {
                 val result = cliService.capabilities(command.options)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.ResolveSymbol -> {
-                val result = cliService.resolveSymbol(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.FindReferences -> {
-                val result = cliService.findReferences(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.CallHierarchy -> {
-                val result = cliService.callHierarchy(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.TypeHierarchy -> {
-                val result = cliService.typeHierarchy(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.WorkspaceFiles -> {
-                val result = cliService.workspaceFiles(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.Implementations -> {
-                val result = cliService.implementations(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.CodeActions -> {
-                val result = cliService.codeActions(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.Completions -> {
-                val result = cliService.completions(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.SemanticInsertionPoint -> {
-                val result = cliService.semanticInsertionPoint(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.Diagnostics -> {
-                val result = cliService.diagnostics(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.FileOutline -> {
-                val result = cliService.fileOutline(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.WorkspaceSymbol -> {
-                val result = cliService.workspaceSymbolSearch(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.Rename -> {
-                val result = cliService.rename(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.ImportOptimize -> {
-                val result = cliService.optimizeImports(command.options, command.query)
-                CliExecutionResult(
-                    output = CliOutput.JsonValue(result.payload),
-                    daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
-                )
-            }
-
-            is CliCommand.ApplyEdits -> {
-                val result = cliService.applyEdits(command.options, command.query)
                 CliExecutionResult(
                     output = CliOutput.JsonValue(result.payload),
                     daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
@@ -340,5 +282,23 @@ internal class DefaultCliCommandExecutor(
                 CliExecutionResult(output = CliOutput.Text(encoded))
             }
         }
+    }
+
+    private suspend fun executeBackendQuery(command: CliCommand.BackendQuery<*>): CliExecutionResult {
+        val dispatcher = backendQueryHandlers[command::class]
+            ?: throw CliFailure(
+                code = "CLI_USAGE",
+                message = "Unsupported backend query command: ${command::class.simpleName}",
+            )
+        val result = dispatcher(command)
+        return CliExecutionResult(
+            output = CliOutput.JsonValue(
+                result.payload ?: throw CliFailure(
+                    code = "CLI_EXECUTION",
+                    message = "Backend query ${command::class.simpleName} completed without a payload",
+                ),
+            ),
+            daemonNote = result.daemonNote ?: daemonNoteForRuntime(result.runtime),
+        )
     }
 }

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandParserTest.kt
@@ -4,6 +4,7 @@ import io.github.amichne.kast.api.contract.query.RefreshQuery
 import io.github.amichne.kast.api.contract.SemanticInsertionTarget
 import io.github.amichne.kast.api.contract.SymbolKind
 import io.github.amichne.kast.api.contract.TypeHierarchyDirection
+import io.github.amichne.kast.cli.options.BackendName
 import io.github.amichne.kast.cli.tty.CliCommand
 import io.github.amichne.kast.cli.tty.CliCommandParser
 import io.github.amichne.kast.cli.tty.CliCompletionShell
@@ -78,7 +79,7 @@ class CliCommandParserTest {
 
         assertTrue(command is CliCommand.CallHierarchy)
         val hierarchyCommand = command as CliCommand.CallHierarchy
-        assertEquals(tempDir, hierarchyCommand.options.workspaceRoot)
+        assertEquals(tempDir, hierarchyCommand.options.workspaceRoot.toJavaPath())
         assertEquals(io.github.amichne.kast.api.contract.CallDirection.INCOMING, hierarchyCommand.query.direction)
         assertEquals(0, hierarchyCommand.query.depth)
         assertEquals(32, hierarchyCommand.query.maxTotalCalls)
@@ -99,7 +100,7 @@ class CliCommandParserTest {
 
         assertTrue(command is CliCommand.WorkspaceRefresh)
         val refreshCommand = command as CliCommand.WorkspaceRefresh
-        assertEquals(tempDir, refreshCommand.options.workspaceRoot)
+        assertEquals(tempDir, refreshCommand.options.workspaceRoot.toJavaPath())
         assertEquals(
             RefreshQuery(
                 filePaths = listOf(
@@ -160,7 +161,7 @@ class CliCommandParserTest {
 
         assertTrue(command is CliCommand.TypeHierarchy)
         val hierarchyCommand = command as CliCommand.TypeHierarchy
-        assertEquals(tempDir, hierarchyCommand.options.workspaceRoot)
+        assertEquals(tempDir, hierarchyCommand.options.workspaceRoot.toJavaPath())
         assertEquals(TypeHierarchyDirection.BOTH, hierarchyCommand.query.direction)
         assertEquals(2, hierarchyCommand.query.depth)
         assertEquals(24, hierarchyCommand.query.maxResults)
@@ -180,7 +181,7 @@ class CliCommandParserTest {
 
         assertTrue(command is CliCommand.SemanticInsertionPoint)
         val insertionCommand = command as CliCommand.SemanticInsertionPoint
-        assertEquals(tempDir, insertionCommand.options.workspaceRoot)
+        assertEquals(tempDir, insertionCommand.options.workspaceRoot.toJavaPath())
         assertEquals(SemanticInsertionTarget.AFTER_IMPORTS, insertionCommand.query.target)
     }
 
@@ -196,7 +197,7 @@ class CliCommandParserTest {
 
         assertTrue(command is CliCommand.ImportOptimize)
         val optimizeCommand = command as CliCommand.ImportOptimize
-        assertEquals(tempDir, optimizeCommand.options.workspaceRoot)
+        assertEquals(tempDir, optimizeCommand.options.workspaceRoot.toJavaPath())
         assertEquals(
             listOf(
                 tempDir.resolve("A.kt").toString(),
@@ -330,7 +331,7 @@ class CliCommandParserTest {
 
         assertTrue(command is CliCommand.WorkspaceStatus)
         val statusCommand = command as CliCommand.WorkspaceStatus
-        assertEquals("intellij", statusCommand.options.backendName)
+        assertEquals(BackendName.INTELLIJ, statusCommand.options.backendName)
     }
 
     @Test
@@ -378,7 +379,7 @@ class CliCommandParserTest {
 
         assertTrue(command is CliCommand.WorkspaceStop)
         val stopCommand = command as CliCommand.WorkspaceStop
-        assertEquals(tempDir, stopCommand.options.workspaceRoot)
+        assertEquals(tempDir, stopCommand.options.workspaceRoot.toJavaPath())
     }
 
     @Test
@@ -462,7 +463,7 @@ class CliCommandParserTest {
 
         assertTrue(command is CliCommand.FileOutline)
         val outlineCommand = command as CliCommand.FileOutline
-        assertEquals(tempDir, outlineCommand.options.workspaceRoot)
+        assertEquals(tempDir, outlineCommand.options.workspaceRoot.toJavaPath())
         assertEquals(tempDir.resolve("Sample.kt").toString(), outlineCommand.query.filePath)
     }
 
@@ -478,7 +479,7 @@ class CliCommandParserTest {
 
         assertTrue(command is CliCommand.WorkspaceSymbol)
         val symbolCommand = command as CliCommand.WorkspaceSymbol
-        assertEquals(tempDir, symbolCommand.options.workspaceRoot)
+        assertEquals(tempDir, symbolCommand.options.workspaceRoot.toJavaPath())
         assertEquals("MyClass", symbolCommand.query.pattern)
         assertEquals(false, symbolCommand.query.regex)
         assertEquals(100, symbolCommand.query.maxResults)

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManagerTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/WorkspaceRuntimeManagerTest.kt
@@ -3,12 +3,15 @@ package io.github.amichne.kast.cli
 import io.github.amichne.kast.api.contract.BackendCapabilities
 import io.github.amichne.kast.api.client.DescriptorRegistry
 import io.github.amichne.kast.api.contract.MutationCapability
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.PositiveLong
 import io.github.amichne.kast.api.contract.ReadCapability
 import io.github.amichne.kast.api.contract.RuntimeState
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.client.ServerInstanceDescriptor
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.client.defaultDescriptorDirectory
+import io.github.amichne.kast.cli.options.BackendName
 import io.github.amichne.kast.cli.options.RuntimeCommandOptions
 import io.github.amichne.kast.cli.tty.CliFailure
 import kotlinx.coroutines.test.runTest
@@ -320,9 +323,9 @@ class WorkspaceRuntimeManagerTest {
         workspaceRoot: Path,
         backendName: String? = "standalone",
     ): RuntimeCommandOptions = RuntimeCommandOptions(
-        workspaceRoot = workspaceRoot,
-        backendName = backendName,
-        waitTimeoutMillis = 2_000L,
+        workspaceRoot = NormalizedPath.ofAbsolute(workspaceRoot),
+        backendName = backendName?.let { BackendName.valueOf(it.uppercase()) },
+        waitTimeoutMillis = PositiveLong(2_000L),
     )
 
     private fun descriptor(

--- a/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/AnalysisBackendContractFixture.kt
+++ b/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/AnalysisBackendContractFixture.kt
@@ -4,6 +4,7 @@ import io.github.amichne.kast.api.contract.AnalysisBackend
 import io.github.amichne.kast.api.contract.CallDirection
 import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
 import io.github.amichne.kast.api.validation.FileHashing
+import io.github.amichne.kast.api.validation.parsed
 import io.github.amichne.kast.api.contract.query.FileOutlineQuery
 import io.github.amichne.kast.api.contract.FilePosition
 import io.github.amichne.kast.api.contract.Location
@@ -245,7 +246,7 @@ object AnalysisBackendContractAssertions {
         backend: AnalysisBackend,
         fixture: AnalysisBackendContractFixture,
     ) {
-        val result = backend.resolveSymbol(fixture.symbolQuery)
+        val result = backend.resolveSymbol(fixture.symbolQuery.parsed())
 
         expectEquals(fixture.symbolFqName, result.symbol.fqName, "resolved symbol fqName")
         expectEquals(SymbolKind.FUNCTION, result.symbol.kind, "resolved symbol kind")
@@ -257,7 +258,7 @@ object AnalysisBackendContractAssertions {
         backend: AnalysisBackend,
         fixture: AnalysisBackendContractFixture,
     ) {
-        val result = backend.findReferences(fixture.referencesQuery)
+        val result = backend.findReferences(fixture.referencesQuery.parsed())
 
         expectEquals(fixture.symbolFqName, result.declaration?.fqName, "references declaration fqName")
         expectEquals(
@@ -276,7 +277,7 @@ object AnalysisBackendContractAssertions {
         backend: AnalysisBackend,
         fixture: AnalysisBackendContractFixture,
     ) {
-        val result = backend.callHierarchy(fixture.callHierarchyQuery)
+        val result = backend.callHierarchy(fixture.callHierarchyQuery.parsed())
 
         expectEquals(fixture.symbolFqName, result.root.symbol.fqName, "call hierarchy root fqName")
         expectEquals(
@@ -298,7 +299,7 @@ object AnalysisBackendContractAssertions {
         backend: AnalysisBackend,
         fixture: AnalysisBackendContractFixture,
     ) {
-        val result = backend.typeHierarchy(fixture.typeHierarchyQuery)
+        val result = backend.typeHierarchy(fixture.typeHierarchyQuery.parsed())
 
         expectEquals(fixture.typeHierarchyRootFqName, result.root.symbol.fqName, "type hierarchy root fqName")
         expectEquals(fixture.typeHierarchyRootSupertypes, result.root.symbol.supertypes, "type hierarchy root supertypes")
@@ -316,7 +317,7 @@ object AnalysisBackendContractAssertions {
         backend: AnalysisBackend,
         fixture: AnalysisBackendContractFixture,
     ) {
-        val result = backend.fileOutline(fixture.fileOutlineQuery)
+        val result = backend.fileOutline(fixture.fileOutlineQuery.parsed())
 
         check(result.symbols.isNotEmpty()) { "file outline should return at least one symbol" }
         val fqNames = result.symbols.map { it.symbol.fqName }
@@ -329,7 +330,7 @@ object AnalysisBackendContractAssertions {
         backend: AnalysisBackend,
         fixture: AnalysisBackendContractFixture,
     ) {
-        val result = backend.workspaceSymbolSearch(fixture.workspaceSymbolQuery)
+        val result = backend.workspaceSymbolSearch(fixture.workspaceSymbolQuery.parsed())
 
         check(result.symbols.isNotEmpty()) { "workspace symbol search should return at least one symbol" }
         val fqNames = result.symbols.map { it.fqName }
@@ -342,7 +343,7 @@ object AnalysisBackendContractAssertions {
         backend: AnalysisBackend,
         fixture: AnalysisBackendContractFixture,
     ) {
-        val result = backend.rename(fixture.renameQuery)
+        val result = backend.rename(fixture.renameQuery.parsed())
 
         expectEquals(
             fixture.renameEdits.map { edit -> edit.filePath to edit.newText },

--- a/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
+++ b/shared-testing/src/main/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
@@ -1,32 +1,25 @@
 package io.github.amichne.kast.testing
 
 import io.github.amichne.kast.api.contract.AnalysisBackend
-import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
+import io.github.amichne.kast.api.validation.*
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
 import io.github.amichne.kast.api.contract.BackendCapabilities
 import io.github.amichne.kast.api.contract.CallDirection
-import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
 import io.github.amichne.kast.api.contract.result.CallHierarchyResult
 import io.github.amichne.kast.api.contract.result.CallHierarchyStats
 import io.github.amichne.kast.api.contract.CallNode
-import io.github.amichne.kast.api.contract.query.CodeActionsQuery
 import io.github.amichne.kast.api.contract.result.CodeActionsResult
 import io.github.amichne.kast.api.contract.result.CompletionItem
-import io.github.amichne.kast.api.contract.query.CompletionsQuery
 import io.github.amichne.kast.api.contract.result.CompletionsResult
 import io.github.amichne.kast.api.contract.Diagnostic
 import io.github.amichne.kast.api.contract.DiagnosticSeverity
-import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
 import io.github.amichne.kast.api.contract.result.DiagnosticsResult
 import io.github.amichne.kast.api.contract.FileHash
 import io.github.amichne.kast.api.validation.FileHashing
-import io.github.amichne.kast.api.contract.query.FileOutlineQuery
 import io.github.amichne.kast.api.contract.result.FileOutlineResult
 import io.github.amichne.kast.api.contract.FilePosition
 import io.github.amichne.kast.api.contract.HealthResponse
-import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
 import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
-import io.github.amichne.kast.api.contract.query.ImplementationsQuery
 import io.github.amichne.kast.api.contract.result.ImplementationsResult
 import io.github.amichne.kast.api.validation.LocalDiskEditApplier
 import io.github.amichne.kast.api.contract.Location
@@ -35,32 +28,24 @@ import io.github.amichne.kast.api.protocol.NotFoundException
 import io.github.amichne.kast.api.contract.OutlineSymbol
 import io.github.amichne.kast.api.contract.ParameterInfo
 import io.github.amichne.kast.api.contract.ReadCapability
-import io.github.amichne.kast.api.contract.query.RefreshQuery
 import io.github.amichne.kast.api.contract.result.RefreshResult
-import io.github.amichne.kast.api.contract.query.ReferencesQuery
 import io.github.amichne.kast.api.contract.result.ReferencesResult
-import io.github.amichne.kast.api.contract.query.RenameQuery
 import io.github.amichne.kast.api.contract.result.RenameResult
-import io.github.amichne.kast.api.contract.SemanticInsertionQuery
 import io.github.amichne.kast.api.contract.SemanticInsertionResult
 import io.github.amichne.kast.api.contract.SemanticInsertionTarget
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.contract.Symbol
 import io.github.amichne.kast.api.contract.SymbolKind
-import io.github.amichne.kast.api.contract.query.SymbolQuery
 import io.github.amichne.kast.api.contract.result.SymbolResult
 import io.github.amichne.kast.api.contract.TextEdit
 import io.github.amichne.kast.api.contract.TypeHierarchyDirection
 import io.github.amichne.kast.api.contract.result.TypeHierarchyNode
-import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
 import io.github.amichne.kast.api.contract.result.TypeHierarchyResult
 import io.github.amichne.kast.api.contract.result.TypeHierarchyStats
 import io.github.amichne.kast.api.contract.result.TypeHierarchyTruncation
 import io.github.amichne.kast.api.contract.result.TypeHierarchyTruncationReason
-import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
 import io.github.amichne.kast.api.contract.result.WorkspaceFilesResult
 import io.github.amichne.kast.api.contract.result.WorkspaceModule
-import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
 import io.github.amichne.kast.api.contract.result.WorkspaceSymbolResult
 import java.nio.file.Files
 import java.nio.file.Path
@@ -122,8 +107,8 @@ class FakeAnalysisBackend private constructor(
         )
     }
 
-    override suspend fun resolveSymbol(query: SymbolQuery): SymbolResult {
-        requireKnownFile(query.position.filePath)
+    override suspend fun resolveSymbol(query: ParsedSymbolQuery): SymbolResult {
+        requireKnownFile(query.position.filePath.value)
         return when {
             hasMatchingAnchor(symbolAnchors, query.position) -> SymbolResult(symbol)
             hasMatchingAnchor(typeHierarchyAnchors, query.position) -> SymbolResult(typeHierarchyRootSymbol)
@@ -131,7 +116,7 @@ class FakeAnalysisBackend private constructor(
         }
     }
 
-    override suspend fun findReferences(query: ReferencesQuery): ReferencesResult {
+    override suspend fun findReferences(query: ParsedReferencesQuery): ReferencesResult {
         requireAnchor(query.position)
 
         val declaration = if (query.includeDeclaration) symbol else null
@@ -141,10 +126,10 @@ class FakeAnalysisBackend private constructor(
         )
     }
 
-    override suspend fun callHierarchy(query: CallHierarchyQuery): CallHierarchyResult {
+    override suspend fun callHierarchy(query: ParsedCallHierarchyQuery): CallHierarchyResult {
         requireAnchor(query.position)
         val outgoingReference = referenceLocations.firstOrNull() ?: symbol.location
-        val rootChildren = if (query.depth == 0) {
+        val rootChildren = if (query.depth.value == 0) {
             emptyList()
         } else if (query.direction == CallDirection.OUTGOING) {
             listOf(
@@ -187,15 +172,15 @@ class FakeAnalysisBackend private constructor(
         )
     }
 
-    override suspend fun typeHierarchy(query: TypeHierarchyQuery): TypeHierarchyResult {
+    override suspend fun typeHierarchy(query: ParsedTypeHierarchyQuery): TypeHierarchyResult {
         requireTypeHierarchyAnchor(query.position)
         val directChildren = when (query.direction) {
             TypeHierarchyDirection.SUPERTYPES -> listOf(typeHierarchySupertypeSymbol)
             TypeHierarchyDirection.SUBTYPES -> listOf(typeHierarchySubtypeSymbol)
             TypeHierarchyDirection.BOTH -> listOf(typeHierarchySupertypeSymbol, typeHierarchySubtypeSymbol)
         }
-        val maxChildren = (query.maxResults - 1).coerceAtLeast(0)
-        val children = if (query.depth == 0) {
+        val maxChildren = (query.maxResults.value - 1).coerceAtLeast(0)
+        val children = if (query.depth.value == 0) {
             emptyList()
         } else {
             directChildren.take(maxChildren).map { childSymbol ->
@@ -205,7 +190,7 @@ class FakeAnalysisBackend private constructor(
                 )
             }
         }
-        val truncated = query.depth > 0 && directChildren.size > children.size
+        val truncated = query.depth.value > 0 && directChildren.size > children.size
 
         return TypeHierarchyResult(
             root = TypeHierarchyNode(
@@ -213,7 +198,7 @@ class FakeAnalysisBackend private constructor(
                 truncation = if (truncated) {
                     TypeHierarchyTruncation(
                         reason = TypeHierarchyTruncationReason.MAX_RESULTS,
-                        details = "Reached maxResults=${query.maxResults}",
+                        details = "Reached maxResults=${query.maxResults.value}",
                     )
                 } else {
                     null
@@ -228,9 +213,9 @@ class FakeAnalysisBackend private constructor(
         )
     }
 
-    override suspend fun semanticInsertionPoint(query: SemanticInsertionQuery): SemanticInsertionResult {
-        requireKnownFile(query.position.filePath)
-        val content = Files.readString(Path.of(query.position.filePath))
+    override suspend fun semanticInsertionPoint(query: ParsedSemanticInsertionQuery): SemanticInsertionResult {
+        requireKnownFile(query.position.filePath.value)
+        val content = Files.readString(Path.of(query.position.filePath.value))
         val insertionOffset = when (query.target) {
             SemanticInsertionTarget.CLASS_BODY_START -> content.indexOf('{')
                 .takeIf { it >= 0 }
@@ -247,20 +232,21 @@ class FakeAnalysisBackend private constructor(
         }
         return SemanticInsertionResult(
             insertionOffset = insertionOffset,
-            filePath = query.position.filePath,
+            filePath = query.position.filePath.value,
         )
     }
 
-    override suspend fun diagnostics(query: DiagnosticsQuery): DiagnosticsResult {
-        query.filePaths.forEach(::requireKnownFile)
+    override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult {
+        val filePaths = query.filePaths.value.map { it.value }
+        filePaths.forEach(::requireKnownFile)
         return DiagnosticsResult(
-            diagnostics = query.filePaths
+            diagnostics = filePaths
                 .flatMap { filePath -> diagnosticsByFile[filePath].orEmpty() }
                 .sortedWith(compareBy({ it.location.filePath }, { it.location.startOffset })),
         )
     }
 
-    override suspend fun rename(query: RenameQuery): RenameResult {
+    override suspend fun rename(query: ParsedRenameQuery): RenameResult {
         requireAnchor(query.position)
         val edits = symbolAnchors
             .map { anchor ->
@@ -268,7 +254,7 @@ class FakeAnalysisBackend private constructor(
                     filePath = anchor.filePath,
                     startOffset = anchor.startOffset,
                     endOffset = anchor.endOffset,
-                    newText = query.newName,
+                    newText = query.newName.value,
                 )
             }
             .distinctBy { edit -> Triple(edit.filePath, edit.startOffset, edit.endOffset) }
@@ -287,8 +273,8 @@ class FakeAnalysisBackend private constructor(
         )
     }
 
-    override suspend fun optimizeImports(query: ImportOptimizeQuery): ImportOptimizeResult {
-        query.filePaths.forEach(::requireKnownFile)
+    override suspend fun optimizeImports(query: ParsedImportOptimizeQuery): ImportOptimizeResult {
+        query.filePaths.value.map { it.value }.forEach(::requireKnownFile)
         return ImportOptimizeResult(
             edits = emptyList(),
             fileHashes = emptyList(),
@@ -296,10 +282,10 @@ class FakeAnalysisBackend private constructor(
         )
     }
 
-    override suspend fun applyEdits(query: ApplyEditsQuery): ApplyEditsResult = LocalDiskEditApplier.apply(query)
+    override suspend fun applyEdits(query: ParsedApplyEditsQuery): ApplyEditsResult = LocalDiskEditApplier.apply(query.toWire())
 
-    override suspend fun refresh(query: RefreshQuery): RefreshResult {
-        val refreshedFiles = query.filePaths
+    override suspend fun refresh(query: ParsedRefreshQuery): RefreshResult {
+        val refreshedFiles = query.filePaths.map { it.value }
             .ifEmpty { availableFiles.toList() }
             .sorted()
         return RefreshResult(
@@ -309,8 +295,8 @@ class FakeAnalysisBackend private constructor(
         )
     }
 
-    override suspend fun fileOutline(query: FileOutlineQuery): FileOutlineResult {
-        requireKnownFile(query.filePath)
+    override suspend fun fileOutline(query: ParsedFileOutlineQuery): FileOutlineResult {
+        requireKnownFile(query.filePath.value)
         val allSymbols = buildList {
             add(symbol)
             add(typeHierarchyRootSymbol)
@@ -318,19 +304,19 @@ class FakeAnalysisBackend private constructor(
             add(typeHierarchySubtypeSymbol)
         }
         val fileSymbols = allSymbols
-            .filter { it.location.filePath == query.filePath }
+            .filter { it.location.filePath == query.filePath.value }
             .map { OutlineSymbol(symbol = it) }
         return FileOutlineResult(symbols = fileSymbols)
     }
 
-    override suspend fun workspaceSymbolSearch(query: WorkspaceSymbolQuery): WorkspaceSymbolResult {
+    override suspend fun workspaceSymbolSearch(query: ParsedWorkspaceSymbolQuery): WorkspaceSymbolResult {
         val allSymbols = buildList {
             add(symbol)
             add(typeHierarchyRootSymbol)
             add(typeHierarchySupertypeSymbol)
             add(typeHierarchySubtypeSymbol)
         }
-        val pattern = query.pattern
+        val pattern = query.pattern.value
         val matcher: (String) -> Boolean = if (query.regex) {
             val regex = Regex(pattern);
             { name -> regex.containsMatchIn(name) }
@@ -342,13 +328,13 @@ class FakeAnalysisBackend private constructor(
                 val simpleName = sym.fqName.substringAfterLast('.')
                 matcher(simpleName) && (query.kind == null || sym.kind == query.kind)
             }
-            .take(query.maxResults)
+            .take(query.maxResults.value)
         return WorkspaceSymbolResult(symbols = matched)
     }
 
-    override suspend fun workspaceFiles(query: WorkspaceFilesQuery): WorkspaceFilesResult {
+    override suspend fun workspaceFiles(query: ParsedWorkspaceFilesQuery): WorkspaceFilesResult {
         val allFiles = availableFiles.filter { it.endsWith(".kt") }.sorted()
-        val fileLimit = query.maxFilesPerModule ?: allFiles.size
+        val fileLimit = query.maxFilesPerModule?.value ?: allFiles.size
         val files = if (query.includeFiles) {
             allFiles.take(fileLimit)
         } else {
@@ -362,7 +348,7 @@ class FakeAnalysisBackend private constructor(
             filesTruncated = query.includeFiles && allFiles.size > files.size,
             fileCount = allFiles.size,
         )
-        val modules = if (query.moduleName == null || query.moduleName == "fake-module") {
+        val modules = if (query.moduleName?.value == null || query.moduleName?.value == "fake-module") {
             listOf(module)
         } else {
             emptyList()
@@ -370,22 +356,22 @@ class FakeAnalysisBackend private constructor(
         return WorkspaceFilesResult(modules = modules)
     }
 
-    override suspend fun implementations(query: ImplementationsQuery): ImplementationsResult {
+    override suspend fun implementations(query: ParsedImplementationsQuery): ImplementationsResult {
         requireTypeHierarchyAnchor(query.position)
         return ImplementationsResult(
             declaration = typeHierarchySupertypeSymbol,
-            implementations = listOf(typeHierarchySubtypeSymbol).take(query.maxResults.coerceAtLeast(1)),
-            exhaustive = query.maxResults >= 1,
+            implementations = listOf(typeHierarchySubtypeSymbol).take(query.maxResults.value),
+            exhaustive = query.maxResults.value >= 1,
         )
     }
 
-    override suspend fun codeActions(query: CodeActionsQuery): CodeActionsResult {
-        requireKnownFile(query.position.filePath)
+    override suspend fun codeActions(query: ParsedCodeActionsQuery): CodeActionsResult {
+        requireKnownFile(query.position.filePath.value)
         return CodeActionsResult(actions = emptyList())
     }
 
-    override suspend fun completions(query: CompletionsQuery): CompletionsResult {
-        requireKnownFile(query.position.filePath)
+    override suspend fun completions(query: ParsedCompletionsQuery): CompletionsResult {
+        requireKnownFile(query.position.filePath.value)
         val kindFilter = query.kindFilter
         val items = listOf(
             CompletionItem(
@@ -397,22 +383,22 @@ class FakeAnalysisBackend private constructor(
                 documentation = symbol.documentation,
             ),
         ).filter { item -> kindFilter == null || item.kind in kindFilter }
-        val capped = items.take(query.maxResults.coerceAtLeast(1))
+        val capped = items.take(query.maxResults.value)
         return CompletionsResult(
             items = capped,
             exhaustive = items.size <= capped.size,
         )
     }
 
-    private fun requireAnchor(position: FilePosition) {
-        requireKnownFile(position.filePath)
+    private fun requireAnchor(position: ParsedFilePosition) {
+        requireKnownFile(position.filePath.value)
         if (!hasMatchingAnchor(symbolAnchors, position)) {
             throw missingSymbol(position)
         }
     }
 
-    private fun requireTypeHierarchyAnchor(position: FilePosition) {
-        requireKnownFile(position.filePath)
+    private fun requireTypeHierarchyAnchor(position: ParsedFilePosition) {
+        requireKnownFile(position.filePath.value)
         if (!hasMatchingAnchor(typeHierarchyAnchors, position)) {
             throw missingSymbol(position)
         }
@@ -429,17 +415,17 @@ class FakeAnalysisBackend private constructor(
 
     private fun hasMatchingAnchor(
         anchors: List<Location>,
-        position: FilePosition,
+        position: ParsedFilePosition,
     ): Boolean = anchors.any { anchor ->
-        anchor.filePath == position.filePath &&
-            position.offset in anchor.startOffset until anchor.endOffset
+        anchor.filePath == position.filePath.value &&
+            position.offset.value in anchor.startOffset until anchor.endOffset
     }
 
-    private fun missingSymbol(position: FilePosition): NotFoundException = NotFoundException(
+    private fun missingSymbol(position: ParsedFilePosition): NotFoundException = NotFoundException(
         message = "No symbol was found at the requested offset",
         details = mapOf(
-            "filePath" to position.filePath,
-            "offset" to position.offset.toString(),
+            "filePath" to position.filePath.value,
+            "offset" to position.offset.value.toString(),
         ),
     )
 


### PR DESCRIPTION
This pull request introduces a robust validation layer for API queries and results in the analysis API, shifting from raw, wire-format query objects to strongly-typed, validated "Parsed" models. It also adds new value classes for stricter type safety, introduces a generic pagination interface, and updates result types to support this interface. The overall effect is improved input validation, safer API contracts, and easier handling of paginated results.

**Validation and Strong Typing for API Queries and Models:**

* Introduced a suite of `Parsed*Query` and related classes in `ParsedModels.kt` to represent validated, strongly-typed versions of API queries, along with conversion functions from wire-format queries. This ensures all incoming requests are validated and parsed before being processed. [[1]](diffhunk://#diff-8a702c5cea7205b8dcbd61be03d78d473bd1678f90858ab651d41b04b88adcb2R4-R21) [[2]](diffhunk://#diff-8a702c5cea7205b8dcbd61be03d78d473bd1678f90858ab651d41b04b88adcb2R55-R163) [[3]](diffhunk://#diff-8a702c5cea7205b8dcbd61be03d78d473bd1678f90858ab651d41b04b88adcb2R194-R368)
* Added new value classes such as `PositiveInt`, `NonNegativeInt`, `PositiveLong`, `NonBlankString`, and `NonEmptyList` in `CoreTypes.kt` to enforce stricter type constraints at compile time for numeric and string fields.

**API Contract and Interface Changes:**

* Updated the `AnalysisBackend` interface to accept the new validated `Parsed*Query` types instead of the previous raw query types, ensuring that only validated data enters backend logic. [[1]](diffhunk://#diff-7c1252c80a34f42607c1ddf9f170a0e332843cb98bd684c65b5b539b2b44cbd9L3-L17) [[2]](diffhunk://#diff-7c1252c80a34f42607c1ddf9f170a0e332843cb98bd684c65b5b539b2b44cbd9R19) [[3]](diffhunk://#diff-7c1252c80a34f42607c1ddf9f170a0e332843cb98bd684c65b5b539b2b44cbd9L60-R126)

**Pagination and Result Handling:**

* Introduced a generic `PageableResult<T>` interface in `PageInfo.kt` to standardize paginated result handling, including methods for accessing items and updating pagination state.
* Updated result classes (`DiagnosticsResult`, `ReferencesResult`, `WorkspaceSymbolResult`) to implement `PageableResult<T>`, providing a unified way to access paginated data and manipulate result items. [[1]](diffhunk://#diff-5b6aec73fa489886b97125a112329e444745e87dbd5d3eebae8d445e67d17564R7) [[2]](diffhunk://#diff-5b6aec73fa489886b97125a112329e444745e87dbd5d3eebae8d445e67d17564L18-R30) [[3]](diffhunk://#diff-28927065d2d94f4c3cfcee8a0aef0dfd0edaaaec2790636cab364efb403be9e7R7) [[4]](diffhunk://#diff-28927065d2d94f4c3cfcee8a0aef0dfd0edaaaec2790636cab364efb403be9e7L22-R36) [[5]](diffhunk://#diff-7cc74dc7957fd88cc64a7c7dbb069b7cded0621b1b945741ecbc0aafb0259b14R6) [[6]](diffhunk://#diff-7cc74dc7957fd88cc64a7c7dbb069b7cded0621b1b945741ecbc0aafb0259b14L18-R30)