### PR TITLE
Add installable agent instructions

### DIFF
--- a/.github/scripts/test-docs-content-contract.sh
+++ b/.github/scripts/test-docs-content-contract.sh
@@ -189,6 +189,7 @@ require_not_contains "$agents_doc" "amichne/kast-action@v1" "Agent docs must not
 require_not_contains "$agents_doc" 'scripts/headless-agent-install.sh' "Agent docs must not document the retired headless agent installer"
 require_not_contains "$agents_doc" 'KAST_AGENT_INSTALL_ROOT' "Agent docs must not mention retired headless agent variables"
 require_contains "$agent_install_doc" '## Install into this repository' "Agent install docs must make repository Copilot install primary"
+require_contains "$agent_install_doc" 'kast install instructions' "Agent install docs must document installable instruction sets"
 require_contains "$agent_install_doc" '--plugin-dir cli-rs/resources/plugin' "Agent install docs must document the Copilot CLI source-plugin validation path"
 require_contains "$use_cases_doc" 'Global binary' "Use case docs must reinforce the global binary scope"
 require_contains "$use_cases_doc" 'Repository Copilot files' "Use case docs must reinforce the repository integration scope"

--- a/cli-rs/resources/kast-instructions/README.md
+++ b/cli-rs/resources/kast-instructions/README.md
@@ -1,0 +1,12 @@
+# Kast Agent Instructions
+
+These instruction files are for agent hosts that can load Markdown guidance but
+do not load the full Kast skill or repository-local Copilot package.
+
+- `cli.md` explains non-interactive command-line usage.
+- `rpc.md` explains direct JSON-RPC request-file workflows.
+- `lsp.md` explains the standard LSP adapter contract.
+
+Prefer `kast install copilot` for Copilot repositories and `kast install skill`
+for hosts that understand skills. Use this instruction set when the host only
+needs portable Markdown operating rules.

--- a/cli-rs/resources/kast-instructions/cli.md
+++ b/cli-rs/resources/kast-instructions/cli.md
@@ -1,0 +1,45 @@
+# Kast CLI Instructions
+
+Use the Rust `kast` CLI before ordinary text search for Kotlin and Gradle
+project navigation. Start by confirming the binary and command surface:
+
+```sh
+command -v kast
+kast --help
+```
+
+For agent automation, prefer machine-readable output and explicit workspace
+roots:
+
+```sh
+kast --output json status --workspace-root "$PWD"
+kast --output json up --workspace-root "$PWD" --backend idea
+```
+
+Use human output only for operator-facing summaries. Use `--output json` when a
+result will be parsed, stored, or used as evidence.
+
+## Non-Interactive Rules
+
+- Prefer `--output json` for agent-run operator commands.
+- Pass command-specific mutation controls explicitly, such as `--apply`,
+  `--dry-run`, or `--force`.
+- Use `kast demo --json` for snapshots; the default demo opens an interactive
+  TUI when stdout is a terminal.
+- Use `kast install affected --apply` only when repairs should be applied.
+
+## Common Commands
+
+```sh
+kast --output json status --workspace-root "$PWD"
+kast --output json capabilities --workspace-root "$PWD"
+kast metrics search EventBean --workspace-root "$PWD" --limit 10
+kast demo --workspace-root "$PWD" --view symbol --query EventBean --json
+```
+
+If the backend is missing or indexing is stale, warm the IDEA backend before
+falling back to non-semantic file tools:
+
+```sh
+kast up --workspace-root "$PWD" --backend idea
+```

--- a/cli-rs/resources/kast-instructions/lsp.md
+++ b/cli-rs/resources/kast-instructions/lsp.md
@@ -1,0 +1,43 @@
+# Kast LSP Instructions
+
+Use `kast lsp --stdio` when an agent host understands Language Server Protocol
+and needs Kotlin semantic operations through a standard LSP adapter.
+
+```sh
+kast lsp --stdio
+```
+
+The adapter speaks LSP over stdio and forwards semantic requests to the active
+Kast backend. The global `kast` binary must be on `PATH`, and the workspace
+must have a ready backend.
+
+## Startup
+
+For local developer machines, warm the IDEA backend before LSP startup if
+semantic state is missing:
+
+```sh
+kast up --workspace-root "$PWD" --backend idea
+```
+
+For hosted Linux agents, warm the headless backend after installing the Linux
+headless bundle:
+
+```sh
+kast up --workspace-root "$PWD" --backend headless
+```
+
+## Capabilities
+
+During initialization, Kast exposes normal LSP capabilities plus custom
+`kast/*` methods under `capabilities.experimental.kastMethods`. Those custom
+methods are generated from `cli-rs/resources/kast-skill/references/commands.json`.
+
+Use the built-in LSP methods for standard editor flows such as definition,
+references, hover, document symbols, implementations, call hierarchy, type
+hierarchy, and rename. Use custom `kast/*` methods when the host can call them
+directly and needs catalog-backed workflows such as `symbol/query` or
+`database/metrics`.
+
+If initialization reports a stale or indexing runtime, warm the backend and
+retry instead of falling back to text search.

--- a/cli-rs/resources/kast-instructions/rpc.md
+++ b/cli-rs/resources/kast-instructions/rpc.md
@@ -1,0 +1,41 @@
+# Kast RPC Instructions
+
+Use `kast rpc` for direct JSON-RPC calls when a host does not expose native
+Kast tools. Request shapes are catalog-backed:
+
+- `references/commands.json` is the complete machine-readable catalog.
+- `references/commands.yaml` is easier to read by hand.
+- `references/requests/` contains generated request schemas and samples.
+
+When these instruction files are installed without the full skill, inspect the
+source repository or installed skill for those catalog files.
+
+## Request Harness
+
+Write nontrivial requests to temp files, validate them, then send them:
+
+```sh
+KAST_TMP="$(mktemp -d)"
+trap 'rm -rf "$KAST_TMP"' EXIT
+KAST_REQUEST="$KAST_TMP/request.json"
+KAST_RESULT="$KAST_TMP/result.json"
+KAST_STDERR="$KAST_TMP/kast.stderr"
+
+printf '%s\n' '{"jsonrpc":"2.0","method":"symbol/query","params":{"query":"EventBean","limit":10},"id":1}' >"$KAST_REQUEST"
+kast validate --request-file "$KAST_REQUEST" >/dev/null
+kast rpc --request-file "$KAST_REQUEST" --workspace-root "$PWD" >"$KAST_RESULT" 2>"$KAST_STDERR"
+```
+
+Every successful response is a single JSON object on stdout. Check `result`
+before using the payload. When a result has an `ok` field, treat `ok=false` as a
+failed operation even if the transport succeeded.
+
+## Method Routing
+
+- Use `symbol/*` when you have names and need Kast to resolve identity.
+- Use `raw/*` when you already have exact files, offsets, or file lists.
+- Use `database/*` for SQLite source-index metrics and impact views.
+- Use `capabilities` before depending on optional backend operations.
+
+Resolve identity before references, hierarchy, rename, or edits. Do not replace
+symbol identity with `grep` or broad text search.

--- a/cli-rs/src/cli.rs
+++ b/cli-rs/src/cli.rs
@@ -503,6 +503,8 @@ pub enum InstallCommand {
     Affected(AffectedInstallArgs),
     /// Install the packaged kast skill into the current workspace.
     Skill(ResourceInstallArgs),
+    /// Install portable agent instruction files.
+    Instructions(ResourceInstallArgs),
     /// Install the packaged Copilot LSP, instructions, agents, and extension tools.
     #[command(alias = "copilot-extension")]
     Copilot(CopilotInstallArgs),

--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 static KAST_SKILL: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/resources/kast-skill");
+static KAST_INSTRUCTIONS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/resources/kast-instructions");
 static COPILOT_PLUGIN: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/resources/plugin");
 const KAST_FORMULA_NAME: &str = "kast";
 const KAST_PLUGIN_CASK_NAME: &str = "kast-plugin";
@@ -205,6 +206,15 @@ pub struct InstallSkillResult {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct InstallInstructionsResult {
+    pub installed_at: String,
+    pub version: String,
+    pub skipped: bool,
+    pub schema_version: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InstallCopilotExtensionResult {
     pub installed_at: String,
     pub version: String,
@@ -325,6 +335,7 @@ pub struct ProjectOpenSetupResult {
 #[serde(untagged)]
 pub enum InstallResult {
     Skill(InstallSkillResult),
+    Instructions(InstallInstructionsResult),
     Copilot(InstallCopilotExtensionResult),
     IdeaPlugin(InstallIdeaPluginResult),
     Shell(InstallShellResult),
@@ -352,6 +363,9 @@ pub fn install(args: InstallArgs, reporter: &mut dyn InstallReporter) -> Result<
         }
         Some(InstallCommand::Skill(resource_args)) => {
             install_skill(resource_args).map(InstallResult::Skill)
+        }
+        Some(InstallCommand::Instructions(resource_args)) => {
+            install_instructions(resource_args).map(InstallResult::Instructions)
         }
         Some(InstallCommand::Copilot(resource_args)) => {
             install_copilot_extension(resource_args).map(InstallResult::Copilot)
@@ -705,6 +719,7 @@ fn reconcile_install_state(
         return Ok(result);
     }
     repair_affected_skill_targets(&args, &mut result, &backup_root)?;
+    repair_affected_instruction_targets(&args, &mut result, &backup_root)?;
     repair_affected_copilot_repos(&args, &mut result, &backup_root)?;
     repair_affected_shell_sources(&args, &mut result, &backup_root)?;
     repair_affected_jetbrains_profiles(&args, &mut result, &backup_root)?;
@@ -1003,6 +1018,43 @@ fn repair_affected_skill_targets(
         if args.apply {
             backup_existing_path(&target, backup_root, result)?;
             install_skill(ResourceInstallArgs {
+                target_dir: Some(target_root),
+                name: Some("kast".to_string()),
+                force: true,
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn repair_affected_instruction_targets(
+    args: &AffectedInstallArgs,
+    result: &mut InstallAffectedResult,
+    backup_root: &Path,
+) -> Result<()> {
+    for target_root in affected_instruction_target_roots()? {
+        let target = target_root.join("kast");
+        if !target.is_dir() {
+            continue;
+        }
+        let marker = target.join(".kast-version");
+        let installed_version = fs::read_to_string(&marker).unwrap_or_default();
+        if installed_version.trim() == cli::version() {
+            continue;
+        }
+        push_affected_action(
+            result,
+            "refresh-instructions",
+            &target,
+            "Back up and refresh stale installed Kast instructions.",
+            Some(format!(
+                "kast install instructions --target-dir {} --force",
+                shell_quote_path(&target_root)
+            )),
+        );
+        if args.apply {
+            backup_existing_path(&target, backup_root, result)?;
+            install_instructions(ResourceInstallArgs {
                 target_dir: Some(target_root),
                 name: Some("kast".to_string()),
                 force: true,
@@ -1351,6 +1403,23 @@ fn affected_skill_target_roots() -> Result<Vec<PathBuf>> {
     Ok(roots.into_iter().map(config::normalize).collect())
 }
 
+fn affected_instruction_target_roots() -> Result<Vec<PathBuf>> {
+    let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let home = config::home_dir();
+    let mut roots = vec![
+        default_instructions_target_dir(),
+        home.join(".codex/instructions"),
+        home.join(".agents/instructions"),
+        home.join(".kast/lib/instructions"),
+        cwd.join(".agents/instructions"),
+        cwd.join(".github/instructions"),
+        cwd.join(".claude/instructions"),
+    ];
+    let mut seen = BTreeSet::new();
+    roots.retain(|path| seen.insert(config::normalize(path.clone()).display().to_string()));
+    Ok(roots.into_iter().map(config::normalize).collect())
+}
+
 fn resolve_command_bin_dir(command_name: &str) -> Result<Option<PathBuf>> {
     let current_exe = env::current_exe()?;
     if current_exe
@@ -1461,6 +1530,25 @@ pub fn install_skill(args: ResourceInstallArgs) -> Result<InstallSkillResult> {
     let target = target_root.join(name);
     let skipped = install_dir(&KAST_SKILL, &target, ".kast-version", args.force)?;
     Ok(InstallSkillResult {
+        installed_at: target.display().to_string(),
+        version: cli::version().to_string(),
+        skipped,
+        schema_version: SCHEMA_VERSION,
+    })
+}
+
+pub fn install_instructions(args: ResourceInstallArgs) -> Result<InstallInstructionsResult> {
+    let target_root = args
+        .target_dir
+        .map(config::normalize)
+        .unwrap_or_else(default_instructions_target_dir);
+    let name = args
+        .name
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "kast".to_string());
+    let target = target_root.join(name);
+    let skipped = install_dir(&KAST_INSTRUCTIONS, &target, ".kast-version", args.force)?;
+    Ok(InstallInstructionsResult {
         installed_at: target.display().to_string(),
         version: cli::version().to_string(),
         skipped,
@@ -2665,6 +2753,21 @@ fn default_skill_target_dir() -> PathBuf {
     config::home_dir().join(".kast/lib/skills")
 }
 
+fn default_instructions_target_dir() -> PathBuf {
+    let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    for candidate in [
+        ".agents/instructions",
+        ".github/instructions",
+        ".claude/instructions",
+    ] {
+        let path = cwd.join(candidate);
+        if path.is_dir() {
+            return config::normalize(path);
+        }
+    }
+    config::home_dir().join(".kast/lib/instructions")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2681,6 +2784,24 @@ mod tests {
         assert!(!first.skipped);
         assert!(temp.path().join("kast/SKILL.md").is_file());
         let second = install_skill(args).unwrap();
+        assert!(second.skipped);
+    }
+
+    #[test]
+    fn install_instructions_writes_marker_and_skips_matching_version() {
+        let temp = tempfile::tempdir().unwrap();
+        let args = ResourceInstallArgs {
+            target_dir: Some(temp.path().to_path_buf()),
+            name: Some("kast".to_string()),
+            force: false,
+        };
+        let first = install_instructions(args.clone()).unwrap();
+        assert!(!first.skipped);
+        assert!(temp.path().join("kast/README.md").is_file());
+        assert!(temp.path().join("kast/cli.md").is_file());
+        assert!(temp.path().join("kast/rpc.md").is_file());
+        assert!(temp.path().join("kast/lsp.md").is_file());
+        let second = install_instructions(args).unwrap();
         assert!(second.skipped);
     }
 

--- a/cli-rs/src/output.rs
+++ b/cli-rs/src/output.rs
@@ -4,7 +4,8 @@ use crate::config::PathResolutionReport;
 use crate::error::{CliError, Result};
 use crate::install::{
     ArchiveInstallResult, InstallAffectedResult, InstallCopilotExtensionResult,
-    InstallIdeaPluginResult, InstallResult, InstallShellResult, InstallSkillResult, SetupResult,
+    InstallIdeaPluginResult, InstallInstructionsResult, InstallResult, InstallShellResult,
+    InstallSkillResult, SetupResult,
 };
 use crate::runtime::{
     DaemonStopResult, RuntimeCandidateStatus, RuntimeState, WorkspaceEnsureResult,
@@ -177,6 +178,7 @@ fn render_markdown_for_test(markdown: &str, style: RenderStyle) -> String {
 pub fn print_install_result(result: &InstallResult) -> Result<()> {
     match result {
         InstallResult::Skill(result) => print_skill_install(result),
+        InstallResult::Instructions(result) => print_instructions_install(result),
         InstallResult::Copilot(result) => print_copilot_install("Kast Copilot install", result),
         InstallResult::IdeaPlugin(result) => print_idea_plugin_install(result),
         InstallResult::Shell(result) => print_shell_install(result),
@@ -499,6 +501,27 @@ fn print_skill_install(result: &InstallSkillResult) -> Result<()> {
     mdln!(
         document,
         "- Read the installed quickstart: `{}/references/quickstart.md`",
+        result.installed_at
+    );
+    print_markdown(&document.into_string())
+}
+
+fn print_instructions_install(result: &InstallInstructionsResult) -> Result<()> {
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast instructions install");
+    mdln!(document);
+    mdln!(document, "- Installed at: `{}`", result.installed_at);
+    mdln!(document, "- Version: `{}`", result.version);
+    mdln!(
+        document,
+        "- Reused existing install: {}",
+        yes_no(result.skipped)
+    );
+    mdln!(document);
+    mdln!(document, "## Next steps");
+    mdln!(
+        document,
+        "- Read the installed guide: `{}/README.md`",
         result.installed_at
     );
     print_markdown(&document.into_string())

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -165,7 +165,14 @@ fn smoke_core_cli_commands() {
         .expect("install help");
     assert!(install_help.status.success());
     let install_help_stdout = String::from_utf8_lossy(&install_help.stdout);
-    for command in ["plugin", "skill", "copilot", "shell", "completion"] {
+    for command in [
+        "plugin",
+        "skill",
+        "instructions",
+        "copilot",
+        "shell",
+        "completion",
+    ] {
         assert!(
             install_help_stdout.contains(command),
             "install help should list {command}: {install_help_stdout}"
@@ -175,7 +182,7 @@ fn smoke_core_cli_commands() {
         !install_help_stdout.contains("headless"),
         "standalone headless install should not be listed as a supported install path: {install_help_stdout}"
     );
-    for command in ["plugin", "skill", "copilot"] {
+    for command in ["plugin", "skill", "instructions", "copilot"] {
         let help = kast(&home, &config_home)
             .args(["install", command, "--help"])
             .output()
@@ -283,6 +290,23 @@ fn smoke_core_cli_commands() {
     );
     assert!(!skill_dir.join("kast/scripts").exists());
     assert_no_script_files(&skill_dir.join("kast"));
+
+    let instructions_dir = temp.path().join("instructions");
+    let instructions = kast(&home, &config_home)
+        .args([
+            "install",
+            "instructions",
+            "--target-dir",
+            instructions_dir.to_str().expect("instructions path"),
+            "--force",
+        ])
+        .output()
+        .expect("install instructions");
+    assert!(instructions.status.success());
+    assert!(instructions_dir.join("kast/README.md").is_file());
+    assert!(instructions_dir.join("kast/cli.md").is_file());
+    assert!(instructions_dir.join("kast/rpc.md").is_file());
+    assert!(instructions_dir.join("kast/lsp.md").is_file());
 
     let github_dir = temp.path().join(".github");
     let copilot = kast(&home, &config_home)
@@ -1719,6 +1743,7 @@ fn install_affected_repairs_stale_local_setup_only_when_applied() {
     let stale_current = home.join(".kast/lib/backends/current");
     let stale_runtime_libs = stale_current.join("runtime-libs");
     let skill = home.join(".codex/skills/kast");
+    let instructions = home.join(".codex/instructions/kast");
     let copilot = repo.join(".github");
     let shell_source = config_home.join("shell/kast.zsh");
     let old_bin = home.join(".kast/bin");
@@ -1726,6 +1751,7 @@ fn install_affected_repairs_stale_local_setup_only_when_applied() {
     std::fs::create_dir_all(&config_home).expect("config home");
     std::fs::create_dir_all(&repo).expect("repo");
     std::fs::create_dir_all(&skill).expect("skill");
+    std::fs::create_dir_all(&instructions).expect("instructions");
     std::fs::create_dir_all(&copilot).expect("copilot");
     std::fs::create_dir_all(&old_bin).expect("old bin");
     std::fs::create_dir_all(&profile_plugins).expect("profile plugins");
@@ -1734,6 +1760,8 @@ fn install_affected_repairs_stale_local_setup_only_when_applied() {
     std::fs::write(old_bin.join("kast"), b"old binary\n").expect("old binary");
     std::fs::write(skill.join(".kast-version"), b"old\n").expect("skill marker");
     std::fs::write(skill.join("old.txt"), b"stale\n").expect("skill stale file");
+    std::fs::write(instructions.join(".kast-version"), b"old\n").expect("instructions marker");
+    std::fs::write(instructions.join("old.txt"), b"stale\n").expect("instructions stale file");
     std::fs::write(copilot.join(".kast-copilot-version"), b"old\n").expect("copilot marker");
     std::fs::write(copilot.join("old.txt"), b"stale\n").expect("copilot stale file");
     std::fs::write(
@@ -1834,6 +1862,11 @@ path = "{}"
         std::fs::read_to_string(skill.join(".kast-version")).expect("skill after dry run"),
         "old\n"
     );
+    assert_eq!(
+        std::fs::read_to_string(instructions.join(".kast-version"))
+            .expect("instructions after dry run"),
+        "old\n"
+    );
 
     let apply = kast(&home, &config_home)
         .env("PATH", &brew_bin)
@@ -1876,6 +1909,13 @@ path = "{}"
         "old\n"
     );
     assert!(!skill.join("old.txt").exists());
+    assert_ne!(
+        std::fs::read_to_string(instructions.join(".kast-version"))
+            .expect("instructions after apply"),
+        "old\n"
+    );
+    assert!(!instructions.join("old.txt").exists());
+    assert!(instructions.join("README.md").is_file());
     assert_ne!(
         std::fs::read_to_string(copilot.join(".kast-copilot-version"))
             .expect("copilot after apply"),
@@ -2162,12 +2202,18 @@ fn install_resource_gateways_support_force_and_current_versions() {
     let home = temp.path().join("home");
     let config_home = temp.path().join("config");
     let skill_dir = temp.path().join("skills");
+    let instructions_dir = temp.path().join("instructions");
     let github_dir = temp.path().join(".github");
     let stale_skill = skill_dir.join("kast");
+    let stale_instructions = instructions_dir.join("kast");
     std::fs::create_dir_all(&home).expect("home");
     std::fs::create_dir_all(&stale_skill).expect("stale skill");
+    std::fs::create_dir_all(&stale_instructions).expect("stale instructions");
     std::fs::write(stale_skill.join(".kast-version"), b"old\n").expect("stale marker");
     std::fs::write(stale_skill.join("old.txt"), b"old\n").expect("stale file");
+    std::fs::write(stale_instructions.join(".kast-version"), b"old\n")
+        .expect("stale instructions marker");
+    std::fs::write(stale_instructions.join("old.txt"), b"old\n").expect("stale instructions file");
 
     let skill = kast(&home, &config_home)
         .args([
@@ -2219,6 +2265,39 @@ fn install_resource_gateways_support_force_and_current_versions() {
     let skill_marker =
         std::fs::read_to_string(stale_skill.join(".kast-version")).expect("skill marker");
     assert_eq!(skill_marker.trim(), skill_stdout["version"]);
+
+    let instructions = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "install",
+            "instructions",
+            "--target-dir",
+            instructions_dir.to_str().expect("instructions path"),
+            "-f",
+        ])
+        .output()
+        .expect("install instructions");
+    assert!(
+        instructions.status.success(),
+        "instructions install should accept -f: stdout={}, stderr={}",
+        String::from_utf8_lossy(&instructions.stdout),
+        String::from_utf8_lossy(&instructions.stderr)
+    );
+    let instructions_stdout: serde_json::Value =
+        serde_json::from_slice(&instructions.stdout).expect("instructions install json");
+    assert_eq!(
+        instructions_stdout["installedAt"],
+        stale_instructions.display().to_string()
+    );
+    assert!(stale_instructions.join("README.md").is_file());
+    assert!(stale_instructions.join("cli.md").is_file());
+    assert!(stale_instructions.join("rpc.md").is_file());
+    assert!(stale_instructions.join("lsp.md").is_file());
+    assert!(!stale_instructions.join("old.txt").exists());
+    let instructions_marker = std::fs::read_to_string(stale_instructions.join(".kast-version"))
+        .expect("instructions marker");
+    assert_eq!(instructions_marker.trim(), instructions_stdout["version"]);
 
     let copilot = kast(&home, &config_home)
         .args([

--- a/docs/for-agents/AGENTS.md
+++ b/docs/for-agents/AGENTS.md
@@ -9,6 +9,8 @@ integration files exist.
 - Keep the global binary vs repository-local Copilot integration split
   explicit.
 - Treat `kast install copilot` as the primary Copilot path.
+- Treat `kast install instructions` as the lightweight fallback for hosts that
+  load Markdown instruction files but not full skills.
 - Treat `kast install skill` as a fallback for hosts that do not load the
   Copilot package.
 - Link detailed command and API material instead of copying it into these
@@ -19,6 +21,8 @@ integration files exist.
 - Copilot package truth lives in `cli-rs/resources/plugin/`.
 - The RPC/tool catalog lives in
   `cli-rs/resources/kast-skill/references/commands.json`.
+- Installable CLI/RPC/LSP instruction source lives in
+  `cli-rs/resources/kast-instructions/`.
 - Generated installed outputs under `.github` are evidence of package shape,
   not the source to edit first.
 - The current product operating model lives in

--- a/docs/for-agents/install-the-skill.md
+++ b/docs/for-agents/install-the-skill.md
@@ -49,6 +49,41 @@ kast install copilot --target-dir=/absolute/path/to/repo/.github --force
     That means the machine running Copilot must have the global `kast` binary
     on `PATH`. Use the install guide if the binary is missing.
 
+## Use installable instructions
+
+Use `kast install instructions` for agent hosts that can load Markdown
+instruction files but do not load the Copilot package or a full skill. The
+installed files cover direct CLI usage, JSON-RPC request workflows, and LSP
+startup.
+
+```console title="Install portable agent instructions"
+kast install instructions
+```
+
+The command picks the default target from whichever of these directories
+already exists in your repo:
+
+- `.agents/instructions/kast`
+- `.github/instructions/kast`
+- `.claude/instructions/kast`
+
+If none of those directories exist, it installs globally at
+`~/.kast/lib/instructions/kast`. Look for `.kast-version` in the target
+directory to confirm the install.
+
+```console title="Force reinstall to a custom instruction path"
+kast install instructions --target-dir=/absolute/path/to/instructions --force
+```
+
+??? info "What's in the instruction directory"
+    The installed tree is lightweight Markdown:
+
+    - `README.md` explains when to use each file.
+    - `cli.md` covers non-interactive CLI usage.
+    - `rpc.md` covers `kast rpc`, `kast validate`, and catalog-backed request
+      workflows.
+    - `lsp.md` covers `kast lsp --stdio` and custom `kast/*` method discovery.
+
 ## Use the packaged skill fallback
 
 Use `kast install skill` for hosts that do not load the Copilot package but do


### PR DESCRIPTION
## Summary
- add `kast install instructions` as a sibling install surface to `kast install skill`
- embed CLI, RPC, and LSP Markdown instruction sets under `cli-rs/resources/kast-instructions`
- refresh stale installed instructions through `kast install affected` and document the agent install path

## Validation
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test cli_smoke`
- `.github/scripts/test-docs-content-contract.sh`
- `zensical build --clean`
- `git diff --check`