### PR TITLE
Refine sidebar navigation and installer documentation

### DIFF
--- a/.github/scripts/test-docs-content-contract.sh
+++ b/.github/scripts/test-docs-content-contract.sh
@@ -52,6 +52,36 @@ require_order() {
   [[ "$earlier_line" -lt "$later_line" ]] || die "${description}: '${earlier}' must appear before '${later}' in ${file_path}"
 }
 
+require_embedded_markdown_links() {
+  local failed="false"
+  local file_path
+
+  while IFS= read -r file_path; do
+    awk '
+      /^```/ { in_fence = !in_fence; next }
+      in_fence { next }
+      /<https?:\/\/[^>]+>/ {
+        printf "%s:%d: use descriptive markdown link text instead of angle autolink\n", FILENAME, FNR
+        failed = 1
+      }
+      /\[[^]]*(https?:\/\/|www\.|[[:alnum:]_.-]+\.[[:alnum:]_.-]+\/)[^]]*\]\(/ {
+        printf "%s:%d: link text should describe the destination, not repeat the URL\n", FILENAME, FNR
+        failed = 1
+      }
+      END { exit failed }
+    ' "$file_path" || failed="true"
+  done < <(
+    {
+      printf '%s\n' "$readme"
+      find "$docs_root" -type f -name '*.md' \
+        ! -path "${docs_root}/reference/api-reference.md" \
+        ! -path "${docs_root}/reference/capabilities.md"
+    } | sort
+  )
+
+  [[ "$failed" != "true" ]] || die "Docs and README links must be embedded in descriptive text"
+}
+
 repo_root="$(resolve_repo_root)"
 docs_root="${repo_root}/docs"
 readme="${repo_root}/README.md"
@@ -101,5 +131,6 @@ require_contains "$quickstart_doc" '--workspace-root="$PWD"' "Quickstart must qu
 require_contains "$agents_doc" "## Local and hosted agent setup" "Agent docs must separate local and hosted setup"
 require_contains "$agents_doc" "GitHub Actions-compatible hosted agent" "Agent docs must document action-based hosted agents"
 require_contains "$agents_doc" "Cloud/headless coding agent" "Agent docs must document cloud/headless agent setup"
+require_embedded_markdown_links
 
 printf '%s\n' "Docs content contract passed"

--- a/.github/scripts/test-installer-selector.sh
+++ b/.github/scripts/test-installer-selector.sh
@@ -91,4 +91,38 @@ PS
 
 test_detects_idea_and_android_studio_processes
 
+test_download_uses_progress_bar_when_requested() {
+  local args_file="${test_tmp_dir}/download-progress-args"
+
+  curl() {
+    printf '%s\n' "$@" > "$args_file"
+  }
+
+  KAST_DOWNLOAD_PROGRESS=always _install_download_file "https://example.invalid/kast.zip" "${test_tmp_dir}/kast.zip"
+
+  local actual_args
+  actual_args="$(<"$args_file")"
+  [[ "$actual_args" == *"--progress-bar"* ]] || die "expected progress-bar curl output, got '${actual_args}'"
+  [[ "$actual_args" != *"--silent"* ]] || die "progress download should not pass --silent, got '${actual_args}'"
+}
+
+test_download_stays_quiet_when_requested() {
+  local args_file="${test_tmp_dir}/download-quiet-args"
+
+  curl() {
+    printf '%s\n' "$@" > "$args_file"
+  }
+
+  KAST_DOWNLOAD_PROGRESS=never _install_download_file "https://example.invalid/kast.zip" "${test_tmp_dir}/kast.zip"
+
+  local actual_args
+  actual_args="$(<"$args_file")"
+  [[ "$actual_args" == *"--silent"* ]] || die "quiet download should pass --silent, got '${actual_args}'"
+  [[ "$actual_args" == *"--show-error"* ]] || die "quiet download should pass --show-error, got '${actual_args}'"
+  [[ "$actual_args" != *"--progress-bar"* ]] || die "quiet download should not pass --progress-bar, got '${actual_args}'"
+}
+
+test_download_uses_progress_bar_when_requested
+test_download_stays_quiet_when_requested
+
 printf '%s\n' "Installer selector test passed"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ For the full comparison, see
 
 ## Documentation
 
-- Documentation site: <https://kast.michne.com/>
-- Install guide: <https://kast.michne.com/getting-started/install/>
-- Backend comparison: <https://kast.michne.com/getting-started/backends/>
+- Read the [documentation site](https://kast.michne.com/).
+- Follow the [install guide](https://kast.michne.com/getting-started/install/).
+- Compare runtime modes in [Backends](https://kast.michne.com/getting-started/backends/).

--- a/docs/architecture/profiling.md
+++ b/docs/architecture/profiling.md
@@ -122,8 +122,8 @@ KAST_OTLP_ENDPOINT=http://localhost:4317 \
   kast daemon start --workspace-root="$PWD"
 ```
 
-Open `http://localhost:16686` to browse traces with parent-child span
-relationships.
+Open the [local Jaeger UI](http://localhost:16686) to browse traces with
+parent-child span relationships.
 
 ## Combining approaches
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -58,7 +58,9 @@ The wizard sniffs your environment (running IDEA-compatible IDEs, existing tools
 Java version), lets you pick an install mode, writes
 `$HOME/.config/kast/config.toml`, installs managed files under
 `$HOME/.kast`, records the install in `~/.kast/.manifest.json`, and can
-install the packaged Copilot surfaces you use next.
+install the packaged Copilot surfaces you use next. Interactive downloads
+show a progress bar; non-interactive downloads stay quiet unless you override
+that with `KAST_DOWNLOAD_PROGRESS`.
 
 ??? info "What the wizard does, step by step"
 
@@ -119,8 +121,8 @@ agent.
 Use `amichne/kast-action@v1` for GitHub Actions-compatible setup steps,
 including hosted coding agents such as Devin when they run inside a workflow.
 The action installs the headless agent bundle, adds the `kast` binary to
-`PATH`, exports the action-managed config and install roots, and marks the
-install as `KAST_INSTALL_SOURCE=action`.
+`PATH`, exports action-managed environment values for config/runtime paths,
+and marks the install as `KAST_INSTALL_SOURCE=action`.
 
 ```yaml title="Install Kast in a GitHub Actions-compatible job"
 steps:
@@ -362,6 +364,7 @@ images, private artifact stores, and CI-style setup scripts.
 | `KAST_EXPECTED_SHA256`           | Verifies `KAST_ARCHIVE_PATH` before extraction    |
 | `KAST_BACKEND_ARCHIVE_PATH`      | Installs the standalone backend from a local zip  |
 | `KAST_BACKEND_EXPECTED_SHA256`   | Verifies `KAST_BACKEND_ARCHIVE_PATH`              |
+| `KAST_DOWNLOAD_PROGRESS`         | Sets download display mode: `auto`, `always`, or `never` |
 | `KAST_INSTALL_SOURCE`            | Writes a custom source label into install metadata |
 | `KAST_SKILL_SCOPE`               | Sets skill scope when prompts are unavailable     |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -207,6 +207,6 @@ If nothing here resolves it:
 1. Run `health` through `kast rpc`, then run `kast status`, and capture the
    output
 2. Check daemon stderr for stack traces
-3. Open an issue at
-   [github.com/amichne/kast](https://github.com/amichne/kast/issues)
-   with the diagnostic output
+3. Open an issue in the
+   [Kast issue tracker](https://github.com/amichne/kast/issues) with the
+   diagnostic output

--- a/kast.sh
+++ b/kast.sh
@@ -628,13 +628,34 @@ _install_detect_platform_id() {
 
 _install_download_file() {
   local url="$1" output_path="$2"
+  local progress_mode="${KAST_DOWNLOAD_PROGRESS:-auto}"
+  local -a progress_args=()
+
+  case "$progress_mode" in
+    auto|"")
+      if [[ -t 2 ]]; then
+        progress_args=(--progress-bar)
+      else
+        progress_args=(--silent --show-error)
+      fi
+      ;;
+    always)
+      progress_args=(--progress-bar)
+      ;;
+    never)
+      progress_args=(--silent --show-error)
+      ;;
+    *)
+      die "KAST_DOWNLOAD_PROGRESS must be auto, always, or never"
+      ;;
+  esac
+
   curl \
     --fail \
     --location \
     --retry 3 \
     --retry-delay 2 \
-    --silent \
-    --show-error \
+    "${progress_args[@]}" \
     --output "$output_path" \
     "$url"
 }
@@ -1733,6 +1754,7 @@ Environment:
   KAST_EXPECTED_SHA256           Expected SHA-256 for KAST_ARCHIVE_PATH
   KAST_BACKEND_ARCHIVE_PATH      Local standalone backend archive path
   KAST_BACKEND_EXPECTED_SHA256   Expected SHA-256 for KAST_BACKEND_ARCHIVE_PATH
+  KAST_DOWNLOAD_PROGRESS         auto, always, or never (default: auto)
   KAST_INSTALL_SOURCE            Install source metadata label (default: kast.sh)
   KAST_SKILL_SCOPE               Skill scope when prompts are unavailable: global, local, both, skip
 USAGE


### PR DESCRIPTION
## Summary

- Refine reader-oriented docs navigation structure.
- Add and test hosted and enterprise setup guidance for the GitHub Action and headless installs.
- Update installer contract checks for descriptive Markdown links and download progress behavior.
