### PR TITLE
Update artifact actions for Node 24

### DIFF
--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -65,9 +65,20 @@ require_order() {
 repo_root="$(resolve_repo_root)"
 ci_workflow="${repo_root}/.github/workflows/ci.yml"
 release_workflow="${repo_root}/.github/workflows/release.yml"
+copilot_setup_workflow="${repo_root}/.github/workflows/copilot-setup-steps.yml"
 
 [[ -f "$ci_workflow" ]] || die "CI workflow not found: $ci_workflow"
 [[ -f "$release_workflow" ]] || die "Release workflow not found: $release_workflow"
+[[ -f "$copilot_setup_workflow" ]] || die "Copilot setup workflow not found: $copilot_setup_workflow"
+
+for workflow in "$ci_workflow" "$release_workflow" "$copilot_setup_workflow"; do
+  require_not_contains "$workflow" "actions/cache@v4" "Workflow actions must not use the Node 20 cache action"
+  require_not_contains "$workflow" "actions/upload-artifact@v4" "Workflow actions must not use the Node 20 upload-artifact action"
+  require_not_contains "$workflow" "actions/upload-artifact@v5" "Workflow actions must not use the preliminary Node 24 upload-artifact action"
+  require_not_contains "$workflow" "actions/download-artifact@v4" "Workflow actions must not use the Node 20 download-artifact action"
+  require_not_contains "$workflow" "actions/download-artifact@v5" "Workflow actions must not use the old-runtime download-artifact action"
+  require_not_contains "$workflow" "actions/download-artifact@v6" "Workflow actions must not use the preliminary Node 24 download-artifact action"
+done
 
 require_contains "$ci_workflow" "Workflow release contracts" "CI must run this workflow contract check"
 require_contains "$ci_workflow" "./.github/scripts/test-release-asset-verifier.sh" "CI must test the release asset verifier"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/kast/intellij-distributions
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload build-and-test test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-and-test-reports-${{ matrix.os }}
           path: |
@@ -74,7 +74,7 @@ jobs:
           retention-days: 3
 
       - name: Upload portable distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: kast-portable-${{ matrix.os }}
           path: kast-cli/build/distributions/kast-cli-*-portable.zip
@@ -138,7 +138,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/kast/intellij-distributions
@@ -156,7 +156,7 @@ jobs:
           :backend-intellij:verifyPlugin
 
       - name: Upload IntelliJ plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: kast-intellij-plugin
           path: backend-intellij/build/distributions/*.zip
@@ -185,7 +185,7 @@ jobs:
           java-version: "21"
 
       - name: Download portable distribution
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: kast-portable-${{ matrix.os }}
           path: kast-cli/build/distributions
@@ -229,7 +229,7 @@ jobs:
           java-version: "21"
 
       - name: Download portable distribution
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: kast-portable-ubuntu-latest
           path: kast-cli/build/distributions
@@ -254,7 +254,7 @@ jobs:
 
       - name: Upload eval result
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: skill-eval-result
           path: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '21'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache IntelliJ distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/kast/intellij-distributions
           key: idea-dist-${{ hashFiles('gradle/libs.versions.toml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,7 +358,7 @@ jobs:
 
       - name: Upload build artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-asset-${{ matrix.asset_id }}-${{ github.run_id }}
           path: |
@@ -384,7 +384,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.gradle/kast/intellij-distributions
           key: idea-dist-${{ hashFiles('gradle/libs.versions.toml') }}
@@ -443,7 +443,7 @@ jobs:
 
       - name: Upload plugin artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: intellij-plugin-${{ github.run_id }}
           path: |
@@ -514,7 +514,7 @@ jobs:
 
       - name: Upload standalone backend artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: standalone-backend-${{ github.run_id }}
           path: |
@@ -536,19 +536,19 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download all provenance artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: provenance-artifacts
           pattern: release-asset-*
 
       - name: Download IntelliJ provenance
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: provenance-intellij
           pattern: intellij-plugin-*
 
       - name: Download standalone backend provenance
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: provenance-standalone
           pattern: standalone-backend-*


### PR DESCRIPTION
## Summary
- update cache, upload-artifact, and download-artifact workflow pins to Node 24 action majors
- extend the release workflow contract test so old Node 20 artifact/cache action majors cannot drift back in

## Validation
- ./.github/scripts/test-release-workflow-contract.sh
- ./.github/scripts/test-release-asset-verifier.sh
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/copilot-setup-steps.yml
- git diff --check