### PR TITLE
Normalize install reconciliation path

### DIFF
--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -303,6 +303,12 @@ fn setup_headless_present() -> Result<bool> {
         .is_some_and(|runtime_libs_dir| runtime_libs_dir.join("classpath.txt").is_file()))
 }
 
+#[derive(Clone, Copy)]
+enum InstallReconciliationScope {
+    ConfigOnly,
+    Full,
+}
+
 pub fn repair_if_running_cli_version_changed() -> Result<Option<InstallAffectedResult>> {
     let Some(install) = self_mgmt::read_global_install_state()? else {
         return Ok(None);
@@ -310,10 +316,13 @@ pub fn repair_if_running_cli_version_changed() -> Result<Option<InstallAffectedR
     if install.version.trim() == cli::version() {
         return Ok(None);
     }
-    install_affected(AffectedInstallArgs {
-        apply: true,
-        jetbrains_config_root: None,
-    })
+    reconcile_install_state(
+        AffectedInstallArgs {
+            apply: true,
+            jetbrains_config_root: None,
+        },
+        InstallReconciliationScope::Full,
+    )
     .map(Some)
 }
 
@@ -332,6 +341,24 @@ pub fn install_headless(args: HeadlessInstallArgs) -> Result<backend::BackendIns
 }
 
 pub fn install_affected(args: AffectedInstallArgs) -> Result<InstallAffectedResult> {
+    reconcile_install_state(args, InstallReconciliationScope::Full)
+}
+
+fn repair_global_config_for_running_cli(apply: bool) -> Result<()> {
+    reconcile_install_state(
+        AffectedInstallArgs {
+            apply,
+            jetbrains_config_root: None,
+        },
+        InstallReconciliationScope::ConfigOnly,
+    )
+    .map(|_| ())
+}
+
+fn reconcile_install_state(
+    args: AffectedInstallArgs,
+    scope: InstallReconciliationScope,
+) -> Result<InstallAffectedResult> {
     let config_path = config::global_config_path();
     let backup_root = config::kast_config_home()
         .join("backups")
@@ -372,59 +399,15 @@ pub fn install_affected(args: AffectedInstallArgs) -> Result<InstallAffectedResu
         &backup_root,
         &mut config_backed_up,
     )?;
+    if matches!(scope, InstallReconciliationScope::ConfigOnly) {
+        return Ok(result);
+    }
     repair_affected_skill_targets(&args, &mut result, &backup_root)?;
     repair_affected_copilot_repos(&args, &mut result, &backup_root)?;
     repair_affected_shell_sources(&args, &mut result, &backup_root)?;
     repair_affected_jetbrains_profiles(&args, &mut result, &backup_root)?;
 
     Ok(result)
-}
-
-fn repair_global_config_for_running_cli(apply: bool) -> Result<()> {
-    let config_path = config::global_config_path();
-    let backup_root = config::kast_config_home()
-        .join("backups")
-        .join(format!("install-affected-{}", backup_timestamp()));
-    let mut result = InstallAffectedResult {
-        applied: apply,
-        config_path: config_path.display().to_string(),
-        apply_command: "kast install affected --apply".to_string(),
-        actions: vec![],
-        backups: vec![],
-        warnings: vec![],
-        schema_version: SCHEMA_VERSION,
-    };
-    let mut config_backed_up = false;
-
-    if !config_path.is_file() {
-        push_affected_action(
-            &mut result,
-            "provision-config",
-            &config_path,
-            "Create the global Kast config from current defaults.",
-            None,
-        );
-        if apply {
-            config::init_config()?;
-        }
-    }
-
-    let args = AffectedInstallArgs {
-        apply,
-        jetbrains_config_root: None,
-    };
-    let Some(global_config) =
-        load_global_config_for_repair(&args, &mut result, &backup_root, &mut config_backed_up)?
-    else {
-        return Ok(());
-    };
-    repair_affected_config_state(
-        &args,
-        &global_config,
-        &mut result,
-        &backup_root,
-        &mut config_backed_up,
-    )
 }
 
 fn load_global_config_for_repair(


### PR DESCRIPTION
## Summary
- collapse duplicate config/install repair setup into one `reconcile_install_state` path
- keep `install affected` and stale-version auto-repair on full reconciliation
- let plugin/config preflight use the same path with a config-only scope

## Validation
- `cargo fmt --manifest-path cli-rs/Cargo.toml`
- `cargo test --manifest-path cli-rs/Cargo.toml --test cli_smoke install_affected_recovers_malformed_global_config_with_backup -- --nocapture`
- `cargo test --manifest-path cli-rs/Cargo.toml --test cli_smoke ordinary_commands_repair_stale_install_version_once -- --nocapture`
- `cargo test --manifest-path cli-rs/Cargo.toml --test cli_smoke plugin_install_repairs_stale_config_before_linking_profiles -- --nocapture`
- `cargo test --manifest-path cli-rs/Cargo.toml --test cli_smoke`
- `cargo test --manifest-path cli-rs/Cargo.toml`
- `git diff --check`

## Notes
- This is intentionally stacked on #255 (`feature/settings-recovery`) because that branch introduced the invalid-config recovery path being consolidated.
- The Homebrew-only/plugin-link branch is a sibling stack; the eventual integration should merge this reconciliation helper with that branch rather than preserve parallel repair paths.
