### PR TITLE
Render CLI output for humans

### DIFF
--- a/cli-rs/docs/reference/cli-cheat-sheet.md
+++ b/cli-rs/docs/reference/cli-cheat-sheet.md
@@ -21,9 +21,11 @@ supports it.
 
 ## Output modes
 
-Operator commands default to readable Markdown-style summaries so humans can
-see status, next steps, paths, and warnings without parsing JSON. Add
-`--output json` when automation needs the structured payload:
+Operator commands default to rendered readable summaries so humans can see
+status, next steps, paths, and warnings without parsing JSON. Interactive
+terminals receive styled headings and inline code; logs and captured output
+receive plain rendered text. Add `--output json` when automation needs the
+structured payload:
 
 ```console title="Machine-readable status"
 kast --output json status

--- a/cli-rs/src/interaction.rs
+++ b/cli-rs/src/interaction.rs
@@ -1,0 +1,125 @@
+use crate::cli::OutputFormat;
+use crate::error::Result;
+use std::io::{self, BufRead, IsTerminal, Write};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PromptPolicy {
+    Enabled,
+    Disabled,
+}
+
+impl PromptPolicy {
+    pub(crate) fn current(output_format: OutputFormat) -> Self {
+        Self::from_streams(
+            output_format,
+            io::stdin().is_terminal(),
+            io::stdout().is_terminal(),
+        )
+    }
+
+    pub(crate) fn from_streams(
+        output_format: OutputFormat,
+        stdin_is_terminal: bool,
+        stdout_is_terminal: bool,
+    ) -> Self {
+        if output_format == OutputFormat::Human && stdin_is_terminal && stdout_is_terminal {
+            Self::Enabled
+        } else {
+            Self::Disabled
+        }
+    }
+
+    pub(crate) fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Confirmation {
+    Accepted,
+    Declined,
+}
+
+pub(crate) fn confirm_affected_install_apply(action_count: usize) -> Result<Confirmation> {
+    let stdin = io::stdin();
+    let mut stdin = stdin.lock();
+    let stderr = io::stderr();
+    let mut stderr = stderr.lock();
+    confirm_affected_install_apply_with_io(action_count, &mut stdin, &mut stderr)
+}
+
+fn confirm_affected_install_apply_with_io(
+    action_count: usize,
+    reader: &mut impl BufRead,
+    writer: &mut impl Write,
+) -> Result<Confirmation> {
+    write!(
+        writer,
+        "Apply {action_count} planned Kast install repair{} now? [y/N] ",
+        if action_count == 1 { "" } else { "s" }
+    )?;
+    writer.flush()?;
+
+    let mut answer = String::new();
+    reader.read_line(&mut answer)?;
+    if matches!(answer.trim(), "y" | "Y" | "yes" | "YES" | "Yes") {
+        Ok(Confirmation::Accepted)
+    } else {
+        Ok(Confirmation::Declined)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoped_interactive_prompt_policy_requires_human_tty_streams() {
+        assert_eq!(
+            PromptPolicy::from_streams(OutputFormat::Human, true, true),
+            PromptPolicy::Enabled
+        );
+        assert_eq!(
+            PromptPolicy::from_streams(OutputFormat::Json, true, true),
+            PromptPolicy::Disabled
+        );
+        assert_eq!(
+            PromptPolicy::from_streams(OutputFormat::Human, false, true),
+            PromptPolicy::Disabled
+        );
+        assert_eq!(
+            PromptPolicy::from_streams(OutputFormat::Human, true, false),
+            PromptPolicy::Disabled
+        );
+    }
+
+    #[test]
+    fn affected_install_confirmation_accepts_yes_only() {
+        let mut input = std::io::Cursor::new("yes\n");
+        let mut output = Vec::new();
+
+        let confirmation = confirm_affected_install_apply_with_io(2, &mut input, &mut output)
+            .expect("confirmation");
+
+        assert_eq!(confirmation, Confirmation::Accepted);
+        assert_eq!(
+            String::from_utf8(output).expect("prompt utf8"),
+            "Apply 2 planned Kast install repairs now? [y/N] "
+        );
+    }
+
+    #[test]
+    fn affected_install_confirmation_defaults_to_decline() {
+        let mut input = std::io::Cursor::new("\n");
+        let mut output = Vec::new();
+
+        let confirmation = confirm_affected_install_apply_with_io(1, &mut input, &mut output)
+            .expect("confirmation");
+
+        assert_eq!(confirmation, Confirmation::Declined);
+        assert_eq!(
+            String::from_utf8(output).expect("prompt utf8"),
+            "Apply 1 planned Kast install repair now? [y/N] "
+        );
+    }
+}

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -7,6 +7,7 @@ mod daemon;
 mod demo;
 mod error;
 mod install;
+mod interaction;
 mod lsp;
 mod metrics;
 mod metrics_database;
@@ -166,6 +167,11 @@ fn run(cli: Cli) -> Result<i32> {
             Ok(0)
         }
         Command::Install(args)
+            if should_prompt_for_affected_install_apply(&args, output_format) =>
+        {
+            run_interactive_affected_install(args)
+        }
+        Command::Install(args)
             if matches!(args.command, Some(cli::InstallCommand::Completion(_))) =>
         {
             let Some(cli::InstallCommand::Completion(completion_args)) = args.command else {
@@ -202,6 +208,46 @@ fn install_reporter(output_format: OutputFormat) -> Box<dyn install::InstallRepo
     } else {
         Box::new(install::NoopInstallReporter)
     }
+}
+
+fn should_prompt_for_affected_install_apply(
+    args: &cli::InstallArgs,
+    output_format: OutputFormat,
+) -> bool {
+    interaction::PromptPolicy::current(output_format).is_enabled()
+        && matches!(
+            &args.command,
+            Some(cli::InstallCommand::Affected(cli::AffectedInstallArgs {
+                apply: false,
+                ..
+            }))
+        )
+}
+
+fn run_interactive_affected_install(args: cli::InstallArgs) -> Result<i32> {
+    let mut reporter = install_reporter(OutputFormat::Human);
+    let planned = install::install(args.clone(), reporter.as_mut())?;
+    let action_count = match &planned {
+        install::InstallResult::Affected(result) => result.actions.len(),
+        _ => 0,
+    };
+    output::print_install_result(&planned)?;
+    if action_count == 0 {
+        return Ok(0);
+    }
+
+    if interaction::confirm_affected_install_apply(action_count)?
+        == interaction::Confirmation::Accepted
+    {
+        let mut apply_args = args;
+        let Some(cli::InstallCommand::Affected(affected_args)) = &mut apply_args.command else {
+            unreachable!("interactive affected install only handles affected install arguments")
+        };
+        affected_args.apply = true;
+        let applied = install::install(apply_args, reporter.as_mut())?;
+        output::print_install_result(&applied)?;
+    }
+    Ok(0)
 }
 
 fn maybe_repair_after_cli_upgrade(command: &Command) -> Result<()> {

--- a/cli-rs/src/metrics.rs
+++ b/cli-rs/src/metrics.rs
@@ -7,6 +7,7 @@ use crate::cli::{
 use crate::config;
 use crate::error::{CliError, Result};
 use crate::metrics_database::{DirectMetricsError, DirectResult, FileFilter, MetricsDatabase};
+use crate::output;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::io;
@@ -201,59 +202,87 @@ fn print_json_value(value: &Value) -> Result<i32> {
 }
 
 fn print_human_metrics_response(request: &MetricsRequest, response: &Value) -> Result<i32> {
-    println!("# Kast metrics {}", metric_display_name(request.metric));
-    println!();
-    println!("- Workspace: `{}`", request.workspace_root.display());
-    println!("- Database: `{}`", request.database.display());
-    println!("- Limit: {}", request.limit);
+    let mut markdown = String::new();
+    push_markdown_line(
+        &mut markdown,
+        format_args!("# Kast metrics {}", metric_display_name(request.metric)),
+    );
+    markdown.push('\n');
+    push_markdown_line(
+        &mut markdown,
+        format_args!("- Workspace: `{}`", request.workspace_root.display()),
+    );
+    push_markdown_line(
+        &mut markdown,
+        format_args!("- Database: `{}`", request.database.display()),
+    );
+    push_markdown_line(&mut markdown, format_args!("- Limit: {}", request.limit));
     if let Some(symbol) = &request.symbol {
-        println!("- Symbol/query: `{symbol}`");
+        push_markdown_line(&mut markdown, format_args!("- Symbol/query: `{symbol}`"));
     }
     if request.depth != 3 || request.metric == "impact" {
-        println!("- Depth: {}", request.depth);
+        push_markdown_line(&mut markdown, format_args!("- Depth: {}", request.depth));
     }
     if let Some(file_glob) = request.filter.file_glob() {
-        println!("- File glob: `{file_glob}`");
+        push_markdown_line(&mut markdown, format_args!("- File glob: `{file_glob}`"));
     }
     if let Some(folder_filter) = request.filter.folder_filter() {
-        println!("- Folder filter: `{folder_filter}`");
+        push_markdown_line(
+            &mut markdown,
+            format_args!("- Folder filter: `{folder_filter}`"),
+        );
     }
-    println!();
-    println!("## Results");
+    markdown.push('\n');
+    push_markdown_line(&mut markdown, format_args!("## Results"));
     let results = response.get("results").unwrap_or(&Value::Null);
-    print_metric_results(results);
-    println!();
-    println!("Use `kast --output json metrics ...` for the structured metrics payload.");
+    push_metric_results(&mut markdown, results);
+    markdown.push('\n');
+    push_markdown_line(
+        &mut markdown,
+        format_args!("Use `kast --output json metrics ...` for the structured metrics payload."),
+    );
+    output::print_markdown(&markdown)?;
     Ok(0)
 }
 
-fn print_metric_results(results: &Value) {
+fn push_markdown_line(markdown: &mut String, args: std::fmt::Arguments<'_>) {
+    use std::fmt::Write as _;
+    markdown
+        .write_fmt(args)
+        .expect("writing to a String cannot fail");
+    markdown.push('\n');
+}
+
+fn push_metric_results(markdown: &mut String, results: &Value) {
     match results {
         Value::Array(items) if items.is_empty() => {
-            println!("No rows matched.");
+            push_markdown_line(markdown, format_args!("No rows matched."));
         }
         Value::Array(items) => {
             for item in items.iter().take(20) {
-                println!("- {}", summarize_value(item));
+                push_markdown_line(markdown, format_args!("- {}", summarize_value(item)));
             }
             if items.len() > 20 {
-                println!("- ... {} more rows", items.len() - 20);
+                push_markdown_line(
+                    markdown,
+                    format_args!("- ... {} more rows", items.len() - 20),
+                );
             }
         }
         Value::Object(object) => {
             if let Some(nodes) = object.get("nodes").and_then(Value::as_array) {
-                println!("- Nodes: {}", nodes.len());
+                push_markdown_line(markdown, format_args!("- Nodes: {}", nodes.len()));
             }
             if let Some(edges) = object.get("edges").and_then(Value::as_array) {
-                println!("- Edges: {}", edges.len());
+                push_markdown_line(markdown, format_args!("- Edges: {}", edges.len()));
             }
             let summary = summarize_value(results);
             if summary != "object" {
-                println!("- {summary}");
+                push_markdown_line(markdown, format_args!("- {summary}"));
             }
         }
-        Value::Null => println!("No results were returned."),
-        other => println!("- {}", summarize_value(other)),
+        Value::Null => push_markdown_line(markdown, format_args!("No results were returned.")),
+        other => push_markdown_line(markdown, format_args!("- {}", summarize_value(other))),
     }
 }
 

--- a/cli-rs/src/output.rs
+++ b/cli-rs/src/output.rs
@@ -10,9 +10,20 @@ use crate::runtime::{
     WorkspaceStatusResult,
 };
 use crate::self_mgmt::SelfDoctorResult;
+use crossterm::style::{Stylize, style};
 use serde::Serialize;
 use serde_json::Value;
-use std::io;
+use std::fmt::{self, Write as FmtWrite};
+use std::io::{self, IsTerminal, Write as IoWrite};
+
+macro_rules! mdln {
+    ($document:expr) => {
+        $document.blank()
+    };
+    ($document:expr, $($arg:tt)*) => {
+        $document.line(format_args!($($arg)*))
+    };
+}
 
 pub fn print_json(value: &impl Serialize) -> Result<()> {
     serde_json::to_writer_pretty(io::stdout(), value)?;
@@ -27,20 +38,147 @@ pub fn print_error(error: &CliError, output: OutputFormat) -> Result<()> {
         return Ok(());
     }
 
-    eprintln!("# Kast error");
-    eprintln!();
-    eprintln!("- Code: {}", error.code);
-    eprintln!("- Message: {}", error.message);
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast error");
+    mdln!(document);
+    mdln!(document, "- Code: {}", error.code);
+    mdln!(document, "- Message: {}", error.message);
     if !error.details.is_empty() {
-        eprintln!();
-        eprintln!("## Details");
+        mdln!(document);
+        mdln!(document, "## Details");
         for (key, value) in &error.details {
-            eprintln!("- {key}: `{value}`");
+            mdln!(document, "- {key}: `{value}`");
         }
     }
-    eprintln!();
-    eprintln!("Use `kast --output json ...` for the machine-readable error payload.");
+    mdln!(document);
+    mdln!(
+        document,
+        "Use `kast --output json ...` for the machine-readable error payload."
+    );
+    print_markdown_stderr(&document.into_string())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RenderStyle {
+    Plain,
+    Ansi,
+}
+
+#[derive(Default)]
+struct MarkdownDocument {
+    text: String,
+}
+
+impl MarkdownDocument {
+    fn line(&mut self, args: fmt::Arguments<'_>) {
+        self.text
+            .write_fmt(args)
+            .expect("writing to a String cannot fail");
+        self.text.push('\n');
+    }
+
+    fn blank(&mut self) {
+        self.text.push('\n');
+    }
+
+    fn into_string(self) -> String {
+        self.text
+    }
+}
+
+pub(crate) fn print_markdown(markdown: &str) -> Result<()> {
+    write_rendered_markdown(io::stdout().lock(), markdown, stdout_render_style())
+}
+
+fn print_markdown_stderr(markdown: &str) -> Result<()> {
+    write_rendered_markdown(io::stderr().lock(), markdown, stderr_render_style())
+}
+
+fn write_rendered_markdown(
+    mut writer: impl IoWrite,
+    markdown: &str,
+    style: RenderStyle,
+) -> Result<()> {
+    writer.write_all(render_markdown(markdown, style).as_bytes())?;
     Ok(())
+}
+
+fn stdout_render_style() -> RenderStyle {
+    terminal_render_style(io::stdout().is_terminal())
+}
+
+fn stderr_render_style() -> RenderStyle {
+    terminal_render_style(io::stderr().is_terminal())
+}
+
+fn terminal_render_style(is_terminal: bool) -> RenderStyle {
+    let color_disabled = std::env::var_os("NO_COLOR").is_some()
+        || std::env::var("TERM").is_ok_and(|terminal| terminal.eq_ignore_ascii_case("dumb"));
+    if is_terminal && !color_disabled {
+        RenderStyle::Ansi
+    } else {
+        RenderStyle::Plain
+    }
+}
+
+fn render_markdown(markdown: &str, style: RenderStyle) -> String {
+    let mut rendered = String::new();
+    for line in markdown.lines() {
+        if let Some(heading) = line.strip_prefix("# ") {
+            push_heading(&mut rendered, heading, '=', style);
+        } else if let Some(heading) = line.strip_prefix("## ") {
+            push_heading(&mut rendered, heading, '-', style);
+        } else if let Some(item) = line.strip_prefix("- ") {
+            rendered.push_str("- ");
+            rendered.push_str(&render_inline(item, style));
+            rendered.push('\n');
+        } else {
+            rendered.push_str(&render_inline(line, style));
+            rendered.push('\n');
+        }
+    }
+    if markdown.is_empty() {
+        rendered.push('\n');
+    }
+    rendered
+}
+
+fn push_heading(rendered: &mut String, heading: &str, underline: char, style: RenderStyle) {
+    rendered.push_str(&style_heading(heading, style));
+    rendered.push('\n');
+    rendered.push_str(&underline.to_string().repeat(heading.chars().count().max(1)));
+    rendered.push('\n');
+}
+
+fn render_inline(line: &str, render_style: RenderStyle) -> String {
+    let mut rendered = String::new();
+    for (index, segment) in line.split('`').enumerate() {
+        if index % 2 == 0 {
+            rendered.push_str(segment);
+        } else {
+            rendered.push_str(&style_code(segment, render_style));
+        }
+    }
+    rendered
+}
+
+fn style_heading(text: &str, render_style: RenderStyle) -> String {
+    match render_style {
+        RenderStyle::Plain => text.to_string(),
+        RenderStyle::Ansi => style(text).bold().to_string(),
+    }
+}
+
+fn style_code(text: &str, render_style: RenderStyle) -> String {
+    match render_style {
+        RenderStyle::Plain => text.to_string(),
+        RenderStyle::Ansi => style(text).cyan().to_string(),
+    }
+}
+
+#[cfg(test)]
+fn render_markdown_for_test(markdown: &str, style: RenderStyle) -> String {
+    render_markdown(markdown, style)
 }
 
 pub fn print_install_result(result: &InstallResult) -> Result<()> {
@@ -56,28 +194,35 @@ pub fn print_install_result(result: &InstallResult) -> Result<()> {
 }
 
 pub fn print_workspace_status(result: &WorkspaceStatusResult) -> Result<()> {
-    println!("# Kast status");
-    println!();
-    println!("- Workspace: `{}`", result.workspace_root);
-    println!("- Descriptor directory: `{}`", result.descriptor_directory);
-    println!("- Candidates: {}", result.candidates.len());
-    println!();
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast status");
+    mdln!(document);
+    mdln!(document, "- Workspace: `{}`", result.workspace_root);
+    mdln!(
+        document,
+        "- Descriptor directory: `{}`",
+        result.descriptor_directory
+    );
+    mdln!(document, "- Candidates: {}", result.candidates.len());
+    mdln!(document);
     if let Some(selected) = &result.selected {
-        print_candidate("Selected runtime", selected);
+        print_candidate(&mut document, "Selected runtime", selected);
     } else {
-        println!("No runtime candidates were found.");
-        println!();
-        println!("## Next steps");
-        println!("- Start a backend: `kast up`");
-        println!(
+        mdln!(document, "No runtime candidates were found.");
+        mdln!(document);
+        mdln!(document, "## Next steps");
+        mdln!(document, "- Start a backend: `kast up`");
+        mdln!(
+            document,
             "- For headless use, install the Linux headless tarball; for macOS IDE use, install Kast through Homebrew."
         );
     }
     if result.selected.is_some() && result.candidates.len() > 1 {
-        println!();
-        println!("## Other candidates");
+        mdln!(document);
+        mdln!(document, "## Other candidates");
         for candidate in &result.candidates {
-            println!(
+            mdln!(
+                document,
                 "- {} pid {} ready {}",
                 candidate.descriptor.backend_name,
                 candidate.descriptor.pid,
@@ -85,321 +230,428 @@ pub fn print_workspace_status(result: &WorkspaceStatusResult) -> Result<()> {
             );
         }
     }
-    Ok(())
+    print_markdown(&document.into_string())
 }
 
 pub fn print_workspace_ensure(result: &WorkspaceEnsureResult) -> Result<()> {
-    println!("# Kast up");
-    println!();
-    println!("- Workspace: `{}`", result.workspace_root);
-    println!("- Started new daemon: {}", yes_no(result.started));
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast up");
+    mdln!(document);
+    mdln!(document, "- Workspace: `{}`", result.workspace_root);
+    mdln!(document, "- Started new daemon: {}", yes_no(result.started));
     if let Some(log_file) = &result.log_file {
-        println!("- Log file: `{log_file}`");
+        mdln!(document, "- Log file: `{log_file}`");
     }
     if let Some(note) = &result.note {
-        println!("- Note: {note}");
+        mdln!(document, "- Note: {note}");
     }
-    println!();
-    print_candidate("Selected runtime", &result.selected);
-    println!();
-    println!("## Next steps");
-    println!("- Check state again: `kast status`");
-    println!("- Send analysis requests with `kast rpc`");
-    Ok(())
+    mdln!(document);
+    print_candidate(&mut document, "Selected runtime", &result.selected);
+    mdln!(document);
+    mdln!(document, "## Next steps");
+    mdln!(document, "- Check state again: `kast status`");
+    mdln!(document, "- Send analysis requests with `kast rpc`");
+    print_markdown(&document.into_string())
 }
 
 pub fn print_stop_result(result: &DaemonStopResult) -> Result<()> {
-    println!("# Kast stop");
-    println!();
-    println!("- Workspace: `{}`", result.workspace_root);
-    println!("- Stopped daemon: {}", yes_no(result.stopped));
-    println!("- Forced termination: {}", yes_no(result.forced));
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast stop");
+    mdln!(document);
+    mdln!(document, "- Workspace: `{}`", result.workspace_root);
+    mdln!(document, "- Stopped daemon: {}", yes_no(result.stopped));
+    mdln!(document, "- Forced termination: {}", yes_no(result.forced));
     if let Some(pid) = result.pid {
-        println!("- PID: {pid}");
+        mdln!(document, "- PID: {pid}");
     }
     if let Some(descriptor_path) = &result.descriptor_path {
-        println!("- Descriptor: `{descriptor_path}`");
+        mdln!(document, "- Descriptor: `{descriptor_path}`");
     }
     if !result.stopped {
-        println!();
-        println!("No matching daemon was running.");
+        mdln!(document);
+        mdln!(document, "No matching daemon was running.");
     }
-    Ok(())
+    print_markdown(&document.into_string())
 }
 
 pub fn print_capabilities(value: &Value) -> Result<()> {
-    println!("# Kast capabilities");
-    println!();
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast capabilities");
+    mdln!(document);
     if let Some(methods) = value.get("methods").and_then(Value::as_array) {
-        println!("- Methods advertised: {}", methods.len());
+        mdln!(document, "- Methods advertised: {}", methods.len());
         for method in methods.iter().filter_map(Value::as_str).take(30) {
-            println!("- `{method}`");
+            mdln!(document, "- `{method}`");
         }
         if methods.len() > 30 {
-            println!("- ... {} more", methods.len() - 30);
+            mdln!(document, "- ... {} more", methods.len() - 30);
         }
     } else if let Some(object) = value.as_object() {
-        println!(
+        mdln!(
+            document,
             "- Top-level fields: {}",
             object.keys().cloned().collect::<Vec<_>>().join(", ")
         );
     } else {
-        println!("- Capabilities payload is available.");
+        mdln!(document, "- Capabilities payload is available.");
     }
-    println!();
-    println!("Use `kast --output json capabilities ...` for the full payload.");
-    Ok(())
+    mdln!(document);
+    mdln!(
+        document,
+        "Use `kast --output json capabilities ...` for the full payload."
+    );
+    print_markdown(&document.into_string())
 }
 
 pub fn print_doctor(result: &SelfDoctorResult) -> Result<()> {
-    println!("# Kast doctor");
-    println!();
-    println!("- Healthy: {}", yes_no(result.ok));
-    println!("- Installed: {}", yes_no(result.installed));
-    println!("- Config valid: {}", yes_no(result.configuration.valid));
-    println!("- Config path: `{}`", result.config_path);
-    println!(
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast doctor");
+    mdln!(document);
+    mdln!(document, "- Healthy: {}", yes_no(result.ok));
+    mdln!(document, "- Installed: {}", yes_no(result.installed));
+    mdln!(
+        document,
+        "- Config valid: {}",
+        yes_no(result.configuration.valid)
+    );
+    mdln!(document, "- Config path: `{}`", result.config_path);
+    mdln!(
+        document,
         "- Canonical directory: `{}`",
         result.canonical_directory.root
     );
-    println!("- Running binary: `{}`", result.binary.running_binary);
-    println!("- Configured binary: `{}`", result.binary.configured_binary);
-    println!(
+    mdln!(
+        document,
+        "- Running binary: `{}`",
+        result.binary.running_binary
+    );
+    mdln!(
+        document,
+        "- Configured binary: `{}`",
+        result.binary.configured_binary
+    );
+    mdln!(
+        document,
         "- Minimum backend version: `{}`",
         result.minimum_backend_version
     );
-    print_messages("Issues", &result.issues);
-    print_warnings(&result.warnings);
+    print_messages(&mut document, "Issues", &result.issues);
+    print_warnings(&mut document, &result.warnings);
     if let Some(install) = &result.install {
-        println!();
-        println!("## Installed versions");
-        println!("- CLI: `{}`", value_or_dash(&install.version));
+        mdln!(document);
+        mdln!(document, "## Installed versions");
+        mdln!(document, "- CLI: `{}`", value_or_dash(&install.version));
         if !install.components.is_empty() {
-            println!("- Components: {}", install.components.join(", "));
+            mdln!(document, "- Components: {}", install.components.join(", "));
         }
         for backend in &install.backends {
-            println!(
+            mdln!(
+                document,
                 "- Backend {}: `{}` runtime `{}`",
-                backend.name, backend.version, backend.runtime_libs_dir
+                backend.name,
+                backend.version,
+                backend.runtime_libs_dir
             );
         }
         for repo in &install.repos {
-            println!(
+            mdln!(
+                document,
                 "- Copilot repo `{}`: `{}`",
-                repo.path, repo.copilot_extension_version
+                repo.path,
+                repo.copilot_extension_version
             );
         }
     }
     if result.ok {
-        println!();
-        println!("No blocking issues were found.");
+        mdln!(document);
+        mdln!(document, "No blocking issues were found.");
     }
-    Ok(())
+    print_markdown(&document.into_string())
 }
 
 pub fn print_setup(result: &SetupResult) -> Result<()> {
-    println!("# Kast setup");
-    println!();
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast setup");
+    mdln!(document);
     if let Some(repair) = &result.repair {
-        println!("- Repair applied: {}", yes_no(repair.applied));
+        mdln!(document, "- Repair applied: {}", yes_no(repair.applied));
     }
     if let Some(headless) = &result.headless {
-        println!("- Headless backend: `{}`", headless.version);
+        mdln!(document, "- Headless backend: `{}`", headless.version);
     }
     if let Some(shell) = &result.shell {
-        println!(
+        mdln!(
+            document,
             "- Shell integration: `{}` profile `{}`",
-            shell.shell, shell.profile
+            shell.shell,
+            shell.profile
         );
     }
     if let Some(skill) = &result.skill {
-        println!("- Skill: `{}`", skill.installed_at);
+        mdln!(document, "- Skill: `{}`", skill.installed_at);
     }
     if let Some(copilot) = &result.copilot {
-        println!("- Copilot plugin: `{}`", copilot.installed_at);
+        mdln!(document, "- Copilot plugin: `{}`", copilot.installed_at);
     }
     if let Some(plugin) = &result.idea_plugin {
-        println!("- IDEA plugin action: `{}`", plugin.brew_action);
+        mdln!(document, "- IDEA plugin action: `{}`", plugin.brew_action);
     }
-    println!(
+    mdln!(
+        document,
         "- Project-open profile auto-init: {}",
         yes_no(result.project_open.profile_auto_init)
     );
-    println!("- Project-open profile: `{}`", result.project_open.profile);
-    println!(
+    mdln!(
+        document,
+        "- Project-open profile: `{}`",
+        result.project_open.profile
+    );
+    mdln!(
+        document,
         "- Auto-exclude generated package files: {}",
         yes_no(result.project_open.auto_exclude_git)
     );
-    print_warnings(&result.warnings);
-    Ok(())
+    print_warnings(&mut document, &result.warnings);
+    print_markdown(&document.into_string())
 }
 
 fn print_backend_install(result: &BackendInstallResult) -> Result<()> {
-    println!("# Kast backend install");
-    println!();
-    println!("- Backend: `{}`", result.backend_name);
-    println!("- Version: `{}`", result.version);
-    println!("- Installed directory: `{}`", result.install_dir);
-    println!("- Runtime libraries: `{}`", result.runtime_libs_dir);
-    print_optional("IDEA home", result.idea_home.as_deref());
-    println!("- Source archive: `{}`", result.source_archive);
-    println!("- Downloaded release asset: {}", yes_no(result.downloaded));
-    println!("- Reused existing install: {}", yes_no(result.skipped));
-    println!();
-    println!("## Next steps");
-    println!("- Start it: `kast up --backend={}`", result.backend_name);
-    println!("- Inspect it: `kast status`");
-    Ok(())
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast backend install");
+    mdln!(document);
+    mdln!(document, "- Backend: `{}`", result.backend_name);
+    mdln!(document, "- Version: `{}`", result.version);
+    mdln!(document, "- Installed directory: `{}`", result.install_dir);
+    mdln!(
+        document,
+        "- Runtime libraries: `{}`",
+        result.runtime_libs_dir
+    );
+    print_optional(&mut document, "IDEA home", result.idea_home.as_deref());
+    mdln!(document, "- Source archive: `{}`", result.source_archive);
+    mdln!(
+        document,
+        "- Downloaded release asset: {}",
+        yes_no(result.downloaded)
+    );
+    mdln!(
+        document,
+        "- Reused existing install: {}",
+        yes_no(result.skipped)
+    );
+    mdln!(document);
+    mdln!(document, "## Next steps");
+    mdln!(
+        document,
+        "- Start it: `kast up --backend={}`",
+        result.backend_name
+    );
+    mdln!(document, "- Inspect it: `kast status`");
+    print_markdown(&document.into_string())
 }
 
 fn print_skill_install(result: &InstallSkillResult) -> Result<()> {
-    println!("# Kast skill install");
-    println!();
-    println!("- Installed at: `{}`", result.installed_at);
-    println!("- Version: `{}`", result.version);
-    println!("- Reused existing install: {}", yes_no(result.skipped));
-    println!();
-    println!("## Next steps");
-    println!(
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast skill install");
+    mdln!(document);
+    mdln!(document, "- Installed at: `{}`", result.installed_at);
+    mdln!(document, "- Version: `{}`", result.version);
+    mdln!(
+        document,
+        "- Reused existing install: {}",
+        yes_no(result.skipped)
+    );
+    mdln!(document);
+    mdln!(document, "## Next steps");
+    mdln!(
+        document,
         "- Read the installed quickstart: `{}/references/quickstart.md`",
         result.installed_at
     );
-    Ok(())
+    print_markdown(&document.into_string())
 }
 
 fn print_copilot_install(title: &str, result: &InstallCopilotExtensionResult) -> Result<()> {
-    println!("# {title}");
-    println!();
-    println!("- Extension path: `{}`", result.installed_at);
-    println!("- Version: `{}`", result.version);
-    println!("- Reused existing install: {}", yes_no(result.skipped));
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# {title}");
+    mdln!(document);
+    mdln!(document, "- Extension path: `{}`", result.installed_at);
+    mdln!(document, "- Version: `{}`", result.version);
+    mdln!(
+        document,
+        "- Reused existing install: {}",
+        yes_no(result.skipped)
+    );
     if result.git_exclude.attempted {
-        println!(
+        mdln!(
+            document,
             "- Git info/exclude updated: {}",
             yes_no(result.git_exclude.updated)
         );
         print_optional(
+            &mut document,
             "Git info/exclude",
             result.git_exclude.exclude_file.as_deref(),
         );
     } else if let Some(reason) = &result.git_exclude.reason {
-        println!("- Git info/exclude: {reason}");
+        mdln!(document, "- Git info/exclude: {reason}");
     }
-    print_warnings(&result.warnings);
-    Ok(())
+    print_warnings(&mut document, &result.warnings);
+    print_markdown(&document.into_string())
 }
 
 fn print_idea_plugin_install(result: &InstallIdeaPluginResult) -> Result<()> {
-    println!("# Kast IDEA plugin install");
-    println!();
-    println!("- Cask token: `{}`", result.cask_token);
-    println!("- Plugin version: `{}`", result.plugin_version);
-    println!("- Download cache: `{}`", result.download_cache);
-    println!("- Downloaded bytes: {}", result.downloaded_bytes);
-    println!("- Homebrew action: `{}`", result.brew_action);
-    println!("- Dry run: {}", yes_no(result.dry_run));
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast IDEA plugin install");
+    mdln!(document);
+    mdln!(document, "- Cask token: `{}`", result.cask_token);
+    mdln!(document, "- Plugin version: `{}`", result.plugin_version);
+    mdln!(document, "- Download cache: `{}`", result.download_cache);
+    mdln!(document, "- Downloaded bytes: {}", result.downloaded_bytes);
+    mdln!(document, "- Homebrew action: `{}`", result.brew_action);
+    mdln!(document, "- Dry run: {}", yes_no(result.dry_run));
     if !result.brew_command.is_empty() {
-        println!("- Brew command: `{}`", result.brew_command.join(" "));
+        mdln!(
+            document,
+            "- Brew command: `{}`",
+            result.brew_command.join(" ")
+        );
     }
     print_optional(
+        &mut document,
         "JetBrains config root",
         result.jetbrains_config_root.as_deref(),
     );
     if !result.plugin_directories.is_empty() {
-        println!();
-        println!("## Plugin directories");
+        mdln!(document);
+        mdln!(document, "## Plugin directories");
         for path in &result.plugin_directories {
-            println!("- `{path}`");
+            mdln!(document, "- `{path}`");
         }
     }
-    print_warnings(&result.warnings);
-    Ok(())
+    print_warnings(&mut document, &result.warnings);
+    print_markdown(&document.into_string())
 }
 
 fn print_shell_install(result: &InstallShellResult) -> Result<()> {
-    println!("# Kast shell install");
-    println!();
-    println!("- Shell: `{}`", result.shell);
-    println!("- Command name: `{}`", result.command_name);
-    println!("- Bin directory: `{}`", result.bin_dir);
-    println!("- Config home: `{}`", result.config_home);
-    println!("- Source file: `{}`", result.source_file);
-    println!("- Profile: `{}`", result.profile);
-    println!("- Profile updated: {}", yes_no(result.profile_updated));
-    println!("- Dry run: {}", yes_no(result.dry_run));
-    println!();
-    println!("## Next steps");
-    println!("- Open a fresh shell or run `{}`.", result.source_line);
-    Ok(())
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast shell install");
+    mdln!(document);
+    mdln!(document, "- Shell: `{}`", result.shell);
+    mdln!(document, "- Command name: `{}`", result.command_name);
+    mdln!(document, "- Bin directory: `{}`", result.bin_dir);
+    mdln!(document, "- Config home: `{}`", result.config_home);
+    mdln!(document, "- Source file: `{}`", result.source_file);
+    mdln!(document, "- Profile: `{}`", result.profile);
+    mdln!(
+        document,
+        "- Profile updated: {}",
+        yes_no(result.profile_updated)
+    );
+    mdln!(document, "- Dry run: {}", yes_no(result.dry_run));
+    mdln!(document);
+    mdln!(document, "## Next steps");
+    mdln!(
+        document,
+        "- Open a fresh shell or run `{}`.",
+        result.source_line
+    );
+    print_markdown(&document.into_string())
 }
 
 fn print_archive_install(result: &ArchiveInstallResult) -> Result<()> {
-    println!("# Kast install");
-    println!();
-    println!("- Installed at: `{}`", result.installed_at);
-    println!("- Instance: `{}`", result.instance);
-    println!("- Reused existing install: {}", yes_no(result.skipped));
-    Ok(())
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast install");
+    mdln!(document);
+    mdln!(document, "- Installed at: `{}`", result.installed_at);
+    mdln!(document, "- Instance: `{}`", result.instance);
+    mdln!(
+        document,
+        "- Reused existing install: {}",
+        yes_no(result.skipped)
+    );
+    print_markdown(&document.into_string())
 }
 
 fn print_affected_install(result: &InstallAffectedResult) -> Result<()> {
-    println!("# Kast affected install repair");
-    println!();
-    println!("- Applied changes: {}", yes_no(result.applied));
-    println!("- Config path: `{}`", result.config_path);
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast affected install repair");
+    mdln!(document);
+    mdln!(document, "- Applied changes: {}", yes_no(result.applied));
+    mdln!(document, "- Config path: `{}`", result.config_path);
     if !result.applied {
-        println!("- Default: no files were changed");
-        println!("- Apply command: `{}`", result.apply_command);
+        mdln!(document, "- Default: no files were changed");
+        mdln!(document, "- Apply command: `{}`", result.apply_command);
     }
     if result.actions.is_empty() {
-        println!();
-        println!("No affected installs or stale paths were found.");
+        mdln!(document);
+        mdln!(document, "No affected installs or stale paths were found.");
     } else {
-        println!();
-        println!("## Actions");
+        mdln!(document);
+        mdln!(document, "## Actions");
         for action in &result.actions {
-            println!("- `{}` `{}`: {}", action.status, action.kind, action.target);
-            println!("  {}", action.message);
+            mdln!(
+                document,
+                "- `{}` `{}`: {}",
+                action.status,
+                action.kind,
+                action.target
+            );
+            mdln!(document, "  {}", action.message);
             if let Some(command) = &action.command {
-                println!("  Command: `{command}`");
+                mdln!(document, "  Command: `{command}`");
             }
         }
     }
-    print_messages("Backups", &result.backups);
-    print_warnings(&result.warnings);
-    Ok(())
+    print_messages(&mut document, "Backups", &result.backups);
+    print_warnings(&mut document, &result.warnings);
+    print_markdown(&document.into_string())
 }
 
-fn print_candidate(title: &str, candidate: &RuntimeCandidateStatus) {
-    println!("## {title}");
-    println!("- Backend: `{}`", candidate.descriptor.backend_name);
-    println!(
+fn print_candidate(
+    document: &mut MarkdownDocument,
+    title: &str,
+    candidate: &RuntimeCandidateStatus,
+) {
+    mdln!(document, "## {title}");
+    mdln!(
+        document,
+        "- Backend: `{}`",
+        candidate.descriptor.backend_name
+    );
+    mdln!(
+        document,
         "- Backend version: `{}`",
         candidate.descriptor.backend_version
     );
-    println!("- PID: {}", candidate.descriptor.pid);
-    println!("- PID alive: {}", yes_no(candidate.pid_alive));
-    println!("- Reachable: {}", yes_no(candidate.reachable));
-    println!("- Ready: {}", yes_no(candidate.ready));
-    println!("- Socket: `{}`", candidate.descriptor.socket_path);
+    mdln!(document, "- PID: {}", candidate.descriptor.pid);
+    mdln!(document, "- PID alive: {}", yes_no(candidate.pid_alive));
+    mdln!(document, "- Reachable: {}", yes_no(candidate.reachable));
+    mdln!(document, "- Ready: {}", yes_no(candidate.ready));
+    mdln!(document, "- Socket: `{}`", candidate.descriptor.socket_path);
     if let Some(status) = &candidate.runtime_status {
-        println!("- Runtime state: `{}`", runtime_state(status.state.clone()));
-        println!("- Active: {}", yes_no(status.active));
-        println!("- Healthy: {}", yes_no(status.healthy));
-        println!("- Indexing: {}", yes_no(status.indexing));
+        mdln!(
+            document,
+            "- Runtime state: `{}`",
+            runtime_state(status.state.clone())
+        );
+        mdln!(document, "- Active: {}", yes_no(status.active));
+        mdln!(document, "- Healthy: {}", yes_no(status.healthy));
+        mdln!(document, "- Indexing: {}", yes_no(status.indexing));
         if !status.source_module_names.is_empty() {
-            println!(
+            mdln!(
+                document,
                 "- Source modules: {}",
                 status.source_module_names.join(", ")
             );
         }
         if let Some(message) = &status.message {
-            println!("- Message: {message}");
+            mdln!(document, "- Message: {message}");
         }
-        print_warnings(&status.warnings);
+        print_warnings(document, &status.warnings);
     }
     if let Some(error_message) = &candidate.error_message {
-        println!("- Error: {error_message}");
+        mdln!(document, "- Error: {error_message}");
     }
 }
 
@@ -412,24 +664,24 @@ fn runtime_state(state: RuntimeState) -> &'static str {
     }
 }
 
-fn print_optional(label: &str, value: Option<&str>) {
+fn print_optional(document: &mut MarkdownDocument, label: &str, value: Option<&str>) {
     if let Some(value) = value.filter(|value| !value.trim().is_empty()) {
-        println!("- {label}: `{value}`");
+        mdln!(document, "- {label}: `{value}`");
     }
 }
 
-fn print_warnings(warnings: &[String]) {
-    print_messages("Warnings", warnings);
+fn print_warnings(document: &mut MarkdownDocument, warnings: &[String]) {
+    print_messages(document, "Warnings", warnings);
 }
 
-fn print_messages(title: &str, messages: &[String]) {
+fn print_messages(document: &mut MarkdownDocument, title: &str, messages: &[String]) {
     if messages.is_empty() {
         return;
     }
-    println!();
-    println!("## {title}");
+    mdln!(document);
+    mdln!(document, "## {title}");
     for message in messages {
-        println!("- {message}");
+        mdln!(document, "- {message}");
     }
 }
 
@@ -439,4 +691,51 @@ fn yes_no(value: bool) -> &'static str {
 
 fn value_or_dash(value: &str) -> &str {
     if value.trim().is_empty() { "-" } else { value }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rendered_human_output_plain_text_does_not_dump_raw_markdown_tokens() {
+        let rendered = render_markdown_for_test(
+            "# Kast status\n\n- Workspace: `/tmp/kast`\n\n## Next steps\n- Run `kast up`\n",
+            RenderStyle::Plain,
+        );
+
+        assert!(
+            rendered.starts_with("Kast status\n==========="),
+            "primary heading should be rendered as text with an underline: {rendered}"
+        );
+        assert!(
+            rendered.contains("Workspace: /tmp/kast"),
+            "inline code markers should be rendered away: {rendered}"
+        );
+        assert!(
+            rendered.contains("Next steps\n----------"),
+            "secondary headings should be rendered as sections: {rendered}"
+        );
+        assert!(
+            !rendered.contains("# Kast status") && !rendered.contains("`/tmp/kast`"),
+            "raw Markdown control tokens should not leak into rendered output: {rendered}"
+        );
+    }
+
+    #[test]
+    fn rendered_human_output_ansi_styles_headings_and_inline_code() {
+        let rendered = render_markdown_for_test(
+            "# Kast status\n- Workspace: `/tmp/kast`\n",
+            RenderStyle::Ansi,
+        );
+
+        assert!(
+            rendered.contains("\x1b["),
+            "ANSI rendering should style headings or inline code: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains("# Kast status") && !rendered.contains("`/tmp/kast`"),
+            "ANSI rendering should still remove raw Markdown control tokens: {rendered:?}"
+        );
+    }
 }

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -696,12 +696,20 @@ fn lifecycle_commands_render_human_text_by_default_and_json_when_selected() {
     );
     let stdout = String::from_utf8_lossy(&human.stdout);
     assert!(
-        stdout.starts_with("# Kast status\n"),
-        "status should default to a readable Markdown-style summary: {stdout}"
+        stdout.starts_with("Kast status\n===========\n"),
+        "status should default to a rendered readable summary: {stdout}"
     );
     assert!(
         stdout.contains("No runtime candidates were found."),
         "status should include an actionable empty-state message: {stdout}"
+    );
+    assert!(
+        stdout.contains("Next steps\n----------"),
+        "status should render Markdown section headings: {stdout}"
+    );
+    assert!(
+        !stdout.contains("# Kast status") && !stdout.contains("`kast up`"),
+        "status should not dump raw Markdown control tokens: {stdout}"
     );
     assert!(
         serde_json::from_slice::<serde_json::Value>(&human.stdout).is_err(),
@@ -729,6 +737,44 @@ fn lifecycle_commands_render_human_text_by_default_and_json_when_selected() {
     assert_eq!(
         stdout["candidates"].as_array().expect("candidates").len(),
         0
+    );
+}
+
+#[test]
+fn install_affected_human_dry_run_renders_without_prompt_when_not_tty() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    std::fs::create_dir_all(&home).expect("home");
+
+    let dry_run = kast(&home, &config_home)
+        .args(["install", "affected"])
+        .output()
+        .expect("install affected");
+
+    assert!(
+        dry_run.status.success(),
+        "dry run should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&dry_run.stdout),
+        String::from_utf8_lossy(&dry_run.stderr)
+    );
+    assert!(
+        dry_run.stderr.is_empty(),
+        "captured dry run should not prompt on stderr: {}",
+        String::from_utf8_lossy(&dry_run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&dry_run.stdout);
+    assert!(
+        stdout.starts_with("Kast affected install repair\n============================"),
+        "dry run should render the affected-install summary: {stdout}"
+    );
+    assert!(
+        stdout.contains("Apply command: kast install affected --apply"),
+        "non-interactive dry run should keep the explicit apply command: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Apply 1 planned Kast install repair now?"),
+        "non-interactive dry run should not prompt on stdout: {stdout}"
     );
 }
 

--- a/cli-rs/tests/metrics_smoke.rs
+++ b/cli-rs/tests/metrics_smoke.rs
@@ -52,8 +52,9 @@ fn reads_metrics_directly_from_source_index_db() {
         String::from_utf8_lossy(&fan_in.stderr)
     );
     let fan_in_stdout = String::from_utf8_lossy(&fan_in.stdout);
-    assert!(fan_in_stdout.starts_with("# Kast metrics fan-in\n"));
-    assert!(fan_in_stdout.contains("targetFqName=`lib.Foo`"));
+    assert!(fan_in_stdout.starts_with("Kast metrics fan-in\n==================="));
+    assert!(!fan_in_stdout.contains("# Kast metrics fan-in"));
+    assert!(fan_in_stdout.contains("targetFqName=lib.Foo"));
     assert!(fan_in_stdout.contains("occurrenceCount=3"));
     assert!(serde_json::from_slice::<Value>(&fan_in.stdout).is_err());
 

--- a/docs/cli-cheat-sheet.md
+++ b/docs/cli-cheat-sheet.md
@@ -21,9 +21,11 @@ supports it.
 
 ## Output modes
 
-Operator commands default to readable Markdown-style summaries so humans can
-see status, next steps, paths, and warnings without parsing JSON. Add
-`--output json` when automation needs the structured payload:
+Operator commands default to rendered readable summaries so humans can see
+status, next steps, paths, and warnings without parsing JSON. Interactive
+terminals receive styled headings and inline code; logs and captured output
+receive plain rendered text. Add `--output json` when automation needs the
+structured payload:
 
 ```console title="Machine-readable status"
 kast --output json status

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -105,8 +105,11 @@ profile needs repair.
     kast install affected
     ```
 
-    Apply the planned repair with `--apply`. The command creates backups under
-    `KAST_CONFIG_HOME/backups` before replacing or removing managed files.
+    In an interactive human terminal, Kast shows the planned repair and asks
+    whether to apply it. Non-interactive runs never prompt; rerun with
+    `--apply` to apply the planned repair from scripts, CI, or captured
+    shells. Apply mode creates backups under `KAST_CONFIG_HOME/backups` before
+    replacing or removing managed files.
 
     ```console title="Repair affected installs"
     kast install affected --apply

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,8 +8,8 @@ icon: lucide/zap
 
 By the end of this page you'll have started a readable CLI session, then
 asked the daemon two compiler-backed questions: "what symbol is this?" and
-"who uses it?" The lifecycle commands print Markdown-style summaries by
-default; raw analysis requests still return JSON-RPC payloads.
+"who uses it?" The lifecycle commands render readable summaries by default;
+raw analysis requests still return JSON-RPC payloads.
 
 The walkthrough uses the headless backend because it works on Linux terminals,
 CI runners, and agent loops after the Linux headless tarball is installed. If
@@ -63,24 +63,28 @@ sequenceDiagram
     Daemon->>K2: Bootstrap session
     K2-->>Daemon: Indexing complete
     Daemon-->>CLI: READY
-    CLI-->>You: Markdown status summary
+    CLI-->>You: Rendered status summary
 ```
 
 The first start indexes every Kotlin file. Later commands reuse the warm
 state — the cost you pay here buys you fast lookups for the rest of the
 session.
 
-The default output is meant to be read:
+The default output is meant to be read. In an interactive terminal, headings
+and inline code are styled; in logs and captured output, the same summary is
+rendered as plain text:
 
-```markdown title="Example output"
-# Kast up
+```text title="Example output"
+  Kast up
+  =======
 
-- Workspace: `/workspace`
-- Started new daemon: yes
+  - Workspace: /workspace
+  - Started new daemon: yes
 
-## Selected runtime
-- Backend: `headless`
-- Runtime state: `READY`
+  Selected runtime
+  ----------------
+  - Backend: headless
+  - Runtime state: READY
 ```
 
 Use `--output json` on lifecycle and install commands when a script needs


### PR DESCRIPTION
## Summary
- render human CLI output through a small Markdown-style formatter instead of dumping raw Markdown tokens
- apply the renderer to lifecycle/install/doctor/metrics output while keeping `--output json` for structured automation
- keep interactive `install affected` prompts scoped to human TTYs and document the prompt behavior

## Validation
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `git diff --check`
- `zensical build --clean`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features`
- `cli-rs/target/debug/kast status --workspace-root "$PWD"`
- `cli-rs/target/debug/kast --output json status --workspace-root "$PWD"`