### PR TITLE
Add Devin headless runtime bundle

### DIFF
--- a/.github/scripts/test-kast-build-contract.sh
+++ b/.github/scripts/test-kast-build-contract.sh
@@ -19,13 +19,21 @@ require_contains() {
   grep -Fq -- "$expected" "$file_path" || die "${description}: missing '${expected}' in ${file_path}"
 }
 
+require_not_contains() {
+  local file_path="$1"
+  local forbidden="$2"
+  local description="$3"
+  ! grep -Fq -- "$forbidden" "$file_path" || die "${description}: found forbidden '${forbidden}' in ${file_path}"
+}
+
 repo_root="$(resolve_repo_root)"
 kast_script="${repo_root}/kast.sh"
 headless_build="${repo_root}/backend-headless/build.gradle.kts"
+headless_project_opener="${repo_root}/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessProjectOpener.kt"
 standalone_app_plugin="${repo_root}/build-logic/src/main/kotlin/kast.standalone-app.gradle.kts"
 verify_layout_task="${repo_root}/build-logic/src/main/kotlin/VerifyClasspathLayoutTask.kt"
 
-for path in "$kast_script" "$headless_build" "$standalone_app_plugin" "$verify_layout_task"; do
+for path in "$kast_script" "$headless_build" "$headless_project_opener" "$standalone_app_plugin" "$verify_layout_task"; do
   [[ -f "$path" ]] || die "Required build contract file is missing: $path"
 done
 
@@ -39,6 +47,7 @@ require_contains "$headless_build" '"plugins/maven/**"' "Agent profile must incl
 require_contains "$headless_build" '"plugins/repository-search/**"' "Agent profile must include repository search support for dependency metadata"
 require_contains "$headless_build" '"plugins/toml/**"' "Agent profile must include TOML support for version catalogs"
 require_contains "$headless_build" '"plugins/yaml/**"' "Agent profile must include YAML support for common project configuration"
+require_not_contains "$headless_project_opener" "waitForSmartMode()" "Headless startup must not block the application starter before the analysis server registers"
 require_contains "$verify_layout_task" "forbiddenPortableDistJarSuffixes" "Headless layout verifier must reject forbidden portable-dist jars"
 
 require_contains "$kast_script" "full|minimal|agent" "kast.sh must accept the agent headless IDEA-home profile"

--- a/.github/scripts/test-kast-build-contract.sh
+++ b/.github/scripts/test-kast-build-contract.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/../.." && pwd
+}
+
+require_contains() {
+  local file_path="$1"
+  local expected="$2"
+  local description="$3"
+  grep -Fq -- "$expected" "$file_path" || die "${description}: missing '${expected}' in ${file_path}"
+}
+
+repo_root="$(resolve_repo_root)"
+kast_script="${repo_root}/kast.sh"
+headless_build="${repo_root}/backend-headless/build.gradle.kts"
+standalone_app_plugin="${repo_root}/build-logic/src/main/kotlin/kast.standalone-app.gradle.kts"
+verify_layout_task="${repo_root}/build-logic/src/main/kotlin/VerifyClasspathLayoutTask.kt"
+
+for path in "$kast_script" "$headless_build" "$standalone_app_plugin" "$verify_layout_task"; do
+  [[ -f "$path" ]] || die "Required build contract file is missing: $path"
+done
+
+require_contains "$standalone_app_plugin" "kastIncludeShadowJar" "Shared app packaging must expose a shadow-jar inclusion property"
+require_contains "$headless_build" 'extra["kastIncludeShadowJar"] = "false"' "Headless backend must opt out of the shadow fat jar"
+require_contains "$headless_build" "agentPackagedIdeaHomeEntries" "Headless backend must define the agent IDEA-home profile"
+require_contains "$headless_build" '"agent" -> agentPackagedIdeaHomeEntries' "Headless backend must select the agent IDEA-home profile"
+require_contains "$headless_build" '"plugins/java-ide-customization/**"' "Agent profile must include the Java IDE customization plugin required by IDEA startup"
+require_contains "$headless_build" '"plugins/json/**"' "Agent profile must include the JSON plugin required by IDEA startup"
+require_contains "$headless_build" '"plugins/maven/**"' "Agent profile must include Maven plugin support for Gradle dependency import"
+require_contains "$headless_build" '"plugins/repository-search/**"' "Agent profile must include repository search support for dependency metadata"
+require_contains "$headless_build" '"plugins/toml/**"' "Agent profile must include TOML support for version catalogs"
+require_contains "$headless_build" '"plugins/yaml/**"' "Agent profile must include YAML support for common project configuration"
+require_contains "$verify_layout_task" "forbiddenPortableDistJarSuffixes" "Headless layout verifier must reject forbidden portable-dist jars"
+
+require_contains "$kast_script" "full|minimal|agent" "kast.sh must accept the agent headless IDEA-home profile"
+require_contains "$kast_script" "--headless-idea-home-profile=full|minimal|agent" "kast.sh help must document the agent profile"
+require_contains "$kast_script" "must not include fat jars" "kast.sh must reject staged headless fat jars"
+
+printf '%s\n' "Kast build contract passed"

--- a/.github/scripts/test-release-asset-verifier.sh
+++ b/.github/scripts/test-release-asset-verifier.sh
@@ -87,6 +87,7 @@ write_expected_assets() {
   write_zip_asset "${release_dir}/kast-headless-${tag}.zip" headless
   write_text_asset "${release_dir}/kast-ubuntu-debian-x86_64-${tag}.tar.gz"
   write_text_asset "${release_dir}/kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz"
+  write_text_asset "${release_dir}/kast-devin-headless-runtime-linux-x64-${tag}.tar.gz"
   printf '%s  %s\n' \
     "$(compute_sha256 "${release_dir}/kast-ubuntu-debian-x86_64-${tag}.tar.gz")" \
     "kast-ubuntu-debian-x86_64-${tag}.tar.gz" \
@@ -95,6 +96,10 @@ write_expected_assets() {
     "$(compute_sha256 "${release_dir}/kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz")" \
     "kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz" \
     > "${release_dir}/kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz.sha256"
+  printf '%s  %s\n' \
+    "$(compute_sha256 "${release_dir}/kast-devin-headless-runtime-linux-x64-${tag}.tar.gz")" \
+    "kast-devin-headless-runtime-linux-x64-${tag}.tar.gz" \
+    > "${release_dir}/kast-devin-headless-runtime-linux-x64-${tag}.tar.gz.sha256"
 }
 
 write_sha256sums() {
@@ -124,6 +129,7 @@ entries = [
     ("cli-macos-arm64", f"kast-{tag}-macos-arm64.zip"),
     ("ubuntu-debian-x86_64", f"kast-ubuntu-debian-x86_64-{tag}.tar.gz"),
     ("ubuntu-debian-headless-x86_64", f"kast-ubuntu-debian-headless-x86_64-{tag}.tar.gz"),
+    ("devin-headless-linux-x64", f"kast-devin-headless-runtime-linux-x64-{tag}.tar.gz"),
     ("headless", f"kast-headless-{tag}.zip"),
     ("intellij", f"kast-intellij-{tag}.zip"),
     ("standalone", f"kast-standalone-{tag}.zip"),
@@ -164,6 +170,7 @@ assets=(
   "kast-${tag}-macos-arm64.zip"
   "kast-ubuntu-debian-x86_64-${tag}.tar.gz"
   "kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz"
+  "kast-devin-headless-runtime-linux-x64-${tag}.tar.gz"
   "kast-headless-${tag}.zip"
   "kast-intellij-${tag}.zip"
   "kast-standalone-${tag}.zip"

--- a/.github/scripts/test-release-provenance-assembler.sh
+++ b/.github/scripts/test-release-provenance-assembler.sh
@@ -74,6 +74,10 @@ write_provenance \
   "${scratch_dir}/provenance-ubuntu-debian/dist/build-provenance-ubuntu-debian.json" \
   "ubuntu-debian-x86_64" \
   "kast-ubuntu-debian-x86_64-${tag}.tar.gz"
+write_provenance \
+  "${scratch_dir}/provenance-devin-headless/dist/build-provenance-devin-headless-linux-x64.json" \
+  "devin-headless-linux-x64" \
+  "kast-devin-headless-runtime-linux-x64-${tag}.tar.gz"
 
 output="${scratch_dir}/dist/build-provenance.json"
 "$assembler" \
@@ -82,6 +86,7 @@ output="${scratch_dir}/dist/build-provenance.json"
   "${scratch_dir}/provenance-cli-linux-x64" \
   "${scratch_dir}/provenance-cli-macos-arm64" \
   "${scratch_dir}/provenance-cli-macos-x64" \
+  "${scratch_dir}/provenance-devin-headless" \
   "${scratch_dir}/provenance-headless" \
   "${scratch_dir}/provenance-intellij" \
   "${scratch_dir}/provenance-standalone" \
@@ -100,6 +105,7 @@ expected = [
     "cli-linux-x64",
     "cli-macos-arm64",
     "cli-macos-x64",
+    "devin-headless-linux-x64",
     "headless",
     "intellij",
     "standalone",
@@ -110,7 +116,7 @@ if platforms != expected:
     raise SystemExit(f"unexpected platform order: {platforms!r}")
 PY
 
-rm -rf "${scratch_dir}/provenance-ubuntu-debian" "${scratch_dir}/provenance-ubuntu-debian-headless"
+rm -rf "${scratch_dir}/provenance-devin-headless" "${scratch_dir}/provenance-ubuntu-debian" "${scratch_dir}/provenance-ubuntu-debian-headless"
 "$assembler" \
   --output "$output" \
   "${scratch_dir}/provenance-cli-linux-arm64" \

--- a/.github/scripts/test-release-provenance-merge.sh
+++ b/.github/scripts/test-release-provenance-merge.sh
@@ -97,6 +97,11 @@ write_optional_provenance \
   "ubuntu-debian-headless-x86_64" \
   "kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz" \
   9
+write_optional_provenance \
+  "${scratch_dir}/devin" \
+  "devin-headless-linux-x64" \
+  "kast-devin-headless-runtime-linux-x64-${tag}.tar.gz" \
+  10
 
 one_output="${scratch_dir}/one.json"
 "$merger" \
@@ -105,30 +110,35 @@ one_output="${scratch_dir}/one.json"
   "${scratch_dir}/standalone"
 assert_platform_count "$one_output" "ubuntu-debian-x86_64" 1
 assert_platform_count "$one_output" "ubuntu-debian-headless-x86_64" 0
+assert_platform_count "$one_output" "devin-headless-linux-x64" 0
 
 both_output="${scratch_dir}/both.json"
 "$merger" \
   --base "$one_output" \
   --output "$both_output" \
   "${scratch_dir}/standalone" \
-  "${scratch_dir}/headless"
+  "${scratch_dir}/headless" \
+  "${scratch_dir}/devin"
 assert_platform_count "$both_output" "ubuntu-debian-x86_64" 1
 assert_platform_count "$both_output" "ubuntu-debian-headless-x86_64" 1
+assert_platform_count "$both_output" "devin-headless-linux-x64" 1
 
 rerun_output="${scratch_dir}/rerun.json"
 "$merger" \
   --base "$both_output" \
   --output "$rerun_output" \
   "${scratch_dir}/standalone" \
-  "${scratch_dir}/headless"
+  "${scratch_dir}/headless" \
+  "${scratch_dir}/devin"
 assert_platform_count "$rerun_output" "ubuntu-debian-x86_64" 1
 assert_platform_count "$rerun_output" "ubuntu-debian-headless-x86_64" 1
+assert_platform_count "$rerun_output" "devin-headless-linux-x64" 1
 
 write_optional_provenance \
   "${scratch_dir}/required" \
   "standalone" \
   "kast-standalone-${tag}.zip" \
-  10
+  11
 if "$merger" \
   --base "$base" \
   --output "${scratch_dir}/required-output.json" \

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -44,6 +44,7 @@ repo_root="$(resolve_repo_root)"
 ci_workflow="${repo_root}/.github/workflows/ci.yml"
 release_workflow="${repo_root}/.github/workflows/release.yml"
 offline_bundle_workflow="${repo_root}/.github/workflows/offline-bundles.yml"
+devin_runtime_workflow="${repo_root}/.github/workflows/devin-runtime.yml"
 snapshot_workflow="${repo_root}/.github/workflows/snapshot.yml"
 docs_workflow="${repo_root}/.github/workflows/docs.yml"
 root_build_file="${repo_root}/build.gradle.kts"
@@ -62,6 +63,7 @@ for path in \
   "$ci_workflow" \
   "$release_workflow" \
   "$offline_bundle_workflow" \
+  "$devin_runtime_workflow" \
   "$snapshot_workflow" \
   "$docs_workflow" \
   "$root_build_file" \
@@ -110,6 +112,9 @@ require_contains "$ci_workflow" "working-directory: cli-rs" "CI Rust commands mu
 require_contains "$ci_workflow" "cache-cleanup: always" "CI Gradle setup must keep persisted Gradle caches pruned"
 require_contains "$ci_workflow" "packaging/homebrew/scripts/test-formulas.py" "CI must validate Homebrew package templates"
 require_contains "$ci_workflow" "Download Rust CLI CI asset" "CI bundle tests must consume a locally built CLI artifact"
+require_contains "$ci_workflow" "Smoke Devin headless runtime contract" "CI must smoke the Devin runtime bundle contract"
+require_contains "$ci_workflow" "-PkastHeadlessIdeaHomeProfile=agent" "CI must build the agent headless IDEA-home profile"
+require_contains "$ci_workflow" "Assert headless distribution excludes fat jar" "CI must guard the headless no-fat-jar layout"
 require_contains "$ci_workflow" "Free standalone distribution workspace before headless build" "CI must free standalone distribution workspace before building headless assets on constrained runners"
 require_not_contains "$ci_workflow" "standalone-dist-cache" "CI must not use a custom Actions cache for generated standalone distributions"
 require_not_contains "$ci_workflow" "headless-dist-cache" "CI must not use a custom Actions cache for generated headless distributions"
@@ -166,12 +171,23 @@ require_contains "$offline_bundle_workflow" "scripts/merge-release-provenance.py
 require_contains "$offline_bundle_workflow" "scripts/verify-release-assets.sh" "Offline bundle workflow must verify appended release assets"
 require_contains "$offline_bundle_workflow" "gh release upload" "Offline bundle workflow must support appending assets to a release"
 
+require_contains "$devin_runtime_workflow" "workflow_dispatch:" "Devin runtime workflow must be manually dispatchable"
+require_contains "$devin_runtime_workflow" "publish_to_release:" "Devin runtime workflow must require explicit release append"
+require_contains "$devin_runtime_workflow" "-PkastHeadlessIdeaHomeProfile=agent" "Devin runtime workflow must build the agent headless profile"
+require_contains "$devin_runtime_workflow" "scripts/package-devin-headless-runtime.sh" "Devin runtime workflow must package the runtime bundle"
+require_contains "$devin_runtime_workflow" "scripts/verify-kast-devin-runtime.sh" "Devin runtime workflow must verify the runtime bundle"
+require_contains "$devin_runtime_workflow" "scripts/merge-release-provenance.py" "Devin runtime workflow must merge optional provenance"
+require_contains "$devin_runtime_workflow" "scripts/verify-release-assets.sh" "Devin runtime workflow must verify appended release assets"
+require_contains "$devin_runtime_workflow" "gh release upload" "Devin runtime workflow must support appending assets to a release"
+
 require_contains "$release_provenance_assembler" '"cli-linux-x64"' "Release provenance must include Linux x64 CLI assets"
 require_contains "$release_provenance_assembler" '"cli-linux-arm64"' "Release provenance must include Linux arm64 CLI assets"
 require_contains "$release_provenance_assembler" '"cli-macos-x64"' "Release provenance must include macOS x64 CLI assets"
 require_contains "$release_provenance_assembler" '"cli-macos-arm64"' "Release provenance must include macOS arm64 CLI assets"
+require_contains "$release_provenance_assembler" '"devin-headless-linux-x64"' "Release provenance must support the optional Devin headless runtime asset"
 require_contains "$release_asset_verifier" '"cli-linux-x64"' "Release verifier must require CLI assets"
 require_contains "$release_asset_verifier" 'kast-{tag}-macos-arm64.zip' "Release verifier must require macOS CLI assets"
+require_contains "$release_asset_verifier" 'kast-devin-headless-runtime-linux-x64-{tag}.tar.gz' "Release verifier must support the optional Devin headless runtime asset"
 require_contains "$kast_script" "-Pname=value" "kast.sh build help must document Gradle property forwarding"
 
 require_not_contains "$docs_workflow" "repository: amichne/kast-rs" "Docs workflow must use in-repo CLI command catalog"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         shell: bash
         run: ./.github/scripts/test-release-workflow-contract.sh
 
+      - name: Test Kast build contract
+        shell: bash
+        run: ./.github/scripts/test-kast-build-contract.sh
+
       - name: Test standalone profile workflow contract
         shell: bash
         run: ./.github/scripts/test-standalone-profile-workflow-contract.sh
@@ -66,6 +70,10 @@ jobs:
       - name: Smoke Ubuntu/Debian headless bundle contract
         shell: bash
         run: ./scripts/smoke-ubuntu-debian-headless-bundle.sh
+
+      - name: Smoke Devin headless runtime contract
+        shell: bash
+        run: ./scripts/smoke-devin-headless-runtime.sh
 
   maven-publication-contract:
     name: Maven publication metadata
@@ -187,6 +195,16 @@ jobs:
       - name: Build headless backend distribution
         run: ./gradlew :backend-headless:portableDistZip
 
+      - name: Assert headless distribution excludes fat jar
+        shell: bash
+        run: |
+          set -euo pipefail
+          if find backend-headless/build/portable-dist -name '*-all.jar' -print -quit | grep -q .; then
+            echo "Headless portable distribution must not contain fat jars" >&2
+            find backend-headless/build/portable-dist -name '*-all.jar' -print >&2
+            exit 1
+          fi
+
       - name: Upload build-and-test test reports
         if: always()
         uses: actions/upload-artifact@v6
@@ -213,6 +231,10 @@ jobs:
           path: backend-headless/build/distributions/backend-headless-*-portable.zip
           if-no-files-found: error
           retention-days: 1
+
+      - name: Build agent headless backend distribution
+        if: matrix.os == 'ubuntu-latest'
+        run: ./gradlew :backend-headless:portableDistZip -PkastHeadlessIdeaHomeProfile=agent
 
   install-ubuntu-debian-container:
     name: Ubuntu/Debian install container (${{ matrix.container-image }}, Java ${{ matrix.java-version }})
@@ -335,6 +357,74 @@ jobs:
           KAST_UBUNTU_DEBIAN_JAVA_VERSION: ${{ matrix.java-version }}
         shell: bash
         run: BUNDLE_PATH="$KAST_UBUNTU_DEBIAN_HEADLESS_BUNDLE" ./scripts/validate-ubuntu-debian-headless-bundle-in-docker.sh
+
+  devin-headless-runtime:
+    name: Devin headless runtime
+    runs-on: ubuntu-22.04
+    needs:
+      - workflow-contracts
+      - rust-cli
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-cleanup: always
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/kast/headless-intellij-distributions
+          key: headless-idea-dist-${{ hashFiles('gradle/libs.versions.toml') }}
+
+      - name: Download Rust CLI CI asset
+        uses: actions/download-artifact@v7
+        with:
+          name: kast-rust-cli-linux-x64
+          path: dist
+
+      - name: Build agent headless backend distribution
+        run: ./gradlew :backend-headless:portableDistZip -PkastHeadlessIdeaHomeProfile=agent -Pversion=9.8.7
+
+      - name: Package and verify Devin runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="v9.8.7"
+          cli_asset="dist/kast-v0.0.0-ci-linux-x64.zip"
+          backend_asset="$(find backend-headless/build/distributions -maxdepth 1 -name 'backend-headless-*-portable.zip' -print -quit)"
+          bundle_asset="dist/kast-devin-headless-runtime-linux-x64-${version}.tar.gz"
+          [[ -f "$cli_asset" ]] || { echo "Missing Rust CLI CI asset: ${cli_asset}" >&2; exit 1; }
+          [[ -n "$backend_asset" ]] || { echo "Missing agent headless backend portable zip" >&2; exit 1; }
+
+          ./scripts/package-devin-headless-runtime.sh \
+            --cli-archive "$cli_asset" \
+            --backend-archive "$backend_asset" \
+            --version "$version" \
+            --output "$bundle_asset"
+
+          extract_dir="$RUNNER_TEMP/kast-devin-runtime"
+          rm -rf "$extract_dir"
+          mkdir -p "$extract_dir"
+          tar -xzf "$bundle_asset" -C "$extract_dir"
+          prefix="${extract_dir}/kast-devin-headless-runtime-linux-x64-${version}"
+          "$prefix/scripts/setup-kast-devin-runtime.sh" --prefix "$prefix"
+          "$prefix/scripts/verify-kast-devin-runtime.sh" --prefix "$prefix"
+
+      - name: Upload Devin runtime artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: kast-devin-headless-runtime-linux-x64
+          path: |
+            dist/kast-devin-headless-runtime-linux-x64-v9.8.7.tar.gz
+            dist/kast-devin-headless-runtime-linux-x64-v9.8.7.tar.gz.sha256
+          if-no-files-found: error
+          retention-days: 1
 
   analysis-server-transport:
     name: Analysis server transport

--- a/.github/workflows/devin-runtime.yml
+++ b/.github/workflows/devin-runtime.yml
@@ -1,0 +1,201 @@
+name: Devin Runtime
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version tag to package, for example v0.7.35"
+        required: true
+        type: string
+      publish_to_release:
+        description: "Append the Devin runtime asset to the existing release"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  package-devin-runtime:
+    name: Package Devin headless runtime
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Validate inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.version }}"
+          [[ "$tag" == v* ]] || { echo "version must start with v: $tag" >&2; exit 1; }
+          printf 'KAST_RELEASE_TAG=%s\n' "$tag" >> "$GITHUB_ENV"
+          printf 'KAST_RELEASE_VERSION=%s\n' "${tag#v}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.version }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-cleanup: always
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.gradle/kast/headless-intellij-distributions
+          key: headless-idea-dist-${{ hashFiles('gradle/libs.versions.toml') }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Linux x64 Rust CLI
+        working-directory: cli-rs
+        shell: bash
+        run: |
+          set -euo pipefail
+          KAST_VERSION="$KAST_RELEASE_VERSION" cargo build --release --locked
+
+      - name: Package Linux x64 CLI input
+        shell: bash
+        run: |
+          set -euo pipefail
+          staging_dir="$RUNNER_TEMP/kast-cli-linux-x64"
+          rm -rf "$staging_dir" dist
+          mkdir -p "$staging_dir" dist
+          cp cli-rs/target/release/kast "$staging_dir/kast"
+          chmod 755 "$staging_dir/kast"
+          (cd "$staging_dir" && zip -9 -q "$GITHUB_WORKSPACE/dist/kast-${KAST_RELEASE_TAG}-linux-x64.zip" kast)
+
+      - name: Build agent headless backend
+        run: >
+          ./gradlew
+          :backend-headless:portableDistZip
+          -PkastHeadlessIdeaHomeProfile=agent
+          -Pversion="${KAST_RELEASE_VERSION}"
+
+      - name: Package Devin runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          cli_asset="dist/kast-${KAST_RELEASE_TAG}-linux-x64.zip"
+          backend_asset="$(find backend-headless/build/distributions -maxdepth 1 -name 'backend-headless-*-portable.zip' -print -quit)"
+          bundle_asset="dist/kast-devin-headless-runtime-linux-x64-${KAST_RELEASE_TAG}.tar.gz"
+          [[ -f "$cli_asset" ]] || { echo "Missing CLI asset: ${cli_asset}" >&2; exit 1; }
+          [[ -n "$backend_asset" ]] || { echo "Missing agent headless backend portable zip" >&2; exit 1; }
+
+          ./scripts/package-devin-headless-runtime.sh \
+            --cli-archive "$cli_asset" \
+            --backend-archive "$backend_asset" \
+            --version "$KAST_RELEASE_TAG" \
+            --output "$bundle_asset"
+
+      - name: Verify Devin runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle_asset="dist/kast-devin-headless-runtime-linux-x64-${KAST_RELEASE_TAG}.tar.gz"
+          extract_dir="$RUNNER_TEMP/kast-devin-runtime"
+          rm -rf "$extract_dir"
+          mkdir -p "$extract_dir"
+          tar -xzf "$bundle_asset" -C "$extract_dir"
+          prefix="${extract_dir}/kast-devin-headless-runtime-linux-x64-${KAST_RELEASE_TAG}"
+          "$prefix/scripts/setup-kast-devin-runtime.sh" --prefix "$prefix"
+          scripts/verify-kast-devin-runtime.sh --prefix "$prefix"
+
+      - name: Write Devin provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle_asset="dist/kast-devin-headless-runtime-linux-x64-${KAST_RELEASE_TAG}.tar.gz"
+          python3 - "$bundle_asset" "dist/provenance/build-provenance-devin-headless-linux-x64.json" <<'PY'
+          import hashlib
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          asset = Path(sys.argv[1])
+          output = Path(sys.argv[2])
+          output.parent.mkdir(parents=True, exist_ok=True)
+          payload = {
+              "runId": os.environ["GITHUB_RUN_ID"],
+              "runNumber": os.environ["GITHUB_RUN_NUMBER"],
+              "runAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
+              "sha": os.environ["GITHUB_SHA"],
+              "ref": os.environ["GITHUB_REF"],
+              "workflowRef": os.environ["GITHUB_WORKFLOW_REF"],
+              "actor": os.environ["GITHUB_ACTOR"],
+              "platformId": "devin-headless-linux-x64",
+              "assetName": asset.name,
+              "assetDigest": "sha256:" + hashlib.sha256(asset.read_bytes()).hexdigest(),
+          }
+          output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+          PY
+
+      - name: Verify and append to release
+        if: ${{ inputs.publish_to_release }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="$KAST_RELEASE_TAG"
+          bundle_asset="dist/kast-devin-headless-runtime-linux-x64-${tag}.tar.gz"
+          bundle_sidecar="${bundle_asset}.sha256"
+          gh release view "$tag" >/dev/null
+          rm -rf release-assets
+          mkdir -p release-assets
+          gh release download "$tag" --dir release-assets --pattern '*.zip'
+          gh release download "$tag" --dir release-assets --pattern '*.tar.gz' || true
+          gh release download "$tag" --dir release-assets --pattern '*.tar.gz.sha256' || true
+          gh release download "$tag" --dir release-assets --pattern 'SHA256SUMS'
+          gh release download "$tag" --dir release-assets --pattern 'build-provenance.json'
+          cp "$bundle_asset" "$bundle_sidecar" release-assets/
+          ./scripts/merge-release-provenance.py \
+            --base release-assets/build-provenance.json \
+            --output dist/build-provenance.json \
+            dist/provenance
+          cp dist/build-provenance.json release-assets/build-provenance.json
+          mapfile -t expected_assets < <(python3 - release-assets/build-provenance.json <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+          payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          for entry in payload.get("builds", []):
+              asset = entry.get("assetName")
+              if isinstance(asset, str):
+                  print(asset)
+          PY
+          )
+          expected_sidecars=()
+          for asset in "${expected_assets[@]}"; do
+            if [[ "$asset" == *.tar.gz ]]; then
+              expected_sidecars+=("${asset}.sha256")
+            fi
+          done
+          for asset in "${expected_assets[@]}"; do
+            [[ -f "release-assets/${asset}" ]] || { echo "Missing release asset: ${asset}" >&2; exit 1; }
+          done
+          for sidecar in "${expected_sidecars[@]}"; do
+            [[ -f "release-assets/${sidecar}" ]] || { echo "Missing release checksum sidecar: ${sidecar}" >&2; exit 1; }
+          done
+          (cd release-assets && sha256sum "${expected_assets[@]}") > release-assets/SHA256SUMS
+          ./scripts/verify-release-assets.sh --release-dir release-assets --tag "$tag"
+          gh release upload "$tag" "$bundle_asset" "$bundle_sidecar" release-assets/build-provenance.json release-assets/SHA256SUMS --clobber
+
+      - name: Upload Devin runtime artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: devin-headless-runtime-${{ github.run_id }}
+          path: |
+            dist/kast-devin-headless-runtime-linux-x64-*.tar.gz
+            dist/kast-devin-headless-runtime-linux-x64-*.tar.gz.sha256
+            dist/provenance/build-provenance-devin-headless-linux-x64.json
+          if-no-files-found: warn

--- a/backend-headless/build.gradle.kts
+++ b/backend-headless/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("kast.standalone-serialization-app")
 }
 
+extra["kastIncludeShadowJar"] = "false"
+
 private val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
 private val intellijIdeaVersion = catalog.findVersion("intellij-idea").get().requiredVersion
 
@@ -93,9 +95,22 @@ val minimalPackagedIdeaHomeEntries = listOf(
     "plugins/Kotlin/**",
 )
 
+val agentPackagedIdeaHomeEntries = minimalPackagedIdeaHomeEntries + listOf(
+    "plugins/gradle/**",
+    "plugins/gradle-java/**",
+    "plugins/java-ide-customization/**",
+    "plugins/json/**",
+    "plugins/maven/**",
+    "plugins/properties/**",
+    "plugins/repository-search/**",
+    "plugins/toml/**",
+    "plugins/yaml/**",
+)
+
 val packagedIdeaHomeEntries = when (headlessIdeaHomeProfile.get()) {
     "full" -> fullPackagedIdeaHomeEntries
     "minimal" -> minimalPackagedIdeaHomeEntries
+    "agent" -> agentPackagedIdeaHomeEntries
     else -> error("Unsupported kastHeadlessIdeaHomeProfile=${headlessIdeaHomeProfile.get()}")
 }
 
@@ -343,7 +358,7 @@ tasks.named<WriteWrapperScriptTask>("writeWrapperScript") {
 val headlessRuntimeRequiredClassEntries = listOf(
     "io/github/amichne/kast/headless/HeadlessMainKt.class",
     "com/intellij/idea/Main.class",
-    "com/intellij/openapi/application/ModernApplicationStarter.class",
+    "com/intellij/openapi/application/ApplicationStarter.class",
     "com/intellij/openapi/project/DumbService.class",
 )
 
@@ -402,11 +417,14 @@ val verifyHeadlessPortableDistLayout by tasks.registering(VerifyClasspathLayoutT
     description = "Verifies headless plugin runtime jars are loaded from the plugin class loader."
     dependsOn("syncPortableDist")
 
+    val portableDistDirectory = layout.buildDirectory.dir("portable-dist/${project.name}")
     val runtimeLibsDirectory = layout.buildDirectory.dir("portable-dist/${project.name}/runtime-libs")
     val pluginLibsDirectory = layout.buildDirectory.dir("portable-dist/${project.name}/idea-home/plugins/kast-headless/lib")
+    this.portableDistDirectory.set(portableDistDirectory)
     this.runtimeLibsDirectory.set(runtimeLibsDirectory)
     runtimeClasspathFile.set(runtimeLibsDirectory.map { it.file("classpath.txt") })
     this.pluginLibsDirectory.set(pluginLibsDirectory)
+    forbiddenPortableDistJarSuffixes.set(listOf("-all.jar"))
     forbiddenRuntimeJarPrefixes.set(headlessPluginRuntimeJarPrefixes)
     requiredRuntimeClassEntries.set(headlessRuntimeRequiredClassEntries)
     requiredPluginJarPrefixes.set(headlessPluginLibJarPrefixes)

--- a/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessMain.kt
+++ b/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessMain.kt
@@ -1,6 +1,6 @@
 package io.github.amichne.kast.headless
 
-import com.intellij.openapi.application.ModernApplicationStarter
+import com.intellij.openapi.application.ApplicationStarter
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
@@ -9,10 +9,10 @@ fun main(args: Array<String>) {
     main.invoke(null, HeadlessRuntime.ideaMainArgs(args))
 }
 
-class HeadlessApplicationStarter : ModernApplicationStarter() {
+class HeadlessApplicationStarter : ApplicationStarter {
     override val isHeadless: Boolean = true
 
-    override suspend fun start(args: List<String>) {
+    override fun main(args: List<String>) {
         runCatching {
             HeadlessRuntime.run(HeadlessServerOptions.parseStarterArgs(args))
         }.onFailure { error ->

--- a/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessProjectOpener.kt
+++ b/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessProjectOpener.kt
@@ -1,7 +1,6 @@
 package io.github.amichne.kast.headless
 
 import com.intellij.ide.impl.OpenProjectTask
-import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ex.ProjectManagerEx
 import java.nio.file.Path
@@ -10,11 +9,19 @@ class HeadlessProjectOpener {
     fun openProject(workspaceRoot: Path): Project {
         val projectPath = workspaceRoot.toAbsolutePath().normalize()
         val project = ProjectManagerEx.getInstanceEx()
-            .openProject(projectPath, OpenProjectTask.build())
+            .openProject(projectPath, openProjectTask())
             ?: error("IntelliJ could not open project: $projectPath")
 
-        DumbService.getInstance(project).waitForSmartMode()
-        println("Project opened and indexes ready: ${project.name}")
+        println("Project opened: ${project.name}")
         return project
+    }
+
+    companion object {
+        fun openProjectTask(): OpenProjectTask = OpenProjectTask.build().copy(
+            isRefreshVfsNeeded = false,
+            runConfigurators = false,
+            runConversionBeforeOpen = false,
+            preloadServices = false,
+        )
     }
 }

--- a/backend-headless/src/test/kotlin/io/github/amichne/kast/headless/HeadlessServerOptionsTest.kt
+++ b/backend-headless/src/test/kotlin/io/github/amichne/kast/headless/HeadlessServerOptionsTest.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.headless
 
+import com.intellij.openapi.application.ApplicationStarter
 import io.github.amichne.kast.api.contract.AnalysisTransport
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -7,6 +8,12 @@ import org.junit.jupiter.api.Test
 import java.nio.file.Path
 
 class HeadlessServerOptionsTest {
+    @Test
+    fun `headless starter implements IDEA app starter extension type`() {
+        assertEquals(Any::class.java, HeadlessApplicationStarter::class.java.superclass)
+        assertTrue(HeadlessApplicationStarter::class.java.interfaces.contains(ApplicationStarter::class.java))
+    }
+
     @Test
     fun `starter args drop command token and preserve existing server options`() {
         val options = HeadlessServerOptions.parseStarterArgs(

--- a/backend-headless/src/test/kotlin/io/github/amichne/kast/headless/HeadlessServerOptionsTest.kt
+++ b/backend-headless/src/test/kotlin/io/github/amichne/kast/headless/HeadlessServerOptionsTest.kt
@@ -68,6 +68,17 @@ class HeadlessServerOptionsTest {
         }
     }
 
+    @Test
+    @Suppress("DEPRECATION")
+    fun `project open task skips IDE startup work before server registration`() {
+        val task = HeadlessProjectOpener.openProjectTask()
+
+        assertEquals(false, task.isRefreshVfsNeeded)
+        assertEquals(false, task.runConfigurators)
+        assertEquals(false, task.runConversionBeforeOpen)
+        assertEquals(false, task.preloadServices)
+    }
+
     private fun withSystemProperties(
         vararg values: Pair<String, String>,
         block: () -> Unit,

--- a/build-logic/src/main/kotlin/SyncRuntimeLibsTask.kt
+++ b/build-logic/src/main/kotlin/SyncRuntimeLibsTask.kt
@@ -158,6 +158,26 @@ object RuntimeClasspathAssertions {
         ZipFile(jarPath.toFile()).use { archive ->
             archive.getEntry(entryName) != null
         }
+
+    fun filesWithAnySuffix(
+        directory: Path,
+        suffixes: List<String>,
+    ): List<String> {
+        if (suffixes.isEmpty() || !Files.isDirectory(directory)) {
+            return emptyList()
+        }
+
+        return Files.walk(directory).use { paths ->
+            paths
+                .filter(Files::isRegularFile)
+                .filter { path -> suffixes.any { suffix -> path.name.endsWith(suffix) } }
+                .map { path ->
+                    directory.relativize(path).joinToString("/")
+                }
+                .sorted()
+                .toList()
+        }
+    }
 }
 
 private fun copyIfChanged(sourcePath: Path, targetPath: Path) {

--- a/build-logic/src/main/kotlin/VerifyClasspathLayoutTask.kt
+++ b/build-logic/src/main/kotlin/VerifyClasspathLayoutTask.kt
@@ -6,6 +6,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
@@ -20,6 +21,7 @@ abstract class VerifyClasspathLayoutTask : DefaultTask() {
         requiredPluginJarPrefixes.convention(emptyList())
         requiredPluginClassEntries.convention(emptyList())
         allowedPluginDescriptorJarPrefixes.convention(emptyList())
+        forbiddenPortableDistJarSuffixes.convention(emptyList())
     }
 
     @get:InputDirectory
@@ -33,6 +35,11 @@ abstract class VerifyClasspathLayoutTask : DefaultTask() {
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val pluginLibsDirectory: DirectoryProperty
+
+    @get:Optional
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val portableDistDirectory: DirectoryProperty
 
     @get:Input
     abstract val forbiddenRuntimeJarPrefixes: ListProperty<String>
@@ -49,8 +56,24 @@ abstract class VerifyClasspathLayoutTask : DefaultTask() {
     @get:Input
     abstract val allowedPluginDescriptorJarPrefixes: ListProperty<String>
 
+    @get:Input
+    abstract val forbiddenPortableDistJarSuffixes: ListProperty<String>
+
     @TaskAction
     fun verify() {
+        if (portableDistDirectory.isPresent) {
+            val forbiddenPortableDistJars = RuntimeClasspathAssertions.filesWithAnySuffix(
+                directory = portableDistDirectory.get().asFile.toPath(),
+                suffixes = forbiddenPortableDistJarSuffixes.get(),
+            )
+            if (forbiddenPortableDistJars.isNotEmpty()) {
+                throw GradleException(
+                    "Headless portable distribution must not include fat jars: " +
+                        forbiddenPortableDistJars.joinToString(),
+                )
+            }
+        }
+
         val runtimeLibsPath = runtimeLibsDirectory.get().asFile.toPath()
         val runtimeClasspathPath = runtimeClasspathFile.get().asFile.toPath()
         val runtimeClasspathEntries = classpathEntries(runtimeClasspathPath)

--- a/build-logic/src/main/kotlin/kast.standalone-app.gradle.kts
+++ b/build-logic/src/main/kotlin/kast.standalone-app.gradle.kts
@@ -24,6 +24,17 @@ val buildVersion: Provider<String> = gitCommitHash.zip(gitDirty) { hash, dirty -
 
 extra["buildVersion"] = buildVersion
 
+val includeShadowJarProperty = providers.gradleProperty("kastIncludeShadowJar")
+val includeShadowJar: Provider<Boolean> = providers.provider {
+    val rawValue = includeShadowJarProperty.orNull ?: findProperty("kastIncludeShadowJar")?.toString()
+    when (val normalized = rawValue?.trim()?.lowercase()) {
+        null, "" -> true
+        "true" -> true
+        "false" -> false
+        else -> error("kastIncludeShadowJar must be true or false, got $normalized")
+    }
+}
+
 tasks.named<Jar>("jar") {
     manifest {
         attributes["Main-Class"] = application.mainClass.get()
@@ -62,7 +73,6 @@ val syncRuntimeLibs by tasks.registering(SyncRuntimeLibsTask::class) {
 }
 
 val writeWrapperScript by tasks.registering(WriteWrapperScriptTask::class) {
-    dependsOn(shadowJar)
     dependsOn(syncRuntimeLibs)
 
     jarFileName.set(shadowJar.flatMap(ShadowJar::getArchiveFileName))
@@ -75,12 +85,22 @@ val syncPortableDist by tasks.registering(Sync::class) {
     duplicatesStrategy = DuplicatesStrategy.FAIL
 
     from(writeWrapperScript)
-    from(shadowJarArchive) {
-        into("libs")
-    }
     // runtime-libs is intentionally absent here: consumers must explicitly wire their
     // own runtime-libs source so that classpath.txt references the correct daemon jars.
     // See backend-standalone/build.gradle.kts for the shipped daemon distribution.
+}
+
+afterEvaluate {
+    if (includeShadowJar.get()) {
+        writeWrapperScript.configure {
+            dependsOn(shadowJar)
+        }
+        syncPortableDist.configure {
+            from(shadowJarArchive) {
+                into("libs")
+            }
+        }
+    }
 }
 
 val portableDistZip by tasks.registering(Zip::class) {

--- a/build-logic/src/test/kotlin/RuntimeClasspathAssertionsTest.kt
+++ b/build-logic/src/test/kotlin/RuntimeClasspathAssertionsTest.kt
@@ -104,6 +104,21 @@ class RuntimeClasspathAssertionsTest {
         )
     }
 
+    @Test
+    fun `portable distribution jars with forbidden suffixes are reported`(@TempDir portableDist: Path) {
+        Files.createDirectories(portableDist.resolve("libs"))
+        Files.createDirectories(portableDist.resolve("runtime-libs"))
+        Files.writeString(portableDist.resolve("libs/backend-headless-1.0-all.jar"), "fat jar")
+        Files.writeString(portableDist.resolve("runtime-libs/backend-headless-1.0-launcher.jar"), "launcher")
+
+        val entries = RuntimeClasspathAssertions.filesWithAnySuffix(
+            directory = portableDist,
+            suffixes = listOf("-all.jar"),
+        )
+
+        assertEquals(listOf("libs/backend-headless-1.0-all.jar"), entries)
+    }
+
     private fun writeJar(path: Path, vararg entryNames: String) {
         Files.createDirectories(path.parent)
         ZipOutputStream(Files.newOutputStream(path)).use { output ->

--- a/cli-rs/src/cli.rs
+++ b/cli-rs/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
@@ -241,6 +242,9 @@ pub struct RpcArgs {
     /// Absolute workspace root for daemon lifecycle and RPC commands.
     #[arg(long)]
     pub workspace_root: Option<PathBuf>,
+    /// Pin the command to a specific backend.
+    #[arg(long = "backend", visible_alias = "backend-name", value_enum)]
+    pub backend_name: Option<BackendName>,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -449,7 +453,8 @@ pub enum UninstallCommand {
     CopilotExtension(ResourceInstallArgs),
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum BackendName {
     Intellij,
     Headless,

--- a/cli-rs/src/config.rs
+++ b/cli-rs/src/config.rs
@@ -10,6 +10,8 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone, Serialize)]
 pub struct KastConfig {
     pub server: ServerConfig,
+    #[serde(skip_serializing_if = "RuntimeConfig::is_default")]
+    pub runtime: RuntimeConfig,
     pub paths: PathsConfig,
     pub backends: BackendsConfig,
     pub cli: CliConfig,
@@ -21,6 +23,19 @@ pub struct ServerConfig {
     pub max_results: u32,
     pub request_timeout_millis: u64,
     pub max_concurrent_requests: u32,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_backend: Option<BackendName>,
+}
+
+impl RuntimeConfig {
+    fn is_default(&self) -> bool {
+        self.default_backend.is_none()
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -64,6 +79,7 @@ pub struct CliConfig {
 #[serde(rename_all = "camelCase")]
 struct PartialConfig {
     server: Option<PartialServer>,
+    runtime: Option<PartialRuntime>,
     paths: Option<PartialPaths>,
     backends: Option<PartialBackends>,
     cli: Option<PartialCli>,
@@ -75,6 +91,12 @@ struct PartialServer {
     max_results: Option<u32>,
     request_timeout_millis: Option<u64>,
     max_concurrent_requests: Option<u32>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PartialRuntime {
+    default_backend: Option<BackendName>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -129,6 +151,7 @@ impl KastConfig {
                 request_timeout_millis: 30_000,
                 max_concurrent_requests: 4,
             },
+            runtime: RuntimeConfig::default(),
             paths: PathsConfig {
                 install_root,
                 bin_dir: bin_dir.clone(),
@@ -228,6 +251,11 @@ impl KastConfig {
                 self.server.max_concurrent_requests = value;
             }
         }
+        if let Some(runtime) = partial.runtime
+            && let Some(value) = runtime.default_backend
+        {
+            self.runtime.default_backend = Some(value);
+        }
         if let Some(backends) = partial.backends {
             if let Some(standalone) = backends.standalone
                 && let Some(value) = standalone.runtime_libs_dir
@@ -264,6 +292,15 @@ pub fn init_config() -> Result<PathBuf> {
 
 pub fn default_config_template() -> Result<String> {
     Ok(toml::to_string_pretty(&KastConfig::defaults())?)
+}
+
+pub fn resolve_runtime_backend(
+    config: &KastConfig,
+    backend_name: Option<BackendName>,
+) -> BackendName {
+    backend_name
+        .or(config.runtime.default_backend)
+        .unwrap_or(BackendName::Standalone)
 }
 
 pub fn backend_runtime_libs_dir(
@@ -514,5 +551,62 @@ mod tests {
         assert_eq!(https.host, "github.com");
         assert_eq!(https.owner, "amichne");
         assert_eq!(https.repo, "kast");
+    }
+
+    #[test]
+    fn parses_runtime_default_backend() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_file = temp.path().join("config.toml");
+        fs::write(
+            &config_file,
+            r#"[runtime]
+defaultBackend = "headless"
+"#,
+        )
+        .unwrap();
+
+        let mut config = KastConfig::defaults();
+        config.apply(read_partial_config(&config_file).unwrap());
+
+        assert_eq!(config.runtime.default_backend, Some(BackendName::Headless));
+    }
+
+    #[test]
+    fn rejects_invalid_runtime_default_backend() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_file = temp.path().join("config.toml");
+        fs::write(
+            &config_file,
+            r#"[runtime]
+defaultBackend = "sidecar"
+"#,
+        )
+        .unwrap();
+
+        let error = read_partial_config(&config_file).unwrap_err();
+
+        assert_eq!(error.code, "CONFIG_ERROR");
+        assert!(error.message.contains("sidecar"), "{}", error.message);
+        assert!(error.message.contains("headless"), "{}", error.message);
+    }
+
+    #[test]
+    fn runtime_backend_resolution_prefers_cli_then_config_then_standalone() {
+        let mut config = KastConfig::defaults();
+
+        assert_eq!(
+            resolve_runtime_backend(&config, None),
+            BackendName::Standalone
+        );
+
+        config.runtime.default_backend = Some(BackendName::Headless);
+        assert_eq!(
+            resolve_runtime_backend(&config, None),
+            BackendName::Headless
+        );
+        assert_eq!(
+            resolve_runtime_backend(&config, Some(BackendName::Standalone)),
+            BackendName::Standalone
+        );
     }
 }

--- a/cli-rs/src/daemon.rs
+++ b/cli-rs/src/daemon.rs
@@ -83,7 +83,7 @@ pub fn java_command(args: &DaemonStartArgs, config: &KastConfig) -> Result<Vec<S
     let mut command = vec![java_exec];
     if backend_name == BackendName::Headless {
         let idea_home = headless_idea_home(args, config)?;
-        command.extend(headless_jvm_args(&idea_home, &runtime_libs_dir, config));
+        command.extend(headless_jvm_args(&idea_home, config));
     }
     if let Ok(java_opts) = env::var("JAVA_OPTS") {
         command.extend(java_opts.split_whitespace().map(ToOwned::to_owned));
@@ -131,11 +131,7 @@ fn headless_idea_home(args: &DaemonStartArgs, config: &KastConfig) -> Result<Pat
         })
 }
 
-fn headless_jvm_args(
-    idea_home: &Path,
-    runtime_libs_dir: &Path,
-    config: &KastConfig,
-) -> Vec<String> {
+fn headless_jvm_args(idea_home: &Path, config: &KastConfig) -> Vec<String> {
     let jna_arch = match env::consts::ARCH {
         "aarch64" => "aarch64",
         _ => "amd64",
@@ -146,15 +142,20 @@ fn headless_jvm_args(
             idea_home.join("lib/nio-fs.jar").display()
         ),
         "-Djava.system.class.loader=com.intellij.util.lang.PathClassLoader".to_string(),
+        "-Didea.force.use.core.classloader=true".to_string(),
         "-Didea.vendor.name=JetBrains".to_string(),
         "-Didea.paths.selector=KastHeadless".to_string(),
         format!(
-            "-Didea.plugins.path={}",
-            runtime_libs_dir
-                .parent()
-                .unwrap_or(runtime_libs_dir)
-                .join("plugins")
-                .display()
+            "-Didea.config.path={}",
+            config.paths.cache_dir.join("idea-config").display()
+        ),
+        format!(
+            "-Didea.system.path={}",
+            config.paths.cache_dir.join("idea-system").display()
+        ),
+        format!(
+            "-Didea.log.path={}",
+            config.paths.logs_dir.join("idea").display()
         ),
         format!(
             "-Djna.boot.library.path={}",
@@ -368,6 +369,24 @@ mod tests {
             "-Dkast.headless.paths.descriptorDir={}",
             config.paths.descriptor_dir.display()
         )));
+        assert!(command.contains(&format!(
+            "-Didea.config.path={}",
+            config.paths.cache_dir.join("idea-config").display()
+        )));
+        assert!(command.contains(&format!(
+            "-Didea.system.path={}",
+            config.paths.cache_dir.join("idea-system").display()
+        )));
+        assert!(command.contains(&format!(
+            "-Didea.log.path={}",
+            config.paths.logs_dir.join("idea").display()
+        )));
+        assert!(command.contains(&"-Didea.force.use.core.classloader=true".to_string()));
+        assert!(
+            !command
+                .iter()
+                .any(|arg| arg.starts_with("-Didea.plugins.path="))
+        );
         assert!(command.contains(&"--add-opens=java.base/java.lang=ALL-UNNAMED".to_string()));
     }
 

--- a/cli-rs/src/runtime.rs
+++ b/cli-rs/src/runtime.rs
@@ -129,7 +129,8 @@ struct WorkspaceInspection {
 
 pub fn workspace_status(args: RuntimeArgs) -> Result<WorkspaceStatusResult> {
     let workspace_root = workspace_root(args.workspace_root.clone())?;
-    let inspection = inspect_workspace(&workspace_root, args.backend_name, false)?;
+    let backend_name = resolve_runtime_backend(&workspace_root, args.backend_name)?;
+    let inspection = inspect_workspace(&workspace_root, Some(backend_name), false)?;
     Ok(WorkspaceStatusResult {
         workspace_root: workspace_root.display().to_string(),
         descriptor_directory: inspection.descriptor_directory.display().to_string(),
@@ -141,10 +142,13 @@ pub fn workspace_status(args: RuntimeArgs) -> Result<WorkspaceStatusResult> {
 
 pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
     let workspace_root = workspace_root(args.workspace_root.clone())?;
-    let inspection = inspect_workspace(&workspace_root, args.backend_name, true)?;
+    let config = KastConfig::load(&workspace_root)?;
+    let backend_name = config::resolve_runtime_backend(&config, args.backend_name);
+    let inspection =
+        inspect_workspace_with_config(&workspace_root, &config, Some(backend_name), true)?;
     if let Some(selected) = select_servable(
         &inspection.candidates,
-        args.backend_name,
+        Some(backend_name),
         args.accept_indexing.unwrap_or(false),
     ) {
         return Ok(WorkspaceEnsureResult {
@@ -158,7 +162,7 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
         });
     }
 
-    if args.backend_name == Some(BackendName::Intellij) {
+    if backend_name == BackendName::Intellij {
         return Err(CliError::new(
             "INTELLIJ_NOT_RUNNING",
             format!(
@@ -169,11 +173,10 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
     }
 
     if args.no_auto_start.unwrap_or(false) {
-        return Err(no_backend_error(&workspace_root, args.backend_name));
+        return Err(no_backend_error(&workspace_root, Some(backend_name)));
     }
 
-    let config = KastConfig::load(&workspace_root)?;
-    let launch_backend = args.backend_name.unwrap_or(BackendName::Standalone);
+    let launch_backend = backend_name;
     let runtime_libs_dir = match launch_backend {
         BackendName::Intellij | BackendName::Standalone => {
             config.backends.standalone.runtime_libs_dir.clone()
@@ -209,11 +212,13 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
 
 pub fn workspace_stop(args: RuntimeArgs) -> Result<DaemonStopResult> {
     let workspace_root = workspace_root(args.workspace_root.clone())?;
-    let inspection = inspect_workspace(&workspace_root, args.backend_name, true)?;
-    let Some(candidate) = inspection.candidates.into_iter().find(|candidate| {
-        args.backend_name
-            .is_none_or(|backend| candidate.descriptor.backend_name == backend.canonical())
-    }) else {
+    let backend_name = resolve_runtime_backend(&workspace_root, args.backend_name)?;
+    let inspection = inspect_workspace(&workspace_root, Some(backend_name), true)?;
+    let Some(candidate) = inspection
+        .candidates
+        .into_iter()
+        .find(|candidate| candidate.descriptor.backend_name == backend_name.canonical())
+    else {
         return Ok(DaemonStopResult {
             workspace_root: workspace_root.display().to_string(),
             stopped: false,
@@ -273,7 +278,7 @@ pub fn rpc_passthrough(args: RpcArgs) -> Result<String> {
     let workspace_root = workspace_root(args.workspace_root)?;
     let ensure = workspace_ensure(RuntimeArgs {
         workspace_root: Some(workspace_root),
-        backend_name: None,
+        backend_name: args.backend_name,
         idea_home: None,
         wait_timeout_ms: 60_000,
         accept_indexing: Some(true),
@@ -306,13 +311,35 @@ pub fn capabilities(args: RuntimeArgs) -> Result<Value> {
     })
 }
 
+fn resolve_runtime_backend(
+    workspace_root: &Path,
+    backend_name: Option<BackendName>,
+) -> Result<BackendName> {
+    let config = KastConfig::load(workspace_root)?;
+    Ok(config::resolve_runtime_backend(&config, backend_name))
+}
+
 fn inspect_workspace(
     workspace_root: &Path,
     backend_name: Option<BackendName>,
     prune_stale_descriptors: bool,
 ) -> Result<WorkspaceInspection> {
     let config = KastConfig::load(workspace_root)?;
-    let descriptor_directory = config.paths.descriptor_dir;
+    inspect_workspace_with_config(
+        workspace_root,
+        &config,
+        backend_name,
+        prune_stale_descriptors,
+    )
+}
+
+fn inspect_workspace_with_config(
+    workspace_root: &Path,
+    config: &KastConfig,
+    backend_name: Option<BackendName>,
+    prune_stale_descriptors: bool,
+) -> Result<WorkspaceInspection> {
+    let descriptor_directory = config.paths.descriptor_dir.clone();
     let registered = find_by_workspace_root(&descriptor_directory, workspace_root)?;
     let mut candidates = Vec::with_capacity(registered.len());
     for descriptor in registered {

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -697,6 +697,150 @@ fn up_without_installed_backend_reports_exact_backend_install_command() {
 }
 
 #[test]
+fn runtime_commands_use_configured_default_backend_when_backend_flag_is_absent() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        config_home.join("config.toml"),
+        "[runtime]\ndefaultBackend = \"headless\"\n",
+    )
+    .expect("config");
+
+    let up = kast(&home, &config_home)
+        .args([
+            "up",
+            "--workspace-root",
+            workspace.to_str().expect("workspace path"),
+        ])
+        .output()
+        .expect("up");
+
+    assert!(
+        !up.status.success(),
+        "up should fail without an installed headless backend"
+    );
+    let stderr = String::from_utf8_lossy(&up.stderr);
+    assert!(
+        stderr.contains("kast backend install headless"),
+        "stderr should include configured default install command: {stderr}"
+    );
+}
+
+#[test]
+fn runtime_backend_flag_overrides_configured_default_backend() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        config_home.join("config.toml"),
+        "[runtime]\ndefaultBackend = \"headless\"\n",
+    )
+    .expect("config");
+
+    let up = kast(&home, &config_home)
+        .args([
+            "up",
+            "--workspace-root",
+            workspace.to_str().expect("workspace path"),
+            "--backend=standalone",
+        ])
+        .output()
+        .expect("up");
+
+    assert!(
+        !up.status.success(),
+        "up should fail without an installed standalone backend"
+    );
+    let stderr = String::from_utf8_lossy(&up.stderr);
+    assert!(
+        stderr.contains("kast backend install standalone"),
+        "stderr should include explicit backend install command: {stderr}"
+    );
+}
+
+#[test]
+fn rpc_uses_configured_default_backend_when_auto_starting() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        config_home.join("config.toml"),
+        "[runtime]\ndefaultBackend = \"headless\"\n",
+    )
+    .expect("config");
+
+    let rpc = kast(&home, &config_home)
+        .args([
+            "rpc",
+            r#"{"jsonrpc":"2.0","method":"runtime/status","id":1}"#,
+            "--workspace-root",
+            workspace.to_str().expect("workspace path"),
+        ])
+        .output()
+        .expect("rpc");
+
+    assert!(
+        !rpc.status.success(),
+        "rpc should fail without an installed headless backend"
+    );
+    let stderr = String::from_utf8_lossy(&rpc.stderr);
+    assert!(
+        stderr.contains("kast backend install headless"),
+        "stderr should include configured default install command: {stderr}"
+    );
+}
+
+#[test]
+fn rpc_backend_flag_overrides_configured_default_backend() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        config_home.join("config.toml"),
+        "[runtime]\ndefaultBackend = \"headless\"\n",
+    )
+    .expect("config");
+
+    let rpc = kast(&home, &config_home)
+        .args([
+            "rpc",
+            r#"{"jsonrpc":"2.0","method":"runtime/status","id":1}"#,
+            "--workspace-root",
+            workspace.to_str().expect("workspace path"),
+            "--backend=standalone",
+        ])
+        .output()
+        .expect("rpc");
+
+    assert!(
+        !rpc.status.success(),
+        "rpc should fail without an installed standalone backend"
+    );
+    let stderr = String::from_utf8_lossy(&rpc.stderr);
+    assert!(
+        stderr.contains("kast backend install standalone"),
+        "stderr should include explicit backend install command: {stderr}"
+    );
+}
+
+#[test]
 fn intellij_plugin_install_defaults_to_downloads_without_jetbrains_profiles() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/kast.sh
+++ b/kast.sh
@@ -134,9 +134,9 @@ _HEADLESS_IDEA_HOME_PROFILE="${KAST_HEADLESS_IDEA_HOME_PROFILE:-full}"
 
 _build_validate_headless_profile() {
   case "$_HEADLESS_IDEA_HOME_PROFILE" in
-    full|minimal) ;;
+    full|minimal|agent) ;;
     *)
-      die "Invalid --headless-idea-home-profile value: ${_HEADLESS_IDEA_HOME_PROFILE}; expected full or minimal"
+      die "Invalid --headless-idea-home-profile value: ${_HEADLESS_IDEA_HOME_PROFILE}; expected full, minimal, or agent"
       ;;
   esac
 }
@@ -244,7 +244,7 @@ _build_headless() {
   shopt -s nullglob
   jars=("${HEADLESS_PORTABLE_DIST_DIR}"/libs/backend-headless-*-all.jar)
   shopt -u nullglob
-  [[ "${#jars[@]}" -eq 1 ]] || die "Expected exactly one staged fat jar under ${HEADLESS_PORTABLE_DIST_DIR}/libs"
+  [[ "${#jars[@]}" -eq 0 ]] || die "Headless portable distribution must not include fat jars under ${HEADLESS_PORTABLE_DIST_DIR}/libs"
 
   local dist_dir="${DIST_ROOT}/headless"
   local dist_zip="${DIST_ROOT}/headless.zip"
@@ -316,7 +316,7 @@ Targets (positional, repeatable):
 
 Options:
   --all            Build all targets.
-  --headless-idea-home-profile=full|minimal  Configure headless IDEA home profile (default: full).
+  --headless-idea-home-profile=full|minimal|agent  Configure headless IDEA home profile (default: full).
   -Pname=value     Forward a Gradle project property to the build.
   --help, -h       Show this help.
 

--- a/scripts/assemble-release-provenance.py
+++ b/scripts/assemble-release-provenance.py
@@ -15,6 +15,7 @@ REQUIRED_PLATFORMS = {
     "standalone",
 }
 OPTIONAL_PLATFORMS = {
+    "devin-headless-linux-x64",
     "ubuntu-debian-headless-x86_64",
     "ubuntu-debian-x86_64",
 }

--- a/scripts/install-ubuntu-debian.sh
+++ b/scripts/install-ubuntu-debian.sh
@@ -232,7 +232,10 @@ runtimeLibsDir = \"$(toml_escape "$standalone_runtime_libs_dir")\""
       components='["cli", "standalone-backend", "config"]'
       ;;
     headless)
-      backend_config="[backends.headless]
+      backend_config="[runtime]
+defaultBackend = \"headless\"
+
+[backends.headless]
 runtimeLibsDir = \"$(toml_escape "$headless_runtime_libs_dir")\"
 ideaHome = \"$(toml_escape "$headless_idea_home")\""
       components='["cli", "headless-backend", "config"]'
@@ -452,6 +455,8 @@ verify_install() {
       [[ -f "$bin_path" && ! -L "$bin_path" ]] || die "Expected headless ${bin_path} to be an executable shim"
       grep -Fq -- "-Didea.force.use.core.classloader=true" "$bin_path" \
         || die "Headless kast shim does not export the core classloader JVM option"
+      grep -Fq 'defaultBackend = "headless"' "$config_file" \
+        || die "config.toml does not default to headless runtime"
       grep -Fq "[backends.headless]" "$config_file" || die "config.toml does not include headless backend config"
       grep -Fq "runtimeLibsDir = \"${headless_runtime_libs_dir}\"" "$config_file" \
         || die "config.toml does not point at ${headless_runtime_libs_dir}"

--- a/scripts/merge-release-provenance.py
+++ b/scripts/merge-release-provenance.py
@@ -15,6 +15,7 @@ REQUIRED_PLATFORMS = {
     "standalone",
 }
 OPTIONAL_PLATFORMS = {
+    "devin-headless-linux-x64",
     "ubuntu-debian-headless-x86_64",
     "ubuntu-debian-x86_64",
 }

--- a/scripts/package-devin-headless-runtime.sh
+++ b/scripts/package-devin-headless-runtime.sh
@@ -114,6 +114,7 @@ need_tool tar
 platform="devin-headless-linux-x64"
 bundle_name="kast-devin-headless-runtime-linux-x64-${version}"
 backend_install_name="headless-${version}"
+normalized_version="${version#v}"
 if [[ -z "$output_path" ]]; then
   output_path="${repo_root}/dist/${bundle_name}.tar.gz"
 fi
@@ -144,6 +145,16 @@ backend_root="${backend_extract}/backend-headless"
 [[ -f "${backend_root}/idea-home/lib/nio-fs.jar" ]] || die "Backend archive missing idea-home/lib/nio-fs.jar"
 [[ -f "${backend_root}/idea-home/modules/module-descriptors.dat" ]] || die "Backend archive missing idea-home/modules/module-descriptors.dat"
 [[ -d "${backend_root}/idea-home/plugins/kast-headless" ]] || die "Backend archive missing bundled kast-headless plugin"
+
+expected_launcher_jar="backend-headless-${normalized_version}-launcher.jar"
+expected_plugin_jar="backend-headless-${normalized_version}-plugin.jar"
+if ! grep -Fxq "$expected_launcher_jar" "${backend_root}/runtime-libs/classpath.txt"; then
+  die "Backend archive does not match requested version ${version}: runtime-libs/classpath.txt must contain ${expected_launcher_jar}"
+fi
+[[ -f "${backend_root}/runtime-libs/${expected_launcher_jar}" ]] \
+  || die "Backend archive does not match requested version ${version}: missing runtime-libs/${expected_launcher_jar}"
+[[ -f "${backend_root}/idea-home/plugins/kast-headless/lib/${expected_plugin_jar}" ]] \
+  || die "Backend archive does not match requested version ${version}: missing idea-home/plugins/kast-headless/lib/${expected_plugin_jar}"
 
 if [[ -d "${backend_root}/libs" ]] && find "${backend_root}/libs" -name '*-all.jar' -print -quit | grep -q .; then
   find "${backend_root}/libs" -name '*-all.jar' -print >&2

--- a/scripts/package-devin-headless-runtime.sh
+++ b/scripts/package-devin-headless-runtime.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+need_tool() {
+  local tool_name="$1"
+  command -v "$tool_name" >/dev/null 2>&1 || die "Missing required tool: $tool_name"
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/.." && pwd
+}
+
+compute_sha256() {
+  local input_path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$input_path" | awk '{ print $1 }'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$input_path" | awk '{ print $1 }'
+    return
+  fi
+  die "Neither sha256sum nor shasum is available"
+}
+
+extract_zip_archive() {
+  local archive_path="$1"
+  local output_dir="$2"
+
+  python3 - "$archive_path" "$output_dir" <<'PY'
+import sys
+import zipfile
+from pathlib import Path
+
+archive_path = Path(sys.argv[1])
+output_dir = Path(sys.argv[2])
+output_dir.mkdir(parents=True, exist_ok=True)
+resolved_output = output_dir.resolve()
+
+with zipfile.ZipFile(archive_path) as archive:
+    for member in archive.namelist():
+        destination = (output_dir / member).resolve()
+        if destination != resolved_output and not str(destination).startswith(str(resolved_output) + "/"):
+            raise SystemExit(f"unsafe zip member: {member}")
+    archive.extractall(output_dir)
+PY
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/package-devin-headless-runtime.sh --cli-archive <zip> --backend-archive <zip> --version <tag> [--output <tar.gz>]
+
+Build a Linux x64 Kast Devin headless runtime bundle from a Rust CLI archive and
+an agent-profile backend-headless portable archive.
+USAGE
+}
+
+repo_root="$(resolve_repo_root)"
+cli_archive=""
+backend_archive=""
+version=""
+output_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cli-archive)
+      [[ $# -ge 2 ]] || die "Missing value for --cli-archive"
+      cli_archive="$2"; shift 2 ;;
+    --cli-archive=*)
+      cli_archive="${1#--cli-archive=}"; shift ;;
+    --backend-archive)
+      [[ $# -ge 2 ]] || die "Missing value for --backend-archive"
+      backend_archive="$2"; shift 2 ;;
+    --backend-archive=*)
+      backend_archive="${1#--backend-archive=}"; shift ;;
+    --version)
+      [[ $# -ge 2 ]] || die "Missing value for --version"
+      version="$2"; shift 2 ;;
+    --version=*)
+      version="${1#--version=}"; shift ;;
+    --output)
+      [[ $# -ge 2 ]] || die "Missing value for --output"
+      output_path="$2"; shift 2 ;;
+    --output=*)
+      output_path="${1#--output=}"; shift ;;
+    --help|-h)
+      usage; exit 0 ;;
+    *)
+      usage; die "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$cli_archive" ]] || { usage; die "--cli-archive is required"; }
+[[ -n "$backend_archive" ]] || { usage; die "--backend-archive is required"; }
+[[ -n "$version" ]] || { usage; die "--version is required"; }
+[[ -f "$cli_archive" ]] || die "CLI archive not found: $cli_archive"
+[[ -f "$backend_archive" ]] || die "Backend archive not found: $backend_archive"
+[[ -x "${repo_root}/scripts/verify-kast-devin-runtime.sh" ]] || die "Missing scripts/verify-kast-devin-runtime.sh"
+
+need_tool python3
+need_tool tar
+
+platform="devin-headless-linux-x64"
+bundle_name="kast-devin-headless-runtime-linux-x64-${version}"
+backend_install_name="headless-${version}"
+if [[ -z "$output_path" ]]; then
+  output_path="${repo_root}/dist/${bundle_name}.tar.gz"
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/kast-devin-headless-package.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+cli_extract="${tmp_dir}/cli"
+backend_extract="${tmp_dir}/backend"
+staging_root="${tmp_dir}/${bundle_name}"
+mkdir -p "$cli_extract" "$backend_extract" "$staging_root/bin" \
+  "${staging_root}/lib/backends" \
+  "${staging_root}/scripts" \
+  "$(dirname -- "$output_path")"
+
+extract_zip_archive "$cli_archive" "$cli_extract"
+extract_zip_archive "$backend_archive" "$backend_extract"
+
+cli_bin="${cli_extract}/kast"
+backend_root="${backend_extract}/backend-headless"
+[[ -f "$cli_bin" ]] || die "CLI archive must contain kast at its root"
+[[ -d "$backend_root" ]] || die "Backend archive must contain backend-headless/"
+[[ -x "${backend_root}/kast-headless" || -f "${backend_root}/kast-headless" ]] || die "Backend archive missing kast-headless launcher"
+[[ -f "${backend_root}/runtime-libs/classpath.txt" ]] || die "Backend archive missing runtime-libs/classpath.txt"
+[[ -f "${backend_root}/idea-home/lib/nio-fs.jar" ]] || die "Backend archive missing idea-home/lib/nio-fs.jar"
+[[ -f "${backend_root}/idea-home/modules/module-descriptors.dat" ]] || die "Backend archive missing idea-home/modules/module-descriptors.dat"
+[[ -d "${backend_root}/idea-home/plugins/kast-headless" ]] || die "Backend archive missing bundled kast-headless plugin"
+
+if [[ -d "${backend_root}/libs" ]] && find "${backend_root}/libs" -name '*-all.jar' -print -quit | grep -q .; then
+  find "${backend_root}/libs" -name '*-all.jar' -print >&2
+  die "Devin headless backend archive must not contain fat jars"
+fi
+
+cp "$cli_bin" "${staging_root}/bin/kast"
+chmod 755 "${staging_root}/bin/kast"
+cp -R "$backend_root" "${staging_root}/lib/backends/${backend_install_name}"
+chmod 755 "${staging_root}/lib/backends/${backend_install_name}/kast-headless"
+cp "${repo_root}/scripts/verify-kast-devin-runtime.sh" "${staging_root}/scripts/verify-kast-devin-runtime.sh"
+chmod 755 "${staging_root}/scripts/verify-kast-devin-runtime.sh"
+
+setup_script="${staging_root}/scripts/setup-kast-devin-runtime.sh"
+cat > "$setup_script" <<'SETUP'
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+toml_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s\n' "$value"
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/setup-kast-devin-runtime.sh [--prefix <bundle-root>]
+
+Generate config.toml for the actual unpacked Kast Devin runtime prefix.
+USAGE
+}
+
+resolve_default_prefix() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+  cd -- "${script_dir}/.." >/dev/null 2>&1 && pwd
+}
+
+prefix=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix)
+      [[ $# -ge 2 ]] || die "Missing value for --prefix"
+      prefix="$2"; shift 2 ;;
+    --prefix=*)
+      prefix="${1#--prefix=}"; shift ;;
+    --help|-h)
+      usage; exit 0 ;;
+    *)
+      usage; die "Unknown argument: $1" ;;
+  esac
+done
+
+if [[ -z "$prefix" ]]; then
+  prefix="$(resolve_default_prefix)"
+fi
+prefix="$(cd -- "$prefix" >/dev/null 2>&1 && pwd)" || die "Bundle prefix not found: $prefix"
+
+version="__KAST_DEVIN_VERSION__"
+normalized_version="${version#v}"
+backend_install_name="__KAST_DEVIN_BACKEND_INSTALL_NAME__"
+platform="devin-headless-linux-x64"
+backend_root="${prefix}/lib/backends/${backend_install_name}"
+runtime_libs="${backend_root}/runtime-libs"
+idea_home="${backend_root}/idea-home"
+bin_path="${prefix}/bin/kast"
+config_file="${prefix}/config.toml"
+
+[[ -x "$bin_path" ]] || die "Missing executable CLI: $bin_path"
+[[ -x "${backend_root}/kast-headless" ]] || die "Missing executable headless launcher: ${backend_root}/kast-headless"
+[[ -f "${runtime_libs}/classpath.txt" ]] || die "Missing runtime classpath: ${runtime_libs}/classpath.txt"
+[[ -f "${idea_home}/lib/nio-fs.jar" ]] || die "Missing IDEA home: ${idea_home}/lib/nio-fs.jar"
+[[ -f "${idea_home}/modules/module-descriptors.dat" ]] || die "Missing IDEA module descriptors"
+
+mkdir -p "${prefix}/cache/daemons" "${prefix}/logs"
+cat > "$config_file" <<TOML
+[server]
+maxResults = 500
+requestTimeoutMillis = 30000
+maxConcurrentRequests = 4
+
+[runtime]
+defaultBackend = "headless"
+
+[paths]
+installRoot = "$(toml_escape "$prefix")"
+binDir = "$(toml_escape "${prefix}/bin")"
+libDir = "$(toml_escape "${prefix}/lib")"
+cacheDir = "$(toml_escape "${prefix}/cache")"
+logsDir = "$(toml_escape "${prefix}/logs")"
+descriptorDir = "$(toml_escape "${prefix}/cache/daemons")"
+socketDir = "$(toml_escape "${TMPDIR:-/tmp}")"
+
+[backends.headless]
+runtimeLibsDir = "$(toml_escape "$runtime_libs")"
+ideaHome = "$(toml_escape "$idea_home")"
+
+[cli]
+binaryPath = "$(toml_escape "$bin_path")"
+
+[install]
+version = "$(toml_escape "$normalized_version")"
+backendVersion = "$(toml_escape "$normalized_version")"
+installedAt = "$(toml_escape "$platform"):${version}"
+platform = "$(toml_escape "$platform")"
+components = ["cli", "headless-backend", "config"]
+managedPaths = ["bin", "lib", "cache", "logs", "config.toml"]
+shellRcPatches = []
+repos = []
+schemaVersion = 6
+
+[[install.backends]]
+name = "headless"
+version = "$(toml_escape "$normalized_version")"
+installDir = "$(toml_escape "$backend_root")"
+runtimeLibsDir = "$(toml_escape "$runtime_libs")"
+ideaHome = "$(toml_escape "$idea_home")"
+TOML
+
+printf '%s\n' "Wrote ${config_file}"
+SETUP
+
+python3 - "$setup_script" "$version" "$backend_install_name" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+content = path.read_text(encoding="utf-8")
+content = content.replace("__KAST_DEVIN_VERSION__", sys.argv[2])
+content = content.replace("__KAST_DEVIN_BACKEND_INSTALL_NAME__", sys.argv[3])
+path.write_text(content, encoding="utf-8")
+PY
+chmod 755 "$setup_script"
+
+cat > "${staging_root}/SETUP.md" <<'SETUP'
+# Kast Devin Headless Runtime
+
+Unpack this archive into the snapshot location, then run:
+
+```bash
+scripts/setup-kast-devin-runtime.sh --prefix "$PWD"
+scripts/verify-kast-devin-runtime.sh --prefix "$PWD"
+```
+
+The setup script writes `config.toml` with absolute paths for the unpacked
+prefix. Run Kast commands with `KAST_CONFIG_HOME` pointing at this directory.
+SETUP
+
+if [[ -f "${repo_root}/LICENSE" ]]; then
+  cp "${repo_root}/LICENSE" "${staging_root}/LICENSE"
+fi
+
+cli_sha="$(compute_sha256 "$cli_archive")"
+backend_sha="$(compute_sha256 "$backend_archive")"
+build_commit="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+
+python3 - "${staging_root}/manifest.json" "$version" "$platform" "$backend_install_name" "$cli_sha" "$backend_sha" "$build_commit" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+version = sys.argv[2]
+platform = sys.argv[3]
+backend_install_name = sys.argv[4]
+cli_sha = sys.argv[5]
+backend_sha = sys.argv[6]
+build_commit = sys.argv[7]
+payload = {
+    "schemaVersion": 1,
+    "kind": "KAST_DEVIN_HEADLESS_RUNTIME",
+    "version": version,
+    "platform": platform,
+    "backendInstallName": backend_install_name,
+    "config": {
+        "generatedBy": "scripts/setup-kast-devin-runtime.sh",
+        "path": "config.toml",
+    },
+    "buildCommit": build_commit,
+    "artifacts": [
+        {
+            "role": "cli",
+            "path": "bin/kast",
+            "sourceSha256": cli_sha,
+        },
+        {
+            "role": "headless-backend",
+            "path": f"lib/backends/{backend_install_name}",
+            "sourceSha256": backend_sha,
+        },
+    ],
+}
+manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+rm -f "$output_path" "${output_path}.sha256"
+COPYFILE_DISABLE=1 tar --no-xattrs -C "$tmp_dir" -czf "$output_path" "$bundle_name"
+printf '%s  %s\n' "$(compute_sha256 "$output_path")" "$(basename -- "$output_path")" > "${output_path}.sha256"
+log "Wrote ${output_path}"

--- a/scripts/smoke-devin-headless-runtime.sh
+++ b/scripts/smoke-devin-headless-runtime.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_tool() {
+  local tool_name="$1"
+  command -v "$tool_name" >/dev/null 2>&1 || die "Missing required tool: $tool_name"
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/.." && pwd
+}
+
+compute_sha256() {
+  local input_path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$input_path" | awk '{ print $1 }'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$input_path" | awk '{ print $1 }'
+    return
+  fi
+  die "Neither sha256sum nor shasum is available"
+}
+
+zip_dir() {
+  local output_path="$1"
+  local input_dir="$2"
+  python3 - "$output_path" "$input_dir" <<'PY'
+import stat
+import sys
+import zipfile
+from pathlib import Path
+
+output_path = Path(sys.argv[1])
+input_dir = Path(sys.argv[2])
+with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+    for path in sorted(input_dir.rglob("*")):
+        if path.is_dir():
+            continue
+        info = zipfile.ZipInfo(str(path.relative_to(input_dir)))
+        mode = path.stat().st_mode
+        info.external_attr = (stat.S_IFREG | (mode & 0o777)) << 16
+        archive.writestr(info, path.read_bytes())
+PY
+}
+
+expect_failure_contains() {
+  local expected="$1"
+  shift
+  local output_path="${scratch_dir}/expected-failure.out"
+
+  set +e
+  "$@" >"$output_path" 2>&1
+  local exit_code="$?"
+  set -e
+
+  [[ "$exit_code" -ne 0 ]] || die "Command unexpectedly succeeded: $*"
+  grep -Fq "$expected" "$output_path" || {
+    cat "$output_path" >&2
+    die "Expected failure output to contain: $expected"
+  }
+}
+
+repo_root="$(resolve_repo_root)"
+packager="${repo_root}/scripts/package-devin-headless-runtime.sh"
+
+need_tool python3
+need_tool tar
+
+scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/kast-devin-headless-smoke.XXXXXX")"
+cleanup() {
+  rm -rf "$scratch_dir"
+}
+trap cleanup EXIT
+
+version="v9.8.7"
+artifact_dir="${scratch_dir}/artifacts"
+cli_tree="${scratch_dir}/cli"
+backend_tree="${scratch_dir}/backend"
+backend_with_fat_tree="${scratch_dir}/backend-with-fat"
+extract_dir="${scratch_dir}/extract"
+
+mkdir -p \
+  "$artifact_dir" \
+  "$cli_tree" \
+  "${backend_tree}/backend-headless/runtime-libs" \
+  "${backend_tree}/backend-headless/idea-home/lib" \
+  "${backend_tree}/backend-headless/idea-home/modules" \
+  "${backend_tree}/backend-headless/idea-home/plugins/kast-headless/lib" \
+  "$extract_dir"
+
+cat > "${cli_tree}/kast" <<'FAKE_KAST'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-help}" in
+  doctor)
+    [[ -n "${KAST_CONFIG_HOME:-}" ]] || { echo "missing KAST_CONFIG_HOME" >&2; exit 1; }
+    [[ -f "${KAST_CONFIG_HOME}/config.toml" ]] || { echo "missing config.toml" >&2; exit 1; }
+    grep -Fq "[runtime]" "${KAST_CONFIG_HOME}/config.toml"
+    grep -Fq 'defaultBackend = "headless"' "${KAST_CONFIG_HOME}/config.toml"
+    grep -Fq "[backends.headless]" "${KAST_CONFIG_HOME}/config.toml"
+    grep -Fq "runtimeLibsDir" "${KAST_CONFIG_HOME}/config.toml"
+    grep -Fq "ideaHome" "${KAST_CONFIG_HOME}/config.toml"
+    printf '%s\n' '{"ok":true}'
+    ;;
+  up)
+    [[ -n "${KAST_CONFIG_HOME:-}" ]] || { echo "missing KAST_CONFIG_HOME" >&2; exit 1; }
+    for arg in "$@"; do
+      case "$arg" in
+        --backend|--backend=*)
+          echo "verify script must not pass --backend to up" >&2
+          exit 1
+          ;;
+      esac
+    done
+    grep -Fq 'defaultBackend = "headless"' "${KAST_CONFIG_HOME}/config.toml"
+    touch "${KAST_CONFIG_HOME}/up-called"
+    printf '%s\n' '{"selected":{"descriptor":{"backendName":"headless"},"runtimeStatus":{"backendName":"headless"}}}'
+    ;;
+  rpc)
+    [[ -n "${KAST_CONFIG_HOME:-}" ]] || { echo "missing KAST_CONFIG_HOME" >&2; exit 1; }
+    for arg in "$@"; do
+      case "$arg" in
+        --backend|--backend=*)
+          echo "verify script must not pass --backend to rpc" >&2
+          exit 1
+          ;;
+      esac
+    done
+    grep -Fq 'defaultBackend = "headless"' "${KAST_CONFIG_HOME}/config.toml"
+    [[ "${2:-}" == *'"method":"runtime/status"'* ]] || { echo "unexpected rpc request: ${2:-}" >&2; exit 1; }
+    touch "${KAST_CONFIG_HOME}/rpc-called"
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"backendName":"headless"}}'
+    ;;
+  stop)
+    [[ -n "${KAST_CONFIG_HOME:-}" ]] || { echo "missing KAST_CONFIG_HOME" >&2; exit 1; }
+    for arg in "$@"; do
+      case "$arg" in
+        --backend|--backend=*)
+          echo "verify script must not pass --backend to stop" >&2
+          exit 1
+          ;;
+      esac
+    done
+    touch "${KAST_CONFIG_HOME}/stop-called"
+    printf '%s\n' '{"stopped":true}'
+    ;;
+  version|--version)
+    printf '%s\n' "Kast CLI 9.8.7"
+    ;;
+  *)
+    printf '%s\n' "fake kast"
+    ;;
+esac
+FAKE_KAST
+chmod 755 "${cli_tree}/kast"
+
+cat > "${backend_tree}/backend-headless/kast-headless" <<'FAKE_BACKEND'
+#!/usr/bin/env bash
+printf '%s\n' "fake headless backend"
+FAKE_BACKEND
+chmod 755 "${backend_tree}/backend-headless/kast-headless"
+printf '%s\n' "fake.jar" > "${backend_tree}/backend-headless/runtime-libs/classpath.txt"
+printf '%s\n' "fake runtime lib" > "${backend_tree}/backend-headless/runtime-libs/fake.jar"
+printf '%s\n' "fake nio fs" > "${backend_tree}/backend-headless/idea-home/lib/nio-fs.jar"
+printf '%s\n' "fake module descriptors" > "${backend_tree}/backend-headless/idea-home/modules/module-descriptors.dat"
+printf '%s\n' "fake plugin lib" > "${backend_tree}/backend-headless/idea-home/plugins/kast-headless/lib/backend-headless.jar"
+
+cp -R "$backend_tree" "$backend_with_fat_tree"
+mkdir -p "${backend_with_fat_tree}/backend-headless/libs"
+printf '%s\n' "fat jar" > "${backend_with_fat_tree}/backend-headless/libs/backend-headless-9.8.7-all.jar"
+
+cli_zip="${artifact_dir}/kast-${version}-linux-x64.zip"
+backend_zip="${artifact_dir}/backend-headless-${version}.zip"
+backend_with_fat_zip="${artifact_dir}/backend-headless-with-fat-${version}.zip"
+bundle_path="${artifact_dir}/kast-devin-headless-runtime-linux-x64-${version}.tar.gz"
+zip_dir "$cli_zip" "$cli_tree"
+zip_dir "$backend_zip" "$backend_tree"
+zip_dir "$backend_with_fat_zip" "$backend_with_fat_tree"
+
+expect_failure_contains \
+  "must not contain fat jars" \
+  "$packager" \
+  --cli-archive "$cli_zip" \
+  --backend-archive "$backend_with_fat_zip" \
+  --version "$version" \
+  --output "${artifact_dir}/must-not-exist.tar.gz"
+
+"$packager" \
+  --cli-archive "$cli_zip" \
+  --backend-archive "$backend_zip" \
+  --version "$version" \
+  --output "$bundle_path"
+
+[[ -f "$bundle_path" ]] || die "Bundle tarball was not created: $bundle_path"
+[[ -f "${bundle_path}.sha256" ]] || die "Bundle SHA-256 sidecar was not created"
+grep -Fq "$(basename -- "$bundle_path")" "${bundle_path}.sha256" || die "SHA-256 sidecar does not name the bundle"
+
+tar -xzf "$bundle_path" -C "$extract_dir"
+bundle_root="${extract_dir}/kast-devin-headless-runtime-linux-x64-${version}"
+bundle_root="$(cd -- "$bundle_root" >/dev/null 2>&1 && pwd)"
+backend_root="${bundle_root}/lib/backends/headless-${version}"
+config_file="${bundle_root}/config.toml"
+
+[[ -x "${bundle_root}/bin/kast" ]] || die "Bundle missing executable Rust CLI"
+[[ -x "${backend_root}/kast-headless" ]] || die "Bundle missing headless launcher"
+[[ -f "${backend_root}/runtime-libs/classpath.txt" ]] || die "Bundle missing runtime classpath"
+[[ -f "${backend_root}/idea-home/lib/nio-fs.jar" ]] || die "Bundle missing IDEA home"
+[[ -f "${backend_root}/idea-home/modules/module-descriptors.dat" ]] || die "Bundle missing module descriptors"
+[[ -d "${backend_root}/idea-home/plugins/kast-headless" ]] || die "Bundle missing headless plugin"
+[[ -x "${bundle_root}/scripts/setup-kast-devin-runtime.sh" ]] || die "Bundle missing setup script"
+[[ -x "${bundle_root}/scripts/verify-kast-devin-runtime.sh" ]] || die "Bundle missing verify script"
+[[ -f "${bundle_root}/SETUP.md" ]] || die "Bundle missing SETUP.md"
+[[ -f "${bundle_root}/manifest.json" ]] || die "Bundle missing manifest"
+[[ ! -e "$config_file" ]] || die "Bundle config.toml must be generated by setup, not baked into the archive"
+
+python3 - "${bundle_root}/manifest.json" "$version" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+version = sys.argv[2]
+assert payload["schemaVersion"] == 1, payload
+assert payload["kind"] == "KAST_DEVIN_HEADLESS_RUNTIME", payload
+assert payload["version"] == version, payload
+assert payload["platform"] == "devin-headless-linux-x64", payload
+assert payload["backendInstallName"] == f"headless-{version}", payload
+roles = {entry["role"] for entry in payload["artifacts"]}
+assert {"cli", "headless-backend"}.issubset(roles), payload
+PY
+
+"${bundle_root}/scripts/setup-kast-devin-runtime.sh" --prefix "$bundle_root"
+
+[[ -f "$config_file" ]] || die "Setup did not write config.toml"
+grep -Fq "[runtime]" "$config_file" || die "config.toml does not include runtime config"
+grep -Fq 'defaultBackend = "headless"' "$config_file" || die "config.toml does not default to headless runtime"
+grep -Fq "[backends.headless]" "$config_file" || die "config.toml does not include headless backend config"
+grep -Fq "runtimeLibsDir = \"${backend_root}/runtime-libs\"" "$config_file" \
+  || die "config.toml does not point at bundled runtime libs"
+grep -Fq "ideaHome = \"${backend_root}/idea-home\"" "$config_file" \
+  || die "config.toml does not point at bundled IDEA home"
+grep -Fq "binaryPath = \"${bundle_root}/bin/kast\"" "$config_file" \
+  || die "config.toml does not point at bundled CLI"
+grep -Fq "version = \"9.8.7\"" "$config_file" || die "config.toml does not normalize install version"
+
+"${bundle_root}/scripts/verify-kast-devin-runtime.sh" --prefix "$bundle_root"
+[[ -f "${bundle_root}/up-called" ]] || die "verify script did not run kast up"
+[[ -f "${bundle_root}/rpc-called" ]] || die "verify script did not run kast rpc"
+[[ -f "${bundle_root}/stop-called" ]] || die "verify script did not stop the runtime"
+
+expected_digest="$(compute_sha256 "$bundle_path")"
+actual_digest="$(awk '{ print $1 }' "${bundle_path}.sha256")"
+[[ "$actual_digest" == "$expected_digest" ]] || die "SHA-256 sidecar digest mismatch"
+
+printf '%s\n' "Devin headless runtime smoke test passed"

--- a/scripts/smoke-devin-headless-runtime.sh
+++ b/scripts/smoke-devin-headless-runtime.sh
@@ -86,6 +86,7 @@ artifact_dir="${scratch_dir}/artifacts"
 cli_tree="${scratch_dir}/cli"
 backend_tree="${scratch_dir}/backend"
 backend_with_fat_tree="${scratch_dir}/backend-with-fat"
+backend_mismatch_tree="${scratch_dir}/backend-mismatch"
 extract_dir="${scratch_dir}/extract"
 
 mkdir -p \
@@ -169,23 +170,32 @@ cat > "${backend_tree}/backend-headless/kast-headless" <<'FAKE_BACKEND'
 printf '%s\n' "fake headless backend"
 FAKE_BACKEND
 chmod 755 "${backend_tree}/backend-headless/kast-headless"
-printf '%s\n' "fake.jar" > "${backend_tree}/backend-headless/runtime-libs/classpath.txt"
-printf '%s\n' "fake runtime lib" > "${backend_tree}/backend-headless/runtime-libs/fake.jar"
 printf '%s\n' "fake nio fs" > "${backend_tree}/backend-headless/idea-home/lib/nio-fs.jar"
 printf '%s\n' "fake module descriptors" > "${backend_tree}/backend-headless/idea-home/modules/module-descriptors.dat"
-printf '%s\n' "fake plugin lib" > "${backend_tree}/backend-headless/idea-home/plugins/kast-headless/lib/backend-headless.jar"
+printf '%s\n' "backend-headless-${version#v}-launcher.jar" > "${backend_tree}/backend-headless/runtime-libs/classpath.txt"
+printf '%s\n' "fake launcher lib" > "${backend_tree}/backend-headless/runtime-libs/backend-headless-${version#v}-launcher.jar"
+printf '%s\n' "fake plugin lib" > "${backend_tree}/backend-headless/idea-home/plugins/kast-headless/lib/backend-headless-${version#v}-plugin.jar"
 
 cp -R "$backend_tree" "$backend_with_fat_tree"
 mkdir -p "${backend_with_fat_tree}/backend-headless/libs"
 printf '%s\n' "fat jar" > "${backend_with_fat_tree}/backend-headless/libs/backend-headless-9.8.7-all.jar"
 
+cp -R "$backend_tree" "$backend_mismatch_tree"
+rm -f "${backend_mismatch_tree}/backend-headless/runtime-libs/backend-headless-${version#v}-launcher.jar"
+rm -f "${backend_mismatch_tree}/backend-headless/idea-home/plugins/kast-headless/lib/backend-headless-${version#v}-plugin.jar"
+printf '%s\n' "backend-headless-1.2.3-launcher.jar" > "${backend_mismatch_tree}/backend-headless/runtime-libs/classpath.txt"
+printf '%s\n' "fake stale launcher lib" > "${backend_mismatch_tree}/backend-headless/runtime-libs/backend-headless-1.2.3-launcher.jar"
+printf '%s\n' "fake stale plugin lib" > "${backend_mismatch_tree}/backend-headless/idea-home/plugins/kast-headless/lib/backend-headless-1.2.3-plugin.jar"
+
 cli_zip="${artifact_dir}/kast-${version}-linux-x64.zip"
 backend_zip="${artifact_dir}/backend-headless-${version}.zip"
 backend_with_fat_zip="${artifact_dir}/backend-headless-with-fat-${version}.zip"
+backend_mismatch_zip="${artifact_dir}/backend-headless-stale-${version}.zip"
 bundle_path="${artifact_dir}/kast-devin-headless-runtime-linux-x64-${version}.tar.gz"
 zip_dir "$cli_zip" "$cli_tree"
 zip_dir "$backend_zip" "$backend_tree"
 zip_dir "$backend_with_fat_zip" "$backend_with_fat_tree"
+zip_dir "$backend_mismatch_zip" "$backend_mismatch_tree"
 
 expect_failure_contains \
   "must not contain fat jars" \
@@ -194,6 +204,14 @@ expect_failure_contains \
   --backend-archive "$backend_with_fat_zip" \
   --version "$version" \
   --output "${artifact_dir}/must-not-exist.tar.gz"
+
+expect_failure_contains \
+  "does not match requested version ${version}" \
+  "$packager" \
+  --cli-archive "$cli_zip" \
+  --backend-archive "$backend_mismatch_zip" \
+  --version "$version" \
+  --output "${artifact_dir}/must-not-exist-stale.tar.gz"
 
 "$packager" \
   --cli-archive "$cli_zip" \

--- a/scripts/smoke-ubuntu-debian-bundle.sh
+++ b/scripts/smoke-ubuntu-debian-bundle.sh
@@ -256,6 +256,7 @@ else
 fi
 [[ -f "$config_file" ]] || die "Installer did not write config.toml"
 if [[ "$bundle_kind" == "headless" ]]; then
+  grep -Fq 'defaultBackend = "headless"' "$config_file" || die "config.toml does not default to headless runtime"
   grep -Fq "[backends.headless]" "$config_file" || die "config.toml does not include headless backend config"
   grep -Fq "runtimeLibsDir = \"${installed_home}/lib/backends/headless-${version}/runtime-libs\"" "$config_file" \
     || die "config.toml does not point at bundled headless runtime libs"

--- a/scripts/verify-kast-devin-runtime.sh
+++ b/scripts/verify-kast-devin-runtime.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/verify-kast-devin-runtime.sh [--prefix <bundle-root>]
+
+Verify an unpacked Kast Devin headless runtime bundle, then prove ordinary
+`kast up` and `kast rpc` commands use its configured headless backend.
+USAGE
+}
+
+resolve_default_prefix() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+  cd -- "${script_dir}/.." >/dev/null 2>&1 && pwd
+}
+
+prefix=""
+tmp_dir=""
+workspace_root=""
+
+cleanup() {
+  if [[ -n "$tmp_dir" ]]; then
+    if [[ -n "$workspace_root" && -x "${prefix:-}/bin/kast" ]]; then
+      KAST_CONFIG_HOME="$prefix" "${prefix}/bin/kast" stop --workspace-root "$workspace_root" >/dev/null 2>&1 || true
+    fi
+    rm -rf -- "$tmp_dir"
+  fi
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix)
+      [[ $# -ge 2 ]] || die "Missing value for --prefix"
+      prefix="$2"; shift 2 ;;
+    --prefix=*)
+      prefix="${1#--prefix=}"; shift ;;
+    --help|-h)
+      usage; exit 0 ;;
+    *)
+      usage; die "Unknown argument: $1" ;;
+  esac
+done
+
+if [[ -z "$prefix" ]]; then
+  prefix="$(resolve_default_prefix)"
+fi
+prefix="$(cd -- "$prefix" >/dev/null 2>&1 && pwd)" || die "Bundle prefix not found: $prefix"
+
+manifest="${prefix}/manifest.json"
+config_file="${prefix}/config.toml"
+[[ -f "$manifest" ]] || die "Missing manifest.json in $prefix"
+[[ -f "$config_file" ]] || die "Missing config.toml in $prefix; run scripts/setup-kast-devin-runtime.sh first"
+
+backend_install_name="$(python3 - "$manifest" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if payload.get("kind") != "KAST_DEVIN_HEADLESS_RUNTIME":
+    raise SystemExit(f"unexpected bundle kind: {payload.get('kind')}")
+if payload.get("platform") != "devin-headless-linux-x64":
+    raise SystemExit(f"unexpected platform: {payload.get('platform')}")
+backend_install_name = payload.get("backendInstallName")
+if not isinstance(backend_install_name, str) or not backend_install_name:
+    raise SystemExit("manifest is missing backendInstallName")
+print(backend_install_name)
+PY
+)"
+
+cli_path="${prefix}/bin/kast"
+backend_root="${prefix}/lib/backends/${backend_install_name}"
+runtime_libs="${backend_root}/runtime-libs"
+idea_home="${backend_root}/idea-home"
+
+[[ -x "$cli_path" ]] || die "Missing executable CLI: $cli_path"
+[[ -x "${backend_root}/kast-headless" ]] || die "Missing executable headless launcher: ${backend_root}/kast-headless"
+[[ -f "${runtime_libs}/classpath.txt" ]] || die "Missing runtime classpath: ${runtime_libs}/classpath.txt"
+[[ -f "${idea_home}/lib/nio-fs.jar" ]] || die "Missing IDEA nio-fs.jar: ${idea_home}/lib/nio-fs.jar"
+[[ -f "${idea_home}/modules/module-descriptors.dat" ]] || die "Missing IDEA module descriptors: ${idea_home}/modules/module-descriptors.dat"
+[[ -d "${idea_home}/plugins/kast-headless" ]] || die "Missing bundled kast-headless plugin"
+
+if [[ -d "${backend_root}/libs" ]] && find "${backend_root}/libs" -name '*-all.jar' -print -quit | grep -q .; then
+  find "${backend_root}/libs" -name '*-all.jar' -print >&2
+  die "Devin headless runtime must not contain fat jars"
+fi
+
+grep -Fq "[backends.headless]" "$config_file" || die "config.toml does not include headless backend config"
+grep -Fq "[runtime]" "$config_file" || die "config.toml does not include runtime config"
+grep -Fq 'defaultBackend = "headless"' "$config_file" || die "config.toml does not default to headless runtime"
+grep -Fq "runtimeLibsDir = \"${runtime_libs}\"" "$config_file" || die "config.toml does not point at bundled runtime libs"
+grep -Fq "ideaHome = \"${idea_home}\"" "$config_file" || die "config.toml does not point at bundled IDEA home"
+grep -Fq "binaryPath = \"${cli_path}\"" "$config_file" || die "config.toml does not point at bundled CLI"
+
+doctor_output="$(KAST_CONFIG_HOME="$prefix" "$cli_path" doctor)"
+python3 - "$doctor_output" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.loads(sys.argv[1])
+except json.JSONDecodeError as error:
+    raise SystemExit(f"kast doctor did not return JSON: {error}")
+if payload.get("ok") is not True:
+    raise SystemExit(f"kast doctor did not report ok=true: {payload}")
+PY
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/kast-devin-runtime-verify.XXXXXX")"
+workspace_root="${tmp_dir}/workspace"
+mkdir -p "$workspace_root"
+
+up_output="$(KAST_CONFIG_HOME="$prefix" "$cli_path" up --workspace-root "$workspace_root" --accept-indexing=true)"
+python3 - "$up_output" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+selected = payload.get("selected") or {}
+descriptor = selected.get("descriptor") or {}
+runtime_status = selected.get("runtimeStatus") or {}
+backend = runtime_status.get("backendName") or descriptor.get("backendName")
+if backend != "headless":
+    raise SystemExit(f"kast up did not select headless backend: {payload}")
+PY
+
+rpc_output="$(KAST_CONFIG_HOME="$prefix" "$cli_path" rpc '{"jsonrpc":"2.0","method":"runtime/status","id":1}' --workspace-root "$workspace_root")"
+python3 - "$rpc_output" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+result = payload.get("result") or {}
+if result.get("backendName") != "headless":
+    raise SystemExit(f"kast rpc runtime/status did not use headless backend: {payload}")
+PY
+
+KAST_CONFIG_HOME="$prefix" "$cli_path" stop --workspace-root "$workspace_root" >/dev/null
+workspace_root=""
+
+printf '%s\n' "Verified Kast Devin headless runtime in ${prefix}"

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -63,6 +63,7 @@ required = {
     "standalone": f"kast-standalone-{tag}.zip",
 }
 optional = {
+    "devin-headless-linux-x64": f"kast-devin-headless-runtime-linux-x64-{tag}.tar.gz",
     "ubuntu-debian-headless-x86_64": f"kast-ubuntu-debian-headless-x86_64-{tag}.tar.gz",
     "ubuntu-debian-x86_64": f"kast-ubuntu-debian-x86_64-{tag}.tar.gz",
 }


### PR DESCRIPTION
## Summary

- add a Devin headless runtime packaging workflow and bundle scripts
- add CLI runtime default backend selection via `[runtime] defaultBackend`, with `--backend` override precedence
- make `kast rpc` accept `--backend` and verify unpinned Devin `up`/`rpc` paths select headless
- tighten headless portable layout and release/provenance contract checks for the agent profile

## Validation

- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --check`
- `./scripts/smoke-devin-headless-runtime.sh`
- `./.github/scripts/test-kast-build-contract.sh`
- `./.github/scripts/test-release-workflow-contract.sh`
- `git diff --check`
- `bash -n scripts/package-devin-headless-runtime.sh`
- `bash -n scripts/smoke-devin-headless-runtime.sh`
- `bash -n scripts/verify-kast-devin-runtime.sh`
