### PR TITLE
docs: align Copilot extension docs with current layout

### DIFF
--- a/.agents/marketplaces.md
+++ b/.agents/marketplaces.md
@@ -37,8 +37,9 @@ or security reason.
 - `.github/skill-shadowing.json` maps repo-local skills to Copilot extensions;
   `kast` is required-read and shadows `cli-rs/resources/kast-skill/SKILL.md`
   when the `.github/extensions/kast/extension.mjs` extension is loaded.
-- `.github/hooks/hooks.json` is the authoritative Copilot hook manifest for
-  this repo. Keep workflow guidance in instructions or skills, not in vendored
+- Packaged Copilot resources for this repo live under
+  `.github/extensions/kast`. Keep workflow guidance in instructions, skills,
+  or packaged extension agent material, not in retired hook paths or vendored
   marketplace payloads.
 - `workspace.repos.toml` records sibling repositories that move with Kast. Treat
   those entries as checkouts, not vendored marketplace or plugin source.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,7 +64,7 @@ requests, while `kast up`, `kast status`, and `kast stop` are the human lifecycl
 - Treat `AnalysisBackend`, the `kast rpc` JSON-RPC method surface, embedded skill resources, and packaged
   Copilot-extension resources as contract surfaces. If one changes, update its consumers together:
   `docs/openapi.yaml`, `cli-rs/resources/kast-skill/**`, `.github/extensions/kast/**`,
-  `.github/hooks/**`, `kast.sh`/`install.sh`, and the related tests.
+  `.github/instructions/**`, `.github/copilot-instructions.md`, `kast.sh`/`install.sh`, and the related tests.
 - Any `AnalysisBackend` operation change must land in every surviving runtime
   that advertises it. Update parity coverage and keep advertised capabilities honest.
 - In this repo, "indexing" means real K2/PSI-backed symbol extraction into the SQLite source index, not file walking.
@@ -73,10 +73,12 @@ requests, while `kast up`, `kast status`, and `kast stop` are the human lifecycl
   `join(timeout)` in `close()` or shutdown paths; otherwise macOS `@TempDir` cleanup races show up in tests.
 - `docs/` plus `zensical.toml` are the documentation source of truth. `site/`
   and generated `docs/reference/*.md` output are build artifacts and should not be hand-edited.
-- `.github/hooks/hooks.json` is the authoritative hook manifest. Packaged
-  Copilot resources are embedded by the Rust CLI in `cli-rs/`.
-- Source `.github/hooks/skill-shadowing.json` intentionally keeps repo-local entries, while the packaged Copilot bundle
-  filters it down to portable entries backed by `shadowingExtensionId`.
+- Packaged Copilot resources are embedded by the Rust CLI under
+  `cli-rs/resources/copilot-extension` and installed into
+  `.github/extensions/kast`.
+- `.github/skill-shadowing.json` maps repo-local skills to Copilot extension
+  shadowing metadata. Keep workflow guidance in instructions or packaged
+  extension agent material, not in retired hook paths.
 - Use `kast` terminology in commands, docs, and packaging targets.
 - CI runs on both ubuntu and macOS. IDEA path filtering should use
   `GlobalSearchScope.projectScope(project)` instead of `project.basePath`

--- a/.github/skill-shadowing.json
+++ b/.github/skill-shadowing.json
@@ -11,8 +11,8 @@
             "id": "kotlin-gradle-loop",
             "skillPath": ".agents/skills/kotlin-gradle-loop/SKILL.md",
             "requireRead": false,
-            "shadowingExtensionId": "kotlin-gradle-loop",
-            "extensionPath": ".github/extensions/kotlin-gradle-loop/extension.mjs"
+            "shadowingExtensionId": "kast",
+            "extensionPath": ".github/extensions/kast/extension.mjs"
         }
     ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,15 +134,15 @@ searching non-Kotlin files. For Kotlin source, use
 `kast_workspace_symbol` for symbol-name searches and
 `kast_workspace_search` for string, comment, and arbitrary content searches.
 
-## Agent hooks
+## Copilot extension resources
 
-`.github/hooks/hooks.json` is the authoritative source for GitHub Copilot hook
-configuration in this repository. Use the standard Copilot hook schema:
-`{"version":1,"hooks":{...}}` with command hooks only. The repo-level hooks
-use `sessionStart` plus `postToolUse` state capture to track session-owned file
-edits, then run final command-based validation from `sessionEnd`. Workflow
-guidance that depends on skills, such as `refresh-affected-agents` or docs
-refresh, belongs in agent instructions rather than in the hook manifest.
+The packaged Copilot integration is extension-only in this repository. Do not
+add `.github/hooks` for Kast install behavior. Managed Copilot files live under
+`.github/extensions/kast`, and `kast install copilot` writes the extension-local
+version marker at `.github/extensions/kast/.kast-copilot-version`. Workflow
+guidance belongs in agent instructions, `.github/copilot-instructions.md`,
+`.github/instructions`, or packaged extension agent material rather than in a
+hook manifest.
 
 ## Copilot extension
 
@@ -161,13 +161,13 @@ never use `grep`/`rg`/`ast-grep` for symbol operations.
 
 ## Skill composition
 
-| Phase               | Primary skill               | Supporting skill     |
-|---------------------|-----------------------------|----------------------|
-| Understand the code | `kast` (scaffold, explore)  | —                    |
-| Plan a change       | `kast` (impact, scaffold)   | —                    |
-| Make the change     | `kast` (write-and-validate) | `kotlin-standards`   |
-| Validate the change | `kast` (diagnostics)        | `kotlin-gradle-loop` |
-| Document the change | `docs-writer`               | —                    |
+| Phase               | Primary route               | Supporting route                  |
+|---------------------|-----------------------------|-----------------------------------|
+| Understand the code | `kast` (scaffold, explore)  | —                                 |
+| Plan a change       | `kast` (impact, scaffold)   | —                                 |
+| Make the change     | `kast` (write-and-validate) | `kotlin-standards`                |
+| Validate the change | `kast` (diagnostics)        | Kast extension Gradle-loop tools  |
+| Document the change | `docs-writer`               | —                                 |
 
 ## Working rules
 
@@ -207,7 +207,8 @@ enumerate all consumers: `docs/openapi.yaml`, `cli-rs/resources/kast-skill/SKILL
 `cli-rs/resources/kast-skill/evals/**/*`,
 `cli-rs/resources/kast-skill/references/*`, `cli-rs/resources/kast-skill/scripts/*`,
 `evaluation/**/*`, `.github/extensions/kast/extension.mjs`,
-`.github/agents/**/*`, `.github/hooks/**/*`, `cli-rs/resources/**/*`, and
+`.github/extensions/kast/**/*`, `.github/instructions/**/*`,
+`.github/copilot-instructions.md`, `cli-rs/resources/**/*`, and
 `kast.sh`.
 These are contract surfaces — a change without updating all consumers silently
 breaks the distribution.

--- a/backend-idea/src/main/resources/META-INF/plugin.xml
+++ b/backend-idea/src/main/resources/META-INF/plugin.xml
@@ -35,11 +35,11 @@
             <action id="io.github.amichne.kast.installCopilotExtension"
                     class="io.github.amichne.kast.idea.actions.InstallCopilotExtensionAction"
                     text="Install Copilot Extension"
-                    description="Install kast Copilot agents and hooks into this project"/>
+                    description="Install kast Copilot extension files into this project"/>
             <action id="io.github.amichne.kast.uninstallCopilotExtension"
                     class="io.github.amichne.kast.idea.actions.UninstallCopilotExtensionAction"
                     text="Uninstall Copilot Extension"
-                    description="Remove kast Copilot agents and hooks from this project"/>
+                    description="Remove kast Copilot extension files from this project"/>
         </group>
     </actions>
 </idea-plugin>

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastInstallActionTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastInstallActionTest.kt
@@ -64,7 +64,11 @@ class KastInstallActionTest {
         )
 
         assertEquals(KastInstallCommandResult.Success, result)
-        assertTrue(Files.isRegularFile(workspaceRoot.resolve(".github/.kast-copilot-version")))
+        assertTrue(
+            Files.isRegularFile(
+                workspaceRoot.resolve(".github/extensions/kast/.kast-copilot-version"),
+            ),
+        )
         assertTrue(Files.isRegularFile(workspaceRoot.resolve(".github/extensions/kast/extension.mjs")))
     }
 
@@ -93,7 +97,7 @@ class KastInstallActionTest {
               done
               [[ -n "${'$'}target_dir" ]] || exit 2
               mkdir -p "${'$'}target_dir/extensions/kast"
-              printf '%s\n' test > "${'$'}target_dir/.kast-copilot-version"
+              printf '%s\n' test > "${'$'}target_dir/extensions/kast/.kast-copilot-version"
               printf '%s\n' '// fake extension' > "${'$'}target_dir/extensions/kast/extension.mjs"
               exit 0
             fi

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/references/routing-improvement.md
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/references/routing-improvement.md
@@ -92,8 +92,9 @@ Once the eval corpus captures the recurring miss, update the narrowest
 surface that explains the behavior:
 
 1. `SKILL.md` for portable, standards-based skill behavior
-2. `.github/agents/*.md` for GitHub Copilot-specific routing and invocation hints
-3. `.github/hooks/*` for enforcement and install drift
+2. `.github/extensions/kast/agents/*.md` for GitHub Copilot-specific routing
+   and invocation hints
+3. `.github/extensions/kast/*` for native tool registration and install drift
 4. optional vendor-specific metadata only when a host actually requires it
 
 Do not change several of these at once unless the evidence says they all

--- a/docs/for-agents/install-the-skill.md
+++ b/docs/for-agents/install-the-skill.md
@@ -87,25 +87,26 @@ kast install skill --target-dir=/absolute/path/to/skills --force
     binaryPath = "/home/alex/.local/bin/kast"
     ```
 
-GitHub Copilot custom agents are a separate surface. Personas and tool
-restrictions for Copilot belong in `.github/agents/*.md` — not in the
-portable Agent Skills bundle.
+GitHub Copilot custom agents are a separate surface. Packaged Kast Copilot
+agent material belongs under `.github/extensions/kast/agents/*.md` — not in
+the portable Agent Skills bundle.
 
 ## Install the Copilot extension files
 
 Use `install copilot` when you want the packaged GitHub Copilot
-agent, hook, and native extension files in the current repository:
+native extension files in the current repository:
 
-```console title="Install Copilot agents, hooks, and extensions"
+```console title="Install Copilot extension files"
 kast install copilot
 ```
 
-The command writes into `<cwd>/.github` by default, including packaged
-`.github/agents`, `.github/hooks`, and self-contained native extension scripts
-under `.github/extensions`. Packaged scripts are installed executable, and the
-command records the installed CLI version in `.github/.kast-copilot-version`.
-Pass `--target-dir` to point at another workspace `.github` directory, and
-`--force` to replace an older installed copy:
+The command writes into `<cwd>/.github` by default. The managed install lives
+under `.github/extensions/kast`, including the extension entry point, helper
+agent material, the RPC command catalog, and support scripts. Packaged scripts
+are installed executable, and the command records the installed CLI version in
+`.github/extensions/kast/.kast-copilot-version`. Pass `--target-dir` to point
+at another workspace `.github` directory, and `--force` to replace an older
+installed copy:
 
 ```console title="Force reinstall Copilot extension files"
 kast install copilot --target-dir=/absolute/path/to/repo/.github --force
@@ -117,7 +118,7 @@ To remove only packaged Copilot files, use the uninstall command:
 kast uninstall copilot-extension
 ```
 
-Uninstall removes the packaged manifest files and the version marker. It
+Uninstall removes the packaged extension files and the version marker. It
 preserves foreign files you created under `.github`.
 
 ## Next steps

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -217,22 +217,24 @@ images, private artifact stores, and CI-style setup scripts.
 ## Install the Copilot extension
 
 Install the Copilot extension when you want the repository-local GitHub
-Copilot files that ship with `kast`. The command copies packaged agents,
-hooks, and native extensions into `.github`, marks scripts executable,
-writes `.github/.kast-copilot-version`, and records the managed repo in the
-CLI-managed inventory.
+Copilot files that ship with `kast`. The command copies the packaged native
+extension into `.github/extensions/kast`, marks scripts executable, writes
+`.github/extensions/kast/.kast-copilot-version`, and records the managed repo
+in the CLI-managed inventory.
 
 From the repository root, run:
 
-```console title="Install Copilot agents, hooks, and extensions"
+```console title="Install Copilot extension files"
 kast install copilot
 ```
 
 The install writes these packaged trees:
 
-- `.github/agents`
-- `.github/hooks`
-- `.github/extensions`
+- `.github/extensions/kast/extension.mjs`
+- `.github/extensions/kast/_shared`
+- `.github/extensions/kast/agents`
+- `.github/extensions/kast/kotlin-gradle-loop`
+- `.github/extensions/kast/scripts`
 
 Pass `--target-dir` when you need to install into another workspace's
 `.github` directory. Pass `--force` to replace an older managed copy:
@@ -243,11 +245,11 @@ kast install copilot --target-dir=/Users/alex/work/project/.github --force
 
 To remove only packaged files, use the uninstall command:
 
-```console title="Uninstall Copilot agents, hooks, and extensions"
+```console title="Uninstall Copilot extension files"
 kast uninstall copilot-extension
 ```
 
-Uninstall removes the packaged manifest entries and the version marker. It
+Uninstall removes the packaged extension files and the version marker. It
 preserves foreign files that you created under `.github`.
 
 ### Install Copilot extension from IDEA or Android Studio

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -86,9 +86,11 @@ that matches what you're seeing.
 ??? question "Copilot extension uninstall leaves files behind"
 
     `kast uninstall copilot-extension` removes only files
-    listed in the packaged manifest plus `.github/.kast-copilot-version`.
-    Files you created under `.github` are preserved, and the CLI-managed
-    inventory drops the repo entry.
+    from the packaged extension file set plus
+    `.github/extensions/kast/.kast-copilot-version`. It also cleans older
+    managed hook files when they are present. Files you created under
+    `.github` are preserved, and the CLI-managed inventory drops the repo
+    entry.
 
     To inspect the managed set, reinstall with `--force`, then uninstall
     again:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #244

