### PR TITLE
fix: require GPG passphrase before Maven release signing

### DIFF
--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -118,6 +118,8 @@ require_not_contains "$snapshot_workflow" "homebrew" "Snapshot workflow must not
 
 require_contains "$release_workflow" "Validate JVM and Maven publications" "Release must validate JVM and Maven publications"
 require_contains "$release_workflow" "Publish Maven Central" "Release must publish public modules to Maven Central"
+require_contains "$release_workflow" "SIGNING_GPG_PRIVATE_KEY \\" "Release Maven Central gate must continue checking after the private key secret"
+require_order "$release_workflow" "SIGNING_GPG_PRIVATE_KEY \\" "SIGNING_GPG_PASSPHRASE" "Release Maven Central gate must require the GPG passphrase secret before signing"
 require_contains "$release_workflow" "Build Rust CLI asset" "Release must build CLI assets from cli-rs"
 require_contains "$release_workflow" "working-directory: cli-rs" "Release CLI build must run from cli-rs"
 require_contains "$release_workflow" "rust-cli-linux-x64" "Release bundles must consume the locally built Linux x64 CLI artifact"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,8 @@ jobs:
             ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME \
             ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD \
             SIGNING_GPG_KEY_NAME \
-            SIGNING_GPG_PRIVATE_KEY
+            SIGNING_GPG_PRIVATE_KEY \
+            SIGNING_GPG_PASSPHRASE
           do
             if [[ -z "${!secret_name:-}" ]]; then
               echo "Missing ${secret_name} secret"
@@ -258,6 +259,7 @@ jobs:
           ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
           SIGNING_GPG_KEY_NAME: ${{ secrets.SIGNING_GPG_KEY_NAME }}
           SIGNING_GPG_PRIVATE_KEY: ${{ secrets.SIGNING_GPG_PRIVATE_KEY }}
+          SIGNING_GPG_PASSPHRASE: ${{ secrets.SIGNING_GPG_PASSPHRASE }}
 
       - name: Import GPG key
         if: steps.gate.outputs.publish == 'true'


### PR DESCRIPTION
## Summary
- require `SIGNING_GPG_PASSPHRASE` in the Maven Central publish gate
- keep Maven publication skipped when signing cannot run non-interactively
- add a release workflow contract guard for the passphrase gate

## Validation
- `.github/scripts/test-release-workflow-contract.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parsed"' && git diff --check`\n\n## Context\nRelease run 26731109334 failed at `Publish Maven Central` because `SIGNING_GPG_PASSPHRASE` was empty and GPG attempted interactive signing (`Inappropriate ioctl for device`). This restores the prior skip-cleanly behavior when signing secrets are incomplete.