### PR TITLE
feat: harden release readiness

### DIFF
--- a/.github/scripts/test-release-asset-verifier.sh
+++ b/.github/scripts/test-release-asset-verifier.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/../.." && pwd
+}
+
+compute_sha256() {
+  local input_path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$input_path" | awk '{ print $1 }'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$input_path" | awk '{ print $1 }'
+    return
+  fi
+  die "Neither sha256sum nor shasum is available"
+}
+
+write_asset() {
+  local asset_path="$1"
+  printf 'contents for %s\n' "$(basename -- "$asset_path")" > "$asset_path"
+}
+
+write_sha256sums() {
+  local release_dir="$1"
+  shift
+
+  : > "${release_dir}/SHA256SUMS"
+  local asset_name
+  for asset_name in "$@"; do
+    printf '%s  %s\n' "$(compute_sha256 "${release_dir}/${asset_name}")" "$asset_name" >> "${release_dir}/SHA256SUMS"
+  done
+}
+
+repo_root="$(resolve_repo_root)"
+verifier="${repo_root}/scripts/verify-release-assets.sh"
+[[ -x "$verifier" ]] || die "release asset verifier is missing or not executable: $verifier"
+
+scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/kast-release-verify.XXXXXX")"
+cleanup() {
+  rm -rf "$scratch_dir"
+}
+trap cleanup EXIT
+
+tag="v9.8.7"
+release_dir="${scratch_dir}/release"
+mkdir -p "$release_dir"
+
+assets=(
+  "kast-${tag}-linux-x64.zip"
+  "kast-${tag}-macos-arm64.zip"
+  "kast-headless-agent-${tag}-linux-x64.zip"
+  "kast-intellij-${tag}.zip"
+  "kast-standalone-${tag}.zip"
+)
+
+for asset in "${assets[@]}"; do
+  write_asset "${release_dir}/${asset}"
+done
+write_sha256sums "$release_dir" "${assets[@]}"
+
+python3 - "$release_dir" "$tag" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+release_dir = Path(sys.argv[1])
+tag = sys.argv[2]
+entries = [
+    ("linux-x64", f"kast-{tag}-linux-x64.zip"),
+    ("macos-arm64", f"kast-{tag}-macos-arm64.zip"),
+    ("headless-agent-linux-x64", f"kast-headless-agent-{tag}-linux-x64.zip"),
+    ("intellij", f"kast-intellij-{tag}.zip"),
+    ("standalone", f"kast-standalone-{tag}.zip"),
+]
+payload = {
+    "builds": [
+        {
+            "platformId": platform,
+            "assetName": asset,
+            "assetDigest": "sha256:" + hashlib.sha256((release_dir / asset).read_bytes()).hexdigest(),
+        }
+        for platform, asset in entries
+    ]
+}
+(release_dir / "build-provenance.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+"$verifier" --release-dir "$release_dir" --tag "$tag"
+
+printf 'tampered\n' >> "${release_dir}/${assets[0]}"
+if "$verifier" --release-dir "$release_dir" --tag "$tag" >/dev/null 2>"${scratch_dir}/checksum.err"; then
+  die "tampered asset unexpectedly verified"
+fi
+grep -Fq "checksum mismatch" "${scratch_dir}/checksum.err" || die "tampered asset failure did not mention checksum mismatch"
+
+write_asset "${release_dir}/${assets[0]}"
+write_sha256sums "$release_dir" "${assets[@]}"
+python3 - "${release_dir}/build-provenance.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["builds"] = [
+    entry for entry in payload["builds"]
+    if entry.get("platformId") != "headless-agent-linux-x64"
+]
+path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+if "$verifier" --release-dir "$release_dir" --tag "$tag" >/dev/null 2>"${scratch_dir}/provenance.err"; then
+  die "missing provenance unexpectedly verified"
+fi
+grep -Fq "missing provenance" "${scratch_dir}/provenance.err" || die "missing provenance failure did not mention missing provenance"
+
+python3 - "$release_dir" "$tag" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+release_dir = Path(sys.argv[1])
+tag = sys.argv[2]
+entries = [
+    ("linux-x64", f"kast-{tag}-linux-x64.zip"),
+    ("macos-arm64", f"kast-{tag}-macos-arm64.zip"),
+    ("headless-agent-linux-x64", f"kast-headless-agent-{tag}-linux-x64.zip"),
+    ("intellij", f"kast-intellij-{tag}.zip"),
+    ("standalone", f"kast-standalone-{tag}.zip"),
+]
+payload = {
+    "builds": [
+        {
+            "platformId": platform,
+            "assetName": asset,
+            "assetDigest": "sha256:" + hashlib.sha256((release_dir / asset).read_bytes()).hexdigest(),
+        }
+        for platform, asset in entries
+    ]
+}
+(release_dir / "build-provenance.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+extra_asset="${release_dir}/kast-${tag}-debug.zip"
+write_asset "$extra_asset"
+printf '%s  %s\n' "$(compute_sha256 "$extra_asset")" "$(basename -- "$extra_asset")" >> "${release_dir}/SHA256SUMS"
+
+if "$verifier" --release-dir "$release_dir" --tag "$tag" >/dev/null 2>"${scratch_dir}/extra.err"; then
+  die "extra release asset unexpectedly verified"
+fi
+grep -Fq "unexpected release asset" "${scratch_dir}/extra.err" || die "extra asset failure did not mention unexpected release asset"
+
+printf '%s\n' "Release asset verifier test passed"

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/../.." && pwd
+}
+
+require_contains() {
+  local file_path="$1"
+  local expected="$2"
+  local description="$3"
+
+  grep -Fq -- "$expected" "$file_path" || die "${description}: missing '${expected}' in ${file_path}"
+}
+
+require_not_contains() {
+  local file_path="$1"
+  local unexpected="$2"
+  local description="$3"
+
+  ! grep -Fq -- "$unexpected" "$file_path" || die "${description}: found '${unexpected}' in ${file_path}"
+}
+
+require_occurrences() {
+  local file_path="$1"
+  local expected="$2"
+  local expected_count="$3"
+  local description="$4"
+
+  local actual_count
+  actual_count="$({ grep -F -- "$expected" "$file_path" || true; } | wc -l | tr -d ' ')"
+  [[ "$actual_count" == "$expected_count" ]] || die "${description}: expected ${expected_count} occurrences of '${expected}' in ${file_path}, found ${actual_count}"
+}
+
+line_number_for() {
+  local file_path="$1"
+  local needle="$2"
+
+  grep -nF -- "$needle" "$file_path" | head -1 | cut -d: -f1
+}
+
+require_order() {
+  local file_path="$1"
+  local earlier="$2"
+  local later="$3"
+  local description="$4"
+
+  local earlier_line
+  local later_line
+  earlier_line="$(line_number_for "$file_path" "$earlier")"
+  later_line="$(line_number_for "$file_path" "$later")"
+
+  [[ -n "$earlier_line" ]] || die "${description}: missing earlier marker '${earlier}' in ${file_path}"
+  [[ -n "$later_line" ]] || die "${description}: missing later marker '${later}' in ${file_path}"
+  [[ "$earlier_line" -lt "$later_line" ]] || die "${description}: '${earlier}' must appear before '${later}' in ${file_path}"
+}
+
+repo_root="$(resolve_repo_root)"
+ci_workflow="${repo_root}/.github/workflows/ci.yml"
+release_workflow="${repo_root}/.github/workflows/release.yml"
+
+[[ -f "$ci_workflow" ]] || die "CI workflow not found: $ci_workflow"
+[[ -f "$release_workflow" ]] || die "Release workflow not found: $release_workflow"
+
+require_contains "$ci_workflow" "Workflow release contracts" "CI must run this workflow contract check"
+require_contains "$ci_workflow" "./.github/scripts/test-release-asset-verifier.sh" "CI must test the release asset verifier"
+require_contains "$ci_workflow" "Analysis server transport" "CI must include an independent analysis-server transport job"
+require_contains "$ci_workflow" "io.github.amichne.kast.server.AnalysisServerSocketTest" "Analysis server job must smoke the socket transport"
+require_contains "$ci_workflow" "Native CLI" "CI must include a native CLI job"
+require_contains "$ci_workflow" "graalvm/setup-graalvm@v1" "Native CLI job must install GraalVM"
+require_contains "$ci_workflow" ":kast-cli:nativeCompile" "Native CLI job must compile the native image"
+require_contains "$ci_workflow" "kast-cli/build/native/nativeCompile/kast" "Native CLI job must smoke the native binary"
+require_contains "$ci_workflow" "./scripts/smoke-native-cli.sh kast-cli/build/native/nativeCompile/kast" "Native CLI job must smoke embedded agent resources"
+
+require_contains "$release_workflow" "Generate and upload SHA256SUMS" "Release must publish aggregate checksums"
+require_contains "$release_workflow" "Dispatch Homebrew tap update" "Release must dispatch the Homebrew tap update"
+require_contains "$release_workflow" "Wait for Homebrew tap update" "Release must wait for the Homebrew tap update"
+require_contains "$release_workflow" "gh run watch" "Release must watch the Homebrew tap workflow result"
+require_contains "$release_workflow" "Package headless agent bundle" "Release must package the headless agent bundle"
+require_contains "$release_workflow" "Smoke headless agent bundle" "Release must smoke the headless agent bundle"
+require_contains "$release_workflow" "build-provenance-headless-agent-linux-x64.json" "Release must write provenance for the headless agent bundle"
+require_contains "$release_workflow" "expected_platforms = {" "Release must validate the complete provenance platform set"
+require_contains "$release_workflow" '"headless-agent-linux-x64"' "Release provenance must include the headless agent bundle"
+require_contains "$release_workflow" "missing_provenance" "Release provenance validation must fail on missing entries"
+require_contains "$release_workflow" "assetDigest" "Release provenance entries must include asset digests"
+require_contains "$release_workflow" "expected_assets=(" "Release must validate the complete shipped asset set"
+require_contains "$release_workflow" '"kast-${tag}-linux-x64.zip"' "Release must require the Linux CLI asset"
+require_contains "$release_workflow" '"kast-${tag}-macos-arm64.zip"' "Release must require the macOS CLI asset"
+require_contains "$release_workflow" '"kast-headless-agent-${tag}-linux-x64.zip"' "Release must require the headless agent bundle"
+require_contains "$release_workflow" '"kast-intellij-${tag}.zip"' "Release must require the IntelliJ plugin asset"
+require_contains "$release_workflow" '"kast-standalone-${tag}.zip"' "Release must require the standalone backend asset"
+require_contains "$release_workflow" 'for asset in "${expected_assets[@]}"; do' "Release must check every expected asset before publishing checksums"
+require_contains "$release_workflow" "./scripts/verify-release-assets.sh --release-dir release-assets --tag \"\$tag\"" "Release must verify assets, checksums, and provenance before publishing"
+require_contains "$release_workflow" 'gh release view "$tag" >/dev/null 2>&1' "Release preparation must tolerate existing releases"
+require_occurrences "$release_workflow" "if: \${{ !contains(needs.prepare-release.outputs.release_tag" 2 "Homebrew tap updates must only run for stable releases"
+require_not_contains "$release_workflow" "needs: [bump-version, prepare-release]" "Release build jobs must not depend on a skipped workflow_dispatch-only job"
+require_not_contains "$release_workflow" "      - bump-version" "Release publish job must not depend on a skipped workflow_dispatch-only job"
+require_contains "$release_workflow" 'release_flags=("--draft=false")' "Release publication must build explicit release flags"
+require_contains "$release_workflow" '[[ "$tag" == *-* ]]' "Release publication must detect prerelease tags"
+require_contains "$release_workflow" 'release_flags+=(--prerelease)' "Prerelease tags must publish as prereleases"
+require_contains "$release_workflow" 'release_flags+=(--latest)' "Stable tags must publish as latest releases"
+require_order "$release_workflow" "Generate and upload SHA256SUMS" "Publish draft release with provenance annotation" "Release must upload checksum manifest before publishing"
+require_order "$release_workflow" "Publish draft release with provenance annotation" "Dispatch Homebrew tap update" "Release must publish GitHub assets before updating Homebrew"
+require_order "$release_workflow" "Dispatch Homebrew tap update" "Wait for Homebrew tap update" "Release must wait only after dispatching Homebrew"
+
+printf '%s\n' "Release workflow contract test passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,24 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  workflow-contracts:
+    name: Workflow release contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Test release workflow contract
+        shell: bash
+        run: ./.github/scripts/test-release-workflow-contract.sh
+
+      - name: Test release asset verifier
+        shell: bash
+        run: ./.github/scripts/test-release-asset-verifier.sh
+
   build-and-test:
     name: Build & test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: workflow-contracts
     strategy:
       fail-fast: false
       matrix:
@@ -66,9 +81,53 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  native-cli:
+    name: Native CLI
+    runs-on: ubuntu-latest
+    needs: workflow-contracts
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          distribution: graalvm-community
+          java-version: "21"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: "true"
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Build native CLI
+        run: ./gradlew :kast-cli:nativeCompile
+
+      - name: Smoke native CLI
+        shell: bash
+        run: ./scripts/smoke-native-cli.sh kast-cli/build/native/nativeCompile/kast
+
+  analysis-server-transport:
+    name: Analysis server transport
+    runs-on: ubuntu-latest
+    needs: workflow-contracts
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Smoke analysis-server socket transport
+        run: >
+          ./gradlew
+          :analysis-server:test
+          --tests io.github.amichne.kast.server.AnalysisServerSocketTest
+
   test-intellij-plugin:
     name: IntelliJ plugin
     runs-on: ubuntu-latest
+    needs: workflow-contracts
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,19 +143,24 @@ jobs:
       - name: Ensure draft release exists
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
           set -euo pipefail
           tag="${{ steps.release-tag.outputs.value }}"
 
-          gh release create "$tag" \
-            --draft \
-            --verify-tag \
-            --title "$tag" \
-            --generate-notes
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release already exists: $tag"
+          else
+            gh release create "$tag" \
+              --draft \
+              --verify-tag \
+              --title "$tag" \
+              --generate-notes
+          fi
 
   build-and-upload:
     name: Build release asset (${{ matrix.asset_id }})
-    needs: [bump-version, prepare-release]
+    needs: [prepare-release]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: write
@@ -247,11 +252,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
           mkdir -p dist
-          digest=""
-          if [[ -f dist/checksums.txt ]]; then
-            digest="$(grep '${{ matrix.asset_id }}' dist/checksums.txt | awk '{print $1}' || true)"
-          fi
+          asset_name="kast-${tag}-${{ matrix.asset_id }}.zip"
+          digest="$(awk -v name="$asset_name" '$2 == name { print $1; found = 1 } END { if (!found) exit 1 }' dist/checksums.txt)"
           cat > dist/build-provenance-${{ matrix.asset_id }}.json <<PROVEOF
           {
             "runId": "${{ github.run_id }}",
@@ -262,10 +266,31 @@ jobs:
             "workflowRef": "${{ github.workflow_ref }}",
             "actor": "${{ github.actor }}",
             "platformId": "${{ matrix.asset_id }}",
+            "assetName": "${asset_name}",
             "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
             "assetDigest": "sha256:${digest}"
           }
           PROVEOF
+
+          if [[ "${{ matrix.asset_id }}" == "linux-x64" ]]; then
+            headless_asset_name="kast-headless-agent-${tag}-linux-x64.zip"
+            headless_digest="$(sha256sum "dist/${headless_asset_name}" | awk '{ print $1 }')"
+            cat > dist/build-provenance-headless-agent-linux-x64.json <<PROVEOF
+          {
+            "runId": "${{ github.run_id }}",
+            "runNumber": "${{ github.run_number }}",
+            "runAttempt": "${{ github.run_attempt }}",
+            "sha": "${{ github.sha }}",
+            "ref": "${{ github.ref }}",
+            "workflowRef": "${{ github.workflow_ref }}",
+            "actor": "${{ github.actor }}",
+            "platformId": "headless-agent-linux-x64",
+            "assetName": "${headless_asset_name}",
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "assetDigest": "sha256:${headless_digest}"
+          }
+          PROVEOF
+          fi
 
       - name: Upload release asset
         shell: bash
@@ -305,7 +330,7 @@ jobs:
 
   build-intellij-plugin:
     name: Build IntelliJ plugin
-    needs: [bump-version, prepare-release]
+    needs: [prepare-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -359,6 +384,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          asset_name="kast-intellij-${tag}.zip"
+          digest="$(sha256sum "dist/${asset_name}" | awk '{ print $1 }')"
           cat > dist/build-provenance-intellij.json <<PROVEOF
           {
             "runId": "${{ github.run_id }}",
@@ -369,7 +397,9 @@ jobs:
             "workflowRef": "${{ github.workflow_ref }}",
             "actor": "${{ github.actor }}",
             "platformId": "intellij",
-            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            "assetName": "${asset_name}",
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "assetDigest": "sha256:${digest}"
           }
           PROVEOF
 
@@ -385,7 +415,7 @@ jobs:
 
   build-standalone-backend:
     name: Build standalone backend
-    needs: [bump-version, prepare-release]
+    needs: [prepare-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -425,6 +455,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          asset_name="kast-standalone-${tag}.zip"
+          digest="$(sha256sum "dist/${asset_name}" | awk '{ print $1 }')"
           cat > dist/build-provenance-standalone.json <<PROVEOF
           {
             "runId": "${{ github.run_id }}",
@@ -435,7 +468,9 @@ jobs:
             "workflowRef": "${{ github.workflow_ref }}",
             "actor": "${{ github.actor }}",
             "platformId": "standalone",
-            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            "assetName": "${asset_name}",
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "assetDigest": "sha256:${digest}"
           }
           PROVEOF
 
@@ -452,7 +487,6 @@ jobs:
   publish-release:
     name: Publish release
     needs:
-      - bump-version
       - prepare-release
       - build-and-upload
       - build-intellij-plugin
@@ -494,19 +528,45 @@ jobs:
             provenance_files+=("$f")
           done
 
-          if [[ ${#provenance_files[@]} -gt 0 ]]; then
-            python3 -c "
-          import json, sys, glob
-          files = sys.argv[1:]
+          python3 - "${provenance_files[@]}" > dist/build-provenance.json <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          expected_platforms = {
+              "linux-x64",
+              "macos-arm64",
+              "headless-agent-linux-x64",
+              "intellij",
+              "standalone",
+          }
           entries = []
-          for f in files:
-              with open(f) as fh:
-                  entries.append(json.load(fh))
-          print(json.dumps({'builds': entries}, indent=2))
-          " "${provenance_files[@]}" > dist/build-provenance.json
-          else
-            echo '{"builds": []}' > dist/build-provenance.json
-          fi
+          for file_name in sys.argv[1:]:
+              with Path(file_name).open(encoding="utf-8") as handle:
+                  entries.append(json.load(handle))
+
+          seen_platforms = {entry.get("platformId") for entry in entries}
+          missing_provenance = expected_platforms - seen_platforms
+          unexpected_provenance = seen_platforms - expected_platforms
+          if missing_provenance or unexpected_provenance:
+              raise SystemExit(
+                  "provenance platform mismatch: "
+                  f"missing={sorted(missing_provenance)} "
+                  f"unexpected={sorted(unexpected_provenance)}"
+              )
+
+          for entry in entries:
+              platform = entry.get("platformId", "<unknown>")
+              asset_name = entry.get("assetName")
+              asset_digest = entry.get("assetDigest")
+              if not isinstance(asset_name, str) or not asset_name.endswith(".zip"):
+                  raise SystemExit(f"provenance entry for {platform} has no zip assetName")
+              if not isinstance(asset_digest, str) or not asset_digest.startswith("sha256:") or asset_digest == "sha256:":
+                  raise SystemExit(f"provenance entry for {platform} has no SHA-256 assetDigest")
+
+          entries.sort(key=lambda item: item["platformId"])
+          print(json.dumps({"builds": entries}, indent=2))
+          PY
 
       - name: Upload combined provenance
         env:
@@ -516,19 +576,6 @@ jobs:
           tag="${{ needs.prepare-release.outputs.release_tag }}"
           gh release upload "$tag" dist/build-provenance.json --clobber
 
-      - name: Publish draft release with provenance annotation
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          tag="${{ needs.prepare-release.outputs.release_tag }}"
-          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          gh release edit "$tag" --draft=false --latest \
-            --notes "$(gh release view "$tag" --json body -q .body)
-
-          ---
-          **Build provenance:** [CI Run #${{ github.run_number }}]($run_url)"
-
       - name: Generate and upload SHA256SUMS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -536,12 +583,50 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ needs.prepare-release.outputs.release_tag }}"
+          expected_assets=(
+            "kast-${tag}-linux-x64.zip"
+            "kast-${tag}-macos-arm64.zip"
+            "kast-headless-agent-${tag}-linux-x64.zip"
+            "kast-intellij-${tag}.zip"
+            "kast-standalone-${tag}.zip"
+          )
+
+          rm -rf release-assets
           mkdir -p release-assets
           gh release download "$tag" --dir release-assets --pattern '*.zip'
-          (cd release-assets && sha256sum *.zip) > SHA256SUMS
+          for asset in "${expected_assets[@]}"; do
+            [[ -f "release-assets/${asset}" ]] || { echo "Missing release asset: ${asset}" >&2; exit 1; }
+          done
+          (cd release-assets && sha256sum "${expected_assets[@]}") > SHA256SUMS
+          cp SHA256SUMS release-assets/SHA256SUMS
+          cp dist/build-provenance.json release-assets/build-provenance.json
+          ./scripts/verify-release-assets.sh --release-dir release-assets --tag "$tag"
           gh release upload "$tag" SHA256SUMS --clobber
 
-      - name: Update Homebrew tap
+      - name: Publish draft release with provenance annotation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          release_flags=("--draft=false")
+          if [[ "$tag" == *-* ]]; then
+            release_flags+=(--prerelease)
+          else
+            release_flags+=(--latest)
+          fi
+
+          gh release edit "$tag" "${release_flags[@]}" \
+            --notes "$(gh release view "$tag" --json body -q .body)
+
+          ---
+          **Build provenance:** [CI Run #${{ github.run_number }}]($run_url)"
+
+      - name: Dispatch Homebrew tap update
+        if: ${{ !contains(needs.prepare-release.outputs.release_tag, '-') }}
+        id: homebrew-dispatch
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         shell: bash
@@ -551,6 +636,9 @@ jobs:
             echo "Missing HOMEBREW_TAP_TOKEN secret; create a token that can dispatch amichne/homebrew-kast workflows." >&2
             exit 1
           fi
+
+          dispatch_started="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          printf 'dispatch_started=%s\n' "$dispatch_started" >> "$GITHUB_OUTPUT"
 
           tag="${{ needs.prepare-release.outputs.release_tag }}"
           linux_asset="kast-${tag}-linux-x64.zip"
@@ -566,3 +654,32 @@ jobs:
             -f "client_payload[version]=${tag}" \
             -f "client_payload[sha256_linux_x64]=${sha_linux}" \
             -f "client_payload[sha256_macos_arm64]=${sha_macos}"
+
+      - name: Wait for Homebrew tap update
+        if: ${{ !contains(needs.prepare-release.outputs.release_tag, '-') }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          started="${{ steps.homebrew-dispatch.outputs.dispatch_started }}"
+          deadline=$((SECONDS + 180))
+          run_id=""
+
+          while [[ -z "$run_id" && "$SECONDS" -lt "$deadline" ]]; do
+            run_id="$(gh run list \
+              --repo amichne/homebrew-kast \
+              --workflow update-formula.yml \
+              --event repository_dispatch \
+              --branch main \
+              --created ">=$started" \
+              --limit 10 \
+              --json databaseId,createdAt,displayTitle \
+              --jq 'map(select(.displayTitle == "release-published")) | sort_by(.createdAt) | last | .databaseId // ""')"
+            if [[ -z "$run_id" ]]; then
+              sleep 5
+            fi
+          done
+
+          [[ -n "$run_id" ]] || { echo "Timed out waiting for Homebrew tap workflow run to appear" >&2; exit 1; }
+          gh run watch "$run_id" --repo amichne/homebrew-kast --exit-status --compact --interval 10

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ planned edit is safe to apply.
 `kast` has two independent runtime modes:
 
 - **Standalone CLI + backend** — install the `kast` CLI and run
-  `kast daemon start` to start the analysis backend. Fully independent from
+  `kast up` to start or warm the analysis backend. Fully independent from
   IntelliJ; works in terminals, CI, and headless agents.
 - **IntelliJ plugin-backed runtime** — runs inside IntelliJ IDEA and reuses the
   IDE's already-open project model, indexes, and analysis session.
@@ -37,7 +37,7 @@ For CI or headless agent installs from internal artifacts or self-contained
 bundles, use the
 [install guide](https://kast.michne.com/getting-started/install/#headless-agent-with-internal-artifacts).
 
-Then start the standalone backend before running analysis commands:
+Warm the standalone backend before running analysis commands:
 
 ```console
 # Start or warm the backend

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,19 +32,21 @@ All operations are available on both backends:
 
 | Operation | Method |
 |-----------|--------|
-| Resolve symbol at position | `resolve` |
-| Find all references | `references` |
-| Incoming / outgoing call hierarchy | `callHierarchy` |
-| Type hierarchy (supertypes & subtypes) | `typeHierarchy` |
-| File outline (declarations) | `outline` |
-| Workspace-wide symbol search | `workspaceSymbol` |
-| Compiler diagnostics | `diagnostics` |
-| Rename symbol (plan + apply) | `rename` |
-| Apply arbitrary edits | `applyEdits` |
-| Optimize imports | `optimizeImports` |
-| Code completions | `completions` |
-| Implementations of interface/abstract | `implementations` |
-| Available code actions | `codeActions` |
+| Resolve symbol at position | `raw/resolve` |
+| Find all references | `raw/references` |
+| Incoming / outgoing call hierarchy | `raw/call-hierarchy` |
+| Type hierarchy (supertypes & subtypes) | `raw/type-hierarchy` |
+| File outline (declarations) | `raw/file-outline` |
+| Workspace-wide symbol search | `raw/workspace-symbol` |
+| Workspace content search | `raw/workspace-search` |
+| Workspace files and source roots | `raw/workspace-files` |
+| Compiler diagnostics | `raw/diagnostics` |
+| Rename symbol (plan + apply) | `raw/rename` |
+| Apply arbitrary edits | `raw/apply-edits` |
+| Optimize imports | `raw/optimize-imports` |
+| Code completions | `raw/completions` |
+| Implementations of interface/abstract | `raw/implementations` |
+| Available code actions | `raw/code-actions` |
 
 ### Source index
 
@@ -64,15 +66,16 @@ restarts and enables sub-millisecond workspace-symbol lookup:
 Every result that may be truncated carries explicit metadata so agents know
 when to paginate or bound their queries:
 
-- `searchScope.exhaustive: boolean` on every `references` result.
-- `stats` and `truncation` on every `callHierarchy` node.
-- SHA-256 conflict detection on `rename` and `applyEdits` — mutations are
+- `searchScope.exhaustive: boolean` on every `raw/references` result.
+- `stats` and `truncation` on every `raw/call-hierarchy` node.
+- SHA-256 conflict detection on `raw/rename` and `raw/apply-edits` — mutations are
   rejected if the file has changed since the plan was computed.
 
 ### Distribution
 
-- **`kast install skill`** — bundles the agent skill (SKILL.md), OpenAPI 3.1
-  spec, and resolver script into `.agents/skills/kast/` inside any target
+- **`kast install skill`** — bundles the agent skill (`SKILL.md`), generated
+  `commands.json` catalog, quickstart reference, resolver/bootstrap scripts,
+  and evaluation assets into `.agents/skills/kast/` inside any target
   repository. One command, no internet access required after the initial
   install.
 - **Portable CLI zip** — `./kast.sh build cli` produces
@@ -80,16 +83,20 @@ when to paginate or bound their queries:
   native launcher, JVM fallback, and all runtime libs.
 - **Portable backend zip** — `./kast.sh build backend --shrink` produces the
   stripped standalone backend zip used by CI and remote deployments.
-- **OpenAPI spec** — `docs/openapi.yaml` is generated from source annotations
-  and kept in sync with every build.
+- **OpenAPI spec** — `docs/openapi.yaml` is generated from the analysis API
+  model registry and kept in sync with every build.
 
 ### CI & release
 
 - GitHub Actions release workflow triggered by `workflow_dispatch` with
   `release_type: major | minor | patch | beta`. The workflow auto-increments
   the semver tag, builds native launchers on Linux (x64) and macOS (ARM64),
-  packages the IntelliJ plugin, and publishes a GitHub release with combined
-  build provenance.
+  packages the IntelliJ plugin and headless agent bundle, uploads aggregate
+  SHA-256 checksums, and publishes a GitHub release with combined build
+  provenance. The workflow verifies every shipped asset against `SHA256SUMS`
+  and `build-provenance.json` before publication. Beta tags publish as GitHub
+  prereleases; stable tags publish the verified GitHub release before updating
+  and watching the Homebrew tap.
 - Upstream sync workflow keeps the standalone backend's bundled IntelliJ
   distribution current.
 - Copilot setup steps pre-warm Gradle caches and Java 21 for GitHub Copilot

--- a/docs/cli-cheat-sheet.md
+++ b/docs/cli-cheat-sheet.md
@@ -26,6 +26,7 @@ command.
 |-------------------------|-------------------------------------------------------------------------------|----------------------------------------------------|
 | `kast up`               | Start the backend if needed and wait until it is servable.                   | `--workspace-root`, `--backend-name`               |
 | `kast status`           | Report whether a backend is running and what state it is in.                 | `--workspace-root`                                 |
+| `kast rpc …runtime/status…` | Return the machine-readable runtime status response.                     | JSON argument or `--request-file`                  |
 | `kast rpc …raw/workspace-refresh…` | Manually request a workspace refresh through raw JSON-RPC.           | JSON argument or `--request-file`                  |
 | `kast stop`             | Shut the backend down cleanly.                                               | `--workspace-root`                                 |
 | `kast capabilities`     | Print which JSON-RPC methods this backend supports.                           | `--workspace-root`                                 |
@@ -47,8 +48,12 @@ same `filePath` and `offset` into the next request.
 | `raw/implementations`            | Find every concrete implementation of an interface or abstract class.       | `position`, `maxResults`                                    |
 | `raw/file-outline`               | Return a tree of named declarations in a file.                              | `filePath`                                                  |
 | `raw/workspace-symbol`           | Search for symbols by name across the workspace.                            | `pattern`, `regex`, `maxResults`                            |
+| `raw/workspace-search`           | Search workspace file contents by text or regex.                            | `pattern`, `regex`, `caseSensitive`, `fileGlob`             |
+| `raw/workspace-files`            | List workspace modules, source roots, and optional file paths.              | `includeFiles`, `maxFilesPerModule`                         |
 | `raw/semantic-insertion-point`   | Find a safe position to insert new code into a class or file.               | `position`, `target`                                        |
 | `raw/diagnostics`                | Return errors and warnings for one or more files.                           | `filePaths`                                                 |
+| `raw/code-actions`               | Return available code actions at a file position.                           | `position`                                                  |
+| `raw/completions`                | Return completion candidates available at a file position.                  | `position`, `maxResults`                                    |
 
 ## Mutations
 
@@ -62,6 +67,24 @@ state `kast` planned against is the state `kast` writes to.
 | `raw/rename`               | Plan a rename of the symbol at a position. Returns edits + file hashes.     | `position`, `newName`, `dryRun`                             |
 | `raw/optimize-imports`     | Plan import cleanup for one or more files.                                  | `filePaths`                                                 |
 | `raw/apply-edits`          | Write a previously-planned edit set, rejecting on hash mismatch.            | `edits`, `fileHashes`, optional `fileOperations`            |
+
+## Operator-level RPC methods
+
+The packaged skill and Copilot extension also use generated `symbol/*`
+and `database/*` methods. They live in the same `kast rpc` transport,
+but their exact request shapes come from
+`.agents/skills/kast/references/commands.json`, not from the OpenAPI
+projection.
+
+| RPC method                    | What it does                                                   | Key params                                              |
+|-------------------------------|----------------------------------------------------------------|---------------------------------------------------------|
+| `symbol/scaffold`             | Gather structural generation context for a Kotlin file.        | `targetFile`                                            |
+| `symbol/resolve`              | Resolve a symbol by name to its declaration.                   | `symbol`, optional `kind`, `containingType`, `fileHint` |
+| `symbol/references`           | Find usages of a named Kotlin symbol.                          | `symbol`, optional scope fields                         |
+| `symbol/callers`              | Expand incoming or outgoing call hierarchy by symbol name.     | `symbol`, `direction`, `depth`                          |
+| `symbol/rename`               | Resolve or target a symbol and apply a rename.                 | request `type`, symbol or offset target, `newName`      |
+| `symbol/write-and-validate`   | Apply generated Kotlin code and validate the result.           | request `type`, file target, edit content               |
+| `database/metrics`            | Query source-index metrics without a running daemon.           | `metric`, optional filters                              |
 
 ## Command tiers
 
@@ -84,4 +107,4 @@ the public CLI command tree.
 - [Understand symbols](what-can-kast-do/understand-symbols.md) —
   long-form reference for the read commands
 - [API specification](reference/api-specification.md) — the
-  JSON-RPC contract these CLI commands wrap
+  OpenAPI projection for raw backend methods

--- a/docs/for-agents/direct-cli.md
+++ b/docs/for-agents/direct-cli.md
@@ -13,6 +13,22 @@ JSON-RPC request and auto-ensures the daemon for the workspace.
 Humans can still manage the daemon lifecycle explicitly with `kast up`,
 `kast status`, and `kast stop`.
 
+## Method families
+
+The CLI accepts the same line-delimited JSON-RPC envelope for every
+family. Pick the family that matches the information you already have.
+
+- `raw/*` methods take explicit file paths, offsets, or file lists and
+  are documented in the generated [API reference](../reference/api-reference.md)
+- `symbol/*` methods are name-based orchestration helpers used by the
+  packaged skill and native `kast_*` tools
+- `database/*` methods read the local SQLite source index, such as
+  `database/metrics`
+
+Exact request and response shapes for the full catalog live in the
+installed `references/commands.json` file. The OpenAPI reference covers
+the raw backend projection.
+
 ## When to call the CLI directly
 
 - The agent already has absolute paths or offsets from a previous response
@@ -98,5 +114,5 @@ Things to check before claiming an answer:
 - [Talk to your agent](talk-to-your-agent.md) — the skill-driven path
 - [Understand symbols](../what-can-kast-do/understand-symbols.md) —
   identity operations in depth
-- [API reference](../reference/api-reference.md) — full schemas and
-  examples
+- [API reference](../reference/api-reference.md) — raw backend schemas
+  and examples

--- a/docs/for-agents/install-the-skill.md
+++ b/docs/for-agents/install-the-skill.md
@@ -53,26 +53,25 @@ kast install skill --target-dir=/absolute/path/to/skills --yes=true
 
 ??? info "What's in the skill directory"
 
-    Only what the agent reads at runtime:
+    The installed tree is the same manifest embedded in the CLI:
 
     - **`SKILL.md`** — the instruction file: workflow, triggers, when to
       use what
-    - **`evals/catalog.json`** and **`evals/pain_points.jsonl`** —
-      durable maintenance cases plus the intake queue for new misses
-    - **`history/progression.json`** — promotion and progression ledger
-      for the durable suite
     - **`references/commands.json`**, **`references/quickstart.md`**, and
-      **`references/routing-improvement.md`** — current wrapper request
-      shapes, quick lookup material, and routing-maintenance guidance
+      **`references/routing-improvement.md`** — generated RPC catalog,
+      quick lookup material, and routing-maintenance guidance
     - **`scripts/resolve-kast.sh`** — portable helper that finds the
       `kast` binary without repo-local hook paths
     - **`scripts/kast-session-start.sh`** — compatibility helper for
       agents that still need a shell bootstrap
     - **`scripts/build-routing-corpus.py`** — maintenance helper that
       turns shared logs and session exports into routing candidate cases
+    - **`fixtures/maintenance/`** — maintenance-only copies of the
+      routing-improvement reference and corpus builder
+    - **`evaluation/`** — embedded evaluation schemas, bindings, and
+      runner scripts used by `kast eval skill`
 
-    Durable eval assets now live in `evals/` and `history/`. Keep
-    transient benchmark outputs in a separate workspace, not in the
+    Keep transient benchmark outputs in a separate workspace, not in the
     installed skill tree.
 
 ??? info "How the agent finds the kast binary"

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -118,7 +118,9 @@ Use the headless agent installer when an image or setup step should install
 Kast from private artifact URLs instead of GitHub releases. The script keeps
 the install contained, writes a sourceable environment file, installs the
 packaged skill, installs the repo-local Copilot extension, and verifies the
-result before it exits.
+result before it exits. Verification checks the CLI launcher, standalone
+runtime libs, packaged skill, install manifest, Copilot hooks, native
+extension files, and executable `resolve-kast.sh` resolver.
 
 Set the direct artifact URLs and run the script from the checked-out
 workspace:
@@ -163,7 +165,8 @@ The bundle is self-describing: `README.md` explains the install flow,
 `manifest.json` lists the bundle kind, platform, entrypoint, and artifact
 digests, and `checksums.txt` records the bundled artifact SHA-256 values.
 Run from a Git checkout or set `KAST_AGENT_WORKSPACE` explicitly because the
-Copilot extension installs into that repository's `.github` directory.
+Copilot extension installs into that repository's `.github` directory and is
+verified before `install.sh` exits.
 
 Use `scripts/package-headless-agent-bundle.sh` when you need to create the
 same bundle shape from local artifacts:
@@ -176,6 +179,22 @@ same bundle shape from local artifacts:
   --platform-id linux-x64 \
   --output dist/kast-headless-agent-v1.2.3-linux-x64.zip
 ```
+
+## Verify release assets
+
+Published releases include the platform zips, headless agent bundle,
+`SHA256SUMS`, and `build-provenance.json`. Mirror or promote those files
+together, then run the same verifier used by CI before importing them into an
+internal artifact store:
+
+```bash title="Verify a downloaded release directory"
+gh release download v1.2.3 --repo amichne/kast --dir kast-release-v1.2.3
+./scripts/verify-release-assets.sh --release-dir kast-release-v1.2.3 --tag v1.2.3
+```
+
+The verifier requires exactly the shipped zip asset set, checks each SHA-256
+digest, and confirms that combined provenance names the same assets and
+digests.
 
 ??? info "Where kast stores configuration"
 

--- a/docs/reference/api-specification.md
+++ b/docs/reference/api-specification.md
@@ -1,15 +1,16 @@
 ---
 title: API specification
-description: Machine-readable OpenAPI 3.1 specification for the Kast analysis
-  daemon JSON-RPC protocol.
+description: Machine-readable OpenAPI 3.1 specification for Kast's raw
+  analysis JSON-RPC protocol.
 icon: lucide/file-code
 ---
 
-The OpenAPI spec documents the `kast` analysis daemon's JSON-RPC
-protocol. It's generated from the Kotlin serialization models in
-`analysis-api` and stays in sync via automated tests.
+The OpenAPI spec documents the backend-level `raw/*` analysis methods
+plus the system methods `health`, `runtime/status`, and `capabilities`.
+It's generated from the Kotlin serialization models in `analysis-api`
+and stays in sync via automated tests.
 
-For human-readable documentation of every operation — schemas,
+For human-readable documentation of every OpenAPI operation — schemas,
 examples, behavioral notes — see the [API reference](api-reference.md).
 
 ## Transport note
@@ -19,6 +20,18 @@ sockets, stdio pipes, or TCP — not HTTP. The OpenAPI spec is a
 logical projection for docs, client codegen, and schema validation.
 Batch requests and JSON-RPC notifications aren't supported.
 
+## Full command catalog
+
+`kast rpc` can also route higher-level `symbol/*` orchestration methods
+and `database/*` index methods. Those are generated into
+`.agents/skills/kast/references/commands.json` by
+`./gradlew :kast-cli:generateVersionedCommandSpec` and packaged with
+the installable skill.
+
+Use OpenAPI when you need the raw backend schema. Use `commands.json`
+when an agent or script needs the complete `kast rpc` catalog,
+including `symbol/resolve`, `symbol/rename`, and `database/metrics`.
+
 ## Capability gating
 
 Read and mutation operations require the daemon to advertise the
@@ -27,7 +40,7 @@ in the spec includes an `x-kast-required-capability` extension
 naming the required capability enum value (e.g. `RESOLVE_SYMBOL`,
 `RENAME`). System methods have no capability requirement.
 
-`edits/apply` additionally needs the `FILE_OPERATIONS` capability
+`raw/apply-edits` additionally needs the `FILE_OPERATIONS` capability
 when the request carries non-empty `fileOperations`. This
 conditional requirement is documented with the
 `x-kast-conditional-capability` extension.

--- a/docs/what-can-kast-do/refactor-safely.md
+++ b/docs/what-can-kast-do/refactor-safely.md
@@ -133,7 +133,7 @@ and rejects the request if anything drifted.
 
 === "JSON-RPC"
 
-    ```json title="edits/apply request" hl_lines="14 15 16 17 18 19"
+    ```json title="raw/apply-edits request" hl_lines="14 15 16 17 18 19"
     {
       "method": "raw/apply-edits",
       "id": 2,
@@ -171,7 +171,7 @@ and rejects the request if anything drifted.
 
 When the hashes match, the daemon writes the edits and responds:
 
-```json title="edits/apply response"
+```json title="raw/apply-edits response"
 {
   "applied": [
     {

--- a/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
+++ b/kast-cli/src/main/kotlin/io/github/amichne/kast/cli/SmokeCommandSupport.kt
@@ -59,7 +59,7 @@ internal class SmokeCommandSupport(
             checks += SmokeCheck(
                 name = "workspace-ensure",
                 status = SmokeCheckStatus.SKIP,
-                message = "No runtime manager available; start a backend with: kast daemon start --workspace-root=${options.workspaceRoot}",
+                message = "No runtime manager available; start a backend with: kast up --workspace-root=${options.workspaceRoot}",
             )
             return false
         }
@@ -83,7 +83,7 @@ internal class SmokeCommandSupport(
                 name = "workspace-ensure",
                 status = if (isNoBackend) SmokeCheckStatus.SKIP else SmokeCheckStatus.FAIL,
                 message = if (isNoBackend) {
-                    "No backend running for ${options.workspaceRoot}; start one with: kast daemon start --workspace-root=${options.workspaceRoot}"
+                    "No backend running for ${options.workspaceRoot}; start one with: kast up --workspace-root=${options.workspaceRoot}"
                 } else {
                     failure?.message ?: "Backend connectivity check failed"
                 },

--- a/kast-cli/src/main/resources/META-INF/native-image/io.github.amichne.kast/kast-cli/resource-config.json
+++ b/kast-cli/src/main/resources/META-INF/native-image/io.github.amichne.kast/kast-cli/resource-config.json
@@ -5,6 +5,9 @@
         "pattern": "packaged-skill/.*"
       },
       {
+        "pattern": "packaged-copilot-extension/.*"
+      },
+      {
         "pattern": "\\QMETA-INF/services/com.sksamuel.hoplite.decoder.Decoder\\E"
       }
     ]

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/NativeImageConfigurationTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/NativeImageConfigurationTest.kt
@@ -51,6 +51,7 @@ class NativeImageConfigurationTest {
             .map { include -> include.jsonObject.getValue("pattern").jsonPrimitive.content }
         val expectedPatterns = listOf(
             "packaged-skill/.*",
+            "packaged-copilot-extension/.*",
             Regex.escape(HOPLITE_DECODER_SERVICE_PATH),
         )
         val missingPatterns = expectedPatterns.filterNot(patterns::contains)

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SmokeCommandSupportTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/SmokeCommandSupportTest.kt
@@ -93,7 +93,7 @@ class SmokeCommandSupportTest {
     }
 
     @Test
-    fun `smoke skips include actionable kast daemon start hint when no daemon`() = runTest {
+    fun `smoke skips include actionable kast up hint when no daemon`() = runTest {
         val manager = managerWith(runtimeStatuses = emptyMap(), processLivenessChecker = { false })
         val support = SmokeCommandSupport(runtimeManager = manager)
         val workspace = tempDir.resolve("no-daemon")
@@ -103,8 +103,8 @@ class SmokeCommandSupportTest {
         val ensureCheck = report.checks.first { it.name == "workspace-ensure" }
         assertNotNull(ensureCheck.message)
         assertTrue(
-            ensureCheck.message.orEmpty().contains("kast daemon start"),
-            "Skip message should mention 'kast daemon start', was: ${ensureCheck.message}",
+            ensureCheck.message.orEmpty().contains("kast up"),
+            "Skip message should mention 'kast up', was: ${ensureCheck.message}",
         )
     }
 

--- a/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/WorkspaceCommandDocsTest.kt
+++ b/kast-cli/src/test/kotlin/io/github/amichne/kast/cli/WorkspaceCommandDocsTest.kt
@@ -1,5 +1,8 @@
 package io.github.amichne.kast.cli
 
+import io.github.amichne.kast.cli.tty.defaultCliJson
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
@@ -61,6 +64,54 @@ class WorkspaceCommandDocsTest {
         assertTrue(
             violations.isEmpty(),
             "Removed CLI command snippets still documented:\n${violations.joinToString("\n")}",
+        )
+    }
+
+    @Test
+    fun `installer guidance uses up as the primary standalone start command`() {
+        val repoRoot = locateRepoRoot()
+        val files = listOf(
+            repoRoot.resolve("README.md"),
+            repoRoot.resolve("docs/getting-started/install.md"),
+            repoRoot.resolve("docs/getting-started/backends.md"),
+            repoRoot.resolve("kast.sh"),
+        )
+        val staleGuidance = listOf(
+            "Start with: kast daemon start",
+            "start the standalone backend before",
+            "Then start the standalone backend",
+            "cd /your/kotlin/project && kast daemon start",
+            "kast daemon start --workspace-root=/absolute/path/to/workspace",
+        )
+        val violations = files.flatMap { path ->
+            val text = path.readText()
+            staleGuidance
+                .filter(text::contains)
+                .map { snippet -> "$path contains $snippet" }
+        }
+
+        assertTrue(
+            violations.isEmpty(),
+            "Standalone lifecycle guidance should point users at kast up:\n${violations.joinToString("\n")}",
+        )
+    }
+
+    @Test
+    fun `cli cheat sheet lists every rpc method from the generated command catalog`() {
+        val repoRoot = locateRepoRoot()
+        val cheatSheet = repoRoot.resolve("docs/cli-cheat-sheet.md").readText()
+        val commands = defaultCliJson()
+            .parseToJsonElement(VersionedCommandSpec.renderJson(version = "test"))
+            .jsonObject["commands"]!!
+            .jsonObject
+            .values
+            .map { command -> command.jsonObject["method"]!!.jsonPrimitive.content }
+
+        val missing = commands.filterNot { method -> cheatSheet.contains(method) }
+
+        assertTrue(
+            missing.isEmpty(),
+            "docs/cli-cheat-sheet.md is missing RPC methods from commands.json:\n${missing.joinToString("\n")}",
         )
     }
 

--- a/kast.sh
+++ b/kast.sh
@@ -1056,7 +1056,7 @@ _install_standalone_backend() {
   ln -sfn "$backend_release_dir" "$current_link"
 
   log_success "Standalone backend installed to ${backend_release_dir}"
-  log_note "Start with: kast daemon start --workspace-root=/absolute/path/to/workspace"
+  log_note "Start with: kast up --workspace-root=/absolute/path/to/workspace"
   return 0
 }
 
@@ -1626,7 +1626,7 @@ _install_summary_phase() {
     printf '  %s\n' "  IntelliJ: Settings → Plugins → ⚙ → Install from Disk" >&2
     printf '  %s\n' "  Select: ${install_root}/plugins/" >&2
   elif [[ "$install_standalone" == "true" ]]; then
-    printf '  %s\n' "  kast daemon start --workspace-root=/absolute/path/to/workspace" >&2
+    printf '  %s\n' "  kast up --workspace-root=/absolute/path/to/workspace" >&2
   fi
   printf '\n' >&2
 }

--- a/scripts/headless-agent-install.sh
+++ b/scripts/headless-agent-install.sh
@@ -99,6 +99,7 @@ verify_install() {
   local runtime_libs_dir="${install_root}/backends/current/runtime-libs"
   local skill_dir="${install_root}/lib/skills/kast"
   local extension_marker="${workspace_root}/.github/.kast-copilot-version"
+  local copilot_root="${workspace_root}/.github"
 
   [[ -x "$kast_bin" ]] || die "Installed kast launcher is missing: $kast_bin"
   "$kast_bin" --help >/dev/null
@@ -111,6 +112,11 @@ verify_install() {
   [[ -f "${skill_dir}/SKILL.md" ]] || die "Packaged skill was not installed: ${skill_dir}/SKILL.md"
   if [[ "$skip_copilot_extension" != "true" ]]; then
     [[ -f "$extension_marker" ]] || die "Copilot extension was not installed: $extension_marker"
+    [[ -f "${copilot_root}/agents/kast-orchestrator.md" ]] || die "Copilot agent was not installed: ${copilot_root}/agents/kast-orchestrator.md"
+    [[ -f "${copilot_root}/hooks/hooks.json" ]] || die "Copilot hooks were not installed: ${copilot_root}/hooks/hooks.json"
+    [[ -f "${copilot_root}/extensions/kast/extension.mjs" ]] || die "Kast Copilot extension was not installed: ${copilot_root}/extensions/kast/extension.mjs"
+    [[ -x "${copilot_root}/extensions/kast/scripts/resolve-kast.sh" ]] || die "Kast resolver was not installed executable: ${copilot_root}/extensions/kast/scripts/resolve-kast.sh"
+    [[ -f "${copilot_root}/extensions/kotlin-gradle-loop/extension.mjs" ]] || die "Kotlin Gradle loop extension was not installed: ${copilot_root}/extensions/kotlin-gradle-loop/extension.mjs"
   fi
   [[ -f "$manifest_file" ]] || die "Install manifest was not written: $manifest_file"
 

--- a/scripts/package-headless-agent-bundle.sh
+++ b/scripts/package-headless-agent-bundle.sh
@@ -203,6 +203,10 @@ This bundle installs the Kast CLI, standalone backend, packaged skill, and
 repo-local Copilot extension from bundle-local artifacts. It is intended for
 Linux x64 headless agent images and CI-like bootstrap flows.
 
+The installer verifies the contained CLI launcher, standalone runtime libs,
+packaged skill, install manifest, Copilot hooks, native extension files, and
+executable resolver before it exits.
+
 ## Contents
 
 - \`install.sh\` - entrypoint for this bundle

--- a/scripts/smoke-headless-agent-bundle.sh
+++ b/scripts/smoke-headless-agent-bundle.sh
@@ -132,6 +132,15 @@ if [[ "$command_name" == "install" ]]; then
       [[ -n "$target_dir" ]] || { printf '%s\n' "missing --target-dir" >&2; exit 1; }
       mkdir -p "${target_dir}/hooks"
       printf '%s\n' '{"version":1,"hooks":{}}' > "${target_dir}/hooks/hooks.json"
+      mkdir -p \
+        "${target_dir}/agents" \
+        "${target_dir}/extensions/kast/scripts" \
+        "${target_dir}/extensions/kotlin-gradle-loop"
+      printf '%s\n' "# fake orchestrator" > "${target_dir}/agents/kast-orchestrator.md"
+      printf '%s\n' "export default {};" > "${target_dir}/extensions/kast/extension.mjs"
+      printf '%s\n' "#!/usr/bin/env bash" "printf '%s\n' fake-kast" > "${target_dir}/extensions/kast/scripts/resolve-kast.sh"
+      chmod +x "${target_dir}/extensions/kast/scripts/resolve-kast.sh"
+      printf '%s\n' "export default {};" > "${target_dir}/extensions/kotlin-gradle-loop/extension.mjs"
       printf '%s\n' "fake" > "${target_dir}/.kast-copilot-version"
       exit 0
       ;;
@@ -195,6 +204,11 @@ grep -Fq "binaryPath = \"${installed_launcher}\"" "$config_file" || die "config.
 [[ -d "$runtime_libs_dir" ]] || die "Missing standalone runtime libs: $runtime_libs_dir"
 [[ -f "${skill_dir}/SKILL.md" ]] || die "Missing installed skill: ${skill_dir}/SKILL.md"
 [[ -f "$extension_marker" ]] || die "Missing Copilot extension marker: $extension_marker"
+[[ -f "${workspace_root}/.github/agents/kast-orchestrator.md" ]] || die "Missing Copilot agent"
+[[ -f "${workspace_root}/.github/hooks/hooks.json" ]] || die "Missing Copilot hooks"
+[[ -f "${workspace_root}/.github/extensions/kast/extension.mjs" ]] || die "Missing kast Copilot extension"
+[[ -x "${workspace_root}/.github/extensions/kast/scripts/resolve-kast.sh" ]] || die "Missing executable kast resolver"
+[[ -f "${workspace_root}/.github/extensions/kotlin-gradle-loop/extension.mjs" ]] || die "Missing Kotlin Gradle loop extension"
 [[ -f "$env_file" ]] || die "Missing sourceable env file: $env_file"
 "$installed_launcher" --help >/dev/null
 

--- a/scripts/smoke-headless-agent-install.sh
+++ b/scripts/smoke-headless-agent-install.sh
@@ -86,6 +86,7 @@ cli_tree="${scratch_dir}/cli"
 backend_tree="${scratch_dir}/backend"
 workspace_root="${scratch_dir}/workspace"
 skip_workspace_root="${scratch_dir}/skip-workspace"
+marker_only_workspace_root="${scratch_dir}/marker-only-workspace"
 home_dir="${scratch_dir}/home"
 install_root="${scratch_dir}/contained-kast"
 skip_install_root="${scratch_dir}/skip-contained-kast"
@@ -96,6 +97,7 @@ mkdir -p \
   "${backend_tree}/backend-standalone/runtime-libs" \
   "${workspace_root}" \
   "${skip_workspace_root}" \
+  "${marker_only_workspace_root}" \
   "${home_dir}"
 
 cat > "${cli_tree}/kast-cli/kast-cli" <<'FAKE_KAST'
@@ -142,6 +144,17 @@ if [[ "$command_name" == "install" ]]; then
       [[ -n "$target_dir" ]] || { printf '%s\n' "missing --target-dir" >&2; exit 1; }
       mkdir -p "${target_dir}/hooks"
       printf '%s\n' '{"version":1,"hooks":{}}' > "${target_dir}/hooks/hooks.json"
+      if [[ "${KAST_FAKE_COPILOT_MARKER_ONLY:-false}" != "true" ]]; then
+        mkdir -p \
+          "${target_dir}/agents" \
+          "${target_dir}/extensions/kast/scripts" \
+          "${target_dir}/extensions/kotlin-gradle-loop"
+        printf '%s\n' "# fake orchestrator" > "${target_dir}/agents/kast-orchestrator.md"
+        printf '%s\n' "export default {};" > "${target_dir}/extensions/kast/extension.mjs"
+        printf '%s\n' "#!/usr/bin/env bash" "printf '%s\n' fake-kast" > "${target_dir}/extensions/kast/scripts/resolve-kast.sh"
+        chmod +x "${target_dir}/extensions/kast/scripts/resolve-kast.sh"
+        printf '%s\n' "export default {};" > "${target_dir}/extensions/kotlin-gradle-loop/extension.mjs"
+      fi
       printf '%s\n' "fake" > "${target_dir}/.kast-copilot-version"
       exit 0
       ;;
@@ -167,6 +180,7 @@ zip_dir "$backend_zip" "$backend_tree"
 
 git -C "$workspace_root" init -q
 git -C "$skip_workspace_root" init -q
+git -C "$marker_only_workspace_root" init -q
 
 HOME="$home_dir" \
 SHELL=/bin/bash \
@@ -194,6 +208,10 @@ grep -Fq "installRoot = \"${install_root}\"" "$config_file" || die "config.toml 
 [[ -f "${skill_dir}/SKILL.md" ]] || die "Missing installed skill: ${skill_dir}/SKILL.md"
 [[ -f "$extension_marker" ]] || die "Missing Copilot extension marker: $extension_marker"
 [[ -f "${workspace_root}/.github/hooks/hooks.json" ]] || die "Missing Copilot hooks"
+[[ -f "${workspace_root}/.github/agents/kast-orchestrator.md" ]] || die "Missing Copilot agent"
+[[ -f "${workspace_root}/.github/extensions/kast/extension.mjs" ]] || die "Missing kast Copilot extension"
+[[ -x "${workspace_root}/.github/extensions/kast/scripts/resolve-kast.sh" ]] || die "Missing executable kast resolver"
+[[ -f "${workspace_root}/.github/extensions/kotlin-gradle-loop/extension.mjs" ]] || die "Missing Kotlin Gradle loop extension"
 [[ -f "$env_file" ]] || die "Missing sourceable env file: $env_file"
 grep -Fq "export KAST_CONFIG_HOME=\"${install_root}/config\"" "$env_file" || die "env file missing KAST_CONFIG_HOME"
 grep -Fq "export PATH=\"${install_root}/bin:\$PATH\"" "$env_file" || die "env file missing PATH export"
@@ -239,6 +257,19 @@ if HOME="$home_dir" \
   KAST_AGENT_WORKSPACE="$workspace_root" \
   "${repo_root}/scripts/headless-agent-install.sh" >/dev/null 2>&1; then
   die "Bad CLI checksum unexpectedly succeeded"
+fi
+
+if HOME="$home_dir" \
+  SHELL=/bin/bash \
+  KAST_AGENT_CLI_URL="$(file_uri "$cli_zip")" \
+  KAST_AGENT_BACKEND_URL="$(file_uri "$backend_zip")" \
+  KAST_AGENT_CLI_SHA256="$(compute_sha256 "$cli_zip")" \
+  KAST_AGENT_BACKEND_SHA256="$(compute_sha256 "$backend_zip")" \
+  KAST_AGENT_INSTALL_ROOT="${scratch_dir}/marker-only-install" \
+  KAST_AGENT_WORKSPACE="$marker_only_workspace_root" \
+  KAST_FAKE_COPILOT_MARKER_ONLY=true \
+  "${repo_root}/scripts/headless-agent-install.sh" >/dev/null 2>&1; then
+  die "Marker-only Copilot extension unexpectedly succeeded"
 fi
 
 printf '%s\n' "Headless agent installer smoke test passed"

--- a/scripts/smoke-native-cli.sh
+++ b/scripts/smoke-native-cli.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/smoke-native-cli.sh <kast-binary>
+
+Smoke a native Kast CLI binary deeply enough to prove embedded agent resources
+are present, not just that --help starts.
+USAGE
+}
+
+[[ "${1:-}" != "--help" && "${1:-}" != "-h" ]] || { usage; exit 0; }
+[[ $# -eq 1 ]] || { usage; die "Expected exactly one kast binary path"; }
+
+kast_bin="$1"
+[[ -x "$kast_bin" ]] || die "Kast binary is missing or not executable: $kast_bin"
+
+scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/kast-native-smoke.XXXXXX")"
+cleanup() {
+  rm -rf "$scratch_dir"
+}
+trap cleanup EXIT
+
+skill_root="${scratch_dir}/skills"
+workspace_root="${scratch_dir}/workspace"
+github_root="${workspace_root}/.github"
+
+mkdir -p "$skill_root" "$workspace_root"
+git -C "$workspace_root" init -q
+
+"$kast_bin" --help >/dev/null
+
+"$kast_bin" install skill --target-dir="$skill_root" --name=kast --yes=true >/dev/null
+[[ -f "${skill_root}/kast/SKILL.md" ]] || die "Native CLI did not install packaged skill"
+[[ -f "${skill_root}/kast/references/commands.json" ]] || die "Native CLI skill install missed commands.json"
+[[ -x "${skill_root}/kast/scripts/resolve-kast.sh" ]] || die "Native CLI skill install missed executable resolver"
+
+"$kast_bin" install copilot-extension --target-dir="$github_root" --yes=true >/dev/null
+[[ -f "${github_root}/agents/kast-orchestrator.md" ]] || die "Native CLI did not install Copilot agent"
+[[ -f "${github_root}/hooks/hooks.json" ]] || die "Native CLI did not install Copilot hooks"
+[[ -f "${github_root}/extensions/kast/extension.mjs" ]] || die "Native CLI did not install kast native extension"
+[[ -x "${github_root}/extensions/kast/scripts/resolve-kast.sh" ]] || die "Native CLI did not install executable kast resolver"
+[[ -f "${github_root}/extensions/kotlin-gradle-loop/extension.mjs" ]] || die "Native CLI did not install Kotlin Gradle loop extension"
+
+printf '%s\n' "Native CLI embedded-resource smoke test passed"

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/verify-release-assets.sh --release-dir <dir> --tag <vX.Y.Z>
+
+Verify a downloaded Kast release directory. The directory must contain the five
+published zip assets, SHA256SUMS, and build-provenance.json.
+USAGE
+}
+
+release_dir=""
+tag=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release-dir)
+      [[ $# -ge 2 ]] || die "Missing value for --release-dir"
+      release_dir="$2"; shift 2 ;;
+    --release-dir=*)
+      release_dir="${1#--release-dir=}"; shift ;;
+    --tag)
+      [[ $# -ge 2 ]] || die "Missing value for --tag"
+      tag="$2"; shift 2 ;;
+    --tag=*)
+      tag="${1#--tag=}"; shift ;;
+    --help|-h)
+      usage; exit 0 ;;
+    *)
+      usage; die "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$release_dir" ]] || { usage; die "--release-dir is required"; }
+[[ -n "$tag" ]] || { usage; die "--tag is required"; }
+[[ "$tag" == v* ]] || die "--tag must start with v: $tag"
+[[ -d "$release_dir" ]] || die "Release directory not found: $release_dir"
+[[ -f "${release_dir}/SHA256SUMS" ]] || die "SHA256SUMS not found in $release_dir"
+[[ -f "${release_dir}/build-provenance.json" ]] || die "build-provenance.json not found in $release_dir"
+
+python3 - "$release_dir" "$tag" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+release_dir = Path(sys.argv[1])
+tag = sys.argv[2]
+
+expected = {
+    "linux-x64": f"kast-{tag}-linux-x64.zip",
+    "macos-arm64": f"kast-{tag}-macos-arm64.zip",
+    "headless-agent-linux-x64": f"kast-headless-agent-{tag}-linux-x64.zip",
+    "intellij": f"kast-intellij-{tag}.zip",
+    "standalone": f"kast-standalone-{tag}.zip",
+}
+expected_assets = set(expected.values())
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+sha_entries = {}
+for raw_line in (release_dir / "SHA256SUMS").read_text(encoding="utf-8").splitlines():
+    line = raw_line.strip()
+    if not line:
+        continue
+    parts = line.split()
+    if len(parts) != 2:
+        fail(f"invalid SHA256SUMS line: {raw_line}")
+    digest, asset_name = parts
+    if asset_name in sha_entries:
+        fail(f"duplicate checksum entry for {asset_name}")
+    sha_entries[asset_name] = digest
+
+actual_assets = {path.name for path in release_dir.glob("*.zip")}
+unexpected_assets = sorted(actual_assets - expected_assets)
+if unexpected_assets:
+    fail(f"unexpected release asset: {unexpected_assets}")
+
+missing_assets = sorted(expected_assets - actual_assets)
+if missing_assets:
+    fail(f"missing release asset: {missing_assets}")
+
+unexpected_checksums = sorted(set(sha_entries) - expected_assets)
+if unexpected_checksums:
+    fail(f"unexpected checksum entry: {unexpected_checksums}")
+
+for asset_name in expected_assets:
+    asset_path = release_dir / asset_name
+    expected_digest = sha_entries.get(asset_name)
+    if expected_digest is None:
+        fail(f"missing checksum entry for {asset_name}")
+    actual_digest = hashlib.sha256(asset_path.read_bytes()).hexdigest()
+    if actual_digest != expected_digest:
+        fail(f"checksum mismatch for {asset_name}: expected {expected_digest}, got {actual_digest}")
+
+payload = json.loads((release_dir / "build-provenance.json").read_text(encoding="utf-8"))
+builds = payload.get("builds")
+if not isinstance(builds, list):
+    fail("build-provenance.json must contain a builds array")
+
+by_platform = {}
+for entry in builds:
+    if not isinstance(entry, dict):
+        fail("build-provenance.json builds entries must be objects")
+    platform_id = entry.get("platformId")
+    if platform_id in by_platform:
+        fail(f"duplicate provenance entry for {platform_id}")
+    by_platform[platform_id] = entry
+
+missing_provenance = sorted(set(expected) - set(by_platform))
+if missing_provenance:
+    fail(f"missing provenance for {missing_provenance}")
+
+unexpected_provenance = sorted(set(by_platform) - set(expected))
+if unexpected_provenance:
+    fail(f"unexpected provenance for {unexpected_provenance}")
+
+for platform_id, asset_name in expected.items():
+    entry = by_platform[platform_id]
+    provenance_asset = entry.get("assetName")
+    if provenance_asset != asset_name:
+        fail(f"provenance asset mismatch for {platform_id}: expected {asset_name}, got {provenance_asset}")
+    provenance_digest = entry.get("assetDigest")
+    expected_digest = "sha256:" + sha_entries[asset_name]
+    if provenance_digest != expected_digest:
+        fail(f"provenance digest mismatch for {platform_id}: expected {expected_digest}, got {provenance_digest}")
+
+print(f"Verified Kast release assets for {tag} in {release_dir}")
+PY


### PR DESCRIPTION
## Summary

Harden the release and enterprise install path so the release workflow validates the full published artifact set before public publication, records per-asset provenance, and only updates Homebrew after the GitHub release is verified.

This also adds smoke coverage for the headless agent bundle, installer verification, native-image embedded resources, and the release asset verifier. The docs now point operators at the verified release path and current `kast` CLI commands.

## Validation

- `git diff --check`
- `bash -n .github/scripts/test-release-asset-verifier.sh .github/scripts/test-release-workflow-contract.sh scripts/headless-agent-install.sh scripts/package-headless-agent-bundle.sh scripts/smoke-headless-agent-bundle.sh scripts/smoke-headless-agent-install.sh scripts/smoke-native-cli.sh scripts/verify-release-assets.sh kast.sh`
- `./.github/scripts/test-release-workflow-contract.sh`
- `./.github/scripts/test-release-asset-verifier.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/release.yml`
- `./scripts/smoke-headless-agent-install.sh`
- `./scripts/smoke-headless-agent-bundle.sh`
- `./scripts/smoke-native-cli.sh kast-cli/build/scripts/kast-cli`
- `bash /Users/amichne/code/apollo/skills/kotlin-gradle-loop/scripts/gradle/run_task.sh /Users/amichne/code/kast :kast-cli:test --tests io.github.amichne.kast.cli.NativeImageConfigurationTest --tests io.github.amichne.kast.cli.SmokeCommandSupportTest --tests io.github.amichne.kast.cli.WorkspaceCommandDocsTest`
- `bash /Users/amichne/code/apollo/skills/kotlin-gradle-loop/scripts/gradle/run_task.sh /Users/amichne/code/kast :analysis-server:test --tests io.github.amichne.kast.server.AnalysisServerSocketTest`

## Notes

Local `:kast-cli:nativeCompile` is still left to CI because this machine is on Temurin and does not provide `native-image`. The CI native lane installs GraalVM and then runs `scripts/smoke-native-cli.sh` against the produced native binary.