### PR TITLE
Bound IDEA reference fallback

### DIFF
--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
@@ -66,7 +66,11 @@ import kotlinx.serialization.json.JsonNull
 import java.util.UUID
 import io.github.amichne.kast.api.validation.parsed
 import io.github.amichne.kast.api.contract.skill.*
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CancellationException
 
 class RpcAnalysisDispatcher(
     private val backend: AnalysisBackend,
@@ -119,6 +123,21 @@ class RpcAnalysisDispatcher(
                         code = JSON_RPC_METHOD_NOT_FOUND,
                         message = exception.message ?: "Unknown JSON-RPC method",
                     ),
+                ),
+            )
+        } catch (_: TimeoutCancellationException) {
+            json.encodeToString(
+                JsonRpcErrorResponse(
+                    id = request.id,
+                    error = timeoutJsonRpcError(request, config.effectiveRequestTimeoutMillis),
+                ),
+            )
+        } catch (exception: CancellationException) {
+            if (!currentCoroutineContext().isActive) throw exception
+            json.encodeToString(
+                JsonRpcErrorResponse(
+                    id = request.id,
+                    error = timeoutJsonRpcError(request, config.effectiveRequestTimeoutMillis),
                 ),
             )
         } catch (exception: Throwable) {
@@ -446,6 +465,24 @@ private class UnknownRpcMethodException(
     method: String,
 ) : RuntimeException("Unknown JSON-RPC method: $method")
 
+private fun timeoutJsonRpcError(
+    request: JsonRpcRequest,
+    timeoutMillis: Long,
+): JsonRpcErrorObject = JsonRpcErrorObject(
+    code = JSON_RPC_SERVER_ERROR_BASE - REQUEST_TIMEOUT_STATUS_CODE,
+    message = "Request timed out after ${timeoutMillis}ms",
+    data = ApiErrorResponse(
+        requestId = requestId(request.id),
+        code = "TIMEOUT",
+        message = "Request timed out after ${timeoutMillis}ms",
+        retryable = true,
+        details = mapOf(
+            "method" to request.method,
+            "timeoutMillis" to timeoutMillis.toString(),
+        ),
+    ),
+)
+
 private fun AnalysisException.toJsonRpcError(id: JsonElement): JsonRpcErrorObject = JsonRpcErrorObject(
     code = JSON_RPC_SERVER_ERROR_BASE - statusCode,
     message = message,
@@ -471,6 +508,8 @@ private fun diagnosticPageToken(diagnostic: io.github.amichne.kast.api.contract.
     diagnostic.location.startOffset.toString()
 
 private fun workspaceSymbolPageToken(limit: Int): String = limit.toString()
+
+private const val REQUEST_TIMEOUT_STATUS_CODE = 504
 
 @Suppress("UNCHECKED_CAST")
 private fun <T, R : PageableResult<T>> R.withLimit(

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.server
 
+import io.github.amichne.kast.api.contract.AnalysisBackend
 import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
 import io.github.amichne.kast.api.contract.BackendCapabilities
@@ -52,6 +53,7 @@ import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
 import io.github.amichne.kast.api.contract.skill.*
 import io.github.amichne.kast.api.contract.result.WorkspaceSymbolResult
 import io.github.amichne.kast.testing.FakeAnalysisBackend
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.serializer
 import kotlinx.serialization.json.Json
@@ -66,6 +68,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import java.util.concurrent.CancellationException
 import kotlin.io.path.readText
 
 class AnalysisDispatcherTest {
@@ -345,6 +348,43 @@ class AnalysisDispatcherTest {
 
         assertEquals("sample.greet", result.declaration?.fqName)
         assertEquals(1, result.references.size)
+    }
+
+    @Test
+    fun `dispatcher maps request timeout to timeout api error`() {
+        val dispatcher = RpcAnalysisDispatcher(
+            backend = DispatcherTimeoutHealthBackend(FakeAnalysisBackend.sample(tempDir), delayMillis = 100),
+            config = AnalysisServerConfig(requestTimeoutMillis = 1),
+        )
+        val raw = runBlocking {
+            dispatcher.dispatch(JsonRpcRequest(id = JsonPrimitive(1), method = "health"))
+        }
+
+        val response = json.parseToJsonElement(raw).jsonObject
+        val error = json.decodeFromJsonElement(JsonRpcErrorResponse.serializer(), response)
+
+        assertEquals("TIMEOUT", error.error.data?.code)
+        assertEquals(true, error.error.data?.retryable)
+        assertEquals("health", error.error.data?.details?.get("method"))
+        assertEquals("1", error.error.data?.details?.get("timeoutMillis"))
+    }
+
+    @Test
+    fun `dispatcher maps backend cancellation to timeout api error`() {
+        val dispatcher = RpcAnalysisDispatcher(
+            backend = DispatcherCancellationHealthBackend(FakeAnalysisBackend.sample(tempDir)),
+            config = AnalysisServerConfig(requestTimeoutMillis = 1),
+        )
+        val raw = runBlocking {
+            dispatcher.dispatch(JsonRpcRequest(id = JsonPrimitive(1), method = "health"))
+        }
+
+        val response = json.parseToJsonElement(raw).jsonObject
+        val error = json.decodeFromJsonElement(JsonRpcErrorResponse.serializer(), response)
+
+        assertEquals("TIMEOUT", error.error.data?.code)
+        assertEquals(true, error.error.data?.retryable)
+        assertEquals("health", error.error.data?.details?.get("method"))
     }
 
     @Test
@@ -889,4 +929,20 @@ class AnalysisDispatcherTest {
             String(input.readBytes(), StandardCharsets.ISO_8859_1)
         }
 
+}
+
+private class DispatcherTimeoutHealthBackend(
+    private val delegate: AnalysisBackend,
+    private val delayMillis: Long,
+) : AnalysisBackend by delegate {
+    override suspend fun health() = run {
+        delay(delayMillis)
+        delegate.health()
+    }
+}
+
+private class DispatcherCancellationHealthBackend(
+    private val delegate: AnalysisBackend,
+) : AnalysisBackend by delegate {
+    override suspend fun health() = throw CancellationException("backend cancelled")
 }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastIdeaBackendRuntime.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastIdeaBackendRuntime.kt
@@ -73,6 +73,7 @@ object KastIdeaBackendRuntime {
         )
         val diagnostics = KastDiagnosticsService.getInstance(project)
         val limits = ideaServerLimits(config)
+        val sourceIndexStore = SqliteSourceIndexStore(workspaceIdentity.workspaceIdentity)
         val backend = ObservedAnalysisBackend(
             delegate = KastPluginBackend(
                 project = project,
@@ -81,6 +82,7 @@ object KastIdeaBackendRuntime {
                 telemetry = IdeaBackendTelemetry.fromConfig(workspaceRoot, config),
                 backendName = backendName,
                 workspaceIdentity = workspaceIdentity,
+                referenceIndexLookup = DiagnosticsReferenceIndexLookup(diagnostics, sourceIndexStore),
             ),
             diagnostics = diagnostics,
         )
@@ -98,7 +100,13 @@ object KastIdeaBackendRuntime {
             detail = mapOf("transport" to transport.toString()) + workspaceIdentity.traceDetails(),
         )
         diagnostics.recordBackendStarted(transport)
-        val projectIndexing = KastIdeaProjectIndexing(project, workspaceIdentity, config, diagnostics).also { it.start() }
+        val projectIndexing = KastIdeaProjectIndexing(
+            project = project,
+            workspaceIdentity = workspaceIdentity,
+            config = config,
+            diagnostics = diagnostics,
+            indexStore = sourceIndexStore,
+        ).also { it.start() }
         return RunningKastIdeaBackend(
             backend = backend,
             server = server,
@@ -112,13 +120,19 @@ internal class KastIdeaProjectIndexing(
     private val workspaceIdentity: IdeaWorkspaceIdentity,
     private val config: KastConfig,
     private val diagnostics: KastDiagnosticsService = KastDiagnosticsService.getInstance(project),
+    private val indexStore: SqliteSourceIndexStore = SqliteSourceIndexStore(workspaceIdentity.workspaceIdentity),
 ) {
     constructor(
         project: Project,
         workspaceRoot: Path,
         config: KastConfig,
         diagnostics: KastDiagnosticsService = KastDiagnosticsService.getInstance(project),
-    ) : this(project, IdeaWorkspaceIdentity.fromProject(project, workspaceRoot, config.paths.descriptorDir.toPath()), config, diagnostics)
+    ) : this(
+        project,
+        IdeaWorkspaceIdentity.fromProject(project, workspaceRoot, config.paths.descriptorDir.toPath()),
+        config,
+        diagnostics,
+    )
 
     private val workspaceRoot: Path = workspaceIdentity.workspaceRootPath
 
@@ -126,9 +140,6 @@ internal class KastIdeaProjectIndexing(
 
     @Volatile
     private var indexingThread: Thread? = null
-
-    @Volatile
-    private var indexStore: SqliteSourceIndexStore? = null
 
     fun start() {
         if (indexingThread != null) return
@@ -169,8 +180,6 @@ internal class KastIdeaProjectIndexing(
                     }.onFailure { error ->
                         LOG.warn("Kast IDEA remote source index hydration failed", error)
                     }
-                    val store = SqliteSourceIndexStore(workspaceIdentity.workspaceIdentity)
-                    indexStore = store
                     KastStructuredTrace.event(
                         eventName = "idea.index.started",
                         project = project,
@@ -182,11 +191,11 @@ internal class KastIdeaProjectIndexing(
                     IdeaProjectIndexer(
                         project = project,
                         workspaceRoot = workspaceRoot,
-                        store = store,
+                        store = indexStore,
                         cancelled = { cancelled.get() || Thread.currentThread().isInterrupted || project.isDisposed },
                         workspaceIdentity = workspaceIdentity.workspaceIdentity,
                     ).indexProject(config)
-                    store.loadKastSourceIndexSummary()
+                    indexStore.loadKastSourceIndexSummary()
                 }.onSuccess { summary ->
                     if (!cancelled.get()) {
                         KastStructuredTrace.event(
@@ -234,11 +243,8 @@ internal class KastIdeaProjectIndexing(
             indexingThread?.join(2_000)
         }
         indexingThread = null
-        indexStore?.let { store ->
-            runCatching { store.close() }
-                .onFailure { LOG.warn("Error closing kast project index store", it) }
-        }
-        indexStore = null
+        runCatching { indexStore.close() }
+            .onFailure { LOG.warn("Error closing kast project index store", it) }
         if (wasRunning) {
             KastStructuredTrace.event(
                 eventName = "idea.index.cancelled",

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
@@ -6,20 +6,29 @@ import com.intellij.openapi.application.readAction
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.PsiReference
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiShortNamesCache
+import com.intellij.psi.search.PsiSearchHelper
+import com.intellij.psi.search.UsageSearchContext
 import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.util.Processor
 import io.github.amichne.kast.api.contract.AnalysisBackend
 import io.github.amichne.kast.api.validation.*
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
@@ -67,6 +76,7 @@ import io.github.amichne.kast.shared.analysis.declarationEdit
 import io.github.amichne.kast.shared.analysis.resolveTarget
 import io.github.amichne.kast.shared.analysis.resolvedFilePath
 import io.github.amichne.kast.shared.analysis.supertypeNames
+import io.github.amichne.kast.shared.analysis.targetFqNameAndPackage
 import io.github.amichne.kast.shared.analysis.toApiDiagnostics
 import io.github.amichne.kast.shared.analysis.toKastLocation
 import io.github.amichne.kast.shared.analysis.toSymbolModel
@@ -78,6 +88,7 @@ import io.github.amichne.kast.shared.hierarchy.TypeHierarchyBudget
 import io.github.amichne.kast.shared.hierarchy.TypeHierarchyEngine
 import io.github.amichne.kast.shared.hierarchy.ReadAccessScope
 import io.github.amichne.kast.shared.hierarchy.TraversalBudget
+import io.github.amichne.kast.indexstore.api.reference.SymbolReferenceRow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -94,6 +105,7 @@ import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import java.nio.file.FileSystems
 import java.nio.file.Path
+import java.util.concurrent.CancellationException
 
 @OptIn(KaExperimentalApi::class)
 internal class KastPluginBackend(
@@ -103,6 +115,8 @@ internal class KastPluginBackend(
     private val telemetry: IdeaBackendTelemetry = IdeaBackendTelemetry.disabled(),
     private val backendName: String? = null,
     private val workspaceIdentity: IdeaWorkspaceIdentity = IdeaWorkspaceIdentity.fromProject(project, workspaceRoot),
+    private val referenceIndexLookup: ReferenceIndexLookup = ReferenceIndexLookup.Unavailable,
+    private val referenceSearchClock: ReferenceSearchClock = ReferenceSearchClock.System,
 ) : AnalysisBackend {
 
     private val readDispatcher = Dispatchers.Default.limitedParallelism(limits.maxConcurrentRequests)
@@ -115,6 +129,15 @@ internal class KastPluginBackend(
 
     private fun kotlinFileType(): FileType? =
         FileTypeManager.getInstance().findFileTypeByName("Kotlin")
+
+    private fun kotlinCandidateFiles(scope: GlobalSearchScope): List<VirtualFile> =
+        kotlinFileType()?.let { fileType ->
+            FileTypeIndex.getFiles(fileType, scope)
+                .asSequence()
+                .filter { file -> file.isValid && !file.isDirectory && isWorkspaceFile(file.path) }
+                .sortedBy { file -> file.path }
+                .toList()
+        } ?: emptyList()
 
     override suspend fun capabilities(): BackendCapabilities = BackendCapabilities(
         backendName = backendName ?: defaultBackendName(),
@@ -201,63 +224,381 @@ internal class KastPluginBackend(
     }
 
     override suspend fun findReferences(query: ParsedReferencesQuery): ReferencesResult = withContext(readDispatcher) {
-        telemetry.inSpan(IdeaTelemetryScope.REFERENCES, "kast.idea.findReferences") {
-        val (snapshot, references) = collectInShortReadActions(
-            collectSnapshot = {
+        telemetry.inSpan(IdeaTelemetryScope.REFERENCES, "kast.idea.findReferences") { span ->
+            val plan = referenceSearchPlan(query, span)
+            val outcome = indexedReferenceSearch(query, plan, span)
+                ?: ideaReferenceSearch(query, plan, span)
+            val sortedReferences = outcome.references
+                .distinctBy { reference -> ReferenceLocationKey(reference.filePath, reference.startOffset, reference.endOffset) }
+                .sortedWith(compareBy({ it.filePath }, { it.startOffset }, { it.endOffset }))
+
+            span.setAttribute("kast.references.source", outcome.source.name.lowercase())
+            span.setAttribute("kast.references.visibility", plan.visibility.name)
+            span.setAttribute("kast.references.scope", plan.scopeKind.name)
+            span.setAttribute("kast.references.candidateFileCount", outcome.candidateFileCount)
+            span.setAttribute("kast.references.searchedFileCount", outcome.searchedFileCount)
+            span.setAttribute("kast.references.resultCount", sortedReferences.size)
+            span.setAttribute("kast.references.exhaustive", outcome.completion.exhaustive)
+            span.setAttribute("kast.references.partialReason", outcome.completion.partialReason)
+
+            ReferencesResult(
+                declaration = plan.declaration,
+                references = sortedReferences,
+                searchScope = SearchScope(
+                    visibility = plan.visibility,
+                    scope = plan.scopeKind,
+                    exhaustive = outcome.completion.exhaustive,
+                    candidateFileCount = outcome.candidateFileCount,
+                    searchedFileCount = outcome.searchedFileCount,
+                ),
+            )
+        }
+    }
+
+    private suspend fun referenceSearchPlan(
+        query: ParsedReferencesQuery,
+        span: IdeaTelemetrySpan,
+    ): ReferenceSearchPlan {
+        val target = span.child("kast.idea.findReferences.targetResolution") {
+            timedReadAction(
+                telemetry = telemetry,
+                scope = IdeaTelemetryScope.REFERENCES,
+                name = "kast.idea.findReferences.targetResolution.readAction",
+            ) {
                 val file = findKtFile(query.position.filePath.value)
-                val target = resolveTarget(file, query.position.offset.value)
-                val visibility = target.visibility()
-                val (searchScope, scopeKind) = visibilityScopedSearch(target, visibility)
-                val refs = mutableListOf<PsiReference>()
-                ReferencesSearch.search(target, searchScope).forEach { ref ->
-                    ProgressManager.checkCanceled()
-                    refs.add(ref)
-                    true
-                }
-                ReferenceSearchSnapshot(
+                val element = resolveTarget(file, query.position.offset.value)
+                val targetFqName = element.targetFqNameAndPackage()?.first?.value
+                ReferenceResolvedTarget(
+                    pointer = SmartPointerManager.getInstance(project).createSmartPsiElementPointer(element),
+                    targetFqName = targetFqName,
+                    searchNeedle = ReferenceSearchNeedle.from(element, targetFqName),
                     declaration = if (query.includeDeclaration) {
-                        analyze(file) { target.toSymbolModel(containingDeclaration = null) }
+                        analyze(file) { element.toSymbolModel(containingDeclaration = null) }
                     } else {
                         null
                     },
-                    visibility = visibility,
+                    visibility = element.visibility(),
+                )
+            }
+        }
+        val scope = span.child("kast.idea.findReferences.scopeCalculation") {
+            timedReadAction(
+                telemetry = telemetry,
+                scope = IdeaTelemetryScope.REFERENCES,
+                name = "kast.idea.findReferences.scopeCalculation.readAction",
+            ) {
+                val element = target.pointer.element
+                    ?: throw NotFoundException(
+                        "Cannot resolve symbol at ${query.position.filePath.value}:${query.position.offset.value}",
+                    )
+                val (searchScope, scopeKind) = visibilityScopedSearch(element, target.visibility)
+                ReferenceScopePlan(
+                    searchScope = searchScope,
                     scopeKind = scopeKind,
-                    candidateFileCount = searchScope.let { scope ->
-                        kotlinFileType()?.let { fileType ->
-                            FileTypeIndex.getFiles(fileType, scope)
-                                .count { isWorkspaceFile(it.path) }
-                        } ?: 0
-                    },
-                ) to refs
-            },
-            processItem = { ref ->
-                val element = ref.element
-                if (!element.isValid) return@collectInShortReadActions null
-                val baseLocation = element.toKastLocation()
-                val location = if (query.includeUsageSiteScope) {
-                    baseLocation.copy(usageSiteScope = element.usageSiteDeclarationScope())
-                } else {
-                    baseLocation
-                }
-                if (isWorkspaceFile(location.filePath)) location else null
-            },
-            runInitialReadAction = { action -> runIdeaReadAction(action) },
-            runBatchReadAction = { action -> runIdeaReadAction(action) },
-        )
-        val sortedReferences = references.sortedWith(compareBy({ it.filePath }, { it.startOffset }))
-        val searchedFileCount = snapshot.candidateFileCount
+                )
+            }
+        }
 
-        ReferencesResult(
-            declaration = snapshot.declaration,
-            references = sortedReferences,
-            searchScope = SearchScope(
-                visibility = snapshot.visibility,
-                scope = snapshot.scopeKind,
-                exhaustive = true,
-                candidateFileCount = snapshot.candidateFileCount,
-                searchedFileCount = searchedFileCount,
-            ),
+        return ReferenceSearchPlan(
+            target = target.pointer,
+            targetFqName = target.targetFqName,
+            searchNeedle = target.searchNeedle,
+            declaration = target.declaration,
+            visibility = target.visibility,
+            searchScope = scope.searchScope,
+            scopeKind = scope.scopeKind,
         )
+    }
+
+    private fun indexedReferenceSearch(
+        query: ParsedReferencesQuery,
+        plan: ReferenceSearchPlan,
+        span: IdeaTelemetrySpan,
+    ): ReferenceSearchOutcome? = span.child("kast.idea.findReferences.indexLookup") { indexSpan ->
+        val targetFqName = plan.targetFqName ?: return@child null
+        when (val lookup = referenceIndexLookup.referencesTo(targetFqName)) {
+            IndexedReferenceLookupResult.NotReady -> {
+                indexSpan.setAttribute("kast.references.indexReady", false)
+                null
+            }
+            is IndexedReferenceLookupResult.Ready -> {
+                val indexedRows = runIdeaReadAction {
+                    lookup.references
+                        .filter { row -> indexedReferenceRowInScope(row, plan.searchScope) }
+                        .sortedWith(compareBy({ it.sourcePath }, { it.sourceOffset }))
+                }
+                val indexedSourcePathCount = indexedRows.mapTo(mutableSetOf()) { row -> row.sourcePath }.size
+                val locations = indexedReferenceLocations(
+                    rows = indexedRows,
+                    includeUsageSiteScope = query.includeUsageSiteScope,
+                )
+                indexSpan.setAttribute("kast.references.indexReady", true)
+                indexSpan.setAttribute("kast.references.indexRowCount", indexedRows.size)
+                indexSpan.setAttribute("kast.references.indexLocationCount", locations.size)
+                ReferenceSearchOutcome(
+                    source = ReferenceSearchSource.INDEX,
+                    references = locations,
+                    candidateFileCount = indexedSourcePathCount,
+                    searchedFileCount = indexedSourcePathCount,
+                    completion = if (indexedRows.size == locations.size) {
+                        ReferenceSearchCompletion.Exhaustive
+                    } else {
+                        ReferenceSearchCompletion.Partial(ReferencePartialReason.INDEX_LOCATION_UNRESOLVED)
+                    },
+                )
+            }
+        }
+    }
+
+    private fun indexedReferenceRowInScope(
+        row: SymbolReferenceRow,
+        searchScope: GlobalSearchScope,
+    ): Boolean {
+        if (!isWorkspaceFile(row.sourcePath)) return false
+        val virtualFile = LocalFileSystem.getInstance().findFileByPath(row.sourcePath) ?: return false
+        return virtualFile.isValid && !virtualFile.isDirectory && searchScope.contains(virtualFile)
+    }
+
+    private fun indexedReferenceLocations(
+        rows: List<SymbolReferenceRow>,
+        includeUsageSiteScope: Boolean,
+    ): List<Location> {
+        val locations = mutableListOf<Location>()
+        for (batch in rows.chunked(READ_ACTION_BATCH_SIZE)) {
+            val batchLocations = runIdeaReadAction {
+                batch.mapNotNull { row -> indexedReferenceLocationOrNull(row, includeUsageSiteScope) }
+            }
+            locations.addAll(batchLocations)
+        }
+        return locations
+    }
+
+    private fun indexedReferenceLocationOrNull(
+        row: SymbolReferenceRow,
+        includeUsageSiteScope: Boolean,
+    ): Location? = try {
+        indexedReferenceLocation(row, includeUsageSiteScope)
+    } catch (error: ProcessCanceledException) {
+        throw error
+    } catch (error: CancellationException) {
+        throw error
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun indexedReferenceLocation(
+        row: SymbolReferenceRow,
+        includeUsageSiteScope: Boolean,
+    ): Location? {
+        if (!isWorkspaceFile(row.sourcePath)) return null
+        val file = findKtFile(row.sourcePath)
+        val sourceOffset = row.sourceOffset.coerceIn(0, file.textLength)
+        val anchor = file.findElementAt(sourceOffset) ?: return null
+        val reference = anchor.referenceAtOffset(sourceOffset)
+        val element = reference?.element ?: anchor
+        if (!element.isValid) return null
+        val range = reference?.absoluteTextRange() ?: indexedFallbackRange(file, row)
+        val location = element.toKastLocation(range)
+        return if (includeUsageSiteScope) {
+            location.copy(usageSiteScope = element.usageSiteDeclarationScope())
+        } else {
+            location
+        }
+    }
+
+    private fun indexedFallbackRange(
+        file: KtFile,
+        row: SymbolReferenceRow,
+    ): TextRange {
+        val start = row.sourceOffset.coerceIn(0, file.textLength)
+        val nameLength = row.targetFqName.substringAfterLast('.').length.coerceAtLeast(1)
+        val end = (start + nameLength).coerceAtMost(file.textLength)
+        return TextRange(start, end)
+    }
+
+    private fun ideaReferenceSearch(
+        query: ParsedReferencesQuery,
+        plan: ReferenceSearchPlan,
+        span: IdeaTelemetrySpan,
+    ): ReferenceSearchOutcome = span.child("kast.idea.findReferences.findUsagesFallback") { fallbackSpan ->
+        val budget = ReferenceSearchBudget.start(limits, referenceSearchClock)
+        fallbackSpan.setAttribute("kast.references.fallbackApi", "PsiSearchHelper.processCandidateFilesForText")
+        fallbackSpan.setAttribute("kast.references.resolutionApi", "ReferencesSearch.search(fileScope)")
+
+        val candidateDiscovery = referenceCandidateFiles(plan, budget, fallbackSpan)
+        val resolution = fallbackSpan.child("kast.idea.findReferences.referenceResolution") { resolutionSpan ->
+            val locations = mutableListOf<Location>()
+            var searchedFileCount = 0
+            var completion: ReferenceSearchCompletion = ReferenceSearchCompletion.Exhaustive
+
+            for (candidateFile in candidateDiscovery.files) {
+                ProgressManager.checkCanceled()
+                if (budget.requestExhausted()) {
+                    completion = ReferenceSearchCompletion.Partial(ReferencePartialReason.REQUEST_BUDGET_EXHAUSTED)
+                    break
+                }
+                val fileStartedNanos = budget.fileStarted()
+                val fileOutcome = runIdeaReadAction {
+                    val target = plan.target.element
+                        ?: return@runIdeaReadAction ReferenceFileSearchOutcome(
+                            references = emptyList(),
+                            completion = ReferenceSearchCompletion.Partial(ReferencePartialReason.TARGET_INVALIDATED),
+                        )
+                    val fileLocations = mutableListOf<Location>()
+                    var fileCompletion: ReferenceSearchCompletion = ReferenceSearchCompletion.Exhaustive
+                    ReferencesSearch.search(target, GlobalSearchScope.fileScope(project, candidateFile)).forEach(
+                        object : Processor<PsiReference> {
+                            override fun process(ref: PsiReference): Boolean {
+                                ProgressManager.checkCanceled()
+                                fileCompletion = when {
+                                    budget.requestExhausted() ->
+                                        ReferenceSearchCompletion.Partial(ReferencePartialReason.REQUEST_BUDGET_EXHAUSTED)
+                                    budget.fileExhausted(fileStartedNanos) ->
+                                        ReferenceSearchCompletion.Partial(ReferencePartialReason.FILE_BUDGET_EXHAUSTED)
+                                    else -> ReferenceSearchCompletion.Exhaustive
+                                }
+                                if (!fileCompletion.exhaustive) {
+                                    return false
+                                }
+                                ref.toReferenceLocation(query.includeUsageSiteScope)?.let(fileLocations::add)
+                                return true
+                            }
+                        }
+                    )
+                    ReferenceFileSearchOutcome(
+                        references = fileLocations,
+                        completion = fileCompletion,
+                    )
+                }
+
+                searchedFileCount += 1
+                locations.addAll(fileOutcome.references)
+                if (!fileOutcome.completion.exhaustive) {
+                    completion = fileOutcome.completion
+                    break
+                }
+            }
+
+            resolutionSpan.setAttribute("kast.references.resolvedFileCount", searchedFileCount)
+            ReferenceResolutionOutcome(
+                references = locations,
+                searchedFileCount = searchedFileCount,
+                completion = completion,
+            )
+        }
+
+        val completion = candidateDiscovery.completion.combine(resolution.completion)
+        fallbackSpan.setAttribute("kast.references.candidateFileCount", candidateDiscovery.candidateFileCount)
+        fallbackSpan.setAttribute("kast.references.searchedFileCount", resolution.searchedFileCount)
+        fallbackSpan.setAttribute("kast.references.partialReason", completion.partialReason)
+
+        ReferenceSearchOutcome(
+            source = ReferenceSearchSource.IDEA,
+            references = resolution.references,
+            candidateFileCount = candidateDiscovery.candidateFileCount,
+            searchedFileCount = resolution.searchedFileCount,
+            completion = completion,
+        )
+    }
+
+    private fun referenceCandidateFiles(
+        plan: ReferenceSearchPlan,
+        budget: ReferenceSearchBudget,
+        span: IdeaTelemetrySpan,
+    ): ReferenceCandidateDiscovery = span.child("kast.idea.findReferences.candidateDiscovery") { discoverySpan ->
+        val needle = plan.searchNeedle
+        discoverySpan.setAttribute("kast.references.candidateApi", if (needle == null) "FileTypeIndex.getFiles" else "PsiSearchHelper.processCandidateFilesForText")
+        discoverySpan.setAttribute("kast.references.searchNeedle", needle?.value)
+
+        val discovery = if (needle == null) {
+            fileTypeCandidateFiles(plan, budget)
+        } else {
+            textIndexedCandidateFiles(plan, budget, needle)
+        }
+
+        discoverySpan.setAttribute("kast.references.candidateFileCount", discovery.candidateFileCount)
+        discoverySpan.setAttribute("kast.references.candidateDiscoveryExhaustive", discovery.completion.exhaustive)
+        discoverySpan.setAttribute("kast.references.partialReason", discovery.completion.partialReason)
+        discovery
+    }
+
+    private fun textIndexedCandidateFiles(
+        plan: ReferenceSearchPlan,
+        budget: ReferenceSearchBudget,
+        needle: ReferenceSearchNeedle,
+    ): ReferenceCandidateDiscovery {
+        val files = mutableListOf<VirtualFile>()
+        var candidateFileCount = 0
+        var completion: ReferenceSearchCompletion = ReferenceSearchCompletion.Exhaustive
+        val helper = PsiSearchHelper.getInstance(project)
+        val processor = object : Processor<VirtualFile> {
+            override fun process(file: VirtualFile): Boolean {
+                ProgressManager.checkCanceled()
+                candidateFileCount += 1
+                if (budget.requestExhausted()) {
+                    completion = ReferenceSearchCompletion.Partial(ReferencePartialReason.REQUEST_BUDGET_EXHAUSTED)
+                    return false
+                }
+                if (file.isValid && !file.isDirectory && isWorkspaceFile(file.path)) {
+                    files += file
+                }
+                return true
+            }
+        }
+        val continued = runIdeaReadAction {
+            helper.processCandidateFilesForText(
+                plan.searchScope,
+                UsageSearchContext.IN_CODE,
+                false,
+                needle.value,
+                processor,
+            )
+        }
+        if (!continued && completion.exhaustive) {
+            completion = ReferenceSearchCompletion.Partial(ReferencePartialReason.CANDIDATE_DISCOVERY_STOPPED)
+        }
+        return ReferenceCandidateDiscovery(
+            files = files.sortedBy { file -> file.path },
+            candidateFileCount = candidateFileCount,
+            completion = completion,
+        )
+    }
+
+    private fun fileTypeCandidateFiles(
+        plan: ReferenceSearchPlan,
+        budget: ReferenceSearchBudget,
+    ): ReferenceCandidateDiscovery {
+        val files = mutableListOf<VirtualFile>()
+        var candidateFileCount = 0
+        var completion: ReferenceSearchCompletion = ReferenceSearchCompletion.Exhaustive
+        val allKotlinFiles = runIdeaReadAction {
+            kotlinCandidateFiles(plan.searchScope)
+        }
+        for (file in allKotlinFiles) {
+            ProgressManager.checkCanceled()
+            candidateFileCount += 1
+            if (budget.requestExhausted()) {
+                completion = ReferenceSearchCompletion.Partial(ReferencePartialReason.REQUEST_BUDGET_EXHAUSTED)
+                break
+            }
+            files += file
+        }
+        return ReferenceCandidateDiscovery(
+            files = files,
+            candidateFileCount = candidateFileCount,
+            completion = completion,
+        )
+    }
+
+    private fun PsiReference.toReferenceLocation(includeUsageSiteScope: Boolean): Location? {
+        val referenceElement = element
+        if (!referenceElement.isValid) return null
+        val location = referenceElement.toKastLocation(absoluteTextRange())
+        if (!isWorkspaceFile(location.filePath)) return null
+        return if (includeUsageSiteScope) {
+            location.copy(usageSiteScope = referenceElement.usageSiteDeclarationScope())
+        } else {
+            location
         }
     }
 
@@ -537,11 +878,15 @@ internal class KastPluginBackend(
                         .count { isWorkspaceFile(it.path) }
                 } ?: 0
                 val refs = mutableListOf<PsiReference>()
-                ReferencesSearch.search(target, searchScope).forEach { ref ->
-                    ProgressManager.checkCanceled()
-                    refs.add(ref)
-                    true
-                }
+                ReferencesSearch.search(target, searchScope).forEach(
+                    object : Processor<PsiReference> {
+                        override fun process(ref: PsiReference): Boolean {
+                            ProgressManager.checkCanceled()
+                            refs.add(ref)
+                            return true
+                        }
+                    },
+                )
                 RenameSnapshot(
                     declarationEdit = target.declarationEdit(query.newName.value),
                     visibility = visibility,
@@ -831,27 +1176,19 @@ internal class KastPluginBackend(
             val vf = file.virtualFile
             GlobalSearchScope.fileScope(project, vf) to SearchScopeKind.FILE
         }
-        SymbolVisibility.INTERNAL -> {
-            val file = target.containingFile as? KtFile
-                ?: return GlobalSearchScope.projectScope(project) to SearchScopeKind.DEPENDENT_MODULES
-            val vf = file.virtualFile
-            val module = ProjectFileIndex.getInstance(project).getModuleForFile(vf)
-            if (module != null) {
-                GlobalSearchScope.moduleWithDependentsScope(module) to SearchScopeKind.DEPENDENT_MODULES
-            } else {
-                GlobalSearchScope.projectScope(project) to SearchScopeKind.DEPENDENT_MODULES
-            }
-        }
-        SymbolVisibility.PUBLIC, SymbolVisibility.PROTECTED, SymbolVisibility.UNKNOWN ->
+        SymbolVisibility.INTERNAL, SymbolVisibility.PUBLIC, SymbolVisibility.PROTECTED ->
+            (moduleWithDependentsScope(target) ?: GlobalSearchScope.projectScope(project)) to
+                SearchScopeKind.DEPENDENT_MODULES
+        SymbolVisibility.UNKNOWN ->
             GlobalSearchScope.projectScope(project) to SearchScopeKind.DEPENDENT_MODULES
     }
 
-    private data class ReferenceSearchSnapshot(
-        val declaration: Symbol?,
-        val visibility: SymbolVisibility,
-        val scopeKind: SearchScopeKind,
-        val candidateFileCount: Int,
-    )
+    private fun moduleWithDependentsScope(target: PsiElement): GlobalSearchScope? {
+        val file = target.containingFile as? KtFile ?: return null
+        val virtualFile = file.virtualFile ?: return null
+        val module = ProjectFileIndex.getInstance(project).getModuleForFile(virtualFile) ?: return null
+        return GlobalSearchScope.moduleWithDependentsScope(module)
+    }
 
     private data class RenameSnapshot(
         val declarationEdit: TextEdit,
@@ -872,6 +1209,169 @@ internal class KastPluginBackend(
     }
 }
 
+private data class ReferenceResolvedTarget(
+    val pointer: SmartPsiElementPointer<PsiElement>,
+    val targetFqName: String?,
+    val searchNeedle: ReferenceSearchNeedle?,
+    val declaration: Symbol?,
+    val visibility: SymbolVisibility,
+)
+
+private data class ReferenceScopePlan(
+    val searchScope: GlobalSearchScope,
+    val scopeKind: SearchScopeKind,
+)
+
+private data class ReferenceSearchPlan(
+    val target: SmartPsiElementPointer<PsiElement>,
+    val targetFqName: String?,
+    val searchNeedle: ReferenceSearchNeedle?,
+    val declaration: Symbol?,
+    val visibility: SymbolVisibility,
+    val searchScope: GlobalSearchScope,
+    val scopeKind: SearchScopeKind,
+)
+
+private data class ReferenceSearchOutcome(
+    val source: ReferenceSearchSource,
+    val references: List<Location>,
+    val candidateFileCount: Int,
+    val searchedFileCount: Int,
+    val completion: ReferenceSearchCompletion,
+)
+
+private data class ReferenceCandidateDiscovery(
+    val files: List<VirtualFile>,
+    val candidateFileCount: Int,
+    val completion: ReferenceSearchCompletion,
+)
+
+private data class ReferenceResolutionOutcome(
+    val references: List<Location>,
+    val searchedFileCount: Int,
+    val completion: ReferenceSearchCompletion,
+)
+
+private data class ReferenceFileSearchOutcome(
+    val references: List<Location>,
+    val completion: ReferenceSearchCompletion,
+)
+
+private data class ReferenceLocationKey(
+    val filePath: String,
+    val startOffset: Int,
+    val endOffset: Int,
+)
+
+private enum class ReferenceSearchSource {
+    INDEX,
+    IDEA,
+}
+
+@JvmInline
+private value class ReferenceSearchNeedle private constructor(val value: String) {
+    companion object {
+        fun from(
+            target: PsiElement,
+            targetFqName: String?,
+        ): ReferenceSearchNeedle? {
+            val candidate = (target as? PsiNamedElement)?.name
+                ?: targetFqName?.substringAfterLast('.')
+                ?: target.text?.takeIf { text -> text.length in 1..MAX_NEEDLE_LENGTH }
+            return candidate
+                ?.trim()
+                ?.takeIf(String::isNotEmpty)
+                ?.let(::ReferenceSearchNeedle)
+        }
+
+        private const val MAX_NEEDLE_LENGTH = 128
+    }
+}
+
+private sealed interface ReferenceSearchCompletion {
+    val exhaustive: Boolean
+    val partialReason: String?
+
+    object Exhaustive : ReferenceSearchCompletion {
+        override val exhaustive: Boolean = true
+        override val partialReason: String? = null
+    }
+
+    data class Partial(
+        val reason: ReferencePartialReason,
+    ) : ReferenceSearchCompletion {
+        override val exhaustive: Boolean = false
+        override val partialReason: String = reason.name.lowercase()
+    }
+}
+
+private fun ReferenceSearchCompletion.combine(
+    other: ReferenceSearchCompletion,
+): ReferenceSearchCompletion =
+    if (this.exhaustive) other else this
+
+private enum class ReferencePartialReason {
+    REQUEST_BUDGET_EXHAUSTED,
+    FILE_BUDGET_EXHAUSTED,
+    TARGET_INVALIDATED,
+    CANDIDATE_DISCOVERY_STOPPED,
+    INDEX_LOCATION_UNRESOLVED,
+}
+
+internal fun interface ReferenceSearchClock {
+    fun nanoTime(): Long
+
+    companion object {
+        val System: ReferenceSearchClock = ReferenceSearchClock { java.lang.System.nanoTime() }
+    }
+}
+
+private class ReferenceSearchBudget(
+    private val requestStartedNanos: Long,
+    private val requestBudgetNanos: Long,
+    private val perFileBudgetNanos: Long,
+    private val clock: ReferenceSearchClock,
+) {
+    fun requestExhausted(): Boolean =
+        clock.nanoTime() - requestStartedNanos >= requestBudgetNanos
+
+    fun fileStarted(): Long = clock.nanoTime()
+
+    fun fileExhausted(fileStartedNanos: Long): Boolean =
+        clock.nanoTime() - fileStartedNanos >= perFileBudgetNanos
+
+    companion object {
+        fun start(
+            limits: ServerLimits,
+            clock: ReferenceSearchClock,
+        ): ReferenceSearchBudget = ReferenceSearchBudget(
+            requestStartedNanos = clock.nanoTime(),
+            requestBudgetNanos = limits.requestTimeoutMillis.toBudgetNanos(),
+            perFileBudgetNanos = limits.perFileScanBudgetMillis.toBudgetNanos(),
+            clock = clock,
+        )
+    }
+}
+
+private fun Long.toBudgetNanos(): Long {
+    val millis = coerceAtLeast(1L)
+    return if (millis > Long.MAX_VALUE / NANOS_PER_MILLI) {
+        Long.MAX_VALUE
+    } else {
+        millis * NANOS_PER_MILLI
+    }
+}
+
+private fun PsiElement.referenceAtOffset(offset: Int): PsiReference? =
+    generateSequence(this as PsiElement?) { element -> element.parent }
+        .flatMap { element -> element.references.asSequence() }
+        .filter { reference -> reference.absoluteTextRange().containsOffset(offset) }
+        .minByOrNull { reference -> reference.absoluteTextRange().length }
+
+private fun PsiReference.absoluteTextRange(): TextRange =
+    rangeInElement.shiftRight(element.textRange.startOffset)
+
+private const val NANOS_PER_MILLI = 1_000_000L
 private const val READ_ACTION_BATCH_SIZE = 50
 
 internal inline fun <S, T, R : Any> collectInShortReadActions(

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/ReferenceIndexLookup.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/ReferenceIndexLookup.kt
@@ -1,0 +1,34 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.indexstore.api.reference.SymbolReferenceRow
+import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
+
+internal fun interface ReferenceIndexLookup {
+    fun referencesTo(targetFqName: String): IndexedReferenceLookupResult
+
+    companion object {
+        val Unavailable: ReferenceIndexLookup = ReferenceIndexLookup {
+            IndexedReferenceLookupResult.NotReady
+        }
+    }
+}
+
+internal sealed interface IndexedReferenceLookupResult {
+    data object NotReady : IndexedReferenceLookupResult
+
+    data class Ready(
+        val references: List<SymbolReferenceRow>,
+    ) : IndexedReferenceLookupResult
+}
+
+internal class DiagnosticsReferenceIndexLookup(
+    private val diagnostics: KastDiagnosticsService,
+    private val store: SqliteSourceIndexStore,
+) : ReferenceIndexLookup {
+    override fun referencesTo(targetFqName: String): IndexedReferenceLookupResult =
+        if (diagnostics.snapshot().indexSummary.state == KastIndexState.READY) {
+            IndexedReferenceLookupResult.Ready(store.referencesToSymbol(targetFqName))
+        } else {
+            IndexedReferenceLookupResult.NotReady
+        }
+}

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaBackendPerformanceTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaBackendPerformanceTest.kt
@@ -52,7 +52,7 @@ class IdeaBackendPerformanceTest {
 
         // Warmup
         repeat(100) {
-            telemetry.inSpan(IdeaTelemetryScope.RESOLVE, "warmup") { 42 }
+            assertEquals(42, telemetry.inSpan(IdeaTelemetryScope.RESOLVE, "warmup") { 42 })
         }
 
         val elapsed = measureTimeMillis {
@@ -103,7 +103,7 @@ class IdeaBackendPerformanceTest {
         val iterations = 100
 
         repeat(20) {
-            telemetry.inSpan(IdeaTelemetryScope.RESOLVE, "warmup") { 42 }
+            assertEquals(42, telemetry.inSpan(IdeaTelemetryScope.RESOLVE, "warmup") { 42 })
         }
 
         val elapsed = measureTimeMillis {
@@ -176,6 +176,8 @@ class IdeaBackendOperationPerformanceTest {
         )
 
         private const val FIND_REFERENCES_BUDGET_MS = 5_000L
+        private const val FIND_REFERENCES_P95_BUDGET_MS = 1_000L
+        private const val FIND_REFERENCES_P95_ITERATIONS = 10
         private const val DIAGNOSTICS_BUDGET_MS = 10_000L
         private const val WORKSPACE_SYMBOL_SEARCH_BUDGET_MS = 5_000L
 
@@ -299,6 +301,42 @@ class IdeaBackendOperationPerformanceTest {
         println("findReferences_public_ms: $elapsed")
         assertTrue(elapsed < FIND_REFERENCES_BUDGET_MS) {
             "findReferences for public symbol took ${elapsed}ms, exceeds ${FIND_REFERENCES_BUDGET_MS}ms budget"
+        }
+    }
+
+    @Test
+    fun `findReferences for warm public symbol stays under p95 budget`() = runBlocking {
+        ensureProjectReady()
+
+        val (filePath, offset) = readAction {
+            publicFileFixture.get().virtualFile.path to
+                publicFileFixture.get().text.indexOf("publicHelper")
+        }
+        val backend = backend()
+        val query = ReferencesQuery(
+            position = FilePosition(filePath = filePath, offset = offset),
+            includeDeclaration = false,
+        )
+
+        backend.findReferences(query)
+        val durations = List(FIND_REFERENCES_P95_ITERATIONS) {
+            var candidateFileCount = Int.MAX_VALUE
+            val elapsed = measureTimeMillis {
+                val result = backend.findReferences(query)
+                assertEquals(SearchScopeKind.DEPENDENT_MODULES, result.searchScope?.scope)
+                candidateFileCount = result.searchScope?.candidateFileCount ?: Int.MAX_VALUE
+            }
+            assertTrue(candidateFileCount <= 1) {
+                "Expected text-index candidate discovery to avoid broad public search, got $candidateFileCount candidates"
+            }
+            elapsed
+        }.sorted()
+        val p95Index = ((durations.size * 95 + 99) / 100 - 1).coerceIn(0, durations.lastIndex)
+        val p95 = durations[p95Index]
+
+        println("findReferences_public_warm_p95_ms: $p95 durations=$durations")
+        assertTrue(p95 < FIND_REFERENCES_P95_BUDGET_MS) {
+            "findReferences warm public p95 was ${p95}ms, exceeds ${FIND_REFERENCES_P95_BUDGET_MS}ms budget"
         }
     }
 

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.DependencyScope
 import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
 import com.intellij.testFramework.junit5.TestApplication
@@ -24,11 +25,14 @@ import io.github.amichne.kast.api.contract.query.SymbolQuery
 import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceSearchQuery
+import io.github.amichne.kast.indexstore.api.reference.SymbolReferenceRow
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.nio.file.Files
 import java.nio.file.Path
 
 @TestApplication
@@ -100,10 +104,19 @@ class KastPluginBackendContractTest {
     private val hierarchyFile: PsiFile
         get() = hierarchyFileFixture.get()
 
-    private fun backend(workspaceRoot: Path = Path.of(project.basePath!!)): KastPluginBackend = KastPluginBackend(
+    private fun backend(
+        workspaceRoot: Path = Path.of(project.basePath!!),
+        limits: ServerLimits = defaultLimits,
+        telemetry: IdeaBackendTelemetry = IdeaBackendTelemetry.disabled(),
+        referenceIndexLookup: ReferenceIndexLookup = ReferenceIndexLookup.Unavailable,
+        referenceSearchClock: ReferenceSearchClock = ReferenceSearchClock.System,
+    ): KastPluginBackend = KastPluginBackend(
         project = project,
         workspaceRoot = workspaceRoot,
-        limits = defaultLimits,
+        limits = limits,
+        telemetry = telemetry,
+        referenceIndexLookup = referenceIndexLookup,
+        referenceSearchClock = referenceSearchClock,
     )
 
     private fun ensureProjectReady() {
@@ -253,6 +266,169 @@ class KastPluginBackendContractTest {
     }
 
     @Test
+    fun `fallback candidate discovery uses text index before reference resolution`() = runBlocking {
+        ensureProjectReady()
+        createIrrelevantKotlinFiles(count = 25)
+
+        val (workspaceRoot, filePath, offset) = readAction {
+            val usageFile = sampleUsageFileFixture.get()
+            Triple(
+                commonWorkspaceRoot(sampleFile.virtualFile.path, usageFile.virtualFile.path),
+                sampleFile.virtualFile.path,
+                sampleFile.text.indexOf("greet"),
+            )
+        }
+
+        val result = backend(workspaceRoot).findReferences(
+            ReferencesQuery(
+                position = FilePosition(filePath = filePath, offset = offset),
+                includeDeclaration = false,
+            ),
+        )
+
+        val searchScope = checkNotNull(result.searchScope)
+        assertTrue(searchScope.candidateFileCount <= 2) {
+            "Expected text-index candidate discovery to skip irrelevant Kotlin files, got ${searchScope.candidateFileCount}"
+        }
+        assertTrue(searchScope.searchedFileCount <= searchScope.candidateFileCount)
+        assertTrue(result.references.any { reference -> reference.preview.contains("greet(\"idea\")") })
+    }
+
+    @Test
+    fun `find references trace includes fallback candidate and resolution spans`() = runBlocking {
+        ensureProjectReady()
+
+        val traceFile = Files.createTempFile("kast-references-trace", ".jsonl")
+        val telemetry = IdeaBackendTelemetry.create(
+            IdeaTelemetryConfig(
+                enabled = true,
+                scopes = setOf(IdeaTelemetryScope.REFERENCES),
+                detail = IdeaTelemetryDetail.BASIC,
+                outputFile = traceFile,
+            ),
+        )
+        val (workspaceRoot, filePath, offset) = readAction {
+            val usageFile = sampleUsageFileFixture.get()
+            Triple(
+                commonWorkspaceRoot(sampleFile.virtualFile.path, usageFile.virtualFile.path),
+                sampleFile.virtualFile.path,
+                sampleFile.text.indexOf("greet"),
+            )
+        }
+
+        backend(
+            workspaceRoot = workspaceRoot,
+            telemetry = telemetry,
+        ).findReferences(
+            ReferencesQuery(
+                position = FilePosition(filePath = filePath, offset = offset),
+                includeDeclaration = false,
+            ),
+        )
+
+        val trace = Files.readString(traceFile)
+        listOf(
+            "kast.idea.findReferences.indexLookup",
+            "kast.idea.findReferences.findUsagesFallback",
+            "kast.idea.findReferences.candidateDiscovery",
+            "kast.idea.findReferences.referenceResolution",
+        ).forEach { spanName ->
+            assertTrue(trace.contains("\"name\":\"$spanName\"")) {
+                "Expected trace span $spanName in:\n$trace"
+            }
+        }
+    }
+
+    @Test
+    fun `find references uses ready source index before IDEA enumeration`() = runBlocking {
+        ensureProjectReady()
+
+        val referenceData = readAction {
+            val usageFile = sampleUsageFileFixture.get()
+            IndexedReferenceTestData(
+                workspaceRoot = commonWorkspaceRoot(sampleFile.virtualFile.path, usageFile.virtualFile.path),
+                declarationFilePath = sampleFile.virtualFile.path,
+                declarationOffset = sampleFile.text.indexOf("greet"),
+                usageFilePath = usageFile.virtualFile.path,
+                usageOffset = usageFile.text.indexOf("greet(\"idea\")"),
+            )
+        }
+        var lookedUpFqName: String? = null
+        val referenceIndexLookup = ReferenceIndexLookup { targetFqName ->
+            lookedUpFqName = targetFqName
+            IndexedReferenceLookupResult.Ready(
+                listOf(
+                    SymbolReferenceRow(
+                        sourcePath = referenceData.usageFilePath,
+                        sourceOffset = referenceData.usageOffset,
+                        targetFqName = targetFqName,
+                        targetPath = referenceData.declarationFilePath,
+                        targetOffset = referenceData.declarationOffset,
+                    ),
+                ),
+            )
+        }
+
+        val result = backend(
+            workspaceRoot = referenceData.workspaceRoot,
+            referenceIndexLookup = referenceIndexLookup,
+        ).findReferences(
+            ReferencesQuery(
+                position = FilePosition(
+                    filePath = referenceData.declarationFilePath,
+                    offset = referenceData.declarationOffset,
+                ),
+                includeDeclaration = false,
+                includeUsageSiteScope = true,
+            ),
+        )
+
+        assertEquals("demo.greet", lookedUpFqName)
+        val reference = result.references.single()
+        assertEquals(referenceData.usageFilePath, reference.filePath)
+        assertTrue(reference.preview.contains("greet(\"idea\")"))
+        assertNotNull(reference.usageSiteScope)
+        assertEquals(true, result.searchScope?.exhaustive)
+        assertEquals(result.searchScope?.candidateFileCount, result.searchScope?.searchedFileCount)
+    }
+
+    @Test
+    fun `find references reports non exhaustive scope when fallback budget is exhausted`() = runBlocking {
+        ensureProjectReady()
+
+        val (workspaceRoot, filePath, offset) = readAction {
+            val usageFile = sampleUsageFileFixture.get()
+            Triple(
+                commonWorkspaceRoot(sampleFile.virtualFile.path, usageFile.virtualFile.path),
+                sampleFile.virtualFile.path,
+                sampleFile.text.indexOf("greet"),
+            )
+        }
+        var currentNanos = 0L
+        val exhaustedClock = ReferenceSearchClock {
+            currentNanos += 2_000_000L
+            currentNanos
+        }
+
+        val result = backend(
+            workspaceRoot = workspaceRoot,
+            limits = defaultLimits.copy(requestTimeoutMillis = 1L),
+            referenceSearchClock = exhaustedClock,
+        ).findReferences(
+            ReferencesQuery(
+                position = FilePosition(filePath = filePath, offset = offset),
+                includeDeclaration = false,
+            ),
+        )
+
+        assertFalse(result.searchScope?.exhaustive ?: true)
+        assertTrue(
+            (result.searchScope?.searchedFileCount ?: Int.MAX_VALUE) <
+                (result.searchScope?.candidateFileCount ?: 0),
+        )
+    }
+
+    @Test
     fun `find references for internal symbol searches declaring module dependents`() = runBlocking {
         ensureInternalVisibilityProjectReady()
 
@@ -290,6 +466,28 @@ class KastPluginBackendContractTest {
         val secondPath = Path.of(second).toAbsolutePath().normalize()
         return generateSequence(firstPath.parent) { it.parent }
             .first { candidate -> secondPath.startsWith(candidate) }
+    }
+
+    private fun createIrrelevantKotlinFiles(count: Int) {
+        val suffix = System.nanoTime().toString()
+        val application = ApplicationManager.getApplication()
+        application.invokeAndWait {
+            application.runWriteAction {
+                val sourceRoot = mainSourceRootFixture.get().virtualFile
+                repeat(count) { index ->
+                    val file = sourceRoot.createChildData(this, "Irrelevant${suffix}_$index.kt")
+                    VfsUtil.saveText(
+                        file,
+                        """
+                        package demo
+
+                        fun unrelated${suffix}_$index(): Int = $index
+                        """.trimIndent(),
+                    )
+                }
+            }
+        }
+        waitUntilIndexesAreReady(project)
     }
 
     @Test
@@ -352,3 +550,11 @@ class KastPluginBackendContractTest {
         assertEquals(expectedVersion, backend().capabilities().backendVersion)
     }
 }
+
+private data class IndexedReferenceTestData(
+    val workspaceRoot: Path,
+    val declarationFilePath: String,
+    val declarationOffset: Int,
+    val usageFilePath: String,
+    val usageOffset: Int,
+)


### PR DESCRIPTION
## Summary
- Keep source-index references as the preferred ready path and add manifest-backed IDEA runtime lookup wiring.
- Bound the IDEA fallback by discovering text-index candidate files with `PsiSearchHelper.processCandidateFilesForText`, then resolving references per candidate file with explicit budget checks.
- Add explicit partial/exhaustive reference completion reasons, trace spans for index lookup/fallback/candidate discovery/resolution, and retryable `TIMEOUT` mapping for backend cancellations.

## Validation
- `./gradlew :backend-idea:test --no-configuration-cache`
- `./gradlew :backend-idea:test -PincludeTags=performance --no-configuration-cache`
  - `findReferences_public_warm_p95_ms: 2`, durations `[1, 1, 1, 2, 2, 2, 2, 2, 2, 2]`
- `./gradlew :analysis-server:test`
- `kast-dev raw/workspace-refresh` and `kast-dev raw/diagnostics` for changed files returned clean diagnostics before rebasing onto the clean branch.

## Notes
- Published from a fresh branch based on `origin/main`; the stale local branch history was not included.