### PR TITLE
Tighten value-proof measurement: oracles, paired stats, deterministic tool-call counting

### DIFF
--- a/.agents/skills/kast-value-proof-runner/SKILL.md
+++ b/.agents/skills/kast-value-proof-runner/SKILL.md
@@ -5,29 +5,47 @@ description: Run the existing Kast value-proof benchmark end-to-end for the curr
 
 # Kast Value Proof Runner
 
-Run the benchmark workflow in `.agents/skills/kast/value-proof/` and present the resulting benchmark plus executive summary.
+Run the v2 benchmark workflow in `.agents/skills/kast/value-proof/` and present the resulting benchmark plus executive summary. The headline metric is `outcome_pass_rate` over `applicability='both'` outcome assertions; never quote raw `pass_rate` from `summary` for cross-config comparison — it is inflated by tautological "Uses kast_X" assertions.
 
 ## Workflow
 
 1. Treat the current repository as the target. Keep transient artifacts outside the skill tree under `.benchmarks/kast-value-proof/<timestamp>/`.
-2. Look for `.agents/skills/kast/value-proof/bindings/<repo-name>.json`, where `<repo-name>` is the current repo directory name. Reuse it if present.
-3. If the bindings file is missing, load `references/bindings.md`, create the bindings from `../kast/value-proof/bindings/template.json`, and validate that `scripts/render_prompts.py` can render the catalog successfully before moving on.
-4. Render the catalog with `.agents/skills/kast/value-proof/scripts/render_prompts.py`.
-5. Scaffold a fresh iteration workspace with `.agents/skills/kast/value-proof/scripts/run_value_proof.py`, then read `manifest.json`.
-6. Dispatch every run with `.agents/skills/kast/value-proof/scripts/dispatch_runs.py`, providing the child-session command template for the current host:
-   - `with_skill`: Kast skill and `kast_*` tools enabled
-   - `without_skill`: do not use the Kast skill or `kast_*` tools
-7. Save each full transcript to `outputs/transcript.md`; the dispatcher records parent-side executor timing in `timing.json` and retries missing or empty transcripts. Do not fake baseline isolation; if the host cannot create an honest `without_skill` run, stop and report that blocker.
-8. Grade every run with `.agents/skills/skill-creator/agents/grader.md` and write `grading.json`.
-9. Aggregate with `.agents/skills/skill-creator/scripts/aggregate_benchmark.py`, analyze the resulting `benchmark.json` with `.agents/skills/skill-creator/agents/analyzer.md`, and then generate `executive-summary.md` plus `executive-summary.html` with `.agents/skills/kast/value-proof/scripts/generate_executive_summary.py`.
-10. Return a concise summary with pass-rate, token, and time deltas plus the paths to `benchmark.json`, `benchmark.md`, `executive-summary.md`, and `executive-summary.html`.
+2. Bindings:
+   - Look for `.agents/skills/kast/value-proof/bindings/<repo-name>.json`.
+   - If missing, load `references/bindings.md`, copy `bindings/template.json`, fill every slot, **and populate every `expected` block** (ground-truth oracles for recall/precision/compile checks). Without `expected`, outcome assertions cannot be graded — they fall back to the LLM grader and the headline becomes unreliable.
+   - Record the target's current git SHA into `bindings/<repo>.json:git_sha` so reproducibility lives with the bindings file.
+3. Render the catalog with `.agents/skills/kast/value-proof/scripts/render_prompts.py`. The renderer fails loud if any `{{...}}` placeholder survives — fix the bindings, do not paper over.
+4. Scaffold the iteration workspace with `.agents/skills/kast/value-proof/scripts/run_value_proof.py`. **Default is now 5 runs per (eval × config)** to give the paired Wilcoxon test enough power; do not override unless you have a reason.
+5. Dispatch every run with `.agents/skills/kast/value-proof/scripts/dispatch_runs.py`:
+   - `with_skill`: Kast skill and `kast_*` tools enabled.
+   - `without_skill`: Kast skill AND `kast_*` tools disabled at the harness level. Do not rely on prompt-level inhibition. The dispatcher will auto-run `parse_tool_calls.py` after every successful run, and the aggregator will FLAG the iteration if any `without_skill` run shows a non-zero `kast_calls` count.
+   - For `safe-mutations-chain` runs, perform `git stash --include-untracked` before the chain and `git stash pop` (or `git checkout -- .`) after. Chain runs mutate the workspace and contaminate later evals if not isolated. Record the pre/post SHA on the run's `integrity` block.
+6. Save each full transcript verbatim to `outputs/transcript.md`. The dispatcher records authoritative executor timing in `timing.json` and retries empty/failed runs.
+7. Grade each run with `.agents/skills/skill-creator/agents/grader.md`. Then **always** run `.agents/skills/kast/value-proof/scripts/finalize_grading.py --run-dir <run> --workspace-root <target-checkout>` — it merges dispatcher timing, replaces grader-reported tool counts with the deterministic transcript-parsed counts, marks expectations whose applicability does not match the run config as `skipped`, and detects contradictions (`passed=true` with evidence containing `= 0` / `missing` / `not present`).
+8. Aggregate with `.agents/skills/kast/value-proof/scripts/value_proof_aggregate.py`. Do **not** use the generic `skill-creator/scripts/aggregate_benchmark.py` for value-proof iterations — it lacks the applicability split and the paired Wilcoxon. The new aggregator also appends a row to `history/progression.json` so iteration trends are persisted.
+9. Run the analyzer with `.agents/skills/skill-creator/agents/analyzer.md` over `benchmark.json`. Then generate `executive-summary.md` plus `executive-summary.html` with `.agents/skills/kast/value-proof/scripts/generate_executive_summary.py`.
+10. Return a concise summary: `outcome_pass_rate` delta with the Wilcoxon p-value, `kast_calls` and `grep_or_find_calls` deltas (these are the honest "did the skill change behaviour" signal), the count of integrity violations (contradictions, isolation), and the paths to `benchmark.json`, `benchmark.md`, `executive-summary.md`, `executive-summary.html`, and `history/progression.json`.
+
+## Integrity contract — fail loudly
+
+If any of the following are true, STOP and surface to the user before reporting numbers:
+
+- The host cannot create an honest `without_skill` run (no harness-level kast disabling).
+- The aggregator reports any `baseline_violations` entry — at least one `without_skill` run touched a kast tool.
+- The aggregator reports `contradictions` — at least one `passed=true` verdict had self-contradicting evidence.
+- The bindings file lacks `expected` blocks. Outcome grading silently degrades to LLM judgment and the headline number is no longer paired with ground truth.
+
+These are not warnings; they invalidate the run.
 
 ## Resources
 
 - `references/bindings.md`: only load when the repo does not already have a bindings file.
 - `.agents/skills/kast/value-proof/scripts/render_prompts.py`
 - `.agents/skills/kast/value-proof/scripts/run_value_proof.py`
+- `.agents/skills/kast/value-proof/scripts/dispatch_runs.py`
+- `.agents/skills/kast/value-proof/scripts/parse_tool_calls.py`
+- `.agents/skills/kast/value-proof/scripts/finalize_grading.py`
+- `.agents/skills/kast/value-proof/scripts/value_proof_aggregate.py`
 - `.agents/skills/kast/value-proof/scripts/generate_executive_summary.py`
 - `.agents/skills/skill-creator/agents/grader.md`
 - `.agents/skills/skill-creator/agents/analyzer.md`
-- `.agents/skills/skill-creator/scripts/aggregate_benchmark.py`

--- a/.agents/skills/kast/value-proof/README.md
+++ b/.agents/skills/kast/value-proof/README.md
@@ -18,19 +18,31 @@ use `without_skill` only when no previous skill exists.
 Every completed iteration must produce:
 
 - `manifest.json` mapping durable eval ids to on-disk `eval-*` directories;
-- `eval_metadata.json` for each eval case;
-- one run directory per configuration and run number;
+- `eval_metadata.json` for each eval case (carrying the catalog's structured
+  expectations: `id`, `kind`, `applicability`, `graded_by`, `oracle`);
+- one run directory per configuration and run number (default: 5 runs);
 - `outputs/transcript.md` for each run;
-- `timing.json` with duration and token data when available;
-- `grading.json` using the skill-creator fields `text`, `passed`, and
-  `evidence` for each expectation;
-- `benchmark.json` and `benchmark.md`;
+- `outputs/tool_calls.jsonl` produced by `parse_tool_calls.py` (deterministic;
+  do NOT trust the LLM grader's tool counts);
+- `timing.json` with dispatcher-recorded executor duration and attempt count;
+- `grading.json` v2 — produced by the LLM grader and then **always**
+  finalised with `finalize_grading.py`, which merges authoritative timing,
+  injects deterministic tool-call counts, marks non-applicable expectations
+  as `skipped`, computes `outcome_pass_rate` (the only fair cross-config
+  metric), and records `integrity.contradictions` /
+  `integrity.baseline_isolation_violation` / `integrity.attempts`;
+- `benchmark.json` and `benchmark.md` produced by `value_proof_aggregate.py`,
+  which adds paired Wilcoxon p-values, Tukey outlier flags, and per-eval
+  deltas;
+- a row appended to `history/progression.json` for cross-iteration trend;
 - an analyzer note set that calls out discriminating assertions, weak
   assertions, variance, and token or timing tradeoffs;
 - a generated `eval-viewer` HTML review artifact before the next rewrite.
 
 Do not record a promoted case in `history/progression.json` until the benchmark
-has real transcripts, grading, and aggregation evidence.
+has real transcripts, grading, and aggregation evidence — and never with
+`integrity.contradictions` or `integrity.baseline_isolation_violation`
+non-empty.
 
 ## Quick start with the default binding
 
@@ -47,13 +59,14 @@ changed.
      --output rendered-catalog.json
    ```
 
-2. Scaffold the iteration workspace:
+2. Scaffold the iteration workspace (5 runs per config is the default —
+   keep it; 3 is too few for paired Wilcoxon to discriminate):
 
    ```bash
    python3 scripts/run_value_proof.py \
      --catalog rendered-catalog.json \
      --workspace ../kast-value-proof-workspace \
-     --runs-per-config 3 \
+     --runs-per-config 5 \
      --iteration iteration-001
    ```
 
@@ -81,20 +94,43 @@ changed.
    immediately. Missing timing is acceptable only when the executor did not
    expose it; mark that explicitly in the file.
 
-5. Grade each run with the skill-creator grading schema.
+5. Grade each run with the skill-creator grading schema, then finalise:
 
    Use `/Users/amichne/.agents/skills/skill-creator/agents/grader.md` as the
-   grading guide. Programmatic checks are preferred when an expectation can be
-   verified from the transcript or output files.
-
-6. Aggregate the benchmark:
+   grading guide. After grading lands its raw `grading.json`, run:
 
    ```bash
-   python3 /Users/amichne/.agents/skills/skill-creator/scripts/aggregate_benchmark.py \
-     ../kast-value-proof-workspace/iteration-001 \
-     --skill-name kast \
-     --skill-path /Users/amichne/code/kast/.agents/skills/kast
+   python3 scripts/finalize_grading.py \
+     --run-dir ../kast-value-proof-workspace/iteration-001/eval-XYZ/with_skill/run-1 \
+     --workspace-root /absolute/path/to/target/checkout \
+     --strict
    ```
+
+   This step is mandatory — it merges authoritative dispatcher timing,
+   injects the deterministic tool-call counts produced by
+   `parse_tool_calls.py`, marks `with_skill_only` expectations as `skipped`
+   in `without_skill` runs (so the headline pass-rate is fair), and rejects
+   self-contradictory verdicts. `--strict` fails the script when integrity
+   issues are detected; remove it only if you want to inspect the issues
+   first.
+
+6. Aggregate the benchmark with the value-proof-aware aggregator:
+
+   ```bash
+   python3 scripts/value_proof_aggregate.py \
+     ../kast-value-proof-workspace/iteration-001 \
+     --skill-name kast-value-proof \
+     --bindings bindings/konditional.json \
+     --catalog ../kast-value-proof-workspace/iteration-001/rendered-catalog.json
+   ```
+
+   Use this rather than `aggregate_benchmark.py` from skill-creator. The
+   value-proof aggregator splits process vs outcome assertions, restricts
+   the cross-config delta to `applicability='both'` outcome assertions
+   (kills the tautology-inflated headline), runs paired Wilcoxon, flags
+   Tukey outliers, surfaces baseline-isolation violations and grading
+   contradictions, and appends to `history/progression.json` so iteration
+   trends are persisted.
 
 7. Run the analyzer pass against `benchmark.json`.
 
@@ -138,16 +174,40 @@ large structural files, and safe rename targets.
 ## Files
 
 - `bindings.schema.json`: Schema for mapping abstract eval slots to concrete
-  codebase symbols.
+  codebase symbols. Each slot supports an optional `expected` ground-truth
+  block (recall/precision oracles, expected file lists, compile commands,
+  module file counts).
 - `bindings/konditional.json`: Default binding for the `konditional`
-  repository.
-- `catalog.json`: Parameterized value-proof eval cases.
-- `scripts/render_prompts.py`: Hydrates `{{SLOT.field}}` template variables.
+  repository, with populated ground truth.
+- `catalog.json`: Parameterized eval cases. Each expectation declares
+  `kind` (`outcome` | `process`), `applicability`
+  (`both` | `with_skill_only` | `without_skill_only`), `graded_by`
+  (`script` | `llm`), and an optional `oracle` reference into the bindings
+  ground truth.
+- `grading.schema.json`: v2 grading contract. Adds `outcome_pass_rate` (the
+  fair cross-config metric), structured `tool_calls`, `kast_calls`,
+  `grep_or_find_calls`, and an `integrity` block.
+- `scripts/render_prompts.py`: Hydrates `{{SLOT.field}}` template variables;
+  fails loud on any unresolved placeholder.
 - `scripts/run_value_proof.py`: Creates iteration workspaces,
-  `manifest.json`, `run_manifest.json`, and per-run instructions.
+  `manifest.json`, `run_manifest.json`, and per-run instructions. Default
+  runs-per-config is 5.
 - `scripts/dispatch_runs.py`: Dispatches scaffolded runs with concurrency,
-  chain serialization, parent-side timing, and transcript guards.
+  chain serialization, parent-side timing, transcript guards, and an
+  automatic `parse_tool_calls.py` step on each successful run.
+- `scripts/parse_tool_calls.py`: Deterministic transcript → JSONL tool-call
+  log. Counts kast tool invocations and grep/find/ls invocations by
+  inspecting fenced JSON tool blocks, XML tool blocks, inline call markers,
+  and fenced bash blocks. Pure prose mentions are explicitly NOT counted.
+- `scripts/finalize_grading.py`: Normalises a raw grader output by merging
+  authoritative dispatcher timing, replacing grader-reported tool counts
+  with deterministic counts, marking non-applicable expectations as
+  skipped, computing the outcome pass-rate, and detecting contradictions
+  + baseline-isolation violations.
+- `scripts/value_proof_aggregate.py`: Iteration aggregator with paired
+  Wilcoxon, applicability-aware pass-rate, Tukey outlier detection, and
+  history append.
 - `scripts/generate_executive_summary.py`: Creates Markdown and HTML
   executive summaries from `benchmark.json`.
-- `history/progression.json`: Non-regression ledger for promoted cases and
-  benchmark history.
+- `history/progression.json`: Non-regression ledger; the aggregator appends
+  one row per iteration with `outcome_pass_rate` deltas and Wilcoxon p.

--- a/.agents/skills/kast/value-proof/bindings.schema.json
+++ b/.agents/skills/kast/value-proof/bindings.schema.json
@@ -2,14 +2,12 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/amichne/kast/.agents/skills/kast/value-proof/bindings.schema.json",
   "title": "Kast value-proof codebase bindings",
-  "description": "Maps abstract eval slots to concrete symbols in a target Kotlin codebase.",
+  "description": "Maps abstract eval slots to concrete symbols in a target Kotlin codebase, plus optional ground-truth oracles used for outcome grading.",
   "type": "object",
   "required": ["target_repo", "workspace_root", "slots"],
   "additionalProperties": false,
   "properties": {
-    "_comment": {
-      "type": "string"
-    },
+    "_comment": { "type": "string" },
     "target_repo": {
       "type": "string",
       "minLength": 1,
@@ -19,6 +17,10 @@
       "type": "string",
       "minLength": 1,
       "description": "Absolute path to the target repository checkout."
+    },
+    "git_sha": {
+      "type": "string",
+      "description": "Optional git SHA recorded at run time for reproducibility. The runner SHOULD overwrite this before each iteration."
     },
     "slots": {
       "type": "object",
@@ -33,133 +35,242 @@
       ],
       "additionalProperties": false,
       "properties": {
-        "SEALED_HIERARCHY": {
-          "$ref": "#/$defs/symbol_slot"
-        },
-        "DISAMBIGUATE_MEMBER": {
-          "$ref": "#/$defs/member_slot"
-        },
-        "CROSS_MODULE_CLASS": {
-          "$ref": "#/$defs/symbol_slot"
-        },
-        "OVERLOADED_OR_COMMON_FUNCTION": {
-          "$ref": "#/$defs/member_slot"
-        },
-        "RENAME_TARGET": {
-          "$ref": "#/$defs/rename_slot"
-        },
-        "LARGE_CLASS": {
-          "$ref": "#/$defs/symbol_slot"
-        },
-        "MODULE_LIST": {
-          "type": "object",
-          "required": ["modules", "description"],
-          "additionalProperties": false,
-          "properties": {
-            "_comment": {
-              "type": "string"
-            },
-            "modules": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "string",
-                "minLength": 1
-              }
-            },
-            "description": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        }
+        "SEALED_HIERARCHY": { "$ref": "#/$defs/sealed_slot" },
+        "DISAMBIGUATE_MEMBER": { "$ref": "#/$defs/member_slot" },
+        "CROSS_MODULE_CLASS": { "$ref": "#/$defs/cross_module_slot" },
+        "OVERLOADED_OR_COMMON_FUNCTION": { "$ref": "#/$defs/function_slot" },
+        "RENAME_TARGET": { "$ref": "#/$defs/rename_slot" },
+        "LARGE_CLASS": { "$ref": "#/$defs/large_class_slot" },
+        "MODULE_LIST": { "$ref": "#/$defs/module_list_slot" }
       }
     }
   },
   "$defs": {
-    "symbol_slot": {
+    "_base_symbol": {
       "type": "object",
       "required": ["symbol", "fqName", "file", "description"],
-      "additionalProperties": false,
       "properties": {
-        "_comment": {
-          "type": "string"
-        },
-        "symbol": {
-          "type": "string",
-          "minLength": 1
-        },
-        "fqName": {
-          "type": "string",
-          "minLength": 1
-        },
-        "file": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
-        }
+        "_comment": { "type": "string" },
+        "symbol": { "type": "string", "minLength": 1 },
+        "fqName": { "type": "string", "minLength": 1 },
+        "file": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 }
       }
+    },
+    "sealed_slot": {
+      "allOf": [
+        { "$ref": "#/$defs/_base_symbol" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "_comment": {}, "symbol": {}, "fqName": {}, "file": {}, "description": {},
+            "expected": {
+              "type": "object",
+              "description": "Ground truth for sealed-hierarchy traceability. Implementation list is a closed set under the workspace; populate completely.",
+              "required": ["implementations"],
+              "additionalProperties": false,
+              "properties": {
+                "implementations": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "required": ["fqName", "module"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "fqName": { "type": "string", "minLength": 1 },
+                      "module": { "type": "string", "minLength": 1 },
+                      "file": { "type": "string" }
+                    }
+                  }
+                },
+                "modules": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 },
+                  "description": "Modules expected to host at least one implementation."
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "member_slot": {
-      "type": "object",
-      "required": ["symbol", "containingType", "fqName", "file", "description"],
-      "additionalProperties": false,
-      "properties": {
-        "_comment": {
-          "type": "string"
-        },
-        "symbol": {
-          "type": "string",
-          "minLength": 1
-        },
-        "containingType": {
-          "type": "string",
-          "minLength": 1
-        },
-        "fqName": {
-          "type": "string",
-          "minLength": 1
-        },
-        "file": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
+      "allOf": [
+        { "$ref": "#/$defs/_base_symbol" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "_comment": {}, "symbol": {}, "fqName": {}, "file": {}, "description": {},
+            "containingType": { "type": "string", "minLength": 1 },
+            "expected": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "minimumUsageSites": { "type": "integer", "minimum": 1 },
+                "expectedFiles": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 },
+                  "description": "Files expected to contain a real usage. Set is a non-strict subset (recall floor)."
+                },
+                "decoyFiles": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 },
+                  "description": "Files containing the same identifier on UNRELATED types — a precision-trap a grep-only run will hit."
+                }
+              }
+            }
+          },
+          "required": ["containingType"]
         }
-      }
+      ]
+    },
+    "function_slot": {
+      "allOf": [
+        { "$ref": "#/$defs/_base_symbol" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "_comment": {}, "symbol": {}, "fqName": {}, "file": {}, "description": {},
+            "containingType": { "type": "string", "minLength": 1 },
+            "expected": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "minimumCallers": { "type": "integer", "minimum": 1 },
+                "expectedCallerFqNames": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 }
+                },
+                "expectedCallerModules": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          },
+          "required": ["containingType"]
+        }
+      ]
+    },
+    "cross_module_slot": {
+      "allOf": [
+        { "$ref": "#/$defs/_base_symbol" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "_comment": {}, "symbol": {}, "fqName": {}, "file": {}, "description": {},
+            "expected": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "minimumReferences": { "type": "integer", "minimum": 1 },
+                "expectedConsumerModules": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "type": "string", "minLength": 1 }
+                },
+                "expectedConsumerFiles": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "rename_slot": {
+      "allOf": [
+        { "$ref": "#/$defs/_base_symbol" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "_comment": {}, "symbol": {}, "fqName": {}, "file": {}, "description": {},
+            "newName": { "type": "string", "minLength": 1 },
+            "expected": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "affectedFiles": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "type": "string", "minLength": 1 },
+                  "description": "Every file the rename must touch (declaration + references + imports). Closed set."
+                },
+                "expectedFileCount": { "type": "integer", "minimum": 1 },
+                "compileCommand": {
+                  "type": "string",
+                  "description": "Optional shell command used by outcome graders to verify post-rename compile state. Default: ./gradlew --offline compileKotlin"
+                }
+              }
+            }
+          },
+          "required": ["newName"]
+        }
+      ]
+    },
+    "large_class_slot": {
+      "allOf": [
+        { "$ref": "#/$defs/_base_symbol" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "_comment": {}, "symbol": {}, "fqName": {}, "file": {}, "description": {},
+            "expected": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "rawFileLineCount": { "type": "integer", "minimum": 1 },
+                "publicMembers": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 },
+                  "description": "Public members the scaffold output MUST mention. Hallucination check: anything outside this list is suspect."
+                },
+                "nestedTypes": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "module_list_slot": {
       "type": "object",
-      "required": ["symbol", "fqName", "newName", "file", "description"],
+      "required": ["modules", "description"],
       "additionalProperties": false,
       "properties": {
-        "_comment": {
-          "type": "string"
+        "_comment": { "type": "string" },
+        "modules": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
         },
-        "symbol": {
-          "type": "string",
-          "minLength": 1
-        },
-        "fqName": {
-          "type": "string",
-          "minLength": 1
-        },
-        "newName": {
-          "type": "string",
-          "minLength": 1
-        },
-        "file": {
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "type": "string",
-          "minLength": 1
+        "description": { "type": "string", "minLength": 1 },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "moduleFileCounts": {
+              "type": "object",
+              "description": "Map of module name to expected Kotlin source file count. Used to grade kast_workspace_files accuracy.",
+              "additionalProperties": { "type": "integer", "minimum": 0 }
+            },
+            "fileCountTolerance": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "description": "Absolute tolerance allowed when comparing reported counts to ground truth (build artifacts, generated files)."
+            }
+          }
         }
       }
     }

--- a/.agents/skills/kast/value-proof/bindings/konditional.json
+++ b/.agents/skills/kast/value-proof/bindings/konditional.json
@@ -1,49 +1,128 @@
 {
   "target_repo": "konditional",
-  "workspace_root": "/absolute/path/to/konditional",
+  "workspace_root": "/Users/amichne/code/konditional",
+  "git_sha": "",
   "slots": {
     "SEALED_HIERARCHY": {
       "symbol": "Konstrained",
       "fqName": "io.amichne.konditional.core.types.Konstrained",
       "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt",
-      "description": "A sealed interface with 3+ subtypes, ideally cross-module"
+      "description": "A sealed interface with 9 nested implementations spanning 4 shape categories. Defined in konditional-types but consumed cross-module.",
+      "expected": {
+        "implementations": [
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.Primitive", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" },
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.Primitive.Int", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" },
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.Primitive.String", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" },
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.Primitive.Boolean", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" },
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.Primitive.Double", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" },
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.Object", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" },
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.Array", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" },
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.AsString", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" },
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.AsInt", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" },
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.AsBoolean", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" },
+          { "fqName": "io.amichne.konditional.core.types.Konstrained.AsDouble", "module": "konditional-types", "file": "konditional-types/src/main/kotlin/io/amichne/konditional/core/types/Konstrained.kt" }
+        ],
+        "modules": ["konditional-types"]
+      }
     },
     "DISAMBIGUATE_MEMBER": {
       "symbol": "key",
       "containingType": "Feature",
       "fqName": "io.amichne.konditional.core.features.Feature.key",
       "file": "konditional-engine/src/main/kotlin/io/amichne/konditional/core/features/Feature.kt",
-      "description": "A property name that appears on many unrelated types — grep returns false positives"
+      "description": "Feature.key is a property name shared with map-style 'key' usages on unrelated types (HashMap.key, FlagKey, etc.). Grep over-matches.",
+      "expected": {
+        "minimumUsageSites": 5,
+        "expectedFiles": [
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/core/features/Feature.kt",
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/core/Namespace.kt"
+        ],
+        "decoyFiles": [
+          "konditional-json/src/main/kotlin/io/amichne/konditional/internal/serialization/models/FlagValue.kt"
+        ]
+      }
     },
     "CROSS_MODULE_CLASS": {
       "symbol": "FlagValue",
       "fqName": "io.amichne.konditional.internal.serialization.models.FlagValue",
       "file": "konditional-json/src/main/kotlin/io/amichne/konditional/internal/serialization/models/FlagValue.kt",
-      "description": "A class referenced across module boundaries"
+      "description": "FlagValue is declared in konditional-json and consumed across the json module's serialization graph (5 distinct files).",
+      "expected": {
+        "minimumReferences": 8,
+        "expectedConsumerModules": ["konditional-json"],
+        "expectedConsumerFiles": [
+          "konditional-json/src/main/kotlin/io/amichne/konditional/serialization/snapshot/ConfigurationCodec.kt",
+          "konditional-json/src/main/kotlin/io/amichne/konditional/internal/serialization/models/SerializableFlag.kt",
+          "konditional-json/src/main/kotlin/io/amichne/konditional/internal/serialization/models/SerializableRule.kt",
+          "konditional-json/src/main/kotlin/io/amichne/konditional/internal/serialization/adapters/FlagValueAdapter.kt"
+        ]
+      }
     },
     "OVERLOADED_OR_COMMON_FUNCTION": {
       "symbol": "resolve",
       "containingType": "ConditionalValue.ContextualResolver",
       "fqName": "io.amichne.konditional.rules.ConditionalValue.ContextualResolver.resolve",
       "file": "konditional-engine/src/main/kotlin/io/amichne/konditional/rules/ConditionalValue.kt",
-      "description": "A function name that appears in many classes — disambiguation required"
+      "description": "ContextualResolver.resolve is one of many resolve() functions in the workspace. Disambiguation requires containingType.",
+      "expected": {
+        "minimumCallers": 1,
+        "expectedCallerFqNames": [
+          "io.amichne.konditional.core.FlagDefinition"
+        ],
+        "expectedCallerModules": ["konditional-engine"]
+      }
     },
     "RENAME_TARGET": {
       "symbol": "NamespaceRegistry",
       "fqName": "io.amichne.konditional.core.registry.NamespaceRegistry",
       "newName": "FeatureRegistry",
       "file": "konditional-engine/src/main/kotlin/io/amichne/konditional/core/registry/NamespaceRegistry.kt",
-      "description": "An interface referenced across multiple modules — rename touches many files"
+      "description": "NamespaceRegistry is referenced in 11 files total (9 main + 2 test). Rename must touch declarations, references, and imports.",
+      "expected": {
+        "expectedFileCount": 9,
+        "affectedFiles": [
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/core/registry/NamespaceRegistry.kt",
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/core/registry/InMemoryNamespaceRegistry.kt",
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/core/registry/NamespaceSnapshot.kt",
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/core/Namespace.kt",
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/core/FlagDefinition.kt",
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/core/dsl/rules/RuleValueScope.kt",
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/api/FeatureEvaluation.kt",
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/api/FeatureEvaluationMetrics.kt",
+          "konditional-engine/src/main/kotlin/io/amichne/konditional/rules/ConditionalValue.kt"
+        ],
+        "compileCommand": "./gradlew --offline -q :konditional-engine:compileKotlin"
+      }
     },
     "LARGE_CLASS": {
       "symbol": "EvaluationDiagnostics",
       "fqName": "io.amichne.konditional.internal.evaluation.EvaluationDiagnostics",
       "file": "konditional-engine/src/main/kotlin/io/amichne/konditional/internal/evaluation/EvaluationDiagnostics.kt",
-      "description": "A 200+ line class with nested types — scaffold vs raw read shows token savings"
+      "description": "265-line data class with nested sealed Decision hierarchy and TargetingNode tree. Scaffold should produce <2KB summary; raw read >8KB.",
+      "expected": {
+        "rawFileLineCount": 265,
+        "publicMembers": [
+          "namespaceId", "featureKey", "configVersion", "mode", "durationNanos", "value", "decision"
+        ],
+        "nestedTypes": [
+          "Decision", "Decision.Rule", "Decision.Default",
+          "RuleMatch", "RuleDetails",
+          "ExtensionType", "ConditionalContextType",
+          "TargetingNode", "TargetingNode.All", "TargetingNode.AnyOf", "TargetingNode.Locale"
+        ]
+      }
     },
     "MODULE_LIST": {
       "modules": ["konditional-types", "konditional-engine", "konditional-json"],
-      "description": "The modules in the target project"
+      "description": "Production modules in the konditional workspace. 'smoke-test' is included in settings.gradle.kts but is a fixture, not part of the public surface.",
+      "expected": {
+        "moduleFileCounts": {
+          "konditional-types": 84,
+          "konditional-engine": 70,
+          "konditional-json": 18
+        },
+        "fileCountTolerance": 5
+      }
     }
   }
 }

--- a/.agents/skills/kast/value-proof/bindings/template.json
+++ b/.agents/skills/kast/value-proof/bindings/template.json
@@ -1,14 +1,23 @@
 {
-  "_comment": "Copy this file to bindings/<your-project>.json, remove _comment fields if desired, and replace every placeholder with a representative symbol from your Kotlin workspace.",
+  "_comment": "Copy to bindings/<your-project>.json and replace every placeholder. The 'expected' blocks are optional; populate them to enable outcome-quality grading (recall, precision, compile-pass).",
   "target_repo": "your-project",
   "workspace_root": "/absolute/path/to/your/project",
+  "git_sha": "",
   "slots": {
     "SEALED_HIERARCHY": {
       "_comment": "A sealed interface/class with multiple implementations.",
       "symbol": "YourSealedRoot",
       "fqName": "com.example.YourSealedRoot",
       "file": "module/src/main/kotlin/com/example/YourSealedRoot.kt",
-      "description": "Why this hierarchy proves semantic subtype discovery"
+      "description": "Why this hierarchy proves semantic subtype discovery",
+      "expected": {
+        "_comment": "Closed set: list every implementation. The grader checks recall (found ⊇ expected) and precision (found ⊆ expected ∪ known-noise).",
+        "implementations": [
+          { "fqName": "com.example.YourSealedRoot.Foo", "module": "module-a" },
+          { "fqName": "com.example.YourSealedRoot.Bar", "module": "module-b" }
+        ],
+        "modules": ["module-a", "module-b"]
+      }
     },
     "DISAMBIGUATE_MEMBER": {
       "_comment": "A member name that appears on unrelated types.",
@@ -16,14 +25,24 @@
       "containingType": "Feature",
       "fqName": "com.example.Feature.key",
       "file": "module/src/main/kotlin/com/example/Feature.kt",
-      "description": "Why raw text search would over-match"
+      "description": "Why raw text search would over-match",
+      "expected": {
+        "minimumUsageSites": 3,
+        "expectedFiles": ["module/src/main/kotlin/com/example/Caller.kt"],
+        "decoyFiles": ["module/src/main/kotlin/com/example/UnrelatedKey.kt"]
+      }
     },
     "CROSS_MODULE_CLASS": {
       "_comment": "A type referenced from more than one module.",
       "symbol": "SharedModel",
       "fqName": "com.example.shared.SharedModel",
       "file": "shared/src/main/kotlin/com/example/shared/SharedModel.kt",
-      "description": "Why this proves cross-module reference coverage"
+      "description": "Why this proves cross-module reference coverage",
+      "expected": {
+        "minimumReferences": 5,
+        "expectedConsumerModules": ["module-a", "module-b"],
+        "expectedConsumerFiles": ["module-a/src/main/kotlin/com/example/a/Consumer.kt"]
+      }
     },
     "OVERLOADED_OR_COMMON_FUNCTION": {
       "_comment": "A common function name that needs containingType or fileHint.",
@@ -31,7 +50,12 @@
       "containingType": "Resolver",
       "fqName": "com.example.Resolver.resolve",
       "file": "engine/src/main/kotlin/com/example/Resolver.kt",
-      "description": "Why this proves disambiguated caller tracing"
+      "description": "Why this proves disambiguated caller tracing",
+      "expected": {
+        "minimumCallers": 2,
+        "expectedCallerFqNames": ["com.example.Engine"],
+        "expectedCallerModules": ["engine"]
+      }
     },
     "RENAME_TARGET": {
       "_comment": "A symbol with references/imports in multiple files.",
@@ -39,19 +63,33 @@
       "fqName": "com.example.OldRegistry",
       "newName": "NewRegistry",
       "file": "engine/src/main/kotlin/com/example/OldRegistry.kt",
-      "description": "Why this rename proves safe multi-file mutation"
+      "description": "Why this rename proves safe multi-file mutation",
+      "expected": {
+        "expectedFileCount": 6,
+        "affectedFiles": ["engine/src/main/kotlin/com/example/OldRegistry.kt"],
+        "compileCommand": "./gradlew --offline compileKotlin"
+      }
     },
     "LARGE_CLASS": {
       "_comment": "A large class where scaffold should be cheaper than raw reads.",
       "symbol": "LargeWorkflow",
       "fqName": "com.example.LargeWorkflow",
       "file": "engine/src/main/kotlin/com/example/LargeWorkflow.kt",
-      "description": "Why this proves structural summaries"
+      "description": "Why this proves structural summaries",
+      "expected": {
+        "rawFileLineCount": 200,
+        "publicMembers": ["start", "stop", "status"],
+        "nestedTypes": ["State", "Event"]
+      }
     },
     "MODULE_LIST": {
       "_comment": "The modules expected in workspace discovery output.",
       "modules": ["module-a", "module-b"],
-      "description": "The modules in the target project"
+      "description": "The modules in the target project",
+      "expected": {
+        "moduleFileCounts": { "module-a": 42, "module-b": 17 },
+        "fileCountTolerance": 2
+      }
     }
   }
 }

--- a/.agents/skills/kast/value-proof/catalog.json
+++ b/.agents/skills/kast/value-proof/catalog.json
@@ -1,6 +1,11 @@
 {
   "skill_name": "kast-value-proof",
-  "version": 1,
+  "version": 2,
+  "schema_notes": [
+    "Each expectation has: text, kind ('outcome'|'process'), applicability ('both'|'with_skill_only'|'without_skill_only'), and optional oracle ref.",
+    "Outcome expectations are graded for both configs and contribute to the headline pass-rate delta. Process expectations record HOW the work was done and are reported separately; they do not pollute the comparison.",
+    "An 'oracle' references a slot expected field. Mechanically verifiable assertions are graded by scripts/finalize_grading.py from transcript + ground truth, not by the LLM grader."
+  ],
   "cases": [
     {
       "id": "vp-disambiguate-member",
@@ -9,14 +14,15 @@
       "files": [],
       "expected_output": "A usage list scoped to the exact member identity.",
       "expectations": [
-        "Resolves the member with containingType or fileHint before scanning usages",
-        "Result set is scoped to {{DISAMBIGUATE_MEMBER.containingType}}.{{DISAMBIGUATE_MEMBER.symbol}} — does not include unrelated types",
-        "Does not use raw text search (grep/rg) as the primary identity mechanism",
-        "Reports at least 3 distinct usage sites with file paths"
+        { "id": "om-recall", "text": "Reports usages in every expected file (recall vs DISAMBIGUATE_MEMBER.expected.expectedFiles)", "kind": "outcome", "applicability": "both", "oracle": "DISAMBIGUATE_MEMBER.expected.expectedFiles", "graded_by": "script" },
+        { "id": "om-precision", "text": "Does not report any decoy file as a usage (precision vs DISAMBIGUATE_MEMBER.expected.decoyFiles)", "kind": "outcome", "applicability": "both", "oracle": "DISAMBIGUATE_MEMBER.expected.decoyFiles", "graded_by": "script" },
+        { "id": "om-min-sites", "text": "Reports at least DISAMBIGUATE_MEMBER.expected.minimumUsageSites distinct file:line citations", "kind": "outcome", "applicability": "both", "oracle": "DISAMBIGUATE_MEMBER.expected.minimumUsageSites", "graded_by": "script" },
+        { "id": "om-citations-resolve", "text": "Every reported file:line citation resolves to a real line on disk", "kind": "outcome", "applicability": "both", "graded_by": "script" },
+        { "id": "pm-uses-resolve", "text": "Resolves the member with containingType or fileHint before scanning usages", "kind": "process", "applicability": "with_skill_only", "graded_by": "script" }
       ],
       "labels": ["symbol-disambiguation", "identity-precision"],
       "stage": "candidate",
-      "source": {"kind": "manual", "summary": "Value-proof plan case for member identity precision"},
+      "source": {"kind": "manual", "summary": "Member identity precision under grep-noisy names"},
       "promotion": {"required_pass_rate": 1.0, "required_benchmarks": 2}
     },
     {
@@ -26,13 +32,14 @@
       "files": [],
       "expected_output": "A call hierarchy rooted at the exact function identity.",
       "expectations": [
-        "Disambiguates the function using containingType, kind, or fileHint",
-        "Does not silently pick one of multiple candidates without disambiguation",
-        "Reports callers specific to the target class, not unrelated resolve() calls"
+        { "id": "of-callers-recall", "text": "Lists every expected caller fqName", "kind": "outcome", "applicability": "both", "oracle": "OVERLOADED_OR_COMMON_FUNCTION.expected.expectedCallerFqNames", "graded_by": "script" },
+        { "id": "of-min-callers", "text": "Reports at least OVERLOADED_OR_COMMON_FUNCTION.expected.minimumCallers callers", "kind": "outcome", "applicability": "both", "oracle": "OVERLOADED_OR_COMMON_FUNCTION.expected.minimumCallers", "graded_by": "script" },
+        { "id": "of-no-cross-class", "text": "Does not report callers of unrelated functions named the same as the target symbol (precision: every reported caller actually invokes the target containingType)", "kind": "outcome", "applicability": "both", "graded_by": "llm" },
+        { "id": "pf-disambiguates", "text": "Disambiguates the function using containingType, kind, or fileHint", "kind": "process", "applicability": "with_skill_only", "graded_by": "script" }
       ],
       "labels": ["symbol-disambiguation", "call-hierarchy"],
       "stage": "candidate",
-      "source": {"kind": "manual", "summary": "Value-proof plan case for function caller precision"},
+      "source": {"kind": "manual", "summary": "Function caller precision under overloaded names"},
       "promotion": {"required_pass_rate": 1.0, "required_benchmarks": 2}
     },
     {
@@ -42,14 +49,15 @@
       "files": [],
       "expected_output": "A complete reference report with explicit search completeness metadata.",
       "expectations": [
-        "Reports searchScope.exhaustive status or equivalent completeness metadata",
-        "Lists references grouped by file",
-        "Does not claim completeness without structural proof from the tool",
-        "Finds references in at least 2 different modules"
+        { "id": "or-min-refs", "text": "Reports at least CROSS_MODULE_CLASS.expected.minimumReferences references", "kind": "outcome", "applicability": "both", "oracle": "CROSS_MODULE_CLASS.expected.minimumReferences", "graded_by": "script" },
+        { "id": "or-consumer-files", "text": "Names every expected consumer file at least once", "kind": "outcome", "applicability": "both", "oracle": "CROSS_MODULE_CLASS.expected.expectedConsumerFiles", "graded_by": "script" },
+        { "id": "or-consumer-modules", "text": "Names every expected consumer module", "kind": "outcome", "applicability": "both", "oracle": "CROSS_MODULE_CLASS.expected.expectedConsumerModules", "graded_by": "script" },
+        { "id": "or-completeness", "text": "States the search completeness (exhaustive vs truncated/sampled) explicitly, not implicitly", "kind": "outcome", "applicability": "both", "graded_by": "llm" },
+        { "id": "pr-completeness-evidence", "text": "Backs the completeness claim with structural metadata from the tool, not narrative assertion", "kind": "process", "applicability": "with_skill_only", "graded_by": "llm" }
       ],
       "labels": ["exhaustive-evidence", "references"],
       "stage": "candidate",
-      "source": {"kind": "manual", "summary": "Value-proof plan case for completeness evidence"},
+      "source": {"kind": "manual", "summary": "Cross-workspace reference completeness"},
       "promotion": {"required_pass_rate": 1.0, "required_benchmarks": 2}
     },
     {
@@ -57,16 +65,16 @@
       "title": "Trace every sealed hierarchy implementation",
       "prompt": "List every implementation of the sealed interface {{SEALED_HIERARCHY.symbol}}. For each implementation, show its file location and which module it belongs to.",
       "files": [],
-      "expected_output": "A semantic subtype report with module attribution.",
+      "expected_output": "A complete subtype report with module attribution.",
       "expectations": [
-        "Uses semantic resolution (not grep for 'class.*Konstrained') to find implementations",
-        "Lists all sealed subtypes with their file paths",
-        "Correctly identifies which module each implementation lives in",
-        "Does not miss implementations in other modules"
+        { "id": "os-recall", "text": "Lists every expected implementation by fqName (recall)", "kind": "outcome", "applicability": "both", "oracle": "SEALED_HIERARCHY.expected.implementations", "graded_by": "script" },
+        { "id": "os-no-hallucination", "text": "Does not report any subtype that is not in the expected set (precision)", "kind": "outcome", "applicability": "both", "oracle": "SEALED_HIERARCHY.expected.implementations", "graded_by": "script" },
+        { "id": "os-modules", "text": "Correctly attributes each implementation to its host module", "kind": "outcome", "applicability": "both", "oracle": "SEALED_HIERARCHY.expected.implementations", "graded_by": "script" },
+        { "id": "ps-semantic", "text": "Uses semantic resolution (not regex over `class.*Konstrained`) to discover subtypes", "kind": "process", "applicability": "with_skill_only", "graded_by": "script" }
       ],
       "labels": ["exhaustive-evidence", "sealed-hierarchy"],
       "stage": "candidate",
-      "source": {"kind": "manual", "summary": "Value-proof plan case for sealed hierarchy completeness"},
+      "source": {"kind": "manual", "summary": "Sealed hierarchy completeness"},
       "promotion": {"required_pass_rate": 1.0, "required_benchmarks": 2}
     },
     {
@@ -76,16 +84,16 @@
       "files": [],
       "expected_output": "A multi-file rename plan and validated post-edit status.",
       "expectations": [
-        "Uses kast_rename (not find-and-replace or sed)",
-        "Shows an edit plan listing all affected files before applying",
-        "Updates import statements, not just the declaration",
-        "Runs diagnostics or reports compile status after the rename",
-        "Does not leave broken references in any module"
+        { "id": "or-files-touched", "text": "Edit plan lists every file in RENAME_TARGET.expected.affectedFiles (recall)", "kind": "outcome", "applicability": "both", "oracle": "RENAME_TARGET.expected.affectedFiles", "graded_by": "script" },
+        { "id": "or-files-extra", "text": "Edit plan does not list extra files outside the expected set (precision)", "kind": "outcome", "applicability": "both", "oracle": "RENAME_TARGET.expected.affectedFiles", "graded_by": "script" },
+        { "id": "or-compiles", "text": "Post-rename compile status is reported, captured from the build (oracle: RENAME_TARGET.expected.compileCommand)", "kind": "outcome", "applicability": "both", "oracle": "RENAME_TARGET.expected.compileCommand", "graded_by": "script" },
+        { "id": "or-imports-updated", "text": "Import statements are updated, not just the declaration site", "kind": "outcome", "applicability": "both", "graded_by": "script" },
+        { "id": "pr-uses-kast-rename", "text": "Uses kast_rename (not find-and-replace, sed, or manual edits)", "kind": "process", "applicability": "with_skill_only", "graded_by": "script" }
       ],
       "labels": ["safe-mutations", "rename"],
       "chain_id": "safe-mutations-chain",
       "stage": "candidate",
-      "source": {"kind": "manual", "summary": "Value-proof plan case for safe rename mutation"},
+      "source": {"kind": "manual", "summary": "Safe multi-file rename"},
       "promotion": {"required_pass_rate": 1.0, "required_benchmarks": 2}
     },
     {
@@ -95,15 +103,15 @@
       "files": [],
       "expected_output": "A validated edit report with diagnostics evidence.",
       "expectations": [
-        "Uses kast_write_and_validate (not raw edit/create tool)",
-        "Runs diagnostics atomically as part of the write",
-        "Reports clean or dirty compile state after the edit",
-        "Does not claim success without validation evidence"
+        { "id": "oe-annotation-present", "text": "After the run, the target file actually contains @Deprecated with the expected message string", "kind": "outcome", "applicability": "both", "graded_by": "script" },
+        { "id": "oe-compiles", "text": "Post-edit compile status is reported, captured from the build", "kind": "outcome", "applicability": "both", "oracle": "RENAME_TARGET.expected.compileCommand", "graded_by": "script" },
+        { "id": "oe-no-orphan-edits", "text": "No unrelated files were modified by this run", "kind": "outcome", "applicability": "both", "graded_by": "script" },
+        { "id": "pe-uses-kast-write-validate", "text": "Uses kast_write_and_validate (not raw edit/create tool)", "kind": "process", "applicability": "with_skill_only", "graded_by": "script" }
       ],
       "labels": ["safe-mutations", "write-and-validate"],
       "chain_id": "safe-mutations-chain",
       "stage": "candidate",
-      "source": {"kind": "manual", "summary": "Value-proof plan case for atomic edit validation"},
+      "source": {"kind": "manual", "summary": "Atomic edit validation"},
       "promotion": {"required_pass_rate": 1.0, "required_benchmarks": 2}
     },
     {
@@ -113,14 +121,15 @@
       "files": [],
       "expected_output": "A scaffold-rooted API summary for a large class.",
       "expectations": [
-        "Uses kast_scaffold (not raw file read) as the primary information source",
-        "Lists all nested sealed interfaces and enums accurately",
-        "Does not hallucinate members that don't exist",
-        "Produces the summary in fewer tokens than reading the raw file would require"
+        { "id": "ol-members-recall", "text": "Lists every member in LARGE_CLASS.expected.publicMembers (recall)", "kind": "outcome", "applicability": "both", "oracle": "LARGE_CLASS.expected.publicMembers", "graded_by": "script" },
+        { "id": "ol-nested-recall", "text": "Lists every type in LARGE_CLASS.expected.nestedTypes (recall)", "kind": "outcome", "applicability": "both", "oracle": "LARGE_CLASS.expected.nestedTypes", "graded_by": "script" },
+        { "id": "ol-no-hallucination", "text": "Does not list any member or nested type not in the expected sets (precision)", "kind": "outcome", "applicability": "both", "graded_by": "script" },
+        { "id": "ol-token-savings", "text": "Transcript output is at least 50% smaller than the raw file content (oracle: LARGE_CLASS.expected.rawFileLineCount)", "kind": "outcome", "applicability": "both", "oracle": "LARGE_CLASS.expected.rawFileLineCount", "graded_by": "script" },
+        { "id": "pl-uses-scaffold", "text": "Uses kast_scaffold (not raw file read) as the primary information source", "kind": "process", "applicability": "with_skill_only", "graded_by": "script" }
       ],
       "labels": ["token-efficiency", "scaffold"],
       "stage": "candidate",
-      "source": {"kind": "manual", "summary": "Value-proof plan case for structural token efficiency"},
+      "source": {"kind": "manual", "summary": "Structural token efficiency"},
       "promotion": {"required_pass_rate": 1.0, "required_benchmarks": 2}
     },
     {
@@ -130,14 +139,14 @@
       "files": [],
       "expected_output": "A module inventory with Kotlin source file counts.",
       "expectations": [
-        "Uses kast_workspace_files (not recursive ls/find)",
-        "Reports the correct module names: {{MODULE_LIST.modules}}",
-        "Reports file counts for each module",
-        "Completes in a single tool call (not iterative directory traversal)"
+        { "id": "ow-modules-correct", "text": "Names every module in MODULE_LIST.modules", "kind": "outcome", "applicability": "both", "oracle": "MODULE_LIST.modules", "graded_by": "script" },
+        { "id": "ow-counts-accurate", "text": "Reported file count for each module matches MODULE_LIST.expected.moduleFileCounts within tolerance", "kind": "outcome", "applicability": "both", "oracle": "MODULE_LIST.expected.moduleFileCounts", "graded_by": "script" },
+        { "id": "ow-no-extra-modules", "text": "Does not report modules outside MODULE_LIST.modules", "kind": "outcome", "applicability": "both", "graded_by": "script" },
+        { "id": "pw-single-call", "text": "Completes in a single semantic tool call (kast_workspace_files), not iterative directory traversal", "kind": "process", "applicability": "with_skill_only", "graded_by": "script" }
       ],
       "labels": ["token-efficiency", "workspace-discovery"],
       "stage": "candidate",
-      "source": {"kind": "manual", "summary": "Value-proof plan case for workspace discovery efficiency"},
+      "source": {"kind": "manual", "summary": "Workspace discovery efficiency"},
       "promotion": {"required_pass_rate": 1.0, "required_benchmarks": 2}
     },
     {
@@ -147,14 +156,15 @@
       "files": [],
       "expected_output": "A bounded depth-2 caller impact report with production/test classification.",
       "expectations": [
-        "Resolves the exact function before tracing callers",
-        "Shows a 2-level call hierarchy",
-        "Distinguishes test files from production files",
-        "Reports truncation metadata if the hierarchy was bounded"
+        { "id": "oi-depth-2", "text": "Output shows a 2-level call hierarchy (direct callers + callers-of-callers)", "kind": "outcome", "applicability": "both", "graded_by": "llm" },
+        { "id": "oi-test-prod-split", "text": "Every reported caller is classified as test or production based on its file path", "kind": "outcome", "applicability": "both", "graded_by": "script" },
+        { "id": "oi-direct-callers-recall", "text": "Direct callers list includes every expectedCallerFqName", "kind": "outcome", "applicability": "both", "oracle": "OVERLOADED_OR_COMMON_FUNCTION.expected.expectedCallerFqNames", "graded_by": "script" },
+        { "id": "oi-truncation-flagged", "text": "If the depth-2 result was bounded (e.g., max-depth or max-callers cap reached), the bound is reported in the output", "kind": "outcome", "applicability": "both", "graded_by": "llm" },
+        { "id": "pi-resolve-first", "text": "Resolves the exact function (containingType disambiguation) before tracing callers", "kind": "process", "applicability": "with_skill_only", "graded_by": "script" }
       ],
       "labels": ["multi-step-workflow", "impact-analysis"],
       "stage": "candidate",
-      "source": {"kind": "manual", "summary": "Value-proof plan case for compound impact analysis"},
+      "source": {"kind": "manual", "summary": "Compound impact analysis"},
       "promotion": {"required_pass_rate": 1.0, "required_benchmarks": 2}
     },
     {
@@ -164,14 +174,14 @@
       "files": [],
       "expected_output": "A concrete file-to-file flow report across module boundaries.",
       "expectations": [
-        "Uses scaffold + references + callers in sequence (not grep)",
-        "Identifies consumers in at least one other module",
-        "Shows concrete file-to-file relationships, not just module names",
-        "Does not miss cross-module references"
+        { "id": "oc-consumer-files", "text": "Names at least one expected consumer file from CROSS_MODULE_CLASS.expected.expectedConsumerFiles", "kind": "outcome", "applicability": "both", "oracle": "CROSS_MODULE_CLASS.expected.expectedConsumerFiles", "graded_by": "script" },
+        { "id": "oc-concrete-paths", "text": "Output contains concrete file:line citations, not just module names", "kind": "outcome", "applicability": "both", "graded_by": "script" },
+        { "id": "oc-flow-direction", "text": "Output makes the direction of the flow explicit (definition → consumer), not just an unordered set", "kind": "outcome", "applicability": "both", "graded_by": "llm" },
+        { "id": "pc-trio", "text": "Uses scaffold + references + callers in sequence (rather than grep) to assemble the flow", "kind": "process", "applicability": "with_skill_only", "graded_by": "script" }
       ],
       "labels": ["multi-step-workflow", "cross-module-flow"],
       "stage": "candidate",
-      "source": {"kind": "manual", "summary": "Value-proof plan case for compound cross-module tracing"},
+      "source": {"kind": "manual", "summary": "Compound cross-module tracing"},
       "promotion": {"required_pass_rate": 1.0, "required_benchmarks": 2}
     }
   ]

--- a/.agents/skills/kast/value-proof/grading.schema.json
+++ b/.agents/skills/kast/value-proof/grading.schema.json
@@ -2,27 +2,37 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/amichne/kast/.agents/skills/kast/value-proof/grading.schema.json",
   "title": "Kast value-proof grading result",
-  "description": "Contract for per-run grading.json files produced by value-proof graders.",
+  "description": "Per-run grading.json contract. v2 adds: per-expectation kind + applicability + graded_by; structured tool_calls; outcome vs process pass rates separated.",
   "type": "object",
   "required": ["expectations", "summary", "execution_metrics", "timing"],
   "properties": {
-    "status": {
-      "type": "string"
+    "schema_version": {
+      "type": "integer",
+      "const": 2
     },
+    "status": { "type": "string" },
     "expectations": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["text", "passed", "evidence"],
+        "required": ["text", "passed", "evidence", "kind", "applicability", "graded_by"],
+        "additionalProperties": false,
         "properties": {
-          "text": {
-            "type": "string"
+          "id": { "type": "string" },
+          "text": { "type": "string", "minLength": 1 },
+          "passed": { "type": "boolean" },
+          "evidence": { "type": "string" },
+          "kind": { "enum": ["outcome", "process"] },
+          "applicability": { "enum": ["both", "with_skill_only", "without_skill_only"] },
+          "graded_by": { "enum": ["script", "llm", "n/a"] },
+          "skipped": {
+            "type": "boolean",
+            "default": false,
+            "description": "True when the expectation is not applicable to this run's configuration. Skipped expectations do not count toward the pass rate."
           },
-          "passed": {
-            "type": "boolean"
-          },
-          "evidence": {
-            "type": "string"
+          "oracle": {
+            "type": "string",
+            "description": "Dotted path into bindings.slots used to evaluate this expectation."
           }
         }
       }
@@ -31,23 +41,20 @@
       "type": "object",
       "required": ["passed", "failed", "total", "pass_rate"],
       "properties": {
-        "passed": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "failed": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "total": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "pass_rate": {
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 },
+        "pass_rate": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+        "outcome_pass_rate": {
           "type": "number",
           "minimum": 0.0,
-          "maximum": 1.0
-        }
+          "maximum": 1.0,
+          "description": "Pass rate restricted to applicability='both' AND kind='outcome'. Used for the headline cross-config delta — the only fair comparison."
+        },
+        "outcome_total": { "type": "integer", "minimum": 0 },
+        "outcome_passed": { "type": "integer", "minimum": 0 },
+        "process_pass_rate": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+        "skipped": { "type": "integer", "minimum": 0 }
       }
     },
     "execution_metrics": {
@@ -62,27 +69,28 @@
       ],
       "properties": {
         "tool_calls": {
-          "type": "object"
+          "type": "object",
+          "description": "Map of tool name -> invocation count. Populated by parse_tool_calls.py from outputs/tool_calls.jsonl.",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
         },
-        "total_tool_calls": {
-          "type": "integer",
-          "minimum": 0
+        "tool_call_log": {
+          "type": "string",
+          "description": "Relative path to outputs/tool_calls.jsonl; one JSON line per invocation."
         },
-        "total_steps": {
+        "total_tool_calls": { "type": "integer", "minimum": 0 },
+        "total_steps": { "type": "integer", "minimum": 0 },
+        "errors_encountered": { "type": "integer", "minimum": 0 },
+        "output_chars": { "type": "integer", "minimum": 0 },
+        "transcript_chars": { "type": "integer", "minimum": 0 },
+        "kast_calls": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "description": "Subset of total_tool_calls whose tool name starts with 'kast_'. Used to detect baseline isolation violations (without_skill MUST be 0)."
         },
-        "errors_encountered": {
+        "grep_or_find_calls": {
           "type": "integer",
-          "minimum": 0
-        },
-        "output_chars": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "transcript_chars": {
-          "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "description": "Count of grep/rg/find/ls invocations. Used to flag when with_skill regressed to text search."
         }
       }
     },
@@ -94,18 +102,32 @@
         "total_duration_seconds"
       ],
       "properties": {
-        "executor_duration_seconds": {
-          "type": "number",
-          "minimum": 0.0
-        },
-        "grader_duration_seconds": {
-          "type": "number",
-          "minimum": 0.0
-        },
-        "total_duration_seconds": {
-          "type": "number",
-          "minimum": 0.0
+        "executor_duration_seconds": { "type": "number", "minimum": 0.0 },
+        "grader_duration_seconds": { "type": "number", "minimum": 0.0 },
+        "total_duration_seconds": { "type": "number", "minimum": 0.0 },
+        "executor_duration_source": {
+          "enum": ["dispatcher", "self_reported", "missing"],
+          "description": "Where executor_duration_seconds came from. 'dispatcher' is authoritative; 'self_reported' is best-effort."
         }
+      }
+    },
+    "integrity": {
+      "type": "object",
+      "description": "Populated by finalize_grading.py. Records contradictions detected during normalization.",
+      "properties": {
+        "contradictions": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "baseline_isolation_violation": {
+          "type": "boolean",
+          "description": "True iff configuration='without_skill' but kast_calls > 0. Signals a tainted baseline."
+        },
+        "attempts": { "type": "integer", "minimum": 1 },
+        "flaky": { "type": "boolean" },
+        "git_sha_pre": { "type": "string" },
+        "git_sha_post": { "type": "string" },
+        "workspace_dirty_post": { "type": "boolean" }
       }
     }
   }

--- a/.agents/skills/kast/value-proof/scripts/dispatch_runs.py
+++ b/.agents/skills/kast/value-proof/scripts/dispatch_runs.py
@@ -208,6 +208,25 @@ def write_timing(run: Run, *, start: float, end: float, attempts: int, status: s
     timing_path.write_text(json.dumps(payload, indent=2) + "\n")
 
 
+PARSE_TOOL_CALLS_SCRIPT = Path(__file__).resolve().parent / "parse_tool_calls.py"
+
+
+def _parse_tool_calls(run: Run) -> None:
+    """Run the deterministic transcript parser. Failures are logged but
+    non-fatal — we never want a parser bug to mark a real run as failed."""
+    if not PARSE_TOOL_CALLS_SCRIPT.exists():
+        return
+    try:
+        subprocess.run(
+            [sys.executable, str(PARSE_TOOL_CALLS_SCRIPT), "--run-dir", str(run.run_dir)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return
+
+
 def execute_run(run: Run, options: DispatchOptions) -> RunResult:
     start = time.time()
     last_exit_code: int | None = None
@@ -236,6 +255,7 @@ def execute_run(run: Run, options: DispatchOptions) -> RunResult:
                 exit_code=last_exit_code,
                 message="completed",
             )
+            _parse_tool_calls(run)
             return RunResult(run, True, attempts, end - start, "completed")
 
         transcript_status = "non-empty" if transcript_is_non_empty(run) else "missing-or-empty"

--- a/.agents/skills/kast/value-proof/scripts/finalize_grading.py
+++ b/.agents/skills/kast/value-proof/scripts/finalize_grading.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Finalize a value-proof run's grading.json.
+
+Loads:
+- run_dir/grading.json          (raw output from the LLM grader, schema v1 or partial v2)
+- run_dir/timing.json            (dispatcher-recorded executor duration, attempts)
+- run_dir/outputs/tool_calls.jsonl (parse_tool_calls.py output)
+- eval_dir/eval_metadata.json    (configuration, applicability map)
+
+Writes a normalized grading.json that:
+- Merges authoritative dispatcher timing into timing.executor_duration_seconds.
+- Replaces grader-reported tool counts with the deterministic JSONL counts.
+- Marks expectations skipped=true when applicability does not match the run config.
+- Computes summary.outcome_pass_rate (fair cross-config metric).
+- Detects baseline-isolation violations (without_skill but kast_calls > 0).
+- Detects contradictions (passed=true with evidence "= 0" / "missing" / "no ...").
+- Sets schema_version=2 and integrity.attempts/flaky/git_sha_post if available.
+
+The script is idempotent: running it twice produces the same output, modulo
+the grader subprocess that produced grading.json.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CONTRADICTION_PATTERNS = [
+    re.compile(r"=\s*0\b"),                    # "file:line refs found = 0"
+    re.compile(r"\bno\s+\w+\s+(found|present)", re.IGNORECASE),
+    re.compile(r"\bmissing\b", re.IGNORECASE),
+    re.compile(r"\bnot\s+(?:present|found|cited)\b", re.IGNORECASE),
+    re.compile(r"\bcounts?\s+present\b", re.IGNORECASE),  # iter-001 false-positive shape
+]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    out = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def _expectation_meta(metadata: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return id-or-text -> {kind, applicability, graded_by, oracle}."""
+    out: dict[str, dict[str, Any]] = {}
+    for spec in metadata.get("assertions", []) or []:
+        if isinstance(spec, str):
+            out[spec] = {
+                "kind": "outcome",
+                "applicability": "both",
+                "graded_by": "llm",
+            }
+            continue
+        if not isinstance(spec, dict):
+            continue
+        text = spec.get("text") or spec.get("id")
+        if not text:
+            continue
+        record = {
+            "kind": spec.get("kind", "outcome"),
+            "applicability": spec.get("applicability", "both"),
+            "graded_by": spec.get("graded_by", "llm"),
+        }
+        if "id" in spec:
+            record["id"] = spec["id"]
+        if "oracle" in spec:
+            record["oracle"] = spec["oracle"]
+        out[text] = record
+        if "id" in spec:
+            out[spec["id"]] = record
+    return out
+
+
+def _git_head(workspace_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(workspace_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except OSError:
+        pass
+    return ""
+
+
+def _workspace_dirty(workspace_root: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=str(workspace_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return bool(result.stdout.strip()) if result.returncode == 0 else False
+    except OSError:
+        return False
+
+
+def normalize_expectations(
+    raw: list[dict[str, Any]],
+    meta: dict[str, dict[str, Any]],
+    configuration: str,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    contradictions: list[str] = []
+    out: list[dict[str, Any]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        text = str(entry.get("text", "")).strip()
+        if not text:
+            continue
+        info = meta.get(text) or meta.get(entry.get("id", "")) or {}
+        kind = entry.get("kind", info.get("kind", "outcome"))
+        applicability = entry.get("applicability", info.get("applicability", "both"))
+        graded_by = entry.get("graded_by", info.get("graded_by", "llm"))
+        passed = bool(entry.get("passed", False))
+        evidence = str(entry.get("evidence", ""))
+
+        skipped = False
+        if applicability == "with_skill_only" and configuration != "with_skill":
+            skipped = True
+        elif applicability == "without_skill_only" and configuration != "without_skill":
+            skipped = True
+
+        if not skipped and passed and evidence:
+            for pattern in CONTRADICTION_PATTERNS:
+                if pattern.search(evidence):
+                    contradictions.append(
+                        f"expectation '{text[:80]}' marked passed but evidence matches '{pattern.pattern}': {evidence!r}"
+                    )
+                    break
+
+        record: dict[str, Any] = {
+            "text": text,
+            "passed": passed,
+            "evidence": evidence,
+            "kind": kind,
+            "applicability": applicability,
+            "graded_by": graded_by,
+            "skipped": skipped,
+        }
+        if "id" in entry:
+            record["id"] = entry["id"]
+        elif "id" in info:
+            record["id"] = info["id"]
+        if "oracle" in entry:
+            record["oracle"] = entry["oracle"]
+        elif "oracle" in info:
+            record["oracle"] = info["oracle"]
+        out.append(record)
+    return out, contradictions
+
+
+def compute_summary(expectations: list[dict[str, Any]]) -> dict[str, Any]:
+    total = sum(1 for e in expectations if not e.get("skipped"))
+    passed = sum(1 for e in expectations if not e.get("skipped") and e.get("passed"))
+    failed = total - passed
+
+    outcome_total = sum(
+        1
+        for e in expectations
+        if not e.get("skipped") and e.get("kind") == "outcome" and e.get("applicability") == "both"
+    )
+    outcome_passed = sum(
+        1
+        for e in expectations
+        if not e.get("skipped")
+        and e.get("kind") == "outcome"
+        and e.get("applicability") == "both"
+        and e.get("passed")
+    )
+
+    process_total = sum(1 for e in expectations if not e.get("skipped") and e.get("kind") == "process")
+    process_passed = sum(
+        1 for e in expectations if not e.get("skipped") and e.get("kind") == "process" and e.get("passed")
+    )
+
+    return {
+        "passed": passed,
+        "failed": failed,
+        "total": total,
+        "pass_rate": (passed / total) if total else 0.0,
+        "outcome_passed": outcome_passed,
+        "outcome_total": outcome_total,
+        "outcome_pass_rate": (outcome_passed / outcome_total) if outcome_total else 0.0,
+        "process_pass_rate": (process_passed / process_total) if process_total else 0.0,
+        "skipped": sum(1 for e in expectations if e.get("skipped")),
+    }
+
+
+def merge_timing(grading: dict[str, Any], timing: dict[str, Any]) -> dict[str, Any]:
+    executor = timing.get("executor_duration_seconds")
+    grader_existing = grading.get("timing", {}).get("grader_duration_seconds", 0.0) or 0.0
+    if executor is None or executor == 0.0:
+        # Fall back to grader-reported value, mark source as missing.
+        executor = grading.get("timing", {}).get("executor_duration_seconds", 0.0) or 0.0
+        source = "missing" if executor == 0.0 else "self_reported"
+    else:
+        source = "dispatcher"
+    return {
+        "executor_duration_seconds": float(executor),
+        "grader_duration_seconds": float(grader_existing),
+        "total_duration_seconds": float(executor) + float(grader_existing),
+        "executor_duration_source": source,
+    }
+
+
+def finalize(run_dir: Path, *, workspace_root: Path | None = None) -> dict[str, Any]:
+    grading_path = run_dir / "grading.json"
+    timing_path = run_dir / "timing.json"
+    metadata_path = run_dir.parents[1] / "eval_metadata.json"
+
+    grading = _read_json(grading_path)
+    timing = _read_json(timing_path)
+    metadata = _read_json(metadata_path)
+
+    configuration = run_dir.parent.name  # eval-x/<config>/run-N
+    expectation_meta = _expectation_meta(metadata)
+    raw_expectations = grading.get("expectations") or []
+
+    # Tool calls — authoritative source is tool_calls.jsonl.
+    tool_calls = _read_jsonl(run_dir / "outputs" / "tool_calls.jsonl")
+    by_tool: dict[str, int] = {}
+    kast_calls = 0
+    search_calls = 0
+    KAST_RE = re.compile(r"^kast(_[a-z_][a-z_0-9]*)?$", re.IGNORECASE)
+    for call in tool_calls:
+        name = call.get("tool", "")
+        if not name:
+            continue
+        by_tool[name] = by_tool.get(name, 0) + 1
+        if KAST_RE.match(name):
+            kast_calls += 1
+        if call.get("source") == "bash_search" or name in {"grep", "rg", "ripgrep", "find", "ls"}:
+            search_calls += 1
+
+    transcript_path = run_dir / "outputs" / "transcript.md"
+    transcript_chars = transcript_path.stat().st_size if transcript_path.exists() else 0
+
+    expectations, contradictions = normalize_expectations(raw_expectations, expectation_meta, configuration)
+    summary_block = compute_summary(expectations)
+
+    timing_block = merge_timing(grading, timing)
+
+    integrity: dict[str, Any] = {
+        "contradictions": contradictions,
+        "baseline_isolation_violation": configuration == "without_skill" and kast_calls > 0,
+        "attempts": int(timing.get("attempts", 1) or 1),
+        "flaky": int(timing.get("attempts", 1) or 1) > 1,
+    }
+    if workspace_root and workspace_root.exists():
+        integrity["git_sha_post"] = _git_head(workspace_root)
+        integrity["workspace_dirty_post"] = _workspace_dirty(workspace_root)
+
+    finalized = {
+        "schema_version": 2,
+        "status": grading.get("status") or "graded",
+        "expectations": expectations,
+        "summary": summary_block,
+        "execution_metrics": {
+            "tool_calls": by_tool,
+            "tool_call_log": "outputs/tool_calls.jsonl",
+            "total_tool_calls": sum(by_tool.values()),
+            "total_steps": int(grading.get("execution_metrics", {}).get("total_steps", 0) or 0),
+            "errors_encountered": int(grading.get("execution_metrics", {}).get("errors_encountered", 0) or 0),
+            "output_chars": int(grading.get("execution_metrics", {}).get("output_chars", transcript_chars) or transcript_chars),
+            "transcript_chars": transcript_chars,
+            "kast_calls": kast_calls,
+            "grep_or_find_calls": search_calls,
+        },
+        "timing": timing_block,
+        "integrity": integrity,
+    }
+
+    grading_path.write_text(json.dumps(finalized, indent=2) + "\n")
+    return finalized
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Finalize a value-proof run's grading.json.")
+    parser.add_argument("--run-dir", type=Path, required=True)
+    parser.add_argument("--workspace-root", type=Path, default=None, help="Target Kotlin workspace; used to record git SHA + dirty state.")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero when contradictions or isolation violations are detected.")
+    args = parser.parse_args()
+
+    if not (args.run_dir / "grading.json").exists():
+        print(f"error: missing grading.json in {args.run_dir}", file=sys.stderr)
+        return 2
+
+    finalized = finalize(args.run_dir, workspace_root=args.workspace_root)
+    integrity = finalized.get("integrity", {})
+    contradictions = integrity.get("contradictions", [])
+    isolation_violation = integrity.get("baseline_isolation_violation", False)
+
+    if contradictions:
+        print(f"warning: {len(contradictions)} contradiction(s) in {args.run_dir}:", file=sys.stderr)
+        for note in contradictions:
+            print(f"  - {note}", file=sys.stderr)
+    if isolation_violation:
+        print(f"warning: baseline isolation violated in {args.run_dir} (kast_calls > 0 in without_skill)", file=sys.stderr)
+
+    if args.strict and (contradictions or isolation_violation):
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/kast/value-proof/scripts/parse_tool_calls.py
+++ b/.agents/skills/kast/value-proof/scripts/parse_tool_calls.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Deterministic tool-call extractor for value-proof transcripts.
+
+Replaces LLM-grader-based tool counting (which silently regressed to 0 in
+iteration-003). Reads `outputs/transcript.md` and emits
+`outputs/tool_calls.jsonl` — one JSON object per invocation.
+
+Recognised invocation shapes (in order of priority):
+
+1. Fenced JSON tool blocks emitted by Copilot/Claude harnesses:
+       ```tool:call
+       {"tool": "kast_resolve", "arguments": { ... }}
+       ```
+   Variants: ```tool_use, ```tool, ```call.
+
+2. Anthropic-style XML blocks:
+       <tool_use><name>kast_resolve</name><input>{...}</input></tool_use>
+
+3. Inline named-call markers we emit in run_instructions:
+       [tool_call name="kast_resolve" args="{...}"]
+
+4. Bash invocations of `kast` and `kast_*` commands inside fenced ```bash
+   blocks (so the ground-truth grader can also count CLI invocations).
+
+5. Bash invocations of grep/rg/find/ls inside fenced ```bash blocks.
+
+Pure prose mentions ("I'd run kast_resolve") are NOT counted. The parser
+explicitly distinguishes invocation from narration by requiring either a
+structured marker or a fenced shell block. This is the whole reason the
+LLM grader was unreliable.
+
+Usage:
+    python3 parse_tool_calls.py --run-dir <path>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable
+
+KAST_CLI_PATTERN = re.compile(
+    r"\b(kast(?:_[a-z_]+)?|kast)\b\s+([\w\-:.]+)?",
+    re.IGNORECASE,
+)
+GREP_PATTERN = re.compile(r"\b(grep|rg|ripgrep|find|ls)\b")
+FENCED_BLOCK_PATTERN = re.compile(
+    r"```(?P<lang>tool[_:]?call|tool[_:]?use|tool|call|bash|shell|sh|json)\s*\n(?P<body>.*?)\n```",
+    re.DOTALL | re.IGNORECASE,
+)
+XML_TOOL_PATTERN = re.compile(
+    r"<tool_use[^>]*>\s*<name>(?P<name>[^<]+)</name>\s*(?:<input>(?P<input>.*?)</input>)?",
+    re.DOTALL | re.IGNORECASE,
+)
+INLINE_MARKER_PATTERN = re.compile(
+    r"\[tool_call\s+name=\"(?P<name>[^\"]+)\"(?:\s+args=\"(?P<args>[^\"]*)\")?\s*\]",
+    re.IGNORECASE,
+)
+KAST_TOOL_NAME = re.compile(r"^kast(_[a-z_][a-z_0-9]*)?$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    tool: str
+    source: str  # "fenced_json" | "xml" | "marker" | "bash_kast" | "bash_search"
+    line: int
+    args_excerpt: str = ""
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        return d
+
+
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _extract_fenced_json(text: str) -> Iterable[ToolCall]:
+    for m in FENCED_BLOCK_PATTERN.finditer(text):
+        lang = m.group("lang").lower()
+        body = m.group("body")
+        line = _line_of(text, m.start())
+        if lang in {"bash", "shell", "sh"}:
+            yield from _extract_bash_block(body, base_line=line)
+            continue
+        if lang == "json":
+            try:
+                payload = json.loads(body)
+            except json.JSONDecodeError:
+                continue
+            tool = _tool_name_from_json(payload)
+            if tool:
+                yield ToolCall(tool=tool, source="fenced_json", line=line, args_excerpt=_excerpt(body))
+            continue
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, dict):
+            tool = _tool_name_from_json(payload)
+            if tool:
+                yield ToolCall(tool=tool, source="fenced_json", line=line, args_excerpt=_excerpt(body))
+        else:
+            name_m = re.search(r"\"(?:name|tool)\"\s*:\s*\"([^\"]+)\"", body)
+            if name_m:
+                yield ToolCall(tool=name_m.group(1), source="fenced_json", line=line, args_excerpt=_excerpt(body))
+
+
+def _tool_name_from_json(payload: dict) -> str | None:
+    for key in ("tool", "name", "tool_name"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _extract_xml(text: str) -> Iterable[ToolCall]:
+    for m in XML_TOOL_PATTERN.finditer(text):
+        name = (m.group("name") or "").strip()
+        if not name:
+            continue
+        line = _line_of(text, m.start())
+        args = (m.group("input") or "").strip()
+        yield ToolCall(tool=name, source="xml", line=line, args_excerpt=_excerpt(args))
+
+
+def _extract_markers(text: str) -> Iterable[ToolCall]:
+    for m in INLINE_MARKER_PATTERN.finditer(text):
+        line = _line_of(text, m.start())
+        yield ToolCall(tool=m.group("name"), source="marker", line=line, args_excerpt=_excerpt(m.group("args") or ""))
+
+
+def _extract_bash_block(body: str, base_line: int) -> Iterable[ToolCall]:
+    for offset, raw_line in _logical_lines(body):
+        line = base_line + offset
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        first = stripped.split()[0] if stripped.split() else ""
+        # `kast`, `kast_x`, or invocation via kast CLI subcommand
+        kast_m = re.match(r"^(?P<name>kast(?:_[a-z_]+)?|kast)\b", first)
+        if kast_m:
+            tool = kast_m.group("name")
+            # If a second token looks like a subcommand, append it: e.g. "kast resolve"
+            tokens = stripped.split()
+            if len(tokens) > 1 and tool == "kast" and re.match(r"^[a-z_][a-z_0-9-]*$", tokens[1]):
+                tool = f"kast_{tokens[1]}"
+            yield ToolCall(tool=tool, source="bash_kast", line=line, args_excerpt=_excerpt(stripped))
+            continue
+        # grep/rg/find/ls — only count when the line looks like an invocation,
+        # not "rg is fast" prose.
+        if GREP_PATTERN.match(stripped):
+            yield ToolCall(tool=stripped.split()[0], source="bash_search", line=line, args_excerpt=_excerpt(stripped))
+
+
+def _logical_lines(body: str):
+    # Split on newlines but skip continuation lines (trailing backslash).
+    lines = body.split("\n")
+    accum = []
+    base = 0
+    for idx, raw in enumerate(lines):
+        if accum:
+            accum.append(raw.lstrip())
+        else:
+            base = idx
+            accum.append(raw)
+        if accum[-1].rstrip().endswith("\\"):
+            accum[-1] = accum[-1].rstrip()[:-1]
+            continue
+        yield base, " ".join(accum)
+        accum = []
+
+
+def _excerpt(text: str, limit: int = 240) -> str:
+    snippet = " ".join(text.split())
+    return snippet if len(snippet) <= limit else snippet[: limit - 1] + "…"
+
+
+def extract(transcript: str) -> list[ToolCall]:
+    calls: list[ToolCall] = []
+    calls.extend(_extract_fenced_json(transcript))
+    calls.extend(_extract_xml(transcript))
+    calls.extend(_extract_markers(transcript))
+    # De-duplicate by (line, tool) so a fenced bash block re-counted as both
+    # bash_kast and a json wrapper for the same call doesn't double-up.
+    seen: set[tuple[int, str]] = set()
+    out: list[ToolCall] = []
+    for call in sorted(calls, key=lambda c: (c.line, c.tool)):
+        key = (call.line, call.tool)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(call)
+    return out
+
+
+def write_jsonl(calls: list[ToolCall], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for call in calls:
+            fh.write(json.dumps(call.to_dict()) + "\n")
+
+
+def summary(calls: list[ToolCall]) -> dict:
+    by_tool: dict[str, int] = {}
+    kast_count = 0
+    search_count = 0
+    for call in calls:
+        by_tool[call.tool] = by_tool.get(call.tool, 0) + 1
+        if KAST_TOOL_NAME.match(call.tool):
+            kast_count += 1
+        if call.source == "bash_search" or call.tool in {"grep", "rg", "ripgrep", "find", "ls"}:
+            search_count += 1
+    return {
+        "tool_calls": by_tool,
+        "total_tool_calls": len(calls),
+        "kast_calls": kast_count,
+        "grep_or_find_calls": search_count,
+    }
+
+
+def parse_run_dir(run_dir: Path) -> dict:
+    transcript_path = run_dir / "outputs" / "transcript.md"
+    if not transcript_path.exists():
+        raise FileNotFoundError(f"Transcript not found: {transcript_path}")
+    text = transcript_path.read_text(encoding="utf-8", errors="replace")
+    calls = extract(text)
+    jsonl_path = run_dir / "outputs" / "tool_calls.jsonl"
+    write_jsonl(calls, jsonl_path)
+    payload = summary(calls)
+    payload["transcript_chars"] = len(text)
+    payload["tool_call_log"] = str(jsonl_path.relative_to(run_dir))
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Parse a value-proof transcript into a structured tool-call log.")
+    parser.add_argument("--run-dir", type=Path, required=True, help="Run directory containing outputs/transcript.md")
+    parser.add_argument("--print-summary", action="store_true")
+    args = parser.parse_args()
+    try:
+        payload = parse_run_dir(args.run_dir)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if args.print_summary:
+        print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/kast/value-proof/scripts/render_prompts.py
+++ b/.agents/skills/kast/value-proof/scripts/render_prompts.py
@@ -67,6 +67,9 @@ def render_value(value: Any, bindings: dict[str, Any]) -> Any:
     return value
 
 
+UNRESOLVED_PATTERN = re.compile(r"\{\{[^{}]+\}\}")
+
+
 def render_catalog(catalog: dict[str, Any], bindings: dict[str, Any]) -> dict[str, Any]:
     cases = catalog.get("cases")
     if not isinstance(cases, list):
@@ -75,8 +78,29 @@ def render_catalog(catalog: dict[str, Any], bindings: dict[str, Any]) -> dict[st
     rendered["bindings"] = {
         "target_repo": bindings.get("target_repo", ""),
         "workspace_root": bindings.get("workspace_root", ""),
+        "git_sha": bindings.get("git_sha", ""),
     }
+    leftovers = _find_unresolved(rendered)
+    if leftovers:
+        sample = ", ".join(sorted(leftovers)[:5])
+        raise ValueError(
+            f"Rendered catalog still contains {len(leftovers)} unresolved template placeholder(s): {sample}. "
+            "Add the missing slot/field to the bindings file before continuing."
+        )
     return rendered
+
+
+def _find_unresolved(payload: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(payload, str):
+        found.update(UNRESOLVED_PATTERN.findall(payload))
+    elif isinstance(payload, list):
+        for item in payload:
+            found.update(_find_unresolved(item))
+    elif isinstance(payload, dict):
+        for value in payload.values():
+            found.update(_find_unresolved(value))
+    return found
 
 
 def main() -> None:

--- a/.agents/skills/kast/value-proof/scripts/run_value_proof.py
+++ b/.agents/skills/kast/value-proof/scripts/run_value_proof.py
@@ -60,11 +60,14 @@ def run_instruction_text(config: str, prompt: str) -> str:
 
 
 def metadata_for_case(case: dict[str, Any]) -> dict[str, Any]:
+    """Embed the full structured expectation list (with kind/applicability/oracle/graded_by)
+    so finalize_grading.py can normalize raw grader output without re-loading the catalog."""
+    expectations = case.get("expectations", []) or []
     return {
         "eval_id": case["id"],
         "eval_name": case.get("title", case["id"]),
         "prompt": case["prompt"],
-        "assertions": case.get("expectations", []),
+        "assertions": expectations,
         "expected_output": case.get("expected_output", ""),
         "labels": case.get("labels", []),
         "stage": case.get("stage", "candidate"),
@@ -75,21 +78,42 @@ def metadata_for_case(case: dict[str, Any]) -> dict[str, Any]:
 def write_placeholder_grading(path: Path) -> None:
     schema = load_grading_schema()
     payload = {
+        "schema_version": 2,
         "status": "pending_grading",
         "expectations": [],
-        "summary": {"passed": 0, "failed": 0, "total": 0, "pass_rate": 0.0},
+        "summary": {
+            "passed": 0,
+            "failed": 0,
+            "total": 0,
+            "pass_rate": 0.0,
+            "outcome_passed": 0,
+            "outcome_total": 0,
+            "outcome_pass_rate": 0.0,
+            "process_pass_rate": 0.0,
+            "skipped": 0,
+        },
         "execution_metrics": {
             "tool_calls": {},
+            "tool_call_log": "outputs/tool_calls.jsonl",
             "total_tool_calls": 0,
             "total_steps": 0,
             "errors_encountered": 0,
             "output_chars": 0,
             "transcript_chars": 0,
+            "kast_calls": 0,
+            "grep_or_find_calls": 0,
         },
         "timing": {
             "executor_duration_seconds": 0.0,
             "grader_duration_seconds": 0.0,
             "total_duration_seconds": 0.0,
+            "executor_duration_source": "missing",
+        },
+        "integrity": {
+            "contradictions": [],
+            "baseline_isolation_violation": False,
+            "attempts": 1,
+            "flaky": False,
         },
     }
     missing = sorted(set(schema.get("required", [])) - set(payload))
@@ -113,7 +137,7 @@ def scaffold_workspace(
     *,
     catalog_path: Path,
     workspace_dir: Path,
-    runs_per_config: int = 3,
+    runs_per_config: int = 5,
     configs: list[str] | None = None,
     iteration: str = "iteration-001",
     aggregate: bool = True,
@@ -202,21 +226,22 @@ def aggregate_if_graded(iteration_dir: Path, skill_name: str) -> None:
         return
 
     value_proof_dir = Path(__file__).resolve().parents[1]
-    skill_dir = value_proof_dir.parent
-    skills_root = skill_dir.parent
-    aggregate_script = skills_root / "skill-creator" / "scripts" / "aggregate_benchmark.py"
-    subprocess.run(
-        [
-            sys.executable,
-            str(aggregate_script),
-            str(iteration_dir),
-            "--skill-name",
-            skill_name,
-            "--skill-path",
-            str(value_proof_dir),
-        ],
-        check=True,
-    )
+    aggregate_script = value_proof_dir / "scripts" / "value_proof_aggregate.py"
+    catalog_path = iteration_dir / "rendered-catalog.json"
+    bindings_candidates = sorted((value_proof_dir / "bindings").glob("*.json"))
+    bindings_path = bindings_candidates[0] if len(bindings_candidates) == 1 else None
+    cmd = [
+        sys.executable,
+        str(aggregate_script),
+        str(iteration_dir),
+        "--skill-name",
+        skill_name,
+    ]
+    if catalog_path.exists():
+        cmd.extend(["--catalog", str(catalog_path)])
+    if bindings_path and bindings_path.exists():
+        cmd.extend(["--bindings", str(bindings_path)])
+    subprocess.run(cmd, check=True)
 
 
 def parse_configs(value: str) -> list[str]:
@@ -230,7 +255,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Scaffold a Kast value-proof benchmark workspace.")
     parser.add_argument("--catalog", required=True, type=Path, help="Rendered catalog JSON")
     parser.add_argument("--workspace", required=True, type=Path, help="Workspace root to create")
-    parser.add_argument("--runs-per-config", type=int, default=3, help="Runs per eval/configuration")
+    parser.add_argument("--runs-per-config", type=int, default=5, help="Runs per eval/configuration. Defaults to 5 so paired Wilcoxon has signal — 3 is insufficient for stddev estimates.")
     parser.add_argument("--configs", type=parse_configs, default=["with_skill", "without_skill"], help="Comma-separated configurations")
     parser.add_argument("--iteration", default="iteration-001", help="Iteration directory name")
     parser.add_argument("--no-aggregate", action="store_true", help="Skip aggregation even when grading files are complete")

--- a/.agents/skills/kast/value-proof/scripts/value_proof_aggregate.py
+++ b/.agents/skills/kast/value-proof/scripts/value_proof_aggregate.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""Value-proof aggregator with applicability-aware pass-rate and paired stats.
+
+Replaces the headline numbers in the standard skill-creator benchmark.json
+with a fairer comparison and a paired-test significance estimate.
+
+Inputs:
+  iteration_dir/eval-*/<config>/run-*/grading.json   (schema v2)
+  iteration_dir/manifest.json                         (eval -> dir/chain map)
+  bindings JSON                                       (optional; for metadata)
+
+Outputs:
+  iteration_dir/benchmark.json   — extended with:
+       run_summary[config].outcome_pass_rate         {mean, stddev, min, max}
+       run_summary.delta.outcome_pass_rate           "+0.NN [N=K runs, p=0.NN]"
+       run_summary.delta.paired_wilcoxon             {statistic, p_value, n_pairs}
+       paired_stats.eval_deltas                      [{eval_id, delta_outcome_pass_rate, delta_tokens, delta_time}]
+       paired_stats.outliers                         [{eval_id, metric, value, fence}]
+       paired_stats.flaky_runs                       [{eval_id, configuration, run, attempts}]
+       paired_stats.baseline_violations              [{eval_id, run, kast_calls}]
+       paired_stats.contradictions                   [{eval_id, configuration, run, count}]
+  iteration_dir/benchmark.md     — Markdown rollup including the above.
+  iteration_dir/../history/progression.json
+                                — appends a row {iteration, target_repo, git_sha,
+                                  outcome_pass_rate_with, outcome_pass_rate_without,
+                                  delta, p_value}.
+
+The Wilcoxon signed-rank statistic is implemented in pure Python (no SciPy
+required) using the exact distribution for n <= 20 and a normal approximation
+for n > 20. Good enough for the 10-eval, 5-run regime we're in.
+
+Usage:
+    python3 value_proof_aggregate.py <iteration_dir>           \\
+        --skill-name kast-value-proof                          \\
+        [--bindings <path>]                                    \\
+        [--catalog <path>]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+# ---------- IO -------------------------------------------------------------
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return {}
+
+
+def _iter_runs(iteration_dir: Path) -> Iterable[tuple[str, str, int, Path]]:
+    for grading_path in sorted(iteration_dir.glob("eval-*/*/run-*/grading.json")):
+        eval_dir = grading_path.parents[2]
+        config_dir = grading_path.parents[1]
+        run_dir = grading_path.parent
+        eval_id = eval_dir.name.removeprefix("eval-")
+        try:
+            run_number = int(run_dir.name.removeprefix("run-"))
+        except ValueError:
+            continue
+        yield eval_id, config_dir.name, run_number, run_dir
+
+
+# ---------- stats ----------------------------------------------------------
+
+
+def _mean_stddev(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0, "n": 0}
+    mean = statistics.fmean(values)
+    stddev = statistics.pstdev(values) if len(values) > 1 else 0.0
+    return {
+        "mean": round(mean, 4),
+        "stddev": round(stddev, 4),
+        "min": round(min(values), 4),
+        "max": round(max(values), 4),
+        "n": len(values),
+    }
+
+
+def _wilcoxon_signed_rank(diffs: list[float]) -> dict[str, float | int | str]:
+    """Two-sided Wilcoxon signed-rank test on the paired differences.
+
+    Returns {statistic: W, p_value, n_pairs, method}.
+    Drops zero differences (Pratt would keep them; we use the simpler
+    Wilcoxon convention since exact ties are rare on continuous metrics).
+    """
+    nonzero = [d for d in diffs if d != 0]
+    n = len(nonzero)
+    if n == 0:
+        return {"statistic": 0.0, "p_value": 1.0, "n_pairs": 0, "method": "no_signal"}
+
+    abs_vals = sorted(((abs(d), 1 if d > 0 else -1) for d in nonzero), key=lambda t: t[0])
+    # Average ranks for ties.
+    ranks: list[float] = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and abs_vals[j + 1][0] == abs_vals[i][0]:
+            j += 1
+        avg_rank = (i + j) / 2.0 + 1.0  # 1-indexed
+        for k in range(i, j + 1):
+            ranks[k] = avg_rank
+        i = j + 1
+    w_plus = sum(r for r, (_, sign) in zip(ranks, abs_vals) if sign > 0)
+    w_minus = sum(r for r, (_, sign) in zip(ranks, abs_vals) if sign < 0)
+    statistic = min(w_plus, w_minus)
+
+    if n <= 20:
+        p = _wilcoxon_exact_p(nonzero, statistic)
+        method = "exact"
+    else:
+        # Normal approximation with continuity correction.
+        mean = n * (n + 1) / 4.0
+        var = n * (n + 1) * (2 * n + 1) / 24.0
+        if var == 0:
+            return {"statistic": float(statistic), "p_value": 1.0, "n_pairs": n, "method": "no_variance"}
+        z = (statistic - mean + 0.5) / math.sqrt(var)
+        p = 2 * _normal_sf(abs(z))
+        method = "normal_approx"
+    return {
+        "statistic": round(float(statistic), 4),
+        "p_value": round(min(1.0, max(0.0, p)), 4),
+        "n_pairs": n,
+        "method": method,
+    }
+
+
+def _wilcoxon_exact_p(diffs: list[float], statistic: float) -> float:
+    n = len(diffs)
+    # Enumerate all 2^n sign assignments of ranks 1..n; count those with W <= statistic.
+    if n > 20:
+        return 1.0
+    abs_sorted = sorted(abs(d) for d in diffs)
+    ranks: list[float] = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and abs_sorted[j + 1] == abs_sorted[i]:
+            j += 1
+        avg_rank = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1):
+            ranks[k] = avg_rank
+        i = j + 1
+    total = 1 << n
+    le_count = 0
+    for mask in range(total):
+        w_plus = 0.0
+        for k in range(n):
+            if mask & (1 << k):
+                w_plus += ranks[k]
+        w_minus = sum(ranks) - w_plus
+        w = min(w_plus, w_minus)
+        if w <= statistic + 1e-9:
+            le_count += 1
+    return le_count / total
+
+
+def _normal_sf(z: float) -> float:
+    return 0.5 * math.erfc(z / math.sqrt(2))
+
+
+def _tukey_outliers(values: dict[str, float]) -> list[tuple[str, float, str]]:
+    """Return [(eval_id, value, 'low'|'high'), ...] using 1.5×IQR fences."""
+    if len(values) < 4:
+        return []
+    sorted_vals = sorted(values.values())
+    q1 = sorted_vals[len(sorted_vals) // 4]
+    q3 = sorted_vals[(3 * len(sorted_vals)) // 4]
+    iqr = q3 - q1
+    if iqr == 0:
+        return []
+    low = q1 - 1.5 * iqr
+    high = q3 + 1.5 * iqr
+    out = []
+    for k, v in values.items():
+        if v < low:
+            out.append((k, v, "low"))
+        elif v > high:
+            out.append((k, v, "high"))
+    return out
+
+
+# ---------- main aggregation ----------------------------------------------
+
+
+def collect_runs(iteration_dir: Path) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """eval_id -> config -> list[run grading dict]."""
+    out: dict[str, dict[str, list[dict[str, Any]]]] = defaultdict(lambda: defaultdict(list))
+    for eval_id, config, run_number, run_dir in _iter_runs(iteration_dir):
+        grading = _read_json(run_dir / "grading.json")
+        if not grading:
+            continue
+        grading.setdefault("_run_dir", str(run_dir))
+        grading.setdefault("_run_number", run_number)
+        out[eval_id][config].append(grading)
+    return out
+
+
+def per_config_metrics(runs: list[dict[str, Any]]) -> dict[str, list[float]]:
+    metrics: dict[str, list[float]] = defaultdict(list)
+    for grading in runs:
+        summary = grading.get("summary", {})
+        em = grading.get("execution_metrics", {})
+        timing = grading.get("timing", {})
+        metrics["pass_rate"].append(float(summary.get("pass_rate", 0.0)))
+        metrics["outcome_pass_rate"].append(float(summary.get("outcome_pass_rate", 0.0)))
+        metrics["process_pass_rate"].append(float(summary.get("process_pass_rate", 0.0)))
+        metrics["transcript_chars"].append(float(em.get("transcript_chars", 0)))
+        metrics["tool_calls"].append(float(em.get("total_tool_calls", 0)))
+        metrics["kast_calls"].append(float(em.get("kast_calls", 0)))
+        metrics["grep_or_find_calls"].append(float(em.get("grep_or_find_calls", 0)))
+        metrics["executor_duration_seconds"].append(float(timing.get("executor_duration_seconds", 0.0)))
+    return metrics
+
+
+def aggregate(iteration_dir: Path, *, skill_name: str, bindings_path: Path | None, catalog_path: Path | None) -> dict[str, Any]:
+    runs_by_eval = collect_runs(iteration_dir)
+
+    bindings = _read_json(bindings_path) if bindings_path else {}
+    catalog = _read_json(catalog_path) if catalog_path else {}
+
+    configs = sorted({c for ev in runs_by_eval.values() for c in ev.keys()})
+    eval_ids = sorted(runs_by_eval.keys())
+
+    # Per (eval, config): mean of each metric.
+    eval_means: dict[str, dict[str, dict[str, float]]] = defaultdict(dict)
+    runs_flat: list[dict[str, Any]] = []
+    flaky: list[dict[str, Any]] = []
+    baseline_violations: list[dict[str, Any]] = []
+    contradictions: list[dict[str, Any]] = []
+
+    for eval_id in eval_ids:
+        for config in configs:
+            run_grades = runs_by_eval.get(eval_id, {}).get(config, [])
+            if not run_grades:
+                continue
+            metrics = per_config_metrics(run_grades)
+            eval_means[eval_id][config] = {k: statistics.fmean(v) if v else 0.0 for k, v in metrics.items()}
+            for grading in run_grades:
+                summary = grading.get("summary", {})
+                em = grading.get("execution_metrics", {})
+                timing = grading.get("timing", {})
+                integrity = grading.get("integrity", {}) or {}
+                runs_flat.append({
+                    "eval_id": eval_id,
+                    "configuration": config,
+                    "run_number": grading.get("_run_number"),
+                    "result": {
+                        "pass_rate": summary.get("pass_rate", 0.0),
+                        "outcome_pass_rate": summary.get("outcome_pass_rate", 0.0),
+                        "process_pass_rate": summary.get("process_pass_rate", 0.0),
+                        "passed": summary.get("passed", 0),
+                        "failed": summary.get("failed", 0),
+                        "total": summary.get("total", 0),
+                        "outcome_total": summary.get("outcome_total", 0),
+                        "outcome_passed": summary.get("outcome_passed", 0),
+                        "transcript_chars": em.get("transcript_chars", 0),
+                        "tool_calls": em.get("total_tool_calls", 0),
+                        "kast_calls": em.get("kast_calls", 0),
+                        "grep_or_find_calls": em.get("grep_or_find_calls", 0),
+                        "time_seconds": timing.get("executor_duration_seconds", 0.0),
+                        "executor_duration_source": timing.get("executor_duration_source", "missing"),
+                        "errors": em.get("errors_encountered", 0),
+                    },
+                    "expectations": grading.get("expectations", []),
+                    "integrity": integrity,
+                })
+                if integrity.get("attempts", 1) > 1:
+                    flaky.append({
+                        "eval_id": eval_id,
+                        "configuration": config,
+                        "run_number": grading.get("_run_number"),
+                        "attempts": integrity.get("attempts", 1),
+                    })
+                if integrity.get("baseline_isolation_violation"):
+                    baseline_violations.append({
+                        "eval_id": eval_id,
+                        "run_number": grading.get("_run_number"),
+                        "kast_calls": em.get("kast_calls", 0),
+                    })
+                if integrity.get("contradictions"):
+                    contradictions.append({
+                        "eval_id": eval_id,
+                        "configuration": config,
+                        "run_number": grading.get("_run_number"),
+                        "count": len(integrity["contradictions"]),
+                        "samples": integrity["contradictions"][:3],
+                    })
+
+    # Run-summary across all runs of a configuration.
+    run_summary: dict[str, Any] = {}
+    for config in configs:
+        all_metrics: dict[str, list[float]] = defaultdict(list)
+        for eval_id in eval_ids:
+            run_grades = runs_by_eval.get(eval_id, {}).get(config, [])
+            metrics = per_config_metrics(run_grades)
+            for k, vs in metrics.items():
+                all_metrics[k].extend(vs)
+        run_summary[config] = {k: _mean_stddev(v) for k, v in all_metrics.items()}
+
+    # Paired analysis: per-eval mean delta on outcome_pass_rate, transcript_chars, time.
+    paired_stats: dict[str, Any] = {}
+    if "with_skill" in configs and "without_skill" in configs:
+        outcome_diffs: list[float] = []
+        token_diffs: list[float] = []
+        time_diffs: list[float] = []
+        per_eval = []
+        for eval_id in eval_ids:
+            with_skill_means = eval_means.get(eval_id, {}).get("with_skill")
+            without_skill_means = eval_means.get(eval_id, {}).get("without_skill")
+            if not with_skill_means or not without_skill_means:
+                continue
+            d_outcome = with_skill_means["outcome_pass_rate"] - without_skill_means["outcome_pass_rate"]
+            d_tokens = with_skill_means["transcript_chars"] - without_skill_means["transcript_chars"]
+            d_time = with_skill_means["executor_duration_seconds"] - without_skill_means["executor_duration_seconds"]
+            outcome_diffs.append(d_outcome)
+            token_diffs.append(d_tokens)
+            time_diffs.append(d_time)
+            per_eval.append({
+                "eval_id": eval_id,
+                "delta_outcome_pass_rate": round(d_outcome, 4),
+                "delta_transcript_chars": round(d_tokens, 1),
+                "delta_time_seconds": round(d_time, 3),
+                "with_skill_outcome_pass_rate": round(with_skill_means["outcome_pass_rate"], 4),
+                "without_skill_outcome_pass_rate": round(without_skill_means["outcome_pass_rate"], 4),
+            })
+        paired_stats["eval_deltas"] = per_eval
+        paired_stats["outcome_pass_rate_paired"] = _wilcoxon_signed_rank(outcome_diffs)
+        paired_stats["transcript_chars_paired"] = _wilcoxon_signed_rank(token_diffs)
+        paired_stats["time_seconds_paired"] = _wilcoxon_signed_rank(time_diffs)
+
+        # Outliers across evals (per-config) on outcome_pass_rate and tokens.
+        outliers: list[dict[str, Any]] = []
+        for config in ("with_skill", "without_skill"):
+            for metric in ("outcome_pass_rate", "transcript_chars", "executor_duration_seconds"):
+                series = {ev: eval_means[ev][config][metric] for ev in eval_ids if config in eval_means.get(ev, {})}
+                for eval_id, value, side in _tukey_outliers(series):
+                    outliers.append({
+                        "configuration": config,
+                        "metric": metric,
+                        "eval_id": eval_id,
+                        "value": round(value, 4),
+                        "side": side,
+                    })
+        paired_stats["outliers"] = outliers
+
+    paired_stats["flaky_runs"] = flaky
+    paired_stats["baseline_violations"] = baseline_violations
+    paired_stats["contradictions"] = contradictions
+
+    # Headline delta as a string.
+    delta = {}
+    if "with_skill" in configs and "without_skill" in configs:
+        for metric in ("pass_rate", "outcome_pass_rate", "transcript_chars", "executor_duration_seconds", "tool_calls", "kast_calls", "grep_or_find_calls", "process_pass_rate"):
+            w = run_summary["with_skill"].get(metric, {}).get("mean", 0.0)
+            wo = run_summary["without_skill"].get(metric, {}).get("mean", 0.0)
+            delta[metric] = f"{w - wo:+.2f}"
+        wilcoxon = paired_stats.get("outcome_pass_rate_paired", {})
+        delta["outcome_pass_rate_significance"] = (
+            f"p={wilcoxon.get('p_value', 1.0):.3f} ({wilcoxon.get('method', 'n/a')}, n_pairs={wilcoxon.get('n_pairs', 0)})"
+        )
+
+    benchmark = {
+        "metadata": {
+            "skill_name": skill_name,
+            "skill_path": ".agents/skills/kast/value-proof",
+            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "iteration_dir": str(iteration_dir),
+            "target_repo": (bindings or {}).get("target_repo", ""),
+            "workspace_root": (bindings or {}).get("workspace_root", ""),
+            "git_sha_target": (bindings or {}).get("git_sha", ""),
+            "evals_run": eval_ids,
+            "configs": configs,
+            "runs_per_eval_per_config": {
+                eval_id: {config: len(runs_by_eval[eval_id].get(config, [])) for config in configs}
+                for eval_id in eval_ids
+            },
+            "catalog_version": (catalog or {}).get("version", 0),
+        },
+        "runs": runs_flat,
+        "run_summary": {**run_summary, "delta": delta},
+        "paired_stats": paired_stats,
+    }
+    return benchmark
+
+
+def write_outputs(iteration_dir: Path, benchmark: dict[str, Any]) -> None:
+    benchmark_path = iteration_dir / "benchmark.json"
+    benchmark_path.write_text(json.dumps(benchmark, indent=2) + "\n")
+
+    md_lines: list[str] = []
+    meta = benchmark["metadata"]
+    md_lines.append(f"# Benchmark: {meta['skill_name']} — {meta.get('target_repo', '?')}")
+    md_lines.append("")
+    md_lines.append(f"_iteration: `{Path(meta['iteration_dir']).name}`, evals: {len(meta['evals_run'])}, configs: {meta['configs']}_")
+    md_lines.append("")
+    md_lines.append("## Headline (paired across evals)")
+    delta = benchmark["run_summary"].get("delta", {})
+    md_lines.append("")
+    md_lines.append("| Metric | with_skill | without_skill | Δ (with − without) |")
+    md_lines.append("| --- | ---: | ---: | ---: |")
+    for metric in ("pass_rate", "outcome_pass_rate", "transcript_chars", "executor_duration_seconds", "tool_calls", "kast_calls"):
+        w = benchmark["run_summary"].get("with_skill", {}).get(metric, {}).get("mean", 0.0)
+        wo = benchmark["run_summary"].get("without_skill", {}).get(metric, {}).get("mean", 0.0)
+        md_lines.append(f"| {metric} | {w:.3f} | {wo:.3f} | {delta.get(metric, '?')} |")
+    md_lines.append("")
+    md_lines.append(f"**Outcome pass-rate significance:** {delta.get('outcome_pass_rate_significance', 'n/a')}")
+    md_lines.append("")
+
+    paired = benchmark.get("paired_stats", {})
+    if paired.get("eval_deltas"):
+        md_lines.append("## Per-eval deltas (mean across runs)")
+        md_lines.append("")
+        md_lines.append("| eval_id | Δ outcome_pass_rate | Δ transcript_chars | Δ time (s) |")
+        md_lines.append("| --- | ---: | ---: | ---: |")
+        for ed in paired["eval_deltas"]:
+            md_lines.append(f"| {ed['eval_id']} | {ed['delta_outcome_pass_rate']:+.3f} | {ed['delta_transcript_chars']:+,.0f} | {ed['delta_time_seconds']:+.2f} |")
+        md_lines.append("")
+
+    if paired.get("baseline_violations"):
+        md_lines.append("## ⚠ Baseline-isolation violations")
+        md_lines.append("")
+        for v in paired["baseline_violations"]:
+            md_lines.append(f"- `{v['eval_id']}` run {v['run_number']} → kast_calls={v['kast_calls']}")
+        md_lines.append("")
+
+    if paired.get("contradictions"):
+        md_lines.append("## ⚠ Grading contradictions")
+        md_lines.append("")
+        for c in paired["contradictions"]:
+            md_lines.append(f"- `{c['eval_id']}` ({c['configuration']}, run {c['run_number']}): {c['count']} contradiction(s)")
+            for sample in c.get("samples", []):
+                md_lines.append(f"    - {sample}")
+        md_lines.append("")
+
+    if paired.get("outliers"):
+        md_lines.append("## Tukey outliers (1.5×IQR)")
+        md_lines.append("")
+        for o in paired["outliers"]:
+            md_lines.append(f"- `{o['eval_id']}` {o['configuration']}: {o['metric']} = {o['value']} ({o['side']})")
+        md_lines.append("")
+
+    if paired.get("flaky_runs"):
+        md_lines.append("## Flaky runs (succeeded after retry)")
+        md_lines.append("")
+        for r in paired["flaky_runs"]:
+            md_lines.append(f"- `{r['eval_id']}` {r['configuration']} run {r['run_number']} attempts={r['attempts']}")
+        md_lines.append("")
+
+    (iteration_dir / "benchmark.md").write_text("\n".join(md_lines) + "\n")
+
+
+def append_progression(iteration_dir: Path, benchmark: dict[str, Any]) -> None:
+    skill_dir = iteration_dir
+    while skill_dir.parent != skill_dir and skill_dir.name != "value-proof":
+        skill_dir = skill_dir.parent
+    if skill_dir.name != "value-proof":
+        # Fall back to skill path from metadata.
+        skill_dir = Path(benchmark["metadata"].get("skill_path", "."))
+    history_path = skill_dir / "history" / "progression.json"
+    history = _read_json(history_path) or {"skill_name": benchmark["metadata"]["skill_name"], "benchmarks": [], "case_history": {}}
+    history.setdefault("benchmarks", [])
+    delta = benchmark["run_summary"].get("delta", {})
+    paired = benchmark.get("paired_stats", {}).get("outcome_pass_rate_paired", {})
+    history["benchmarks"].append({
+        "iteration": Path(benchmark["metadata"]["iteration_dir"]).name,
+        "timestamp": benchmark["metadata"]["timestamp"],
+        "target_repo": benchmark["metadata"].get("target_repo", ""),
+        "git_sha_target": benchmark["metadata"].get("git_sha_target", ""),
+        "with_skill_outcome_pass_rate": benchmark["run_summary"].get("with_skill", {}).get("outcome_pass_rate", {}).get("mean", 0.0),
+        "without_skill_outcome_pass_rate": benchmark["run_summary"].get("without_skill", {}).get("outcome_pass_rate", {}).get("mean", 0.0),
+        "delta_outcome_pass_rate": delta.get("outcome_pass_rate", "?"),
+        "p_value": paired.get("p_value"),
+        "n_pairs": paired.get("n_pairs"),
+    })
+    history["updated_at"] = benchmark["metadata"]["timestamp"]
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    history_path.write_text(json.dumps(history, indent=2) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Aggregate value-proof results with paired statistics.")
+    parser.add_argument("iteration_dir", type=Path)
+    parser.add_argument("--skill-name", default="kast-value-proof")
+    parser.add_argument("--bindings", type=Path, default=None)
+    parser.add_argument("--catalog", type=Path, default=None)
+    parser.add_argument("--no-progression", action="store_true")
+    args = parser.parse_args()
+
+    if not args.iteration_dir.exists():
+        print(f"error: iteration directory missing: {args.iteration_dir}", file=sys.stderr)
+        return 2
+
+    benchmark = aggregate(
+        args.iteration_dir,
+        skill_name=args.skill_name,
+        bindings_path=args.bindings,
+        catalog_path=args.catalog,
+    )
+    write_outputs(args.iteration_dir, benchmark)
+    if not args.no_progression:
+        append_progression(args.iteration_dir, benchmark)
+    print(f"wrote {args.iteration_dir / 'benchmark.json'}")
+    print(f"wrote {args.iteration_dir / 'benchmark.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The recent value-proof benchmark exposed measurement gaps that made the headline `+0.31 pass-rate` undefendable: `tool_calls` collapsed to 0 across `with_skill` runs in iteration-003 (LLM grader regressed), `time_seconds` zeroed for many runs while authoritative dispatcher timing was discarded, self-contradicting verdicts (`passed=true` with evidence `= 0`), N=1 runs per (eval × config), and tautological "Uses kast_X" assertions inflating the cross-config delta on top of no ground-truth oracle for recall/precision/compile-pass.

This change implements A + B + D + F from the audit.

### A. Telemetry pipeline
- New [`parse_tool_calls.py`](.agents/skills/kast/value-proof/scripts/parse_tool_calls.py): deterministic transcript → `tool_calls.jsonl`. Classifies fenced JSON tool blocks, XML tool blocks, inline `[tool_call ...]` markers, and fenced bash kast/grep/find/ls invocations. Pure prose mentions are explicitly NOT counted.
- [`dispatch_runs.py`](.agents/skills/kast/value-proof/scripts/dispatch_runs.py) auto-runs the parser on every successful run.
- New [`finalize_grading.py`](.agents/skills/kast/value-proof/scripts/finalize_grading.py): merges authoritative dispatcher timing (over the grader's broken `0.0s`), replaces grader-reported tool counts with deterministic ones, marks applicability-mismatched expectations as `skipped`, computes `outcome_pass_rate`, and detects two failure modes — **contradictions** (`passed=true` with evidence matching `= 0` / `missing` / `not present`) and **baseline-isolation violations** (`without_skill` runs with `kast_calls > 0`).

### B. Ground-truth oracles
- [`bindings.schema.json`](.agents/skills/kast/value-proof/bindings.schema.json) grows an optional `expected` block per slot: implementations (recall set), expectedFiles/decoyFiles, consumer modules+files, affectedFiles + compileCommand, publicMembers/nestedTypes/rawFileLineCount, moduleFileCounts + tolerance, plus a top-level `git_sha`.
- [`bindings/konditional.json`](.agents/skills/kast/value-proof/bindings/konditional.json) populated from the konditional checkout: the 11 `Konstrained` implementations, the 9 `NamespaceRegistry` rename targets, `EvaluationDiagnostics` structure (7 public members + 11 nested types), module file counts (84/70/18), and `FlagValue`'s expected consumer files.

### D. Multi-run statistics
- Default `runs-per-config` 3 → 5.
- New [`value_proof_aggregate.py`](.agents/skills/kast/value-proof/scripts/value_proof_aggregate.py): per-eval mean deltas, paired Wilcoxon signed-rank (exact for n≤20, normal approx otherwise; pure Python — no SciPy), Tukey 1.5×IQR outlier flags, surfaces flaky/violation/contradiction summaries, and appends to `history/progression.json` so iteration trends are persisted.

### F. Drop tautological assertions; add capability assertions
- [`catalog.json`](.agents/skills/kast/value-proof/catalog.json) expectations now declare `kind` (`outcome` | `process`), `applicability` (`both` | `with_skill_only` | `without_skill_only`), `graded_by` (`script` | `llm`), and an optional `oracle` reference into the bindings ground truth.
- "Uses kast_X" assertions demoted to `process` + `with_skill_only` so they no longer pollute the cross-config delta.
- Outcome assertions per case now check recall against expected sets, precision against decoy/affectedFile sets, citation resolution, and post-edit compile state via `expected.compileCommand`.

### Schema + runner contract
- [`grading.schema.json`](.agents/skills/kast/value-proof/grading.schema.json) v2: required `kind`/`applicability`/`graded_by`/`skipped` per expectation; `outcome_pass_rate` / `process_pass_rate` / `skipped` in summary; structured `tool_calls` map plus `kast_calls` / `grep_or_find_calls`; `executor_duration_source`; `integrity` block with contradictions / baseline_isolation_violation / attempts / flaky.
- [`render_prompts.py`](.agents/skills/kast/value-proof/scripts/render_prompts.py) fails loud on any unresolved `{{...}}` placeholder.
- [`run_value_proof.py`](.agents/skills/kast/value-proof/scripts/run_value_proof.py) wires aggregation through `value_proof_aggregate.py` (not the generic skill-creator aggregator) and embeds the structured expectation list in `eval_metadata.json` so `finalize_grading.py` can normalize raw grader output without re-loading the catalog.
- [README](.agents/skills/kast/value-proof/README.md) and [kast-value-proof-runner SKILL](.agents/skills/kast-value-proof-runner/SKILL.md) document the new pipeline and the rule that `outcome_pass_rate` (not `pass_rate`) is the cross-config headline.

## Why now

The iter-003 benchmark on the version-gated-skill worktree reported `+0.31` pass-rate with `tool_calls=0` for 9/10 with_skill runs and `time_seconds=0.0` for several. None of those numbers are reproducible. With this change the headline is `outcome_pass_rate` over `applicability='both'` outcome assertions only, paired across evals with a Wilcoxon p-value and tagged with integrity warnings — a defensible number we can show stakeholders.

## Test plan

- [x] `python3 .agents/skills/kast/value-proof/scripts/render_prompts.py` against konditional bindings — all 10 cases hydrate, no leftover placeholders.
- [x] `parse_tool_calls.py` smoke test: synthetic transcript with 2 fenced kast tool blocks → `kast_calls=2, grep_or_find_calls=0`. Synthetic baseline with `grep` block + smuggled `kast_resolve` → flagged.
- [x] `finalize_grading.py` smoke test: contradiction `"passed=true with evidence '= 0'"` detected; isolation violation flagged; dispatcher's `12.34s` overrides grader's `0.0s`; `with_skill_only` process assertion correctly `skipped` in the `without_skill` run; outcome_pass_rate computed from outcome+both assertions only.
- [x] `value_proof_aggregate.py` smoke test: produces benchmark.md with paired Wilcoxon p-value, per-eval delta table, baseline-isolation call-out, contradictions section, flaky-runs section, and outlier flagging.
- [x] `python3 .agents/skills/kast/value-proof/scripts/tests/test_value_proof_scripts.py` — all 5 tests pass.
- [x] `python3 .agents/skills/kast/value-proof/scripts/tests/test_workstream_d.py` — all 3 tests pass.
- [x] End-to-end: `render_prompts.py` → `run_value_proof.py` produces a workspace whose `eval_metadata.json` carries the new structured assertions and whose placeholder `grading.json` is schema v2 with `integrity` + `outcome_pass_rate` populated.

Next iteration on konditional should be the first one that produces numbers we can quote.