### PR TITLE
fix: preflight stable release automation

### DIFF
--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -80,6 +80,9 @@ require_contains "$ci_workflow" "kast-cli/build/native/nativeCompile/kast" "Nati
 require_contains "$ci_workflow" "./scripts/smoke-native-cli.sh kast-cli/build/native/nativeCompile/kast" "Native CLI job must smoke embedded agent resources"
 
 require_contains "$release_workflow" "Generate and upload SHA256SUMS" "Release must publish aggregate checksums"
+require_contains "$release_workflow" "Preflight stable release automation" "Release must preflight stable-release automation before side effects"
+require_contains "$release_workflow" "Require Homebrew token for stable releases" "Stable releases must require the Homebrew tap token before tagging"
+require_contains "$release_workflow" "HOMEBREW_TAP_TOKEN: \${{ secrets.HOMEBREW_TAP_TOKEN }}" "Stable release preflight must inspect the Homebrew tap token"
 require_contains "$release_workflow" "Dispatch Homebrew tap update" "Release must dispatch the Homebrew tap update"
 require_contains "$release_workflow" "Wait for Homebrew tap update" "Release must wait for the Homebrew tap update"
 require_contains "$release_workflow" "gh run watch" "Release must watch the Homebrew tap workflow result"
@@ -107,6 +110,8 @@ require_contains "$release_workflow" '[[ "$tag" == *-* ]]' "Release publication 
 require_contains "$release_workflow" 'release_flags+=(--prerelease)' "Prerelease tags must publish as prereleases"
 require_contains "$release_workflow" 'release_flags+=(--latest)' "Stable tags must publish as latest releases"
 require_order "$release_workflow" "Generate and upload SHA256SUMS" "Publish draft release with provenance annotation" "Release must upload checksum manifest before publishing"
+require_order "$release_workflow" "Preflight stable release automation" "Bump version" "Release must check stable-release automation before tagging"
+require_order "$release_workflow" "Preflight stable release automation" "Prepare release" "Release must check stable-release automation before creating releases"
 require_order "$release_workflow" "Publish draft release with provenance annotation" "Dispatch Homebrew tap update" "Release must publish GitHub assets before updating Homebrew"
 require_order "$release_workflow" "Dispatch Homebrew tap update" "Wait for Homebrew tap update" "Release must wait only after dispatching Homebrew"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,47 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-preflight:
+    name: Preflight stable release automation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Classify release
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          requires_homebrew=false
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$RELEASE_TYPE" != "beta" ]]; then
+              requires_homebrew=true
+            fi
+          elif [[ "$REF_NAME" == v* && "$REF_NAME" != *-* ]]; then
+            requires_homebrew=true
+          fi
+
+          printf 'requires_homebrew=%s\n' "$requires_homebrew" >> "$GITHUB_OUTPUT"
+
+      - name: Require Homebrew token for stable releases
+        if: steps.classify.outputs.requires_homebrew == 'true'
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOMEBREW_TAP_TOKEN:-}" ]]; then
+            echo "::error::Missing HOMEBREW_TAP_TOKEN secret; stable releases cannot update amichne/homebrew-kast."
+            exit 1
+          fi
+
   # ── Step 0 (workflow_dispatch only): auto-increment semver and push new tag ──
   bump-version:
     name: Bump version (${{ inputs.release_type }})
+    needs: [release-preflight]
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -112,8 +150,8 @@ jobs:
     name: Prepare release
     # Run after bump-version (workflow_dispatch) or directly (push tag).
     # 'always()' lets us proceed even when bump-version was skipped.
-    needs: [bump-version]
-    if: always() && (needs.bump-version.result == 'success' || needs.bump-version.result == 'skipped')
+    needs: [release-preflight, bump-version]
+    if: always() && needs.release-preflight.result == 'success' && (needs.bump-version.result == 'success' || needs.bump-version.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.release-tag.outputs.value }}


### PR DESCRIPTION
## Summary

Add a release preflight job so stable releases require `HOMEBREW_TAP_TOKEN` before the workflow can create a tag or draft release.

The v0.7.4 release proved the GitHub asset path, checksum/provenance verification, and published release path, but the final Homebrew dispatch failed after publication because the secret is absent. This patch makes that failure happen before release side effects on future stable releases.

## Validation

- `./.github/scripts/test-release-workflow-contract.sh`
- `./.github/scripts/test-release-asset-verifier.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/ci.yml`
- `git diff --check`

## Notes

`HOMEBREW_TAP_TOKEN` is still not configured in `amichne/kast`; `gh secret list --repo amichne/kast` currently shows only `CLAUDE_CODE_OAUTH_TOKEN`. I manually dispatched `amichne/homebrew-kast` for v0.7.4 with the verified release checksums, and that tap workflow succeeded.