### PR TITLE
Fix Homebrew release state verifier

### DIFF
--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -194,6 +194,8 @@ require_contains "$release_state_verifier" "scripts/verify-release-assets.sh" "R
 require_contains "$release_state_verifier" "scripts/verify-maven-central.sh" "Release state verifier must verify Maven Central"
 require_contains "$release_state_verifier" "releases/latest" "Release state verifier must prove stable releases are latest"
 require_contains "$release_state_verifier" "homebrew-kast" "Release state verifier must prove stable Homebrew state"
+require_contains "$release_state_verifier" "referenced_cli_assets" "Release state verifier must derive formula assets from the rendered tap"
+require_not_contains "$release_state_verifier" "formula_assets = [" "Release state verifier must not require release assets that the rendered formula does not reference"
 require_contains "$maven_central_verifier" "kast-analysis-api" "Maven Central verifier must check analysis-api"
 require_contains "$maven_central_verifier" "kast-analysis-server" "Maven Central verifier must check analysis-server"
 require_contains "$maven_central_verifier" "kast-index-store" "Maven Central verifier must check index-store"

--- a/scripts/verify-release-state.sh
+++ b/scripts/verify-release-state.sh
@@ -167,13 +167,26 @@ for raw_line in sha_file.read_text(encoding="utf-8").splitlines():
     if len(parts) == 2:
         sha_entries[parts[1]] = parts[0]
 
-formula_assets = [
-    f"kast-{tag}-linux-arm64.zip",
-    f"kast-{tag}-linux-x64.zip",
-    f"kast-{tag}-macos-arm64.zip",
-    f"kast-{tag}-macos-x64.zip",
-]
-cask_assets = [f"kast-idea-{tag}.zip"]
+def referenced_cli_assets(content: str) -> list[str]:
+    assets = []
+    for platform in ("linux-arm64", "linux-x64", "macos-arm64", "macos-x64"):
+        templated = f"kast-v#{{ARTIFACT_VERSION}}-{platform}.zip"
+        literal = f"kast-{tag}-{platform}.zip"
+        if templated in content or literal in content:
+            assets.append(literal)
+    if not assets:
+        fail("Formula/kast.rb does not reference any Kast CLI release assets")
+    return assets
+
+def referenced_cask_assets(content: str) -> list[str]:
+    templated = "kast-idea-v#{version}.zip"
+    literal = f"kast-idea-{tag}.zip"
+    if templated in content or literal in content:
+        return [literal]
+    fail("Casks/kast-plugin.rb does not reference the Kast IDEA release asset")
+
+formula_assets = referenced_cli_assets(formula)
+cask_assets = referenced_cask_assets(cask)
 
 for asset_name in formula_assets:
     digest = sha_entries.get(asset_name)


### PR DESCRIPTION
## Summary
- derive Homebrew formula asset expectations from the rendered tap instead of hard-coding every CLI release zip
- keep cask verification tied to the rendered IDEA plugin asset
- add a release workflow contract assertion for the derived formula-asset behavior

## Validation
- `.github/scripts/test-release-workflow-contract.sh`
- `scripts/verify-release-state.sh --tag v0.10.2 --repository amichne/kast --maven-attempts 1 --work-dir <tmp>`