### PR TITLE
Add Kast Copilot reader and writer agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,11 +20,11 @@
   `kast rpc '<jsonrpc-request>'` directly instead of relying on exported shell
   state across tool calls.
 - `cli-rs/resources/plugin/` is the primary Copilot package source for this
-  repo. It owns only the `kast-kotlin` LSP configuration. Hooks, agents,
-  instructions, skills, and the deprecated SDK extension runtime are not shipped
-  by the package. Generated install copies
-  under `.github` are local outputs, not checked-in
-  sources of truth.
+  repo. It owns the `kast-kotlin` LSP configuration, Kotlin instructions,
+  `kast-reader` and `kast-writer` agent profiles, and the SDK extension that
+  exposes catalog-backed `kast_*` tools. Hooks and standalone package skills
+  are not shipped by the package. Generated install copies under `.github` are
+  local outputs, not checked-in sources of truth.
 - Read `AGENTS.md` at the repo root first, then any deeper `AGENTS.md` in the module you touch. The narrower file
   overrides the root guide.
 

--- a/.github/scripts/test-docs-content-contract.sh
+++ b/.github/scripts/test-docs-content-contract.sh
@@ -140,6 +140,9 @@ require_contains "$install_doc" 'scripts/verify-release-assets.sh' "Install docs
 require_contains "$install_doc" '## Install the Copilot LSP package' "Install docs must document the Copilot LSP package"
 require_contains "$install_doc" 'kast install copilot' "Install docs must make the CLI Copilot install path primary"
 require_contains "$install_doc" '.github/lsp.json' "Install docs must document the LSP config output"
+require_contains "$install_doc" '.github/agents/kast-reader.agent.md' "Install docs must document the reader agent output"
+require_contains "$install_doc" '.github/agents/kast-writer.agent.md' "Install docs must document the writer agent output"
+require_contains "$install_doc" '--plugin-dir cli-rs/resources/plugin' "Install docs must document the Copilot CLI source-plugin validation path"
 require_not_contains "$install_doc" '## Install the legacy Copilot extension' "Install docs must not make the deprecated SDK extension an install path"
 require_not_contains "$install_doc" 'KAST_AGENT_CLI_URL' "Install docs must not mention retired headless agent variables"
 require_not_contains "$install_doc" 'KAST_AGENT_BACKEND_URL' "Install docs must not mention retired headless agent variables"
@@ -162,6 +165,7 @@ require_not_contains "$agents_doc" "amichne/kast-action@v1" "Agent docs must not
 require_not_contains "$agents_doc" 'scripts/headless-agent-install.sh' "Agent docs must not document the retired headless agent installer"
 require_not_contains "$agents_doc" 'KAST_AGENT_INSTALL_ROOT' "Agent docs must not mention retired headless agent variables"
 require_contains "$agents_doc" "Ubuntu/Debian hosted agent" "Agent docs must document hosted setup through the canonical Ubuntu/Debian installer"
+require_contains "${docs_root}/for-agents/install-the-skill.md" '--plugin-dir cli-rs/resources/plugin' "Agent install docs must document the Copilot CLI source-plugin validation path"
 require_embedded_markdown_links
 python3 "${repo_root}/.github/scripts/render-rpc-contract-summary.py" --check
 

--- a/.github/scripts/test-kast-copilot-plugin.sh
+++ b/.github/scripts/test-kast-copilot-plugin.sh
@@ -40,6 +40,11 @@ assertSameArray(
   "instructions entrypoint",
 );
 assertSameArray(
+  entrypoints.agents,
+  ["agents/kast-reader.agent.md", "agents/kast-writer.agent.md"],
+  "agents entrypoint",
+);
+assertSameArray(
   entrypoints.extensions,
   ["extensions/kast/extension.mjs"],
   "extensions entrypoint",
@@ -47,6 +52,8 @@ assertSameArray(
 assert(entrypoints.manifest === "primitive-manifest.json", "unexpected primitive manifest");
 assert(existsSync(join(root, entrypoints.lsp)), "missing LSP entrypoint file");
 assert(existsSync(join(root, entrypoints.instructions[0])), "missing instructions file");
+assert(existsSync(join(root, entrypoints.agents[0])), "missing reader agent file");
+assert(existsSync(join(root, entrypoints.agents[1])), "missing writer agent file");
 assert(existsSync(join(root, entrypoints.extensions[0])), "missing extension file");
 
 const primitive = readJson("primitive-manifest.json");
@@ -56,9 +63,12 @@ assert(
 );
 const targets = new Set(primitive.outputs.map((output) => output.target));
 const expectedTargets = new Set([
+  "agents/kast-reader.agent.md",
+  "agents/kast-writer.agent.md",
   "lsp.json",
   "instructions/kast-kotlin.instructions.md",
   "extensions/kast/extension.mjs",
+  "extensions/kast/_shared/kast-agents.mjs",
   "extensions/kast/_shared/kast-tools.mjs",
   "extensions/kast/_shared/commands.json",
 ]);
@@ -80,6 +90,10 @@ assert(
   "instructions must route through the LSP",
 );
 assert(
+  instruction.includes("`kast-reader` for read-only analysis and `kast-writer` for"),
+  "instructions must route delegation through the two Kast agents",
+);
+assert(
   instruction.includes(
     "Treat stale, not-ready, missing, ambiguous, partial, or truncated compiler facts",
   ),
@@ -90,6 +104,19 @@ assert(instruction.includes("as blockers"), "instructions must fail closed on bl
 const tools = readText("extensions/kast/_shared/kast-tools.mjs");
 assert(tools.includes("Preferred Kotlin funnel tool"), "tool guidance must prefer funnel tools");
 assert(tools.includes("Bounded raw escape hatch"), "tool guidance must bound raw escape hatches");
+
+const reader = readText("agents/kast-reader.agent.md");
+const writer = readText("agents/kast-writer.agent.md");
+assert(reader.includes("name: Kast Reader"), "reader agent must be named");
+assert(writer.includes("name: Kast Writer"), "writer agent must be named");
+assert(!reader.includes("kast_write_and_validate"), "reader must not expose write-and-validate");
+assert(!reader.includes("kast_rename"), "reader must not expose rename");
+assert(!reader.includes("  - edit"), "reader must not expose edit");
+assert(!reader.includes("  - execute"), "reader must not expose execute");
+assert(writer.includes("kast_write_and_validate"), "writer must expose write-and-validate");
+assert(writer.includes("kast_rename"), "writer must expose rename");
+assert(writer.includes("  - edit"), "writer must expose edit");
+assert(writer.includes("  - execute"), "writer must expose execute");
 NODE
 
 ensure_kast_bin() {
@@ -110,11 +137,36 @@ ensure_kast_bin() {
 
 ensure_kast_bin
 
+node --input-type=module - "$plugin_root" <<'NODE'
+const pluginRoot = process.argv[2];
+const toolsModule = await import(`file://${pluginRoot}/extensions/kast/_shared/kast-tools.mjs`);
+const agentsModule = await import(`file://${pluginRoot}/extensions/kast/_shared/kast-agents.mjs`);
+const tools = toolsModule.makeKastTools((method, args) =>
+  Promise.resolve(JSON.stringify({ ok: true, method, args })),
+);
+const names = new Set(tools.map((tool) => tool.name));
+for (const required of ["kast_resolve", "kast_references", "kast_workspace_search", "kast_metrics"]) {
+  if (!names.has(required)) throw new Error(`source plugin import missing ${required}`);
+}
+const agents = agentsModule.makeKastCustomAgents();
+const reader = agents.find((agent) => agent.name === "kast-reader");
+const writer = agents.find((agent) => agent.name === "kast-writer");
+if (!reader) throw new Error("source plugin import missing kast-reader");
+if (!writer) throw new Error("source plugin import missing kast-writer");
+for (const writeTool of ["kast_rename", "kast_write_and_validate", "edit", "execute"]) {
+  if (reader.tools.includes(writeTool)) throw new Error(`source reader must not include ${writeTool}`);
+  if (!writer.tools.includes(writeTool)) throw new Error(`source writer must include ${writeTool}`);
+}
+NODE
+
 "${plugin_root}/scripts/install-local.sh" --target "$tmp_dir" --force >"${tmp_dir}/install.json"
 
 test -f "$tmp_dir/.github/lsp.json"
 test -f "$tmp_dir/.github/instructions/kast-kotlin.instructions.md"
+test -f "$tmp_dir/.github/agents/kast-reader.agent.md"
+test -f "$tmp_dir/.github/agents/kast-writer.agent.md"
 test -f "$tmp_dir/.github/extensions/kast/extension.mjs"
+test -f "$tmp_dir/.github/extensions/kast/_shared/kast-agents.mjs"
 test -f "$tmp_dir/.github/extensions/kast/_shared/kast-tools.mjs"
 test -f "$tmp_dir/.github/extensions/kast/_shared/commands.json"
 
@@ -140,6 +192,7 @@ NODE
 node --input-type=module - "$tmp_dir" <<'NODE'
 const target = process.argv[2];
 const toolsModule = await import(`file://${target}/.github/extensions/kast/_shared/kast-tools.mjs`);
+const agentsModule = await import(`file://${target}/.github/extensions/kast/_shared/kast-agents.mjs`);
 const tools = toolsModule.makeKastTools((method, args) =>
   Promise.resolve(JSON.stringify({ ok: true, method, args })),
 );
@@ -154,6 +207,21 @@ if (!resolveTool.description.includes("Preferred Kotlin funnel tool")) {
 const workspaceFiles = tools.find((tool) => tool.name === "kast_workspace_files");
 if (!workspaceFiles.description.includes("Secondary workspace inspection tool")) {
   throw new Error("workspace files must be secondary");
+}
+const agents = agentsModule.makeKastCustomAgents();
+const agentNames = new Set(agents.map((agent) => agent.name));
+for (const required of ["kast-reader", "kast-writer"]) {
+  if (!agentNames.has(required)) throw new Error(`missing ${required}`);
+}
+const reader = agents.find((agent) => agent.name === "kast-reader");
+const writer = agents.find((agent) => agent.name === "kast-writer");
+for (const writeTool of ["kast_rename", "kast_write_and_validate", "edit", "execute"]) {
+  if (reader.tools.includes(writeTool)) throw new Error(`reader must not include ${writeTool}`);
+  if (!writer.tools.includes(writeTool)) throw new Error(`writer must include ${writeTool}`);
+}
+for (const readTool of ["kast_resolve", "kast_references", "kast_workspace_search", "kast_diagnostics"]) {
+  if (!reader.tools.includes(readTool)) throw new Error(`reader missing ${readTool}`);
+  if (!writer.tools.includes(readTool)) throw new Error(`writer missing ${readTool}`);
 }
 NODE
 

--- a/.github/scripts/test-lsp-pivot-gates.sh
+++ b/.github/scripts/test-lsp-pivot-gates.sh
@@ -10,10 +10,6 @@ die() {
   exit 1
 }
 
-sdk_surfaces=(
-  "${repo_root}/cli-rs/resources/plugin"
-)
-
 node --input-type=module - "$repo_root" <<'NODE'
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -61,6 +57,7 @@ assertSameJson(
   {
     lsp: "lsp.json",
     instructions: ["instructions/kast-kotlin.instructions.md"],
+    agents: ["agents/kast-reader.agent.md", "agents/kast-writer.agent.md"],
     extensions: ["extensions/kast/extension.mjs"],
     manifest: "primitive-manifest.json",
   },
@@ -114,6 +111,8 @@ requireText(".github/copilot-instructions.md", {
   "LSP custom methods": "capabilities.experimental.kastMethods",
   "primary Copilot package": "cli-rs/resources/plugin/",
   "generated copy wording": "Generated install copies",
+  "reader agent": "kast-reader",
+  "writer agent": "kast-writer",
 });
 
 const skillShadowing = readJson(".github/skill-shadowing.json");

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ kast-copilot-plugin/
 .github/hooks/
 .github/agents/
 .github/instructions/kast-kotlin.md
+.github/instructions/kast-kotlin.instructions.md
 .github/extensions/kast/
 .agents/skills/kast-api-surface-change/
 .agents/skills/kast-callgraph-review/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,28 +133,17 @@ searching non-Kotlin files. For Kotlin source, use
 `kast_workspace_symbol` for symbol-name searches and
 `kast_workspace_search` for string, comment, and arbitrary content searches.
 
-## Agent hooks
-
-`cli-rs/resources/plugin/hooks/hooks.json` is the authoritative source for
-GitHub Copilot hook configuration shipped by Kast. Generated `.github/hooks`
-copies are install outputs and should not be hand-edited. Use the standard
-Copilot hook schema:
-`{"version":1,"hooks":{...}}` with command hooks only. The repo-level hooks
-use `sessionStart` plus `postToolUse` state capture to track session-owned file
-edits, then run final command-based validation from `sessionEnd`. Workflow
-guidance that depends on skills, such as `refresh-affected-agents` or docs
-refresh, belongs in agent instructions rather than in the hook manifest.
-
 ## Copilot plugin
 
 `cli-rs/resources/plugin/` is the primary source for Copilot-assisted Kotlin
 work. It
 
 - provides the LSP server configuration that starts `kast lsp --stdio`,
-- provides command hooks, instructions, agents, and skills for Copilot hosts,
-  and
+- provides Kotlin instructions plus `kast-reader` and `kast-writer` agent
+  profiles for Copilot hosts,
+- provides the SDK extension that exposes catalog-backed `kast_*` tools, and
 - is embedded by the Rust CLI so `kast install copilot` can regenerate local
-  `.github` and `.agents` outputs.
+  `.github` outputs.
 
 Fall back to `cli-rs/resources/kast-skill/SKILL.md` when native host tooling is
 unavailable or when you need deeper command-shape or recovery guidance, and

--- a/cli-rs/resources/plugin/README.md
+++ b/cli-rs/resources/plugin/README.md
@@ -5,9 +5,15 @@ This package distributes the minimal reliable Kast Copilot primitive set:
 - `kast-kotlin` LSP configuration
 - Kotlin-scoped instructions that route agents through LSP and Kast methods
 - a small SDK extension that exposes catalog-backed `kast_*` tools
+- two custom agents: `kast-reader` for read-only analysis and `kast-writer` for
+  scoped edits and validation
 
-The package source is `primitive-manifest.json`; generated files under
-`.github` are install outputs.
+The package source is `plugin.json` plus `primitive-manifest.json`; generated
+files under `.github` are install outputs. When validating the SDK extension in
+Copilot CLI, load this source directory explicitly with `--plugin-dir`.
+Project-installed `.github/agents` load as `kast-reader` and `kast-writer`;
+source-plugin agents load under the plugin namespace, such as
+`kast-copilot-lsp:kast-reader`.
 
 Install into a repository:
 
@@ -19,4 +25,13 @@ Validate this package from the Kast repository:
 
 ```console
 .github/scripts/test-kast-copilot-plugin.sh
+```
+
+Validate a live Copilot CLI source-plugin load with a short request:
+
+```console
+copilot -C /path/to/repo --plugin-dir cli-rs/resources/plugin \
+  --agent kast-copilot-lsp:kast-reader \
+  --model gpt-5-mini --effort low \
+  -p 'Validation only. Reply exactly: KAST_READER_LOADED'
 ```

--- a/cli-rs/resources/plugin/agents/kast-reader.agent.md
+++ b/cli-rs/resources/plugin/agents/kast-reader.agent.md
@@ -1,0 +1,42 @@
+---
+name: Kast Reader
+description: Read-only Kotlin and Gradle analysis for questions, reviews, impact checks, and plans that need Kast LSP or kast_* compiler-backed evidence before shell or text fallback.
+tools:
+  - read
+  - search
+  - agent
+  - kast_callers
+  - kast_diagnostics
+  - kast_file_outline
+  - kast_metrics
+  - kast_references
+  - kast_resolve
+  - kast_scaffold
+  - kast_symbol_discover
+  - kast_workspace_files
+  - kast_workspace_search
+  - kast_workspace_symbol
+---
+
+# Kast Reader
+
+You are a read-only Kotlin and Gradle analysis agent for Kast-backed work.
+
+## Responsibilities
+
+1. Answer codebase questions with compiler-backed symbol identity.
+2. Review Kotlin impact, references, callers, hierarchy, diagnostics, and source-index evidence.
+3. Build implementation or migration plans without modifying files.
+4. Identify the smallest safe writer action when edits are needed.
+
+## Process
+
+1. Start with the `kast-kotlin` LSP server when the target is Kotlin or Gradle project structure.
+2. Use `kast_*` tools before broad text search, recursive file reads, or shell fallback.
+3. Prefer symbol and source-index tools for named declarations; use raw workspace search only for strings, comments, literals, or bounded file discovery.
+4. Treat stale, not-ready, missing, ambiguous, partial, or truncated Kast facts as blockers.
+5. Do not edit files, run write tools, or suggest a rename/refactor until references and impact have been checked.
+
+## Output
+
+Return concise findings with file paths, symbol identities, references checked, diagnostics status, and any blocked facts. If edits are needed, hand back the exact next action for `kast-writer`.

--- a/cli-rs/resources/plugin/agents/kast-writer.agent.md
+++ b/cli-rs/resources/plugin/agents/kast-writer.agent.md
@@ -1,0 +1,47 @@
+---
+name: Kast Writer
+description: Scoped Kotlin and Gradle implementation agent for edits, renames, migrations, and fixes that must resolve symbols, use Kast write paths, and validate with diagnostics or focused tests.
+tools:
+  - read
+  - search
+  - edit
+  - execute
+  - agent
+  - todo
+  - kast_callers
+  - kast_diagnostics
+  - kast_file_outline
+  - kast_metrics
+  - kast_references
+  - kast_rename
+  - kast_resolve
+  - kast_scaffold
+  - kast_symbol_discover
+  - kast_workspace_files
+  - kast_workspace_search
+  - kast_workspace_symbol
+  - kast_write_and_validate
+---
+
+# Kast Writer
+
+You are a Kotlin and Gradle implementation agent for scoped Kast-backed changes.
+
+## Responsibilities
+
+1. Make narrow edits after compiler-backed identity and impact are established.
+2. Use Kast rename and write-and-validate paths for Kotlin symbol edits whenever possible.
+3. Keep shared contract, capability, and package surfaces honest when a change touches them.
+4. Validate changes with Kast diagnostics and the smallest relevant test or build command.
+
+## Process
+
+1. Start by resolving the target through `kast-kotlin` LSP or `kast_*` tools.
+2. Enumerate references, callers, hierarchy, or diagnostics before changing Kotlin behavior.
+3. Prefer `kast_rename` and `kast_write_and_validate` over manual text edits for Kotlin source.
+4. Use shell execution only for validation, package checks, or narrowly scoped commands that Kast cannot perform directly.
+5. Stop and report a blocker when Kast facts are stale, not-ready, missing, ambiguous, partial, or truncated.
+
+## Output
+
+Return the changed files, the Kast evidence used before editing, validation commands run, and any residual risks or blocked checks.

--- a/cli-rs/resources/plugin/extensions/kast/_shared/kast-agents.mjs
+++ b/cli-rs/resources/plugin/extensions/kast/_shared/kast-agents.mjs
@@ -1,0 +1,35 @@
+import { KAST_READ_TOOL_NAMES, KAST_TOOL_NAMES } from "./kast-tools.mjs";
+
+const READER_BASE_TOOLS = Object.freeze(["read", "search", "agent"]);
+const WRITER_BASE_TOOLS = Object.freeze(["read", "search", "edit", "execute", "agent", "todo"]);
+
+export function kastReaderTools() {
+  return [...READER_BASE_TOOLS, ...KAST_READ_TOOL_NAMES];
+}
+
+export function kastWriterTools() {
+  return [...WRITER_BASE_TOOLS, ...KAST_TOOL_NAMES];
+}
+
+export function makeKastCustomAgents() {
+  return [
+    {
+      name: "kast-reader",
+      displayName: "Kast Reader",
+      description:
+        "Read-only Kotlin and Gradle analysis with Kast LSP and kast_* tools before shell or text fallback.",
+      tools: kastReaderTools(),
+      prompt:
+        "You are Kast Reader. Inspect Kotlin and Gradle work without editing files. Start with the kast-kotlin LSP server, then use kast_* tools for symbol identity, references, callers, hierarchy, diagnostics, workspace search, and source-index metrics. Treat stale, missing, ambiguous, partial, or truncated compiler facts as blockers. Return concise evidence with file paths, symbol identities, references checked, and the next safe writer action when edits are needed.",
+    },
+    {
+      name: "kast-writer",
+      displayName: "Kast Writer",
+      description:
+        "Scoped Kotlin and Gradle edits using Kast resolution, rename, write-and-validate, diagnostics, and focused tests.",
+      tools: kastWriterTools(),
+      prompt:
+        "You are Kast Writer. Make narrowly scoped Kotlin and Gradle changes only after compiler-backed identity is established. Resolve symbols and enumerate impact with kast-kotlin LSP or kast_* tools before editing. Prefer kast_rename and kast_write_and_validate for Kotlin changes, then run Kast diagnostics and the narrowest relevant tests. Stop and report the blocker instead of guessing when Kast facts are stale, missing, ambiguous, partial, or truncated.",
+    },
+  ];
+}

--- a/cli-rs/resources/plugin/extensions/kast/_shared/kast-tools.mjs
+++ b/cli-rs/resources/plugin/extensions/kast/_shared/kast-tools.mjs
@@ -4,12 +4,26 @@ import { fileURLToPath } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const COMMAND_CATALOG_PATH = join(HERE, "commands.json");
+const SOURCE_TREE_COMMAND_CATALOG_PATH = join(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "..",
+  "kast-skill",
+  "references",
+  "commands.json",
+);
 
 function loadCommandCatalog() {
-  if (!existsSync(COMMAND_CATALOG_PATH)) {
-    throw new Error(`Kast command catalog not found at ${COMMAND_CATALOG_PATH}`);
+  for (const path of [COMMAND_CATALOG_PATH, SOURCE_TREE_COMMAND_CATALOG_PATH]) {
+    if (existsSync(path)) {
+      return JSON.parse(readFileSync(path, "utf8"));
+    }
   }
-  return JSON.parse(readFileSync(COMMAND_CATALOG_PATH, "utf8"));
+  throw new Error(
+    `Kast command catalog not found at ${COMMAND_CATALOG_PATH} or ${SOURCE_TREE_COMMAND_CATALOG_PATH}`,
+  );
 }
 
 const COMMAND_CATALOG = loadCommandCatalog();
@@ -189,6 +203,13 @@ function buildToolSpecs(catalog) {
 const TOOL_SPECS = buildToolSpecs(COMMAND_CATALOG);
 
 export const KAST_TOOL_NAMES = Object.freeze(new Set(TOOL_SPECS.map((spec) => spec.name)));
+export const KAST_WRITE_TOOL_NAMES = Object.freeze(new Set([
+  "kast_rename",
+  "kast_write_and_validate",
+]));
+export const KAST_READ_TOOL_NAMES = Object.freeze(new Set(
+  Array.from(KAST_TOOL_NAMES).filter((name) => !KAST_WRITE_TOOL_NAMES.has(name)),
+));
 
 function normalizeArgs(spec, args) {
   const normalized = { ...(args ?? {}) };

--- a/cli-rs/resources/plugin/extensions/kast/extension.mjs
+++ b/cli-rs/resources/plugin/extensions/kast/extension.mjs
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { joinSession } from "@github/copilot-sdk/extension";
+import { makeKastCustomAgents } from "./_shared/kast-agents.mjs";
 import { KAST_TOOL_NAMES, makeKastTools } from "./_shared/kast-tools.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -197,6 +198,7 @@ async function callKast(method, params) {
 
 const session = await joinSession({
   tools: makeKastTools((method, args) => callKast(method, args)),
+  customAgents: makeKastCustomAgents(),
   disabledSkills: ["kast"],
 });
 

--- a/cli-rs/resources/plugin/instructions/kast-kotlin.instructions.md
+++ b/cli-rs/resources/plugin/instructions/kast-kotlin.instructions.md
@@ -9,6 +9,11 @@ For every Kotlin file, start with the `kast-kotlin` LSP server from
 workspace symbols, implementations, call hierarchy, type hierarchy, prepare
 rename, and rename before broad text search or manual file inspection.
 
+When delegating, use `kast-reader` for read-only analysis and `kast-writer` for
+edits. Both subagents must keep using `kast-kotlin` LSP and the catalog-backed
+`kast_*` tools; do not delegate Kotlin work to a general-purpose subagent that
+lacks those tools.
+
 For Kast-specific work outside standard LSP, inspect
 `capabilities.experimental.kastMethods` from the LSP `initialize` response and
 use the advertised `kast/*` methods before native tools or shell fallbacks.

--- a/cli-rs/resources/plugin/plugin.json
+++ b/cli-rs/resources/plugin/plugin.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "name": "kast-copilot-lsp",
   "version": "0.1.0",
-  "description": "Kast Copilot package for compiler-backed Kotlin work through LSP, instructions, and catalog-backed tools.",
+  "description": "Kast Copilot package for compiler-backed Kotlin work through LSP, instructions, reader/writer agents, and catalog-backed tools.",
   "requires": {
     "kast": ">=0.9.3",
     "copilotCli": ">=1.0.60"
@@ -12,6 +12,10 @@
     "instructions": [
       "instructions/kast-kotlin.instructions.md"
     ],
+    "agents": [
+      "agents/kast-reader.agent.md",
+      "agents/kast-writer.agent.md"
+    ],
     "extensions": [
       "extensions/kast/extension.mjs"
     ],
@@ -19,8 +23,5 @@
   },
   "install": {
     "script": "scripts/install-local.sh"
-  },
-  "deprecatedSurfaces": [
-    "Hooks, agents, and standalone package skills are intentionally out of scope for the first rewritten primitive package."
-  ]
+  }
 }

--- a/cli-rs/resources/plugin/primitive-manifest.json
+++ b/cli-rs/resources/plugin/primitive-manifest.json
@@ -17,6 +17,18 @@
     },
     {
       "type": "PACKAGE_FILE",
+      "source": "agents/kast-reader.agent.md",
+      "target": "agents/kast-reader.agent.md",
+      "executable": false
+    },
+    {
+      "type": "PACKAGE_FILE",
+      "source": "agents/kast-writer.agent.md",
+      "target": "agents/kast-writer.agent.md",
+      "executable": false
+    },
+    {
+      "type": "PACKAGE_FILE",
       "source": "extensions/kast/extension.mjs",
       "target": "extensions/kast/extension.mjs",
       "executable": true
@@ -25,6 +37,12 @@
       "type": "PACKAGE_FILE",
       "source": "extensions/kast/_shared/kast-tools.mjs",
       "target": "extensions/kast/_shared/kast-tools.mjs",
+      "executable": false
+    },
+    {
+      "type": "PACKAGE_FILE",
+      "source": "extensions/kast/_shared/kast-agents.mjs",
+      "target": "extensions/kast/_shared/kast-agents.mjs",
       "executable": false
     },
     {

--- a/cli-rs/src/cli.rs
+++ b/cli-rs/src/cli.rs
@@ -447,7 +447,7 @@ pub struct SetupArgs {
     /// Target root directory for --include-skill.
     #[arg(long)]
     pub skill_target_dir: Option<PathBuf>,
-    /// Install the packaged Copilot LSP, hooks, agents, and skills.
+    /// Install the packaged Copilot LSP, instructions, agents, and extension tools.
     #[arg(long)]
     pub include_copilot: bool,
     /// Skip packaged Copilot LSP plugin installation even when --include-copilot is present.
@@ -491,7 +491,7 @@ pub enum InstallCommand {
     Affected(AffectedInstallArgs),
     /// Install the packaged kast skill into the current workspace.
     Skill(ResourceInstallArgs),
-    /// Install the packaged Copilot LSP plugin resources.
+    /// Install the packaged Copilot LSP, instructions, agents, and extension tools.
     #[command(alias = "copilot-extension")]
     Copilot(ResourceInstallArgs),
     /// Install the Homebrew-managed IDEA plugin cask and link JetBrains profiles.

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -294,6 +294,8 @@ fn smoke_core_cli_commands() {
         .expect("install copilot plugin");
     assert!(copilot.status.success());
     assert!(github_dir.join("lsp.json").is_file());
+    assert!(github_dir.join("agents/kast-reader.agent.md").is_file());
+    assert!(github_dir.join("agents/kast-writer.agent.md").is_file());
     assert!(github_dir.join(".kast-copilot-version").is_file());
 
     let status = kast(&home, &config_home)
@@ -1003,6 +1005,8 @@ fn setup_skip_headless_keeps_clean_machine_backend_free() {
     assert_eq!(stdout["copilot"]["skipped"], false);
     assert!(skill_dir.join("kast/SKILL.md").is_file());
     assert!(github_dir.join("lsp.json").is_file());
+    assert!(github_dir.join("agents/kast-reader.agent.md").is_file());
+    assert!(github_dir.join("agents/kast-writer.agent.md").is_file());
     assert!(
         !home
             .join(".kast/lib/backends/headless/current/runtime-libs/classpath.txt")
@@ -2154,9 +2158,16 @@ fn install_resource_gateways_support_force_and_current_versions() {
     assert!(github_dir.join("extensions/kast/extension.mjs").is_file());
     assert!(
         github_dir
+            .join("extensions/kast/_shared/kast-agents.mjs")
+            .is_file()
+    );
+    assert!(
+        github_dir
             .join("extensions/kast/_shared/commands.json")
             .is_file()
     );
+    assert!(github_dir.join("agents/kast-reader.agent.md").is_file());
+    assert!(github_dir.join("agents/kast-writer.agent.md").is_file());
 
     let copilot_marker =
         std::fs::read_to_string(github_dir.join(".kast-copilot-version")).expect("copilot marker");
@@ -2349,6 +2360,8 @@ fn copilot_extension_install_preserves_existing_github_content() {
             .is_file()
     );
     assert!(github_dir.join("extensions/kast/extension.mjs").is_file());
+    assert!(github_dir.join("agents/kast-reader.agent.md").is_file());
+    assert!(github_dir.join("agents/kast-writer.agent.md").is_file());
     assert!(
         github_dir
             .join("extensions/kast/_shared/commands.json")

--- a/cli-rs/tests/rpc_catalog_smoke.rs
+++ b/cli-rs/tests/rpc_catalog_smoke.rs
@@ -472,6 +472,9 @@ fn copilot_plugin_source_stays_inside_cli_resources_plugin() {
     assert_eq!(
         targets,
         BTreeSet::from([
+            "agents/kast-reader.agent.md",
+            "agents/kast-writer.agent.md",
+            "extensions/kast/_shared/kast-agents.mjs",
             "extensions/kast/_shared/commands.json",
             "extensions/kast/_shared/kast-tools.mjs",
             "extensions/kast/extension.mjs",
@@ -488,6 +491,14 @@ fn copilot_plugin_source_stays_inside_cli_resources_plugin() {
     assert!(
         plugin_root.join("extensions/kast/extension.mjs").is_file(),
         "plugin source must own the Copilot SDK extension entrypoint"
+    );
+    assert!(
+        plugin_root.join("agents/kast-reader.agent.md").is_file(),
+        "plugin source must own the reader agent"
+    );
+    assert!(
+        plugin_root.join("agents/kast-writer.agent.md").is_file(),
+        "plugin source must own the writer agent"
     );
     let extension = std::fs::read_to_string(plugin_root.join("extensions/kast/extension.mjs"))
         .expect("extension source");
@@ -566,6 +577,18 @@ fn copilot_install_receives_the_manifest_declared_package_outputs() {
         installed_instruction.contains("start with the `kast-kotlin` LSP server"),
         "Kotlin instruction must force the LSP route"
     );
+
+    let installed_reader = std::fs::read_to_string(target.join("agents/kast-reader.agent.md"))
+        .expect("installed reader agent");
+    assert!(installed_reader.contains("name: Kast Reader"));
+    assert!(!installed_reader.contains("kast_write_and_validate"));
+    assert!(!installed_reader.contains("  - edit"));
+
+    let installed_writer = std::fs::read_to_string(target.join("agents/kast-writer.agent.md"))
+        .expect("installed writer agent");
+    assert!(installed_writer.contains("name: Kast Writer"));
+    assert!(installed_writer.contains("kast_write_and_validate"));
+    assert!(installed_writer.contains("  - edit"));
 
     let extension_source = std::fs::read_to_string(
         manifest_dir.join("resources/plugin/extensions/kast/extension.mjs"),

--- a/docs/for-agents/install-the-skill.md
+++ b/docs/for-agents/install-the-skill.md
@@ -87,20 +87,24 @@ kast install skill --target-dir=/absolute/path/to/skills --force
     binaryPath = "/home/alex/.local/bin/kast"
     ```
 
-GitHub Copilot custom agents are a separate surface from the Kast Copilot LSP
-package.
-
 ## Install the Copilot LSP package
 
 Use `kast install copilot` when you want Copilot to use the `kast-kotlin` LSP
-server:
+server, Kotlin-scoped instructions, the `kast-reader` and `kast-writer` custom
+agents, and the catalog-backed `kast_*` extension source:
 
 ```console title="Install the LSP-first Copilot package"
 kast install copilot
 ```
 
-The command writes `.github/lsp.json` into the target `.github` directory and
-records the installed version in `.github/.kast-copilot-version`.
+The command writes these managed files into the target `.github` directory:
+
+- `lsp.json`
+- `instructions/kast-kotlin.instructions.md`
+- `agents/kast-reader.agent.md`
+- `agents/kast-writer.agent.md`
+- `extensions/kast/extension.mjs`
+- `.kast-copilot-version`
 
 Pass `--target-dir` to point at another workspace `.github` directory, and
 `--force` to replace an older installed copy:
@@ -112,6 +116,11 @@ kast install copilot --target-dir=/absolute/path/to/repo/.github --force
 From this source checkout, `cli-rs/resources/plugin/scripts/install-local.sh`
 installs the same package into a target repository root for local development.
 Validate the source package with `.github/scripts/test-kast-copilot-plugin.sh`.
+For live Copilot CLI validation of the SDK extension tools, load the source
+package explicitly with `--plugin-dir cli-rs/resources/plugin`. Project
+installs expose the agents as `kast-reader` and `kast-writer`; source-plugin
+validation exposes them under the plugin namespace, such as
+`kast-copilot-lsp:kast-reader`.
 
 ## Next steps
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -198,8 +198,8 @@ images, private artifact stores, and CI-style setup scripts.
 ## Install the Copilot LSP package
 
 Install the Copilot LSP package when you want repository-local GitHub
-Copilot files that use standard LSP, hooks, instructions, agents, and skills
-without depending on the deprecated Copilot SDK extension path.
+Copilot files that use standard LSP, Kotlin instructions, two Kast-routed
+custom agents, and the catalog-backed `kast_*` extension source.
 
 From an installed CLI, run:
 
@@ -210,6 +210,10 @@ kast install copilot
 The CLI writes these packaged entries:
 
 - `.github/lsp.json`
+- `.github/instructions/kast-kotlin.instructions.md`
+- `.github/agents/kast-reader.agent.md`
+- `.github/agents/kast-writer.agent.md`
+- `.github/extensions/kast/extension.mjs`
 - `.github/.kast-copilot-version`
 
 Pass `--target-dir` when you need to install into another workspace's
@@ -227,6 +231,11 @@ cli-rs/resources/plugin/scripts/install-local.sh --target /Users/alex/work/proje
 ```
 
 Validate the source package with `.github/scripts/test-kast-copilot-plugin.sh`.
+For live Copilot CLI validation of the SDK extension tools, load the source
+package explicitly with `--plugin-dir cli-rs/resources/plugin`. Project
+installs expose the agents as `kast-reader` and `kast-writer`; source-plugin
+validation exposes them under the plugin namespace, such as
+`kast-copilot-lsp:kast-reader`.
 
 To refresh packaged files in place, reinstall with `--force`. This replaces
 the managed LSP package file.


### PR DESCRIPTION
## Summary
- simplify the Copilot package agent surface to `kast-reader` and `kast-writer`
- route both agents through the Kast LSP and catalog-backed `kast_*` tools
- keep the reader read-only while the writer owns edit/execute/rename/write-and-validate flows
- document the source-plugin `--plugin-dir` validation path and project-installed agent names

## Validation
- `.github/scripts/test-kast-copilot-plugin.sh`
- `.github/scripts/test-lsp-pivot-gates.sh`
- `.github/scripts/test-docs-content-contract.sh`
- `.github/scripts/test-release-workflow-contract.sh`
- `zensical build --clean`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --check`
- `cargo test --manifest-path cli-rs/Cargo.toml --test cli_smoke -- --nocapture`
- `cargo test --manifest-path cli-rs/Cargo.toml --test rpc_catalog_smoke -- --nocapture`
- `git diff --check`

## Live Copilot checks
- `gpt-5-mini`: source-plugin reader/writer load and `kast_workspace_search` tool execution
- `claude-sonnet-4.6`: source-plugin `kast_workspace_search` tool execution
- `claude-haiku-4.5`: source-plugin reader/writer load, project-installed reader/writer load, and `kast_workspace_search` tool execution without `--effort`

All live validation sessions reported zero file changes.