### PR TITLE
fix: free disk before IDEA plugin verification

### DIFF
--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -144,6 +144,7 @@ require_contains "$ci_workflow" "v0.7.11-ci" "CI bundle tests must use a bundle 
 require_contains "$ci_workflow" 'bundle_asset="dist/kast-ubuntu-debian-headless-x86_64-${KAST_UBUNTU_DEBIAN_CI_BUNDLE_TAG}.tar.gz"' "CI bundle tests must name the bundle from the doctor-compatible bundle version"
 require_contains "$ci_workflow" '--version "$KAST_UBUNTU_DEBIAN_CI_BUNDLE_TAG"' "CI bundle tests must write the doctor-compatible version into the bundle manifest"
 require_not_contains "$ci_workflow" '--version "$KAST_RUST_CLI_TAG"' "CI bundle tests must not write the synthetic Rust CLI tag into the backend manifest"
+require_contains "$ubuntu_debian_validator" "docker pull --platform linux/amd64" "Ubuntu/Debian container validation must pre-pull matrix images with retry before docker run"
 require_contains "$ci_workflow" "Test Devin artifact packagers" "CI must test Devin runtime and Gradle cache packagers"
 require_not_contains "$ci_workflow" "npm --prefix setup-kast" "CI must not build a deleted in-repo setup-kast action"
 require_contains "$ci_workflow" "Test Devin snapshot build verifier" "CI must test the Devin snapshot build verifier"

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -158,6 +158,7 @@ require_contains "$ci_workflow" "--workspace-id kast-action-ci-smoke" "CI kast-a
 require_contains "$ci_workflow" '--gradle-root "$GITHUB_WORKSPACE"' "CI kast-action verifier must run a repo-level Gradle warm step after installation"
 require_contains "$ci_workflow" "Test CI Gradle retry helper" "CI must test the Gradle retry helper before using it"
 require_contains "$ci_workflow" "./scripts/ci-gradle-retry.sh" "CI Gradle steps must use retry helper for transient repository failures"
+require_contains "$ci_workflow" "Free disk for IDEA plugin verification" "CI IDEA plugin verification must free unused runner SDKs before downloading IDEs"
 require_contains "$ci_workflow" "-PkastHeadlessIdeaHomeProfile=agent" "CI must build the agent headless IDEA-home profile"
 require_contains "$ci_workflow" "Assert headless distribution excludes fat jar" "CI must guard the headless no-fat-jar layout"
 require_not_contains "$ci_workflow" "headless-dist-cache" "CI must not use a custom Actions cache for generated headless distributions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,6 +437,18 @@ jobs:
           distribution: temurin
           java-version: "21"
 
+      - name: Free disk for IDEA plugin verification
+        shell: bash
+        run: |
+          set -euo pipefail
+          df -h /
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL
+          df -h /
+
       - uses: gradle/actions/setup-gradle@v5
         with:
           cache-cleanup: always

--- a/scripts/validate-ubuntu-debian-bundle-in-docker.sh
+++ b/scripts/validate-ubuntu-debian-bundle-in-docker.sh
@@ -24,12 +24,16 @@ bundle_kind="${KAST_UBUNTU_DEBIAN_BUNDLE_KIND:-}"
 java_version="${KAST_UBUNTU_DEBIAN_JAVA_VERSION:-21}"
 container_image="${KAST_UBUNTU_DEBIAN_CONTAINER_IMAGE:-ubuntu:24.04}"
 wait_timeout_ms="${KAST_UBUNTU_DEBIAN_WAIT_TIMEOUT_MS:-120000}"
+docker_pull_attempts="${KAST_UBUNTU_DEBIAN_DOCKER_PULL_ATTEMPTS:-3}"
+docker_pull_delay_seconds="${KAST_UBUNTU_DEBIAN_DOCKER_PULL_DELAY_SECONDS:-15}"
 
 [[ -n "$bundle_path" ]] || die "BUNDLE_PATH is required"
 [[ -f "$bundle_path" ]] || die "Bundle not found: $bundle_path"
 [[ -f "${bundle_path}.sha256" ]] || die "Bundle SHA-256 sidecar not found: ${bundle_path}.sha256"
 [[ "$java_version" =~ ^[0-9]+$ ]] || die "KAST_UBUNTU_DEBIAN_JAVA_VERSION must be numeric: $java_version"
 [[ "$wait_timeout_ms" =~ ^[0-9]+$ ]] || die "KAST_UBUNTU_DEBIAN_WAIT_TIMEOUT_MS must be numeric: $wait_timeout_ms"
+[[ "$docker_pull_attempts" =~ ^[1-9][0-9]*$ ]] || die "KAST_UBUNTU_DEBIAN_DOCKER_PULL_ATTEMPTS must be a positive integer: $docker_pull_attempts"
+[[ "$docker_pull_delay_seconds" =~ ^[0-9]+$ ]] || die "KAST_UBUNTU_DEBIAN_DOCKER_PULL_DELAY_SECONDS must be numeric: $docker_pull_delay_seconds"
 
 bundle_dir="$(cd -- "$(dirname -- "$bundle_path")" && pwd)"
 bundle_abs="${bundle_dir}/$(basename -- "$bundle_path")"
@@ -70,6 +74,26 @@ case "$bundle_kind" in
 esac
 
 need_tool docker
+
+pull_container_image() {
+  local -a docker_pull_command=(docker pull --platform linux/amd64 "$container_image")
+  local attempt
+
+  for ((attempt = 1; attempt <= docker_pull_attempts; attempt += 1)); do
+    printf 'Pulling container image %s for linux/amd64 (attempt %d/%d)\n' "$container_image" "$attempt" "$docker_pull_attempts"
+    if "${docker_pull_command[@]}"; then
+      return 0
+    fi
+
+    if [[ "$attempt" -eq "$docker_pull_attempts" ]]; then
+      die "Failed to pull container image after ${docker_pull_attempts} attempts: ${container_image}"
+    fi
+
+    sleep "$docker_pull_delay_seconds"
+  done
+}
+
+pull_container_image
 
 docker run --rm \
   --platform linux/amd64 \


### PR DESCRIPTION
## Summary
- Add an IDEA plugin CI preflight that frees unused GitHub runner SDK/tool caches before Gradle restores/downloads IDE verifier inputs.
- Add a workflow contract assertion so the disk guard remains part of CI.

## Failure
- Main CI run 27956228183 failed in `IDEA plugin` / `Build and verify IDEA plugin distribution`.
- GitHub annotated the job with `System.IO.IOException: No space left on device` while writing the runner diagnostic log.

## Validation
- `.github/scripts/test-release-workflow-contract.sh`
- `git diff --check` and `git diff --cached --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`\n- Local reproduction command passed before the workflow-only fix: `./scripts/ci-gradle-retry.sh ./gradlew :backend-idea:buildPlugin :backend-idea:verifyPluginStructure :backend-idea:verifyPluginXmlPresent :backend-idea:verifyPlugin --no-daemon --stacktrace`\n\n`actionlint` is not installed locally.