### PR TITLE
docs: add visual command documentation

### DIFF
--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -27,6 +27,28 @@ as a failed operation even when the process exited cleanly.
 Stderr may contain human-readable startup or progress messages. Scripts should
 parse stdout and keep stderr for diagnostics.
 
+```mermaid
+flowchart LR
+    command["kast agent ..."]
+    envelope["JSON envelope"]
+    ok["ok: true<br/>result"]
+    error["ok: false<br/>error"]
+    next["nextRequest or workflow files"]
+
+    command --> envelope
+    envelope --> ok
+    envelope --> error
+    ok --> next
+```
+
+| Envelope field | Contract |
+|----------------|----------|
+| `ok` | Boolean success signal for scripts; do not rely on process exit alone |
+| `method` | Catalog or alias method actually invoked |
+| `request` | Normalized request payload after CLI flag parsing |
+| `result` | Present only when `ok` is true |
+| `error` | Present when the operation failed or the backend rejected the request |
+
 ## Bring Up A Repository
 
 Use `kast agent up` when a repository should be ready for an agent in one
@@ -58,6 +80,11 @@ the executable token used for the dry run, so copied binaries and absolute CLI
 paths remain directly callable. `stage`, `nextActions`, and `manualSteps`
 explain what happened and what the user should do next.
 
+!!! tip "Plan before mutating a repository"
+    Use `kast agent up --dry-run` when the harness, setup target, or backend is
+    not obvious. The dry run reports the resource install command and runtime
+    warmup command without writing repository files.
+
 ## Setup
 
 Use `kast agent setup` to install harness-agnostic agent resources. The default
@@ -75,6 +102,13 @@ When root `AGENTS.md` is missing, default setup installs only the skill.
 Pass `--agents-md <path/to/AGENTS.md>` to explicitly create or patch a scoped
 guidance file. In JSON dry-runs, `skillTarget`, `agentsMdTargets`, and
 `installCommand` report the exact writes and equivalent command.
+
+| Harness | Typical target | Use when |
+|---------|----------------|----------|
+| `copilot` | `.github` | The repository should expose the Copilot LSP package and tool catalog |
+| `skill` | `.agents/skills` or `.codex/skills` | The host loads reusable skills but not the Copilot package |
+| `instructions` | `.agents/instructions` or `.codex/instructions` | The host reads Markdown instructions without a skill runtime |
+| `auto` | Detected from config or existing roots | The same command should adapt across repositories |
 
 ## Tool Discovery
 
@@ -101,6 +135,23 @@ Before registering or invoking returned tools, validate the discovery envelope:
 `toolCount` matches the returned tools length, and `result.invocation.argv`
 has the `agent call <method>` shape. Treat a failed validation as a stale
 binary or package install.
+
+```mermaid
+sequenceDiagram
+    participant Host as Agent host
+    participant CLI as kast CLI
+    participant Catalog as Embedded catalog
+    participant Backend as Workspace backend
+
+    Host->>CLI: kast agent tools
+    CLI->>Catalog: Read catalog-backed specs
+    Catalog-->>CLI: Tool schemas and invocation argv
+    CLI-->>Host: KAST_AGENT_TOOLS envelope
+    Host->>CLI: kast agent call <method>
+    CLI->>Backend: Normalized request
+    Backend-->>CLI: Semantic result or typed error
+    CLI-->>Host: JSON envelope
+```
 
 ## Alias commands
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -16,6 +16,23 @@ Start with the group that matches the job in front of you. Run `kast help` or
 `kast help <command>` locally for the exact flags supported by your installed
 binary.
 
+```mermaid
+flowchart LR
+    ready["ready"]
+    setup["agent up<br/>agent setup"]
+    runtime["runtime up/status"]
+    inspect["inspect ..."]
+    semantic["agent raw-*<br/>agent workflow ..."]
+    repair["ready --fix<br/>machine ..."]
+
+    ready --> setup
+    ready --> runtime
+    setup --> semantic
+    runtime --> semantic
+    inspect --> semantic
+    ready -. stale install .-> repair
+```
+
 | Group | Commands | Use when |
 |-------|----------|----------|
 | Readiness | `ready` | Prove the active binary, manifest, and task surface are usable |
@@ -31,14 +48,27 @@ Operator commands are designed for humans first. They render readable summaries
 in terminals and plain text in captured logs. Add `--output json` to preserve
 the structured payload for automation.
 
-```console title="Readable by default, JSON when requested"
-kast runtime status
-kast --output json runtime status
-```
+=== "Human terminal"
+
+    ```console title="Readable by default"
+    kast runtime status
+    ```
+
+=== "Script"
+
+    ```console title="Structured output"
+    kast --output json runtime status
+    ```
 
 `kast agent` is different by design. It always emits a single JSON envelope
 with `ok`, `method`, `request`, and either `result` or `error`. Use it when a
 script, agent, or CI step needs stable machine output.
+
+| Surface | Output default | Use it for |
+|---------|----------------|------------|
+| `kast ready` and `kast runtime ...` | Human-readable text | Operator inspection and repair loops |
+| `kast --output json ...` | Structured JSON for supported operator commands | CI and scripts that still use high-level operator commands |
+| `kast agent ...` | One JSON envelope on stdout | Agent tools, command chaining, and stable semantic evidence |
 
 ## Workspace selection
 
@@ -56,6 +86,7 @@ kast agent health --workspace-root "$PWD" --backend=headless
 
 ## Debug escape hatch
 
-Raw `kast rpc` still exists for low-level debugging and compatibility. The
-published command docs teach `kast agent` first because it normalizes inputs,
-wraps results consistently, and works better for scripts.
+!!! warning "Prefer the public agent surface"
+    Raw `kast rpc` still exists for low-level debugging and compatibility. The
+    published command docs teach `kast agent` first because it normalizes
+    inputs, wraps results consistently, and works better for scripts.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -16,6 +16,17 @@ You need Kast installed and a Kotlin workspace on disk. Use the developer
 machine install on macOS, or the Linux headless bundle on CI runners, hosted
 agents, and server images.
 
+```mermaid
+flowchart TD
+    ready["1. Check the install<br/>kast ready"]
+    start["2. Start or warm backend<br/>kast runtime up"]
+    resolve["3. Resolve symbol identity<br/>kast agent raw-resolve"]
+    refs["4. Find references<br/>kast agent raw-references"]
+    scope["5. Check completeness<br/>result.searchScope"]
+
+    ready --> start --> resolve --> refs --> scope
+```
+
 ```console title="Check the active install"
 kast ready
 kast inspect paths
@@ -31,10 +42,19 @@ Use the backend that matches the machine. The headless backend works well for
 servers and CI. The IDEA backend reuses an already-open IDEA or Android Studio
 project on developer machines.
 
-```console title="Start or warm a backend"
-kast runtime up --backend=headless
-kast runtime status --backend=headless
-```
+=== "Headless"
+
+    ```console title="Start or warm a headless backend"
+    kast runtime up --backend=headless
+    kast runtime status --backend=headless
+    ```
+
+=== "IDEA"
+
+    ```console title="Reuse an open IDEA or Android Studio project"
+    kast runtime up --backend=idea
+    kast runtime status --backend=idea
+    ```
 
 Use JSON output for automation:
 
@@ -59,6 +79,13 @@ kast agent raw-resolve \
 The important fields are in `result`: fully qualified name, kind, signature,
 and source location. That is compiler-backed symbol identity, not a text match.
 
+| Field | Why it matters |
+|-------|----------------|
+| `result.fqName` | Names the declaration the Kotlin analysis engine resolved |
+| `result.kind` | Distinguishes classes, functions, properties, and other declaration shapes |
+| `result.signature` | Gives scripts a stable comparison point when overloads exist |
+| `result.location` | Feeds the next command without falling back to text search |
+
 ## Step 3: find references
 
 Use the same file and offset to ask for usages. Include the declaration when
@@ -74,6 +101,11 @@ kast agent raw-references \
 
 Read `result.searchScope.exhaustive` before claiming the list is complete. If
 it is false, compare the candidate and searched file counts in the payload.
+
+!!! warning "Completeness is data, not intent"
+    Treat partial reference results as bounded evidence. A successful command
+    proves that the request ran; only an exhaustive search scope proves that the
+    returned list is complete for the selected backend and workspace state.
 
 ## Step 4: bridge from a name to an offset
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,28 +14,64 @@ should use it, then drive the workspace with `kast` commands.
 
 ## Start here
 
-The normal developer-machine path is two commands plus an IDE restart.
-Homebrew installs the global `kast` binary and version-coupled IDEA or Android
-Studio plugin. The repository command writes managed Copilot files under that
-repository's `.github` directory.
+Choose the path by host first, then run the same semantic command surface from
+the repository. Developer machines use the IDE-backed runtime; CI runners,
+hosted agents, and server images use the headless runtime.
 
-```console title="Install Kast, then enable one repository"
-brew tap amichne/kast
-brew install kast
+=== "Developer machine"
 
-cd /path/to/your/repository
-kast agent setup copilot
+    Homebrew installs the global `kast` binary and version-coupled IDEA or
+    Android Studio plugin. The repository command writes managed Copilot files
+    under that repository's `.github` directory.
+
+    ```console title="Install Kast, then enable one repository"
+    brew tap amichne/kast
+    brew install kast
+
+    cd /path/to/your/repository
+    kast agent setup copilot
+    ```
+
+=== "Headless Linux"
+
+    Use the Linux headless bundle when the machine is a CI runner, hosted
+    agent, server image, or other host without Homebrew or an open developer
+    IDE.
+
+    ```console title="Install on Ubuntu or Debian"
+    export KAST_UBUNTU_DEBIAN_VERSION="v1.2.3"
+    ./scripts/install-ubuntu-debian.sh install
+    ./scripts/install-ubuntu-debian.sh verify
+    kast runtime up --backend=headless
+    ```
+
+## Operating model
+
+Kast separates the machine install, repository agent resources, runtime
+backend, and semantic command layer. Keep those layers separate when debugging
+or automating a workspace.
+
+```mermaid
+flowchart LR
+    machine["Machine install<br/>kast binary and runtime files"]
+    repo["Repository resources<br/>Copilot, skill, or instructions"]
+    backend["Workspace backend<br/>IDEA or headless"]
+    commands["Semantic commands<br/>kast runtime and kast agent"]
+    evidence["Evidence<br/>JSON envelopes, hashes, diagnostics"]
+
+    machine --> repo
+    machine --> backend
+    repo --> commands
+    backend --> commands
+    commands --> evidence
 ```
 
-Use the Linux headless bundle instead when the machine is a CI runner, hosted
-agent, server image, or other host without Homebrew or an open developer IDE.
-
-```console title="Install on Ubuntu or Debian"
-export KAST_UBUNTU_DEBIAN_VERSION="v1.2.3"
-./scripts/install-ubuntu-debian.sh install
-./scripts/install-ubuntu-debian.sh verify
-kast runtime up --backend=headless
-```
+| Layer | First command | Proves |
+|-------|---------------|--------|
+| Machine install | `kast ready` | The active binary, manifest, and local paths are coherent |
+| Repository resources | `kast agent setup ...` | Agent-facing files match the running CLI version |
+| Runtime backend | `kast runtime status` | A workspace backend is reachable and reports capabilities |
+| Semantic command layer | `kast agent ...` | The request uses compiler-backed Kotlin evidence |
 
 ## Command manual
 
@@ -89,6 +125,7 @@ declaration the Kotlin analysis engine sees, report whether reference and
 hierarchy evidence was complete or bounded, and plan mutations with file hashes
 before applying edits.
 
-Use `--output json` on operator commands when automation needs structured
-payloads. Use `kast agent` for pipe-friendly advanced command calls. Raw
-`kast rpc` remains a hidden debug transport, not the published docs path.
+!!! tip "Automation boundary"
+    Use `--output json` on operator commands when automation needs structured
+    payloads. Use `kast agent` for pipe-friendly advanced command calls. Raw
+    `kast rpc` remains a hidden debug transport, not the published docs path.


### PR DESCRIPTION
## Summary
- add Zensical/Material tabs for install path, backend selection, and output-mode choices
- add Mermaid diagrams for the command operating model, quickstart flow, command groups, agent envelope flow, and tool discovery
- add compact tables and admonitions for proof boundaries, envelope contracts, harness selection, and raw RPC fallback

## Validation
- `.github/scripts/test-docs-navigation-contract.sh`
- `.github/scripts/test-docs-content-contract.sh`
- `zensical build --clean`
- `git diff --check`

## Notes
- Authored docs only; generated `site/` output is not committed.