### PR TITLE
Normalize Homebrew plugin profile links

### DIFF
--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -834,7 +834,7 @@ fn repair_affected_jetbrains_profiles(
             if let Some(parent) = plugin_link.parent() {
                 fs::create_dir_all(parent)?;
             }
-            create_plugin_link(&expected_plugin_target, &plugin_link, result)?;
+            create_plugin_link(&expected_plugin_target, &plugin_link, &mut result.warnings)?;
         }
     }
     Ok(())
@@ -1047,10 +1047,16 @@ fn resolve_command_bin_dir(command_name: &str) -> Result<Option<PathBuf>> {
 }
 
 fn expected_homebrew_plugin_target(result: &mut InstallAffectedResult) -> Result<Option<PathBuf>> {
+    expected_homebrew_plugin_target_with_warnings(&mut result.warnings)
+}
+
+fn expected_homebrew_plugin_target_with_warnings(
+    warnings: &mut Vec<String>,
+) -> Result<Option<PathBuf>> {
     let brew_prefix = match homebrew_prefix(&["--prefix"]) {
         Ok(value) => value,
         Err(error) => {
-            result.warnings.push(format!(
+            warnings.push(format!(
                 "Could not resolve Homebrew prefix; skipping JetBrains plugin link repair: {}",
                 error.message
             ));
@@ -1058,7 +1064,7 @@ fn expected_homebrew_plugin_target(result: &mut InstallAffectedResult) -> Result
         }
     };
     let formula_tap = homebrew_formula_tap().unwrap_or_else(|error| {
-        result.warnings.push(format!(
+        warnings.push(format!(
             "Could not resolve the Homebrew tap for kast; using {DEFAULT_KAST_TAP}: {}",
             error.message
         ));
@@ -1066,8 +1072,16 @@ fn expected_homebrew_plugin_target(result: &mut InstallAffectedResult) -> Result
     });
     let cask_token = format!("{formula_tap}/{KAST_PLUGIN_CASK_NAME}");
     let cask_name = cask_name(&cask_token);
-    let Some(version) = homebrew_cask_version(&cask_name)? else {
-        result.warnings.push(format!(
+    expected_homebrew_plugin_target_for_cask(&cask_name, &brew_prefix, warnings)
+}
+
+fn expected_homebrew_plugin_target_for_cask(
+    cask_name: &str,
+    brew_prefix: &Path,
+    warnings: &mut Vec<String>,
+) -> Result<Option<PathBuf>> {
+    let Some(version) = homebrew_cask_version(cask_name)? else {
+        warnings.push(format!(
             "Homebrew cask {cask_name} is not installed; skipping JetBrains plugin link repair"
         ));
         return Ok(None);
@@ -1082,22 +1096,14 @@ fn expected_homebrew_plugin_target(result: &mut InstallAffectedResult) -> Result
 }
 
 #[cfg(unix)]
-fn create_plugin_link(
-    source: &Path,
-    target: &Path,
-    _result: &mut InstallAffectedResult,
-) -> Result<()> {
+fn create_plugin_link(source: &Path, target: &Path, _warnings: &mut Vec<String>) -> Result<()> {
     std::os::unix::fs::symlink(source, target)?;
     Ok(())
 }
 
 #[cfg(not(unix))]
-fn create_plugin_link(
-    _source: &Path,
-    target: &Path,
-    result: &mut InstallAffectedResult,
-) -> Result<()> {
-    result.warnings.push(format!(
+fn create_plugin_link(_source: &Path, target: &Path, warnings: &mut Vec<String>) -> Result<()> {
+    warnings.push(format!(
         "Cannot create JetBrains plugin symlink on this platform; left {} unchanged",
         target.display()
     ));
@@ -1368,7 +1374,7 @@ fn install_idea_plugin_into_jetbrains_profiles(
     args: IdeaPluginInstallArgs,
     homebrew: HomebrewContext,
     cask_token: String,
-    warnings: Vec<String>,
+    mut warnings: Vec<String>,
 ) -> Result<InstallIdeaPluginResult> {
     let jetbrains_config_root = args
         .jetbrains_config_root
@@ -1415,6 +1421,12 @@ fn install_idea_plugin_into_jetbrains_profiles(
                 &output,
             ));
         }
+        ensure_homebrew_plugin_profile_links(
+            &homebrew,
+            &cask_name,
+            &plugin_directories,
+            &mut warnings,
+        )?;
     }
 
     Ok(InstallIdeaPluginResult {
@@ -1435,6 +1447,68 @@ fn install_idea_plugin_into_jetbrains_profiles(
         warnings,
         schema_version: SCHEMA_VERSION,
     })
+}
+
+fn ensure_homebrew_plugin_profile_links(
+    homebrew: &HomebrewContext,
+    cask_name: &str,
+    plugin_directories: &[PathBuf],
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let Some(expected_plugin_target) =
+        expected_homebrew_plugin_target_for_cask(cask_name, &homebrew.brew_prefix, warnings)?
+    else {
+        return Ok(());
+    };
+    for plugin_dir in plugin_directories {
+        let plugin_link = plugin_dir.join("kast");
+        ensure_homebrew_plugin_profile_link(&expected_plugin_target, &plugin_link, warnings)?;
+    }
+    Ok(())
+}
+
+fn ensure_homebrew_plugin_profile_link(
+    expected_plugin_target: &Path,
+    plugin_link: &Path,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    if fs::read_link(plugin_link)
+        .ok()
+        .is_some_and(|target| target == expected_plugin_target)
+    {
+        return Ok(());
+    }
+    if path_exists_or_symlink(plugin_link) {
+        let Some(current_target) = fs::read_link(plugin_link).ok() else {
+            warnings.push(format!(
+                "Not replacing existing JetBrains plugin path {}; run `kast install affected --apply` for backed-up repair",
+                plugin_link.display()
+            ));
+            return Ok(());
+        };
+        if !current_target
+            .display()
+            .to_string()
+            .contains("/Caskroom/kast-plugin/")
+            && !current_target
+                .display()
+                .to_string()
+                .contains("/kast-plugin/")
+        {
+            warnings.push(format!(
+                "Not replacing existing JetBrains plugin link {} -> {}; run `kast install affected --apply` for backed-up repair",
+                plugin_link.display(),
+                current_target.display()
+            ));
+            return Ok(());
+        }
+        remove_existing_path(plugin_link)?;
+    }
+    if let Some(parent) = plugin_link.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    create_plugin_link(expected_plugin_target, plugin_link, warnings)?;
+    Ok(())
 }
 
 fn install_archive(args: InstallArgs) -> Result<ArchiveInstallResult> {

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -25,6 +25,7 @@ fn write_fake_brew(bin_dir: &Path, formula_prefix: &Path) -> PathBuf {
         format!(
             r#"#!/bin/sh
 set -eu
+state_file="${{HOME:-/tmp}}/.fake-brew-kast-plugin-version"
 if [ "$1" = "--prefix" ] && [ "$#" -eq 1 ]; then
   printf '%s\n' "/opt/homebrew"
 elif [ "$1" = "--prefix" ] && [ "$2" = "kast" ]; then
@@ -38,12 +39,17 @@ elif [ "$1" = "fetch" ] && [ "$2" = "--cask" ]; then
 elif [ "$1" = "--cache" ] && [ "$2" = "--cask" ]; then
   printf '%s\n' "${{HOME:-/tmp}}/000--kast-plugin.zip"
 elif [ "$1" = "install" ] && [ "$2" = "--cask" ]; then
+  printf '%s\n' "${{KAST_FAKE_BREW_INSTALL_VERSION:-9.8.7}}" > "$state_file"
   printf 'fake brew installed kast plugin\n' >&2
 elif [ "$1" = "reinstall" ] && [ "$2" = "--cask" ]; then
+  printf '%s\n' "${{KAST_FAKE_BREW_INSTALL_VERSION:-9.8.7}}" > "$state_file"
   printf 'fake brew reinstalled kast plugin\n' >&2
 elif [ "$1" = "list" ] && [ "$2" = "--cask" ]; then
   if [ "${{KAST_FAKE_BREW_CASK_VERSION:-}}" != "" ]; then
     printf 'kast-plugin %s\n' "$KAST_FAKE_BREW_CASK_VERSION"
+  elif [ -f "$state_file" ]; then
+    read -r installed_version < "$state_file"
+    printf 'kast-plugin %s\n' "$installed_version"
   else
     exit 1
   fi
@@ -1906,6 +1912,12 @@ fn plugin_install_gateway_installs_homebrew_cask_and_links_profiles() {
     );
     assert!(stdout.get("downloadDir").is_none(), "{stdout}");
     assert!(stdout.get("downloadedPath").is_none(), "{stdout}");
+    #[cfg(unix)]
+    assert_eq!(
+        std::fs::read_link(jetbrains_root.join("IntelliJIdea2026.1/plugins/kast"))
+            .expect("plugin symlink"),
+        Path::new("/opt/homebrew/Caskroom/kast-plugin/9.8.7/backend-idea")
+    );
 }
 
 #[test]
@@ -1934,6 +1946,53 @@ fn plugin_install_rejects_manual_download_directory() {
     assert!(
         stderr.contains("unexpected argument '--download-dir'"),
         "stderr should reject the retired manual download flag: {stderr}"
+    );
+}
+
+#[test]
+fn plugin_install_repairs_stale_homebrew_profile_link() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let brew_bin = temp.path().join("bin");
+    let jetbrains_root = temp.path().join("jetbrains");
+    let plugins_dir = jetbrains_root.join("IntelliJIdea2026.1/plugins");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&plugins_dir).expect("profile plugins");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(
+        "/opt/homebrew/Caskroom/kast-plugin/0.7.35/backend-idea",
+        plugins_dir.join("kast"),
+    )
+    .expect("stale plugin symlink");
+    let formula_prefix = Path::new(env!("CARGO_BIN_EXE_kast"))
+        .parent()
+        .expect("binary parent");
+    write_fake_brew(&brew_bin, formula_prefix);
+
+    let install = kast(&home, &config_home)
+        .env("PATH", &brew_bin)
+        .args([
+            "--output",
+            "json",
+            "install",
+            "plugin",
+            "--jetbrains-config-root",
+            jetbrains_root.to_str().expect("jetbrains root"),
+        ])
+        .output()
+        .expect("install plugin");
+
+    assert!(
+        install.status.success(),
+        "plugin install should repair stale Homebrew links: stdout={}, stderr={}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        std::fs::read_link(plugins_dir.join("kast")).expect("plugin symlink after repair"),
+        Path::new("/opt/homebrew/Caskroom/kast-plugin/9.8.7/backend-idea")
     );
 }
 


### PR DESCRIPTION
## Summary
- share Homebrew cask target resolution between repair and plugin install paths
- have `kast install plugin` create missing JetBrains `plugins/kast` links after Homebrew installs the cask
- have `kast install plugin` refresh stale Homebrew-managed JetBrains links to the current Caskroom target
- keep unrelated existing plugin paths intact and report repair guidance via warnings

## Validation
- `cargo test --manifest-path cli-rs/Cargo.toml --test cli_smoke plugin_install`
- `cargo test --manifest-path cli-rs/Cargo.toml --test cli_smoke`
- `git diff --check`

Stacked on #253 (`feature/homebrew-macos-boundary`).