### PR TITLE
fix: avoid native config reflection in native CLI

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/ConfigurationFieldDecoder.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/ConfigurationFieldDecoder.kt
@@ -1,73 +1,153 @@
 package io.github.amichne.kast.api.client
 
 import io.github.amichne.kast.api.client.fields.*
+import com.sksamuel.hoplite.ArrayNode
+import com.sksamuel.hoplite.BooleanNode
 import com.sksamuel.hoplite.ConfigFailure
 import com.sksamuel.hoplite.ConfigResult
 import com.sksamuel.hoplite.DecoderContext
+import com.sksamuel.hoplite.DoubleNode
+import com.sksamuel.hoplite.LongNode
 import com.sksamuel.hoplite.Node
+import com.sksamuel.hoplite.PrimitiveNode
+import com.sksamuel.hoplite.StringNode
 import com.sksamuel.hoplite.decoder.NullHandlingDecoder
-import com.sksamuel.hoplite.fp.flatMap
 import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
-import kotlin.reflect.KFunction
-import kotlin.reflect.KParameter
+import kotlin.reflect.KClass
 import kotlin.reflect.KType
-import kotlin.reflect.full.createType
-import kotlin.reflect.full.isSubclassOf
-import kotlin.reflect.full.primaryConstructor
-import kotlin.reflect.jvm.jvmErasure
 
 class ConfigurationFieldDecoder : NullHandlingDecoder<ConfigurationField<*>> {
     override fun supports(type: KType): Boolean =
-        type.jvmErasure.isSubclassOf(ConfigurationField::class) && type.jvmErasure != ConfigurationField::class
+        type.classifier in fieldDecodersByType
 
     override fun safeDecode(
         node: Node,
         type: KType,
         context: DecoderContext,
     ): ConfigResult<ConfigurationField<*>> {
-        val constructor = type.jvmErasure.primaryConstructor
-                          ?: return ConfigFailure.MissingPrimaryConstructor(type).invalid()
-        val valueParameter = constructor.parameters.singleOrNull { it.name == "value" }
-                             ?: return ConfigFailure.Generic("${type.jvmErasure.simpleName} must have exactly one value constructor parameter")
-                                 .invalid()
+        val fieldDecoder = fieldDecodersByType[type.classifier]
+            ?: return ConfigFailure.DecodeError(node, type).invalid()
 
-        return decodeValue(node, valueParameter, context).flatMap { value ->
-            construct(type, constructor, value)
-        }
+        return decodeValue(node, type, context, fieldDecoder.valueKind)
+            .map(fieldDecoder.construct)
     }
 
     private fun decodeValue(
         node: Node,
-        valueParameter: KParameter,
+        targetType: KType,
         context: DecoderContext,
-    ): ConfigResult<Any?> = if (valueParameter.type.jvmErasure == OptionalConfigString::class) {
-        context.decoder(stringType)
-            .flatMap { decoder -> decoder.decode(node, stringType, context) }
-            .map { OptionalConfigString(it as String) }
-    } else {
-        context.decoder(valueParameter)
-            .flatMap { decoder -> decoder.decode(node, valueParameter.type, context) }
+        valueKind: ValueKind,
+    ): ConfigResult<Any> = when (valueKind) {
+        ValueKind.Boolean -> decodeBoolean(node, targetType)
+        ValueKind.Int -> decodeInt(node, targetType)
+        ValueKind.Long -> decodeLong(node, targetType)
+        ValueKind.String -> decodeString(node, targetType, context)
+        ValueKind.OptionalString -> decodeOptionalConfigString(node, targetType)
     }
 
-    private fun construct(
-        type: KType,
-        constructor: KFunction<*>,
-        value: Any?,
-    ): ConfigResult<ConfigurationField<*>> = try {
-        val decoded = constructor.call(value) as? ConfigurationField<*>
-        decoded?.valid()
-        ?: ConfigFailure.Generic("${type.jvmErasure.simpleName} did not construct a ConfigurationField").invalid()
-    } catch (exception: IllegalArgumentException) {
-        ConfigFailure.InvalidConstructorParameters(
-            type,
-            constructor,
-            mapOf(constructor.parameters.single() to value),
-            exception
-        ).invalid()
+    private fun decodeOptionalConfigString(
+        node: Node,
+        targetType: KType,
+    ): ConfigResult<Any> = when (val decoded = decodeString(node, targetType, context = null)) {
+        is com.sksamuel.hoplite.fp.Validated.Valid -> OptionalConfigString(decoded.value as String).valid()
+        is com.sksamuel.hoplite.fp.Validated.Invalid -> decoded
     }
+
+    private fun decodeString(
+        node: Node,
+        targetType: KType,
+        context: DecoderContext?,
+    ): ConfigResult<Any> = when (node) {
+        is StringNode -> node.value.valid()
+        is BooleanNode -> node.value.toString().valid()
+        is LongNode -> node.value.toString().valid()
+        is DoubleNode -> node.value.toString().valid()
+        is ArrayNode -> if (context?.config?.flattenArraysToString == true && node.elements.all { it is PrimitiveNode }) {
+            node.elements.joinToString(",") { (it as PrimitiveNode).value.toString() }.valid()
+        } else {
+            ConfigFailure.DecodeError(node, targetType).invalid()
+        }
+        else -> ConfigFailure.DecodeError(node, targetType).invalid()
+    }
+
+    private fun decodeBoolean(node: Node, targetType: KType): ConfigResult<Any> = when (node) {
+        is BooleanNode -> node.value.valid()
+        is StringNode -> when (node.value.lowercase()) {
+            "true", "t", "1", "yes" -> true.valid()
+            "false", "f", "0", "no" -> false.valid()
+            else -> ConfigFailure.DecodeError(node, targetType).invalid()
+        }
+        else -> ConfigFailure.DecodeError(node, targetType).invalid()
+    }
+
+    private fun decodeInt(node: Node, targetType: KType): ConfigResult<Any> = when (node) {
+        is LongNode -> node.value.toInt().valid()
+        is DoubleNode -> node.value.toInt().valid()
+        is StringNode -> node.value.toIntOrNull()?.valid()
+            ?: ConfigFailure.NumberConversionError(node, targetType).invalid()
+        else -> ConfigFailure.DecodeError(node, targetType).invalid()
+    }
+
+    private fun decodeLong(node: Node, targetType: KType): ConfigResult<Any> = when (node) {
+        is LongNode -> node.value.valid()
+        is StringNode -> node.value.toLongOrNull()?.valid()
+            ?: ConfigFailure.NumberConversionError(node, targetType).invalid()
+        else -> ConfigFailure.DecodeError(node, targetType).invalid()
+    }
+
+    private enum class ValueKind {
+        Boolean,
+        Int,
+        Long,
+        String,
+        OptionalString,
+    }
+
+    private data class FieldDecoder(
+        val valueKind: ValueKind,
+        val construct: (Any) -> ConfigurationField<*>,
+    )
 
     private companion object {
-        val stringType: KType = String::class.createType()
+        val fieldDecodersByType: Map<KClass<*>, FieldDecoder> = mapOf(
+            CacheEnabled::class to FieldDecoder(ValueKind.Boolean) { CacheEnabled(it as Boolean) },
+            CacheSourceIndexSaveDelayMillis::class to FieldDecoder(ValueKind.Long) { CacheSourceIndexSaveDelayMillis(it as Long) },
+            CacheWriteDelayMillis::class to FieldDecoder(ValueKind.Long) { CacheWriteDelayMillis(it as Long) },
+            CliBinaryPath::class to FieldDecoder(ValueKind.String) { CliBinaryPath(it as String) },
+            GradleMaxIncludedProjects::class to FieldDecoder(ValueKind.Int) { GradleMaxIncludedProjects(it as Int) },
+            GradleToolingApiTimeoutMillis::class to FieldDecoder(ValueKind.Long) { GradleToolingApiTimeoutMillis(it as Long) },
+            IndexingIdentifierIndexWaitMillis::class to FieldDecoder(ValueKind.Long) { IndexingIdentifierIndexWaitMillis(it as Long) },
+            IndexingPhase2BatchSize::class to FieldDecoder(ValueKind.Int) { IndexingPhase2BatchSize(it as Int) },
+            IndexingPhase2Enabled::class to FieldDecoder(ValueKind.Boolean) { IndexingPhase2Enabled(it as Boolean) },
+            IndexingPhase2Parallelism::class to FieldDecoder(ValueKind.Int) { IndexingPhase2Parallelism(it as Int) },
+            IndexingReferenceBatchSize::class to FieldDecoder(ValueKind.Int) { IndexingReferenceBatchSize(it as Int) },
+            IndexingRemoteEnabled::class to FieldDecoder(ValueKind.Boolean) { IndexingRemoteEnabled(it as Boolean) },
+            IndexingRemoteSourceIndexUrl::class to FieldDecoder(ValueKind.OptionalString) { IndexingRemoteSourceIndexUrl(it as OptionalConfigString) },
+            IntellijBackendEnabled::class to FieldDecoder(ValueKind.Boolean) { IntellijBackendEnabled(it as Boolean) },
+            PathsBinDir::class to FieldDecoder(ValueKind.String) { PathsBinDir(it as String) },
+            PathsCacheDir::class to FieldDecoder(ValueKind.String) { PathsCacheDir(it as String) },
+            PathsDescriptorDir::class to FieldDecoder(ValueKind.String) { PathsDescriptorDir(it as String) },
+            PathsInstallRoot::class to FieldDecoder(ValueKind.String) { PathsInstallRoot(it as String) },
+            PathsLibDir::class to FieldDecoder(ValueKind.String) { PathsLibDir(it as String) },
+            PathsLogsDir::class to FieldDecoder(ValueKind.String) { PathsLogsDir(it as String) },
+            PathsSocketDir::class to FieldDecoder(ValueKind.String) { PathsSocketDir(it as String) },
+            ProfilingDurationSeconds::class to FieldDecoder(ValueKind.Long) { ProfilingDurationSeconds(it as Long) },
+            ProfilingEmitManifest::class to FieldDecoder(ValueKind.Boolean) { ProfilingEmitManifest(it as Boolean) },
+            ProfilingEnabled::class to FieldDecoder(ValueKind.Boolean) { ProfilingEnabled(it as Boolean) },
+            ProfilingModes::class to FieldDecoder(ValueKind.String) { ProfilingModes(it as String) },
+            ProfilingOtlpEndpoint::class to FieldDecoder(ValueKind.OptionalString) { ProfilingOtlpEndpoint(it as OptionalConfigString) },
+            ProfilingOutputDir::class to FieldDecoder(ValueKind.String) { ProfilingOutputDir(it as String) },
+            ServerMaxConcurrentRequests::class to FieldDecoder(ValueKind.Int) { ServerMaxConcurrentRequests(it as Int) },
+            ServerMaxResults::class to FieldDecoder(ValueKind.Int) { ServerMaxResults(it as Int) },
+            ServerRequestTimeoutMillis::class to FieldDecoder(ValueKind.Long) { ServerRequestTimeoutMillis(it as Long) },
+            StandaloneBackendEnabled::class to FieldDecoder(ValueKind.Boolean) { StandaloneBackendEnabled(it as Boolean) },
+            StandaloneRuntimeLibsDir::class to FieldDecoder(ValueKind.OptionalString) { StandaloneRuntimeLibsDir(it as OptionalConfigString) },
+            TelemetryDetail::class to FieldDecoder(ValueKind.String) { TelemetryDetail(it as String) },
+            TelemetryEnabled::class to FieldDecoder(ValueKind.Boolean) { TelemetryEnabled(it as Boolean) },
+            TelemetryOutputFile::class to FieldDecoder(ValueKind.OptionalString) { TelemetryOutputFile(it as OptionalConfigString) },
+            TelemetryScopes::class to FieldDecoder(ValueKind.String) { TelemetryScopes(it as String) },
+            WatcherDebounceMillis::class to FieldDecoder(ValueKind.Long) { WatcherDebounceMillis(it as Long) },
+        )
     }
 }

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/KastConfig.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/KastConfig.kt
@@ -1,8 +1,6 @@
 package io.github.amichne.kast.api.client
 
 import io.github.amichne.kast.api.client.fields.*
-import com.sksamuel.hoplite.ConfigLoaderBuilder
-import com.sksamuel.hoplite.ExperimentalHoplite
 import io.github.amichne.kast.api.contract.ServerLimits
 import java.nio.file.Files
 import java.nio.file.Path
@@ -91,7 +89,6 @@ data class KastConfig(
             )
         }
 
-        @OptIn(ExperimentalHoplite::class)
         fun load(
             workspaceRoot: Path,
             configHome: () -> Path = { kastConfigHome() },
@@ -101,26 +98,226 @@ data class KastConfig(
             val configFiles = listOf(
                 workspaceDirectoryResolver.workspaceDataDirectory(workspaceRoot).resolve("config.toml"),
                 configHome().resolve("config.toml"),
-            ).filter(Files::isRegularFile).map(Path::toString)
-            val loaded = if (configFiles.isEmpty()) {
-                KastConfigOverride()
-            } else {
-                ConfigLoaderBuilder.empty()
-                    .withClassLoader(KastConfig::class.java.classLoader)
-                    .addDefaultDecoders()
-                    .addDefaultPreprocessors()
-                    .addDefaultNodeTransformers()
-                    .addDefaultParamMappers()
-                    .addDefaultParsers()
-                    .withExplicitSealedTypes()
-                    .allowEmptyConfigFiles()
-                    .build()
-                    .loadConfigOrThrow<KastConfigOverride>(configFiles)
-            }
+            ).filter(Files::isRegularFile)
+            val loaded = loadConfigOverrides(configFiles)
             return defaults().merge(loaded).merge(overrides)
         }
     }
 }
+
+private fun loadConfigOverrides(configFiles: List<Path>): KastConfigOverride {
+    val values = linkedMapOf<String, String>()
+    configFiles.asReversed().forEach { configFile ->
+        values.putAll(parseConfigValues(configFile))
+    }
+    return values.toKastConfigOverride()
+}
+
+private fun parseConfigValues(configFile: Path): Map<String, String> {
+    val values = linkedMapOf<String, String>()
+    var section = ""
+    Files.readAllLines(configFile).forEachIndexed { index, rawLine ->
+        val line = rawLine.withoutTomlComment().trim()
+        if (line.isBlank()) return@forEachIndexed
+        if (line.startsWith("[") && line.endsWith("]")) {
+            section = normalizeConfigPath(line.removePrefix("[").removeSuffix("]"))
+            return@forEachIndexed
+        }
+
+        val separator = line.indexOf('=')
+        require(separator > 0) { "Invalid Kast config line ${index + 1} in $configFile: $rawLine" }
+        val key = normalizeConfigPath(
+            listOf(section, line.substring(0, separator).trim())
+                .filter(String::isNotBlank)
+                .joinToString("."),
+        )
+        values[key] = line.substring(separator + 1).trim().parseTomlScalar()
+    }
+    return values
+}
+
+private fun String.withoutTomlComment(): String {
+    var quoted = false
+    var quote = '\u0000'
+    var escaped = false
+    forEachIndexed { index, char ->
+        when {
+            escaped -> escaped = false
+            quoted && char == '\\' -> escaped = true
+            quoted && char == quote -> quoted = false
+            !quoted && (char == '"' || char == '\'') -> {
+                quoted = true
+                quote = char
+            }
+            !quoted && char == '#' -> return substring(0, index)
+        }
+    }
+    return this
+}
+
+private fun String.parseTomlScalar(): String {
+    val trimmed = trim().removeSuffix(",").trim()
+    if (trimmed.length >= 2 && trimmed.first() == '"' && trimmed.last() == '"') {
+        return trimmed.substring(1, trimmed.lastIndex)
+            .replace("\\\"", "\"")
+            .replace("\\\\", "\\")
+            .replace("\\n", "\n")
+            .replace("\\t", "\t")
+    }
+    if (trimmed.length >= 2 && trimmed.first() == '\'' && trimmed.last() == '\'') {
+        return trimmed.substring(1, trimmed.lastIndex)
+    }
+    return trimmed
+}
+
+private fun normalizeConfigPath(path: String): String =
+    path.split('.')
+        .joinToString(".") { segment -> segment.filterNot { it == '-' || it == '_' }.lowercase() }
+
+private fun Map<String, String>.toKastConfigOverride(): KastConfigOverride = KastConfigOverride(
+    server = serverOverride(),
+    indexing = indexingOverride(),
+    cache = cacheOverride(),
+    watcher = watcherOverride(),
+    gradle = gradleOverride(),
+    telemetry = telemetryOverride(),
+    profiling = profilingOverride(),
+    backends = backendsOverride(),
+    paths = pathsOverride(),
+    cli = cliOverride(),
+)
+
+private fun Map<String, String>.serverOverride(): ServerConfigOverride? {
+    val maxResults = intValue("server.maxresults")?.let(::ServerMaxResults)
+    val requestTimeoutMillis = longValue("server.requesttimeoutmillis")?.let(::ServerRequestTimeoutMillis)
+    val maxConcurrentRequests = intValue("server.maxconcurrentrequests")?.let(::ServerMaxConcurrentRequests)
+    return takeIfAny(maxResults, requestTimeoutMillis, maxConcurrentRequests) {
+        ServerConfigOverride(maxResults, requestTimeoutMillis, maxConcurrentRequests)
+    }
+}
+
+private fun Map<String, String>.indexingOverride(): IndexingConfigOverride? {
+    val phase2Enabled = booleanValue("indexing.phase2enabled")?.let(::IndexingPhase2Enabled)
+    val phase2BatchSize = intValue("indexing.phase2batchsize")?.let(::IndexingPhase2BatchSize)
+    val phase2Parallelism = intValue("indexing.phase2parallelism")?.let(::IndexingPhase2Parallelism)
+    val identifierIndexWaitMillis = longValue("indexing.identifierindexwaitmillis")?.let(::IndexingIdentifierIndexWaitMillis)
+    val referenceBatchSize = intValue("indexing.referencebatchsize")?.let(::IndexingReferenceBatchSize)
+    val remote = remoteIndexOverride()
+    return takeIfAny(phase2Enabled, phase2BatchSize, phase2Parallelism, identifierIndexWaitMillis, referenceBatchSize, remote) {
+        IndexingConfigOverride(
+            phase2Enabled = phase2Enabled,
+            phase2BatchSize = phase2BatchSize,
+            phase2Parallelism = phase2Parallelism,
+            identifierIndexWaitMillis = identifierIndexWaitMillis,
+            referenceBatchSize = referenceBatchSize,
+            remote = remote,
+        )
+    }
+}
+
+private fun Map<String, String>.remoteIndexOverride(): RemoteIndexConfigOverride? {
+    val enabled = booleanValue("indexing.remote.enabled")?.let(::IndexingRemoteEnabled)
+    val sourceIndexUrl = optionalStringValue("indexing.remote.sourceindexurl")?.let(::IndexingRemoteSourceIndexUrl)
+    return takeIfAny(enabled, sourceIndexUrl) { RemoteIndexConfigOverride(enabled, sourceIndexUrl) }
+}
+
+private fun Map<String, String>.cacheOverride(): CacheConfigOverride? {
+    val enabled = booleanValue("cache.enabled")?.let(::CacheEnabled)
+    val writeDelayMillis = longValue("cache.writedelaymillis")?.let(::CacheWriteDelayMillis)
+    val sourceIndexSaveDelayMillis = longValue("cache.sourceindexsavedelaymillis")?.let(::CacheSourceIndexSaveDelayMillis)
+    return takeIfAny(enabled, writeDelayMillis, sourceIndexSaveDelayMillis) {
+        CacheConfigOverride(enabled, writeDelayMillis, sourceIndexSaveDelayMillis)
+    }
+}
+
+private fun Map<String, String>.watcherOverride(): WatcherConfigOverride? {
+    val debounceMillis = longValue("watcher.debouncemillis")?.let(::WatcherDebounceMillis)
+    return takeIfAny(debounceMillis) { WatcherConfigOverride(debounceMillis) }
+}
+
+private fun Map<String, String>.gradleOverride(): GradleConfigOverride? {
+    val toolingApiTimeoutMillis = longValue("gradle.toolingapitimeoutmillis")?.let(::GradleToolingApiTimeoutMillis)
+    val maxIncludedProjects = intValue("gradle.maxincludedprojects")?.let(::GradleMaxIncludedProjects)
+    return takeIfAny(toolingApiTimeoutMillis, maxIncludedProjects) {
+        GradleConfigOverride(toolingApiTimeoutMillis, maxIncludedProjects)
+    }
+}
+
+private fun Map<String, String>.telemetryOverride(): TelemetryConfigOverride? {
+    val enabled = booleanValue("telemetry.enabled")?.let(::TelemetryEnabled)
+    val scopes = stringValue("telemetry.scopes")?.let(::TelemetryScopes)
+    val detail = stringValue("telemetry.detail")?.let(::TelemetryDetail)
+    val outputFile = optionalStringValue("telemetry.outputfile")?.let(::TelemetryOutputFile)
+    return takeIfAny(enabled, scopes, detail, outputFile) {
+        TelemetryConfigOverride(enabled, scopes, detail, outputFile)
+    }
+}
+
+private fun Map<String, String>.profilingOverride(): ProfilingConfigOverride? {
+    val enabled = booleanValue("profiling.enabled")?.let(::ProfilingEnabled)
+    val modes = stringValue("profiling.modes")?.let(::ProfilingModes)
+    val durationSeconds = longValue("profiling.durationseconds")?.let(::ProfilingDurationSeconds)
+    val outputDir = stringValue("profiling.outputdir")?.let(::ProfilingOutputDir)
+    val otlpEndpoint = optionalStringValue("profiling.otlpendpoint")?.let(::ProfilingOtlpEndpoint)
+    val emitManifest = booleanValue("profiling.emitmanifest")?.let(::ProfilingEmitManifest)
+    return takeIfAny(enabled, modes, durationSeconds, outputDir, otlpEndpoint, emitManifest) {
+        ProfilingConfigOverride(enabled, modes, durationSeconds, outputDir, otlpEndpoint, emitManifest)
+    }
+}
+
+private fun Map<String, String>.backendsOverride(): BackendsConfigOverride? {
+    val standalone = standaloneBackendOverride()
+    val intellij = intellijBackendOverride()
+    return takeIfAny(standalone, intellij) { BackendsConfigOverride(standalone, intellij) }
+}
+
+private fun Map<String, String>.standaloneBackendOverride(): StandaloneBackendConfigOverride? {
+    val enabled = booleanValue("backends.standalone.enabled")?.let(::StandaloneBackendEnabled)
+    val runtimeLibsDir = optionalStringValue("backends.standalone.runtimelibsdir")?.let(::StandaloneRuntimeLibsDir)
+    return takeIfAny(enabled, runtimeLibsDir) { StandaloneBackendConfigOverride(enabled, runtimeLibsDir) }
+}
+
+private fun Map<String, String>.intellijBackendOverride(): IntellijBackendConfigOverride? {
+    val enabled = booleanValue("backends.intellij.enabled")?.let(::IntellijBackendEnabled)
+    return takeIfAny(enabled) { IntellijBackendConfigOverride(enabled) }
+}
+
+private fun Map<String, String>.pathsOverride(): PathsConfigOverride? {
+    val installRoot = stringValue("paths.installroot")?.let(::PathsInstallRoot)
+    val binDir = stringValue("paths.bindir")?.let(::PathsBinDir)
+    val libDir = stringValue("paths.libdir")?.let(::PathsLibDir)
+    val cacheDir = stringValue("paths.cachedir")?.let(::PathsCacheDir)
+    val logsDir = stringValue("paths.logsdir")?.let(::PathsLogsDir)
+    val descriptorDir = stringValue("paths.descriptordir")?.let(::PathsDescriptorDir)
+    val socketDir = stringValue("paths.socketdir")?.let(::PathsSocketDir)
+    return takeIfAny(installRoot, binDir, libDir, cacheDir, logsDir, descriptorDir, socketDir) {
+        PathsConfigOverride(installRoot, binDir, libDir, cacheDir, logsDir, descriptorDir, socketDir)
+    }
+}
+
+private fun Map<String, String>.cliOverride(): CliConfigOverride? {
+    val binaryPath = stringValue("cli.binarypath")?.let(::CliBinaryPath)
+    return takeIfAny(binaryPath) { CliConfigOverride(binaryPath) }
+}
+
+private fun Map<String, String>.stringValue(key: String): String? = get(key)
+
+private fun Map<String, String>.optionalStringValue(key: String): OptionalConfigString? = get(key)?.let(::OptionalConfigString)
+
+private fun Map<String, String>.intValue(key: String): Int? = get(key)?.toInt()
+
+private fun Map<String, String>.longValue(key: String): Long? = get(key)?.toLong()
+
+private fun Map<String, String>.booleanValue(key: String): Boolean? = get(key)?.let { value ->
+    when (value.lowercase()) {
+        "true", "t", "1", "yes" -> true
+        "false", "f", "0", "no" -> false
+        else -> error("Invalid boolean value for $key: $value")
+    }
+}
+
+private inline fun <T> takeIfAny(vararg values: Any?, build: () -> T): T? =
+    if (values.any { it != null }) build() else null
 
 data class ServerConfig(
     val maxResults: ServerMaxResults,

--- a/scripts/smoke-native-cli.sh
+++ b/scripts/smoke-native-cli.sh
@@ -28,13 +28,21 @@ cleanup() {
 trap cleanup EXIT
 
 skill_root="${scratch_dir}/skills"
+config_home="${scratch_dir}/config"
 workspace_root="${scratch_dir}/workspace"
 github_root="${workspace_root}/.github"
 
-mkdir -p "$skill_root" "$workspace_root"
+mkdir -p "$skill_root" "$config_home" "$workspace_root"
 git -C "$workspace_root" init -q
 
+cat > "${config_home}/config.toml" <<EOF_CONFIG
+[backends.standalone]
+runtimeLibsDir = "${scratch_dir}/runtime-libs"
+EOF_CONFIG
+
 "$kast_bin" --help >/dev/null
+
+KAST_CONFIG_HOME="$config_home" "$kast_bin" status --workspace-root="$workspace_root" >/dev/null
 
 "$kast_bin" install skill --target-dir="$skill_root" --name=kast --yes=true >/dev/null
 [[ -f "${skill_root}/kast/SKILL.md" ]] || die "Native CLI did not install packaged skill"


### PR DESCRIPTION
## Summary
- replace native CLI config loading with a schema-aware TOML override parser
- keep Hoplite field decoding reflection-free for direct decoder coverage
- extend native smoke coverage to load config before packaged release artifacts are accepted

## Validation
- ./gradlew :analysis-api:test --tests '*KastConfigTest' :kast-cli:test --tests 'io.github.amichne.kast.cli.NativeImageConfigurationTest'
- PR checks: Native CLI, Build & test, Smoke CLI, CodeQL, and release-contract jobs all passed