### PR TITLE
Add release operator preflight

### DIFF
--- a/.github/scripts/test-release-preflight.sh
+++ b/.github/scripts/test-release-preflight.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/../.." && pwd
+}
+
+repo_root="$(resolve_repo_root)"
+preflight="${repo_root}/scripts/release-preflight.sh"
+[[ -x "$preflight" ]] || die "release preflight helper is missing or not executable: $preflight"
+
+scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/kast-release-preflight.XXXXXX")"
+cleanup() {
+  rm -rf "$scratch_dir"
+}
+trap cleanup EXIT
+
+fake_bin="${scratch_dir}/bin"
+mkdir -p "$fake_bin"
+cat > "${fake_bin}/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${GH_CALL_LOG:?}"
+
+case "$1" in
+  auth)
+    [[ "$2" == "status" ]]
+    exit 0
+    ;;
+  workflow)
+    [[ "$2" == "view" && "$3" == "release.yml" ]]
+    exit 0
+    ;;
+  repo)
+    [[ "$2" == "view" ]]
+    exit 0
+    ;;
+  secret)
+    [[ "$2" == "list" ]]
+    if [[ "${FAKE_HOMEBREW_SECRET:-missing}" == "present" ]]; then
+      printf 'CLAUDE_CODE_OAUTH_TOKEN\t2026-04-15T01:16:57Z\n'
+      printf 'HOMEBREW_TAP_TOKEN\t2026-05-21T00:00:00Z\n'
+    else
+      printf 'CLAUDE_CODE_OAUTH_TOKEN\t2026-04-15T01:16:57Z\n'
+    fi
+    ;;
+  *)
+    printf 'unexpected gh command: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+GH
+chmod +x "${fake_bin}/gh"
+
+export PATH="${fake_bin}:${PATH}"
+export GH_CALL_LOG="${scratch_dir}/gh-calls.log"
+
+if FAKE_HOMEBREW_SECRET=missing "$preflight" --release-type patch >"${scratch_dir}/missing.out" 2>"${scratch_dir}/missing.err"; then
+  die "stable release preflight unexpectedly passed without HOMEBREW_TAP_TOKEN"
+fi
+grep -Fq "Missing required GitHub secret HOMEBREW_TAP_TOKEN" "${scratch_dir}/missing.err" || die "missing-secret failure did not name HOMEBREW_TAP_TOKEN"
+
+: > "$GH_CALL_LOG"
+FAKE_HOMEBREW_SECRET=missing "$preflight" --release-type beta >"${scratch_dir}/beta.out"
+grep -Fq "Homebrew token is not required for beta releases" "${scratch_dir}/beta.out" || die "beta preflight did not explain Homebrew token scope"
+
+: > "$GH_CALL_LOG"
+FAKE_HOMEBREW_SECRET=present "$preflight" --release-type patch >"${scratch_dir}/stable.out"
+grep -Fq "Release preflight passed for patch" "${scratch_dir}/stable.out" || die "stable preflight did not pass with HOMEBREW_TAP_TOKEN"
+grep -Fq "auth status --hostname github.com" "$GH_CALL_LOG" || die "preflight did not check GitHub auth"
+grep -Fq "workflow view release.yml --repo amichne/kast" "$GH_CALL_LOG" || die "preflight did not check the release workflow"
+grep -Fq "repo view amichne/homebrew-kast" "$GH_CALL_LOG" || die "preflight did not check Homebrew tap visibility"
+
+printf '%s\n' "Release preflight test passed"

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -82,6 +82,7 @@ done
 
 require_contains "$ci_workflow" "Workflow release contracts" "CI must run this workflow contract check"
 require_contains "$ci_workflow" "./.github/scripts/test-release-asset-verifier.sh" "CI must test the release asset verifier"
+require_contains "$ci_workflow" "./.github/scripts/test-release-preflight.sh" "CI must test the release preflight helper"
 require_contains "$ci_workflow" "Analysis server transport" "CI must include an independent analysis-server transport job"
 require_contains "$ci_workflow" "io.github.amichne.kast.server.AnalysisServerSocketTest" "Analysis server job must smoke the socket transport"
 require_contains "$ci_workflow" "Native CLI" "CI must include a native CLI job"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         shell: bash
         run: ./.github/scripts/test-release-asset-verifier.sh
 
+      - name: Test release preflight helper
+        shell: bash
+        run: ./.github/scripts/test-release-preflight.sh
+
   build-and-test:
     name: Build & test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -97,6 +97,10 @@ when to paginate or bound their queries:
   and `build-provenance.json` before publication. Beta tags publish as GitHub
   prereleases; stable tags publish the verified GitHub release before updating
   and watching the Homebrew tap.
+- Run `scripts/release-preflight.sh --release-type patch` before dispatching a
+  stable release. The helper checks GitHub CLI auth, release workflow
+  visibility, the `HOMEBREW_TAP_TOKEN` repository secret, and Homebrew tap
+  visibility before the workflow can create a tag or release.
 - Upstream sync workflow keeps the standalone backend's bundled IntelliJ
   distribution current.
 - Copilot setup steps pre-warm Gradle caches and Java 21 for GitHub Copilot

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/release-preflight.sh [--release-type major|minor|patch|beta] [--repo owner/name] [--homebrew-tap owner/name]
+
+Check operator-side GitHub prerequisites before dispatching the Kast release
+workflow. Stable releases require HOMEBREW_TAP_TOKEN so the release workflow can
+update amichne/homebrew-kast without publishing a release first and failing late.
+USAGE
+}
+
+release_type="patch"
+repo="${KAST_RELEASE_REPO:-amichne/kast}"
+homebrew_tap="${KAST_HOMEBREW_TAP_REPO:-amichne/homebrew-kast}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release-type)
+      [[ $# -ge 2 ]] || die "Missing value for --release-type"
+      release_type="$2"; shift 2 ;;
+    --release-type=*)
+      release_type="${1#--release-type=}"; shift ;;
+    --repo)
+      [[ $# -ge 2 ]] || die "Missing value for --repo"
+      repo="$2"; shift 2 ;;
+    --repo=*)
+      repo="${1#--repo=}"; shift ;;
+    --homebrew-tap)
+      [[ $# -ge 2 ]] || die "Missing value for --homebrew-tap"
+      homebrew_tap="$2"; shift 2 ;;
+    --homebrew-tap=*)
+      homebrew_tap="${1#--homebrew-tap=}"; shift ;;
+    --help|-h)
+      usage; exit 0 ;;
+    *)
+      usage; die "Unknown argument: $1" ;;
+  esac
+done
+
+case "$release_type" in
+  major|minor|patch|beta) ;;
+  *) die "--release-type must be one of: major, minor, patch, beta" ;;
+esac
+
+command -v gh >/dev/null 2>&1 || die "GitHub CLI is required: install gh and authenticate first"
+
+gh auth status --hostname github.com >/dev/null
+gh repo view "$repo" >/dev/null
+gh workflow view release.yml --repo "$repo" >/dev/null
+
+if [[ "$release_type" == "beta" ]]; then
+  printf '%s\n' "Homebrew token is not required for beta releases"
+  printf '%s\n' "Release preflight passed for beta"
+  exit 0
+fi
+
+secret_names="$(gh secret list --repo "$repo" | awk '{ print $1 }')"
+if ! grep -Fxq "HOMEBREW_TAP_TOKEN" <<<"$secret_names"; then
+  die "Missing required GitHub secret HOMEBREW_TAP_TOKEN in ${repo}; set it with: gh secret set HOMEBREW_TAP_TOKEN --repo ${repo}"
+fi
+
+gh repo view "$homebrew_tap" >/dev/null
+
+printf '%s\n' "Release preflight passed for ${release_type}"


### PR DESCRIPTION
## Summary
- add `scripts/release-preflight.sh` so maintainers can verify GitHub release prerequisites before dispatching a release
- cover stable missing-secret, stable ready, and beta preflight behavior with a stubbed `gh` test
- wire the preflight helper test into the release workflow contract CI job and document the operator command

## Validation
- bash -n scripts/release-preflight.sh .github/scripts/test-release-preflight.sh .github/scripts/test-release-workflow-contract.sh .github/scripts/test-release-asset-verifier.sh
- ./.github/scripts/test-release-preflight.sh
- ./.github/scripts/test-release-workflow-contract.sh
- ./.github/scripts/test-release-asset-verifier.sh
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/copilot-setup-steps.yml
- ./scripts/release-preflight.sh --release-type beta
- ./scripts/release-preflight.sh --release-type patch (expected failure until HOMEBREW_TAP_TOKEN is configured)
- git diff --check

Note: shellcheck is not installed in this environment.