### PR TITLE
Improve IntelliJ config visibility and CLI status output

### DIFF
--- a/.github/scripts/test-kast-copilot-plugin.sh
+++ b/.github/scripts/test-kast-copilot-plugin.sh
@@ -100,15 +100,31 @@ assert(
   "instructions must identify blocked compiler facts",
 );
 assert(instruction.includes("as blockers"), "instructions must fail closed on blockers");
+assert(
+  instruction.includes('kast up --workspace-root "$PWD" --backend idea'),
+  "instructions must warm the IDEA backend before missing-index fallback",
+);
 
 const tools = readText("extensions/kast/_shared/kast-tools.mjs");
 assert(tools.includes("Preferred Kotlin funnel tool"), "tool guidance must prefer funnel tools");
 assert(tools.includes("Bounded raw escape hatch"), "tool guidance must bound raw escape hatches");
+const extension = readText("extensions/kast/extension.mjs");
+assert(extension.includes("RECOVERABLE_WARMUP_CODES"), "extension must classify warmup errors");
+assert(extension.includes('"INDEX_UNAVAILABLE"'), "extension must recover missing source indexes");
+assert(extension.includes('"up"'), "extension must invoke kast up for warmup");
 
 const reader = readText("agents/kast-reader.agent.md");
 const writer = readText("agents/kast-writer.agent.md");
 assert(reader.includes("name: Kast Reader"), "reader agent must be named");
 assert(writer.includes("name: Kast Writer"), "writer agent must be named");
+assert(
+  reader.includes('kast up --workspace-root "$PWD" --backend idea'),
+  "reader agent must warm the IDEA backend before fallback",
+);
+assert(
+  writer.includes('kast up --workspace-root "$PWD" --backend idea'),
+  "writer agent must warm the IDEA backend before fallback",
+);
 assert(!reader.includes("kast_write_and_validate"), "reader must not expose write-and-validate");
 assert(!reader.includes("kast_rename"), "reader must not expose rename");
 assert(!reader.includes("  - edit"), "reader must not expose edit");
@@ -153,6 +169,12 @@ const reader = agents.find((agent) => agent.name === "kast-reader");
 const writer = agents.find((agent) => agent.name === "kast-writer");
 if (!reader) throw new Error("source plugin import missing kast-reader");
 if (!writer) throw new Error("source plugin import missing kast-writer");
+if (!reader.prompt.includes('kast up --workspace-root "$PWD" --backend idea')) {
+  throw new Error("source reader prompt must warm the IDEA backend before fallback");
+}
+if (!writer.prompt.includes('kast up --workspace-root "$PWD" --backend idea')) {
+  throw new Error("source writer prompt must warm the IDEA backend before fallback");
+}
 for (const writeTool of ["kast_rename", "kast_write_and_validate", "edit", "execute"]) {
   if (reader.tools.includes(writeTool)) throw new Error(`source reader must not include ${writeTool}`);
   if (!writer.tools.includes(writeTool)) throw new Error(`source writer must include ${writeTool}`);
@@ -215,6 +237,12 @@ for (const required of ["kast-reader", "kast-writer"]) {
 }
 const reader = agents.find((agent) => agent.name === "kast-reader");
 const writer = agents.find((agent) => agent.name === "kast-writer");
+if (!reader.prompt.includes('kast up --workspace-root "$PWD" --backend idea')) {
+  throw new Error("installed reader prompt must warm the IDEA backend before fallback");
+}
+if (!writer.prompt.includes('kast up --workspace-root "$PWD" --backend idea')) {
+  throw new Error("installed writer prompt must warm the IDEA backend before fallback");
+}
 for (const writeTool of ["kast_rename", "kast_write_and_validate", "edit", "execute"]) {
   if (reader.tools.includes(writeTool)) throw new Error(`reader must not include ${writeTool}`);
   if (!writer.tools.includes(writeTool)) throw new Error(`writer must include ${writeTool}`);

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastRecentFilesIndexPreview.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastRecentFilesIndexPreview.kt
@@ -1,0 +1,74 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.indexstore.api.index.SourceIndexSnapshot
+import java.nio.file.Path
+
+internal enum class KastRecentFileIndexState(
+    val displayName: String,
+) {
+    INDEXED("Indexed"),
+    MISSING_FROM_INDEX("Not indexed"),
+    INDEX_UNAVAILABLE("Database unavailable"),
+}
+
+internal data class KastRecentFileIndexRow(
+    val displayPath: String,
+    val absolutePath: String,
+    val state: KastRecentFileIndexState,
+    val moduleName: String?,
+    val packageName: String?,
+    val identifierCount: Int?,
+    val importCount: Int?,
+    val wildcardImportCount: Int?,
+)
+
+internal fun recentFileIndexRows(
+    recentFilePaths: List<Path>,
+    workspaceRoot: Path,
+    snapshot: SourceIndexSnapshot?,
+): List<KastRecentFileIndexRow> {
+    val root = workspaceRoot.toAbsolutePath().normalize()
+    val identifierCountByPath = snapshot?.identifierCountByPath().orEmpty()
+    val indexedPaths = snapshot?.indexedPaths().orEmpty()
+    return recentFilePaths
+        .map { path -> path.toAbsolutePath().normalize() }
+        .distinct()
+        .map { path ->
+            val key = path.toString()
+            KastRecentFileIndexRow(
+                displayPath = path.displayPath(root),
+                absolutePath = key,
+                state = when {
+                    snapshot == null -> KastRecentFileIndexState.INDEX_UNAVAILABLE
+                    key in indexedPaths -> KastRecentFileIndexState.INDEXED
+                    else -> KastRecentFileIndexState.MISSING_FROM_INDEX
+                },
+                moduleName = snapshot?.moduleNameByPath?.get(key),
+                packageName = snapshot?.packageByPath?.get(key),
+                identifierCount = identifierCountByPath[key],
+                importCount = snapshot?.importsByPath?.get(key)?.size,
+                wildcardImportCount = snapshot?.wildcardImportPackagesByPath?.get(key)?.size,
+            )
+        }
+}
+
+private fun SourceIndexSnapshot.indexedPaths(): Set<String> = buildSet {
+    addAll(moduleNameByPath.keys)
+    addAll(packageByPath.keys)
+    addAll(importsByPath.keys)
+    addAll(wildcardImportPackagesByPath.keys)
+    candidatePathsByIdentifier.values.forEach(::addAll)
+}
+
+private fun SourceIndexSnapshot.identifierCountByPath(): Map<String, Int> = buildMap {
+    candidatePathsByIdentifier.values
+        .flatten()
+        .forEach { path -> put(path, getOrDefault(path, 0) + 1) }
+}
+
+private fun Path.displayPath(workspaceRoot: Path): String =
+    if (startsWith(workspaceRoot)) {
+        workspaceRoot.relativize(this).joinToString("/")
+    } else {
+        toString()
+    }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastSettingsConfigurable.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastSettingsConfigurable.kt
@@ -2,13 +2,14 @@
 
 package io.github.amichne.kast.idea
 
-import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogPanel
-import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.panel
 import io.github.amichne.kast.api.client.KastConfig
 import io.github.amichne.kast.api.client.WorkspaceDirectoryResolver
@@ -25,7 +26,7 @@ internal class KastSettingsConfigurable(
     private lateinit var backendsIdeaEnabled: JBCheckBox
     private lateinit var projectOpenProfileAutoInit: JBCheckBox
     private lateinit var projectOpenAutoExcludeGit: JBCheckBox
-    private lateinit var cliBinaryPath: TextFieldWithBrowseButton
+    private lateinit var cliBinaryPath: JBTextField
 
     override fun getDisplayName(): String = "Kast"
 
@@ -37,8 +38,7 @@ internal class KastSettingsConfigurable(
         return selectedRuntimeDefaultBackend().configValue != state.runtimeDefaultBackend ||
             backendsIdeaEnabled.isSelected != (state.backendsIdeaEnabled ?: false) ||
             projectOpenProfileAutoInit.isSelected != (state.projectOpenProfileAutoInit ?: false) ||
-            projectOpenAutoExcludeGit.isSelected != (state.projectOpenAutoExcludeGit ?: true) ||
-            cliBinaryPath.text != state.cliBinaryPath.orEmpty()
+            projectOpenAutoExcludeGit.isSelected != (state.projectOpenAutoExcludeGit ?: true)
     }
 
     override fun reset() {
@@ -55,9 +55,7 @@ internal class KastSettingsConfigurable(
         val state = KastSettingsState.getInstance(project)
         updateStateFromFields(state)
 
-        val configPath = WorkspaceDirectoryResolver()
-            .workspaceDataDirectory(workspaceRoot)
-            .resolve("config.toml")
+        val configPath = workspaceConfigPath(workspaceRoot)
         val existingToml = if (Files.isRegularFile(configPath)) Files.readString(configPath) else ""
         val nextToml = mergePublicWorkspaceToml(existingToml, state)
         Files.createDirectories(configPath.parent)
@@ -93,11 +91,11 @@ internal class KastSettingsConfigurable(
 
         group("CLI") {
             row("Binary path:") {
-                cliBinaryPath = textFieldWithBrowseButton(
-                    FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
-                        .withTitle("Select Kast CLI Binary"),
-                    project,
-                ) { it.path }.component
+                cliBinaryPath = textField().component.apply {
+                    isEditable = false
+                    emptyText.text = "Resolved from Kast config"
+                }
+                button("Open config") { openWorkspaceConfig() }
             }
         }
     }
@@ -118,14 +116,28 @@ internal class KastSettingsConfigurable(
         state.projectOpenProfileAutoInit = projectOpenProfileAutoInit.isSelected
         state.projectOpenProfile = io.github.amichne.kast.api.client.fields.ProjectOpenProfile.COPILOT_LSP
         state.projectOpenAutoExcludeGit = projectOpenAutoExcludeGit.isSelected
-        state.cliBinaryPath = cliBinaryPath.text.takeIf(String::isNotBlank)
     }
 
     private fun selectedRuntimeDefaultBackend(): KastRuntimeDefaultBackendOption =
         runtimeDefaultBackend.selectedItem as? KastRuntimeDefaultBackendOption
             ?: KastRuntimeDefaultBackendOption.AUTO
 
+    private fun openWorkspaceConfig() {
+        val workspaceRoot = workspaceRoot() ?: return
+        val configPath = workspaceConfigPath(workspaceRoot)
+        Files.createDirectories(configPath.parent)
+        if (Files.notExists(configPath)) {
+            Files.writeString(configPath, "")
+        }
+        val virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(configPath) ?: return
+        FileEditorManager.getInstance(project).openFile(virtualFile, true)
+    }
+
     private fun workspaceRoot(): Path? = project.basePath?.let { Path.of(it).toAbsolutePath().normalize() }
+
+    private fun workspaceConfigPath(workspaceRoot: Path): Path = WorkspaceDirectoryResolver()
+        .workspaceDataDirectory(workspaceRoot)
+        .resolve("config.toml")
 }
 
 private enum class KastRuntimeDefaultBackendOption(

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastSettingsState.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastSettingsState.kt
@@ -8,13 +8,11 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.util.xmlb.XmlSerializerUtil
 import io.github.amichne.kast.api.client.BackendsConfigOverride
-import io.github.amichne.kast.api.client.CliConfigOverride
 import io.github.amichne.kast.api.client.IdeaBackendConfigOverride
 import io.github.amichne.kast.api.client.KastConfig
 import io.github.amichne.kast.api.client.KastConfigOverride
 import io.github.amichne.kast.api.client.ProjectOpenConfigOverride
 import io.github.amichne.kast.api.client.RuntimeConfigOverride
-import io.github.amichne.kast.api.client.fields.CliBinaryPath
 import io.github.amichne.kast.api.client.fields.IdeaBackendEnabled
 import io.github.amichne.kast.api.client.fields.ProjectOpenAutoExcludeGit
 import io.github.amichne.kast.api.client.fields.ProjectOpenProfile
@@ -78,7 +76,6 @@ internal class KastSettingsState : PersistentStateComponent<KastSettingsState> {
         backends = BackendsConfigOverride(
             idea = IdeaBackendConfigOverride(enabled = backendsIdeaEnabled?.let(::IdeaBackendEnabled)).takeIfAny(),
         ).takeIfAny(),
-        cli = CliConfigOverride(binaryPath = cliBinaryPath?.takeIf(String::isNotBlank)?.let(::CliBinaryPath)).takeIfAny(),
     )
 
     companion object {
@@ -97,6 +94,3 @@ private fun BackendsConfigOverride.takeIfAny(): BackendsConfigOverride? =
 
 private fun IdeaBackendConfigOverride.takeIfAny(): IdeaBackendConfigOverride? =
     takeIf { enabled != null }
-
-private fun CliConfigOverride.takeIfAny(): CliConfigOverride? =
-    takeIf { binaryPath != null }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastSettingsToml.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastSettingsToml.kt
@@ -19,7 +19,6 @@ internal fun KastSettingsState.toWorkspaceToml(defaults: KastConfig = KastConfig
             ),
         )
         add(tomlSection("backends.idea", "enabled" to backendsIdeaEnabled.changedFrom(defaults.backends.idea.enabled.value)))
-        add(tomlSection("cli", "binaryPath" to cliBinaryPath.changedFrom(defaults.cli.binaryPath.value)))
     }.filter(String::isNotBlank)
 
     if (sections.isEmpty()) return ""
@@ -68,7 +67,6 @@ private val managedPublicKeys = setOf(
     "projectopen.profile",
     "projectopen.autoexcludegit",
     "backends.idea.enabled",
-    "cli.binarypath",
 )
 
 private fun removeManagedPublicSettings(toml: String): String {

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastToolWindowFactory.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastToolWindowFactory.kt
@@ -1,32 +1,53 @@
+@file:Suppress("UnstableApiUsage")
+
 package io.github.amichne.kast.idea
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.impl.EditorHistoryManager
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
-import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
 import com.intellij.ui.components.JBScrollPane
-import com.intellij.ui.content.ContentFactory
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
+import io.github.amichne.kast.indexstore.api.index.SourceIndexSnapshot
+import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import java.awt.BorderLayout
+import java.awt.FlowLayout
 import java.awt.GridLayout
+import java.nio.file.Path
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
 import javax.swing.table.AbstractTableModel
 
 internal class KastToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        val panel = KastActivityPanel(project)
-        Disposer.register(toolWindow.disposable, panel)
-        val content = ContentFactory.getInstance().createContent(panel, "Activity", false)
-        toolWindow.contentManager.addContent(content)
+        val contentManager = toolWindow.contentManager
+        val activityPanel = KastActivityPanel(project)
+        val recentFilesPanel = KastRecentFilesPanel(project)
+
+        contentManager.addContent(
+            contentManager.factory.createContent(activityPanel, "Activity", false).apply {
+                setPreferredFocusableComponent(activityPanel)
+                setDisposer(activityPanel)
+            },
+        )
+        contentManager.addContent(
+            contentManager.factory.createContent(recentFilesPanel, "Recent files", false).apply {
+                setPreferredFocusableComponent(recentFilesPanel)
+                setDisposer(recentFilesPanel)
+            },
+        )
     }
 
     override fun shouldBeAvailable(project: Project): Boolean = !project.isDisposed
@@ -106,6 +127,97 @@ private class KastActivityPanel(
     }
 }
 
+private class KastRecentFilesPanel(
+    private val project: Project,
+) : SimpleToolWindowPanel(true, true), Disposable {
+    private val diagnostics = KastDiagnosticsService.getInstance(project)
+    private val recentFilesModel = KastRecentFilesIndexTableModel()
+    private val recentFilesStatus = JBLabel()
+
+    init {
+        setContent(buildContent())
+        diagnostics.addListener(this) { snapshot -> render(snapshot) }
+    }
+
+    override fun dispose() = Unit
+
+    private fun buildContent(): JComponent {
+        val panel = JBPanel<JBPanel<*>>(BorderLayout())
+        panel.border = JBUI.Borders.empty(8)
+
+        val toolbar = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 0, 0))
+        recentFilesStatus.foreground = JBColor.GRAY
+        toolbar.add(JButton("Refresh").apply {
+            addActionListener { refreshRecentFilesPreview(diagnostics.snapshot()) }
+        })
+        toolbar.add(JBPanel<JBPanel<*>>().apply {
+            border = JBUI.Borders.emptyLeft(8)
+            add(recentFilesStatus)
+        })
+        panel.add(toolbar, BorderLayout.NORTH)
+
+        val table = JBTable(recentFilesModel)
+        table.emptyText.text = "No recent files recorded by IDEA"
+        table.setShowColumns(true)
+        table.setStriped(true)
+        table.autoCreateRowSorter = true
+        panel.add(JBScrollPane(table), BorderLayout.CENTER)
+        return panel
+    }
+
+    private fun render(snapshot: KastDiagnosticsSnapshot) {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            SwingUtilities.invokeLater { render(snapshot) }
+            return
+        }
+
+        refreshRecentFilesPreview(snapshot)
+    }
+
+    private fun refreshRecentFilesPreview(snapshot: KastDiagnosticsSnapshot) {
+        val workspaceRoot = snapshot.workspaceRoot?.let { Path.of(it).toAbsolutePath().normalize() }
+            ?: project.basePath?.let { Path.of(it).toAbsolutePath().normalize() }
+        if (workspaceRoot == null) {
+            recentFilesModel.setRows(emptyList())
+            recentFilesStatus.text = "No workspace"
+            return
+        }
+        val recentFiles = recentFiles()
+        val sourceIndexSnapshot = loadSourceIndexSnapshot(workspaceRoot)
+        val recentFilePaths = recentFiles.mapNotNull { file ->
+            runCatching { Path.of(file.path) }.getOrNull()
+        }
+        recentFilesModel.setRows(recentFileIndexRows(recentFilePaths, workspaceRoot, sourceIndexSnapshot))
+        recentFilesStatus.text = when {
+            recentFiles.isEmpty() -> "No recent files"
+            sourceIndexSnapshot == null -> "source-index.db unavailable"
+            else -> "Showing ${recentFiles.size.coerceAtMost(RECENT_FILE_LIMIT)} recent files as indexed"
+        }
+    }
+
+    private fun recentFiles(): List<VirtualFile> {
+        val history = EditorHistoryManager.getInstance(project).fileList
+        val openFiles = FileEditorManager.getInstance(project).openFiles.toList()
+        return (history + openFiles)
+            .asSequence()
+            .filterNot(VirtualFile::isDirectory)
+            .distinctBy(VirtualFile::getPath)
+            .take(RECENT_FILE_LIMIT)
+            .toList()
+    }
+
+    private fun loadSourceIndexSnapshot(workspaceRoot: Path): SourceIndexSnapshot? =
+        runCatching {
+            SqliteSourceIndexStore(workspaceRoot).use { store ->
+                if (store.dbExists()) store.loadSourceIndexSnapshot() else null
+            }
+        }.getOrNull()
+
+    companion object {
+        private const val RECENT_FILE_LIMIT = 20
+    }
+}
+
 private class KastActivityTableModel : AbstractTableModel() {
     private var events: List<KastActivityEvent> = emptyList()
 
@@ -143,5 +255,47 @@ private class KastActivityTableModel : AbstractTableModel() {
 
     companion object {
         private val TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault())
+    }
+}
+
+private class KastRecentFilesIndexTableModel : AbstractTableModel() {
+    private var rows: List<KastRecentFileIndexRow> = emptyList()
+
+    fun setRows(nextRows: List<KastRecentFileIndexRow>) {
+        rows = nextRows
+        fireTableDataChanged()
+    }
+
+    override fun getRowCount(): Int = rows.size
+
+    override fun getColumnCount(): Int = Column.entries.size
+
+    override fun getColumnName(column: Int): String = Column.entries[column].title
+
+    override fun getValueAt(rowIndex: Int, columnIndex: Int): Any {
+        val row = rows[rowIndex]
+        return when (Column.entries[columnIndex]) {
+            Column.FILE -> row.displayPath
+            Column.INDEX -> row.state.displayName
+            Column.MODULE -> row.moduleName.orEmpty()
+            Column.PACKAGE -> row.packageName.orEmpty()
+            Column.IDENTIFIERS -> row.identifierCount?.toString().orEmpty()
+            Column.IMPORTS -> row.importSummary()
+        }
+    }
+
+    private fun KastRecentFileIndexRow.importSummary(): String {
+        val imports = importCount ?: return ""
+        val wildcardImports = wildcardImportCount ?: 0
+        return if (wildcardImports == 0) imports.toString() else "$imports + $wildcardImports wildcard"
+    }
+
+    private enum class Column(val title: String) {
+        FILE("File"),
+        INDEX("Index"),
+        MODULE("Module"),
+        PACKAGE("Package"),
+        IDENTIFIERS("Identifiers"),
+        IMPORTS("Imports"),
     }
 }

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastRecentFilesIndexPreviewTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastRecentFilesIndexPreviewTest.kt
@@ -1,0 +1,56 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.indexstore.api.index.SourceIndexSnapshot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+class KastRecentFilesIndexPreviewTest {
+    @Test
+    fun `recent files render source index metadata by workspace relative path`() {
+        val root = Path.of("/workspace").toAbsolutePath().normalize()
+        val indexedFile = root.resolve("src/main/kotlin/app/App.kt")
+        val snapshot = SourceIndexSnapshot(
+            candidatePathsByIdentifier = mapOf(
+                "App" to listOf(indexedFile.toString()),
+                "main" to listOf(indexedFile.toString()),
+            ),
+            moduleNameByPath = mapOf(indexedFile.toString() to ":[main]"),
+            packageByPath = mapOf(indexedFile.toString() to "app"),
+            importsByPath = mapOf(indexedFile.toString() to listOf("kotlin.collections.List")),
+            wildcardImportPackagesByPath = mapOf(indexedFile.toString() to listOf("kotlin.io")),
+        )
+
+        val rows = recentFileIndexRows(
+            recentFilePaths = listOf(indexedFile),
+            workspaceRoot = root,
+            snapshot = snapshot,
+        )
+
+        assertEquals(1, rows.size)
+        assertEquals("src/main/kotlin/app/App.kt", rows.single().displayPath)
+        assertEquals(KastRecentFileIndexState.INDEXED, rows.single().state)
+        assertEquals(":[main]", rows.single().moduleName)
+        assertEquals("app", rows.single().packageName)
+        assertEquals(2, rows.single().identifierCount)
+        assertEquals(1, rows.single().importCount)
+        assertEquals(1, rows.single().wildcardImportCount)
+    }
+
+    @Test
+    fun `recent files stay visible when the source index is unavailable`() {
+        val root = Path.of("/workspace").toAbsolutePath().normalize()
+        val recentFile = root.resolve("src/test/kotlin/app/AppTest.kt")
+
+        val rows = recentFileIndexRows(
+            recentFilePaths = listOf(recentFile, recentFile),
+            workspaceRoot = root,
+            snapshot = null,
+        )
+
+        assertEquals(1, rows.size)
+        assertEquals("src/test/kotlin/app/AppTest.kt", rows.single().displayPath)
+        assertEquals(KastRecentFileIndexState.INDEX_UNAVAILABLE, rows.single().state)
+        assertEquals(null, rows.single().identifierCount)
+    }
+}

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastSettingsConfigurableTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastSettingsConfigurableTest.kt
@@ -36,8 +36,8 @@ class KastSettingsConfigurableTest {
         assertTrue(toml.contains("[projectOpen]"))
         assertTrue(toml.contains("profileAutoInit = true"))
         assertTrue(toml.contains("autoExcludeGit = false"))
-        assertTrue(toml.contains("[cli]"))
-        assertTrue(toml.contains("binaryPath = \"/tmp/kast\""))
+        assertFalse(toml.contains("[cli]"))
+        assertFalse(toml.contains("binaryPath = \"/tmp/kast\""))
         assertTrue(toml.contains("[backends.idea]"))
         assertTrue(toml.contains("enabled = false"))
         assertFalse(toml.contains("maxResults"))
@@ -60,7 +60,7 @@ class KastSettingsConfigurableTest {
     }
 
     @Test
-    fun `public settings merge preserves unrelated advanced toml`() {
+    fun `public settings merge preserves cli binary path as manually edited toml`() {
         val existingToml = """
             [server]
             maxResults = 1000
@@ -106,11 +106,11 @@ class KastSettingsConfigurableTest {
         assertTrue(toml.contains("profileAutoInit = true"))
         assertTrue(toml.contains("autoExcludeGit = false"))
         assertTrue(toml.contains("[cli]"))
-        assertTrue(toml.contains("binaryPath = \"/new/kast\""))
+        assertTrue(toml.contains("binaryPath = \"/old/kast\""))
         assertFalse(toml.contains("defaultBackend = \"headless\""))
         assertFalse(toml.contains("profileAutoInit = false"))
         assertFalse(toml.contains("autoExcludeGit = true"))
-        assertFalse(toml.contains("binaryPath = \"/old/kast\""))
+        assertFalse(toml.contains("binaryPath = \"/new/kast\""))
     }
 
     @Test
@@ -130,7 +130,7 @@ class KastSettingsConfigurableTest {
         assertEquals("copilot-lsp", override.projectOpen?.profile?.value)
         assertEquals(false, override.projectOpen?.autoExcludeGit?.value)
         assertEquals(false, override.backends?.idea?.enabled?.value)
-        assertEquals("/tmp/kast", override.cli?.binaryPath?.value)
+        assertEquals(null, override.cli)
         assertEquals(null, override.server)
         assertEquals(null, override.indexing)
         assertEquals(null, override.telemetry)

--- a/cli-rs/Cargo.lock
+++ b/cli-rs/Cargo.lock
@@ -251,6 +251,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "charmed-glamour"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1bb7457c2ffa52e1f66b255e9632fcd0bf43fd9f7bda652771d4044d9a96d9"
+dependencies = [
+ "charmed-lipgloss",
+ "lru 0.12.5",
+ "pulldown-cmark",
+ "tracing",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "charmed-lipgloss"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5986a4a6d84055da99e44a6c532fd412d636fe5c3fe17da105a7bf40287ccd1"
+dependencies = [
+ "bitflags 2.11.1",
+ "colored",
+ "crossterm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "toml 0.8.23",
+ "tracing",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +335,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "combine"
@@ -765,6 +806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +864,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1156,6 +1208,7 @@ dependencies = [
 name = "kast"
 version = "0.1.0"
 dependencies = [
+ "charmed-glamour",
  "clap",
  "clap_complete",
  "crossterm",
@@ -1172,7 +1225,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "ureq",
  "uuid",
  "zip",
@@ -1265,6 +1318,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru"
@@ -1678,6 +1740,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.11.1",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,12 +1820,12 @@ dependencies = [
  "indoc",
  "itertools",
  "kasuari",
- "lru",
+ "lru 0.16.4",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1795,7 +1876,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2114,6 +2195,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2460,17 +2550,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2483,19 +2594,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "typenum"
@@ -2508,6 +2670,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-general-category"
@@ -2535,8 +2703,14 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -3046,6 +3220,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/cli-rs/Cargo.toml
+++ b/cli-rs/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.95"
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 crossterm = "0.29"
+glamour = { package = "charmed-glamour", version = "0.2.0" }
 glob = "0.3"
 hex = "0.4"
 include_dir = "0.7"

--- a/cli-rs/resources/kast-skill/SKILL.md
+++ b/cli-rs/resources/kast-skill/SKILL.md
@@ -23,6 +23,18 @@ Run `command -v kast` and `kast --help` before project exploration. If `kast`
 is missing, stop and report the setup blocker instead of switching to
 non-semantic Kotlin search.
 
+If `kast` is present but no backend or source index is available, try to warm
+the IDE-hosted backend before falling back:
+
+```console
+kast up --workspace-root "$PWD" --backend idea
+```
+
+This may open IDEA or Android Studio only when `runtime.ideaLaunch.enabled` is
+set in Kast config; otherwise it reports that the project must be opened in the
+IDE. Treat the failure as a blocker only after this dynamic IDE warmup path has
+failed.
+
 ## Gradle File Routing
 
 - Use for Gradle project file work, not only direct Kotlin edits.

--- a/cli-rs/resources/kast-skill/references/quickstart.md
+++ b/cli-rs/resources/kast-skill/references/quickstart.md
@@ -13,8 +13,20 @@ kast --help
 
 If `kast` is missing in an installed skill session, stop and report that setup
 blocker instead of switching to non-semantic Kotlin search. The installed skill
-does not ship bootstrap scripts; `kast setup` and `kast install affected` own
-durable repair.
+does not ship bootstrap scripts; `kast setup` owns durable repair.
+
+If `kast` exists but a command reports `NO_BACKEND_AVAILABLE`,
+`INDEX_UNAVAILABLE`, `METRICS_DB_UNAVAILABLE`, or a missing source-index
+database, warm the IDEA backend before using text fallback:
+
+```console
+kast up --workspace-root "$PWD" --backend idea
+```
+
+Kast opens IDEA or Android Studio dynamically only when
+`runtime.ideaLaunch.enabled` allows it. If launch is not enabled, the command
+reports that the project must be opened in the IDE with the Kast plugin
+installed. That is the blocker; do not stop at the first missing-index result.
 
 ## Contract reference
 

--- a/cli-rs/resources/kast-skill/references/runbook.md
+++ b/cli-rs/resources/kast-skill/references/runbook.md
@@ -18,6 +18,13 @@ run_kast_rpc() {
     >"$KAST_RESULT" 2>"$KAST_STDERR"
 }
 
+warm_idea_backend_if_needed() {
+  # Use this when kast is installed but RPC/source-index output reports
+  # NO_BACKEND_AVAILABLE, INDEX_UNAVAILABLE, METRICS_DB_UNAVAILABLE, or a
+  # missing source-index database.
+  kast up --workspace-root "$PWD" --backend idea
+}
+
 run_kast_rpc '{"jsonrpc":"2.0","method":"symbol/query","params":{"query":"EventBean","modes":["exact","lexical"],"filters":{"relativePathPrefix":"src/"},"limit":10},"id":1}'
 run_kast_rpc '{"jsonrpc":"2.0","method":"raw/workspace-files","params":{"moduleName":":analysis-api","includeFiles":false,"maxFilesPerModule":25},"id":1}'
 run_kast_rpc '{"jsonrpc":"2.0","method":"symbol/resolve","params":{"symbol":"date","kind":"property","containingType":"com.example.EventBean"},"id":1}'

--- a/cli-rs/resources/plugin/agents/kast-reader.agent.md
+++ b/cli-rs/resources/plugin/agents/kast-reader.agent.md
@@ -34,8 +34,9 @@ You are a read-only Kotlin and Gradle analysis agent for Kast-backed work.
 1. Start with the `kotlin` LSP server when the target is Kotlin or Gradle project structure.
 2. Use `kast_*` tools before broad text search, recursive file reads, or shell fallback.
 3. Prefer symbol and source-index tools for named declarations; use raw workspace search only for strings, comments, literals, or bounded file discovery.
-4. Treat stale, not-ready, missing, ambiguous, partial, or truncated Kast facts as blockers.
-5. Do not edit files, run write tools, or suggest a rename/refactor until references and impact have been checked.
+4. When Kast is installed but backend/index facts are missing, first run `kast up --workspace-root "$PWD" --backend idea` so the IDE-hosted backend can open or warm the project dynamically when config allows it.
+5. Treat stale, not-ready, missing, ambiguous, partial, or truncated Kast facts as blockers only after the IDE warmup path fails.
+6. Do not edit files, run write tools, or suggest a rename/refactor until references and impact have been checked.
 
 ## Output
 

--- a/cli-rs/resources/plugin/agents/kast-writer.agent.md
+++ b/cli-rs/resources/plugin/agents/kast-writer.agent.md
@@ -39,8 +39,9 @@ You are a Kotlin and Gradle implementation agent for scoped Kast-backed changes.
 1. Start by resolving the target through `kotlin` LSP or `kast_*` tools.
 2. Enumerate references, callers, hierarchy, or diagnostics before changing Kotlin behavior.
 3. Prefer `kast_rename` and `kast_write_and_validate` over manual text edits for Kotlin source.
-4. Use shell execution only for validation, package checks, or narrowly scoped commands that Kast cannot perform directly.
-5. Stop and report a blocker when Kast facts are stale, not-ready, missing, ambiguous, partial, or truncated.
+4. If Kast is installed but backend/index facts are missing, run `kast up --workspace-root "$PWD" --backend idea` before falling back so the IDE-hosted backend can open or warm the project dynamically when config allows it.
+5. Use shell execution only for validation, package checks, narrowly scoped commands that Kast cannot perform directly, or the IDEA warmup command above.
+6. Stop and report a blocker when Kast facts are stale, not-ready, missing, ambiguous, partial, or truncated after the IDE warmup path fails.
 
 ## Output
 

--- a/cli-rs/resources/plugin/extensions/kast/_shared/kast-agents.mjs
+++ b/cli-rs/resources/plugin/extensions/kast/_shared/kast-agents.mjs
@@ -20,7 +20,7 @@ export function makeKastCustomAgents() {
         "Read-only Kotlin and Gradle analysis with Kast LSP and kast_* tools before shell or text fallback.",
       tools: kastReaderTools(),
       prompt:
-        "You are Kast Reader. Inspect Kotlin and Gradle work without editing files. Start with the kotlin LSP server, then use kast_* tools for symbol identity, references, callers, hierarchy, diagnostics, workspace search, and source-index metrics. Treat stale, missing, ambiguous, partial, or truncated compiler facts as blockers. Return concise evidence with file paths, symbol identities, references checked, and the next safe writer action when edits are needed.",
+        "You are Kast Reader. Inspect Kotlin and Gradle work without editing files. Start with the kotlin LSP server, then use kast_* tools for symbol identity, references, callers, hierarchy, diagnostics, workspace search, and source-index metrics. If Kast is installed but backend or source-index facts are missing, run kast up --workspace-root \"$PWD\" --backend idea before falling back so the IDE-hosted backend can open or warm the project when config allows it. Treat stale, missing, ambiguous, partial, or truncated compiler facts as blockers only after that IDE warmup path fails. Return concise evidence with file paths, symbol identities, references checked, and the next safe writer action when edits are needed.",
     },
     {
       name: "kast-writer",
@@ -29,7 +29,7 @@ export function makeKastCustomAgents() {
         "Scoped Kotlin and Gradle edits using Kast resolution, rename, write-and-validate, diagnostics, and focused tests.",
       tools: kastWriterTools(),
       prompt:
-        "You are Kast Writer. Make narrowly scoped Kotlin and Gradle changes only after compiler-backed identity is established. Resolve symbols and enumerate impact with kotlin LSP or kast_* tools before editing. Prefer kast_rename and kast_write_and_validate for Kotlin changes, then run Kast diagnostics and the narrowest relevant tests. Stop and report the blocker instead of guessing when Kast facts are stale, missing, ambiguous, partial, or truncated.",
+        "You are Kast Writer. Make narrowly scoped Kotlin and Gradle changes only after compiler-backed identity is established. Resolve symbols and enumerate impact with kotlin LSP or kast_* tools before editing. If Kast is installed but backend or source-index facts are missing, run kast up --workspace-root \"$PWD\" --backend idea before falling back so the IDE-hosted backend can open or warm the project when config allows it. Prefer kast_rename and kast_write_and_validate for Kotlin changes, then run Kast diagnostics and the narrowest relevant tests. Stop and report the blocker instead of guessing when Kast facts are stale, missing, ambiguous, partial, or truncated after that IDE warmup path fails.",
     },
   ];
 }

--- a/cli-rs/resources/plugin/extensions/kast/extension.mjs
+++ b/cli-rs/resources/plugin/extensions/kast/extension.mjs
@@ -10,6 +10,13 @@ import { KAST_TOOL_NAMES, makeKastTools } from "./_shared/kast-tools.mjs";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT_MARKER = "workspace.repos.toml";
 const COPILOT_IDEA_AUTOSTART_ENV = "KAST_COPILOT_IDEA_AUTOSTART";
+const RECOVERABLE_WARMUP_CODES = new Set([
+  "INDEX_UNAVAILABLE",
+  "METRICS_DB_UNAVAILABLE",
+  "DEMO_SOURCE_INDEX_MISSING",
+  "DEMO_SOURCE_INDEX_STALE",
+  "NO_BACKEND_AVAILABLE",
+]);
 
 let kastBinary = null;
 let resolveError = null;
@@ -145,6 +152,80 @@ function backendArgs() {
   return ["1", "true", "yes", "on"].includes(value) ? ["--backend", "idea"] : [];
 }
 
+function parseJsonOrNull(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function resultCode(value) {
+  if (!value || typeof value !== "object") return null;
+  if (typeof value.code === "string") return value.code;
+  if (typeof value.error?.data?.code === "string") return value.error.data.code;
+  const result = value.result;
+  if (result && typeof result === "object") {
+    if (typeof result.reason === "string") return result.reason;
+    if (typeof result.code === "string") return result.code;
+  }
+  return null;
+}
+
+function needsIdeaWarmup(value) {
+  return RECOVERABLE_WARMUP_CODES.has(resultCode(value));
+}
+
+function rpcArgs(request, args = backendArgs()) {
+  return [
+    "--output",
+    "json",
+    "rpc",
+    request,
+    "--workspace-root",
+    REPO_ROOT,
+    ...args,
+  ];
+}
+
+async function warmIdeaBackend(bin) {
+  return execCommand(bin, [
+    "--output",
+    "json",
+    "up",
+    "--workspace-root",
+    REPO_ROOT,
+    "--backend",
+    "idea",
+  ]);
+}
+
+function formattedRpcResult(method, result, warmup = null) {
+  const out = result.stdout.trim();
+  if (!out) {
+    return JSON.stringify({
+      ok: false,
+      stage: "extension.exec",
+      method,
+      message: `kast rpc ${method} produced no output`,
+      exitCode: result.code,
+      errorText: result.stderr.trim() || null,
+      ideaWarmup: warmup,
+    });
+  }
+  if (parseJsonOrNull(out)) return out;
+  return JSON.stringify({
+    ok: false,
+    stage: "extension.parse",
+    method,
+    message: `kast rpc ${method} returned non-JSON`,
+    exitCode: result.code,
+    raw: out,
+    errorText: result.stderr.trim() || null,
+    ideaWarmup: warmup,
+  });
+}
+
 async function callKast(method, params) {
   const bin = await resolveKastBinary();
   if (!bin) {
@@ -162,38 +243,23 @@ async function callKast(method, params) {
     params: params ?? {},
     id: 1,
   });
-  const result = await execCommand(bin, [
-    "rpc",
-    request,
-    "--workspace-root",
-    REPO_ROOT,
-    ...backendArgs(),
-  ]);
-  const out = result.stdout.trim();
-  if (!out) {
-    return JSON.stringify({
+  const first = await execCommand(bin, rpcArgs(request));
+  const firstJson = parseJsonOrNull(first.stdout.trim());
+  if (needsIdeaWarmup(firstJson)) {
+    const warmup = await warmIdeaBackend(bin);
+    const warmupJson = parseJsonOrNull(warmup.stdout.trim());
+    if (warmup.ok) {
+      return formattedRpcResult(method, await execCommand(bin, rpcArgs(request, ["--backend", "idea"])));
+    }
+    return formattedRpcResult(method, first, {
+      attempted: true,
       ok: false,
-      stage: "extension.exec",
-      method,
-      message: `kast rpc ${method} produced no output`,
-      exitCode: result.code,
-      errorText: result.stderr.trim() || null,
+      exitCode: warmup.code,
+      error: warmupJson,
+      errorText: warmup.stderr.trim() || null,
     });
   }
-  try {
-    JSON.parse(out);
-    return out;
-  } catch {
-    return JSON.stringify({
-      ok: false,
-      stage: "extension.parse",
-      method,
-      message: `kast rpc ${method} returned non-JSON`,
-      exitCode: result.code,
-      raw: out,
-      errorText: result.stderr.trim() || null,
-    });
-  }
+  return formattedRpcResult(method, first);
 }
 
 const session = await joinSession({

--- a/cli-rs/resources/plugin/instructions/kast-kotlin.instructions.md
+++ b/cli-rs/resources/plugin/instructions/kast-kotlin.instructions.md
@@ -18,6 +18,19 @@ For Kast-specific work outside standard LSP, inspect
 `capabilities.experimental.kastMethods` from the LSP `initialize` response and
 use the advertised `kast/*` methods before native tools or shell fallbacks.
 
+If `kast` is available but the LSP or `kast_*` tools report a missing backend,
+missing source-index database, `INDEX_UNAVAILABLE`, or
+`METRICS_DB_UNAVAILABLE`, warm the IDE backend before treating the fact as
+blocked:
+
+```console
+kast up --workspace-root "$PWD" --backend idea
+```
+
+This command may open IDEA or Android Studio dynamically only when
+`runtime.ideaLaunch.enabled` allows it. If that warmup fails, report the exact
+backend/index blocker instead of replacing compiler facts with text search.
+
 Prefer the narrow funnel:
 
 1. `symbol/query` or LSP workspace symbols for unknown names.
@@ -29,4 +42,5 @@ Prefer the narrow funnel:
    list that the raw method requires.
 
 Treat stale, not-ready, missing, ambiguous, partial, or truncated compiler facts
-as blockers. Do not replace them with grep, recursive file dumps, or guesses.
+as blockers after the IDE warmup path has failed. Do not replace them with
+grep, recursive file dumps, or guesses.

--- a/cli-rs/src/output.rs
+++ b/cli-rs/src/output.rs
@@ -10,11 +10,14 @@ use crate::runtime::{
     WorkspaceStatusResult,
 };
 use crate::self_mgmt::SelfDoctorResult;
-use crossterm::style::{Stylize, style};
+use glamour::{Renderer, Style};
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Write as FmtWrite};
 use std::io::{self, IsTerminal, Write as IoWrite};
+
+const SOURCE_MODULE_DISPLAY_LIMIT: usize = 30;
 
 macro_rules! mdln {
     ($document:expr) => {
@@ -122,18 +125,25 @@ fn terminal_render_style(is_terminal: bool) -> RenderStyle {
 }
 
 fn render_markdown(markdown: &str, style: RenderStyle) -> String {
+    match style {
+        RenderStyle::Plain => render_plain_markdown(markdown),
+        RenderStyle::Ansi => Renderer::new().with_style(Style::Dark).render(markdown),
+    }
+}
+
+fn render_plain_markdown(markdown: &str) -> String {
     let mut rendered = String::new();
     for line in markdown.lines() {
         if let Some(heading) = line.strip_prefix("# ") {
-            push_heading(&mut rendered, heading, '=', style);
+            push_heading(&mut rendered, heading, '=');
         } else if let Some(heading) = line.strip_prefix("## ") {
-            push_heading(&mut rendered, heading, '-', style);
+            push_heading(&mut rendered, heading, '-');
         } else if let Some(item) = line.strip_prefix("- ") {
             rendered.push_str("- ");
-            rendered.push_str(&render_inline(item, style));
+            rendered.push_str(&render_inline_plain(item));
             rendered.push('\n');
         } else {
-            rendered.push_str(&render_inline(line, style));
+            rendered.push_str(&render_inline_plain(line));
             rendered.push('\n');
         }
     }
@@ -143,37 +153,19 @@ fn render_markdown(markdown: &str, style: RenderStyle) -> String {
     rendered
 }
 
-fn push_heading(rendered: &mut String, heading: &str, underline: char, style: RenderStyle) {
-    rendered.push_str(&style_heading(heading, style));
+fn push_heading(rendered: &mut String, heading: &str, underline: char) {
+    rendered.push_str(heading);
     rendered.push('\n');
     rendered.push_str(&underline.to_string().repeat(heading.chars().count().max(1)));
     rendered.push('\n');
 }
 
-fn render_inline(line: &str, render_style: RenderStyle) -> String {
+fn render_inline_plain(line: &str) -> String {
     let mut rendered = String::new();
-    for (index, segment) in line.split('`').enumerate() {
-        if index % 2 == 0 {
-            rendered.push_str(segment);
-        } else {
-            rendered.push_str(&style_code(segment, render_style));
-        }
+    for segment in line.split('`') {
+        rendered.push_str(segment);
     }
     rendered
-}
-
-fn style_heading(text: &str, render_style: RenderStyle) -> String {
-    match render_style {
-        RenderStyle::Plain => text.to_string(),
-        RenderStyle::Ansi => style(text).bold().to_string(),
-    }
-}
-
-fn style_code(text: &str, render_style: RenderStyle) -> String {
-    match render_style {
-        RenderStyle::Plain => text.to_string(),
-        RenderStyle::Ansi => style(text).cyan().to_string(),
-    }
 }
 
 #[cfg(test)]
@@ -638,13 +630,7 @@ fn print_candidate(
         mdln!(document, "- Active: {}", yes_no(status.active));
         mdln!(document, "- Healthy: {}", yes_no(status.healthy));
         mdln!(document, "- Indexing: {}", yes_no(status.indexing));
-        if !status.source_module_names.is_empty() {
-            mdln!(
-                document,
-                "- Source modules: {}",
-                status.source_module_names.join(", ")
-            );
-        }
+        print_source_modules(document, &status.source_module_names);
         if let Some(message) = &status.message {
             mdln!(document, "- Message: {message}");
         }
@@ -652,6 +638,87 @@ fn print_candidate(
     }
     if let Some(error_message) = &candidate.error_message {
         mdln!(document, "- Error: {error_message}");
+    }
+}
+
+fn print_source_modules(document: &mut MarkdownDocument, module_names: &[String]) {
+    let modules = normalized_modules(module_names);
+    if modules.is_empty() {
+        return;
+    }
+
+    let displayed = modules
+        .iter()
+        .take(SOURCE_MODULE_DISPLAY_LIMIT)
+        .cloned()
+        .collect::<Vec<_>>();
+    let remaining = modules.len().saturating_sub(displayed.len());
+
+    let mut tree = ModuleTree::default();
+    for module in displayed {
+        tree.insert(&module);
+    }
+
+    mdln!(document);
+    mdln!(document, "## Source modules");
+    tree.print(document);
+    if remaining > 0 {
+        mdln!(document, "- ... {remaining} more modules");
+    }
+}
+
+fn normalized_modules(module_names: &[String]) -> Vec<Vec<String>> {
+    module_names
+        .iter()
+        .filter_map(|module_name| normalize_module_name(module_name))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn normalize_module_name(module_name: &str) -> Option<Vec<String>> {
+    let trimmed = module_name.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let without_root = trimmed.trim_start_matches(':');
+    let parts = without_root
+        .split(':')
+        .filter(|part| !part.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+
+    if parts.is_empty() {
+        Some(vec![trimmed.to_string()])
+    } else {
+        Some(parts)
+    }
+}
+
+#[derive(Default)]
+struct ModuleTree {
+    children: BTreeMap<String, ModuleTree>,
+}
+
+impl ModuleTree {
+    fn insert(&mut self, path: &[String]) {
+        let Some((first, rest)) = path.split_first() else {
+            return;
+        };
+        self.children.entry(first.clone()).or_default().insert(rest);
+    }
+
+    fn print(&self, document: &mut MarkdownDocument) {
+        self.print_at_depth(document, 0);
+    }
+
+    fn print_at_depth(&self, document: &mut MarkdownDocument, depth: usize) {
+        let indent = "  ".repeat(depth);
+        for (name, child) in &self.children {
+            mdln!(document, "{indent}- `{name}`");
+            child.print_at_depth(document, depth + 1);
+        }
     }
 }
 
@@ -737,5 +804,61 @@ mod tests {
             !rendered.contains("# Kast status") && !rendered.contains("`/tmp/kast`"),
             "ANSI rendering should still remove raw Markdown control tokens: {rendered:?}"
         );
+    }
+
+    #[test]
+    fn source_modules_render_as_plain_text_tree() {
+        let rendered = render_source_modules_for_test(&[
+            ":backend:idea",
+            ":analysis-api",
+            ":backend:headless",
+            "secondary",
+        ]);
+
+        assert!(
+            rendered.contains(
+                "Source modules\n--------------\n- analysis-api\n- backend\n  - headless\n  - idea\n- secondary\n"
+            ),
+            "source modules should render as a sorted tree: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Source modules:"),
+            "source modules should not render as a comma-separated list: {rendered}"
+        );
+    }
+
+    #[test]
+    fn source_modules_truncate_after_display_limit() {
+        let modules = (0..32)
+            .map(|index| format!(":module-{index:02}"))
+            .collect::<Vec<_>>();
+        let rendered = render_source_modules_for_owned_test(&modules);
+
+        assert!(
+            rendered.contains("- module-29"),
+            "the thirtieth module should still render: {rendered}"
+        );
+        assert!(
+            !rendered.contains("- module-30"),
+            "modules after the display limit should be omitted: {rendered}"
+        );
+        assert!(
+            rendered.contains("- ... 2 more modules"),
+            "truncation summary should report hidden modules: {rendered}"
+        );
+    }
+
+    fn render_source_modules_for_test(module_names: &[&str]) -> String {
+        let module_names = module_names
+            .iter()
+            .map(|module_name| module_name.to_string())
+            .collect::<Vec<_>>();
+        render_source_modules_for_owned_test(&module_names)
+    }
+
+    fn render_source_modules_for_owned_test(module_names: &[String]) -> String {
+        let mut document = MarkdownDocument::default();
+        print_source_modules(&mut document, module_names);
+        render_markdown_for_test(&document.into_string(), RenderStyle::Plain)
     }
 }

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -2842,11 +2842,14 @@ fn packaged_skill_targets_rust_kast_only() {
     assert!(skill.contains("raw/semantic-insertion-point"));
     assert!(skill.contains("raw/completions"));
     assert!(skill.contains("raw/apply-edits"));
+    assert!(skill.contains("kast up --workspace-root \"$PWD\" --backend idea"));
     assert!(quickstart.contains("command -v kast"));
     assert!(quickstart.contains("kast validate --request-file"));
     assert!(quickstart.contains("kast rpc"));
     assert!(quickstart.contains("kast metrics impact"));
     assert!(quickstart.contains("kast demo"));
+    assert!(quickstart.contains("INDEX_UNAVAILABLE"));
+    assert!(quickstart.contains("kast up --workspace-root \"$PWD\" --backend idea"));
     assert!(routing_reference.contains("rust-kast-cli"));
     assert!(!routing_reference.contains("evals/"));
     assert!(!skill.contains("JVM CLI"));

--- a/cli-rs/tests/rpc_catalog_smoke.rs
+++ b/cli-rs/tests/rpc_catalog_smoke.rs
@@ -506,6 +506,12 @@ fn copilot_plugin_source_stays_inside_cli_resources_plugin() {
         !extension.contains("\"bash\""),
         "extension must resolve kast without shelling through bash"
     );
+    assert!(
+        extension.contains("RECOVERABLE_WARMUP_CODES")
+            && extension.contains("\"INDEX_UNAVAILABLE\"")
+            && extension.contains("\"up\""),
+        "extension must warm the IDEA backend for missing backend/index results"
+    );
     let install_local = std::fs::read_to_string(plugin_root.join("scripts/install-local.sh"))
         .expect("local plugin installer");
     assert!(
@@ -577,16 +583,22 @@ fn copilot_install_receives_the_manifest_declared_package_outputs() {
         installed_instruction.contains("start with the `kotlin` LSP server"),
         "Kotlin instruction must force the LSP route"
     );
+    assert!(
+        installed_instruction.contains("kast up --workspace-root \"$PWD\" --backend idea"),
+        "Kotlin instruction must warm the IDEA backend before missing-index fallback"
+    );
 
     let installed_reader = std::fs::read_to_string(target.join("agents/kast-reader.agent.md"))
         .expect("installed reader agent");
     assert!(installed_reader.contains("name: Kast Reader"));
+    assert!(installed_reader.contains("kast up --workspace-root \"$PWD\" --backend idea"));
     assert!(!installed_reader.contains("kast_write_and_validate"));
     assert!(!installed_reader.contains("  - edit"));
 
     let installed_writer = std::fs::read_to_string(target.join("agents/kast-writer.agent.md"))
         .expect("installed writer agent");
     assert!(installed_writer.contains("name: Kast Writer"));
+    assert!(installed_writer.contains("kast up --workspace-root \"$PWD\" --backend idea"));
     assert!(installed_writer.contains("kast_write_and_validate"));
     assert!(installed_writer.contains("  - edit"));
 


### PR DESCRIPTION
## Summary
- make the IDEA settings binary path read-only and open the workspace Kast config in the IDE
- add a native tool-window tab that previews recent IDEA files as they appear in source-index.db
- warm the IDEA backend from shipped Copilot primitives when Kast is present but the backend or index is unavailable
- update shipped instructions, agents, skill docs, and contract tests for the warmup behavior
- render human CLI Markdown with embedded Glamour styling on TTYs while keeping non-TTY output script-safe
- render `kast status` source modules as a sorted indented tree capped at 30 modules with a hidden-count summary

## Validation
- ./gradlew :backend-idea:test --console=plain
- .github/scripts/test-kast-copilot-plugin.sh
- .github/scripts/test-lsp-pivot-gates.sh
- node .github/scripts/test-lsp-config.mjs
- node --check cli-rs/resources/plugin/extensions/kast/extension.mjs
- cargo test --manifest-path cli-rs/Cargo.toml --locked packaged_skill_targets_rust_kast_only --test cli_smoke
- cargo test --manifest-path cli-rs/Cargo.toml --locked copilot_plugin_source_stays_inside_cli_resources_plugin --test rpc_catalog_smoke
- cargo test --manifest-path cli-rs/Cargo.toml --locked copilot_install_receives_the_manifest_declared_package_outputs --test rpc_catalog_smoke
- cargo test --manifest-path cli-rs/Cargo.toml --locked repo_local_copilot_plugin_content_is_generated_not_tracked --test cli_smoke
- cargo fmt --manifest-path cli-rs/Cargo.toml -- --check
- cargo test --manifest-path cli-rs/Cargo.toml --locked output
- cargo test --manifest-path cli-rs/Cargo.toml --locked --test cli_smoke
- cargo clippy --manifest-path cli-rs/Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path cli-rs/Cargo.toml --locked
- git diff --check
- git diff --cached --check
