### PR TITLE
fix: share source index schema version

### DIFF
--- a/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/SqliteCacheInvariantTest.kt
+++ b/backend-standalone/src/test/kotlin/io/github/amichne/kast/standalone/SqliteCacheInvariantTest.kt
@@ -1,6 +1,7 @@
 package io.github.amichne.kast.standalone
 
 import io.github.amichne.kast.indexstore.api.index.FileIndexUpdate
+import io.github.amichne.kast.indexstore.store.SOURCE_INDEX_SCHEMA_VERSION
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import io.github.amichne.kast.indexstore.store.cache.kastCacheDirectory
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -62,7 +63,7 @@ class SqliteCacheInvariantTest {
             conn.prepareStatement("SELECT version FROM schema_version LIMIT 1").use { stmt ->
                 val rs = stmt.executeQuery()
                 assertTrue(rs.next())
-                assertEquals(7, rs.getInt(1))
+                assertEquals(SOURCE_INDEX_SCHEMA_VERSION, rs.getInt(1))
             }
         }
     }

--- a/build-logic/src/main/kotlin/WriteSourceIndexSchemaVersionTask.kt
+++ b/build-logic/src/main/kotlin/WriteSourceIndexSchemaVersionTask.kt
@@ -1,0 +1,50 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+abstract class WriteSourceIndexSchemaVersionTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val releaseStateFile: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun write() {
+        val version = sourceIndexSchemaVersion(releaseStateFile.get().asFile.readText())
+        outputDirectory
+            .file("io/github/amichne/kast/indexstore/store/SourceIndexSchemaVersion.kt")
+            .get()
+            .asFile
+            .apply {
+                parentFile.mkdirs()
+                writeText(
+                    """
+                    package io.github.amichne.kast.indexstore.store
+
+                    /**
+                     * SQLite source-index schema version declared by the release state.
+                     */
+                    const val SOURCE_INDEX_SCHEMA_VERSION: Int = $version
+                    """.trimIndent() + "\n",
+                )
+            }
+    }
+
+    private fun sourceIndexSchemaVersion(content: String): Int {
+        val regex = Regex(""""source_index_schema_version"\s*:\s*(\d+)""")
+        val matches = regex.findAll(content).toList()
+        require(matches.size == 1) {
+            "release-state.json must contain exactly one source_index_schema_version field"
+        }
+        return matches.single().groupValues[1].toInt().also { version ->
+            require(version > 0) { "source_index_schema_version must be positive" }
+        }
+    }
+}

--- a/cli-rs/build.rs
+++ b/cli-rs/build.rs
@@ -1,0 +1,57 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let release_state = manifest_dir
+        .parent()
+        .expect("repo root")
+        .join("packaging/homebrew/release-state.json");
+    println!("cargo:rerun-if-changed={}", release_state.display());
+
+    let content = fs::read_to_string(&release_state).unwrap_or_else(|error| {
+        panic!("failed to read {}: {error}", release_state.display());
+    });
+    let version = source_index_schema_version(&content).unwrap_or_else(|error| {
+        panic!("invalid {}: {error}", release_state.display());
+    });
+
+    let output =
+        PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR")).join("source_index_schema.rs");
+    fs::write(
+        output,
+        format!("pub(crate) const SOURCE_INDEX_SCHEMA_VERSION: i64 = {version};\n"),
+    )
+    .expect("write generated source-index schema");
+    println!("cargo:rustc-env=KAST_SOURCE_INDEX_SCHEMA_VERSION={version}");
+}
+
+fn source_index_schema_version(content: &str) -> Result<i64, String> {
+    let key = "\"source_index_schema_version\"";
+    let count = content.matches(key).count();
+    if count != 1 {
+        return Err(format!("expected exactly one {key} field, found {count}"));
+    }
+    let (_, after_key) = content
+        .split_once(key)
+        .ok_or_else(|| format!("missing {key}"))?;
+    let (_, after_colon) = after_key
+        .split_once(':')
+        .ok_or_else(|| format!("{key} must have a value"))?;
+    let digits: String = after_colon
+        .trim_start()
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    if digits.is_empty() {
+        return Err(format!("{key} must be a positive integer"));
+    }
+    let version = digits
+        .parse::<i64>()
+        .map_err(|error| format!("{key} is not a valid integer: {error}"))?;
+    if version <= 0 {
+        return Err(format!("{key} must be positive"));
+    }
+    Ok(version)
+}

--- a/cli-rs/docs/architecture/source-index-reader.md
+++ b/cli-rs/docs/architecture/source-index-reader.md
@@ -63,8 +63,8 @@ target/release/kast-metrics-bench \
 
 The helper runs Rust direct SQLite timings for `fan-in`, `graph`,
 `search`, and `impact`. Metrics commands no longer fall back to JVM
-JSON-RPC, so stale or missing schema-6 indexes fail directly instead of
-hiding the read path being measured. It prints JSON with per-operation
+JSON-RPC, so stale or schema-incompatible indexes fail directly instead
+of hiding the read path being measured. It prints JSON with per-operation
 `minMs`, `medianMs`, `maxMs`, raw `timingsMs`, and any skipped or failed
 comparison runs.
 

--- a/cli-rs/docs/reference/cli-cheat-sheet.md
+++ b/cli-rs/docs/reference/cli-cheat-sheet.md
@@ -57,8 +57,8 @@ not mutate source files.
 | `kast demo` | Open the symbol or spatial demo, or print a JSON snapshot. | `--workspace-root`, `--view`, `--symbol`, `--query`, `--limit`, `--json` |
 
 `metrics` and `kast demo` are direct-index only because they need
-schema-6 relation rows, persistent FTS, spatial structure, and local
-source previews.
+current source-index relation rows, persistent FTS, spatial structure,
+and local source previews.
 
 ## Install and self-management
 

--- a/cli-rs/docs/what-can-kast-do/symbol-walk-demo.md
+++ b/cli-rs/docs/what-can-kast-do/symbol-walk-demo.md
@@ -212,8 +212,9 @@ and also calls `kast demo --view spatial --json --symbol app.A`.
 ## Source-index requirements
 
 The demo expects the current source-index schema used by `cli-rs`.
-It verifies that the database exists, has schema version `6`, and
-contains the tables needed for symbol names, persistent symbol FTS,
+It verifies that the database exists, has the published source-index
+schema version, and contains the tables needed for symbol names,
+persistent symbol FTS,
 declarations, file metadata, file manifests, and symbol references.
 
 If no database exists for the workspace, run:

--- a/cli-rs/src/demo.rs
+++ b/cli-rs/src/demo.rs
@@ -3,6 +3,7 @@ use crate::cli::{DemoArgs, DemoView};
 use crate::config;
 use crate::error::{CliError, Result};
 use crate::source_index_db;
+use crate::source_index_schema::SOURCE_INDEX_SCHEMA_VERSION;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::execute;
 use crossterm::terminal::{
@@ -23,7 +24,6 @@ use std::io::{self, IsTerminal, Stdout};
 use std::path::PathBuf;
 use std::time::Duration;
 
-const SOURCE_INDEX_SCHEMA_VERSION: i64 = 6;
 const PREVIEW_RADIUS: usize = 7;
 const SPATIAL_VIEWPORT_WIDTH: u16 = 120;
 const SPATIAL_VIEWPORT_HEIGHT: u16 = 40;

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -11,6 +11,7 @@ mod rpc;
 mod runtime;
 mod self_mgmt;
 mod source_index_db;
+mod source_index_schema;
 mod symbol_query;
 
 use clap::{CommandFactory, Parser};

--- a/cli-rs/src/metrics_database.rs
+++ b/cli-rs/src/metrics_database.rs
@@ -2,6 +2,7 @@ use crate::config;
 use crate::error::{CliError, Result};
 use crate::metrics::MetricsRequest;
 use crate::source_index_db;
+use crate::source_index_schema::SOURCE_INDEX_SCHEMA_VERSION;
 use glob::Pattern;
 use rusqlite::{Connection, ErrorCode, OpenFlags, OptionalExtension, Row, params};
 use serde::{Deserialize, Serialize};
@@ -14,8 +15,6 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 use std::time::Instant;
-
-const SOURCE_INDEX_SCHEMA_VERSION: i64 = 6;
 
 #[derive(Debug, Clone)]
 pub(crate) struct FileFilter {
@@ -1692,10 +1691,10 @@ mod tests {
     }
 
     fn seed_schema(conn: &Connection) {
-        conn.execute_batch(
+        conn.execute_batch(&format!(
             r#"
             CREATE TABLE schema_version (version INTEGER NOT NULL, generation INTEGER NOT NULL DEFAULT 0, head_commit TEXT);
-            INSERT INTO schema_version (version, generation, head_commit) VALUES (6, 0, NULL);
+            INSERT INTO schema_version (version, generation, head_commit) VALUES ({}, 0, NULL);
             CREATE TABLE path_prefixes (prefix_id INTEGER PRIMARY KEY, dir_path TEXT NOT NULL UNIQUE);
             CREATE TABLE fq_names (fq_id INTEGER PRIMARY KEY, fq_name TEXT NOT NULL UNIQUE);
             CREATE VIRTUAL TABLE fq_names_fts USING fts5(fq_name, tokenize='trigram');
@@ -1736,7 +1735,8 @@ mod tests {
                 PRIMARY KEY (src_prefix_id, src_filename, source_offset, target_fq_id)
             );
             "#,
-        )
+            SOURCE_INDEX_SCHEMA_VERSION,
+        ))
         .expect("schema");
     }
 

--- a/cli-rs/src/source_index_schema.rs
+++ b/cli-rs/src/source_index_schema.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/source_index_schema.rs"));

--- a/cli-rs/src/symbol_query.rs
+++ b/cli-rs/src/symbol_query.rs
@@ -1,6 +1,7 @@
 use crate::config;
 use crate::error::{CliError, Result};
 use crate::source_index_db;
+use crate::source_index_schema::SOURCE_INDEX_SCHEMA_VERSION;
 use glob::Pattern;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, params};
 use serde::{Deserialize, Serialize};
@@ -9,8 +10,6 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::path::{Path, PathBuf};
-
-const SOURCE_INDEX_SCHEMA_VERSION: i64 = 6;
 
 pub(crate) fn try_handle_raw_rpc(
     raw_request: &str,

--- a/cli-rs/tests/metrics_smoke.rs
+++ b/cli-rs/tests/metrics_smoke.rs
@@ -393,10 +393,10 @@ fn seed_source_index(workspace: &std::path::Path) {
     std::fs::create_dir_all(db_path.parent().expect("db parent")).expect("db parent");
     seed_source_files(workspace);
     let conn = Connection::open(db_path).expect("sqlite");
-    conn.execute_batch(
+    conn.execute_batch(&format!(
         r#"
         CREATE TABLE schema_version (version INTEGER NOT NULL, generation INTEGER NOT NULL DEFAULT 0, head_commit TEXT);
-        INSERT INTO schema_version (version, generation, head_commit) VALUES (6, 0, NULL);
+        INSERT INTO schema_version (version, generation, head_commit) VALUES ({}, 0, NULL);
         CREATE TABLE path_prefixes (prefix_id INTEGER PRIMARY KEY, dir_path TEXT NOT NULL UNIQUE);
         CREATE TABLE fq_names (fq_id INTEGER PRIMARY KEY, fq_name TEXT NOT NULL UNIQUE);
         CREATE VIRTUAL TABLE fq_names_fts USING fts5(fq_name, tokenize='trigram');
@@ -437,7 +437,8 @@ fn seed_source_index(workspace: &std::path::Path) {
             PRIMARY KEY (src_prefix_id, src_filename, source_offset, target_fq_id)
         );
         "#,
-    )
+        source_index_schema_version(),
+    ))
     .expect("schema");
 
     conn.execute("INSERT INTO path_prefixes VALUES (1, 'app')", [])
@@ -518,6 +519,12 @@ fn seed_source_index(workspace: &std::path::Path) {
         )
         .expect("reference");
     }
+}
+
+fn source_index_schema_version() -> i64 {
+    env!("KAST_SOURCE_INDEX_SCHEMA_VERSION")
+        .parse()
+        .expect("numeric source_index_schema_version")
 }
 
 fn seed_source_files(workspace: &std::path::Path) {

--- a/docs/architecture/scip-ingestion-audit.md
+++ b/docs/architecture/scip-ingestion-audit.md
@@ -74,7 +74,7 @@ around the same durable source-index schema, not competing sources of truth.
 
 | Priority | Finding | Evidence | Why it matters |
 | --- | --- | --- | --- |
-| P0 | Source-index schema version is duplicated across Kotlin and Rust | `SqliteSourceIndexStore` declares version `7`; Rust `symbol/query` checks version `6` in `cli-rs/` and `../kast-rs` | A Kotlin-written DB can be rejected by the Rust-owned query path. SCIP import would hit the same drift immediately. |
+| P0 | Source-index schema version must stay rooted outside language bindings | The active monorepo now declares `source_index_schema_version` in `packaging/homebrew/release-state.json`; earlier drift had Kotlin writing version `7` while Rust readers accepted version `6` | A Kotlin-written DB can be rejected by the Rust-owned query path whenever the version is duplicated. SCIP import would hit the same drift immediately. |
 | P0 | `symbol/query` wire models are duplicated | Kotlin models live in `analysis-api`; Rust has private serde structs with the same request and response concepts | Contract changes can compile in one language while breaking the other. |
 | P0 | The durable source-index schema is implicit | Storage tables, Kotlin row data classes, and Rust row structs collectively define the contract | A Rust-only writer cannot be built safely while the JVM writer is the practical source of truth. |
 | P1 | Scanner APIs are PSI-shaped instead of producer-shaped | `PsiSourceIndexScanner` and `PsiReferenceScanner` produce useful rows, but their input boundary is IntelliJ PSI | SCIP import should not need a JVM parser or PSI just to emit declaration and reference rows. |
@@ -256,8 +256,7 @@ guide and update the matching docs, generated resources, and tests together.
 
 ## Next steps
 
-Start with the schema source-of-truth work. If the current version mismatch is
-intentional, encode the compatibility rule in the schema manifest and teach
-the Rust reader and writer how to accept the supported range. If it is
-accidental, fix it before introducing the SCIP importer, because external
-ingestion will otherwise build on a broken contract.
+Continue from the schema source-of-truth work. The immediate schema-version
+drift is fixed by the external release-state value; the remaining work is to
+make the DDL, table semantics, compatibility rules, and Rust writer fixtures
+equally explicit before introducing the SCIP importer.

--- a/index-store/build.gradle.kts
+++ b/index-store/build.gradle.kts
@@ -3,6 +3,19 @@ plugins {
     kotlin("plugin.serialization")
 }
 
+val sourceIndexReleaseStateFile = rootProject.layout.projectDirectory.file("packaging/homebrew/release-state.json")
+val generatedSourceIndexSchemaDir = layout.buildDirectory.dir("generated/source-index-schema/kotlin")
+val generateSourceIndexSchema by tasks.registering(WriteSourceIndexSchemaVersionTask::class) {
+    releaseStateFile.set(sourceIndexReleaseStateFile)
+    outputDirectory.set(generatedSourceIndexSchemaDir)
+}
+
+kotlin {
+    sourceSets.named("main") {
+        kotlin.srcDir(generateSourceIndexSchema)
+    }
+}
+
 kastPublishing {
     artifactId.set("kast-index-store")
     moduleName.set("Kast Index Store")

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.kt
@@ -20,8 +20,6 @@ import java.nio.file.Path
 import java.sql.Connection
 import java.sql.DriverManager
 
-internal const val SOURCE_INDEX_SCHEMA_VERSION = 7
-
 /**
  * SQLite-backed store for the source identifier index, file manifest,
  * symbol references, and workspace discovery cache.

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SqliteSourceIndexStoreTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SqliteSourceIndexStoreTest.kt
@@ -1,6 +1,7 @@
 package io.github.amichne.kast.indexstore
 
 import io.github.amichne.kast.indexstore.api.index.FileIndexUpdate
+import io.github.amichne.kast.indexstore.store.SOURCE_INDEX_SCHEMA_VERSION
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import io.github.amichne.kast.indexstore.store.cache.kastCacheDirectory
 import io.github.amichne.kast.indexstore.store.cache.sourceIndexDatabasePath
@@ -65,7 +66,7 @@ class SqliteSourceIndexStoreTest {
             conn.prepareStatement("SELECT version FROM schema_version LIMIT 1").use { stmt ->
                 val rs = stmt.executeQuery()
                 assertTrue(rs.next())
-                assertEquals(7, rs.getInt(1))
+                assertEquals(SOURCE_INDEX_SCHEMA_VERSION, rs.getInt(1))
             }
         }
     }

--- a/packaging/homebrew/release-state.json
+++ b/packaging/homebrew/release-state.json
@@ -1,4 +1,5 @@
 {
   "schema_version": 1,
+  "source_index_schema_version": 7,
   "current_release": "v0.7.29"
 }

--- a/packaging/homebrew/scripts/release-state.py
+++ b/packaging/homebrew/scripts/release-state.py
@@ -47,6 +47,9 @@ def load_state() -> dict[str, object]:
 
     if state.get("schema_version") != 1:
         fail("release-state.json schema_version must be 1")
+    source_index_schema = state.get("source_index_schema_version")
+    if not isinstance(source_index_schema, int) or source_index_schema <= 0:
+        fail("release-state.json source_index_schema_version must be a positive integer")
     current = state.get("current_release")
     if not isinstance(current, str):
         fail("release-state.json current_release must be a string")

--- a/packaging/homebrew/scripts/test-formulas.py
+++ b/packaging/homebrew/scripts/test-formulas.py
@@ -44,11 +44,16 @@ kast = kast_formula.read_text(encoding="utf-8")
 plugin = plugin_cask.read_text(encoding="utf-8")
 docs = readme.read_text(encoding="utf-8")
 state = json.loads(release_state.read_text(encoding="utf-8"))
+source_index_schema_version = state.get("source_index_schema_version")
 
 kast_version = formula_version(kast, "Formula/kast.rb")
 plugin_version = cask_version(plugin, "Casks/kast-plugin.rb")
 require(kast_version == plugin_version, f"Package versions must match: kast={kast_version}, kast-plugin={plugin_version}")
 require(state.get("schema_version") == 1, "release-state.json schema_version must be 1")
+require(
+    isinstance(source_index_schema_version, int) and source_index_schema_version > 0,
+    "release-state.json source_index_schema_version must be a positive integer",
+)
 require(
     state.get("current_release") == f"v{kast_version}",
     f"release-state.json must match package version v{kast_version}",
@@ -131,6 +136,10 @@ with tempfile.TemporaryDirectory() as tmp:
     require(formula_version(updated_kast, "updated Formula/kast.rb") == "9.8.7", "updater must set the CLI version")
     require(cask_version(updated_plugin, "updated Casks/kast-plugin.rb") == "9.8.7", "updater must set the plugin version")
     require(updated_state.get("current_release") == "v9.8.7", "updater must set the current release state")
+    require(
+        updated_state.get("source_index_schema_version") == source_index_schema_version,
+        "updater must preserve the source-index schema version",
+    )
     require("/v9.8.7/kast-v9.8.7-macos-arm64.zip" in updated_docs, "updater must set the README CLI mirror example")
     require("/v9.8.7/kast-intellij-v9.8.7.zip" in updated_docs, "updater must set the README plugin mirror example")
     require('sha256 "' + ("1" * 64) + '"' in updated_kast, "updater must set macOS x64 sha")

--- a/packaging/homebrew/scripts/update-formulas.py
+++ b/packaging/homebrew/scripts/update-formulas.py
@@ -66,6 +66,10 @@ def update_release_state(root: Path, version: str) -> None:
 
     state = json.loads(release_state.read_text(encoding="utf-8"))
     require(state.get("schema_version") == 1, "release-state.json schema_version must be 1")
+    require(
+        isinstance(state.get("source_index_schema_version"), int) and state["source_index_schema_version"] > 0,
+        "release-state.json source_index_schema_version must be a positive integer",
+    )
     state["current_release"] = f"v{version}"
     release_state.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- declare source_index_schema_version in packaging/homebrew/release-state.json alongside tap release state
- generate the Kotlin index-store schema constant and Rust CLI source-index reader constant from that release-state value
- update Rust/Kotlin fixtures, packaging validation, and docs to avoid duplicated schema-version values

## Validation
- cargo fmt --all -- --check
- cargo test --locked --all-targets --all-features
- cargo clippy --locked --all-targets --all-features -- -D warnings
- ./gradlew :index-store:test
- ./gradlew :backend-standalone:test --tests "io.github.amichne.kast.standalone.SqliteCacheInvariantTest.schema version mismatch triggers full rebuild"
- python3 packaging/homebrew/scripts/test-formulas.py
- zensical build --clean (repo root)
- zensical build --clean (cli-rs)
- git diff --check
