### PR TITLE
Report canonical doctor diagnostics

### DIFF
--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -303,6 +303,12 @@ fn setup_headless_present() -> Result<bool> {
         .is_some_and(|runtime_libs_dir| runtime_libs_dir.join("classpath.txt").is_file()))
 }
 
+#[derive(Clone, Copy)]
+enum InstallReconciliationScope {
+    ConfigOnly,
+    Full,
+}
+
 pub fn repair_if_running_cli_version_changed() -> Result<Option<InstallAffectedResult>> {
     let Some(install) = self_mgmt::read_global_install_state()? else {
         return Ok(None);
@@ -310,10 +316,13 @@ pub fn repair_if_running_cli_version_changed() -> Result<Option<InstallAffectedR
     if install.version.trim() == cli::version() {
         return Ok(None);
     }
-    install_affected(AffectedInstallArgs {
-        apply: true,
-        jetbrains_config_root: None,
-    })
+    reconcile_install_state(
+        AffectedInstallArgs {
+            apply: true,
+            jetbrains_config_root: None,
+        },
+        InstallReconciliationScope::Full,
+    )
     .map(Some)
 }
 
@@ -332,6 +341,24 @@ pub fn install_headless(args: HeadlessInstallArgs) -> Result<backend::BackendIns
 }
 
 pub fn install_affected(args: AffectedInstallArgs) -> Result<InstallAffectedResult> {
+    reconcile_install_state(args, InstallReconciliationScope::Full)
+}
+
+fn repair_global_config_for_running_cli(apply: bool) -> Result<()> {
+    reconcile_install_state(
+        AffectedInstallArgs {
+            apply,
+            jetbrains_config_root: None,
+        },
+        InstallReconciliationScope::ConfigOnly,
+    )
+    .map(|_| ())
+}
+
+fn reconcile_install_state(
+    args: AffectedInstallArgs,
+    scope: InstallReconciliationScope,
+) -> Result<InstallAffectedResult> {
     let config_path = config::global_config_path();
     let backup_root = config::kast_config_home()
         .join("backups")
@@ -360,7 +387,11 @@ pub fn install_affected(args: AffectedInstallArgs) -> Result<InstallAffectedResu
         }
     }
 
-    let global_config = config::KastConfig::load_global()?;
+    let Some(global_config) =
+        load_global_config_for_repair(&args, &mut result, &backup_root, &mut config_backed_up)?
+    else {
+        return Ok(result);
+    };
     repair_affected_config_state(
         &args,
         &global_config,
@@ -368,6 +399,9 @@ pub fn install_affected(args: AffectedInstallArgs) -> Result<InstallAffectedResu
         &backup_root,
         &mut config_backed_up,
     )?;
+    if matches!(scope, InstallReconciliationScope::ConfigOnly) {
+        return Ok(result);
+    }
     repair_affected_skill_targets(&args, &mut result, &backup_root)?;
     repair_affected_copilot_repos(&args, &mut result, &backup_root)?;
     repair_affected_shell_sources(&args, &mut result, &backup_root)?;
@@ -376,46 +410,40 @@ pub fn install_affected(args: AffectedInstallArgs) -> Result<InstallAffectedResu
     Ok(result)
 }
 
-fn repair_global_config_for_running_cli(apply: bool) -> Result<()> {
-    let config_path = config::global_config_path();
-    let backup_root = config::kast_config_home()
-        .join("backups")
-        .join(format!("install-affected-{}", backup_timestamp()));
-    let mut result = InstallAffectedResult {
-        applied: apply,
-        config_path: config_path.display().to_string(),
-        apply_command: "kast install affected --apply".to_string(),
-        actions: vec![],
-        backups: vec![],
-        warnings: vec![],
-        schema_version: SCHEMA_VERSION,
-    };
-    let mut config_backed_up = false;
-
-    if !config_path.is_file() {
-        push_affected_action(
-            &mut result,
-            "provision-config",
-            &config_path,
-            "Create the global Kast config from current defaults.",
-            None,
-        );
-        if apply {
-            config::init_config()?;
+fn load_global_config_for_repair(
+    args: &AffectedInstallArgs,
+    result: &mut InstallAffectedResult,
+    backup_root: &Path,
+    config_backed_up: &mut bool,
+) -> Result<Option<config::KastConfig>> {
+    match config::KastConfig::load_global() {
+        Ok(global_config) => Ok(Some(global_config)),
+        Err(error) if error.code == "CONFIG_ERROR" => {
+            let config_path = config::global_config_path();
+            push_affected_action(
+                result,
+                "recover-invalid-config",
+                &config_path,
+                "Back up the invalid global Kast config and restore safe defaults.",
+                Some("kast install affected --apply".to_string()),
+            );
+            if !args.apply {
+                result.warnings.push(format!(
+                    "Global config is invalid at {}; rerun with --apply to back it up and restore safe defaults: {}",
+                    config_path.display(),
+                    error.message
+                ));
+                return Ok(None);
+            }
+            backup_config_once(result, backup_root, config_backed_up)?;
+            if let Some(parent) = config_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(&config_path, config::default_config_template()?)?;
+            Ok(Some(config::KastConfig::load_global()?))
         }
+        Err(error) => Err(error),
     }
-
-    let global_config = config::KastConfig::load_global()?;
-    repair_affected_config_state(
-        &AffectedInstallArgs {
-            apply,
-            jetbrains_config_root: None,
-        },
-        &global_config,
-        &mut result,
-        &backup_root,
-        &mut config_backed_up,
-    )
 }
 
 fn repair_affected_config_state(

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -190,7 +190,11 @@ fn maybe_repair_after_cli_upgrade(command: &Command) -> Result<()> {
     ) {
         return Ok(());
     }
-    install::repair_if_running_cli_version_changed().map(|_| ())
+    match install::repair_if_running_cli_version_changed() {
+        Ok(_) => Ok(()),
+        Err(error) if matches!(command, Command::Doctor) && error.code == "CONFIG_ERROR" => Ok(()),
+        Err(error) => Err(error),
+    }
 }
 
 fn print_completion(args: cli::CompletionArgs) {

--- a/cli-rs/src/output.rs
+++ b/cli-rs/src/output.rs
@@ -154,7 +154,14 @@ pub fn print_doctor(result: &SelfDoctorResult) -> Result<()> {
     println!();
     println!("- Healthy: {}", yes_no(result.ok));
     println!("- Installed: {}", yes_no(result.installed));
+    println!("- Config valid: {}", yes_no(result.configuration.valid));
     println!("- Config path: `{}`", result.config_path);
+    println!(
+        "- Canonical directory: `{}`",
+        result.canonical_directory.root
+    );
+    println!("- Running binary: `{}`", result.binary.running_binary);
+    println!("- Configured binary: `{}`", result.binary.configured_binary);
     println!(
         "- Minimum backend version: `{}`",
         result.minimum_backend_version

--- a/cli-rs/src/self_mgmt.rs
+++ b/cli-rs/src/self_mgmt.rs
@@ -4,6 +4,7 @@ use crate::config;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -52,9 +53,47 @@ pub struct ManagedRepo {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DoctorConfigurationDiagnostic {
+    pub config_home: String,
+    pub config_path: String,
+    pub exists: bool,
+    pub valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub schema_version: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoctorCanonicalDirectoryDiagnostic {
+    pub root: String,
+    pub bin_dir: String,
+    pub lib_dir: String,
+    pub cache_dir: String,
+    pub logs_dir: String,
+    pub descriptor_dir: String,
+    pub socket_dir: String,
+    pub schema_version: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoctorBinaryDiagnostic {
+    pub running_binary: String,
+    pub configured_binary: String,
+    pub configured_exists: bool,
+    pub configured_matches_running: bool,
+    pub schema_version: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SelfDoctorResult {
     pub installed: bool,
     pub config_path: String,
+    pub configuration: DoctorConfigurationDiagnostic,
+    pub canonical_directory: DoctorCanonicalDirectoryDiagnostic,
+    pub binary: DoctorBinaryDiagnostic,
     pub minimum_backend_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub install: Option<InstallState>,
@@ -66,12 +105,46 @@ pub struct SelfDoctorResult {
 
 pub fn doctor() -> Result<SelfDoctorResult> {
     let config_path = config::global_config_path();
-    let install = read_install_state(&config_path)?;
-    let global_config = config::KastConfig::load_global()?;
-    let install_root = global_config.paths.install_root;
-    let minimum_backend_version = minimum_backend_version();
     let mut issues = vec![];
     let mut warnings = vec![];
+    let global_config = match config::KastConfig::load_global() {
+        Ok(global_config) => global_config,
+        Err(error) => {
+            issues.push(format!(
+                "Config is invalid at {}: {}",
+                config_path.display(),
+                error.message
+            ));
+            config::KastConfig::defaults()
+        }
+    };
+    let configuration = configuration_diagnostic(&config_path, issues.first().cloned());
+    let install = match read_install_state(&config_path) {
+        Ok(install) => install,
+        Err(error) => {
+            issues.push(format!(
+                "Install state could not be read from {}: {}",
+                config_path.display(),
+                error.message
+            ));
+            None
+        }
+    };
+    let install_root = global_config.paths.install_root.clone();
+    let canonical_directory = canonical_directory_diagnostic(&global_config.paths);
+    let binary = binary_diagnostic(&global_config.cli);
+    if !binary.configured_exists {
+        warnings.push(format!(
+            "Configured kast binary is missing: {}",
+            binary.configured_binary
+        ));
+    } else if !binary.configured_matches_running {
+        warnings.push(format!(
+            "Configured kast binary {} does not match the running binary {}",
+            binary.configured_binary, binary.running_binary
+        ));
+    }
+    let minimum_backend_version = minimum_backend_version();
     if let Some(install) = &install {
         for path in &install.managed_paths {
             let managed_path = managed_path(&install_root, path);
@@ -115,6 +188,9 @@ pub fn doctor() -> Result<SelfDoctorResult> {
     Ok(SelfDoctorResult {
         installed: install.is_some(),
         config_path: config_path.display().to_string(),
+        configuration,
+        canonical_directory,
+        binary,
         minimum_backend_version: minimum_backend_version.to_string(),
         install,
         ok: issues.is_empty(),
@@ -122,6 +198,49 @@ pub fn doctor() -> Result<SelfDoctorResult> {
         warnings,
         schema_version: SCHEMA_VERSION,
     })
+}
+
+fn configuration_diagnostic(
+    config_path: &Path,
+    error: Option<String>,
+) -> DoctorConfigurationDiagnostic {
+    DoctorConfigurationDiagnostic {
+        config_home: config::kast_config_home().display().to_string(),
+        config_path: config_path.display().to_string(),
+        exists: config_path.is_file(),
+        valid: error.is_none(),
+        error,
+        schema_version: SCHEMA_VERSION,
+    }
+}
+
+fn canonical_directory_diagnostic(
+    paths: &config::PathsConfig,
+) -> DoctorCanonicalDirectoryDiagnostic {
+    DoctorCanonicalDirectoryDiagnostic {
+        root: paths.install_root.display().to_string(),
+        bin_dir: paths.bin_dir.display().to_string(),
+        lib_dir: paths.lib_dir.display().to_string(),
+        cache_dir: paths.cache_dir.display().to_string(),
+        logs_dir: paths.logs_dir.display().to_string(),
+        descriptor_dir: paths.descriptor_dir.display().to_string(),
+        socket_dir: paths.socket_dir.display().to_string(),
+        schema_version: SCHEMA_VERSION,
+    }
+}
+
+fn binary_diagnostic(cli: &config::CliConfig) -> DoctorBinaryDiagnostic {
+    let running_binary = env::current_exe().unwrap_or_else(|_| cli.binary_path.clone());
+    let configured_binary = cli.binary_path.clone();
+    let configured_exists = configured_binary.is_file();
+    DoctorBinaryDiagnostic {
+        running_binary: running_binary.display().to_string(),
+        configured_binary: configured_binary.display().to_string(),
+        configured_exists,
+        configured_matches_running: configured_exists
+            && config::normalize(configured_binary) == config::normalize(running_binary),
+        schema_version: SCHEMA_VERSION,
+    }
 }
 
 pub fn write_install_state(install: &InstallState) -> Result<PathBuf> {

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -2171,6 +2171,116 @@ version = "v0.7.35"
 }
 
 #[test]
+fn install_affected_recovers_malformed_global_config_with_backup() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::write(config_home.join("config.toml"), "[runtime\n").expect("malformed config");
+
+    let dry_run = kast(&home, &config_home)
+        .args(["--output", "json", "install", "affected"])
+        .output()
+        .expect("dry-run affected");
+
+    assert!(
+        dry_run.status.success(),
+        "dry-run repair should report malformed config without failing: stdout={}, stderr={}",
+        String::from_utf8_lossy(&dry_run.stdout),
+        String::from_utf8_lossy(&dry_run.stderr)
+    );
+    let dry_run_stdout: serde_json::Value =
+        serde_json::from_slice(&dry_run.stdout).expect("dry-run json");
+    assert_eq!(dry_run_stdout["applied"], false);
+    assert!(
+        dry_run_stdout["actions"]
+            .as_array()
+            .expect("actions")
+            .iter()
+            .any(|action| action["kind"] == "recover-invalid-config"),
+        "dry-run should plan config recovery: {dry_run_stdout}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(config_home.join("config.toml")).expect("config after dry-run"),
+        "[runtime\n"
+    );
+
+    let apply = kast(&home, &config_home)
+        .args(["--output", "json", "install", "affected", "--apply"])
+        .output()
+        .expect("apply affected");
+
+    assert!(
+        apply.status.success(),
+        "apply repair should recover malformed config: stdout={}, stderr={}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let apply_stdout: serde_json::Value =
+        serde_json::from_slice(&apply.stdout).expect("apply json");
+    assert_eq!(apply_stdout["applied"], true);
+    assert!(
+        apply_stdout["actions"]
+            .as_array()
+            .expect("actions")
+            .iter()
+            .any(|action| action["kind"] == "recover-invalid-config"),
+        "apply should report config recovery: {apply_stdout}"
+    );
+    let backups = apply_stdout["backups"].as_array().expect("backups");
+    assert!(
+        !backups.is_empty(),
+        "apply should preserve the malformed config"
+    );
+    let backup =
+        std::fs::read_to_string(backups[0].as_str().expect("backup path")).expect("backup content");
+    assert_eq!(backup, "[runtime\n");
+    let recovered =
+        std::fs::read_to_string(config_home.join("config.toml")).expect("recovered config");
+    assert!(recovered.contains("[server]"), "{recovered}");
+    recovered
+        .parse::<toml::Table>()
+        .expect("recovered config should be valid TOML");
+    assert!(!recovered.contains("[runtime\n"), "{recovered}");
+
+    std::fs::write(config_home.join("config.toml"), "[runtime\n")
+        .expect("malformed config before setup");
+    let setup = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "setup",
+            "--skip-shell",
+            "--skip-headless",
+            "--skip-plugin",
+        ])
+        .output()
+        .expect("setup after recovery");
+    assert!(
+        setup.status.success(),
+        "setup should accept recovered defaults: stdout={}, stderr={}",
+        String::from_utf8_lossy(&setup.stdout),
+        String::from_utf8_lossy(&setup.stderr)
+    );
+    let setup_stdout: serde_json::Value =
+        serde_json::from_slice(&setup.stdout).expect("setup json");
+    assert!(
+        setup_stdout["repair"]["actions"]
+            .as_array()
+            .expect("setup repair actions")
+            .iter()
+            .any(|action| action["kind"] == "recover-invalid-config"),
+        "setup should report config recovery: {setup_stdout}"
+    );
+    let setup_recovered =
+        std::fs::read_to_string(config_home.join("config.toml")).expect("setup recovered config");
+    setup_recovered
+        .parse::<toml::Table>()
+        .expect("setup recovered config should be valid TOML");
+}
+
+#[test]
 fn ordinary_commands_repair_stale_install_version_once() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -2579,13 +2579,17 @@ fn doctor_resolves_relative_managed_paths_under_install_root() {
             r#"[paths]
 installRoot = "{}"
 
+[cli]
+binaryPath = "{}"
+
 [install]
 version = "0.1.0"
 components = []
 managedPaths = ["backends"]
 schemaVersion = 3
 "#,
-            install_root.display()
+            install_root.display(),
+            env!("CARGO_BIN_EXE_kast")
         ),
     )
     .expect("config");
@@ -2601,9 +2605,72 @@ schemaVersion = 3
         String::from_utf8_lossy(&doctor.stdout),
         String::from_utf8_lossy(&doctor.stderr),
     );
-    let stdout = String::from_utf8_lossy(&doctor.stdout);
-    assert!(stdout.contains("\"ok\": true"), "{stdout}");
-    assert!(!stdout.contains("Managed path is missing"), "{stdout}");
+    let stdout: serde_json::Value = serde_json::from_slice(&doctor.stdout).expect("doctor json");
+    assert_eq!(stdout["ok"], true, "{stdout}");
+    assert_eq!(stdout["configuration"]["valid"], true, "{stdout}");
+    assert_eq!(
+        stdout["canonicalDirectory"]["root"],
+        install_root.display().to_string(),
+        "{stdout}"
+    );
+    assert_eq!(stdout["binary"]["configuredExists"], true, "{stdout}");
+    assert_eq!(
+        stdout["binary"]["configuredMatchesRunning"], true,
+        "{stdout}"
+    );
+    assert!(
+        !stdout["warnings"]
+            .as_array()
+            .expect("warnings")
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .expect("warning")
+                .contains("Managed path is missing")),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn doctor_reports_invalid_config_without_crashing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::write(config_home.join("config.toml"), "[paths\ninstallRoot =")
+        .expect("invalid config");
+
+    let doctor = kast(&home, &config_home)
+        .args(["--output", "json", "doctor"])
+        .output()
+        .expect("doctor");
+
+    assert!(
+        !doctor.status.success(),
+        "doctor should return unhealthy status for invalid config: stdout={}, stderr={}",
+        String::from_utf8_lossy(&doctor.stdout),
+        String::from_utf8_lossy(&doctor.stderr),
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&doctor.stdout).expect("doctor json");
+    assert_eq!(stdout["ok"], false, "{stdout}");
+    assert_eq!(stdout["configuration"]["exists"], true, "{stdout}");
+    assert_eq!(stdout["configuration"]["valid"], false, "{stdout}");
+    assert!(
+        stdout["configuration"]["error"]
+            .as_str()
+            .expect("configuration error")
+            .contains("Config is invalid"),
+        "{stdout}"
+    );
+    assert!(
+        stdout["issues"]
+            .as_array()
+            .expect("issues")
+            .iter()
+            .any(|issue| issue.as_str().expect("issue").contains("Config is invalid")),
+        "{stdout}"
+    );
 }
 
 #[test]

--- a/docs/cli-cheat-sheet.md
+++ b/docs/cli-cheat-sheet.md
@@ -49,6 +49,7 @@ command.
 | `kast rpc …raw/workspace-refresh…` | Manually request a workspace refresh through raw JSON-RPC.           | JSON argument or `--request-file`                  |
 | `kast stop`             | Shut the backend down cleanly and print what was removed.                    | `--output`                                         |
 | `kast capabilities`     | Summarize which JSON-RPC methods this backend supports.                       | `--output`                                         |
+| `kast doctor`           | Verify install metadata, config validity, canonical paths, and binary linkage. | `--output`                                      |
 | `kast lsp --stdio`      | Run the Language Server Protocol adapter over stdio.                          | `--workspace-root`, `--backend`                    |
 | `kast rpc …health…`     | Lightweight liveness ping. Returns immediately.                               | JSON argument or `--request-file`                  |
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -78,6 +78,9 @@ kast install affected
 
 To apply the planned repair, rerun with `--apply`. The command creates backups
 under `KAST_CONFIG_HOME/backups` before replacing or removing managed files.
+If `config.toml` is malformed, apply mode preserves the original file in that
+backup directory, writes safe default settings, and reports the recovery in the
+repair result.
 
 ```console title="Repair affected installs"
 kast install affected --apply

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,6 +12,20 @@ that matches what you're seeing.
 
 ## Installation and startup
 
+??? question "I need to know which Kast install is active"
+
+    Run doctor in JSON mode first:
+
+    ```console
+    kast --output json doctor
+    ```
+
+    The payload reports `configuration.valid`, `canonicalDirectory`,
+    `binary.runningBinary`, `binary.configuredBinary`, install metadata,
+    issues, and warnings. `doctor` still emits this payload when
+    `config.toml` is malformed, so configuration failures can be diagnosed
+    without guessing which file or binary was active.
+
 ??? question "Daemon won't start"
 
     **Symptoms:** a `health` JSON-RPC request returns an error or


### PR DESCRIPTION
## Summary
- add structured `configuration`, `canonicalDirectory`, and `binary` diagnostics to `kast doctor`
- let `doctor` emit JSON diagnostics for malformed config instead of failing before output
- preserve stale install metadata repair for valid doctor runs
- document doctor as the install/config/binary linkage inspection command

## Validation
- `cargo test --manifest-path cli-rs/Cargo.toml --test cli_smoke`
- `zensical build --clean`
- `git diff --check`

## Notes
This is an additive CLI-owned diagnostics contract. It does not change the JSON-RPC daemon/OpenAPI surface.