### PR TITLE
Update docs workflow actions for Node 24

### DIFF
--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -66,12 +66,14 @@ repo_root="$(resolve_repo_root)"
 ci_workflow="${repo_root}/.github/workflows/ci.yml"
 release_workflow="${repo_root}/.github/workflows/release.yml"
 copilot_setup_workflow="${repo_root}/.github/workflows/copilot-setup-steps.yml"
+docs_workflow="${repo_root}/.github/workflows/docs.yml"
 
 [[ -f "$ci_workflow" ]] || die "CI workflow not found: $ci_workflow"
 [[ -f "$release_workflow" ]] || die "Release workflow not found: $release_workflow"
 [[ -f "$copilot_setup_workflow" ]] || die "Copilot setup workflow not found: $copilot_setup_workflow"
+[[ -f "$docs_workflow" ]] || die "Documentation workflow not found: $docs_workflow"
 
-for workflow in "$ci_workflow" "$release_workflow" "$copilot_setup_workflow"; do
+for workflow in "$ci_workflow" "$release_workflow" "$copilot_setup_workflow" "$docs_workflow"; do
   require_not_contains "$workflow" "actions/cache@v4" "Workflow actions must not use the Node 20 cache action"
   require_not_contains "$workflow" "actions/upload-artifact@v4" "Workflow actions must not use the Node 20 upload-artifact action"
   require_not_contains "$workflow" "actions/upload-artifact@v5" "Workflow actions must not use the preliminary Node 24 upload-artifact action"
@@ -79,6 +81,13 @@ for workflow in "$ci_workflow" "$release_workflow" "$copilot_setup_workflow"; do
   require_not_contains "$workflow" "actions/download-artifact@v5" "Workflow actions must not use the old-runtime download-artifact action"
   require_not_contains "$workflow" "actions/download-artifact@v6" "Workflow actions must not use the preliminary Node 24 download-artifact action"
 done
+
+require_not_contains "$docs_workflow" "actions/configure-pages@v5" "Documentation workflow must not use the Node 20 configure-pages action"
+require_not_contains "$docs_workflow" "actions/deploy-pages@v4" "Documentation workflow must not use the Node 20 deploy-pages action"
+require_not_contains "$docs_workflow" "actions/setup-python@v5" "Documentation workflow must not use the Node 20 setup-python action"
+require_not_contains "$docs_workflow" "actions/upload-pages-artifact@v4" "Documentation workflow must not use the Node 20 upload-pages-artifact action"
+require_contains "$docs_workflow" "pull_request:" "Documentation workflow must validate docs changes on pull requests"
+require_contains "$docs_workflow" "if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'" "Documentation deployment must be limited to main, not pull requests or branch dispatches"
 
 require_contains "$ci_workflow" "Workflow release contracts" "CI must run this workflow contract check"
 require_contains "$ci_workflow" "./.github/scripts/test-release-asset-verifier.sh" "CI must test the release asset verifier"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,12 @@
 name: Documentation
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/docs.yml"
+      - "docs/**"
+      - "requirements-docs.txt"
+      - "zensical.toml"
   push:
     branches:
       - main
@@ -17,27 +23,33 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: requirements-docs.txt
       - run: pip install -r requirements-docs.txt
       - run: zensical build --clean
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
-      - uses: actions/deploy-pages@v4
+
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -18,7 +18,7 @@ USAGE
 
 release_type="patch"
 repo="${KAST_RELEASE_REPO:-amichne/kast}"
-homebrew_tap="${KAST_HOMEBREW_TAP_REPO:-amichne/homebrew-kast}"
+homebrew_tap="${KAST_RELEASE_TAP_REPO:-amichne/homebrew-kast}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in


### PR DESCRIPTION
## Summary
- update the documentation workflow to Node 24 action majors for Pages, Python setup, and Pages artifact upload/deploy
- split docs build from protected Pages deployment so PR/manual branch runs validate docs without deploying
- extend the workflow contract guard so docs workflow action pins cannot drift back to Node 20 majors
- rename the release preflight tap override env var away from the removed `KAST_HOME` token prefix

## Validation
- ./.github/scripts/test-release-workflow-contract.sh
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs.yml .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/copilot-setup-steps.yml
- rg -n "actions/(configure-pages@v5|deploy-pages@v4|setup-python@v5|upload-pages-artifact@v4|cache@v4|upload-artifact@v[45]|download-artifact@v[456])" .github/workflows || true
- bash /Users/amichne/code/apollo/skills/kotlin-gradle-loop/scripts/gradle/run_task.sh /Users/amichne/code/kast :kast-cli:test --tests io.github.amichne.kast.cli.ForbiddenEnvironmentTokenGuardTest
- ./.github/scripts/test-release-preflight.sh
- ./scripts/release-preflight.sh --release-type beta
- ./scripts/release-preflight.sh --release-type patch (expected failure until HOMEBREW_TAP_TOKEN is configured)
- git diff --check