### PR TITLE
Add install and current gateway commands

### DIFF
--- a/.github/scripts/test-docs-content-contract.sh
+++ b/.github/scripts/test-docs-content-contract.sh
@@ -107,7 +107,7 @@ require_not_contains "$readme" 'IntelliJ-backed' "README must use IDEA-backed na
 require_not_contains "$readme" 'backend-intellij' "README must use idea as the IDE-hosted backend module name"
 
 require_contains "$readme" "brew tap amichne/kast" "README must document the Homebrew tap install"
-require_contains "$readme" "kast backend install headless" "README must document on-demand headless backend installation"
+require_contains "$readme" "kast install headless" "README must document on-demand headless backend installation"
 require_not_contains "$readme" "curl -fsSL https://raw.githubusercontent.com/amichne/kast/HEAD/kast.sh | bash" "README must not document the retired shell installer"
 require_not_contains "$readme" "amichne/kast-action@v1" "README must not document a separate hosted-agent installer"
 require_contains "$readme" "scripts/install-ubuntu-debian.sh" "README must point non-Brew users to the canonical Ubuntu/Debian installer"
@@ -115,7 +115,7 @@ require_contains "$index_doc" "brew install kast" "Docs overview must promote Ho
 
 require_contains "$install_doc" "## Homebrew install" "Install docs must distinguish the Homebrew path"
 require_contains "$install_doc" "## Install a backend" "Install docs must make backend installation a separate CLI-owned step"
-require_contains "$install_doc" "kast backend install headless" "Install docs must document headless backend installation"
+require_contains "$install_doc" "kast install headless" "Install docs must document headless backend installation"
 require_not_contains "$install_doc" "## Shell installer" "Install docs must not document the retired shell installer"
 require_not_contains "$install_doc" "## Install modes" "Install docs must not document retired kast.sh install modes"
 require_not_contains "$install_doc" "amichne/kast-action@v1" "Install docs must not document a separate hosted-agent installer"
@@ -144,7 +144,7 @@ require_contains "$backends_doc" '`idea` backend name' "Backend docs must docume
 require_contains "$quickstart_doc" 'APP_FILE="$PWD/src/main/kotlin/App.kt"' "Quickstart must show a shell-expanded absolute file path"
 require_contains "$quickstart_doc" '--workspace-root="$PWD"' "Quickstart must quote the workspace root"
 require_contains "$agents_doc" "## Local and hosted agent setup" "Agent docs must separate local and hosted setup"
-require_contains "$agents_doc" "kast backend install headless" "Agent docs must show on-demand backend installation"
+require_contains "$agents_doc" "kast install headless" "Agent docs must show on-demand backend installation"
 require_not_contains "$agents_doc" "amichne/kast-action@v1" "Agent docs must not document a separate hosted-agent installer"
 require_not_contains "$agents_doc" 'scripts/headless-agent-install.sh' "Agent docs must not document the retired headless agent installer"
 require_not_contains "$agents_doc" 'KAST_AGENT_INSTALL_ROOT' "Agent docs must not mention retired headless agent variables"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ planned edit is safe to apply.
 `kast` has two independent runtime modes:
 
 - **Headless CLI + backend** — install the `kast` CLI and run
-  `kast backend install headless` for a packaged IDEA-backed runtime.
+  `kast install headless` for a packaged IDEA-backed runtime.
   Works in terminals, CI, hosted agents, and images that need an offline,
   self-contained Ubuntu/Debian bundle.
 - **IDEA / Android Studio plugin-backed runtime** — runs inside a supported
@@ -42,7 +42,7 @@ Install exactly one backend for the runtime you want:
 
 ```console
 # Terminal, CI, or agent runtime without an IDE
-kast backend install headless
+kast install headless
 ```
 
 Use the Ubuntu/Debian installer when Homebrew is not available, or when the

--- a/cli-rs/docs/reference/cli-cheat-sheet.md
+++ b/cli-rs/docs/reference/cli-cheat-sheet.md
@@ -69,10 +69,15 @@ installation state recorded in `config.toml`.
 |---------|--------------|
 | `kast config init` | Write the default global config file with concrete paths if missing. |
 | `kast install` | Initialize a portable archive install and record install state in `config.toml`. |
+| `kast install headless` | Install the packaged headless backend. |
 | `kast install skill` | Install the packaged Kast skill into a target directory. |
-| `kast install copilot-extension` | Install packaged Copilot agents, hooks, and extensions. |
-| `kast install idea-plugin` | Download the Homebrew `kast-plugin` cask ZIP to `~/Downloads`. |
-| `kast install idea-plugin --link-jetbrains-profiles` | Install or reinstall the Homebrew `kast-plugin` cask and link it into local JetBrains IDE profiles. |
+| `kast install copilot` | Install packaged Copilot agents, hooks, and extensions. |
+| `kast install plugin` | Download the Homebrew `kast-plugin` cask ZIP to `~/Downloads`. |
+| `kast install plugin --link-jetbrains-profiles` | Install or reinstall the Homebrew `kast-plugin` cask and link it into local JetBrains IDE profiles. |
+| `kast current headless` | Print the recorded headless backend version. |
+| `kast current skill` | Print the installed packaged skill version. |
+| `kast current copilot` | Print the installed Copilot extension version for the current repo. |
+| `kast current plugin` | Print the Homebrew-installed IDEA plugin cask version. |
 | `kast info` | Print the recorded global install state. |
 | `kast doctor` | Verify the global install is still healthy. |
 | `kast uninstall copilot-extension` | Remove managed Copilot resources. |

--- a/cli-rs/docs/reference/json-rpc-operations.md
+++ b/cli-rs/docs/reference/json-rpc-operations.md
@@ -22,7 +22,7 @@ nested object fields, variants, enum values, response types, and Copilot
 The Copilot extension does not maintain a parallel tool schema. Its shared
 `kast-tools.mjs` module loads the same catalog, derives each tool's parameter
 schema from the command request model, and calls the catalog's JSON-RPC
-`method` value. During `kast install copilot-extension`, the Rust installer
+`method` value. During `kast install copilot`, the Rust installer
 copies the catalog into `extensions/_shared/commands.json` so installed
 extensions use the same operation definitions as the packaged skill.
 

--- a/cli-rs/resources/copilot-extension/extensions/kast/extension.mjs
+++ b/cli-rs/resources/copilot-extension/extensions/kast/extension.mjs
@@ -258,7 +258,7 @@ if (!bin) {
   const installedVersion = readInstalledExtensionVersion();
   if (cliVersion && installedVersion && cliVersion !== installedVersion) {
     const syncResult = await execBash(
-      `${JSON.stringify(bin)} install copilot-extension --target-dir=${JSON.stringify(join(REPO_ROOT, ".github"))}`,
+      `${JSON.stringify(bin)} install copilot --target-dir=${JSON.stringify(join(REPO_ROOT, ".github"))}`,
     );
     if (syncResult.ok) {
       await session.log(
@@ -268,7 +268,7 @@ if (!bin) {
     } else {
       const msg =
         `kast version mismatch: CLI=${cliVersion}, extension=${installedVersion}. ` +
-        "Auto-sync failed. Run `kast install copilot-extension` manually.";
+        "Auto-sync failed. Run `kast install copilot` manually.";
       await session.log(`kast extension: ${msg}`, { level: "warning" });
     }
   }

--- a/cli-rs/src/backend.rs
+++ b/cli-rs/src/backend.rs
@@ -90,7 +90,8 @@ fn install(args: BackendInstallArgs) -> Result<BackendInstallResult> {
     let (archive, downloaded, temp_download) = resolve_archive(&args, &version)?;
     let install_dir = install_dir(&config, args.backend, &version);
     let current_dir = current_dir(&config, args.backend);
-    let skipped = install_dir.exists() && !args.yes.unwrap_or(false);
+    let force = args.force || args.yes.unwrap_or(false);
+    let skipped = install_dir.exists() && !force;
 
     if !skipped {
         let temp = temp_tree("kast-backend-install")?;

--- a/cli-rs/src/cli.rs
+++ b/cli-rs/src/cli.rs
@@ -57,6 +57,11 @@ pub enum Command {
     },
     /// Install a portable archive or packaged resources.
     Install(InstallArgs),
+    /// Report the current installed version of a Kast component.
+    Current {
+        #[command(subcommand)]
+        command: CurrentCommand,
+    },
     /// Report the recorded global Kast install state.
     Info,
     /// Verify the global Kast install is still healthy.
@@ -103,6 +108,9 @@ pub struct BackendInstallArgs {
     #[arg(long)]
     pub base_url: Option<String>,
     /// Replace an existing installed backend version.
+    #[arg(short = 'f', long)]
+    pub force: bool,
+    /// Deprecated alias for --force.
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     pub yes: Option<bool>,
 }
@@ -397,13 +405,36 @@ pub struct InstallArgs {
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum InstallCommand {
+    /// Install the headless JVM backend.
+    Headless(HeadlessInstallArgs),
     /// Install the packaged kast skill into the current workspace.
     Skill(ResourceInstallArgs),
     /// Install the packaged Copilot agents and extensions.
-    CopilotExtension(ResourceInstallArgs),
+    #[command(alias = "copilot-extension")]
+    Copilot(ResourceInstallArgs),
     /// Download the Homebrew-managed IDEA plugin cask.
-    #[command(alias = "developer-plugin")]
-    IdeaPlugin(IdeaPluginInstallArgs),
+    #[command(alias = "idea-plugin", alias = "developer-plugin")]
+    Plugin(IdeaPluginInstallArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct HeadlessInstallArgs {
+    /// Local backend zip archive. When omitted, kast downloads the release asset.
+    #[arg(long)]
+    pub archive: Option<PathBuf>,
+    /// Release tag or version. Defaults to this CLI version.
+    #[arg(long)]
+    pub version: Option<String>,
+    /// Release directory URL containing backend zip, SHA256SUMS, and build-provenance.json.
+    /// Defaults to the matching GitHub release.
+    #[arg(long)]
+    pub base_url: Option<String>,
+    /// Replace an existing installed backend version.
+    #[arg(short = 'f', long)]
+    pub force: bool,
+    /// Deprecated alias for --force.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub yes: Option<bool>,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -420,6 +451,9 @@ pub struct IdeaPluginInstallArgs {
     /// Override the cask token. Defaults to <kast formula tap>/kast-plugin.
     #[arg(long)]
     pub cask_token: Option<String>,
+    /// Replace or refetch the plugin artifact when the installer supports it.
+    #[arg(short = 'f', long)]
+    pub force: bool,
     /// Print the planned Homebrew command without running it.
     #[arg(long)]
     pub dry_run: bool,
@@ -437,6 +471,9 @@ pub struct ResourceInstallArgs {
     #[arg(long)]
     pub link_name: Option<String>,
     /// Overwrite existing managed resources.
+    #[arg(short = 'f', long)]
+    pub force: bool,
+    /// Deprecated alias for --force.
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     pub yes: Option<bool>,
 }
@@ -451,6 +488,31 @@ pub struct UninstallArgs {
 pub enum UninstallCommand {
     /// Remove packaged Copilot agents and extensions from the current workspace.
     CopilotExtension(ResourceInstallArgs),
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum CurrentCommand {
+    /// Report the current Homebrew-managed IDEA plugin version.
+    Plugin,
+    /// Report the current installed headless backend version.
+    Headless,
+    /// Report the current installed packaged skill version.
+    Skill(ResourceCurrentArgs),
+    /// Report the current installed Copilot extension version.
+    Copilot(ResourceCurrentArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct ResourceCurrentArgs {
+    /// Target root directory.
+    #[arg(long)]
+    pub target_dir: Option<PathBuf>,
+    /// Directory name for the installed skill. Defaults to kast.
+    #[arg(long)]
+    pub name: Option<String>,
+    /// Deprecated alias for --name.
+    #[arg(long)]
+    pub link_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq, Serialize, Deserialize)]

--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -1,8 +1,10 @@
 use crate::SCHEMA_VERSION;
+use crate::backend::{self, BackendResult};
 use crate::cli;
 use crate::cli::{
-    IdeaPluginInstallArgs, InstallArgs, InstallCommand, ResourceInstallArgs, UninstallArgs,
-    UninstallCommand,
+    BackendComponent, BackendInstallArgs, CurrentCommand, HeadlessInstallArgs,
+    IdeaPluginInstallArgs, InstallArgs, InstallCommand, ResourceCurrentArgs, ResourceInstallArgs,
+    UninstallArgs, UninstallCommand,
 };
 use crate::config;
 use crate::error::{CliError, Result};
@@ -98,6 +100,7 @@ pub enum InstallResult {
     Skill(InstallSkillResult),
     Copilot(InstallCopilotExtensionResult),
     IdeaPlugin(InstallIdeaPluginResult),
+    Headless(backend::BackendInstallResult),
     Archive(ArchiveInstallResult),
 }
 
@@ -117,18 +120,59 @@ pub enum UninstallResult {
     Copilot(InstallCopilotExtensionResult),
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CurrentComponentResult {
+    pub component: String,
+    pub installed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cask_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_libs_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idea_home: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    pub schema_version: u32,
+}
+
 pub fn install(args: InstallArgs) -> Result<InstallResult> {
     match args.command {
+        Some(InstallCommand::Headless(headless_args)) => {
+            install_headless(headless_args).map(InstallResult::Headless)
+        }
         Some(InstallCommand::Skill(resource_args)) => {
             install_skill(resource_args).map(InstallResult::Skill)
         }
-        Some(InstallCommand::CopilotExtension(resource_args)) => {
+        Some(InstallCommand::Copilot(resource_args)) => {
             install_copilot_extension(resource_args).map(InstallResult::Copilot)
         }
-        Some(InstallCommand::IdeaPlugin(resource_args)) => {
+        Some(InstallCommand::Plugin(resource_args)) => {
             install_idea_plugin(resource_args).map(InstallResult::IdeaPlugin)
         }
         None => install_archive(args).map(InstallResult::Archive),
+    }
+}
+
+pub fn current(command: CurrentCommand) -> Result<CurrentComponentResult> {
+    match command {
+        CurrentCommand::Plugin => current_plugin(),
+        CurrentCommand::Headless => current_headless(),
+        CurrentCommand::Skill(args) => {
+            current_resource("skill", current_skill_target(args), ".kast-version", vec![])
+        }
+        CurrentCommand::Copilot(args) => current_resource(
+            "copilot",
+            current_copilot_target(args),
+            COPILOT_EXTENSION_MARKER,
+            vec![],
+        ),
     }
 }
 
@@ -139,6 +183,150 @@ pub fn uninstall(args: UninstallArgs) -> Result<UninstallResult> {
         }
         None => self_mgmt::uninstall().map(UninstallResult::SelfManaged),
     }
+}
+
+fn current_plugin() -> Result<CurrentComponentResult> {
+    let mut warnings = vec![];
+    let cask_token = match homebrew_formula_tap() {
+        Ok(tap) => format!("{tap}/{KAST_PLUGIN_CASK_NAME}"),
+        Err(error) => {
+            warnings.push(format!(
+                "Could not resolve the Homebrew tap for kast; using {DEFAULT_KAST_TAP}: {}",
+                error.message
+            ));
+            format!("{DEFAULT_KAST_TAP}/{KAST_PLUGIN_CASK_NAME}")
+        }
+    };
+    let cask_name = cask_name(&cask_token);
+    let version = match homebrew_cask_version(&cask_name) {
+        Ok(version) => version,
+        Err(error) => {
+            warnings.push(format!(
+                "Could not resolve the installed Homebrew cask version for {cask_name}: {}",
+                error.message
+            ));
+            None
+        }
+    };
+    Ok(CurrentComponentResult {
+        component: "plugin".to_string(),
+        installed: version.is_some(),
+        version,
+        cask_token: Some(cask_token),
+        install_dir: None,
+        target_dir: None,
+        runtime_libs_dir: None,
+        idea_home: None,
+        warnings,
+        schema_version: SCHEMA_VERSION,
+    })
+}
+
+fn install_headless(args: HeadlessInstallArgs) -> Result<backend::BackendInstallResult> {
+    let backend_args = BackendInstallArgs {
+        backend: BackendComponent::Headless,
+        archive: args.archive,
+        version: args.version,
+        base_url: args.base_url,
+        force: args.force,
+        yes: args.yes,
+    };
+    match backend::run(cli::BackendCommand::Install(backend_args))? {
+        BackendResult::Install(result) => Ok(result),
+        BackendResult::Uninstall(_) => Err(CliError::new(
+            "CLI_USAGE",
+            "install headless unexpectedly returned an uninstall result",
+        )),
+    }
+}
+
+fn current_headless() -> Result<CurrentComponentResult> {
+    let backend = self_mgmt::read_global_install_state()?.and_then(|install| {
+        install
+            .backends
+            .into_iter()
+            .find(|backend| backend.name == BackendComponent::Headless.canonical())
+    });
+    Ok(match backend {
+        Some(backend) => CurrentComponentResult {
+            component: "headless".to_string(),
+            installed: true,
+            version: Some(backend.version),
+            cask_token: None,
+            install_dir: Some(backend.install_dir),
+            target_dir: None,
+            runtime_libs_dir: Some(backend.runtime_libs_dir),
+            idea_home: backend.idea_home,
+            warnings: vec![],
+            schema_version: SCHEMA_VERSION,
+        },
+        None => CurrentComponentResult {
+            component: "headless".to_string(),
+            installed: false,
+            version: None,
+            cask_token: None,
+            install_dir: None,
+            target_dir: None,
+            runtime_libs_dir: None,
+            idea_home: None,
+            warnings: vec![],
+            schema_version: SCHEMA_VERSION,
+        },
+    })
+}
+
+fn current_resource(
+    component: &str,
+    target: PathBuf,
+    marker_name: &str,
+    warnings: Vec<String>,
+) -> Result<CurrentComponentResult> {
+    let marker = target.join(marker_name);
+    let version = marker
+        .is_file()
+        .then(|| {
+            fs::read_to_string(&marker)
+                .unwrap_or_default()
+                .trim()
+                .to_string()
+        })
+        .filter(|value| !value.is_empty());
+    Ok(CurrentComponentResult {
+        component: component.to_string(),
+        installed: version.is_some(),
+        version,
+        cask_token: None,
+        install_dir: None,
+        target_dir: Some(target.display().to_string()),
+        runtime_libs_dir: None,
+        idea_home: None,
+        warnings,
+        schema_version: SCHEMA_VERSION,
+    })
+}
+
+fn current_skill_target(args: ResourceCurrentArgs) -> PathBuf {
+    let target_root = args
+        .target_dir
+        .map(config::normalize)
+        .unwrap_or_else(default_skill_target_dir);
+    let name = args
+        .name
+        .or(args.link_name)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "kast".to_string());
+    target_root.join(name)
+}
+
+fn current_copilot_target(args: ResourceCurrentArgs) -> PathBuf {
+    let target = args.target_dir.map(config::normalize).unwrap_or_else(|| {
+        config::normalize(
+            env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(".github"),
+        )
+    });
+    target.join(COPILOT_EXTENSION_DIR)
 }
 
 pub fn install_skill(args: ResourceInstallArgs) -> Result<InstallSkillResult> {
@@ -156,7 +344,7 @@ pub fn install_skill(args: ResourceInstallArgs) -> Result<InstallSkillResult> {
         &KAST_SKILL,
         &target,
         ".kast-version",
-        args.yes.unwrap_or(false),
+        args.force || args.yes.unwrap_or(false),
     )?;
     Ok(InstallSkillResult {
         installed_at: target.display().to_string(),
@@ -177,7 +365,7 @@ pub fn install_copilot_extension(
         )
     });
     let extension_target = target.join(COPILOT_EXTENSION_DIR);
-    let skipped = install_copilot_extension_dir(&extension_target)?;
+    let skipped = install_copilot_extension_dir(&extension_target, args.force)?;
     write_copilot_rpc_catalog(&extension_target)?;
     self_mgmt::record_copilot_repo(&target, cli::version())?;
     Ok(InstallCopilotExtensionResult {
@@ -234,6 +422,7 @@ fn download_idea_plugin(
     let mut downloaded_path = None;
     if !args.dry_run {
         fs::create_dir_all(&download_dir)?;
+        eprintln!("Fetching Kast IDEA plugin cask {cask_token} with Homebrew...");
         let output = run_brew_command(&brew_args)?;
         if !output.status.success() {
             return Err(command_error(
@@ -246,6 +435,7 @@ fn download_idea_plugin(
         let cache_path = homebrew_cask_cache_path(&cask_token)?;
         let destination = download_destination(&cache_path, &download_dir)?;
         fs::copy(&cache_path, &destination)?;
+        eprintln!("Downloaded Kast IDEA plugin to {}", destination.display());
         downloaded_path = Some(destination.display().to_string());
     }
 
@@ -301,11 +491,14 @@ fn install_idea_plugin_into_jetbrains_profiles(
     } else {
         "install"
     };
-    let brew_args = vec![
+    let mut brew_args = vec![
         brew_action.to_string(),
         "--cask".to_string(),
         cask_token.clone(),
     ];
+    if args.force {
+        brew_args.insert(2, "--force".to_string());
+    }
     if !args.dry_run {
         let output = run_brew_with_jetbrains_root(&brew_args, &jetbrains_config_root)?;
         if !output.status.success() {
@@ -462,12 +655,13 @@ fn write_copilot_rpc_catalog(target: &Path) -> Result<()> {
     Ok(())
 }
 
-fn install_copilot_extension_dir(target: &Path) -> Result<bool> {
+fn install_copilot_extension_dir(target: &Path, force: bool) -> Result<bool> {
     let marker = target.join(COPILOT_EXTENSION_MARKER);
-    let skipped = marker
-        .is_file()
-        .then(|| fs::read_to_string(&marker).unwrap_or_default())
-        .is_some_and(|current| current.trim() == cli::version());
+    let skipped = !force
+        && marker
+            .is_file()
+            .then(|| fs::read_to_string(&marker).unwrap_or_default())
+            .is_some_and(|current| current.trim() == cli::version());
     let source = COPILOT_EXTENSION
         .get_dir(COPILOT_EXTENSION_DIR)
         .ok_or_else(|| {
@@ -486,7 +680,7 @@ fn install_dir(dir: &Dir<'_>, target: &Path, marker_name: &str, force: bool) -> 
     let marker = target.join(marker_name);
     if marker.is_file() {
         let current = fs::read_to_string(&marker).unwrap_or_default();
-        if current.trim() == cli::version() {
+        if !force && current.trim() == cli::version() {
             return Ok(true);
         }
     }
@@ -710,7 +904,7 @@ fn verify_homebrew_cli(homebrew: &HomebrewContext) -> Result<()> {
     let mut error = CliError::new(
         "HOMEBREW_INSTALL_REQUIRED",
         format!(
-            "`kast install idea-plugin` must be run from the Homebrew-installed kast binary under {}",
+            "`kast install plugin` must be run from the Homebrew-installed kast binary under {}",
             homebrew.formula_prefix.display()
         ),
     );
@@ -788,6 +982,27 @@ fn parse_homebrew_formula_tap(json: &str) -> Option<String> {
 fn homebrew_cask_installed(cask_name: &str) -> Result<bool> {
     let output = run_brew(&["list", "--cask", cask_name])?;
     Ok(output.status.success())
+}
+
+fn homebrew_cask_version(cask_name: &str) -> Result<Option<String>> {
+    let output = run_brew(&["list", "--cask", "--versions", cask_name])?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_homebrew_cask_version(&stdout, cask_name))
+}
+
+fn parse_homebrew_cask_version(output: &str, cask_name: &str) -> Option<String> {
+    output.lines().find_map(|line| {
+        let mut parts = line.split_whitespace();
+        let name = parts.next()?;
+        if name != cask_name {
+            return None;
+        }
+        let version = parts.collect::<Vec<_>>().join(" ");
+        (!version.trim().is_empty()).then_some(version)
+    })
 }
 
 fn homebrew_cask_cache_path(cask_token: &str) -> Result<PathBuf> {
@@ -1009,6 +1224,7 @@ mod tests {
             target_dir: Some(temp.path().to_path_buf()),
             name: Some("kast".to_string()),
             link_name: None,
+            force: false,
             yes: Some(false),
         };
         let first = install_skill(args.clone()).unwrap();

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -111,6 +111,12 @@ fn run() -> Result<i32> {
             println!();
             Ok(0)
         }
+        Command::Current { command } => {
+            let result = install::current(command)?;
+            serde_json::to_writer_pretty(io::stdout(), &result)?;
+            println!();
+            Ok(0)
+        }
         Command::Info => {
             let result = self_mgmt::status()?;
             serde_json::to_writer_pretty(io::stdout(), &result)?;

--- a/cli-rs/src/runtime.rs
+++ b/cli-rs/src/runtime.rs
@@ -599,7 +599,7 @@ fn workspace_root(value: Option<PathBuf>) -> Result<PathBuf> {
 
 fn no_backend_error(workspace_root: &Path, backend_name: Option<BackendName>) -> CliError {
     let backend_name = backend_name.unwrap_or(BackendName::Headless);
-    let install_command = format!("kast backend install {}", backend_name.canonical());
+    let install_command = format!("kast install {}", backend_name.canonical());
     let mut error = CliError::new(
         "NO_BACKEND_AVAILABLE",
         format!(

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -31,8 +31,18 @@ elif [ "$1" = "--prefix" ] && [ "$2" = "kast" ]; then
   printf '%s\n' "{}"
 elif [ "$1" = "info" ] && [ "$2" = "--json=v2" ] && [ "$3" = "kast" ]; then
   printf '%s\n' '{{"formulae":[{{"name":"kast","tap":"amichne/kast"}}],"casks":[]}}'
+elif [ "$1" = "fetch" ] && [ "$2" = "--cask" ]; then
+  cache="${{HOME:-/tmp}}/000--kast-plugin.zip"
+  printf 'fake plugin zip\n' > "$cache"
+  printf 'fake brew fetched kast plugin\n' >&2
+elif [ "$1" = "--cache" ] && [ "$2" = "--cask" ]; then
+  printf '%s\n' "${{HOME:-/tmp}}/000--kast-plugin.zip"
 elif [ "$1" = "list" ] && [ "$2" = "--cask" ]; then
-  exit 1
+  if [ "${{KAST_FAKE_BREW_CASK_VERSION:-}}" != "" ]; then
+    printf 'kast-plugin %s\n' "$KAST_FAKE_BREW_CASK_VERSION"
+  else
+    exit 1
+  fi
 else
   printf 'unexpected brew args:' >&2
   printf ' %s' "$@" >&2
@@ -257,6 +267,46 @@ fn smoke_core_cli_commands() {
         .expect("help");
     assert!(help.status.success());
     assert!(String::from_utf8_lossy(&help.stdout).contains("Usage: kast"));
+
+    let install_help = kast(&home, &config_home)
+        .args(["install", "--help"])
+        .output()
+        .expect("install help");
+    assert!(install_help.status.success());
+    let install_help_stdout = String::from_utf8_lossy(&install_help.stdout);
+    for command in ["plugin", "headless", "skill", "copilot"] {
+        assert!(
+            install_help_stdout.contains(command),
+            "install help should list {command}: {install_help_stdout}"
+        );
+    }
+    for command in ["plugin", "headless", "skill", "copilot"] {
+        let help = kast(&home, &config_home)
+            .args(["install", command, "--help"])
+            .output()
+            .unwrap_or_else(|error| panic!("install {command} help: {error}"));
+        assert!(
+            help.status.success(),
+            "install {command} help should succeed"
+        );
+        let stdout = String::from_utf8_lossy(&help.stdout);
+        assert!(
+            stdout.contains("-f, --force"),
+            "install {command} help should expose -f/--force: {stdout}"
+        );
+    }
+    let current_help = kast(&home, &config_home)
+        .args(["current", "--help"])
+        .output()
+        .expect("current help");
+    assert!(current_help.status.success());
+    let current_help_stdout = String::from_utf8_lossy(&current_help.stdout);
+    for command in ["plugin", "headless", "skill", "copilot"] {
+        assert!(
+            current_help_stdout.contains(command),
+            "current help should list {command}: {current_help_stdout}"
+        );
+    }
 
     let demo_help = kast(&home, &config_home)
         .args(["demo", "--help"])
@@ -632,6 +682,68 @@ fn backend_install_headless_archive_configures_runtime_and_install_state() {
 }
 
 #[test]
+fn install_headless_gateway_and_current_report_installed_version() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    std::fs::create_dir_all(&home).expect("home");
+    let archive = write_backend_archive(temp.path(), "headless", "v9.8.7");
+
+    let install = kast(&home, &config_home)
+        .args([
+            "install",
+            "headless",
+            "--archive",
+            archive.to_str().expect("archive path"),
+            "--version",
+            "v9.8.7",
+            "--force",
+        ])
+        .output()
+        .expect("install headless");
+
+    assert!(
+        install.status.success(),
+        "install headless gateway should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&install.stdout).expect("install headless json");
+    assert_eq!(stdout["backendName"], "headless");
+    assert_eq!(stdout["version"], "v9.8.7");
+
+    let current = kast(&home, &config_home)
+        .args(["current", "headless"])
+        .output()
+        .expect("current headless");
+
+    assert!(
+        current.status.success(),
+        "current headless should report installed backend: stdout={}, stderr={}",
+        String::from_utf8_lossy(&current.stdout),
+        String::from_utf8_lossy(&current.stderr)
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&current.stdout).expect("current headless json");
+    assert_eq!(stdout["component"], "headless");
+    assert_eq!(stdout["installed"], true);
+    assert_eq!(stdout["version"], "v9.8.7");
+    assert!(
+        stdout["installDir"]
+            .as_str()
+            .expect("install dir")
+            .ends_with(".kast/lib/backends/headless/headless-v9.8.7")
+    );
+    assert!(
+        stdout["runtimeLibsDir"]
+            .as_str()
+            .expect("runtime libs dir")
+            .ends_with(".kast/lib/backends/headless/current/runtime-libs")
+    );
+}
+
+#[test]
 fn backend_uninstall_removes_headless_component() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -711,7 +823,7 @@ fn up_without_installed_backend_reports_exact_backend_install_command() {
         "{stderr}"
     );
     assert!(
-        stderr.contains("kast backend install headless"),
+        stderr.contains("kast install headless"),
         "stderr should include exact install command: {stderr}"
     );
 }
@@ -746,7 +858,7 @@ fn runtime_commands_use_configured_default_backend_when_backend_flag_is_absent()
     );
     let stderr = String::from_utf8_lossy(&up.stderr);
     assert!(
-        stderr.contains("kast backend install headless"),
+        stderr.contains("kast install headless"),
         "stderr should include configured default install command: {stderr}"
     );
 }
@@ -782,7 +894,7 @@ fn runtime_backend_flag_overrides_configured_default_backend() {
     );
     let stderr = String::from_utf8_lossy(&up.stderr);
     assert!(
-        stderr.contains("kast backend install headless"),
+        stderr.contains("kast install headless"),
         "stderr should include explicit backend install command: {stderr}"
     );
 }
@@ -818,7 +930,7 @@ fn rpc_uses_configured_default_backend_when_auto_starting() {
     );
     let stderr = String::from_utf8_lossy(&rpc.stderr);
     assert!(
-        stderr.contains("kast backend install headless"),
+        stderr.contains("kast install headless"),
         "stderr should include configured default install command: {stderr}"
     );
 }
@@ -855,7 +967,7 @@ fn rpc_backend_flag_overrides_configured_default_backend() {
     );
     let stderr = String::from_utf8_lossy(&rpc.stderr);
     assert!(
-        stderr.contains("kast backend install headless"),
+        stderr.contains("kast install headless"),
         "stderr should include explicit backend install command: {stderr}"
     );
 }
@@ -894,6 +1006,206 @@ fn idea_plugin_install_defaults_to_downloads_without_jetbrains_profiles() {
     assert_eq!(stdout["brewCommand"][2], "--cask");
     assert_eq!(stdout["brewCommand"][5], "amichne/kast/kast-plugin");
     assert!(stdout.get("jetbrainsConfigRoot").is_none(), "{stdout}");
+}
+
+#[test]
+fn plugin_install_gateway_downloads_with_progress_on_stderr() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let brew_bin = temp.path().join("bin");
+    let download_dir = temp.path().join("downloads");
+    std::fs::create_dir_all(&home).expect("home");
+    let formula_prefix = Path::new(env!("CARGO_BIN_EXE_kast"))
+        .parent()
+        .expect("binary parent");
+    write_fake_brew(&brew_bin, formula_prefix);
+
+    let install = kast(&home, &config_home)
+        .env("PATH", &brew_bin)
+        .args([
+            "install",
+            "plugin",
+            "--download-dir",
+            download_dir.to_str().expect("download dir"),
+        ])
+        .output()
+        .expect("install plugin");
+
+    assert!(
+        install.status.success(),
+        "plugin gateway should download cask: stdout={}, stderr={}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&install.stderr);
+    assert!(
+        stderr.contains("Fetching Kast IDEA plugin"),
+        "stderr should announce the download before JSON output: {stderr}"
+    );
+    assert!(
+        stderr.contains("Downloaded Kast IDEA plugin"),
+        "stderr should confirm the downloaded artifact: {stderr}"
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&install.stdout).expect("install json");
+    assert_eq!(stdout["brewAction"], "fetch");
+    assert_eq!(
+        stdout["downloadedPath"],
+        download_dir.join("kast-plugin.zip").display().to_string()
+    );
+    assert!(download_dir.join("kast-plugin.zip").is_file());
+}
+
+#[test]
+fn current_plugin_reports_homebrew_cask_version() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let brew_bin = temp.path().join("bin");
+    std::fs::create_dir_all(&home).expect("home");
+    let formula_prefix = Path::new(env!("CARGO_BIN_EXE_kast"))
+        .parent()
+        .expect("binary parent");
+    write_fake_brew(&brew_bin, formula_prefix);
+
+    let current = kast(&home, &config_home)
+        .env("PATH", &brew_bin)
+        .env("KAST_FAKE_BREW_CASK_VERSION", "9.8.7")
+        .args(["current", "plugin"])
+        .output()
+        .expect("current plugin");
+
+    assert!(
+        current.status.success(),
+        "current plugin should report cask version: stdout={}, stderr={}",
+        String::from_utf8_lossy(&current.stdout),
+        String::from_utf8_lossy(&current.stderr)
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&current.stdout).expect("current plugin json");
+    assert_eq!(stdout["component"], "plugin");
+    assert_eq!(stdout["installed"], true);
+    assert_eq!(stdout["version"], "9.8.7");
+    assert_eq!(stdout["caskToken"], "amichne/kast/kast-plugin");
+}
+
+#[test]
+fn install_resource_gateways_support_force_and_current_versions() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let skill_dir = temp.path().join("skills");
+    let github_dir = temp.path().join(".github");
+    let stale_skill = skill_dir.join("kast");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&stale_skill).expect("stale skill");
+    std::fs::write(stale_skill.join(".kast-version"), b"old\n").expect("stale marker");
+    std::fs::write(stale_skill.join("old.txt"), b"old\n").expect("stale file");
+
+    let skill = kast(&home, &config_home)
+        .args([
+            "install",
+            "skill",
+            "--target-dir",
+            skill_dir.to_str().expect("skill path"),
+            "-f",
+        ])
+        .output()
+        .expect("install skill");
+    assert!(
+        skill.status.success(),
+        "skill install should accept -f: stdout={}, stderr={}",
+        String::from_utf8_lossy(&skill.stdout),
+        String::from_utf8_lossy(&skill.stderr)
+    );
+    let skill_stdout: serde_json::Value =
+        serde_json::from_slice(&skill.stdout).expect("skill install json");
+    assert!(stale_skill.join("SKILL.md").is_file());
+    assert!(!stale_skill.join("old.txt").exists());
+
+    std::fs::write(stale_skill.join("force-removes.txt"), b"stale\n").expect("force marker");
+    let forced_skill = kast(&home, &config_home)
+        .args([
+            "install",
+            "skill",
+            "--target-dir",
+            skill_dir.to_str().expect("skill path"),
+            "-f",
+        ])
+        .output()
+        .expect("force reinstall skill");
+    assert!(
+        forced_skill.status.success(),
+        "skill force reinstall should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&forced_skill.stdout),
+        String::from_utf8_lossy(&forced_skill.stderr)
+    );
+    let forced_skill_stdout: serde_json::Value =
+        serde_json::from_slice(&forced_skill.stdout).expect("forced skill json");
+    assert_eq!(forced_skill_stdout["skipped"], false);
+    assert!(!stale_skill.join("force-removes.txt").exists());
+
+    let current_skill = kast(&home, &config_home)
+        .args([
+            "current",
+            "skill",
+            "--target-dir",
+            skill_dir.to_str().expect("skill path"),
+        ])
+        .output()
+        .expect("current skill");
+    assert!(
+        current_skill.status.success(),
+        "current skill should report installed version: stdout={}, stderr={}",
+        String::from_utf8_lossy(&current_skill.stdout),
+        String::from_utf8_lossy(&current_skill.stderr)
+    );
+    let current_skill_stdout: serde_json::Value =
+        serde_json::from_slice(&current_skill.stdout).expect("current skill json");
+    assert_eq!(current_skill_stdout["component"], "skill");
+    assert_eq!(current_skill_stdout["installed"], true);
+    assert_eq!(current_skill_stdout["version"], skill_stdout["version"]);
+
+    let copilot = kast(&home, &config_home)
+        .args([
+            "install",
+            "copilot",
+            "--target-dir",
+            github_dir.to_str().expect("github path"),
+            "--force",
+        ])
+        .output()
+        .expect("install copilot");
+    assert!(
+        copilot.status.success(),
+        "copilot install should accept --force: stdout={}, stderr={}",
+        String::from_utf8_lossy(&copilot.stdout),
+        String::from_utf8_lossy(&copilot.stderr)
+    );
+    let copilot_stdout: serde_json::Value =
+        serde_json::from_slice(&copilot.stdout).expect("copilot install json");
+    assert!(github_dir.join("extensions/kast/extension.mjs").is_file());
+
+    let current_copilot = kast(&home, &config_home)
+        .args([
+            "current",
+            "copilot",
+            "--target-dir",
+            github_dir.to_str().expect("github path"),
+        ])
+        .output()
+        .expect("current copilot");
+    assert!(
+        current_copilot.status.success(),
+        "current copilot should report installed version: stdout={}, stderr={}",
+        String::from_utf8_lossy(&current_copilot.stdout),
+        String::from_utf8_lossy(&current_copilot.stderr)
+    );
+    let current_copilot_stdout: serde_json::Value =
+        serde_json::from_slice(&current_copilot.stdout).expect("current copilot json");
+    assert_eq!(current_copilot_stdout["component"], "copilot");
+    assert_eq!(current_copilot_stdout["installed"], true);
+    assert_eq!(current_copilot_stdout["version"], copilot_stdout["version"]);
 }
 
 #[test]

--- a/docs/for-agents/index.md
+++ b/docs/for-agents/index.md
@@ -20,7 +20,7 @@ results.
 kast install skill
 
 # 2. Install the backend this agent will use
-kast backend install headless
+kast install headless
 
 # 3. Warm the workspace daemon for this repo
 kast up --workspace-root="$PWD"
@@ -42,15 +42,15 @@ project, reusing the IDE's project model, indexes, and analysis session.
 ## Local and hosted agent setup
 
 Local agents usually inherit a developer's installed CLI and workspace, then
-install the backend with `kast backend install headless`. Hosted Ubuntu/Debian
+install the backend with `kast install headless`. Hosted Ubuntu/Debian
 agents can either install the headless backend on demand or install into a
 contained root from the self-contained offline bundle before the session starts.
 Homebrew is still the developer install path when the target supports it.
 
 | Agent environment | Install path | Runtime path | What to hand the agent |
 |-------------------|--------------|--------------|-------------------------|
-| Local developer agent | `kast install skill` and optional `kast install copilot-extension` | `kast backend install headless` or IDEA backend | The packaged skill and native `kast_*` tools |
-| CI review agent | `kast backend install headless` | Headless backend warmed with `kast up --backend=headless` | `kast rpc` commands and structured JSON outputs |
+| Local developer agent | `kast install skill` and optional `kast install copilot` | `kast install headless` or IDEA backend | The packaged skill and native `kast_*` tools |
+| CI review agent | `kast install headless` | Headless backend warmed with `kast up --backend=headless` | `kast rpc` commands and structured JSON outputs |
 | Ubuntu/Debian hosted agent | `scripts/install-ubuntu-debian.sh install` from the offline release bundle | Contained CLI and headless backend under `KAST_UBUNTU_DEBIAN_ROOT` | `kast` on `PATH` plus `KAST_CONFIG_HOME` when a custom config root is used |
 
 Use the Ubuntu/Debian path when the agent image cannot rely on a human shell

--- a/docs/for-agents/install-the-skill.md
+++ b/docs/for-agents/install-the-skill.md
@@ -44,11 +44,11 @@ From the workspace root:
 
 ## Force a reinstall
 
-Pass `--yes=true` to skip the confirmation. Use `--target-dir` for a
+Pass `--force` to skip the confirmation. Use `--target-dir` for a
 custom path:
 
 ```console title="Force reinstall to a custom path"
-kast install skill --target-dir=/absolute/path/to/skills --yes=true
+kast install skill --target-dir=/absolute/path/to/skills --force
 ```
 
 ??? info "What's in the skill directory"
@@ -93,11 +93,11 @@ portable Agent Skills bundle.
 
 ## Install the Copilot extension files
 
-Use `install copilot-extension` when you want the packaged GitHub Copilot
+Use `install copilot` when you want the packaged GitHub Copilot
 agent, hook, and native extension files in the current repository:
 
 ```console title="Install Copilot agents, hooks, and extensions"
-kast install copilot-extension
+kast install copilot
 ```
 
 The command writes into `<cwd>/.github` by default, including packaged
@@ -105,10 +105,10 @@ The command writes into `<cwd>/.github` by default, including packaged
 under `.github/extensions`. Packaged scripts are installed executable, and the
 command records the installed CLI version in `.github/.kast-copilot-version`.
 Pass `--target-dir` to point at another workspace `.github` directory, and
-`--yes=true` to replace an older installed copy:
+`--force` to replace an older installed copy:
 
 ```console title="Force reinstall Copilot extension files"
-kast install copilot-extension --target-dir=/absolute/path/to/repo/.github --yes=true
+kast install copilot --target-dir=/absolute/path/to/repo/.github --force
 ```
 
 To remove only packaged Copilot files, use the uninstall command:

--- a/docs/getting-started/backends.md
+++ b/docs/getting-started/backends.md
@@ -14,7 +14,7 @@ your scripts and prompts don't change when you switch.
 
 | Runtime           | What runs                            | Best for                              | How it starts                        |
 |-------------------|--------------------------------------|---------------------------------------|--------------------------------------|
-| Headless          | `kast` CLI plus a packaged IDEA backend | Terminals, CI, agents, no-IDE machines | `kast backend install headless`, then `kast up` |
+| Headless          | `kast` CLI plus a packaged IDEA backend | Terminals, CI, agents, no-IDE machines | `kast install headless`, then `kast up` |
 | IDEA plugin       | A `kast` server inside an open IDE   | Local work with IDEA or Android Studio already open | Boots when the IDE opens the project |
 
 ## Headless backend
@@ -36,7 +36,7 @@ Install:
 ```console title="Install the headless backend"
 brew tap amichne/kast
 brew install kast
-kast backend install headless
+kast install headless
 ```
 
 On Ubuntu/Debian x86_64 hosts where Homebrew is not available, use the offline
@@ -72,7 +72,7 @@ How a session unfolds:
 1. You run `kast up --workspace-root="$PWD"` somewhere. It
    starts or reuses the daemon, discovers the project, and waits until
    the analysis session is warm. If the backend is missing, `kast up`
-   reports the exact `kast backend install <backend>` command.
+   reports the exact `kast install <backend>` command.
 2. You run more `kast` commands against the same workspace. The CLI
    finds the running backend and reuses it.
 3. The daemon stays alive. No cold starts between commands.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -37,7 +37,7 @@ Use Homebrew for ordinary terminal use when your platform is supported.
 Install one backend component after the CLI is on `PATH`.
 
 ```console title="Install the headless backend"
-kast backend install headless
+kast install headless
 ```
 
 Use the headless backend for terminal work, local automation, and CI jobs that
@@ -51,12 +51,12 @@ Use the headless backend for hosted Linux agents that need a packaged
 IDEA-backed runtime:
 
 ```console title="Install and warm the headless backend"
-kast backend install headless
+kast install headless
 kast up --backend=headless --workspace-root="$PWD"
 ```
 
 If `kast up` cannot find the selected backend, it reports the exact
-`kast backend install <backend>` command to run.
+`kast install <backend>` command to run.
 
 ## Ubuntu/Debian bundle
 
@@ -200,7 +200,7 @@ CLI-managed inventory.
 From the repository root, run:
 
 ```console title="Install Copilot agents, hooks, and extensions"
-kast install copilot-extension
+kast install copilot
 ```
 
 The install writes these packaged trees:
@@ -210,10 +210,10 @@ The install writes these packaged trees:
 - `.github/extensions`
 
 Pass `--target-dir` when you need to install into another workspace's
-`.github` directory. Pass `--yes=true` to replace an older managed copy:
+`.github` directory. Pass `--force` to replace an older managed copy:
 
 ```console title="Install into another workspace"
-kast install copilot-extension --target-dir=/Users/alex/work/project/.github --yes=true
+kast install copilot --target-dir=/Users/alex/work/project/.github --force
 ```
 
 To remove only packaged files, use the uninstall command:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -90,11 +90,11 @@ that matches what you're seeing.
     Files you created under `.github` are preserved, and the CLI-managed
     inventory drops the repo entry.
 
-    To inspect the managed set, reinstall with `--yes=true`, then uninstall
+    To inspect the managed set, reinstall with `--force`, then uninstall
     again:
 
     ```console
-    kast install copilot-extension --yes=true
+    kast install copilot --force
     kast uninstall copilot-extension
     ```
 


### PR DESCRIPTION
## Summary
- add `kast install plugin|headless|skill|copilot` gateway commands
- add `kast current plugin|headless|skill|copilot` version reporting
- update CLI/docs guidance to use the new install/current paths

## Validation
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --all-targets`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets -- -D warnings`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --check`
- `./.github/scripts/test-docs-navigation-contract.sh`
- `git diff --check`