### PR TITLE
fix: harden idea config and enterprise TLS downloads

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginService.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginService.kt
@@ -27,7 +27,7 @@ internal class KastPluginService(
 
         LOG.info("Starting kast idea backend for workspace: $workspaceRoot")
 
-        val kastConfig = KastConfig.load(workspaceRoot)
+        val kastConfig = loadIdeaKastConfig(workspaceRoot)
         val socketPath = defaultSocketPath(workspaceRoot)
         runningBackend = KastIdeaBackendRuntime.start(
             project = project,
@@ -63,6 +63,23 @@ internal class KastPluginService(
         private val LOG = Logger.getInstance(KastPluginService::class.java)
     }
 }
+
+internal fun loadIdeaKastConfig(
+    workspaceRoot: Path,
+    loader: (Path) -> KastConfig = KastConfig::load,
+    reportFailure: (Path, Exception) -> Unit = { path, error ->
+        Logger.getInstance(KastPluginService::class.java).warn(
+            "Failed to load Kast config for workspace $path; starting IDEA backend with defaults.",
+            error,
+        )
+    },
+): KastConfig =
+    try {
+        loader(workspaceRoot)
+    } catch (error: Exception) {
+        reportFailure(workspaceRoot, error)
+        KastConfig.defaults()
+    }
 
 internal fun ideaServerLimits(config: KastConfig): ServerLimits = ServerLimits(
     maxConcurrentRequests = config.server.maxConcurrentRequests.value.coerceAtLeast(1),

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginServiceConfigTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginServiceConfigTest.kt
@@ -55,6 +55,55 @@ class KastPluginServiceConfigTest {
     }
 
     @Test
+    fun `idea config loader returns loaded config when config is valid`() {
+        val workspaceRoot = Path.of("/tmp/workspace")
+        val expectedConfig = KastConfig.defaults().copy(
+            server = KastConfig.defaults().server.copy(
+                maxResults = ServerMaxResults(42),
+            ),
+        )
+
+        val config = loadIdeaKastConfig(
+            workspaceRoot = workspaceRoot,
+            loader = { path ->
+                assertEquals(workspaceRoot, path)
+                expectedConfig
+            },
+            reportFailure = { _, error -> error("Unexpected config load failure: $error") },
+        )
+
+        assertEquals(42, config.server.maxResults.value)
+    }
+
+    @Test
+    fun `idea config loader falls back to defaults when config is invalid`() {
+        val workspaceRoot = Path.of("/tmp/workspace")
+        var reportedWorkspace: Path? = null
+        var reportedError: Exception? = null
+
+        val config = loadIdeaKastConfig(
+            workspaceRoot = workspaceRoot,
+            loader = { error("Invalid Kast config line 1 in config.toml") },
+            reportFailure = { path, error ->
+                reportedWorkspace = path
+                reportedError = error
+            },
+        )
+
+        assertEquals(KastConfig.defaults(), config)
+        assertEquals(
+            ServerLimits(
+                maxResults = 500,
+                requestTimeoutMillis = 30_000L,
+                maxConcurrentRequests = 4,
+            ),
+            ideaServerLimits(config),
+        )
+        assertEquals(workspaceRoot, reportedWorkspace)
+        assertTrue(reportedError?.message?.contains("Invalid Kast config") == true)
+    }
+
+    @Test
     fun `idea telemetry uses config`() {
         val telemetry = IdeaBackendTelemetry.fromConfig(
             workspaceRoot = Path.of("/tmp/workspace"),

--- a/cli-rs/Cargo.lock
+++ b/cli-rs/Cargo.lock
@@ -233,6 +233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +306,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +343,22 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -1038,6 +1070,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1478,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -1867,6 +1949,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +1968,33 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1899,10 +2020,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2392,6 +2554,7 @@ dependencies = [
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "ureq-proto",
  "utf8-zero",
  "webpki-roots",
@@ -2474,6 +2637,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2580,6 +2753,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,6 +2859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,11 +2881,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2708,19 +2908,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2730,9 +2951,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2748,9 +2981,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2760,9 +3005,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/cli-rs/Cargo.toml
+++ b/cli-rs/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0"
 sha2 = "0.11"
 thiserror = "2.0"
 toml = "1.1"
-ureq = "3"
+ureq = { version = "3", features = ["platform-verifier"] }
 uuid = { version = "1.18", features = ["v4"] }
 zip = { version = "6.0", default-features = false, features = ["deflate"] }
 

--- a/cli-rs/src/backend.rs
+++ b/cli-rs/src/backend.rs
@@ -44,6 +44,11 @@ struct TempTree {
     path: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct DownloadTlsPolicy {
+    insecure_skip_tls_verify: bool,
+}
+
 #[derive(Debug, Deserialize)]
 struct ReleaseProvenance {
     builds: Vec<ReleaseProvenanceBuild>,
@@ -151,15 +156,36 @@ fn resolve_archive(
     let base_url = base_url.trim_end_matches('/');
     let checksums = temp.path.join("SHA256SUMS");
     let provenance = temp.path.join("build-provenance.json");
-    download_with_http(&format!("{base_url}/SHA256SUMS"), &checksums)?;
-    download_with_http(&format!("{base_url}/build-provenance.json"), &provenance)?;
-    download_with_http(&format!("{base_url}/{asset_name}"), &archive)?;
+    let agent = download_agent(DownloadTlsPolicy {
+        insecure_skip_tls_verify: args.insecure_skip_tls_verify,
+    });
+    download_with_http(&agent, &format!("{base_url}/SHA256SUMS"), &checksums)?;
+    download_with_http(
+        &agent,
+        &format!("{base_url}/build-provenance.json"),
+        &provenance,
+    )?;
+    download_with_http(&agent, &format!("{base_url}/{asset_name}"), &archive)?;
     verify_downloaded_release_asset(args.backend, &asset_name, &archive, &checksums, &provenance)?;
     Ok((archive, true, Some(temp)))
 }
 
-fn download_with_http(url: &str, output: &Path) -> Result<()> {
-    let mut response = ureq::get(url).call().map_err(|error| {
+fn download_agent(policy: DownloadTlsPolicy) -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .tls_config(download_tls_config(policy))
+        .build()
+        .new_agent()
+}
+
+fn download_tls_config(policy: DownloadTlsPolicy) -> ureq::tls::TlsConfig {
+    ureq::tls::TlsConfig::builder()
+        .root_certs(ureq::tls::RootCerts::PlatformVerifier)
+        .disable_verification(policy.insecure_skip_tls_verify)
+        .build()
+}
+
+fn download_with_http(agent: &ureq::Agent, url: &str, output: &Path) -> Result<()> {
+    let mut response = agent.get(url).call().map_err(|error| {
         CliError::new(
             "BACKEND_DOWNLOAD_FAILED",
             format!("Failed to download backend release asset from {url}: {error}"),
@@ -548,4 +574,41 @@ fn current_timestamp() -> String {
         .unwrap_or_default()
         .as_secs();
     format!("unix:{seconds}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn download_tls_config_uses_platform_verifier_by_default() {
+        let config = download_tls_config(DownloadTlsPolicy {
+            insecure_skip_tls_verify: false,
+        });
+
+        assert!(
+            matches!(config.root_certs(), ureq::tls::RootCerts::PlatformVerifier),
+            "backend downloads should trust the operating system certificate store by default"
+        );
+        assert!(
+            !config.disable_verification(),
+            "default backend downloads must keep TLS verification enabled"
+        );
+    }
+
+    #[test]
+    fn download_tls_config_can_disable_verification_for_enterprise_escape_hatch() {
+        let config = download_tls_config(DownloadTlsPolicy {
+            insecure_skip_tls_verify: true,
+        });
+
+        assert!(
+            matches!(config.root_certs(), ureq::tls::RootCerts::PlatformVerifier),
+            "the escape hatch should only disable verification, not change other TLS policy"
+        );
+        assert!(
+            config.disable_verification(),
+            "the explicit escape hatch should disable TLS verification"
+        );
+    }
 }

--- a/cli-rs/src/cli.rs
+++ b/cli-rs/src/cli.rs
@@ -78,6 +78,9 @@ pub struct BackendInstallArgs {
     /// Defaults to the matching GitHub release.
     #[arg(long)]
     pub base_url: Option<String>,
+    /// Disable TLS certificate verification for downloads; SHA256SUMS and provenance checks still run.
+    #[arg(long)]
+    pub insecure_skip_tls_verify: bool,
     /// Replace an existing installed backend version.
     #[arg(short = 'f', long)]
     pub force: bool,
@@ -259,6 +262,9 @@ pub struct RuntimeArgs {
     /// Release directory URL to use when auto-installing a missing headless backend.
     #[arg(long, hide = true)]
     pub install_base_url: Option<String>,
+    /// Disable TLS certificate verification for auto-install downloads.
+    #[arg(long, hide = true)]
+    pub install_insecure_skip_tls_verify: bool,
     #[arg(skip = true)]
     pub auto_install_headless: bool,
 }
@@ -463,6 +469,9 @@ pub struct HeadlessInstallArgs {
     /// Defaults to the matching GitHub release.
     #[arg(long)]
     pub base_url: Option<String>,
+    /// Disable TLS certificate verification for downloads; SHA256SUMS and provenance checks still run.
+    #[arg(long)]
+    pub insecure_skip_tls_verify: bool,
     /// Replace an existing installed backend version.
     #[arg(short = 'f', long)]
     pub force: bool,

--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -213,6 +213,7 @@ pub fn setup(args: SetupArgs) -> Result<SetupResult> {
             archive: args.headless_archive,
             version: args.version.clone(),
             base_url: args.base_url,
+            insecure_skip_tls_verify: false,
             force: args.force,
         })?)
     };
@@ -322,6 +323,7 @@ pub fn install_headless(args: HeadlessInstallArgs) -> Result<backend::BackendIns
         archive: args.archive,
         version: args.version,
         base_url: args.base_url,
+        insecure_skip_tls_verify: args.insecure_skip_tls_verify,
         force: args.force,
     };
     match backend::run(cli::BackendCommand::Install(backend_args))? {

--- a/cli-rs/src/runtime.rs
+++ b/cli-rs/src/runtime.rs
@@ -234,6 +234,7 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
                 archive: None,
                 version: args.install_version.clone(),
                 base_url: args.install_base_url.clone(),
+                insecure_skip_tls_verify: args.install_insecure_skip_tls_verify,
                 force: false,
             })?;
             config = KastConfig::load(&workspace_root)?;
@@ -362,6 +363,7 @@ pub fn rpc_passthrough(args: RpcArgs) -> Result<String> {
         profile_otlp_endpoint: None,
         install_version: None,
         install_base_url: None,
+        install_insecure_skip_tls_verify: false,
         auto_install_headless: false,
     })?;
     rpc::raw(

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -333,6 +333,12 @@ fn smoke_core_cli_commands() {
             stdout.contains("-f, --force"),
             "install {command} help should expose -f/--force: {stdout}"
         );
+        if command == "headless" {
+            assert!(
+                stdout.contains("--insecure-skip-tls-verify"),
+                "install headless help should expose the enterprise TLS escape hatch: {stdout}"
+            );
+        }
         assert!(
             !stdout.contains("--yes"),
             "install {command} help should not expose deprecated --yes: {stdout}"
@@ -930,6 +936,7 @@ fn backend_install_downloaded_archive_verifies_release_metadata() {
             "v9.8.7",
             "--base-url",
             &base_url,
+            "--insecure-skip-tls-verify",
         ])
         .output()
         .expect("install headless");


### PR DESCRIPTION
## Summary
- make the IDEA plugin fall back to default Kast config when local config parsing fails
- use platform certificate verification for backend downloads on enterprise machines
- add an explicit TLS verification escape hatch without weakening SHA256SUMS or provenance checks

## Root cause
The IDEA backend still loaded config through the Kotlin-side parser during startup, so an invalid local config could prevent plugin startup. The CLI download path used `ureq` defaults, which rely on static webpki roots and can reject enterprise-issued certificates even when the OS trust store accepts them.

## Validation
- `./gradlew :backend-idea:test`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --check`
- `git diff --check`
