### PR TITLE
Implement worktree-safe IDEA-first runtime selection

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/GitRemoteParser.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/GitRemoteParser.kt
@@ -1,11 +1,19 @@
 package io.github.amichne.kast.api.client
 
+import io.github.amichne.kast.api.validation.FileHashing
 import java.nio.file.Path
 
 data class GitRemote(
     val host: String,
     val owner: String,
     val repo: String,
+)
+
+data class GitWorkspace(
+    val toplevel: Path,
+    val commonDir: Path,
+    val gitDir: Path,
+    val remote: GitRemote?,
 )
 
 object GitRemoteParser {
@@ -33,3 +41,49 @@ object GitRemoteParser {
         if (process.waitFor() == 0) parse(remoteUrl) else null
     }.getOrNull()
 }
+
+object GitWorkspaceResolver {
+    fun discover(workspaceRoot: Path): GitWorkspace? = runCatching {
+        val normalizedRoot = workspaceRoot.toAbsolutePath().normalize()
+        val toplevel = gitPath(normalizedRoot, "rev-parse", "--show-toplevel") ?: return null
+        val commonDir = gitPath(normalizedRoot, "rev-parse", "--git-common-dir") ?: return null
+        val gitDir = gitPath(normalizedRoot, "rev-parse", "--git-dir") ?: return null
+        val remote = gitOutput(normalizedRoot, "config", "--get", "remote.origin.url")
+            ?.let(GitRemoteParser::parse)
+        GitWorkspace(
+            toplevel = toplevel,
+            commonDir = commonDir,
+            gitDir = gitDir,
+            remote = remote,
+        )
+    }.getOrNull()
+
+    private fun gitPath(workspaceRoot: Path, vararg args: String): Path? =
+        gitOutput(workspaceRoot, *args)
+            ?.let(Path::of)
+            ?.let { path ->
+                if (path.isAbsolute) path else workspaceRoot.resolve(path)
+            }
+            ?.toAbsolutePath()
+            ?.normalize()
+
+    private fun gitOutput(workspaceRoot: Path, vararg args: String): String? = runCatching {
+        val process = ProcessBuilder("git", *args)
+            .directory(workspaceRoot.toFile())
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
+        output.takeIf { process.waitFor() == 0 && it.isNotBlank() }
+    }.getOrNull()
+}
+
+fun gitWorktreeHash(toplevel: Path, gitDir: Path): String = FileHashing.sha256(
+    listOf(
+        toplevel.toAbsolutePath().normalize().toString(),
+        gitDir.toAbsolutePath().normalize().toString(),
+    ).joinToString(separator = "\n"),
+).take(12)
+
+fun gitCommonDirHash(commonDir: Path): String = FileHashing.sha256(
+    commonDir.toAbsolutePath().normalize().toString(),
+).take(12)

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspaceDirectoryResolver.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspaceDirectoryResolver.kt
@@ -13,17 +13,26 @@ import java.util.UUID
 class WorkspaceDirectoryResolver(
     configHome: () -> Path = { kastConfigHome() },
     private val installRoot: () -> Path = ::kastInstallRoot,
+    private val gitWorkspaceResolver: (Path) -> GitWorkspace? = GitWorkspaceResolver::discover,
     private val gitRemoteResolver: (Path) -> GitRemote? = GitRemoteParser::origin,
     private val uuidGenerator: () -> UUID = UUID::randomUUID,
 ) {
     fun workspaceDataDirectory(workspaceRoot: Path): Path {
         val normalizedRoot = workspaceRoot.toAbsolutePath().normalize()
-        val remote = gitRemoteResolver(normalizedRoot)
-        return if (remote != null) {
-            workspacesRoot()
-                .resolve(remote.host)
-                .resolve(remote.owner)
-                .resolve(remote.repo)
+        val gitWorkspace = gitWorkspaceResolver(normalizedRoot)
+        val remote = gitWorkspace?.remote ?: gitRemoteResolver(normalizedRoot)
+        return if (gitWorkspace != null) {
+            gitWorkspaceDataDirectory(gitWorkspace, remote)
+        } else if (remote != null) {
+            gitWorkspaceDataDirectory(
+                GitWorkspace(
+                    toplevel = normalizedRoot,
+                    commonDir = normalizedRoot.resolve(".git"),
+                    gitDir = normalizedRoot.resolve(".git"),
+                    remote = remote,
+                ),
+                remote,
+            )
         } else if (isEphemeralLocalWorkspace(normalizedRoot)) {
             normalizedRoot
                 .resolve(".gradle")
@@ -49,6 +58,26 @@ class WorkspaceDirectoryResolver(
     }
 
     private fun workspacesRoot(): Path = installRoot().resolve("workspaces").toAbsolutePath().normalize()
+
+    private fun gitWorkspaceDataDirectory(workspace: GitWorkspace, remote: GitRemote?): Path {
+        val repoRoot = if (remote != null) {
+            workspacesRoot()
+                .resolve("git")
+                .resolve(remote.host)
+                .resolve(remote.owner)
+                .resolve(remote.repo)
+        } else {
+            workspacesRoot()
+                .resolve("git")
+                .resolve("local")
+                .resolve(gitCommonDirHash(workspace.commonDir))
+        }
+        return repoRoot
+            .resolve("worktrees")
+            .resolve("${workspaceSlug(workspace.toplevel)}--${gitWorktreeHash(workspace.toplevel, workspace.gitDir)}")
+            .toAbsolutePath()
+            .normalize()
+    }
 
     private fun localWorkspaceId(workspaceRoot: Path): String {
         val registryPath = workspacesRoot().resolve("local-workspaces.json").toAbsolutePath().normalize()
@@ -87,10 +116,16 @@ class WorkspaceDirectoryResolver(
 
     private fun sanitizedPath(workspaceRoot: Path): String = workspaceRoot
         .toString()
-        .replace(Regex("[^A-Za-z0-9._-]+"), "-")
+        .sanitizedSegment()
+        .take(80)
+
+    private fun workspaceSlug(workspaceRoot: Path): String = (workspaceRoot.fileName?.toString() ?: "workspace")
+        .sanitizedSegment()
+        .take(80)
+
+    private fun String.sanitizedSegment(): String = replace(Regex("[^A-Za-z0-9._-]+"), "-")
         .trim('-')
         .ifBlank { "workspace" }
-        .take(80)
 }
 
 fun kastInstallRoot(): Path = Path.of(System.getProperty("user.home")).resolve(".kast").toAbsolutePath().normalize()

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastConfigTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastConfigTest.kt
@@ -165,20 +165,28 @@ class KastConfigTest {
     }
 
     @Test
-    fun `workspace directory resolver uses git remote hierarchy when origin is parseable`() {
+    fun `workspace directory resolver uses git remote worktree hierarchy when origin is parseable`() {
         val configHome = tempDir.resolve("config-home")
         val installRoot = tempDir.resolve("install-root")
         val workspaceRoot = tempDir.resolve("workspace")
+        val gitDir = tempDir.resolve("main.git").resolve("worktrees").resolve("workspace")
         val resolver = WorkspaceDirectoryResolver(
             configHome = { configHome },
             installRoot = { installRoot },
-            gitRemoteResolver = { GitRemote(host = "github.com", owner = "amichne", repo = "kast") },
+            gitWorkspaceResolver = {
+                GitWorkspace(
+                    toplevel = workspaceRoot,
+                    commonDir = tempDir.resolve("main.git"),
+                    gitDir = gitDir,
+                    remote = GitRemote(host = "github.com", owner = "amichne", repo = "kast"),
+                )
+            },
         )
 
         val dataDirectory = resolver.workspaceDataDirectory(workspaceRoot)
 
         assertEquals(
-            installRoot.resolve("workspaces/github.com/amichne/kast"),
+            installRoot.resolve("workspaces/git/github.com/amichne/kast/worktrees/workspace--${gitWorktreeHash(workspaceRoot, gitDir)}"),
             dataDirectory,
         )
         assertEquals(dataDirectory.resolve("cache"), resolver.workspaceCacheDirectory(workspaceRoot))
@@ -216,7 +224,14 @@ class KastConfigTest {
         val resolver = WorkspaceDirectoryResolver(
             configHome = { configHome },
             installRoot = { installRoot },
-            gitRemoteResolver = { GitRemote(host = "github.com", owner = "amichne", repo = "kast") },
+            gitWorkspaceResolver = {
+                GitWorkspace(
+                    toplevel = workspaceRoot,
+                    commonDir = tempDir.resolve("main.git"),
+                    gitDir = tempDir.resolve("main.git").resolve("worktrees").resolve("workspace"),
+                    remote = GitRemote(host = "github.com", owner = "amichne", repo = "kast"),
+                )
+            },
         )
         configHome.resolve("config.toml").apply {
             parent.toFile().mkdirs()

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspacePathsTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspacePathsTest.kt
@@ -49,16 +49,87 @@ class WorkspacePathsTest {
     }
 
     @Test
-    fun `workspace data directory uses install root for git remotes`() {
+    fun `workspace data directory uses install root git worktree path for git remotes`() {
         val installRoot = tempDir.resolve("install-root")
         val workspaceRoot = tempDir.resolve("workspace")
+        val gitDir = tempDir.resolve("main.git").resolve("worktrees").resolve("workspace")
         val resolver = WorkspaceDirectoryResolver(
             installRoot = { installRoot },
-            gitRemoteResolver = { GitRemote(host = "github.com", owner = "amichne", repo = "kast") },
+            gitWorkspaceResolver = {
+                GitWorkspace(
+                    toplevel = workspaceRoot,
+                    commonDir = tempDir.resolve("main.git"),
+                    gitDir = gitDir,
+                    remote = GitRemote(host = "github.com", owner = "amichne", repo = "kast"),
+                )
+            },
+        )
+        val worktreeHash = gitWorktreeHash(workspaceRoot, gitDir)
+
+        assertEquals(
+            installRoot.resolve("workspaces/git/github.com/amichne/kast/worktrees/workspace--$worktreeHash"),
+            resolver.workspaceDataDirectory(workspaceRoot),
+        )
+    }
+
+    @Test
+    fun `workspace data directory isolates sibling git worktrees from the same remote`() {
+        val installRoot = tempDir.resolve("install-root")
+        val commonDir = tempDir.resolve("main.git")
+        val firstRoot = tempDir.resolve("kast")
+        val secondRoot = tempDir.resolve("kast-feature")
+        val remote = GitRemote(host = "github.com", owner = "amichne", repo = "kast")
+        val resolver = WorkspaceDirectoryResolver(
+            installRoot = { installRoot },
+            gitWorkspaceResolver = { root ->
+                when (root.toAbsolutePath().normalize()) {
+                    firstRoot.toAbsolutePath().normalize() -> GitWorkspace(
+                        toplevel = firstRoot,
+                        commonDir = commonDir,
+                        gitDir = commonDir.resolve("worktrees/kast"),
+                        remote = remote,
+                    )
+                    secondRoot.toAbsolutePath().normalize() -> GitWorkspace(
+                        toplevel = secondRoot,
+                        commonDir = commonDir,
+                        gitDir = commonDir.resolve("worktrees/kast-feature"),
+                        remote = remote,
+                    )
+                    else -> null
+                }
+            },
+        )
+
+        val first = resolver.workspaceDataDirectory(firstRoot)
+        val second = resolver.workspaceDataDirectory(secondRoot)
+
+        assertTrue(first.startsWith(installRoot.resolve("workspaces/git/github.com/amichne/kast/worktrees")))
+        assertTrue(second.startsWith(installRoot.resolve("workspaces/git/github.com/amichne/kast/worktrees")))
+        assertTrue(first != second, "sibling worktrees should not share workspace data: first=$first second=$second")
+        assertEquals(first, resolver.workspaceCacheDirectory(firstRoot).parent)
+        assertEquals(second.resolve("cache/source-index.db"), resolver.workspaceDatabasePath(secondRoot))
+    }
+
+    @Test
+    fun `workspace data directory supports git worktrees without parseable origin`() {
+        val installRoot = tempDir.resolve("install-root")
+        val workspaceRoot = tempDir.resolve("workspace")
+        val commonDir = tempDir.resolve("main.git")
+        val gitDir = commonDir.resolve("worktrees/workspace")
+        val resolver = WorkspaceDirectoryResolver(
+            installRoot = { installRoot },
+            gitWorkspaceResolver = {
+                GitWorkspace(
+                    toplevel = workspaceRoot,
+                    commonDir = commonDir,
+                    gitDir = gitDir,
+                    remote = null,
+                )
+            },
         )
 
         assertEquals(
-            installRoot.resolve("workspaces/github.com/amichne/kast"),
+            installRoot.resolve("workspaces/git/local/${gitCommonDirHash(commonDir)}/worktrees/workspace--${gitWorktreeHash(workspaceRoot, gitDir)}"),
             resolver.workspaceDataDirectory(workspaceRoot),
         )
     }

--- a/cli-rs/src/config.rs
+++ b/cli-rs/src/config.rs
@@ -268,15 +268,6 @@ pub fn default_config_template() -> Result<String> {
     Ok(toml::to_string_pretty(&KastConfig::defaults())?)
 }
 
-pub fn resolve_runtime_backend(
-    config: &KastConfig,
-    backend_name: Option<BackendName>,
-) -> BackendName {
-    backend_name
-        .or(config.runtime.default_backend)
-        .unwrap_or(BackendName::Headless)
-}
-
 pub fn backend_runtime_libs_dir(
     config: &KastConfig,
     backend_name: BackendName,
@@ -383,12 +374,8 @@ pub fn normalize(path: PathBuf) -> PathBuf {
 
 pub fn workspace_data_directory(workspace_root: &Path) -> Result<PathBuf> {
     let root = normalize(workspace_root.to_path_buf());
-    if let Some(remote) = git_remote(&root) {
-        return Ok(home_dir()
-            .join(".kast/workspaces")
-            .join(remote.host)
-            .join(remote.owner)
-            .join(remote.repo));
+    if let Some(workspace) = git_workspace(&root) {
+        return Ok(workspace_data_directory_for_git(&home_dir(), &workspace));
     }
     if root.starts_with(env::temp_dir()) {
         return Ok(root.join(".gradle/kast"));
@@ -419,24 +406,89 @@ fn read_partial_config(path: &Path) -> Result<PartialConfig> {
 }
 
 #[derive(Debug)]
+struct GitWorkspace {
+    toplevel: PathBuf,
+    common_dir: PathBuf,
+    git_dir: PathBuf,
+    remote: Option<GitRemote>,
+}
+
+#[derive(Debug, Clone)]
 struct GitRemote {
     host: String,
     owner: String,
     repo: String,
 }
 
-fn git_remote(workspace_root: &Path) -> Option<GitRemote> {
+fn git_workspace(workspace_root: &Path) -> Option<GitWorkspace> {
+    let toplevel = git_path(workspace_root, &["rev-parse", "--show-toplevel"])?;
+    let common_dir = git_path(workspace_root, &["rev-parse", "--git-common-dir"])?;
+    let git_dir = git_path(workspace_root, &["rev-parse", "--git-dir"])?;
+    let remote = git_output(workspace_root, &["config", "--get", "remote.origin.url"])
+        .and_then(|remote| parse_git_remote(remote.trim()));
+    Some(GitWorkspace {
+        toplevel,
+        common_dir,
+        git_dir,
+        remote,
+    })
+}
+
+fn workspace_data_directory_for_git(home: &Path, workspace: &GitWorkspace) -> PathBuf {
+    let repo_root = if let Some(remote) = &workspace.remote {
+        home.join(".kast/workspaces/git")
+            .join(&remote.host)
+            .join(&remote.owner)
+            .join(&remote.repo)
+    } else {
+        home.join(".kast/workspaces/git/local")
+            .join(git_common_dir_hash(&workspace.common_dir))
+    };
+    repo_root.join("worktrees").join(format!(
+        "{}--{}",
+        workspace_slug(&workspace.toplevel),
+        git_worktree_hash(&workspace.toplevel, &workspace.git_dir)
+    ))
+}
+
+fn git_worktree_hash(toplevel: &Path, git_dir: &Path) -> String {
+    sha256_prefix(&format!(
+        "{}\n{}",
+        normalize(toplevel.to_path_buf()).display(),
+        normalize(git_dir.to_path_buf()).display()
+    ))
+}
+
+fn git_common_dir_hash(common_dir: &Path) -> String {
+    sha256_prefix(&normalize(common_dir.to_path_buf()).display().to_string())
+}
+
+fn sha256_prefix(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    hex::encode(digest)[0..12].to_string()
+}
+
+fn git_path(workspace_root: &Path, args: &[&str]) -> Option<PathBuf> {
+    let raw = git_output(workspace_root, args)?;
+    let path = PathBuf::from(raw.trim());
+    Some(normalize(if path.is_absolute() {
+        path
+    } else {
+        workspace_root.join(path)
+    }))
+}
+
+fn git_output(workspace_root: &Path, args: &[&str]) -> Option<String> {
     let output = std::process::Command::new("git")
-        .arg("config")
-        .arg("--get")
-        .arg("remote.origin.url")
+        .args(args)
         .current_dir(workspace_root)
         .output()
         .ok()?;
     if !output.status.success() {
         return None;
     }
-    parse_git_remote(String::from_utf8_lossy(&output.stdout).trim())
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
 }
 
 fn parse_git_remote(remote_url: &str) -> Option<GitRemote> {
@@ -484,8 +536,20 @@ fn local_workspace_id(workspace_root: &Path) -> Result<String> {
 }
 
 fn sanitized_path(workspace_root: &Path) -> String {
+    sanitized_segment(&workspace_root.to_string_lossy())
+}
+
+fn workspace_slug(workspace_root: &Path) -> String {
+    workspace_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(sanitized_segment)
+        .unwrap_or_else(|| "workspace".to_string())
+}
+
+fn sanitized_segment(value: &str) -> String {
     let mut result = String::new();
-    for ch in workspace_root.to_string_lossy().chars() {
+    for ch in value.chars() {
         if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
             result.push(ch);
         } else if !result.ends_with('-') {
@@ -525,6 +589,88 @@ mod tests {
     }
 
     #[test]
+    fn git_workspace_data_directory_uses_remote_worktree_path() {
+        let home = PathBuf::from("/home/alex");
+        let workspace = GitWorkspace {
+            toplevel: PathBuf::from("/work/kast"),
+            common_dir: PathBuf::from("/work/kast/.git"),
+            git_dir: PathBuf::from("/work/kast/.git"),
+            remote: Some(GitRemote {
+                host: "github.com".to_string(),
+                owner: "amichne".to_string(),
+                repo: "kast".to_string(),
+            }),
+        };
+
+        assert_eq!(
+            workspace_data_directory_for_git(&home, &workspace),
+            home.join(format!(
+                ".kast/workspaces/git/github.com/amichne/kast/worktrees/kast--{}",
+                git_worktree_hash(&workspace.toplevel, &workspace.git_dir)
+            )),
+        );
+    }
+
+    #[test]
+    fn git_workspace_data_directory_isolates_sibling_worktrees() {
+        let home = PathBuf::from("/home/alex");
+        let common_dir = PathBuf::from("/work/kast/.git");
+        let remote = GitRemote {
+            host: "github.com".to_string(),
+            owner: "amichne".to_string(),
+            repo: "kast".to_string(),
+        };
+        let first = GitWorkspace {
+            toplevel: PathBuf::from("/work/kast"),
+            common_dir: common_dir.clone(),
+            git_dir: common_dir.clone(),
+            remote: Some(remote.clone()),
+        };
+        let second = GitWorkspace {
+            toplevel: PathBuf::from("/work/kast-feature"),
+            common_dir,
+            git_dir: PathBuf::from("/work/kast/.git/worktrees/kast-feature"),
+            remote: Some(remote),
+        };
+
+        assert_ne!(
+            workspace_data_directory_for_git(&home, &first),
+            workspace_data_directory_for_git(&home, &second),
+        );
+    }
+
+    #[test]
+    fn git_workspace_data_directory_supports_git_without_origin() {
+        let home = PathBuf::from("/home/alex");
+        let workspace = GitWorkspace {
+            toplevel: PathBuf::from("/work/private"),
+            common_dir: PathBuf::from("/work/private/.git"),
+            git_dir: PathBuf::from("/work/private/.git/worktrees/private"),
+            remote: None,
+        };
+
+        assert_eq!(
+            workspace_data_directory_for_git(&home, &workspace),
+            home.join(format!(
+                ".kast/workspaces/git/local/{}/worktrees/private--{}",
+                git_common_dir_hash(&workspace.common_dir),
+                git_worktree_hash(&workspace.toplevel, &workspace.git_dir)
+            )),
+        );
+    }
+
+    #[test]
+    fn git_worktree_hash_matches_toplevel_and_git_dir_contract() {
+        let toplevel = PathBuf::from("/work/kast");
+        let git_dir = PathBuf::from("/work/kast/.git/worktrees/kast");
+
+        assert_eq!(
+            git_worktree_hash(&toplevel, &git_dir),
+            sha256_prefix("/work/kast\n/work/kast/.git/worktrees/kast"),
+        );
+    }
+
+    #[test]
     fn parses_runtime_default_backend() {
         let temp = tempfile::tempdir().unwrap();
         let config_file = temp.path().join("config.toml");
@@ -559,22 +705,5 @@ defaultBackend = "sidecar"
         assert_eq!(error.code, "CONFIG_ERROR");
         assert!(error.message.contains("sidecar"), "{}", error.message);
         assert!(error.message.contains("headless"), "{}", error.message);
-    }
-
-    #[test]
-    fn runtime_backend_resolution_prefers_cli_then_config_then_headless() {
-        let mut config = KastConfig::defaults();
-
-        assert_eq!(
-            resolve_runtime_backend(&config, None),
-            BackendName::Headless
-        );
-
-        config.runtime.default_backend = Some(BackendName::Idea);
-        assert_eq!(resolve_runtime_backend(&config, None), BackendName::Idea);
-        assert_eq!(
-            resolve_runtime_backend(&config, Some(BackendName::Headless)),
-            BackendName::Headless
-        );
     }
 }

--- a/cli-rs/src/runtime.rs
+++ b/cli-rs/src/runtime.rs
@@ -127,10 +127,33 @@ struct WorkspaceInspection {
     selected: Option<RuntimeCandidateStatus>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeBackendPreference {
+    Automatic,
+    Fixed(BackendName),
+}
+
+impl RuntimeBackendPreference {
+    fn backend_filter(self) -> Option<BackendName> {
+        match self {
+            Self::Automatic => None,
+            Self::Fixed(backend) => Some(backend),
+        }
+    }
+
+    fn fixed_backend(self) -> Option<BackendName> {
+        match self {
+            Self::Automatic => None,
+            Self::Fixed(backend) => Some(backend),
+        }
+    }
+}
+
 pub fn workspace_status(args: RuntimeArgs) -> Result<WorkspaceStatusResult> {
     let workspace_root = workspace_root(args.workspace_root.clone())?;
-    let backend_name = resolve_runtime_backend(&workspace_root, args.backend_name)?;
-    let inspection = inspect_workspace(&workspace_root, Some(backend_name), false)?;
+    let config = KastConfig::load(&workspace_root)?;
+    let preference = runtime_backend_preference(&config, args.backend_name);
+    let inspection = inspect_workspace_with_config(&workspace_root, &config, preference, false)?;
     Ok(WorkspaceStatusResult {
         workspace_root: workspace_root.display().to_string(),
         descriptor_directory: inspection.descriptor_directory.display().to_string(),
@@ -143,12 +166,11 @@ pub fn workspace_status(args: RuntimeArgs) -> Result<WorkspaceStatusResult> {
 pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
     let workspace_root = workspace_root(args.workspace_root.clone())?;
     let config = KastConfig::load(&workspace_root)?;
-    let backend_name = config::resolve_runtime_backend(&config, args.backend_name);
-    let inspection =
-        inspect_workspace_with_config(&workspace_root, &config, Some(backend_name), true)?;
+    let preference = runtime_backend_preference(&config, args.backend_name);
+    let inspection = inspect_workspace_with_config(&workspace_root, &config, preference, true)?;
     if let Some(selected) = select_servable(
         &inspection.candidates,
-        Some(backend_name),
+        preference.backend_filter(),
         args.accept_indexing.unwrap_or(false),
     ) {
         return Ok(WorkspaceEnsureResult {
@@ -162,7 +184,7 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
         });
     }
 
-    if backend_name == BackendName::Idea {
+    let Some(launch_backend) = fallback_launch_backend(preference) else {
         return Err(CliError::new(
             "IDEA_NOT_RUNNING",
             format!(
@@ -170,13 +192,15 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
                 workspace_root.display()
             ),
         ));
-    }
+    };
 
     if args.no_auto_start.unwrap_or(false) {
-        return Err(no_backend_error(&workspace_root, Some(backend_name)));
+        return Err(no_backend_error(
+            &workspace_root,
+            preference.backend_filter(),
+        ));
     }
 
-    let launch_backend = backend_name;
     let runtime_libs_dir = config
         .backends
         .headless
@@ -211,8 +235,12 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
 
 pub fn workspace_stop(args: RuntimeArgs) -> Result<DaemonStopResult> {
     let workspace_root = workspace_root(args.workspace_root.clone())?;
-    let backend_name = resolve_runtime_backend(&workspace_root, args.backend_name)?;
-    let inspection = inspect_workspace(&workspace_root, Some(backend_name), true)?;
+    let backend_name = args.backend_name.unwrap_or(BackendName::Headless);
+    let inspection = inspect_workspace(
+        &workspace_root,
+        RuntimeBackendPreference::Fixed(backend_name),
+        true,
+    )?;
     let Some(candidate) = inspection
         .candidates
         .into_iter()
@@ -310,36 +338,25 @@ pub fn capabilities(args: RuntimeArgs) -> Result<Value> {
     })
 }
 
-fn resolve_runtime_backend(
-    workspace_root: &Path,
-    backend_name: Option<BackendName>,
-) -> Result<BackendName> {
-    let config = KastConfig::load(workspace_root)?;
-    Ok(config::resolve_runtime_backend(&config, backend_name))
-}
-
 fn inspect_workspace(
     workspace_root: &Path,
-    backend_name: Option<BackendName>,
+    preference: RuntimeBackendPreference,
     prune_stale_descriptors: bool,
 ) -> Result<WorkspaceInspection> {
     let config = KastConfig::load(workspace_root)?;
-    inspect_workspace_with_config(
-        workspace_root,
-        &config,
-        backend_name,
-        prune_stale_descriptors,
-    )
+    inspect_workspace_with_config(workspace_root, &config, preference, prune_stale_descriptors)
 }
 
 fn inspect_workspace_with_config(
     workspace_root: &Path,
     config: &KastConfig,
-    backend_name: Option<BackendName>,
+    preference: RuntimeBackendPreference,
     prune_stale_descriptors: bool,
 ) -> Result<WorkspaceInspection> {
     let descriptor_directory = config.paths.descriptor_dir.clone();
-    let registered = find_by_workspace_root(&descriptor_directory, workspace_root)?;
+    let backend_name = preference.backend_filter();
+    let registered =
+        find_compatible_descriptors(&descriptor_directory, workspace_root, backend_name)?;
     let mut candidates = Vec::with_capacity(registered.len());
     for descriptor in registered {
         candidates.push(inspect_descriptor(
@@ -428,8 +445,11 @@ fn wait_for_servable(
     wait_timeout_ms: u64,
 ) -> Result<RuntimeCandidateStatus> {
     let deadline = Instant::now() + Duration::from_millis(wait_timeout_ms);
+    let preference = backend_name
+        .map(RuntimeBackendPreference::Fixed)
+        .unwrap_or(RuntimeBackendPreference::Automatic);
     while Instant::now() < deadline {
-        let inspection = inspect_workspace(workspace_root, backend_name, true)?;
+        let inspection = inspect_workspace(workspace_root, preference, true)?;
         if let Some(selected) =
             select_servable(&inspection.candidates, backend_name, accept_indexing)
         {
@@ -520,22 +540,118 @@ fn is_ready(status: &RuntimeStatusResponse) -> bool {
         && !status.indexing
 }
 
-fn find_by_workspace_root(
+fn find_compatible_descriptors(
     descriptor_directory: &Path,
     workspace_root: &Path,
+    backend_name: Option<BackendName>,
 ) -> Result<Vec<RegisteredDescriptor>> {
     let descriptors = read_descriptors(descriptor_directory)?;
     let normalized = config::normalize(workspace_root.to_path_buf());
+    let workspace_identity = workspace_git_identity(&normalized);
     Ok(descriptors
         .into_iter()
         .filter(|descriptor| {
-            config::normalize(PathBuf::from(&descriptor.workspace_root)) == normalized
+            backend_name.is_none_or(|backend| descriptor.backend_name == backend.canonical())
+        })
+        .filter(|descriptor| {
+            descriptor_matches_workspace(descriptor, &normalized, workspace_identity.as_ref())
         })
         .map(|descriptor| RegisteredDescriptor {
             id: descriptor_id(&descriptor),
             descriptor,
         })
         .collect())
+}
+
+fn descriptor_matches_workspace(
+    descriptor: &ServerInstanceDescriptor,
+    workspace_root: &Path,
+    workspace_identity: Option<&WorkspaceGitIdentity>,
+) -> bool {
+    let descriptor_root = config::normalize(PathBuf::from(&descriptor.workspace_root));
+    if descriptor_root == workspace_root {
+        return true;
+    }
+    if descriptor.backend_name != BackendName::Idea.canonical() {
+        return false;
+    }
+    let Some(workspace_identity) = workspace_identity else {
+        return false;
+    };
+    let Some(descriptor_identity) = workspace_git_identity(&descriptor_root) else {
+        return false;
+    };
+    workspace_git_identities_are_compatible_for_idea(workspace_identity, &descriptor_identity)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkspaceGitIdentity {
+    common_dir: PathBuf,
+    branch: Option<String>,
+    head: Option<String>,
+}
+
+fn workspace_git_identities_are_compatible_for_idea(
+    invocation: &WorkspaceGitIdentity,
+    candidate: &WorkspaceGitIdentity,
+) -> bool {
+    if invocation.common_dir != candidate.common_dir {
+        return false;
+    }
+    match (&invocation.branch, &candidate.branch) {
+        (Some(invocation_branch), Some(candidate_branch)) => invocation_branch == candidate_branch,
+        _ => invocation.head.is_some() && invocation.head == candidate.head,
+    }
+}
+
+fn workspace_git_identity(workspace_root: &Path) -> Option<WorkspaceGitIdentity> {
+    let _root = git_path(workspace_root, &["rev-parse", "--show-toplevel"])?;
+    let _git_dir = git_path(workspace_root, &["rev-parse", "--git-dir"])?;
+    Some(WorkspaceGitIdentity {
+        common_dir: git_path(workspace_root, &["rev-parse", "--git-common-dir"])?,
+        branch: git_output(workspace_root, &["branch", "--show-current"]),
+        head: git_output(workspace_root, &["rev-parse", "HEAD"]),
+    })
+}
+
+fn git_path(workspace_root: &Path, args: &[&str]) -> Option<PathBuf> {
+    let raw = git_output(workspace_root, args)?;
+    let path = PathBuf::from(raw.trim());
+    Some(config::normalize(if path.is_absolute() {
+        path
+    } else {
+        workspace_root.join(path)
+    }))
+}
+
+fn git_output(workspace_root: &Path, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(workspace_root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn runtime_backend_preference(
+    config: &KastConfig,
+    backend_name: Option<BackendName>,
+) -> RuntimeBackendPreference {
+    backend_name
+        .or(config.runtime.default_backend)
+        .map(RuntimeBackendPreference::Fixed)
+        .unwrap_or(RuntimeBackendPreference::Automatic)
+}
+
+fn fallback_launch_backend(preference: RuntimeBackendPreference) -> Option<BackendName> {
+    match preference.fixed_backend() {
+        Some(BackendName::Idea) => None,
+        Some(BackendName::Headless) | None => Some(BackendName::Headless),
+    }
 }
 
 fn read_descriptors(descriptor_directory: &Path) -> Result<Vec<ServerInstanceDescriptor>> {
@@ -700,5 +816,108 @@ mod tests {
         let candidates = vec![candidate("headless", RuntimeState::Indexing, true)];
         assert!(select_servable(&candidates, None, false).is_none());
         assert!(select_servable(&candidates, None, true).is_some());
+    }
+
+    #[test]
+    fn servable_selection_respects_fixed_headless_filter() {
+        let candidates = vec![
+            candidate("headless", RuntimeState::Ready, false),
+            candidate("idea", RuntimeState::Ready, false),
+        ];
+        let selected = select_servable(&candidates, Some(BackendName::Headless), false).unwrap();
+        assert_eq!(selected.descriptor.backend_name, "headless");
+    }
+
+    fn git_identity(common_dir: &str, branch: Option<&str>, head: &str) -> WorkspaceGitIdentity {
+        WorkspaceGitIdentity {
+            common_dir: PathBuf::from(common_dir),
+            branch: branch.map(str::to_string),
+            head: Some(head.to_string()),
+        }
+    }
+
+    #[test]
+    fn idea_workspace_compatibility_accepts_same_common_dir_and_branch() {
+        let invocation = git_identity("/work/kast/.git", Some("feature"), "abc123");
+        let candidate = git_identity("/work/kast/.git", Some("feature"), "def456");
+
+        assert!(workspace_git_identities_are_compatible_for_idea(
+            &invocation,
+            &candidate
+        ));
+    }
+
+    #[test]
+    fn idea_workspace_compatibility_rejects_different_branches() {
+        let invocation = git_identity("/work/kast/.git", Some("feature"), "abc123");
+        let candidate = git_identity("/work/kast/.git", Some("main"), "abc123");
+
+        assert!(!workspace_git_identities_are_compatible_for_idea(
+            &invocation,
+            &candidate
+        ));
+    }
+
+    #[test]
+    fn idea_workspace_compatibility_accepts_detached_matching_head() {
+        let invocation = git_identity("/work/kast/.git", None, "abc123");
+        let candidate = git_identity("/work/kast/.git", Some("main"), "abc123");
+
+        assert!(workspace_git_identities_are_compatible_for_idea(
+            &invocation,
+            &candidate
+        ));
+    }
+
+    #[test]
+    fn idea_workspace_compatibility_rejects_same_remote_different_common_dir() {
+        let invocation = git_identity("/work/kast/.git", Some("feature"), "abc123");
+        let candidate = git_identity("/other/kast/.git", Some("feature"), "abc123");
+
+        assert!(!workspace_git_identities_are_compatible_for_idea(
+            &invocation,
+            &candidate
+        ));
+    }
+
+    #[test]
+    fn runtime_backend_preference_is_automatic_without_cli_or_config() {
+        let config = KastConfig::defaults();
+
+        assert_eq!(
+            runtime_backend_preference(&config, None),
+            RuntimeBackendPreference::Automatic,
+        );
+    }
+
+    #[test]
+    fn runtime_backend_preference_preserves_cli_and_config_authority() {
+        let mut config = KastConfig::defaults();
+        config.runtime.default_backend = Some(BackendName::Idea);
+
+        assert_eq!(
+            runtime_backend_preference(&config, None),
+            RuntimeBackendPreference::Fixed(BackendName::Idea),
+        );
+        assert_eq!(
+            runtime_backend_preference(&config, Some(BackendName::Headless)),
+            RuntimeBackendPreference::Fixed(BackendName::Headless),
+        );
+    }
+
+    #[test]
+    fn fallback_launch_backend_uses_headless_unless_idea_is_fixed() {
+        assert_eq!(
+            fallback_launch_backend(RuntimeBackendPreference::Automatic),
+            Some(BackendName::Headless),
+        );
+        assert_eq!(
+            fallback_launch_backend(RuntimeBackendPreference::Fixed(BackendName::Headless)),
+            Some(BackendName::Headless),
+        );
+        assert_eq!(
+            fallback_launch_backend(RuntimeBackendPreference::Fixed(BackendName::Idea)),
+            None,
+        );
     }
 }

--- a/docs/getting-started/backends.md
+++ b/docs/getting-started/backends.md
@@ -72,7 +72,7 @@ How a session unfolds:
 1. You run `kast up --workspace-root="$PWD"` somewhere. It
    starts or reuses the daemon, discovers the project, and waits until
    the analysis session is warm. If the backend is missing, `kast up`
-   reports the exact `kast install <backend>` command.
+   reports the exact `kast install headless` command.
 2. You run more `kast` commands against the same workspace. The CLI
    finds the running backend and reuses it.
 3. The daemon stays alive. No cold starts between commands.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -56,14 +56,14 @@ kast up --backend=headless --workspace-root="$PWD"
 ```
 
 If `kast up` cannot find the selected backend, it reports the exact
-`kast install <backend>` command to run.
+`kast install headless` command to run.
 
 ## Ubuntu/Debian bundle
 
 Use the Ubuntu/Debian bundle when a CI image, hosted agent snapshot, mirror, or
 air-gapped host should install Kast without Homebrew, Rust, Gradle, or network
 access to individual release assets. This is the offline bundle path; the normal
-interactive path is CLI first, then `kast backend install`.
+interactive path is CLI first, then `kast install headless`.
 
 The release asset is `kast-ubuntu-debian-headless-x86_64-<version>.tar.gz`
 with a matching `.sha256` sidecar. Each bundle contains the


### PR DESCRIPTION
## Summary
- Make Git-backed workspace data directories worktree-specific in both the Kotlin resolver and the Rust CLI.
- Add IDEA-compatible descriptor matching so automatic runtime selection prefers a running IDEA backend when it belongs to the same Git identity.
- Keep explicit `--backend` and configured defaults authoritative, while defaulting automatic startup to headless when IDEA is not selected.
- Update stale docs-contract expectations and user-facing docs to use `kast install headless`.

## Testing
- `./gradlew :analysis-api:test`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `./.github/scripts/test-docs-content-contract.sh`
- `./gradlew :backend-idea:test`
- `cargo run --manifest-path cli-rs/Cargo.toml --locked --bin kast -- status --workspace-root "$PWD"`