### PR TITLE
Recover malformed global config during repair

### DIFF
--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -303,6 +303,12 @@ fn setup_headless_present() -> Result<bool> {
         .is_some_and(|runtime_libs_dir| runtime_libs_dir.join("classpath.txt").is_file()))
 }
 
+#[derive(Clone, Copy)]
+enum InstallReconciliationScope {
+    ConfigOnly,
+    Full,
+}
+
 pub fn repair_if_running_cli_version_changed() -> Result<Option<InstallAffectedResult>> {
     let Some(install) = self_mgmt::read_global_install_state()? else {
         return Ok(None);
@@ -310,10 +316,13 @@ pub fn repair_if_running_cli_version_changed() -> Result<Option<InstallAffectedR
     if install.version.trim() == cli::version() {
         return Ok(None);
     }
-    install_affected(AffectedInstallArgs {
-        apply: true,
-        jetbrains_config_root: None,
-    })
+    reconcile_install_state(
+        AffectedInstallArgs {
+            apply: true,
+            jetbrains_config_root: None,
+        },
+        InstallReconciliationScope::Full,
+    )
     .map(Some)
 }
 
@@ -332,6 +341,24 @@ pub fn install_headless(args: HeadlessInstallArgs) -> Result<backend::BackendIns
 }
 
 pub fn install_affected(args: AffectedInstallArgs) -> Result<InstallAffectedResult> {
+    reconcile_install_state(args, InstallReconciliationScope::Full)
+}
+
+fn repair_global_config_for_running_cli(apply: bool) -> Result<()> {
+    reconcile_install_state(
+        AffectedInstallArgs {
+            apply,
+            jetbrains_config_root: None,
+        },
+        InstallReconciliationScope::ConfigOnly,
+    )
+    .map(|_| ())
+}
+
+fn reconcile_install_state(
+    args: AffectedInstallArgs,
+    scope: InstallReconciliationScope,
+) -> Result<InstallAffectedResult> {
     let config_path = config::global_config_path();
     let backup_root = config::kast_config_home()
         .join("backups")
@@ -372,59 +399,15 @@ pub fn install_affected(args: AffectedInstallArgs) -> Result<InstallAffectedResu
         &backup_root,
         &mut config_backed_up,
     )?;
+    if matches!(scope, InstallReconciliationScope::ConfigOnly) {
+        return Ok(result);
+    }
     repair_affected_skill_targets(&args, &mut result, &backup_root)?;
     repair_affected_copilot_repos(&args, &mut result, &backup_root)?;
     repair_affected_shell_sources(&args, &mut result, &backup_root)?;
     repair_affected_jetbrains_profiles(&args, &mut result, &backup_root)?;
 
     Ok(result)
-}
-
-fn repair_global_config_for_running_cli(apply: bool) -> Result<()> {
-    let config_path = config::global_config_path();
-    let backup_root = config::kast_config_home()
-        .join("backups")
-        .join(format!("install-affected-{}", backup_timestamp()));
-    let mut result = InstallAffectedResult {
-        applied: apply,
-        config_path: config_path.display().to_string(),
-        apply_command: "kast install affected --apply".to_string(),
-        actions: vec![],
-        backups: vec![],
-        warnings: vec![],
-        schema_version: SCHEMA_VERSION,
-    };
-    let mut config_backed_up = false;
-
-    if !config_path.is_file() {
-        push_affected_action(
-            &mut result,
-            "provision-config",
-            &config_path,
-            "Create the global Kast config from current defaults.",
-            None,
-        );
-        if apply {
-            config::init_config()?;
-        }
-    }
-
-    let args = AffectedInstallArgs {
-        apply,
-        jetbrains_config_root: None,
-    };
-    let Some(global_config) =
-        load_global_config_for_repair(&args, &mut result, &backup_root, &mut config_backed_up)?
-    else {
-        return Ok(());
-    };
-    repair_affected_config_state(
-        &args,
-        &global_config,
-        &mut result,
-        &backup_root,
-        &mut config_backed_up,
-    )
 }
 
 fn load_global_config_for_repair(

--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -360,7 +360,11 @@ pub fn install_affected(args: AffectedInstallArgs) -> Result<InstallAffectedResu
         }
     }
 
-    let global_config = config::KastConfig::load_global()?;
+    let Some(global_config) =
+        load_global_config_for_repair(&args, &mut result, &backup_root, &mut config_backed_up)?
+    else {
+        return Ok(result);
+    };
     repair_affected_config_state(
         &args,
         &global_config,
@@ -405,17 +409,58 @@ fn repair_global_config_for_running_cli(apply: bool) -> Result<()> {
         }
     }
 
-    let global_config = config::KastConfig::load_global()?;
+    let args = AffectedInstallArgs {
+        apply,
+        jetbrains_config_root: None,
+    };
+    let Some(global_config) =
+        load_global_config_for_repair(&args, &mut result, &backup_root, &mut config_backed_up)?
+    else {
+        return Ok(());
+    };
     repair_affected_config_state(
-        &AffectedInstallArgs {
-            apply,
-            jetbrains_config_root: None,
-        },
+        &args,
         &global_config,
         &mut result,
         &backup_root,
         &mut config_backed_up,
     )
+}
+
+fn load_global_config_for_repair(
+    args: &AffectedInstallArgs,
+    result: &mut InstallAffectedResult,
+    backup_root: &Path,
+    config_backed_up: &mut bool,
+) -> Result<Option<config::KastConfig>> {
+    match config::KastConfig::load_global() {
+        Ok(global_config) => Ok(Some(global_config)),
+        Err(error) if error.code == "CONFIG_ERROR" => {
+            let config_path = config::global_config_path();
+            push_affected_action(
+                result,
+                "recover-invalid-config",
+                &config_path,
+                "Back up the invalid global Kast config and restore safe defaults.",
+                Some("kast install affected --apply".to_string()),
+            );
+            if !args.apply {
+                result.warnings.push(format!(
+                    "Global config is invalid at {}; rerun with --apply to back it up and restore safe defaults: {}",
+                    config_path.display(),
+                    error.message
+                ));
+                return Ok(None);
+            }
+            backup_config_once(result, backup_root, config_backed_up)?;
+            if let Some(parent) = config_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(&config_path, config::default_config_template()?)?;
+            Ok(Some(config::KastConfig::load_global()?))
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn repair_affected_config_state(

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -2171,6 +2171,116 @@ version = "v0.7.35"
 }
 
 #[test]
+fn install_affected_recovers_malformed_global_config_with_backup() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::write(config_home.join("config.toml"), "[runtime\n").expect("malformed config");
+
+    let dry_run = kast(&home, &config_home)
+        .args(["--output", "json", "install", "affected"])
+        .output()
+        .expect("dry-run affected");
+
+    assert!(
+        dry_run.status.success(),
+        "dry-run repair should report malformed config without failing: stdout={}, stderr={}",
+        String::from_utf8_lossy(&dry_run.stdout),
+        String::from_utf8_lossy(&dry_run.stderr)
+    );
+    let dry_run_stdout: serde_json::Value =
+        serde_json::from_slice(&dry_run.stdout).expect("dry-run json");
+    assert_eq!(dry_run_stdout["applied"], false);
+    assert!(
+        dry_run_stdout["actions"]
+            .as_array()
+            .expect("actions")
+            .iter()
+            .any(|action| action["kind"] == "recover-invalid-config"),
+        "dry-run should plan config recovery: {dry_run_stdout}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(config_home.join("config.toml")).expect("config after dry-run"),
+        "[runtime\n"
+    );
+
+    let apply = kast(&home, &config_home)
+        .args(["--output", "json", "install", "affected", "--apply"])
+        .output()
+        .expect("apply affected");
+
+    assert!(
+        apply.status.success(),
+        "apply repair should recover malformed config: stdout={}, stderr={}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let apply_stdout: serde_json::Value =
+        serde_json::from_slice(&apply.stdout).expect("apply json");
+    assert_eq!(apply_stdout["applied"], true);
+    assert!(
+        apply_stdout["actions"]
+            .as_array()
+            .expect("actions")
+            .iter()
+            .any(|action| action["kind"] == "recover-invalid-config"),
+        "apply should report config recovery: {apply_stdout}"
+    );
+    let backups = apply_stdout["backups"].as_array().expect("backups");
+    assert!(
+        !backups.is_empty(),
+        "apply should preserve the malformed config"
+    );
+    let backup =
+        std::fs::read_to_string(backups[0].as_str().expect("backup path")).expect("backup content");
+    assert_eq!(backup, "[runtime\n");
+    let recovered =
+        std::fs::read_to_string(config_home.join("config.toml")).expect("recovered config");
+    assert!(recovered.contains("[server]"), "{recovered}");
+    recovered
+        .parse::<toml::Table>()
+        .expect("recovered config should be valid TOML");
+    assert!(!recovered.contains("[runtime\n"), "{recovered}");
+
+    std::fs::write(config_home.join("config.toml"), "[runtime\n")
+        .expect("malformed config before setup");
+    let setup = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "setup",
+            "--skip-shell",
+            "--skip-headless",
+            "--skip-plugin",
+        ])
+        .output()
+        .expect("setup after recovery");
+    assert!(
+        setup.status.success(),
+        "setup should accept recovered defaults: stdout={}, stderr={}",
+        String::from_utf8_lossy(&setup.stdout),
+        String::from_utf8_lossy(&setup.stderr)
+    );
+    let setup_stdout: serde_json::Value =
+        serde_json::from_slice(&setup.stdout).expect("setup json");
+    assert!(
+        setup_stdout["repair"]["actions"]
+            .as_array()
+            .expect("setup repair actions")
+            .iter()
+            .any(|action| action["kind"] == "recover-invalid-config"),
+        "setup should report config recovery: {setup_stdout}"
+    );
+    let setup_recovered =
+        std::fs::read_to_string(config_home.join("config.toml")).expect("setup recovered config");
+    setup_recovered
+        .parse::<toml::Table>()
+        .expect("setup recovered config should be valid TOML");
+}
+
+#[test]
 fn ordinary_commands_repair_stale_install_version_once() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -78,6 +78,9 @@ kast install affected
 
 To apply the planned repair, rerun with `--apply`. The command creates backups
 under `KAST_CONFIG_HOME/backups` before replacing or removing managed files.
+If `config.toml` is malformed, apply mode preserves the original file in that
+backup directory, writes safe default settings, and reports the recovery in the
+repair result.
 
 ```console title="Repair affected installs"
 kast install affected --apply


### PR DESCRIPTION
## Summary
- make `kast install affected` dry-run report malformed global config instead of failing with `CONFIG_ERROR`
- make `kast install affected --apply` back up malformed `config.toml`, write safe defaults, and continue repair
- make `kast setup` inherit the same recovery behavior through its normal repair step
- document the backup/default recovery behavior in the install guide

## Validation
- `cargo test --manifest-path cli-rs/Cargo.toml --test cli_smoke install_affected_recovers_malformed_global_config_with_backup`
- `cargo test --manifest-path cli-rs/Cargo.toml --test cli_smoke`
- `zensical build --clean`
- `git diff --check`

Stacked on #251 (`feature/doctor-canonical-diagnostics`).