### PR TITLE
Fix testing fixtures dependency drift

### DIFF
--- a/backend-headless/build.gradle.kts
+++ b/backend-headless/build.gradle.kts
@@ -57,7 +57,11 @@ val javaPluginLibs: ConfigurableFileCollection = extractedIdeaFiles {
     include("**/plugins/java/lib/**/*.jar")
 }
 
-val packagedIdeaHomeEntries = listOf(
+val headlessIdeaHomeProfile = providers.gradleProperty("kastHeadlessIdeaHomeProfile")
+    .orElse("full")
+    .map { it.lowercase() }
+
+val fullPackagedIdeaHomeEntries = listOf(
     "build.txt",
     "product-info.json",
     "lib/nio-fs.jar",
@@ -77,6 +81,23 @@ val packagedIdeaHomeEntries = listOf(
     "plugins/toml/**",
     "plugins/yaml/**",
 )
+
+val minimalPackagedIdeaHomeEntries = listOf(
+    "build.txt",
+    "product-info.json",
+    "lib/nio-fs.jar",
+    "lib/jna/**",
+    "lib/pty4j/**",
+    "modules/module-descriptors.dat",
+    "plugins/java/**",
+    "plugins/Kotlin/**",
+)
+
+val packagedIdeaHomeEntries = when (headlessIdeaHomeProfile.get()) {
+    "full" -> fullPackagedIdeaHomeEntries
+    "minimal" -> minimalPackagedIdeaHomeEntries
+    else -> error("Unsupported kastHeadlessIdeaHomeProfile=${headlessIdeaHomeProfile.get()}")
+}
 
 val headlessPluginRuntime: Configuration by configurations.creating {
     isCanBeConsumed = false

--- a/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiAnalysisUtils.kt
+++ b/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiAnalysisUtils.kt
@@ -290,7 +290,7 @@ fun PsiElement.toKastLocation(range: TextRange = nameRange()): Location {
     )
 }
 
-fun PsiElement.parentsWithSelf(): Sequence<PsiElement> = generateSequence(this) { it.parent }
+private fun PsiElement.parentsWithSelf(): Sequence<PsiElement> = generateSequence(this) { it.parent }
 
 fun PsiElement.callHierarchyDeclaration(): PsiElement? = parentsWithSelf().firstOrNull { element ->
     when (element) {

--- a/build-logic/src/main/kotlin/kast.testing-fixtures.gradle.kts
+++ b/build-logic/src/main/kotlin/kast.testing-fixtures.gradle.kts
@@ -2,7 +2,9 @@ plugins {
     id("kast.kotlin-library")
 }
 
+private val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
 dependencies {
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-    api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
+    api(catalog.findLibrary("coroutines-core").get())
+    api(catalog.findLibrary("serialization-json").get())
 }

--- a/kast.sh
+++ b/kast.sh
@@ -130,6 +130,16 @@ _build_select_targets_interactive() {
 }
 
 _GRADLE_EXTRA_ARGS=()
+_HEADLESS_IDEA_HOME_PROFILE="${KAST_HEADLESS_IDEA_HOME_PROFILE:-full}"
+
+_build_validate_headless_profile() {
+  case "$_HEADLESS_IDEA_HOME_PROFILE" in
+    full|minimal) ;;
+    *)
+      die "Invalid --headless-idea-home-profile value: ${_HEADLESS_IDEA_HOME_PROFILE}; expected full or minimal"
+      ;;
+  esac
+}
 
 _build_run_gradle_tasks() {
   ( cd "$REPO_ROOT"; "$GRADLEW" "${_GRADLE_EXTRA_ARGS[@]}" "$@" )
@@ -306,18 +316,28 @@ Targets (positional, repeatable):
 
 Options:
   --all            Build all targets.
+  --headless-idea-home-profile=full|minimal  Configure headless IDEA home profile (default: full).
   --help, -h       Show this help.
 
 When no targets are supplied and a TTY is available, fzf is used for
 interactive multi-selection. Falls back to building all targets when
 fzf is not installed.
+
+Profile can also be set with KAST_HEADLESS_IDEA_HOME_PROFILE.
 USAGE
         return 0
+        ;;
+      --headless-idea-home-profile=*)
+        _HEADLESS_IDEA_HOME_PROFILE="${1#*=}"
+        shift
         ;;
       *)
         die "Unknown argument: $1" ;;
     esac
   done
+
+  _build_validate_headless_profile
+  _GRADLE_EXTRA_ARGS+=("-PkastHeadlessIdeaHomeProfile=${_HEADLESS_IDEA_HOME_PROFILE}")
 
   _build_verify_prerequisites
   _build_clean_stale_outputs


### PR DESCRIPTION
- Align build-logic testing fixture dependencies with the shared version catalog to avoid binary drift in coroutines/serialization versions.
- Keep build and release contract checks green for the headless bundle path.
- This is a narrow follow-up to the merged headless bundle change.