### PR TITLE
Publish Kast releases to Homebrew and add install-aware upgrade guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,3 +528,36 @@ jobs:
 
           ---
           **Build provenance:** [CI Run #${{ github.run_number }}]($run_url)"
+
+      - name: Generate and upload SHA256SUMS
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          mkdir -p release-assets
+          gh release download "$tag" --dir release-assets --pattern '*.zip'
+          (cd release-assets && sha256sum *.zip) > SHA256SUMS
+          gh release upload "$tag" SHA256SUMS --clobber
+
+      - name: Update Homebrew tap
+        env:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          linux_asset="kast-${tag}-linux-x64.zip"
+          macos_asset="kast-${tag}-macos-arm64.zip"
+          sha_linux="$(awk -v name="$linux_asset" '$2 == name { print $1 }' SHA256SUMS)"
+          sha_macos="$(awk -v name="$macos_asset" '$2 == name { print $1 }' SHA256SUMS)"
+
+          [[ -n "$sha_linux" ]] || { echo "Missing SHA-256 for ${linux_asset}" >&2; exit 1; }
+          [[ -n "$sha_macos" ]] || { echo "Missing SHA-256 for ${macos_asset}" >&2; exit 1; }
+
+          gh api repos/amichne/homebrew-kast/dispatches \
+            -f event_type=release-published \
+            -f "client_payload[version]=${tag}" \
+            -f "client_payload[sha256_linux_x64]=${sha_linux}" \
+            -f "client_payload[sha256_macos_arm64]=${sha_macos}"

--- a/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/IntelliJReferenceIndexEnvironment.kt
+++ b/backend-intellij/src/main/kotlin/io/github/amichne/kast/intellij/IntelliJReferenceIndexEnvironment.kt
@@ -1,6 +1,7 @@
 package io.github.amichne.kast.intellij
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.fileTypes.FileTypeRegistry
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -12,6 +13,7 @@ import io.github.amichne.kast.indexstore.api.index.SourceIndexFilePolicy
 import io.github.amichne.kast.shared.analysis.ReferenceIndexEnvironment
 import org.jetbrains.kotlin.idea.KotlinFileType
 import java.nio.file.Path
+import java.util.concurrent.Callable
 
 internal class IntelliJReferenceIndexEnvironment(
     private val project: Project,
@@ -41,10 +43,11 @@ internal class IntelliJReferenceIndexEnvironment(
     override fun <T> withReadAccess(action: () -> T): T =
         ApplicationManager.getApplication().runReadAction<T>(action)
 
-    // The IntelliJ threading model only requires read access for PSI traversal and
-    // reference resolution; the platform serializes write actions against readers.
     override fun <T> withExclusiveAccess(action: () -> T): T =
-        ApplicationManager.getApplication().runReadAction<T>(action)
+        ReadAction
+            .nonBlocking(Callable { action() })
+            .expireWhen { cancelled() }
+            .executeSynchronously()
 
     override fun isCancelled(): Boolean = cancelled()
 }

--- a/backend-intellij/src/test/kotlin/io/github/amichne/kast/intellij/IntelliJReferenceIndexEnvironmentTest.kt
+++ b/backend-intellij/src/test/kotlin/io/github/amichne/kast/intellij/IntelliJReferenceIndexEnvironmentTest.kt
@@ -1,5 +1,7 @@
 package io.github.amichne.kast.intellij
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.fixture.TestFixture
@@ -12,6 +14,10 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 @TestApplication
 class IntelliJReferenceIndexEnvironmentTest {
@@ -93,5 +99,54 @@ class IntelliJReferenceIndexEnvironmentTest {
             rows.any { row -> row.targetFqName == "demo.target" && row.sourcePath == collectorsFile.virtualFile.path },
             "scanner should continue past compiled PSI failures and still index later source references",
         )
+    }
+
+    @Test
+    fun `exclusive reference indexing read yields to pending EDT write actions`() {
+        val project = projectFixture.get()
+        val callerFile = callerFileFixture.get()
+        waitUntilIndexesAreReady(project)
+
+        val workspaceRoot = Path.of(callerFile.virtualFile.path).root.toAbsolutePath().normalize()
+        val environment = IntelliJReferenceIndexEnvironment(
+            project = project,
+            workspaceRoot = workspaceRoot,
+            cancelled = { false },
+        )
+        val executor = Executors.newFixedThreadPool(2)
+        val readStarted = CountDownLatch(1)
+        val writeCompleted = CountDownLatch(1)
+        val stopRead = AtomicBoolean(false)
+
+        val readFuture = executor.submit {
+            environment.withExclusiveAccess {
+                readStarted.countDown()
+                while (writeCompleted.count > 0 && !stopRead.get()) {
+                    ProgressManager.checkCanceled()
+                    Thread.sleep(10)
+                }
+            }
+        }
+        assertTrue(readStarted.await(1, TimeUnit.SECONDS), "test read action did not start")
+
+        val writeFuture = executor.submit {
+            ApplicationManager.getApplication().invokeAndWait {
+                ApplicationManager.getApplication().runWriteAction {
+                    writeCompleted.countDown()
+                }
+            }
+        }
+
+        try {
+            assertTrue(
+                writeCompleted.await(2, TimeUnit.SECONDS),
+                "Kast reference indexing read action should yield when the EDT needs a write action",
+            )
+        } finally {
+            stopRead.set(true)
+            readFuture.get(2, TimeUnit.SECONDS)
+            writeFuture.get(2, TimeUnit.SECONDS)
+            executor.shutdownNow()
+        }
     }
 }

--- a/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiReferenceScanner.kt
+++ b/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiReferenceScanner.kt
@@ -31,13 +31,12 @@ class PsiReferenceScanner(
     private val environment: ReferenceIndexEnvironment,
     private val moduleNameForFile: (String) -> String? = { null },
 ) {
-    fun scanFileReferences(filePath: String): List<SymbolReferenceRow> {
-        val rows = mutableListOf<SymbolReferenceRow>()
+    fun scanFileReferences(filePath: String): List<SymbolReferenceRow> =
         // Exclusive access required: the standalone backend's K2 FIR lazy declaration
         // resolver is not thread-safe for concurrent resolution within a single session.
-        // The IntelliJ backend implements this as a plain read action.
         environment.withExclusiveAccess {
-            val psiFile = environment.findPsiFile(filePath) ?: return@withExclusiveAccess
+            val rows = mutableListOf<SymbolReferenceRow>()
+            val psiFile = environment.findPsiFile(filePath) ?: return@withExclusiveAccess emptyList()
             val sourceFilePath = runCatching { psiFile.resolvedFilePath().value }.getOrElse { filePath }
 
             psiFile.accept(
@@ -89,14 +88,13 @@ class PsiReferenceScanner(
                     }
                 },
             )
+            rows
         }
-        return rows
-    }
 
-    fun scanFileDeclarations(filePath: String): List<DeclarationRow> {
-        val rows = mutableListOf<DeclarationRow>()
+    fun scanFileDeclarations(filePath: String): List<DeclarationRow> =
         environment.withExclusiveAccess {
-            val psiFile = environment.findPsiFile(filePath) ?: return@withExclusiveAccess
+            val rows = mutableListOf<DeclarationRow>()
+            val psiFile = environment.findPsiFile(filePath) ?: return@withExclusiveAccess emptyList()
             val sourceFilePath = runCatching { psiFile.resolvedFilePath().value }.getOrElse { filePath }
             val (modulePath, sourceSet) = splitModuleName(moduleNameForFile(sourceFilePath))
             psiFile.accept(
@@ -112,9 +110,8 @@ class PsiReferenceScanner(
                     }
                 },
             )
+            rows
         }
-        return rows
-    }
 
     private fun PsiElement.declarationRow(
         sourceFilePath: String,

--- a/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/ReferenceIndexEnvironment.kt
+++ b/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/ReferenceIndexEnvironment.kt
@@ -12,7 +12,10 @@ interface ReferenceIndexEnvironment {
     /**
      * Runs [action] with exclusive access to the underlying analysis state.
      *
-     * In the IntelliJ backend a read action is sufficient for the IDE threading model.
+     * Implementations may cancel and retry [action] to yield to higher-priority IDE work,
+     * so callers should keep side effects inside the returned value.
+     *
+     * In the IntelliJ backend a non-blocking read action is sufficient for the IDE threading model.
      * In the standalone backend this must serialize against all other read/write users
      * of the K2 analysis session, because the K2 FIR lazy declaration resolver is not
      * thread-safe for concurrent resolution within a single standalone session

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SelfManagementService.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SelfManagementService.kt
@@ -6,6 +6,9 @@ import io.github.amichne.kast.cli.results.SelfDoctorResult
 import io.github.amichne.kast.cli.results.SelfStatusResult
 import io.github.amichne.kast.cli.results.SelfUninstallResult
 import io.github.amichne.kast.cli.results.SelfUpgradeResult
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import java.io.IOException
 import java.nio.file.DirectoryNotEmptyException
 import java.nio.file.FileVisitResult
@@ -19,6 +22,8 @@ internal class SelfManagementService(
     private val configHomeProvider: () -> Path = { kastConfigHome() },
     private val commandAvailability: (String) -> Boolean = ::commandAvailable,
     private val resolveScriptVerifier: (Path, String) -> String? = ::verifyResolveScript,
+    private val envLookup: (String) -> String? = System::getenv,
+    private val executablePathProvider: () -> Path? = ::currentExecutablePath,
 ) {
     fun status(): SelfStatusResult {
         val manifest = manifestStore.read()
@@ -141,9 +146,56 @@ internal class SelfManagementService(
         )
     }
 
-    fun upgrade(): SelfUpgradeResult = SelfUpgradeResult(
-        instructions = "Re-run the installer: /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/amichne/kast/HEAD/kast.sh)\"",
-    )
+    fun upgrade(): SelfUpgradeResult = SelfUpgradeResult(instructions = upgradeInstructions())
+
+    private fun upgradeInstructions(): String {
+        val source = installSource()
+        return when {
+            envLookup("CI")?.equals("true", ignoreCase = true) == true || source == "action" ->
+                "Ephemeral environment - pin the version input in your workflow/Blueprint"
+            source == "homebrew" -> "Run: brew upgrade kast"
+            source == "kast.sh" || source == "release" -> "Run: ./kast.sh install"
+            else -> "Re-run the installer: /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/amichne/kast/HEAD/kast.sh)\""
+        }
+    }
+
+    private fun installSource(): String? = installMetadataCandidates()
+        .firstNotNullOfOrNull { candidate ->
+            readInstallMetadata(candidate)?.source?.lowercase()?.takeIf(String::isNotBlank)
+        }
+
+    private fun installMetadataCandidates(): List<Path> = buildList {
+        val installRoot = manifestStore.installRoot()
+        add(installRoot.resolve(".install-metadata.json"))
+        add(installRoot.resolve("current/.install-metadata.json"))
+        listOf("KAST_MANAGED_ROOT")
+            .mapNotNull(envLookup)
+            .map { value -> Path.of(value).toAbsolutePath().normalize() }
+            .forEach { envInstallRoot ->
+                add(envInstallRoot.resolve(".install-metadata.json"))
+                add(envInstallRoot.resolve("current/.install-metadata.json"))
+            }
+        executablePathProvider()?.let { executable ->
+            addMetadataCandidatesForExecutable(executable)
+        }
+    }.distinct()
+
+    private fun MutableList<Path>.addMetadataCandidatesForExecutable(executable: Path) {
+        val normalized = executable.toAbsolutePath().normalize()
+        normalized.parent?.let { add(it.resolve(".install-metadata.json")) }
+        runCatching { normalized.toRealPath() }.getOrNull()
+            ?.parent
+            ?.let { add(it.resolve(".install-metadata.json")) }
+    }
+
+    private fun readInstallMetadata(path: Path): InstallMetadata? {
+        if (!Files.isRegularFile(path)) {
+            return null
+        }
+        return runCatching {
+            metadataJson.decodeFromString<InstallMetadata>(Files.readString(path))
+        }.getOrNull()
+    }
 
     private fun deleteEmptyDirectoriesUpTo(directory: Path?, boundary: Path) {
         var current = directory
@@ -262,12 +314,28 @@ internal class SelfManagementService(
         private const val COMPLETION_END_MARKER = "# <<< Kast completion <<<"
         private const val KAST_ENV_SOURCE_START_MARKER = "# >>> kast env >>>"
         private const val KAST_ENV_SOURCE_END_MARKER = "# <<< kast env <<<"
+        private val metadataJson = Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+        }
+
+        @Serializable
+        private data class InstallMetadata(
+            val source: String = "",
+        )
 
         private fun commandAvailable(command: String): Boolean = runCatching {
             ProcessBuilder("bash", "-lc", "command -v $command >/dev/null 2>&1")
                 .start()
                 .waitFor() == 0
         }.getOrDefault(false)
+
+        private fun currentExecutablePath(): Path? = ProcessHandle.current()
+            .info()
+            .command()
+            .orElse(null)
+            ?.takeIf(String::isNotBlank)
+            ?.let(Path::of)
 
         private fun verifyResolveScript(repoRoot: Path, relativePath: String): String? {
             val script = repoRoot.resolve(relativePath).normalize()

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandCatalog.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/tty/CliCommandCatalog.kt
@@ -456,8 +456,8 @@ internal object CliCommandCatalog {
         CliCommandMetadata(
             path = listOf("self", "upgrade"),
             group = CliCommandGroup.CLI_MANAGEMENT,
-            summary = "Print reinstall instructions for upgrading Kast.",
-            description = "For now this prints the supported reinstall command instead of performing an in-place upgrade.",
+            summary = "Detect install method and show the appropriate upgrade path.",
+            description = "Reads install metadata and the current environment to print the appropriate upgrade path.",
             usages = listOf(
                 "$CLI_EXECUTABLE_NAME self upgrade",
             ),

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandCatalogTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/CliCommandCatalogTest.kt
@@ -63,6 +63,20 @@ class CliCommandCatalogTest {
         )
     }
 
+    @Test
+    fun `self upgrade catalog describes install method detection`() {
+        val command = allCommandMetadata().single { metadata -> metadata.path == listOf("self", "upgrade") }
+
+        assertTrue(
+            command.summary.contains("Detect install method"),
+            "self upgrade summary should describe install-method-aware behavior",
+        )
+        assertTrue(
+            command.description.contains("appropriate upgrade path"),
+            "self upgrade description should describe contextual upgrade guidance",
+        )
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun allCommandMetadata(): List<CliCommandMetadata> {
         val field = CliCommandCatalog::class.java.getDeclaredField("commands")

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SelfManagementServiceTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SelfManagementServiceTest.kt
@@ -136,4 +136,90 @@ class SelfManagementServiceTest {
         assertTrue(result.removedManagedPaths.any { removed -> removed.endsWith("bin/kast") })
         assertTrue(result.cleanedShellRcFiles.contains(bashrc.toString()))
     }
+
+    @Test
+    fun upgradeReportsHomebrewCommandFromInstallMetadata() {
+        val installRoot = tempDir.resolve("home/.kast")
+        val manifestStore = InstallManifestStore(installRootProvider = { installRoot })
+        writeInstallMetadata(installRoot, "homebrew")
+        val service = SelfManagementService(
+            manifestStore = manifestStore,
+            configHomeProvider = { tempDir.resolve("config") },
+            commandAvailability = { true },
+            resolveScriptVerifier = { _, _ -> null },
+        )
+
+        val result = service.upgrade()
+
+        assertEquals("Run: brew upgrade kast", result.instructions)
+    }
+
+    @Test
+    fun upgradeReportsKastShCommandFromReleaseMetadata() {
+        val installRoot = tempDir.resolve("home/.kast")
+        val manifestStore = InstallManifestStore(installRootProvider = { installRoot })
+        writeInstallMetadata(installRoot, "release")
+        val service = SelfManagementService(
+            manifestStore = manifestStore,
+            configHomeProvider = { tempDir.resolve("config") },
+            commandAvailability = { true },
+            resolveScriptVerifier = { _, _ -> null },
+        )
+
+        val result = service.upgrade()
+
+        assertEquals("Run: ./kast.sh install", result.instructions)
+    }
+
+    @Test
+    fun upgradeReportsEphemeralInstructionsForActionInstallMetadata() {
+        val installRoot = tempDir.resolve("home/.kast")
+        val manifestStore = InstallManifestStore(installRootProvider = { installRoot })
+        writeInstallMetadata(installRoot, "action")
+        val service = SelfManagementService(
+            manifestStore = manifestStore,
+            configHomeProvider = { tempDir.resolve("config") },
+            commandAvailability = { true },
+            resolveScriptVerifier = { _, _ -> null },
+        )
+
+        val result = service.upgrade()
+
+        assertEquals(
+            "Ephemeral environment - pin the version input in your workflow/Blueprint",
+            result.instructions,
+        )
+    }
+
+    @Test
+    fun upgradeReportsEphemeralInstructionsInCi() {
+        val installRoot = tempDir.resolve("home/.kast")
+        val manifestStore = InstallManifestStore(installRootProvider = { installRoot })
+        val service = SelfManagementService(
+            manifestStore = manifestStore,
+            configHomeProvider = { tempDir.resolve("config") },
+            commandAvailability = { true },
+            resolveScriptVerifier = { _, _ -> null },
+            envLookup = { name -> if (name == "CI") "true" else null },
+        )
+
+        val result = service.upgrade()
+
+        assertEquals(
+            "Ephemeral environment - pin the version input in your workflow/Blueprint",
+            result.instructions,
+        )
+    }
+
+    private fun writeInstallMetadata(installRoot: Path, source: String) {
+        Files.createDirectories(installRoot.resolve("current"))
+        Files.writeString(
+            installRoot.resolve("current/.install-metadata.json"),
+            """
+            {
+              "source": "$source"
+            }
+            """.trimIndent(),
+        )
+    }
 }

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SelfManagementServiceTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SelfManagementServiceTest.kt
@@ -147,6 +147,7 @@ class SelfManagementServiceTest {
             configHomeProvider = { tempDir.resolve("config") },
             commandAvailability = { true },
             resolveScriptVerifier = { _, _ -> null },
+            envLookup = { null },
         )
 
         val result = service.upgrade()
@@ -164,6 +165,7 @@ class SelfManagementServiceTest {
             configHomeProvider = { tempDir.resolve("config") },
             commandAvailability = { true },
             resolveScriptVerifier = { _, _ -> null },
+            envLookup = { null },
         )
 
         val result = service.upgrade()

--- a/kast.sh
+++ b/kast.sh
@@ -611,9 +611,9 @@ PY
 
 _install_write_metadata() {
   local output_path="$1" release_repo="$2" release_tag="$3" \
-        platform_id="$4" archive_name="$5" archive_source="$6"
+        platform_id="$4" archive_name="$5" archive_source="$6" source="$7"
   python3 - "$output_path" "$release_repo" "$release_tag" \
-            "$platform_id" "$archive_name" "$archive_source" <<'PY'
+            "$platform_id" "$archive_name" "$archive_source" "$source" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -625,6 +625,7 @@ payload = {
     "platformId":    sys.argv[4],
     "archiveName":   sys.argv[5],
     "archiveSource": sys.argv[6],
+    "source":        sys.argv[7],
 }
 output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 PY
@@ -1672,6 +1673,7 @@ Environment:
   KAST_EXPECTED_SHA256           Expected SHA-256 for KAST_ARCHIVE_PATH
   KAST_BACKEND_ARCHIVE_PATH      Local standalone backend archive path
   KAST_BACKEND_EXPECTED_SHA256   Expected SHA-256 for KAST_BACKEND_ARCHIVE_PATH
+  KAST_INSTALL_SOURCE            Install source metadata label (default: kast.sh)
   KAST_SKILL_SCOPE               Skill scope when prompts are unavailable: global, local, both, skip
 USAGE
         return 0 ;;
@@ -1881,7 +1883,7 @@ USAGE
 
     _install_write_metadata \
       "${release_dir}/.install-metadata.json" \
-      "$release_repo" "$release_tag" "$platform_id" "$archive_name" "$archive_source"
+      "$release_repo" "$release_tag" "$platform_id" "$archive_name" "$archive_source" "${KAST_INSTALL_SOURCE:-kast.sh}"
 
     mkdir -p "$install_root" "$bin_dir"
     ln -sfn "$release_dir" "$current_link"

--- a/scripts/headless-agent-install.sh
+++ b/scripts/headless-agent-install.sh
@@ -91,6 +91,7 @@ write_env_file() {
 verify_install() {
   local install_root="$1"
   local workspace_root="$2"
+  local skip_copilot_extension="$3"
 
   local kast_bin="${install_root}/bin/kast"
   local config_file="${install_root}/config/config.toml"
@@ -108,22 +109,25 @@ verify_install() {
   [[ -d "$runtime_libs_dir" ]] || die "Standalone runtime libs were not installed: $runtime_libs_dir"
 
   [[ -f "${skill_dir}/SKILL.md" ]] || die "Packaged skill was not installed: ${skill_dir}/SKILL.md"
-  [[ -f "$extension_marker" ]] || die "Copilot extension was not installed: $extension_marker"
+  if [[ "$skip_copilot_extension" != "true" ]]; then
+    [[ -f "$extension_marker" ]] || die "Copilot extension was not installed: $extension_marker"
+  fi
   [[ -f "$manifest_file" ]] || die "Install manifest was not written: $manifest_file"
 
-  python3 - "$manifest_file" "$workspace_root" <<'PY'
+  python3 - "$manifest_file" "$workspace_root" "$skip_copilot_extension" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 workspace_root = str(Path(sys.argv[2]).resolve())
+skip_copilot_extension = sys.argv[3] == "true"
 components = set(manifest.get("components", []))
 missing = {"cli", "backend", "skill"} - components
 if missing:
     raise SystemExit(f"manifest missing components: {sorted(missing)}")
 repos = {entry.get("path") for entry in manifest.get("repos", [])}
-if workspace_root not in repos:
+if not skip_copilot_extension and workspace_root not in repos:
     raise SystemExit(f"manifest missing managed repo: {workspace_root}")
 PY
 }
@@ -142,6 +146,7 @@ Optional environment:
   KAST_AGENT_INSTALL_ROOT      Contained install root (default: $HOME/.kast-agent)
   KAST_AGENT_WORKSPACE         Git workspace for Copilot extension install (default: $PWD)
   KAST_AGENT_VERSION           Version label written to Kast install metadata (default: agent)
+  KAST_SKIP_COPILOT_EXTENSION  Set true to skip Copilot extension install
 USAGE
 }
 
@@ -187,6 +192,11 @@ download_artifact "$backend_url" "$backend_archive" "standalone backend"
 verify_sha256 "$backend_archive" "${KAST_AGENT_BACKEND_SHA256:-}" "standalone backend"
 
 log "Installing Kast into ${install_root}"
+install_args=(install --components=cli,backend --yes)
+skip_copilot_extension="${KAST_SKIP_COPILOT_EXTENSION:-false}"
+if [[ "$skip_copilot_extension" == "true" ]]; then
+  install_args+=(--skip-copilot-extension)
+fi
 (
   cd "$workspace_root"
   KAST_MANAGED_ROOT="$install_root" \
@@ -198,12 +208,13 @@ log "Installing Kast into ${install_root}"
   KAST_BACKEND_ARCHIVE_PATH="$backend_archive" \
   KAST_BACKEND_EXPECTED_SHA256="${KAST_AGENT_BACKEND_SHA256:-}" \
   KAST_SKILL_SCOPE=global \
+  KAST_INSTALL_SOURCE="${KAST_INSTALL_SOURCE:-release}" \
   KAST_VERSION="${KAST_AGENT_VERSION:-${KAST_VERSION:-agent}}" \
-  /bin/bash "${repo_root}/kast.sh" install --components=cli,backend --yes
+  /bin/bash "${repo_root}/kast.sh" "${install_args[@]}"
 )
 
 write_env_file "${install_root}/kast-env.sh" "$install_root"
-verify_install "$install_root" "$workspace_root"
+verify_install "$install_root" "$workspace_root" "$skip_copilot_extension"
 
 log "Kast headless agent install complete"
 log "Source environment: ${install_root}/kast-env.sh"

--- a/scripts/headless-agent-install.sh
+++ b/scripts/headless-agent-install.sh
@@ -192,7 +192,7 @@ log "Installing Kast into ${install_root}"
   KAST_MANAGED_ROOT="$install_root" \
   KAST_CONFIG_HOME="${install_root}/config" \
   KAST_PATH_RC_FILE="${install_root}/shellrc" \
-  KAST_INSTALL_COMPLETIONS=false \
+  KAST_INSTALL_COMPLETIONS=true \
   KAST_ARCHIVE_PATH="$cli_archive" \
   KAST_EXPECTED_SHA256="${KAST_AGENT_CLI_SHA256:-}" \
   KAST_BACKEND_ARCHIVE_PATH="$backend_archive" \

--- a/scripts/package-headless-agent-bundle.sh
+++ b/scripts/package-headless-agent-bundle.sh
@@ -228,6 +228,7 @@ Optional overrides:
 - \`KAST_AGENT_INSTALL_ROOT\` - contained install root, defaults to \`\$HOME/.kast-agent\`
 - \`KAST_AGENT_WORKSPACE\` - Git workspace for repo-local Copilot extension install
 - \`KAST_AGENT_VERSION\` - install metadata label, defaults to \`${version}\`
+- \`KAST_SKIP_COPILOT_EXTENSION\` - set \`true\` to skip Copilot extension install
 README
 
 python3 - "${staging_dir}/manifest.json" "$version" "$platform_id" "$cli_sha" "$backend_sha" <<'PY'

--- a/scripts/smoke-headless-agent-install.sh
+++ b/scripts/smoke-headless-agent-install.sh
@@ -85,14 +85,17 @@ artifact_dir="${scratch_dir}/artifacts"
 cli_tree="${scratch_dir}/cli"
 backend_tree="${scratch_dir}/backend"
 workspace_root="${scratch_dir}/workspace"
+skip_workspace_root="${scratch_dir}/skip-workspace"
 home_dir="${scratch_dir}/home"
 install_root="${scratch_dir}/contained-kast"
+skip_install_root="${scratch_dir}/skip-contained-kast"
 
 mkdir -p \
   "${artifact_dir}" \
   "${cli_tree}/kast-cli" \
   "${backend_tree}/backend-standalone/runtime-libs" \
   "${workspace_root}" \
+  "${skip_workspace_root}" \
   "${home_dir}"
 
 cat > "${cli_tree}/kast-cli/kast-cli" <<'FAKE_KAST'
@@ -163,6 +166,7 @@ zip_dir "$cli_zip" "$cli_tree"
 zip_dir "$backend_zip" "$backend_tree"
 
 git -C "$workspace_root" init -q
+git -C "$skip_workspace_root" init -q
 
 HOME="$home_dir" \
 SHELL=/bin/bash \
@@ -209,6 +213,21 @@ assert {"cli", "backend", "skill"}.issubset(components), payload
 repos = {entry["path"] for entry in payload.get("repos", [])}
 assert workspace_root in repos, payload
 PY
+
+HOME="$home_dir" \
+SHELL=/bin/bash \
+KAST_AGENT_CLI_URL="$(file_uri "$cli_zip")" \
+KAST_AGENT_BACKEND_URL="$(file_uri "$backend_zip")" \
+KAST_AGENT_CLI_SHA256="$(compute_sha256 "$cli_zip")" \
+KAST_AGENT_BACKEND_SHA256="$(compute_sha256 "$backend_zip")" \
+KAST_AGENT_INSTALL_ROOT="$skip_install_root" \
+KAST_AGENT_WORKSPACE="$skip_workspace_root" \
+KAST_SKIP_COPILOT_EXTENSION=true \
+"${repo_root}/scripts/headless-agent-install.sh"
+
+[[ -x "${skip_install_root}/bin/kast" ]] || die "Skip install missing launcher"
+[[ -f "${skip_install_root}/lib/skills/kast/SKILL.md" ]] || die "Skip install missing skill"
+[[ ! -f "${skip_workspace_root}/.github/.kast-copilot-version" ]] || die "Skip install wrote Copilot extension marker"
 
 if HOME="$home_dir" \
   SHELL=/bin/bash \


### PR DESCRIPTION
## Summary
- Extends the release pipeline to publish release checksums and dispatch Homebrew tap updates from the main Kast release workflow.
- Makes `self upgrade` adapt to the detected install source and environment so users get the right upgrade path for Homebrew, release installs, and ephemeral CI/action setups.
- Tightens the headless agent install flow and installer smoke coverage so bundle installs can skip the Copilot extension cleanly when requested.
- Aligns IntelliJ reference indexing with non-blocking read behavior and updates the shared scanner contract to match that threading model.

## Testing
- `./gradlew :kast-cli:test --tests io.github.amichne.kast.cli.ForbiddenEnvironmentTokenGuardTest --tests io.github.amichne.kast.cli.SelfManagementServiceTest --tests io.github.amichne.kast.cli.CliCommandCatalogTest`
- `./scripts/smoke-headless-agent-install.sh`
- `./scripts/smoke-headless-agent-bundle.sh`
- `kast rpc '{"jsonrpc":"2.0","method":"raw/diagnostics",...}'` on the modified Kotlin files
- `npm run lint`, `npm test`, `npm run build`, `npm audit --omit=dev`
- Ruby/YAML syntax checks for the new tap formula and workflow