### PR TITLE
Consolidate Kast install setup repair path

### DIFF
--- a/cli-rs/src/cli.rs
+++ b/cli-rs/src/cli.rs
@@ -32,17 +32,20 @@ pub enum Command {
     },
     /// Print the packaged CLI version.
     Version,
-    /// Write and inspect Kast configuration.
+    /// Repair Kast configuration.
+    #[command(hide = true)]
     Config {
         #[command(subcommand)]
         command: ConfigCommand,
     },
     /// Start the headless JVM backend for a workspace.
+    #[command(hide = true)]
     Daemon {
         #[command(subcommand)]
         command: DaemonCommand,
     },
     /// Install or remove JVM backend components.
+    #[command(hide = true)]
     Backend {
         #[command(subcommand)]
         command: BackendCommand,
@@ -64,7 +67,7 @@ pub enum Command {
         #[command(subcommand)]
         command: MetricsCommand,
     },
-    /// Install a portable archive or packaged resources.
+    /// Install or repair Kast resources.
     Install(InstallArgs),
     /// Report the current installed version of a Kast component.
     Current {
@@ -72,12 +75,15 @@ pub enum Command {
         command: CurrentCommand,
     },
     /// Report the recorded global Kast install state.
+    #[command(hide = true)]
     Info,
     /// Verify the global Kast install is still healthy.
     Doctor,
     /// Remove config-managed files or packaged resources.
+    #[command(hide = true)]
     Uninstall(UninstallArgs),
     /// Verify the installed Copilot extension version matches this CLI.
+    #[command(hide = true)]
     VerifyExtension,
 }
 
@@ -401,16 +407,16 @@ pub struct InstallArgs {
     #[command(subcommand)]
     pub command: Option<InstallCommand>,
     /// Absolute path to a portable Kast zip archive to install.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub archive: Option<PathBuf>,
     /// Instance name for the installed build.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub instance: Option<String>,
     /// Root directory for instances.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub instances_root: Option<PathBuf>,
     /// Directory for launcher scripts.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub bin_dir: Option<PathBuf>,
 }
 
@@ -418,6 +424,8 @@ pub struct InstallArgs {
 pub enum InstallCommand {
     /// Install the headless JVM backend.
     Headless(HeadlessInstallArgs),
+    /// Audit and repair stale Kast installs, resources, and profile links.
+    Affected(AffectedInstallArgs),
     /// Install the packaged kast skill into the current workspace.
     Skill(ResourceInstallArgs),
     /// Install the packaged Copilot agents and extensions.
@@ -430,6 +438,16 @@ pub enum InstallCommand {
     Shell(ShellInstallArgs),
     /// Print shell completion scripts.
     Completion(CompletionArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct AffectedInstallArgs {
+    /// Apply the planned repairs. Without this flag, no files are changed.
+    #[arg(long)]
+    pub apply: bool,
+    /// JetBrains config root containing IDE profile directories to audit.
+    #[arg(long)]
+    pub jetbrains_config_root: Option<PathBuf>,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -2,7 +2,7 @@ use crate::SCHEMA_VERSION;
 use crate::backend::{self, BackendResult};
 use crate::cli;
 use crate::cli::{
-    BackendComponent, BackendInstallArgs, CurrentCommand, HeadlessInstallArgs,
+    AffectedInstallArgs, BackendComponent, BackendInstallArgs, CurrentCommand, HeadlessInstallArgs,
     IdeaPluginInstallArgs, InstallArgs, InstallCommand, ResourceCurrentArgs, ResourceInstallArgs,
     ShellInstallArgs, ShellKind, UninstallArgs, UninstallCommand,
 };
@@ -12,6 +12,7 @@ use crate::self_mgmt;
 use include_dir::{Dir, DirEntry, include_dir};
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::BTreeSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -103,6 +104,29 @@ pub struct InstallShellResult {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct InstallAffectedAction {
+    pub kind: String,
+    pub target: String,
+    pub status: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallAffectedResult {
+    pub applied: bool,
+    pub config_path: String,
+    pub apply_command: String,
+    pub actions: Vec<InstallAffectedAction>,
+    pub backups: Vec<String>,
+    pub warnings: Vec<String>,
+    pub schema_version: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct VerifyExtensionResult {
     pub ok: bool,
     #[serde(rename = "cli_version")]
@@ -118,6 +142,7 @@ pub enum InstallResult {
     Copilot(InstallCopilotExtensionResult),
     IdeaPlugin(InstallIdeaPluginResult),
     Shell(InstallShellResult),
+    Affected(InstallAffectedResult),
     Headless(backend::BackendInstallResult),
     Archive(ArchiveInstallResult),
 }
@@ -164,6 +189,9 @@ pub fn install(args: InstallArgs) -> Result<InstallResult> {
     match args.command {
         Some(InstallCommand::Headless(headless_args)) => {
             install_headless(headless_args).map(InstallResult::Headless)
+        }
+        Some(InstallCommand::Affected(affected_args)) => {
+            install_affected(affected_args).map(InstallResult::Affected)
         }
         Some(InstallCommand::Skill(resource_args)) => {
             install_skill(resource_args).map(InstallResult::Skill)
@@ -263,6 +291,767 @@ fn install_headless(args: HeadlessInstallArgs) -> Result<backend::BackendInstall
             "install headless unexpectedly returned an uninstall result",
         )),
     }
+}
+
+pub fn install_affected(args: AffectedInstallArgs) -> Result<InstallAffectedResult> {
+    let config_path = config::global_config_path();
+    let backup_root = config::kast_config_home()
+        .join("backups")
+        .join(format!("install-affected-{}", backup_timestamp()));
+    let mut result = InstallAffectedResult {
+        applied: args.apply,
+        config_path: config_path.display().to_string(),
+        apply_command: "kast install affected --apply".to_string(),
+        actions: vec![],
+        backups: vec![],
+        warnings: vec![],
+        schema_version: SCHEMA_VERSION,
+    };
+    let mut config_backed_up = false;
+
+    if !config_path.is_file() {
+        push_affected_action(
+            &mut result,
+            "provision-config",
+            &config_path,
+            "Create the global Kast config from current defaults.",
+            None,
+        );
+        if args.apply {
+            config::init_config()?;
+        }
+    }
+
+    let global_config = config::KastConfig::load_global()?;
+    repair_affected_config_state(
+        &args,
+        &global_config,
+        &mut result,
+        &backup_root,
+        &mut config_backed_up,
+    )?;
+    repair_affected_skill_targets(&args, &mut result, &backup_root)?;
+    repair_affected_copilot_repos(&args, &mut result, &backup_root)?;
+    repair_affected_shell_sources(&args, &mut result, &backup_root)?;
+    repair_affected_jetbrains_profiles(&args, &mut result, &backup_root)?;
+
+    Ok(result)
+}
+
+fn repair_global_config_for_running_cli(apply: bool) -> Result<()> {
+    let config_path = config::global_config_path();
+    let backup_root = config::kast_config_home()
+        .join("backups")
+        .join(format!("install-affected-{}", backup_timestamp()));
+    let mut result = InstallAffectedResult {
+        applied: apply,
+        config_path: config_path.display().to_string(),
+        apply_command: "kast install affected --apply".to_string(),
+        actions: vec![],
+        backups: vec![],
+        warnings: vec![],
+        schema_version: SCHEMA_VERSION,
+    };
+    let mut config_backed_up = false;
+
+    if !config_path.is_file() {
+        push_affected_action(
+            &mut result,
+            "provision-config",
+            &config_path,
+            "Create the global Kast config from current defaults.",
+            None,
+        );
+        if apply {
+            config::init_config()?;
+        }
+    }
+
+    let global_config = config::KastConfig::load_global()?;
+    repair_affected_config_state(
+        &AffectedInstallArgs {
+            apply,
+            jetbrains_config_root: None,
+        },
+        &global_config,
+        &mut result,
+        &backup_root,
+        &mut config_backed_up,
+    )
+}
+
+fn repair_affected_config_state(
+    args: &AffectedInstallArgs,
+    global_config: &config::KastConfig,
+    result: &mut InstallAffectedResult,
+    backup_root: &Path,
+    config_backed_up: &mut bool,
+) -> Result<()> {
+    let config_path = config::global_config_path();
+    let document = read_toml_document(&config_path)?;
+    let remove_standalone_table = document
+        .get("backends")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|backends| backends.contains_key("standalone"));
+    let current_exe = env::current_exe()?;
+    let cli_binary_update = document
+        .get("cli")
+        .and_then(toml::Value::as_table)
+        .and_then(|cli| cli.get("binaryPath"))
+        .and_then(toml::Value::as_str)
+        .map(PathBuf::from)
+        .filter(|path| should_update_cli_binary_path(path, &current_exe))
+        .map(|path| (path, current_exe.clone()));
+
+    if remove_standalone_table {
+        push_affected_action(
+            result,
+            "remove-retired-backend-config",
+            &config_path,
+            "Remove the retired standalone backend config table while preserving supported settings.",
+            None,
+        );
+    }
+    if let Some((old_path, new_path)) = &cli_binary_update {
+        push_affected_action(
+            result,
+            "update-cli-binary-path",
+            old_path,
+            &format!(
+                "Update stale cli.binaryPath to the running kast binary at {}.",
+                new_path.display()
+            ),
+            None,
+        );
+    }
+    if args.apply && (remove_standalone_table || cli_binary_update.is_some()) {
+        backup_config_once(result, backup_root, config_backed_up)?;
+        self_mgmt::update_global_config(|document| {
+            if remove_standalone_table
+                && let Some(toml::Value::Table(backends)) = document.get_mut("backends")
+            {
+                backends.remove("standalone");
+            }
+            if let Some((_, new_path)) = &cli_binary_update {
+                let cli = document
+                    .entry("cli".to_string())
+                    .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+                let toml::Value::Table(cli) = cli else {
+                    return Err(CliError::new(
+                        "CONFIG_UPDATE_FAILED",
+                        "The `cli` config value is not a TOML table.",
+                    ));
+                };
+                cli.insert(
+                    "binaryPath".to_string(),
+                    toml::Value::String(new_path.display().to_string()),
+                );
+            }
+            Ok(())
+        })?;
+    }
+
+    let Some(mut install) = self_mgmt::read_global_install_state()? else {
+        return Ok(());
+    };
+    let mut install_changed = false;
+
+    let mut surviving_backends = vec![];
+    for backend in install.backends {
+        let unsupported = backend.name != BackendComponent::Headless.canonical();
+        let classpath_missing = !Path::new(&backend.runtime_libs_dir)
+            .join("classpath.txt")
+            .is_file();
+        let install_dir_missing = !path_exists_or_symlink(Path::new(&backend.install_dir));
+        if unsupported || classpath_missing || install_dir_missing {
+            let reason = if unsupported {
+                format!(
+                    "Remove retired {} backend state from install metadata.",
+                    backend.name
+                )
+            } else {
+                format!(
+                    "Remove backend state whose runtime files are missing at {}.",
+                    backend.runtime_libs_dir
+                )
+            };
+            push_affected_action(
+                result,
+                "remove-stale-backend-state",
+                Path::new(&backend.install_dir),
+                &reason,
+                Some("kast install headless".to_string()),
+            );
+            if args.apply {
+                let install_dir = Path::new(&backend.install_dir);
+                backup_existing_path(install_dir, backup_root, result)?;
+                remove_existing_path(install_dir)?;
+            }
+            install_changed = true;
+        } else {
+            surviving_backends.push(backend);
+        }
+    }
+    install.backends = surviving_backends;
+
+    let surviving_backend_components = install
+        .backends
+        .iter()
+        .map(|backend| format!("backend:{}", backend.name))
+        .collect::<BTreeSet<_>>();
+    let original_components = install.components.clone();
+    install.components.retain(|component| {
+        !component.starts_with("backend:") || surviving_backend_components.contains(component)
+    });
+    for component in original_components {
+        if !install.components.contains(&component) {
+            push_affected_action(
+                result,
+                "remove-stale-component-state",
+                Path::new(&component),
+                "Remove install metadata for a backend component that is no longer present.",
+                Some("kast install headless".to_string()),
+            );
+            install_changed = true;
+        }
+    }
+
+    let original_managed_paths = std::mem::take(&mut install.managed_paths);
+    for managed_path_value in original_managed_paths {
+        let managed = managed_install_path(&global_config.paths.install_root, &managed_path_value);
+        if !path_exists_or_symlink(&managed) {
+            push_affected_action(
+                result,
+                "prune-missing-managed-path",
+                &managed,
+                "Remove a missing managed path from install metadata.",
+                None,
+            );
+            install_changed = true;
+            continue;
+        }
+        if managed_path_value.contains("standalone") || managed_path_value == "lib/backends/current"
+        {
+            push_affected_action(
+                result,
+                "remove-retired-managed-path",
+                &managed,
+                "Back up and remove a retired managed backend path.",
+                None,
+            );
+            if args.apply {
+                backup_existing_path(&managed, backup_root, result)?;
+                remove_existing_path(&managed)?;
+            }
+            install_changed = true;
+            continue;
+        }
+        install.managed_paths.push(managed_path_value);
+    }
+
+    let mut seen_repos = BTreeSet::new();
+    let mut deduped_repos = vec![];
+    for repo in install.repos {
+        let normalized = config::normalize(PathBuf::from(&repo.path));
+        let normalized_value = normalized.display().to_string();
+        if seen_repos.insert(normalized_value.clone()) {
+            deduped_repos.push(self_mgmt::ManagedRepo {
+                path: normalized_value,
+                copilot_extension_version: repo.copilot_extension_version,
+            });
+        } else {
+            push_affected_action(
+                result,
+                "dedupe-managed-repo",
+                &normalized,
+                "Remove duplicate managed repo install metadata.",
+                None,
+            );
+            install_changed = true;
+        }
+    }
+    install.repos = deduped_repos;
+
+    if install_changed {
+        install.version = cli::version().to_string();
+        install.installed_at = current_timestamp();
+        install.platform = format!("{}-{}", env::consts::OS, env::consts::ARCH);
+    }
+    if args.apply && install_changed {
+        backup_config_once(result, backup_root, config_backed_up)?;
+        if install.components.is_empty()
+            && install.backends.is_empty()
+            && install.managed_paths.is_empty()
+            && install.shell_rc_patches.is_empty()
+            && install.repos.is_empty()
+        {
+            self_mgmt::remove_global_install_state()?;
+        } else {
+            self_mgmt::write_install_state(&install)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn repair_affected_skill_targets(
+    args: &AffectedInstallArgs,
+    result: &mut InstallAffectedResult,
+    backup_root: &Path,
+) -> Result<()> {
+    for target_root in affected_skill_target_roots()? {
+        let target = target_root.join("kast");
+        if !target.is_dir() {
+            continue;
+        }
+        let marker = target.join(".kast-version");
+        let installed_version = fs::read_to_string(&marker).unwrap_or_default();
+        if installed_version.trim() == cli::version() {
+            continue;
+        }
+        push_affected_action(
+            result,
+            "refresh-skill",
+            &target,
+            "Back up and refresh a stale installed Kast skill.",
+            Some(format!(
+                "kast install skill --target-dir {} --force",
+                shell_quote_path(&target_root)
+            )),
+        );
+        if args.apply {
+            backup_existing_path(&target, backup_root, result)?;
+            install_skill(ResourceInstallArgs {
+                target_dir: Some(target_root),
+                name: Some("kast".to_string()),
+                link_name: None,
+                force: true,
+                yes: None,
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn repair_affected_copilot_repos(
+    args: &AffectedInstallArgs,
+    result: &mut InstallAffectedResult,
+    backup_root: &Path,
+) -> Result<()> {
+    let Some(install) = self_mgmt::read_global_install_state()? else {
+        return Ok(());
+    };
+    let mut seen = BTreeSet::new();
+    for repo in install.repos {
+        let repo_root = config::normalize(PathBuf::from(repo.path));
+        if !seen.insert(repo_root.display().to_string()) {
+            continue;
+        }
+        let github_dir = repo_root.join(".github");
+        let extension_target = github_dir.join(COPILOT_EXTENSION_DIR);
+        let marker = extension_target.join(COPILOT_EXTENSION_MARKER);
+        let installed_version = fs::read_to_string(&marker).unwrap_or_default();
+        if installed_version.trim() == cli::version() {
+            continue;
+        }
+        push_affected_action(
+            result,
+            "refresh-copilot-extension",
+            &extension_target,
+            "Back up and refresh a stale managed Copilot extension install.",
+            Some(format!(
+                "kast install copilot --target-dir {} --force",
+                shell_quote_path(&github_dir)
+            )),
+        );
+        if args.apply {
+            backup_existing_path(&extension_target, backup_root, result)?;
+            remove_existing_path(&extension_target)?;
+            install_copilot_extension(ResourceInstallArgs {
+                target_dir: Some(github_dir),
+                name: None,
+                link_name: None,
+                force: true,
+                yes: None,
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn repair_affected_shell_sources(
+    args: &AffectedInstallArgs,
+    result: &mut InstallAffectedResult,
+    backup_root: &Path,
+) -> Result<()> {
+    let shell_dir = config::kast_config_home().join("shell");
+    if !shell_dir.is_dir() {
+        return Ok(());
+    }
+    let mut entries = fs::read_dir(&shell_dir)?.collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(shell) = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .and_then(|extension| match extension {
+                "bash" => Some(ShellKind::Bash),
+                "zsh" => Some(ShellKind::Zsh),
+                _ => None,
+            })
+        else {
+            continue;
+        };
+        let Some(command_name) = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .filter(|name| !name.trim().is_empty())
+        else {
+            continue;
+        };
+        validate_shell_command_name(command_name)?;
+        let content = fs::read_to_string(&path)?;
+        if !content.contains("Managed by `kast install shell`") {
+            continue;
+        }
+        let Some(bin_dir) = resolve_command_bin_dir(command_name)? else {
+            result.warnings.push(format!(
+                "Could not resolve `{command_name}` on PATH; leaving managed shell source {} unchanged",
+                path.display()
+            ));
+            continue;
+        };
+        if content.contains(&format!(
+            "_kast_bin_dir={}",
+            shell_quote(&bin_dir.display().to_string())
+        )) {
+            continue;
+        }
+        push_affected_action(
+            result,
+            "refresh-shell-source",
+            &path,
+            &format!(
+                "Back up and rewrite managed shell integration for `{command_name}` to use {}.",
+                bin_dir.display()
+            ),
+            Some("kast install affected --apply".to_string()),
+        );
+        if args.apply {
+            backup_existing_path(&path, backup_root, result)?;
+            fs::write(
+                &path,
+                shell_source_content(shell, command_name, &bin_dir, &config::kast_config_home()),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn repair_affected_jetbrains_profiles(
+    args: &AffectedInstallArgs,
+    result: &mut InstallAffectedResult,
+    backup_root: &Path,
+) -> Result<()> {
+    let Some(expected_plugin_target) = expected_homebrew_plugin_target(result)? else {
+        return Ok(());
+    };
+    let jetbrains_config_root = args
+        .jetbrains_config_root
+        .clone()
+        .map(config::normalize)
+        .unwrap_or_else(default_jetbrains_config_root);
+    for plugin_dir in jetbrains_plugin_dirs(&jetbrains_config_root)? {
+        let plugin_link = plugin_dir.join("kast");
+        if !path_exists_or_symlink(&plugin_link) {
+            continue;
+        }
+        if fs::read_link(&plugin_link)
+            .ok()
+            .is_some_and(|target| target == expected_plugin_target)
+        {
+            continue;
+        }
+        push_affected_action(
+            result,
+            "refresh-idea-plugin-link",
+            &plugin_link,
+            &format!(
+                "Back up and relink a stale IDEA or Android Studio profile plugin to {}.",
+                expected_plugin_target.display()
+            ),
+            Some("kast install plugin --link-jetbrains-profiles --force".to_string()),
+        );
+        if args.apply {
+            backup_existing_path(&plugin_link, backup_root, result)?;
+            remove_existing_path(&plugin_link)?;
+            if let Some(parent) = plugin_link.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            create_plugin_link(&expected_plugin_target, &plugin_link, result)?;
+        }
+    }
+    Ok(())
+}
+
+fn push_affected_action(
+    result: &mut InstallAffectedResult,
+    kind: &str,
+    target: &Path,
+    message: &str,
+    command: Option<String>,
+) {
+    result.actions.push(InstallAffectedAction {
+        kind: kind.to_string(),
+        target: target.display().to_string(),
+        status: if result.applied { "applied" } else { "planned" }.to_string(),
+        message: message.to_string(),
+        command,
+    });
+}
+
+fn backup_config_once(
+    result: &mut InstallAffectedResult,
+    backup_root: &Path,
+    config_backed_up: &mut bool,
+) -> Result<()> {
+    if *config_backed_up {
+        return Ok(());
+    }
+    backup_existing_path(&config::global_config_path(), backup_root, result)?;
+    *config_backed_up = true;
+    Ok(())
+}
+
+fn backup_existing_path(
+    path: &Path,
+    backup_root: &Path,
+    result: &mut InstallAffectedResult,
+) -> Result<()> {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return Ok(());
+    };
+    fs::create_dir_all(backup_root)?;
+    let backup_path = backup_root.join(format!(
+        "{:03}-{}",
+        result.backups.len() + 1,
+        backup_label(path)
+    ));
+    if metadata.file_type().is_symlink() {
+        let target = fs::read_link(path)?;
+        fs::write(
+            &backup_path,
+            format!("symlink {}\n", target.display()).as_bytes(),
+        )?;
+    } else if metadata.is_file() {
+        fs::copy(path, &backup_path)?;
+    } else if metadata.is_dir() {
+        copy_path_recursive(path, &backup_path)?;
+    }
+    result.backups.push(backup_path.display().to_string());
+    Ok(())
+}
+
+fn copy_path_recursive(source: &Path, target: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(source)?;
+    if metadata.file_type().is_symlink() {
+        let link_target = fs::read_link(source)?;
+        fs::write(
+            target,
+            format!("symlink {}\n", link_target.display()).as_bytes(),
+        )?;
+    } else if metadata.is_file() {
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(source, target)?;
+    } else if metadata.is_dir() {
+        fs::create_dir_all(target)?;
+        for entry in fs::read_dir(source)? {
+            let entry = entry?;
+            copy_path_recursive(&entry.path(), &target.join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+fn backup_label(path: &Path) -> String {
+    let raw = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("path");
+    let sanitized = raw
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        "path".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn remove_existing_path(path: &Path) -> Result<()> {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return Ok(());
+    };
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        fs::remove_file(path)?;
+    } else if metadata.is_dir() {
+        fs::remove_dir_all(path)?;
+    }
+    Ok(())
+}
+
+fn path_exists_or_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok()
+}
+
+fn should_update_cli_binary_path(path: &Path, current_exe: &Path) -> bool {
+    if !path_exists_or_symlink(path) {
+        return true;
+    }
+    if path == current_exe {
+        return false;
+    }
+    let value = path.display().to_string();
+    value.contains("/.kast/bin/kast") || value.contains("/Cellar/kast/")
+}
+
+fn managed_install_path(install_root: &Path, value: &str) -> PathBuf {
+    let path = Path::new(value);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        install_root.join(path)
+    }
+}
+
+fn read_toml_document(path: &Path) -> Result<toml::Table> {
+    if !path.is_file() {
+        return Ok(toml::Table::new());
+    }
+    Ok(fs::read_to_string(path)?.parse::<toml::Table>()?)
+}
+
+fn affected_skill_target_roots() -> Result<Vec<PathBuf>> {
+    let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let home = config::home_dir();
+    let mut roots = vec![
+        default_skill_target_dir(),
+        home.join(".codex/skills"),
+        home.join(".agents/skills"),
+        home.join(".kast/lib/skills"),
+        cwd.join(".agents/skills"),
+        cwd.join(".github/skills"),
+        cwd.join(".claude/skills"),
+    ];
+    let mut seen = BTreeSet::new();
+    roots.retain(|path| seen.insert(config::normalize(path.clone()).display().to_string()));
+    Ok(roots.into_iter().map(config::normalize).collect())
+}
+
+fn resolve_command_bin_dir(command_name: &str) -> Result<Option<PathBuf>> {
+    let current_exe = env::current_exe()?;
+    if current_exe
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == command_name)
+    {
+        return Ok(current_exe.parent().map(Path::to_path_buf));
+    }
+    let output = ProcessCommand::new("which").arg(command_name).output();
+    let Ok(output) = output else {
+        return Ok(None);
+    };
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let command_path = stdout
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty());
+    Ok(command_path
+        .map(PathBuf::from)
+        .and_then(|path| path.parent().map(Path::to_path_buf)))
+}
+
+fn expected_homebrew_plugin_target(result: &mut InstallAffectedResult) -> Result<Option<PathBuf>> {
+    let brew_prefix = match homebrew_prefix(&["--prefix"]) {
+        Ok(value) => value,
+        Err(error) => {
+            result.warnings.push(format!(
+                "Could not resolve Homebrew prefix; skipping JetBrains plugin link repair: {}",
+                error.message
+            ));
+            return Ok(None);
+        }
+    };
+    let formula_tap = homebrew_formula_tap().unwrap_or_else(|error| {
+        result.warnings.push(format!(
+            "Could not resolve the Homebrew tap for kast; using {DEFAULT_KAST_TAP}: {}",
+            error.message
+        ));
+        DEFAULT_KAST_TAP.to_string()
+    });
+    let cask_token = format!("{formula_tap}/{KAST_PLUGIN_CASK_NAME}");
+    let cask_name = cask_name(&cask_token);
+    let Some(version) = homebrew_cask_version(&cask_name)? else {
+        result.warnings.push(format!(
+            "Homebrew cask {cask_name} is not installed; skipping JetBrains plugin link repair"
+        ));
+        return Ok(None);
+    };
+    Ok(Some(
+        brew_prefix
+            .join("Caskroom")
+            .join(cask_name)
+            .join(version)
+            .join("backend-idea"),
+    ))
+}
+
+#[cfg(unix)]
+fn create_plugin_link(
+    source: &Path,
+    target: &Path,
+    _result: &mut InstallAffectedResult,
+) -> Result<()> {
+    std::os::unix::fs::symlink(source, target)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_plugin_link(
+    _source: &Path,
+    target: &Path,
+    result: &mut InstallAffectedResult,
+) -> Result<()> {
+    result.warnings.push(format!(
+        "Cannot create JetBrains plugin symlink on this platform; left {} unchanged",
+        target.display()
+    ));
+    Ok(())
+}
+
+fn backup_timestamp() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs().to_string())
+        .unwrap_or_else(|_| "0".to_string())
 }
 
 fn current_headless() -> Result<CurrentComponentResult> {
@@ -405,6 +1194,7 @@ pub fn install_copilot_extension(
 pub fn install_idea_plugin(args: IdeaPluginInstallArgs) -> Result<InstallIdeaPluginResult> {
     let homebrew = discover_homebrew_context()?;
     verify_homebrew_cli(&homebrew)?;
+    repair_global_config_for_running_cli(!args.dry_run)?;
     let mut warnings = vec![];
     let formula_tap = match homebrew_formula_tap() {
         Ok(tap) => tap,
@@ -437,6 +1227,7 @@ pub fn install_shell(args: ShellInstallArgs) -> Result<InstallShellResult> {
         .trim()
         .to_string();
     validate_shell_command_name(&command_name)?;
+    let bin_dir = shell_integration_bin_dir(&command_name, &config.paths.bin_dir)?;
     let source_file = args.source_file.map(config::normalize).unwrap_or_else(|| {
         config_home
             .join("shell")
@@ -447,8 +1238,7 @@ pub fn install_shell(args: ShellInstallArgs) -> Result<InstallShellResult> {
         .map(config::normalize)
         .unwrap_or_else(|| default_shell_profile(shell));
     let source_line = format!("source {}", shell_quote_path(&source_file));
-    let source_content =
-        shell_source_content(shell, &command_name, &config.paths.bin_dir, &config_home);
+    let source_content = shell_source_content(shell, &command_name, &bin_dir, &config_home);
 
     if !args.dry_run {
         if let Some(parent) = source_file.parent() {
@@ -461,7 +1251,7 @@ pub fn install_shell(args: ShellInstallArgs) -> Result<InstallShellResult> {
     Ok(InstallShellResult {
         shell: shell.canonical().to_string(),
         command_name,
-        bin_dir: config.paths.bin_dir.display().to_string(),
+        bin_dir: bin_dir.display().to_string(),
         config_home: config_home.display().to_string(),
         source_file: source_file.display().to_string(),
         profile: profile.display().to_string(),
@@ -497,6 +1287,19 @@ fn default_shell_command_name() -> String {
         })
         .filter(|name| !name.trim().is_empty())
         .unwrap_or_else(|| "kast".to_string())
+}
+
+fn shell_integration_bin_dir(command_name: &str, configured_bin_dir: &Path) -> Result<PathBuf> {
+    let current_exe = env::current_exe()?;
+    if current_exe
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == command_name)
+        && let Some(parent) = current_exe.parent()
+    {
+        return Ok(parent.to_path_buf());
+    }
+    Ok(resolve_command_bin_dir(command_name)?.unwrap_or_else(|| configured_bin_dir.to_path_buf()))
 }
 
 fn default_shell_profile(shell: ShellKind) -> PathBuf {

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -89,8 +89,15 @@ fn run(cli: Cli) -> Result<i32> {
         }
         Command::Config { command } => match command {
             cli::ConfigCommand::Init => {
-                let path = config::init_config()?;
-                println!("Wrote {}", path.display());
+                let result = install::install_affected(cli::AffectedInstallArgs {
+                    apply: true,
+                    jetbrains_config_root: None,
+                })?;
+                if output_format == OutputFormat::Json {
+                    output::print_json(&result)?;
+                } else {
+                    output::print_install_result(&install::InstallResult::Affected(result))?;
+                }
                 Ok(0)
             }
         },

--- a/cli-rs/src/output.rs
+++ b/cli-rs/src/output.rs
@@ -2,9 +2,9 @@ use crate::backend::{BackendInstallResult, BackendResult, BackendUninstallResult
 use crate::cli::OutputFormat;
 use crate::error::{CliError, Result};
 use crate::install::{
-    ArchiveInstallResult, CurrentComponentResult, InstallCopilotExtensionResult,
-    InstallIdeaPluginResult, InstallResult, InstallShellResult, InstallSkillResult,
-    UninstallResult, VerifyExtensionResult,
+    ArchiveInstallResult, CurrentComponentResult, InstallAffectedResult,
+    InstallCopilotExtensionResult, InstallIdeaPluginResult, InstallResult, InstallShellResult,
+    InstallSkillResult, UninstallResult, VerifyExtensionResult,
 };
 use crate::runtime::{
     DaemonStopResult, RuntimeCandidateStatus, RuntimeState, WorkspaceEnsureResult,
@@ -57,6 +57,7 @@ pub fn print_install_result(result: &InstallResult) -> Result<()> {
         InstallResult::Copilot(result) => print_copilot_install("Kast Copilot install", result),
         InstallResult::IdeaPlugin(result) => print_idea_plugin_install(result),
         InstallResult::Shell(result) => print_shell_install(result),
+        InstallResult::Affected(result) => print_affected_install(result),
         InstallResult::Headless(result) => print_backend_install(result),
         InstallResult::Archive(result) => print_archive_install(result),
     }
@@ -376,6 +377,34 @@ fn print_archive_install(result: &ArchiveInstallResult) -> Result<()> {
     println!("- Installed at: `{}`", result.installed_at);
     println!("- Instance: `{}`", result.instance);
     println!("- Reused existing install: {}", yes_no(result.skipped));
+    Ok(())
+}
+
+fn print_affected_install(result: &InstallAffectedResult) -> Result<()> {
+    println!("# Kast affected install repair");
+    println!();
+    println!("- Applied changes: {}", yes_no(result.applied));
+    println!("- Config path: `{}`", result.config_path);
+    if !result.applied {
+        println!("- Default: no files were changed");
+        println!("- Apply command: `{}`", result.apply_command);
+    }
+    if result.actions.is_empty() {
+        println!();
+        println!("No affected installs or stale paths were found.");
+    } else {
+        println!();
+        println!("## Actions");
+        for action in &result.actions {
+            println!("- `{}` `{}`: {}", action.status, action.kind, action.target);
+            println!("  {}", action.message);
+            if let Some(command) = &action.command {
+                println!("  Command: `{command}`");
+            }
+        }
+    }
+    print_messages("Backups", &result.backups);
+    print_warnings(&result.warnings);
     Ok(())
 }
 

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -37,6 +37,10 @@ elif [ "$1" = "fetch" ] && [ "$2" = "--cask" ]; then
   printf 'fake brew fetched kast plugin\n' >&2
 elif [ "$1" = "--cache" ] && [ "$2" = "--cask" ]; then
   printf '%s\n' "${{HOME:-/tmp}}/000--kast-plugin.zip"
+elif [ "$1" = "install" ] && [ "$2" = "--cask" ]; then
+  printf 'fake brew installed kast plugin\n' >&2
+elif [ "$1" = "reinstall" ] && [ "$2" = "--cask" ]; then
+  printf 'fake brew reinstalled kast plugin\n' >&2
 elif [ "$1" = "list" ] && [ "$2" = "--cask" ]; then
   if [ "${{KAST_FAKE_BREW_CASK_VERSION:-}}" != "" ]; then
     printf 'kast-plugin %s\n' "$KAST_FAKE_BREW_CASK_VERSION"
@@ -432,6 +436,63 @@ fn smoke_core_cli_commands() {
 }
 
 #[test]
+fn top_level_help_hides_recovery_and_internal_install_surfaces() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    std::fs::create_dir_all(&home).expect("home");
+
+    let help = kast(&home, &config_home)
+        .arg("--help")
+        .output()
+        .expect("help");
+    assert!(help.status.success());
+    let stdout = String::from_utf8_lossy(&help.stdout);
+    for command in ["up", "status", "install", "current", "doctor"] {
+        assert!(
+            stdout
+                .lines()
+                .any(|line| line.trim_start().starts_with(command)),
+            "top-level help should show {command}: {stdout}"
+        );
+    }
+    for hidden in [
+        "config",
+        "daemon",
+        "backend",
+        "info",
+        "verify-extension",
+        "uninstall",
+    ] {
+        assert!(
+            !stdout
+                .lines()
+                .any(|line| line.trim_start().starts_with(hidden)),
+            "top-level help should hide {hidden}: {stdout}"
+        );
+    }
+
+    let install_help = kast(&home, &config_home)
+        .args(["install", "--help"])
+        .output()
+        .expect("install help");
+    assert!(install_help.status.success());
+    let install_stdout = String::from_utf8_lossy(&install_help.stdout);
+    assert!(
+        install_stdout.contains("affected"),
+        "install help should show the repair command: {install_stdout}"
+    );
+    assert!(
+        !install_stdout.contains("--archive"),
+        "install help should hide archive install internals: {install_stdout}"
+    );
+    assert!(
+        !install_stdout.contains("portable archive"),
+        "install help should not describe retired portable archive flow: {install_stdout}"
+    );
+}
+
+#[test]
 fn install_completion_command_renders_shell_completion_scripts() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -482,8 +543,10 @@ fn install_shell_writes_path_and_completion_profile_integration() {
     let config_home = temp.path().join("config");
     let install_root = temp.path().join("kast-install");
     let profile = temp.path().join(".zshrc");
+    let empty_path = temp.path().join("empty-path");
     std::fs::create_dir_all(&home).expect("home");
     std::fs::create_dir_all(&config_home).expect("config");
+    std::fs::create_dir_all(&empty_path).expect("empty path");
     std::fs::write(
         config_home.join("config.toml"),
         format!(
@@ -496,6 +559,7 @@ installRoot = "{}"
     .expect("config");
 
     let install = kast(&home, &config_home)
+        .env("PATH", &empty_path)
         .args([
             "--output",
             "json",
@@ -562,6 +626,66 @@ installRoot = "{}"
             shell_single_quote(source_file.to_str().expect("source file path"))
         )),
         "profile should source the managed integration file: {profile_content}"
+    );
+}
+
+#[test]
+fn install_shell_prefers_running_cli_directory_over_stale_config_bin_dir() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let stale_bin = home.join(".kast/bin");
+    let profile = temp.path().join(".zshrc");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config");
+    std::fs::create_dir_all(&stale_bin).expect("stale bin");
+    std::fs::write(
+        config_home.join("config.toml"),
+        format!(
+            r#"[paths]
+binDir = "{}"
+"#,
+            stale_bin.display()
+        ),
+    )
+    .expect("config");
+
+    let install = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "install",
+            "shell",
+            "--shell",
+            "zsh",
+            "--profile",
+            profile.to_str().expect("profile path"),
+        ])
+        .output()
+        .expect("install shell");
+
+    assert!(
+        install.status.success(),
+        "install shell should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&install.stdout).expect("install shell json");
+    let running_bin = Path::new(env!("CARGO_BIN_EXE_kast"))
+        .parent()
+        .expect("binary parent");
+    assert_eq!(stdout["commandName"], "kast");
+    assert_eq!(stdout["binDir"], running_bin.display().to_string());
+    let source_file = PathBuf::from(stdout["sourceFile"].as_str().expect("source file"));
+    let source = std::fs::read_to_string(&source_file).expect("source file content");
+    assert!(
+        !source.contains(&stale_bin.display().to_string()),
+        "source file should not point at stale config binDir: {source}"
+    );
+    assert!(
+        source.contains(&running_bin.display().to_string()),
+        "source file should point at the running kast binary directory: {source}"
     );
 }
 
@@ -1370,6 +1494,267 @@ fn current_plugin_reports_homebrew_cask_version() {
 }
 
 #[test]
+fn install_affected_repairs_stale_local_setup_only_when_applied() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let brew_bin = temp.path().join("bin");
+    let repo = temp.path().join("repo");
+    let jetbrains_root = home.join("Library/Application Support/JetBrains");
+    let profile_plugins = jetbrains_root.join("IntelliJIdea2026.1/plugins");
+    let stale_backend = home.join(".kast/lib/backends/standalone-v0.7.35");
+    let stale_current = home.join(".kast/lib/backends/current");
+    let stale_runtime_libs = stale_current.join("runtime-libs");
+    let skill = home.join(".codex/skills/kast");
+    let copilot = repo.join(".github/extensions/kast");
+    let shell_source = config_home.join("shell/kast.zsh");
+    let old_bin = home.join(".kast/bin");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(&repo).expect("repo");
+    std::fs::create_dir_all(&skill).expect("skill");
+    std::fs::create_dir_all(&copilot).expect("copilot");
+    std::fs::create_dir_all(&old_bin).expect("old bin");
+    std::fs::create_dir_all(&profile_plugins).expect("profile plugins");
+    std::fs::create_dir_all(shell_source.parent().expect("shell source parent"))
+        .expect("shell dir");
+    std::fs::write(old_bin.join("kast"), b"old binary\n").expect("old binary");
+    std::fs::write(skill.join(".kast-version"), b"old\n").expect("skill marker");
+    std::fs::write(skill.join("old.txt"), b"stale\n").expect("skill stale file");
+    std::fs::write(copilot.join(".kast-copilot-version"), b"old\n").expect("copilot marker");
+    std::fs::write(copilot.join("old.txt"), b"stale\n").expect("copilot stale file");
+    std::fs::write(
+        &shell_source,
+        format!(
+            "# Managed by `kast install shell`; re-run that command after moving Kast.\n\
+export KAST_CONFIG_HOME='{}'\n\
+_kast_bin_dir='{}'\n",
+            config_home.display(),
+            old_bin.display()
+        ),
+    )
+    .expect("shell source");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(
+        "/opt/homebrew/Caskroom/kast-plugin/0.7.35/backend-idea",
+        profile_plugins.join("kast"),
+    )
+    .expect("stale plugin symlink");
+    let formula_prefix = Path::new(env!("CARGO_BIN_EXE_kast"))
+        .parent()
+        .expect("binary parent");
+    write_fake_brew(&brew_bin, formula_prefix);
+    std::fs::write(
+        config_home.join("config.toml"),
+        format!(
+            r#"[backends.standalone]
+runtimeLibsDir = "{}"
+
+[cli]
+binaryPath = "{}"
+
+[install]
+components = ["backend:standalone"]
+installedAt = "unix:1"
+managedPaths = [
+    "lib/backends/standalone-v0.7.35",
+    "lib/backends/current",
+]
+platform = "macos-aarch64"
+schemaVersion = 3
+shellRcPatches = []
+version = "0.7.35"
+
+[[install.backends]]
+installDir = "{}"
+name = "standalone"
+runtimeLibsDir = "{}"
+version = "v0.7.35"
+
+[[install.repos]]
+copilotExtensionVersion = "old"
+path = "{}"
+"#,
+            stale_runtime_libs.display(),
+            old_bin.join("kast").display(),
+            stale_backend.display(),
+            stale_runtime_libs.display(),
+            repo.display()
+        ),
+    )
+    .expect("config");
+
+    let dry_run = kast(&home, &config_home)
+        .env("PATH", &brew_bin)
+        .env("KAST_FAKE_BREW_CASK_VERSION", "9.8.7")
+        .args([
+            "--output",
+            "json",
+            "install",
+            "affected",
+            "--jetbrains-config-root",
+            jetbrains_root.to_str().expect("jetbrains root"),
+        ])
+        .output()
+        .expect("dry run affected install");
+
+    assert!(
+        dry_run.status.success(),
+        "dry run should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&dry_run.stdout),
+        String::from_utf8_lossy(&dry_run.stderr)
+    );
+    let dry_run_stdout: serde_json::Value =
+        serde_json::from_slice(&dry_run.stdout).expect("dry run json");
+    assert_eq!(dry_run_stdout["applied"], false);
+    assert_eq!(
+        dry_run_stdout["applyCommand"],
+        "kast install affected --apply"
+    );
+    assert!(dry_run_stdout["actions"].as_array().expect("actions").len() >= 5);
+    assert!(
+        std::fs::read_to_string(config_home.join("config.toml"))
+            .expect("config after dry run")
+            .contains("[backends.standalone]")
+    );
+    assert_eq!(
+        std::fs::read_to_string(skill.join(".kast-version")).expect("skill after dry run"),
+        "old\n"
+    );
+
+    let apply = kast(&home, &config_home)
+        .env("PATH", &brew_bin)
+        .env("KAST_FAKE_BREW_CASK_VERSION", "9.8.7")
+        .args([
+            "--output",
+            "json",
+            "install",
+            "affected",
+            "--jetbrains-config-root",
+            jetbrains_root.to_str().expect("jetbrains root"),
+            "--apply",
+        ])
+        .output()
+        .expect("apply affected install");
+
+    assert!(
+        apply.status.success(),
+        "apply should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let apply_stdout: serde_json::Value =
+        serde_json::from_slice(&apply.stdout).expect("apply json");
+    assert_eq!(apply_stdout["applied"], true);
+    assert!(
+        !apply_stdout["backups"]
+            .as_array()
+            .expect("backups")
+            .is_empty(),
+        "apply should create backups"
+    );
+    let config_after =
+        std::fs::read_to_string(config_home.join("config.toml")).expect("config after apply");
+    assert!(!config_after.contains("[backends.standalone]"));
+    assert!(!config_after.contains("backend:standalone"));
+    assert!(config_after.contains(env!("CARGO_BIN_EXE_kast")));
+    assert_ne!(
+        std::fs::read_to_string(skill.join(".kast-version")).expect("skill after apply"),
+        "old\n"
+    );
+    assert!(!skill.join("old.txt").exists());
+    assert_ne!(
+        std::fs::read_to_string(copilot.join(".kast-copilot-version"))
+            .expect("copilot after apply"),
+        "old\n"
+    );
+    assert!(!copilot.join("old.txt").exists());
+    let shell_after = std::fs::read_to_string(&shell_source).expect("shell after apply");
+    assert!(!shell_after.contains(&old_bin.display().to_string()));
+    #[cfg(unix)]
+    assert_eq!(
+        std::fs::read_link(profile_plugins.join("kast")).expect("plugin symlink after apply"),
+        Path::new("/opt/homebrew/Caskroom/kast-plugin/9.8.7/backend-idea")
+    );
+}
+
+#[test]
+fn config_init_repairs_stale_brew_and_removed_backend_state() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let stale_bin = home.join(".kast/bin");
+    let stale_backend = home.join(".kast/lib/backends/standalone-v0.7.35");
+    let stale_current = home.join(".kast/lib/backends/current");
+    let stale_runtime_libs = stale_current.join("runtime-libs");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(&stale_bin).expect("stale bin");
+    std::fs::write(stale_bin.join("kast"), b"old binary\n").expect("old binary");
+    std::fs::write(
+        config_home.join("config.toml"),
+        format!(
+            r#"[backends.standalone]
+runtimeLibsDir = "{}"
+
+[cli]
+binaryPath = "{}"
+
+[install]
+components = ["backend:standalone"]
+installedAt = "unix:1"
+managedPaths = [
+    "lib/backends/standalone-v0.7.35",
+    "lib/backends/current",
+]
+platform = "macos-aarch64"
+schemaVersion = 3
+shellRcPatches = []
+version = "0.7.35"
+
+[[install.backends]]
+installDir = "{}"
+name = "standalone"
+runtimeLibsDir = "{}"
+version = "v0.7.35"
+"#,
+            stale_runtime_libs.display(),
+            stale_bin.join("kast").display(),
+            stale_backend.display(),
+            stale_runtime_libs.display(),
+        ),
+    )
+    .expect("config");
+
+    let repair = kast(&home, &config_home)
+        .args(["--output", "json", "config", "init"])
+        .output()
+        .expect("config init");
+
+    assert!(
+        repair.status.success(),
+        "config init should repair stale state: stdout={}, stderr={}",
+        String::from_utf8_lossy(&repair.stdout),
+        String::from_utf8_lossy(&repair.stderr)
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&repair.stdout).expect("repair json");
+    assert_eq!(stdout["applied"], true);
+    assert!(
+        stdout["actions"]
+            .as_array()
+            .expect("actions")
+            .iter()
+            .any(|action| action["kind"] == "update-cli-binary-path"),
+        "config init should update stale cli binary path: {stdout}"
+    );
+    let config_after =
+        std::fs::read_to_string(config_home.join("config.toml")).expect("config after repair");
+    assert!(!config_after.contains("[backends.standalone]"));
+    assert!(!config_after.contains("backend:standalone"));
+    assert!(config_after.contains(env!("CARGO_BIN_EXE_kast")));
+}
+
+#[test]
 fn install_resource_gateways_support_force_and_current_versions() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -1549,6 +1934,85 @@ fn idea_plugin_link_flag_uses_profile_install_mode() {
             .to_string()
     );
     assert!(stdout.get("downloadDir").is_none(), "{stdout}");
+}
+
+#[test]
+fn plugin_install_repairs_stale_config_before_linking_profiles() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let brew_bin = temp.path().join("bin");
+    let jetbrains_root = temp.path().join("jetbrains");
+    let stale_bin = home.join(".kast/bin");
+    let stale_backend = home.join(".kast/lib/backends/standalone-v0.7.35");
+    let stale_runtime_libs = home.join(".kast/lib/backends/current/runtime-libs");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(&stale_bin).expect("stale bin");
+    std::fs::create_dir_all(jetbrains_root.join("IntelliJIdea2026.1")).expect("profile");
+    std::fs::write(stale_bin.join("kast"), b"old binary\n").expect("old binary");
+    std::fs::write(
+        config_home.join("config.toml"),
+        format!(
+            r#"[backends.standalone]
+runtimeLibsDir = "{}"
+
+[cli]
+binaryPath = "{}"
+
+[install]
+components = ["backend:standalone"]
+installedAt = "unix:1"
+managedPaths = ["lib/backends/standalone-v0.7.35", "lib/backends/current"]
+platform = "macos-aarch64"
+schemaVersion = 3
+version = "0.7.35"
+
+[[install.backends]]
+installDir = "{}"
+name = "standalone"
+runtimeLibsDir = "{}"
+version = "v0.7.35"
+"#,
+            stale_runtime_libs.display(),
+            stale_bin.join("kast").display(),
+            stale_backend.display(),
+            stale_runtime_libs.display(),
+        ),
+    )
+    .expect("config");
+    let formula_prefix = Path::new(env!("CARGO_BIN_EXE_kast"))
+        .parent()
+        .expect("binary parent");
+    write_fake_brew(&brew_bin, formula_prefix);
+
+    let install = kast(&home, &config_home)
+        .env("PATH", &brew_bin)
+        .args([
+            "--output",
+            "json",
+            "install",
+            "plugin",
+            "--link-jetbrains-profiles",
+            "--jetbrains-config-root",
+            jetbrains_root.to_str().expect("jetbrains root"),
+        ])
+        .output()
+        .expect("install plugin");
+
+    assert!(
+        install.status.success(),
+        "plugin install should repair config before linking profiles: stdout={}, stderr={}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&install.stdout).expect("install json");
+    assert_eq!(stdout["brewAction"], "install");
+    let config_after =
+        std::fs::read_to_string(config_home.join("config.toml")).expect("config after repair");
+    assert!(!config_after.contains("[backends.standalone]"));
+    assert!(!config_after.contains("backend:standalone"));
+    assert!(config_after.contains(env!("CARGO_BIN_EXE_kast")));
 }
 
 #[test]

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -27,10 +27,13 @@ the `amichne/kast` tap. `kast` installs the Rust CLI from `amichne/kast`;
 ```console title="Install kast with Homebrew"
 brew tap amichne/kast
 brew install kast
-brew install kast-plugin
+kast install plugin --link-jetbrains-profiles
 ```
 
-Use Homebrew for ordinary terminal use when your platform is supported.
+Use Homebrew for ordinary local use when your platform is supported. The plugin
+install command installs or refreshes the Homebrew cask, links existing
+JetBrains profile plugin directories, and repairs stale global CLI config paths
+before it touches profiles.
 
 ## Install a backend
 
@@ -57,6 +60,28 @@ kast up --backend=headless --workspace-root="$PWD"
 
 If `kast up` cannot find the selected backend, it reports the exact
 `kast install headless` command to run.
+
+## Repair affected local installs
+
+Use `kast install affected` after upgrading Kast, moving between install
+methods, or seeing `kast doctor` report stale managed paths. The default mode
+is a dry run: it audits global config, retired backend state, installed Kast
+skills, managed Copilot extension copies, managed shell source files, and
+existing JetBrains profile plugin links without changing files.
+
+```console title="Audit affected installs"
+kast install affected
+```
+
+To apply the planned repair, rerun with `--apply`. The command creates backups
+under `KAST_CONFIG_HOME/backups` before replacing or removing managed files.
+
+```console title="Repair affected installs"
+kast install affected --apply
+```
+
+Backend downloads stay explicit. If the repair removes stale backend metadata
+and you need the headless backend, run `kast install headless` afterwards.
 
 ## Ubuntu/Debian bundle
 
@@ -231,7 +256,14 @@ The IDEA / Android Studio plugin exposes the same install and uninstall flow
 from the IDE. The action calls the CLI path from `[cli] binaryPath` in
 `config.toml`; it doesn't search `PATH`.
 
-Before using the action, confirm the configured binary exists and is
+Before using the action, run the local plugin install once so the CLI path is
+written or repaired:
+
+```console title="Install and link local IDE profiles"
+kast install plugin --link-jetbrains-profiles
+```
+
+If you manage config by hand, keep the configured binary absolute and
 executable:
 
 ```toml title="$HOME/.config/kast/config.toml"
@@ -288,9 +320,10 @@ replacing the plugin.
 
 ## Install shell integration
 
-Use `kast install shell` to add the configured `binDir` to your `PATH`,
-export the active `KAST_CONFIG_HOME`, and source completions from a managed
-file under `KAST_CONFIG_HOME/shell`.
+Use `kast install shell` to add the directory that contains the active `kast`
+binary to your `PATH`, export the active `KAST_CONFIG_HOME`, and source
+completions from a managed file under `KAST_CONFIG_HOME/shell`. When the command
+name cannot be resolved, Kast falls back to the configured `binDir`.
 
 === "Bash"
 


### PR DESCRIPTION
Callouts / risks:
- This is a stacked PR targeting `feature/redesign-dualpane-demo-search` so it only reviews the install/config repair commit.
- `kast install headless` remains supported and visible, but plugin-only setup no longer requires headless.

What changed:
- Adds `kast install affected` as a dry-run-first repair command with `--apply` for stale config, resource, shell, Copilot, and JetBrains profile fixes.
- Makes `kast config init` run the applied repair path instead of silently leaving stale config untouched.
- Makes `kast install plugin --link-jetbrains-profiles` repair stale global config before linking profiles.
- Hides low-level recovery/internal commands and retired archive flags from normal help output.
- Updates install docs around the standard Brew + plugin path.

Validation:
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `.github/scripts/test-development-cli-install-contract.sh`
- `.github/scripts/test-docs-content-contract.sh`
- `git diff --check`