### PR TITLE
fix: keep agent setup dry-runs read-only

### DIFF
--- a/cli-rs/src/cli.rs
+++ b/cli-rs/src/cli.rs
@@ -1410,6 +1410,9 @@ pub struct ResourceInstallArgs {
     /// Do not add managed resource paths to Git info/exclude.
     #[arg(long)]
     pub no_auto_exclude_git: bool,
+    /// Print the planned install without writing files.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -1423,6 +1426,9 @@ pub struct CopilotInstallArgs {
     /// Do not add managed package paths to Git info/exclude.
     #[arg(long)]
     pub no_auto_exclude_git: bool,
+    /// Print the planned install without writing files.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]

--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -537,6 +537,7 @@ pub fn install_agent_guidance(
         name: Some("kast".to_string()),
         force: args.force,
         no_auto_exclude_git: args.no_auto_exclude_git,
+        dry_run: false,
     })?;
     let agents_md_targets = resolve_agents_md_targets(&workspace_root, &args.agents_md)?;
     let mut agent_results = Vec::with_capacity(agents_md_targets.len());
@@ -1932,6 +1933,7 @@ fn repair_install_copilot_repos(
                 target_dir: Some(github_dir),
                 force: true,
                 no_auto_exclude_git: false,
+                dry_run: false,
             })?;
         }
     }
@@ -4150,6 +4152,7 @@ mod tests {
             name: Some("kast".to_string()),
             force: false,
             no_auto_exclude_git: false,
+            dry_run: false,
         };
         let first = install_skill(args.clone()).unwrap();
         assert!(!first.skipped);
@@ -4167,6 +4170,7 @@ mod tests {
             name: Some("kast".to_string()),
             force: false,
             no_auto_exclude_git: false,
+            dry_run: false,
         };
         let first = install_instructions(args.clone()).unwrap();
         assert!(!first.skipped);

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -251,19 +251,60 @@ fn agent_up_runtime_command(args: &cli::RuntimeArgs) -> Vec<String> {
 }
 
 fn run_agent_setup(args: cli::AgentSetupArgs, output_format: OutputFormat) -> Result<i32> {
-    match args.command {
-        None => run_agent_guidance_setup(args.guidance, output_format),
-        Some(cli::AgentSetupCommand::Auto(args)) => run_agent_setup_auto(args, output_format),
-        Some(cli::AgentSetupCommand::Copilot(args)) => {
+    let cli::AgentSetupArgs { command, guidance } = args;
+    match command {
+        None => run_agent_guidance_setup(guidance, output_format),
+        Some(cli::AgentSetupCommand::Auto(mut args)) => {
+            args.force |= guidance.force;
+            args.no_auto_exclude_git |= guidance.no_auto_exclude_git;
+            args.dry_run |= guidance.dry_run;
+            run_agent_setup_auto(args, output_format, guidance.workspace_root)
+        }
+        Some(cli::AgentSetupCommand::Copilot(mut args)) => {
+            merge_copilot_guidance(&mut args, &guidance);
             run_install(cli::InstallCommand::Copilot(args), output_format)
         }
-        Some(cli::AgentSetupCommand::Skill(args)) => {
+        Some(cli::AgentSetupCommand::Skill(mut args)) => {
+            merge_resource_guidance(&mut args, &guidance, cli::AgentSetupHarness::Skill);
             run_install(cli::InstallCommand::Skill(args), output_format)
         }
-        Some(cli::AgentSetupCommand::Instructions(args)) => {
+        Some(cli::AgentSetupCommand::Instructions(mut args)) => {
+            merge_resource_guidance(&mut args, &guidance, cli::AgentSetupHarness::Instructions);
             run_install(cli::InstallCommand::Instructions(args), output_format)
         }
     }
+}
+
+fn merge_resource_guidance(
+    args: &mut cli::ResourceInstallArgs,
+    guidance: &cli::AgentGuidanceSetupArgs,
+    harness: cli::AgentSetupHarness,
+) {
+    if args.target_dir.is_none()
+        && let Some(workspace_root) = &guidance.workspace_root
+    {
+        args.target_dir = Some(default_agent_up_target_dir(harness, workspace_root));
+    }
+    args.force |= guidance.force;
+    args.no_auto_exclude_git |= guidance.no_auto_exclude_git;
+    args.dry_run |= guidance.dry_run;
+}
+
+fn merge_copilot_guidance(
+    args: &mut cli::CopilotInstallArgs,
+    guidance: &cli::AgentGuidanceSetupArgs,
+) {
+    if args.target_dir.is_none()
+        && let Some(workspace_root) = &guidance.workspace_root
+    {
+        args.target_dir = Some(default_agent_up_target_dir(
+            cli::AgentSetupHarness::Copilot,
+            workspace_root,
+        ));
+    }
+    args.force |= guidance.force;
+    args.no_auto_exclude_git |= guidance.no_auto_exclude_git;
+    args.dry_run |= guidance.dry_run;
 }
 
 fn run_agent_guidance_setup(
@@ -312,8 +353,12 @@ fn agent_guidance_setup_command(args: &cli::AgentGuidanceSetupArgs) -> Vec<Strin
     command
 }
 
-fn run_agent_setup_auto(args: cli::AgentSetupAutoArgs, output_format: OutputFormat) -> Result<i32> {
-    let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
+fn run_agent_setup_auto(
+    args: cli::AgentSetupAutoArgs,
+    output_format: OutputFormat,
+    workspace_root: Option<PathBuf>,
+) -> Result<i32> {
+    let cwd = workspace_root.unwrap_or_else(|| env::current_dir().unwrap_or_else(|_| ".".into()));
     let selection = agent_setup_auto_selection(&cwd, &args)?;
     if args.dry_run {
         let plan = agent_setup_auto_plan(&selection, &args, &cwd);
@@ -528,12 +573,14 @@ fn agent_setup_command_for_harness(
             target_dir: args.target_dir,
             force: args.force,
             no_auto_exclude_git: args.no_auto_exclude_git,
+            dry_run: false,
         }),
         cli::AgentSetupHarness::Skill => cli::InstallCommand::Skill(cli::ResourceInstallArgs {
             target_dir: args.target_dir,
             name: None,
             force: args.force,
             no_auto_exclude_git: args.no_auto_exclude_git,
+            dry_run: false,
         }),
         cli::AgentSetupHarness::Instructions => {
             cli::InstallCommand::Instructions(cli::ResourceInstallArgs {
@@ -541,6 +588,7 @@ fn agent_setup_command_for_harness(
                 name: None,
                 force: args.force,
                 no_auto_exclude_git: args.no_auto_exclude_git,
+                dry_run: false,
             })
         }
     }
@@ -693,6 +741,14 @@ fn run_install(command: cli::InstallCommand, output_format: OutputFormat) -> Res
         print_completion(completion_args);
         return Ok(0);
     }
+    if let Some(plan) = install_dry_run_plan(&command) {
+        if output_format == OutputFormat::Json {
+            output::print_json(&plan)?;
+        } else {
+            output::print_agent_setup_auto_plan(&plan)?;
+        }
+        return Ok(0);
+    }
     let mut reporter = install_reporter(output_format);
     let result = install::install(cli::InstallArgs { command }, reporter.as_mut())?;
     if output_format == OutputFormat::Json {
@@ -701,6 +757,94 @@ fn run_install(command: cli::InstallCommand, output_format: OutputFormat) -> Res
         output::print_install_result(&result)?;
     }
     Ok(0)
+}
+
+fn install_dry_run_plan(command: &cli::InstallCommand) -> Option<install::AgentSetupAutoPlan> {
+    match command {
+        cli::InstallCommand::Copilot(args) if args.dry_run => Some(resource_install_plan(
+            cli::AgentSetupHarness::Copilot,
+            args.target_dir.clone(),
+            None,
+            args.force,
+            args.no_auto_exclude_git,
+        )),
+        cli::InstallCommand::Skill(args) if args.dry_run => Some(resource_install_plan(
+            cli::AgentSetupHarness::Skill,
+            args.target_dir.clone(),
+            args.name.clone(),
+            args.force,
+            args.no_auto_exclude_git,
+        )),
+        cli::InstallCommand::Instructions(args) if args.dry_run => Some(resource_install_plan(
+            cli::AgentSetupHarness::Instructions,
+            args.target_dir.clone(),
+            args.name.clone(),
+            args.force,
+            args.no_auto_exclude_git,
+        )),
+        _ => None,
+    }
+}
+
+fn resource_install_plan(
+    harness: cli::AgentSetupHarness,
+    target_dir: Option<PathBuf>,
+    name: Option<String>,
+    force: bool,
+    no_auto_exclude_git: bool,
+) -> install::AgentSetupAutoPlan {
+    let command = resource_install_command(
+        harness,
+        target_dir.as_ref(),
+        name.as_deref(),
+        force,
+        no_auto_exclude_git,
+    );
+    let mut plan = install::AgentSetupAutoPlan::new(
+        harness,
+        install::AgentSetupSelectionSource::Explicit,
+        "Concrete agent resource setup command selected.".to_string(),
+        command,
+        target_dir,
+    );
+    plan.dry_run = true;
+    plan
+}
+
+fn resource_install_command(
+    harness: cli::AgentSetupHarness,
+    target_dir: Option<&PathBuf>,
+    name: Option<&str>,
+    force: bool,
+    no_auto_exclude_git: bool,
+) -> Vec<String> {
+    let mut command = vec![
+        current_executable_argument(),
+        "agent".to_string(),
+        "setup".to_string(),
+        match harness {
+            cli::AgentSetupHarness::Auto => unreachable!("auto harness must be resolved"),
+            cli::AgentSetupHarness::Copilot => "copilot",
+            cli::AgentSetupHarness::Skill => "skill",
+            cli::AgentSetupHarness::Instructions => "instructions",
+        }
+        .to_string(),
+    ];
+    if let Some(target_dir) = target_dir {
+        command.push("--target-dir".to_string());
+        command.push(target_dir.display().to_string());
+    }
+    if let Some(name) = name {
+        command.push("--name".to_string());
+        command.push(name.to_string());
+    }
+    if force {
+        command.push("--force".to_string());
+    }
+    if no_auto_exclude_git {
+        command.push("--no-auto-exclude-git".to_string());
+    }
+    command
 }
 
 fn install_reporter(output_format: OutputFormat) -> Box<dyn install::InstallReporter> {

--- a/cli-rs/tests/cli_smoke.rs
+++ b/cli-rs/tests/cli_smoke.rs
@@ -4784,6 +4784,136 @@ agentHarness = "instructions"
 }
 
 #[test]
+fn agent_setup_concrete_parent_dry_run_does_not_install_resources() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let cases = [
+        (
+            "skill",
+            workspace.join("agent/skills"),
+            workspace.join("agent/skills/kast/SKILL.md"),
+        ),
+        (
+            "instructions",
+            workspace.join("agent/instructions"),
+            workspace.join("agent/instructions/kast/README.md"),
+        ),
+        (
+            "copilot",
+            workspace.join("agent/github"),
+            workspace.join("agent/github/lsp.json"),
+        ),
+    ];
+
+    for (command, target_dir, expected_output) in cases {
+        let plan = kast(&home, &config_home)
+            .current_dir(&workspace)
+            .args([
+                "--output",
+                "json",
+                "agent",
+                "setup",
+                "--workspace-root",
+                workspace.to_str().expect("workspace"),
+                "--dry-run",
+                command,
+                "--target-dir",
+                target_dir.to_str().expect("target dir"),
+                "--force",
+            ])
+            .output()
+            .unwrap_or_else(|error| panic!("agent setup {command} dry-run: {error}"));
+
+        assert!(
+            plan.status.success(),
+            "agent setup {command} parent dry-run should succeed: stdout={}, stderr={}",
+            String::from_utf8_lossy(&plan.stdout),
+            String::from_utf8_lossy(&plan.stderr)
+        );
+        let stdout: serde_json::Value =
+            serde_json::from_slice(&plan.stdout).expect("setup plan json");
+        assert_eq!(stdout["harness"], command, "{stdout}");
+        assert_eq!(stdout["selectionSource"], "explicit", "{stdout}");
+        assert_eq!(stdout["dryRun"], true, "{stdout}");
+        assert_eq!(
+            stdout["targetDir"],
+            target_dir.display().to_string(),
+            "{stdout}"
+        );
+        let install_command = stdout["installCommand"]
+            .as_array()
+            .expect("install command");
+        assert!(install_command.iter().any(|arg| arg == command), "{stdout}");
+        assert!(
+            !install_command.iter().any(|arg| arg == "--dry-run"),
+            "planned install command should omit dry-run: {stdout}"
+        );
+        assert!(
+            !expected_output.exists(),
+            "agent setup {command} parent dry-run must not write {}",
+            expected_output.display()
+        );
+    }
+
+    assert!(
+        !install_manifest_path(&home).exists(),
+        "dry-run must not record manifest resources"
+    );
+}
+
+#[test]
+fn agent_setup_concrete_subcommand_dry_run_does_not_install_skill() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let target_dir = workspace.join("agent/skills");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let plan = kast(&home, &config_home)
+        .current_dir(&workspace)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "setup",
+            "skill",
+            "--target-dir",
+            target_dir.to_str().expect("target dir"),
+            "--force",
+            "--dry-run",
+        ])
+        .output()
+        .expect("agent setup skill subcommand dry-run");
+
+    assert!(
+        plan.status.success(),
+        "agent setup skill subcommand dry-run should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&plan.stdout),
+        String::from_utf8_lossy(&plan.stderr)
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&plan.stdout).expect("setup plan json");
+    assert_eq!(stdout["harness"], "skill", "{stdout}");
+    assert_eq!(stdout["dryRun"], true, "{stdout}");
+    assert!(
+        !target_dir.join("kast/SKILL.md").exists(),
+        "subcommand dry-run must not install the skill"
+    );
+    assert!(
+        !install_manifest_path(&home).exists(),
+        "subcommand dry-run must not record manifest resources"
+    );
+}
+
+#[test]
 fn agent_up_dry_run_uses_guidance_setup_and_explicit_workspace_root() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");


### PR DESCRIPTION
## Summary
- honor parent `kast agent setup --dry-run` flags when concrete `skill`, `instructions`, or `copilot` subcommands are selected
- make concrete resource setup dry-runs return a plan instead of mutating files or the install manifest
- add CLI smoke coverage for parent and subcommand dry-run resource setup paths

## Validation
- `cargo fmt --manifest-path cli-rs/Cargo.toml --check`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked agent_setup_concrete -- --nocapture`
- `git diff --check origin/main...HEAD`

## Residual risk
- Remote CI still needs to complete for the pushed head.