### PR TITLE
Reload IDEA backend config live

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginService.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginService.kt
@@ -20,23 +20,13 @@ internal class KastPluginService(
     @Volatile
     private var runningBackend: RunningKastIdeaBackend? = null
 
+    @Volatile
+    private var runningConfig: KastConfig? = null
+
     fun startServer() {
         if (runningBackend != null) return
-        val basePath = project.basePath ?: return
-        val workspaceRoot = Path.of(basePath).toAbsolutePath().normalize()
-
-        LOG.info("Starting kast idea backend for workspace: $workspaceRoot")
-
-        val kastConfig = loadIdeaKastConfig(workspaceRoot)
-        val socketPath = defaultSocketPath(workspaceRoot)
-        runningBackend = KastIdeaBackendRuntime.start(
-            project = project,
-            workspaceRoot = workspaceRoot,
-            socketPath = socketPath,
-            config = kastConfig,
-        )
-
-        LOG.info("Kast idea backend started on socket: $socketPath")
+        val workspaceRoot = workspaceRoot() ?: return
+        startServer(workspaceRoot, loadIdeaKastConfig(workspaceRoot))
     }
 
     override fun dispose() {
@@ -44,8 +34,40 @@ internal class KastPluginService(
     }
 
     fun restartServer() {
+        val workspaceRoot = workspaceRoot() ?: return
+        restartServer(workspaceRoot, loadIdeaKastConfig(workspaceRoot))
+    }
+
+    fun reloadConfig(): KastConfigReloadDecision {
+        val workspaceRoot = workspaceRoot() ?: return KastConfigReloadDecision.UNCHANGED
+        val nextConfig = loadIdeaKastConfig(workspaceRoot)
+        return when (configReloadDecision(runningConfig, nextConfig)) {
+            KastConfigReloadDecision.UNCHANGED -> KastConfigReloadDecision.UNCHANGED
+            KastConfigReloadDecision.RESTART_BACKEND -> {
+                restartServer(workspaceRoot, nextConfig)
+                KastConfigReloadDecision.RESTART_BACKEND
+            }
+        }
+    }
+
+    private fun restartServer(workspaceRoot: Path, config: KastConfig) {
         stopServer()
-        startServer()
+        startServer(workspaceRoot, config)
+    }
+
+    private fun startServer(workspaceRoot: Path, config: KastConfig) {
+        LOG.info("Starting kast idea backend for workspace: $workspaceRoot")
+
+        val socketPath = defaultSocketPath(workspaceRoot)
+        runningBackend = KastIdeaBackendRuntime.start(
+            project = project,
+            workspaceRoot = workspaceRoot,
+            socketPath = socketPath,
+            config = config,
+        )
+        runningConfig = config
+
+        LOG.info("Kast idea backend started on socket: $socketPath")
     }
 
     private fun stopServer() {
@@ -55,7 +77,10 @@ internal class KastPluginService(
                 .onFailure { LOG.warn("Error closing kast server", it) }
             runningBackend = null
         }
+        runningConfig = null
     }
+
+    private fun workspaceRoot(): Path? = project.basePath?.let { Path.of(it).toAbsolutePath().normalize() }
 
     companion object {
         fun getInstance(project: Project): KastPluginService = project.service()
@@ -80,6 +105,17 @@ internal fun loadIdeaKastConfig(
         reportFailure(workspaceRoot, error)
         KastConfig.defaults()
     }
+
+internal enum class KastConfigReloadDecision {
+    UNCHANGED,
+    RESTART_BACKEND,
+}
+
+internal fun configReloadDecision(
+    current: KastConfig?,
+    next: KastConfig,
+): KastConfigReloadDecision =
+    if (current == next) KastConfigReloadDecision.UNCHANGED else KastConfigReloadDecision.RESTART_BACKEND
 
 internal fun ideaServerLimits(config: KastConfig): ServerLimits = ServerLimits(
     maxConcurrentRequests = config.server.maxConcurrentRequests.value.coerceAtLeast(1),

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastSettingsConfigurable.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastSettingsConfigurable.kt
@@ -49,7 +49,6 @@ internal class KastSettingsConfigurable(
         ensurePanel()
         val workspaceRoot = workspaceRoot() ?: return
         val state = KastSettingsState.getInstance(project)
-        val previousBackends = state.toOverride().backends
         updateStateFromFields(state)
 
         val configPath = WorkspaceDirectoryResolver()
@@ -60,10 +59,7 @@ internal class KastSettingsConfigurable(
         Files.createDirectories(configPath.parent)
         Files.writeString(configPath, nextToml)
 
-        val nextBackends = state.toOverride().backends
-        if (previousBackends != nextBackends) {
-            KastPluginService.getInstance(project).restartServer()
-        }
+        KastPluginService.getInstance(project).reloadConfig()
     }
 
     override fun disposeUIResources() {

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginServiceConfigTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginServiceConfigTest.kt
@@ -104,6 +104,19 @@ class KastPluginServiceConfigTest {
     }
 
     @Test
+    fun `config reload restarts backend only when effective config changes`() {
+        val defaults = KastConfig.defaults()
+        val changed = defaults.copy(
+            server = defaults.server.copy(
+                maxResults = ServerMaxResults(42),
+            ),
+        )
+
+        assertEquals(KastConfigReloadDecision.UNCHANGED, configReloadDecision(defaults, defaults))
+        assertEquals(KastConfigReloadDecision.RESTART_BACKEND, configReloadDecision(defaults, changed))
+    }
+
+    @Test
     fun `idea telemetry uses config`() {
         val telemetry = IdeaBackendTelemetry.fromConfig(
             workspaceRoot = Path.of("/tmp/workspace"),

--- a/docs/getting-started/backends.md
+++ b/docs/getting-started/backends.md
@@ -157,6 +157,11 @@ executable CLI binary:
 binaryPath = "/home/alex/.local/bin/kast"
 ```
 
+Applying Kast settings in IDEA reloads the workspace config and restarts the
+local Kast backend when the effective config changes. Installing or relinking
+the Homebrew-managed plugin still requires restarting the IDE so JetBrains can
+load the plugin from the profile link.
+
 To hydrate a remote SQLite source index before local indexing starts, add an
 `indexing.remote` block. `sourceIndexUrl` accepts `file://`, `http://`, and
 `https://` URLs that point to a `source-index.db` snapshot:


### PR DESCRIPTION
## Summary
- track the effective Kast config used by the IDEA backend service
- add a reload decision path that restarts the local backend only when loaded config changes
- make settings Apply call the service reload path instead of owning a partial backend comparison
- document that settings reload live, while plugin/profile relinks still need an IDE restart

## Validation
- red: `./gradlew :backend-idea:test --tests io.github.amichne.kast.idea.KastPluginServiceConfigTest` failed on missing reload API
- `./gradlew :backend-idea:test --tests io.github.amichne.kast.idea.KastPluginServiceConfigTest --tests io.github.amichne.kast.idea.KastSettingsConfigurableTest`
- `./gradlew :backend-idea:test`
- `./gradlew :backend-idea:verifyPluginXmlPresent`
- `zensical build --clean`
- `git diff --check`
