### PR TITLE
docs: refine sidebar navigation

### DIFF
--- a/.github/scripts/test-docs-content-contract.sh
+++ b/.github/scripts/test-docs-content-contract.sh
@@ -70,6 +70,7 @@ require_not_contains "$readme" 'IntelliJ plugin-backed runtime' "README must use
 
 require_contains "$readme" "brew tap amichne/kast" "README must document the Homebrew tap install"
 require_order "$readme" "brew tap amichne/kast" "curl -fsSL https://raw.githubusercontent.com/amichne/kast/HEAD/kast.sh | bash" "README must promote Homebrew before the shell installer"
+require_contains "$readme" "amichne/kast-action@v1" "README must point hosted agents to the GitHub Action install path"
 require_contains "$readme" "headless agent installs from internal artifacts or self-contained" "README must point CI/headless users to the contained install docs"
 require_contains "$index_doc" "brew install kast" "Docs overview must promote Homebrew for the first local install example"
 
@@ -77,6 +78,12 @@ require_contains "$install_doc" "## Homebrew install" "Install docs must disting
 require_contains "$install_doc" "## Shell installer" "Install docs must keep the shell installer for portable and full-stack flows"
 require_order "$install_doc" "## Homebrew install" "## Shell installer" "Install docs must promote Homebrew before the shell installer"
 require_contains "$install_doc" "## Developer, CI, and cloud-agent paths" "Install docs must distinguish developer, CI, and cloud-agent flows"
+require_contains "$install_doc" "## GitHub Actions and hosted agents" "Install docs must cover action-based hosted agent installs"
+require_contains "$install_doc" "amichne/kast-action@v1" "Install docs must document the public Kast GitHub Action"
+require_contains "$install_doc" "bundle-url" "Install docs must document mirrored headless bundle input"
+require_contains "$install_doc" "bundle-sha256" "Install docs must require checksums for mirrored action installs"
+require_contains "$install_doc" "skip-copilot-extension: true" "Install docs must show the conservative enterprise action default"
+require_contains "$install_doc" "KAST_INSTALL_SOURCE=action" "Install docs must document action install metadata"
 require_contains "$install_doc" 'scripts/headless-agent-install.sh' "Install docs must document the headless agent installer"
 require_contains "$install_doc" 'scripts/package-headless-agent-bundle.sh' "Install docs must document bundle packaging"
 require_contains "$install_doc" 'scripts/verify-release-assets.sh' "Install docs must document release asset verification"
@@ -92,6 +99,7 @@ require_contains "$backends_doc" 'IDEA / Android Studio plugin backend' "Backend
 require_contains "$quickstart_doc" 'APP_FILE="$PWD/src/main/kotlin/App.kt"' "Quickstart must show a shell-expanded absolute file path"
 require_contains "$quickstart_doc" '--workspace-root="$PWD"' "Quickstart must quote the workspace root"
 require_contains "$agents_doc" "## Local and hosted agent setup" "Agent docs must separate local and hosted setup"
+require_contains "$agents_doc" "GitHub Actions-compatible hosted agent" "Agent docs must document action-based hosted agents"
 require_contains "$agents_doc" "Cloud/headless coding agent" "Agent docs must document cloud/headless agent setup"
 
 printf '%s\n' "Docs content contract passed"

--- a/.github/scripts/test-docs-navigation-contract.sh
+++ b/.github/scripts/test-docs-navigation-contract.sh
@@ -60,5 +60,35 @@ if actual != expected:
     print("actual:", json.dumps(actual, indent=2), file=sys.stderr)
     sys.exit(1)
 
+groups_by_name = {group["group"]: group["pages"] for group in expected}
+
+required_group_order = [
+    "Overview",
+    "Getting started",
+    "What can Kast do?",
+    "For agents",
+    "Recipes",
+    "Reference",
+    "Troubleshooting",
+    "Architecture",
+    "Changelog",
+]
+actual_group_order = [group["group"] for group in expected]
+if actual_group_order != required_group_order:
+    print("Docs sidebar groups should stay intent-first and reader-oriented", file=sys.stderr)
+    print("expected:", required_group_order, file=sys.stderr)
+    print("actual:", actual_group_order, file=sys.stderr)
+    sys.exit(1)
+
+placement_checks = {
+    "Getting started": "getting-started/backends",
+    "Reference": "cli-cheat-sheet",
+    "Architecture": "architecture/kast-vs-lsp",
+}
+for group_name, page in placement_checks.items():
+    if page not in groups_by_name.get(group_name, []):
+        print(f"{page} must appear under {group_name} in the sidebar", file=sys.stderr)
+        sys.exit(1)
+
 print("Docs navigation contract passed")
 PY

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ skill, or repo-local Copilot extension in one pass:
 curl -fsSL https://raw.githubusercontent.com/amichne/kast/HEAD/kast.sh | bash
 ```
 
+For GitHub Actions-compatible hosted agents, use `amichne/kast-action@v1`.
 For CI or headless agent installs from internal artifacts or self-contained
 bundles, use the
-[install guide](https://kast.michne.com/getting-started/install/#headless-agent-with-internal-artifacts).
+[install guide](https://kast.michne.com/getting-started/install/#github-actions-and-hosted-agents).
 
 Warm the standalone backend before running analysis commands:
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -6,7 +6,7 @@ defining navigation, extensions, and theme configuration.
 
 ## Site structure
 
-The documentation is organized into six sections:
+The documentation is organized into reader-oriented areas:
 
 - `docs/index.md` — focused landing page: differentiators, a 60-second
   quickstart, and navigation cards. No inline capability walkthroughs —
@@ -18,11 +18,14 @@ The documentation is organized into six sections:
   examples.
 - `docs/for-agents/` — agent-facing content (overview, talk-to-agent,
   install-skill, direct-cli)
+- `docs/recipes.md` and `docs/troubleshooting.md` — task-oriented support
+  pages that stay visible as top-level sidebar entries.
 - `docs/architecture/` — how-it-works, behavioral-model, kast-vs-lsp
-- `docs/reference/` — generated pages. `api-reference` and
-  `api-specification` appear in the nav, plus `error-codes`.
-  `capabilities.md` is generated but intentionally excluded from the
-  nav to avoid duplicating `api-reference.md`.
+- `docs/reference/` — generated pages plus the operator-facing CLI cheat
+  sheet. `api-reference`, `api-specification`, `cli-cheat-sheet`, and
+  `error-codes` appear in the nav. `capabilities.md` is generated but
+  intentionally excluded from the nav to avoid duplicating
+  `api-reference.md`.
 
 Generated reference pages under `docs/reference/` are produced by
 `./gradlew :analysis-api:generateDocPages` and drift-tested by

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -26,7 +26,18 @@
         "group": "Getting started",
         "pages": [
           "getting-started/install",
-          "getting-started/quickstart"
+          "getting-started/quickstart",
+          "getting-started/backends"
+        ]
+      },
+      {
+        "group": "What can Kast do?",
+        "pages": [
+          "what-can-kast-do/understand-symbols",
+          "what-can-kast-do/trace-usage",
+          "what-can-kast-do/refactor-safely",
+          "what-can-kast-do/validate-code",
+          "what-can-kast-do/manage-workspaces"
         ]
       },
       {
@@ -45,38 +56,11 @@
         ]
       },
       {
-        "group": "What can Kast do?",
-        "pages": [
-          "what-can-kast-do/understand-symbols",
-          "what-can-kast-do/trace-usage",
-          "what-can-kast-do/refactor-safely",
-          "what-can-kast-do/validate-code",
-          "what-can-kast-do/manage-workspaces"
-        ]
-      },
-      {
-        "group": "CLI cheat sheet",
-        "pages": [
-          "cli-cheat-sheet"
-        ]
-      },
-      {
-        "group": "Backends",
-        "pages": [
-          "getting-started/backends"
-        ]
-      },
-      {
-        "group": "Kast vs LSP",
-        "pages": [
-          "architecture/kast-vs-lsp"
-        ]
-      },
-      {
         "group": "Reference",
         "pages": [
           "reference/api-reference",
           "reference/api-specification",
+          "cli-cheat-sheet",
           "reference/error-codes"
         ]
       },
@@ -91,6 +75,7 @@
         "pages": [
           "architecture/how-it-works",
           "architecture/behavioral-model",
+          "architecture/kast-vs-lsp",
           "architecture/adt-boundaries"
         ]
       },

--- a/docs/for-agents/index.md
+++ b/docs/for-agents/index.md
@@ -47,12 +47,17 @@ release artifacts before the session starts.
 |-------------------|--------------|--------------|-------------------------|
 | Local developer agent | `kast install skill` and optional `kast install copilot-extension` | Existing CLI plus standalone or IDEA backend | The packaged skill and native `kast_*` tools |
 | CI review agent | `./kast.sh install --non-interactive` or release archives | Standalone backend warmed in the job | `kast rpc` commands and structured JSON outputs |
+| GitHub Actions-compatible hosted agent | `amichne/kast-action@v1` or a mirrored action | Contained headless agent bundle under the action install root | `kast` on `PATH`, `KAST_CONFIG_HOME`, and action outputs |
 | Cloud/headless coding agent | `scripts/headless-agent-install.sh` or the headless agent bundle | Contained CLI and standalone backend under `KAST_AGENT_INSTALL_ROOT` | Source `kast-env.sh`, then use the packaged skill and Copilot extension |
 
 Use the headless path when the agent image cannot rely on a human shell
 profile, Homebrew tap state, or an already-open IDE. The headless
 installer verifies the CLI, backend runtime libraries, packaged skill,
 repo-local Copilot hooks, and native extension files before it exits.
+
+For Devin or enterprise runners that start from a GitHub Actions-compatible
+setup step, use the action path and pin mirrored installs with `bundle-url`
+and `bundle-sha256`.
 
 | What it gets         | What `kast` returns                                                                       | Why your agent cares                                                            |
 |----------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -106,12 +106,56 @@ path that matches the machine.
 | Local developer using a terminal | Homebrew or `./kast.sh install --mode=full` | CLI plus standalone backend when using the full installer | `kast up --workspace-root="$PWD"` |
 | Local developer using IDEA or Android Studio | `./kast.sh install --mode=minimal` or the plugin zip | CLI plus optional plugin, or plugin only | Open the project in the IDE |
 | CI job that only gates a workspace | `./kast.sh install --non-interactive` or release archives | CLI only unless archives include backend components | Start or warm standalone before `kast rpc` |
+| GitHub Actions-compatible hosted agent | `amichne/kast-action@v1` or an enterprise mirror | Headless agent bundle installed into a contained root and added to the job environment | Run `kast` directly in later steps |
 | Cloud or headless coding agent | `scripts/headless-agent-install.sh` or a headless agent bundle | CLI, standalone backend, packaged skill, and repo-local Copilot extension | `source "$KAST_AGENT_INSTALL_ROOT/kast-env.sh"` |
 
 For CI and cloud agents, keep the runtime isolated from a human shell
 profile. Use setup-time environment variables or a bundle, then source the
 generated environment file inside the job or image step that runs the
 agent.
+
+## GitHub Actions and hosted agents
+
+Use `amichne/kast-action@v1` for GitHub Actions-compatible setup steps,
+including hosted coding agents such as Devin when they run inside a workflow.
+The action installs the headless agent bundle, adds the `kast` binary to
+`PATH`, exports `KAST_CONFIG_HOME`, `KAST_INSTALL_ROOT`, and
+`KAST_MANAGED_ROOT`, and marks the install as `KAST_INSTALL_SOURCE=action`.
+
+```yaml title="Install Kast in a GitHub Actions-compatible job"
+steps:
+  - uses: actions/checkout@v5
+
+  - uses: amichne/kast-action@v1
+    with:
+      version: v1.2.3
+
+  - run: kast --help
+```
+
+For enterprise or GHES runners, mirror both the action and the headless agent
+bundle. Do not mirror only the action repository: the action consumes
+`kast-headless-agent-<version>-linux-x64.zip`, while `SHA256SUMS` is the
+checksum source to verify before promotion.
+
+```yaml title="Install Kast from an enterprise mirror"
+steps:
+  - uses: actions/checkout@v5
+
+  - uses: enterprise-mirror/kast-action@v1
+    with:
+      version: v1.2.3
+      bundle-url: https://github.enterprise.example/org/kast/releases/download/v1.2.3/kast-headless-agent-v1.2.3-linux-x64.zip
+      bundle-sha256: "<sha256>"
+      skip-copilot-extension: true
+
+  - run: kast --help
+```
+
+Set `skip-copilot-extension: true` unless the setup action is approved to
+write packaged Copilot files into the checked-out repository. When
+`bundle-url` is set, also set a pinned `version` and `bundle-sha256`; the
+action rejects mirrored bundle installs without a checksum.
 
 ## Install modes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,8 @@ title: Kast
 description: Compiler-backed Kotlin analysis for your terminal, CI, agent,
   or IDEA-backed workflow.
 icon: lucide/network
+hide:
+  - toc
 ---
 
 # Compiler-backed Kotlin answers — outside the IDE

--- a/zensical.toml
+++ b/zensical.toml
@@ -18,6 +18,14 @@ nav = [
   { "Getting started" = [
     { "Install" = "getting-started/install.md" },
     { "Quickstart" = "getting-started/quickstart.md" },
+    { "Backends" = "getting-started/backends.md" },
+  ]},
+  { "What can Kast do?" = [
+    { "Understand symbols" = "what-can-kast-do/understand-symbols.md" },
+    { "Trace usage" = "what-can-kast-do/trace-usage.md" },
+    { "Refactor safely" = "what-can-kast-do/refactor-safely.md" },
+    { "Validate code" = "what-can-kast-do/validate-code.md" },
+    { "Manage workspaces" = "what-can-kast-do/manage-workspaces.md" },
   ]},
   { "For agents" = [
     { "Overview" = "for-agents/index.md" },
@@ -26,25 +34,17 @@ nav = [
     { "Direct CLI usage" = "for-agents/direct-cli.md" },
   ]},
   { "Recipes" = "recipes.md" },
-  { "What can Kast do?" = [
-    { "Understand symbols" = "what-can-kast-do/understand-symbols.md" },
-    { "Trace usage" = "what-can-kast-do/trace-usage.md" },
-    { "Refactor safely" = "what-can-kast-do/refactor-safely.md" },
-    { "Validate code" = "what-can-kast-do/validate-code.md" },
-    { "Manage workspaces" = "what-can-kast-do/manage-workspaces.md" },
-  ]},
-  { "CLI cheat sheet" = "cli-cheat-sheet.md" },
-  { "Backends" = "getting-started/backends.md" },
-  { "Kast vs LSP" = "architecture/kast-vs-lsp.md" },
   { "Reference" = [
     { "API reference" = "reference/api-reference.md" },
     { "API specification" = "reference/api-specification.md" },
+    { "CLI cheat sheet" = "cli-cheat-sheet.md" },
     { "Error codes" = "reference/error-codes.md" },
   ]},
   { "Troubleshooting" = "troubleshooting.md" },
   { "Architecture" = [
     { "How Kast works" = "architecture/how-it-works.md" },
     { "Limits and boundaries" = "architecture/behavioral-model.md" },
+    { "Kast vs LSP" = "architecture/kast-vs-lsp.md" },
     { "ADT boundaries" = "architecture/adt-boundaries.md" },
   ]},
   { "Changelog" = "changelog.md" },


### PR DESCRIPTION
## Issue
The rendered docs sidebar was visually usable, but the information architecture had drifted: Backends, CLI cheat sheet, and Kast vs LSP appeared as standalone top-level entries even though they belong under Getting started, Reference, and Architecture respectively. On mobile, the landing page also showed a floating page-TOC button over the entry cards.

A second gap was install coverage for GitHub Actions-compatible hosted agents, including Devin-style and enterprise/GHES bootstrap flows. The docs covered direct headless scripts and bundles, but did not make `amichne/kast-action@v1` or mirrored `bundle-url` / `bundle-sha256` installs explicit.

## Fix
- Move Backends under Getting started.
- Move CLI cheat sheet under Reference.
- Move Kast vs LSP under Architecture.
- Keep the Mintlify `docs/docs.json` mirror aligned with `zensical.toml`.
- Hide the landing-page table of contents so mobile no longer overlays the card content.
- Add navigation contract checks for the reader-oriented sidebar order and key page placements.
- Document the public `amichne/kast-action@v1` setup path for GitHub Actions-compatible hosted agents.
- Document enterprise/GHES mirrored installs with pinned `version`, `bundle-url`, `bundle-sha256`, and `skip-copilot-extension: true`.
- Add content contract checks so the action-based install path does not disappear.

## Validation
- `.github/scripts/test-docs-navigation-contract.sh`
- `.github/scripts/test-docs-content-contract.sh`
- `zensical build --clean`
- `bash -n .github/scripts/test-docs-content-contract.sh .github/scripts/test-docs-navigation-contract.sh`
- `git diff --check`
- Local rendered screenshot pass at desktop and mobile viewport sizes
