### PR TITLE
feat: add Kast routing eval gate

### DIFF
--- a/.github/plugin-eval/kast-routing/emit-kast-routing-metrics.mjs
+++ b/.github/plugin-eval/kast-routing/emit-kast-routing-metrics.mjs
@@ -7,6 +7,7 @@ const [, , rawTargetPath, targetKind = "directory"] = process.argv;
 const manifestDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(manifestDir, "../../..");
 const targetPath = rawTargetPath ? resolve(rawTargetPath) : join(repoRoot, "cli-rs/resources/kast-skill");
+const agentToolsFile = process.env.KAST_AGENT_TOOLS_FILE ? resolve(process.env.KAST_AGENT_TOOLS_FILE) : null;
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
@@ -55,6 +56,68 @@ function collectStrings(value, strings = []) {
 
 function failIf(condition, message, failures) {
   if (condition) failures.push(message);
+}
+
+function checkToolEnvelope(path) {
+  const failures = [];
+  const payload = readJson(path);
+  const result = payload.result ?? {};
+  const tools = Array.isArray(result.tools) ? result.tools : [];
+  const toolByName = new Map(tools.map((tool) => [tool.name, tool]));
+  const methodByName = new Map(tools.map((tool) => [tool.method, tool]));
+  const catalogHash = result.catalogSha256 ?? "";
+
+  failIf(payload.ok !== true, "agent tools envelope must have ok=true", failures);
+  failIf(payload.method !== "agent/tools", "agent tools envelope method must be agent/tools", failures);
+  failIf(result.type !== "KAST_AGENT_TOOLS", "agent tools result.type must be KAST_AGENT_TOOLS", failures);
+  failIf(result.schemaVersion < 3, "agent tools schemaVersion must be at least 3", failures);
+  failIf(result.toolCount !== tools.length, "agent tools toolCount must match tools.length", failures);
+  failIf(!/^[a-f0-9]{64}$/.test(catalogHash), "agent tools catalogSha256 must be a 64-character lowercase hex digest", failures);
+
+  const requiredTools = [
+    "kast_symbol_query",
+    "kast_callers",
+    "kast_metrics",
+    "kast_scaffold",
+    "kast_write_and_validate",
+  ];
+  for (const name of requiredTools) {
+    failIf(!toolByName.has(name), `agent tools envelope missing ${name}`, failures);
+  }
+
+  const requiredMethods = ["symbol/query", "symbol/callers", "database/metrics"];
+  for (const method of requiredMethods) {
+    failIf(!methodByName.has(method), `agent tools envelope missing method ${method}`, failures);
+  }
+
+  const symbolQuery = toolByName.get("kast_symbol_query")?.description ?? "";
+  failIf(!symbolQuery.includes("unknown symbols"), "kast_symbol_query must mention unknown symbols", failures);
+  failIf(!symbolQuery.includes(".kt/.kts"), "kast_symbol_query must mention .kt/.kts discovery", failures);
+
+  const metrics = toolByName.get("kast_metrics")?.description ?? "";
+  failIf(!metrics.includes("source-index metrics"), "kast_metrics must mention source-index metrics", failures);
+  failIf(!metrics.includes("database-backed view"), "kast_metrics must mention database-backed view", failures);
+
+  const leakedTools = [];
+  for (const tool of tools) {
+    for (const needle of leakNeedles) {
+      if ((tool.description ?? "").includes(needle)) {
+        leakedTools.push(`${tool.name}:${needle}`);
+      }
+    }
+  }
+  failures.push(...leakedTools);
+
+  return check(
+    "routing-agent-tools-envelope",
+    failures.length === 0 ? "pass" : "fail",
+    failures.length === 0 ? "info" : "error",
+    failures.length === 0
+      ? "Live agent tool discovery exposes the same public navigation surface as the routing corpus."
+      : "Live agent tool discovery drifted from the routing contract.",
+    failures.length === 0 ? [`tools=${tools.length}`, `catalogSha256=${catalogHash}`] : failures,
+    ["Keep kast agent tools aligned with the routing corpus and public catalog metadata."],
+  );
 }
 
 const skill = readText(join(targetPath, "SKILL.md"));
@@ -256,6 +319,10 @@ checks.push(
     ["Keep generated protocol paths, LSP internals, and implementation routing out of public skill/tool descriptions."],
   ),
 );
+
+if (agentToolsFile) {
+  checks.push(checkToolEnvelope(agentToolsFile));
+}
 
 const localPathNeedles = ["/Users/", "/home/", "/private/", "C:\\"];
 const localPathHits = collectStrings(routing).filter((text) =>

--- a/.github/plugin-eval/kast-routing/emit-kast-routing-metrics.mjs
+++ b/.github/plugin-eval/kast-routing/emit-kast-routing-metrics.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const [, , rawTargetPath, targetKind = "directory"] = process.argv;
+const manifestDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(manifestDir, "../../..");
+const targetPath = rawTargetPath ? resolve(rawTargetPath) : join(repoRoot, "cli-rs/resources/kast-skill");
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function readText(path) {
+  return readFileSync(path, "utf8");
+}
+
+function check(id, status, severity, message, evidence = [], remediation = []) {
+  return {
+    id,
+    category: "kast-routing",
+    severity,
+    status,
+    message,
+    evidence,
+    remediation,
+  };
+}
+
+function metric(id, value, unit, band) {
+  return {
+    id,
+    category: "kast-routing",
+    value,
+    unit,
+    band,
+  };
+}
+
+function includesAll(text, needles) {
+  return needles.every((needle) => text.includes(needle));
+}
+
+function collectStrings(value, strings = []) {
+  if (typeof value === "string") {
+    strings.push(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, strings);
+  } else if (value && typeof value === "object") {
+    for (const item of Object.values(value)) collectStrings(item, strings);
+  }
+  return strings;
+}
+
+function failIf(condition, message, failures) {
+  if (condition) failures.push(message);
+}
+
+const skill = readText(join(targetPath, "SKILL.md"));
+const catalog = readJson(join(targetPath, "references/commands.json"));
+const routing = readJson(join(targetPath, "fixtures/maintenance/evals/routing.json"));
+const routingSchema = readJson(join(targetPath, "fixtures/maintenance/evals/routing.schema.json"));
+const commands = catalog.commands ?? {};
+const toolNames = new Set(
+  Object.values(commands)
+    .map((command) => command.tool?.name)
+    .filter(Boolean),
+);
+const cases = Array.isArray(routing.cases) ? routing.cases : [];
+const checks = [];
+
+const schemaFailures = [];
+failIf(routing.$schema !== "./routing.schema.json", "routing corpus must link ./routing.schema.json", schemaFailures);
+failIf(routing.schemaVersion !== 1, "routing corpus schemaVersion must be 1", schemaFailures);
+failIf(routing.primitive?.name !== "kast", "routing corpus primitive.name must be kast", schemaFailures);
+failIf(routingSchema.properties?.cases?.items?.$ref !== "#/$defs/case", "routing schema must define typed case items", schemaFailures);
+checks.push(
+  check(
+    "routing-schema-backed",
+    schemaFailures.length === 0 ? "pass" : "fail",
+    schemaFailures.length === 0 ? "info" : "error",
+    schemaFailures.length === 0 ? "Routing corpus is schema-backed." : "Routing corpus schema contract failed.",
+    schemaFailures.length === 0 ? [routing.$schema] : schemaFailures,
+    ["Keep routing.json linked to routing.schema.json with schemaVersion 1."],
+  ),
+);
+
+const requiredCaseIds = new Set([
+  "kotlin-file-trigger-all-kt-kts",
+  "unknown-symbol-navigation",
+  "relationship-navigation",
+  "source-index-database-access",
+  "agent-workflow-public-surface",
+  "public-api-boundary",
+]);
+const caseIds = new Set(cases.map((item) => item.id));
+const missingCaseIds = [...requiredCaseIds].filter((id) => !caseIds.has(id));
+checks.push(
+  check(
+    "routing-required-cases",
+    missingCaseIds.length === 0 ? "pass" : "fail",
+    missingCaseIds.length === 0 ? "info" : "error",
+    missingCaseIds.length === 0
+      ? "Routing corpus covers Kotlin files, symbols, relationships, database, workflows, and public API boundary."
+      : "Routing corpus is missing required coverage cases.",
+    missingCaseIds.length === 0 ? [...caseIds].sort() : missingCaseIds,
+    ["Add missing cases to fixtures/maintenance/evals/routing.json."],
+  ),
+);
+
+const actionFailures = [];
+const actionNames = new Set();
+for (const item of cases) {
+  for (const action of item.allowedActions ?? []) {
+    actionNames.add(action.name);
+    if (action.kind === "method" && !commands[action.name]) {
+      actionFailures.push(`${item.id}: missing method ${action.name}`);
+    } else if (action.kind === "tool" && !toolNames.has(action.name)) {
+      actionFailures.push(`${item.id}: missing tool ${action.name}`);
+    } else if (
+      action.kind === "command" &&
+      !action.name.startsWith("kast agent") &&
+      !action.name.startsWith("kast inspect metrics")
+    ) {
+      actionFailures.push(`${item.id}: non-public command ${action.name}`);
+    }
+  }
+}
+checks.push(
+  check(
+    "routing-actions-resolve",
+    actionFailures.length === 0 ? "pass" : "fail",
+    actionFailures.length === 0 ? "info" : "error",
+    actionFailures.length === 0 ? "All routing actions resolve to public Kast methods, tools, or commands." : "Some routing actions do not resolve.",
+    actionFailures.length === 0 ? [...actionNames].sort() : actionFailures,
+    ["Keep allowedActions aligned with references/commands.json and kast agent tools."],
+  ),
+);
+
+const triggerEvidence = [
+  "all Kotlin `.kt` and `.kts`",
+  "every `.kt` and `.kts` file",
+  "only navigation surface",
+  "Any `.kt` or `.kts` file",
+];
+checks.push(
+  check(
+    "routing-kotlin-file-trigger",
+    includesAll(skill, triggerEvidence) ? "pass" : "fail",
+    includesAll(skill, triggerEvidence) ? "info" : "error",
+    includesAll(skill, triggerEvidence)
+      ? "Skill explicitly triggers for all Kotlin source and script files."
+      : "Skill trigger language does not fully cover Kotlin source and script files.",
+    triggerEvidence,
+    ["Keep SKILL.md explicit about every .kt and .kts file and the sole-navigation rule."],
+  ),
+);
+
+const caseShapeFailures = [];
+const allowedTypes = new Set([
+  "TRIGGER_MISS",
+  "WRONG_PRIMITIVE",
+  "LOADED_BYPASSED",
+  "ADAPTER_DRIFT",
+  "SCHEMA_FRICTION",
+  "SETUP_FRICTION",
+]);
+for (const item of cases) {
+  failIf(!allowedTypes.has(item.type), `${item.id}: invalid type ${item.type}`, caseShapeFailures);
+  failIf(item.expectedPrimitive?.name !== "kast", `${item.id}: expectedPrimitive must be kast`, caseShapeFailures);
+  failIf(!item.observedRoute?.risk, `${item.id}: observedRoute.risk is required`, caseShapeFailures);
+  failIf(!item.recoveryExpectation, `${item.id}: recoveryExpectation is required`, caseShapeFailures);
+  failIf((item.verificationEvidence ?? []).length < 2, `${item.id}: verificationEvidence needs at least two entries`, caseShapeFailures);
+}
+checks.push(
+  check(
+    "routing-case-evidence",
+    caseShapeFailures.length === 0 ? "pass" : "fail",
+    caseShapeFailures.length === 0 ? "info" : "error",
+    caseShapeFailures.length === 0
+      ? "Every routing case has a miss class, observed-route risk, recovery expectation, and verification evidence."
+      : "One or more routing cases are missing evidence fields.",
+    caseShapeFailures.length === 0 ? cases.map((item) => `${item.id}:${item.type}`) : caseShapeFailures,
+    ["Preserve typed routing miss evidence in every case."],
+  ),
+);
+
+const fallbackFailures = [];
+for (const item of cases) {
+  const forbidden = new Set(item.forbiddenActions ?? []);
+  failIf(!forbidden.has("grep"), `${item.id}: must forbid grep`, fallbackFailures);
+  failIf(!forbidden.has("rg"), `${item.id}: must forbid rg`, fallbackFailures);
+}
+checks.push(
+  check(
+    "routing-forbidden-fallbacks",
+    fallbackFailures.length === 0 ? "pass" : "fail",
+    fallbackFailures.length === 0 ? "info" : "error",
+    fallbackFailures.length === 0 ? "Every routing case forbids generic text-search fallbacks." : "Some routing cases do not reject text-search fallbacks.",
+    fallbackFailures.length === 0 ? cases.map((item) => item.id) : fallbackFailures,
+    ["For Kotlin semantics, every routing case must reject grep and rg."],
+  ),
+);
+
+const requiredActions = [
+  "symbol/query",
+  "symbol/callers",
+  "database/metrics",
+  "kast_symbol_query",
+  "kast_callers",
+  "kast_metrics",
+  "kast agent workflow diagnostics",
+  "kast agent tools",
+];
+const missingActions = requiredActions.filter((name) => !actionNames.has(name));
+checks.push(
+  check(
+    "routing-required-public-actions",
+    missingActions.length === 0 ? "pass" : "fail",
+    missingActions.length === 0 ? "info" : "error",
+    missingActions.length === 0
+      ? "Routing eval exposes symbol calls, database metrics, high-level workflows, and agent tool discovery."
+      : "Routing eval is missing required public action coverage.",
+    missingActions.length === 0 ? requiredActions : missingActions,
+    ["Add allowedActions for missing public methods, tools, or workflow commands."],
+  ),
+);
+
+const leakNeedles = [
+  "capabilities.experimental.kastMethods",
+  "/rpc/",
+  "daemon passthrough",
+  "JVM backends",
+  "Rust-owned",
+];
+const publicSurfaceTexts = [
+  skill,
+  commands["symbol/query"]?.tool?.description ?? "",
+  commands["symbol/callers"]?.tool?.description ?? "",
+  commands["database/metrics"]?.tool?.description ?? "",
+];
+const leaks = [];
+for (const needle of leakNeedles) {
+  if (publicSurfaceTexts.some((text) => text.includes(needle))) {
+    leaks.push(needle);
+  }
+}
+checks.push(
+  check(
+    "routing-public-api-boundary",
+    leaks.length === 0 ? "pass" : "fail",
+    leaks.length === 0 ? "info" : "error",
+    leaks.length === 0 ? "Skill and public tool descriptions avoid internal endpoint and implementation leaks." : "Public routing surface leaks internal details.",
+    leaks.length === 0 ? ["SKILL.md", "symbol/query", "symbol/callers", "database/metrics"] : leaks,
+    ["Keep generated protocol paths, LSP internals, and implementation routing out of public skill/tool descriptions."],
+  ),
+);
+
+const localPathNeedles = ["/Users/", "/home/", "/private/", "C:\\"];
+const localPathHits = collectStrings(routing).filter((text) =>
+  localPathNeedles.some((needle) => text.includes(needle)),
+);
+checks.push(
+  check(
+    "routing-corpus-sanitized",
+    localPathHits.length === 0 ? "pass" : "fail",
+    localPathHits.length === 0 ? "info" : "error",
+    localPathHits.length === 0 ? "Routing corpus contains no local absolute path markers." : "Routing corpus contains local absolute path markers.",
+    localPathHits.length === 0 ? [`cases=${cases.length}`] : localPathHits,
+    ["Sanitize durable routing cases before committing."],
+  ),
+);
+
+const passCount = checks.filter((item) => item.status === "pass").length;
+const score = Math.round((passCount / checks.length) * 100);
+
+console.log(
+  JSON.stringify(
+    {
+      checks,
+      metrics: [
+        metric("kast-routing-score", score, "percent", score === 100 ? "excellent" : score >= 85 ? "good" : "needs-work"),
+        metric("kast-routing-cases", cases.length, "cases", cases.length >= requiredCaseIds.size ? "good" : "needs-work"),
+        metric("kast-routing-public-actions", actionNames.size, "actions", actionNames.size >= requiredActions.length ? "good" : "needs-work"),
+        metric("kast-routing-agent-tools", toolNames.size, "tools", toolNames.size >= 14 ? "good" : "needs-work"),
+      ],
+      artifacts: [
+        {
+          id: "kast-routing-corpus",
+          type: "json",
+          label: "Kast routing eval corpus",
+          description: "Schema-backed corpus for Kotlin navigation and public API boundary routing checks.",
+        },
+      ],
+    },
+    null,
+    2,
+  ),
+);

--- a/.github/plugin-eval/kast-routing/manifest.json
+++ b/.github/plugin-eval/kast-routing/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "kast-routing-surface",
+  "version": "1.0.0",
+  "supportedTargetKinds": [
+    "skill",
+    "directory"
+  ],
+  "command": [
+    "node",
+    "./emit-kast-routing-metrics.mjs"
+  ]
+}

--- a/.github/scripts/render-rpc-contract-summary.py
+++ b/.github/scripts/render-rpc-contract-summary.py
@@ -26,7 +26,7 @@ CATEGORY_PURPOSES = {
     "system": "Runtime readiness, backend state, and capability discovery.",
     "symbol": "Name-based orchestration for agent and script workflows.",
     "raw": "Position- and file-based backend primitives.",
-    "database": "Rust-owned SQLite source-index queries for metrics and impact views.",
+    "database": "Source-index queries for metrics and impact views.",
 }
 
 FLOW_BLOCKS = [
@@ -81,7 +81,7 @@ FLOW_BLOCKS = [
     ),
     (
         "Read the index",
-        "Use the Rust source-index reader for coupling, dead-code, search, graph, and impact questions.",
+        "Use the source-index metrics reader for coupling, dead-code, search, graph, and impact questions.",
         ["database/metrics"],
     ),
 ]

--- a/.github/scripts/test-kast-copilot-plugin.sh
+++ b/.github/scripts/test-kast-copilot-plugin.sh
@@ -175,7 +175,7 @@ const tools = toolsModule.makeKastTools(specs, (method, args) =>
   Promise.resolve(JSON.stringify({ ok: true, method, args })),
 );
 const names = new Set(tools.map((tool) => tool.name));
-for (const required of ["kast_resolve", "kast_references", "kast_workspace_search", "kast_metrics"]) {
+for (const required of ["kast_symbol_query", "kast_resolve", "kast_references", "kast_workspace_search", "kast_metrics"]) {
   if (!names.has(required)) throw new Error(`source plugin import missing ${required}`);
 }
 const sourceResolveTool = tools.find((tool) => tool.name === "kast_resolve");
@@ -309,7 +309,7 @@ const tools = toolsModule.makeKastTools(specs, (method, args) =>
   Promise.resolve(JSON.stringify({ ok: true, method, args })),
 );
 const names = new Set(tools.map((tool) => tool.name));
-for (const required of ["kast_resolve", "kast_references", "kast_workspace_files", "kast_metrics"]) {
+for (const required of ["kast_symbol_query", "kast_resolve", "kast_references", "kast_workspace_files", "kast_metrics"]) {
   if (!names.has(required)) throw new Error(`missing ${required}`);
 }
 const resolveTool = tools.find((tool) => tool.name === "kast_resolve");

--- a/.github/scripts/test-kast-routing-evals.sh
+++ b/.github/scripts/test-kast-routing-evals.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1 && pwd)"
+metric_pack_dir="${repo_root}/.github/plugin-eval/kast-routing"
+target="${repo_root}/cli-rs/resources/kast-skill"
+tmp_file="$(mktemp "${TMPDIR:-/tmp}/kast-routing-evals.XXXXXX.json")"
+trap 'rm -f -- "$tmp_file"' EXIT
+
+node "${metric_pack_dir}/emit-kast-routing-metrics.mjs" "$target" skill >"$tmp_file"
+
+node --input-type=module - "$tmp_file" <<'NODE'
+import { readFileSync } from "node:fs";
+
+const payload = JSON.parse(readFileSync(process.argv[2], "utf8"));
+const failed = payload.checks.filter((check) => check.status !== "pass");
+if (failed.length > 0) {
+  for (const check of failed) {
+    console.error(`${check.id}: ${check.message}`);
+    for (const evidence of check.evidence ?? []) {
+      console.error(`  - ${evidence}`);
+    }
+  }
+  process.exit(1);
+}
+const score = payload.metrics.find((metric) => metric.id === "kast-routing-score")?.value;
+if (score !== 100) {
+  throw new Error(`expected kast-routing-score=100, got ${score}`);
+}
+console.log(JSON.stringify({ ok: true, checks: payload.checks.length, score }));
+NODE
+
+printf '%s\n' "Kast routing evals passed"

--- a/.github/scripts/test-kast-routing-evals.sh
+++ b/.github/scripts/test-kast-routing-evals.sh
@@ -5,9 +5,18 @@ repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1 && 
 metric_pack_dir="${repo_root}/.github/plugin-eval/kast-routing"
 target="${repo_root}/cli-rs/resources/kast-skill"
 tmp_file="$(mktemp "${TMPDIR:-/tmp}/kast-routing-evals.XXXXXX.json")"
-trap 'rm -f -- "$tmp_file"' EXIT
+tools_file="$(mktemp "${TMPDIR:-/tmp}/kast-routing-tools.XXXXXX.json")"
+trap 'rm -f -- "$tmp_file" "$tools_file"' EXIT
 
-node "${metric_pack_dir}/emit-kast-routing-metrics.mjs" "$target" skill >"$tmp_file"
+if [[ -n "${KAST_BIN:-}" ]]; then
+  kast_bin="${KAST_BIN}"
+else
+  cargo build --manifest-path "${repo_root}/cli-rs/Cargo.toml" --bin kast --locked
+  kast_bin="${repo_root}/cli-rs/target/debug/kast"
+fi
+
+"$kast_bin" agent tools >"$tools_file"
+KAST_AGENT_TOOLS_FILE="$tools_file" node "${metric_pack_dir}/emit-kast-routing-metrics.mjs" "$target" skill >"$tmp_file"
 
 node --input-type=module - "$tmp_file" <<'NODE'
 import { readFileSync } from "node:fs";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
         shell: bash
         run: ./.github/scripts/test-terminal-onboarding-contract.sh
 
+      - name: Test Kast routing evals
+        shell: bash
+        run: ./.github/scripts/test-kast-routing-evals.sh
+
       - name: Test Kast Copilot plugin package
         shell: bash
         run: ./.github/scripts/test-kast-copilot-plugin.sh

--- a/cli-rs/protocol/api-specification.md
+++ b/cli-rs/protocol/api-specification.md
@@ -54,7 +54,7 @@ The families below are the top-level namespaces accepted by `kast rpc`.
 | `system` | Runtime readiness, backend state, and capability discovery. | backend | `health`<br>`runtime/status`<br>`runtime/shutdown`<br>`runtime/restart`<br>`capabilities` |
 | `symbol` | Name-based orchestration for agent and script workflows. | backend, sqlite | `symbol/scaffold`<br>`symbol/discover`<br>`symbol/query`<br>`symbol/resolve`<br>`symbol/references`<br>`symbol/callers`<br>`symbol/rename`<br>`symbol/write-and-validate` |
 | `raw` | Position- and file-based backend primitives. | backend | `raw/resolve`<br>`raw/references`<br>`raw/call-hierarchy`<br>`raw/type-hierarchy`<br>`raw/semantic-insertion-point`<br>`raw/diagnostics`<br>`raw/rename`<br>`raw/optimize-imports`<br>`raw/apply-edits`<br>`raw/workspace-refresh`<br>`raw/file-outline`<br>`raw/workspace-symbol`<br>`raw/workspace-search`<br>`raw/workspace-files`<br>`raw/implementations`<br>`raw/code-actions`<br>`raw/completions` |
-| `database` | Rust-owned SQLite source-index queries for metrics and impact views. | sqlite | `database/metrics` |
+| `database` | Source-index queries for metrics and impact views. | sqlite | `database/metrics` |
 
 #### Composition building blocks
 
@@ -69,7 +69,7 @@ Each method listed here is validated against the generated catalog.
 | Trace relationships | Move from one declaration to usages, callers, callees, and type relationships. | `symbol/references`<br>`raw/references`<br>`symbol/callers`<br>`raw/call-hierarchy`<br>`raw/type-hierarchy` |
 | Plan changes | Ask Kast to derive edit plans or generation context before mutating files. | `symbol/scaffold`<br>`symbol/rename`<br>`raw/rename`<br>`raw/optimize-imports` |
 | Apply and validate | Write prepared changes, refresh affected workspace state, and re-run diagnostics. | `symbol/write-and-validate`<br>`raw/apply-edits`<br>`raw/workspace-refresh`<br>`raw/diagnostics` |
-| Read the index | Use the Rust source-index reader for coupling, dead-code, search, graph, and impact questions. | `database/metrics` |
+| Read the index | Use the source-index metrics reader for coupling, dead-code, search, graph, and impact questions. | `database/metrics` |
 
 #### Command catalog
 
@@ -109,7 +109,7 @@ uses a discriminated response envelope.
 | `raw/implementations` | `raw` | backend | Find concrete implementations and subclasses for a declaration | `position` | `maxResults` | `ImplementationsResult` | single result |
 | `raw/code-actions` | `raw` | backend | Return available code actions at a file position | `position` | `diagnosticCode` | `CodeActionsResult` | single result |
 | `raw/completions` | `raw` | backend | Return completion candidates available at a file position | `position` | `maxResults`<br>`kindFilter` | `CompletionsResult` | single result |
-| `database/metrics` | `database` | sqlite | Query Rust-owned source-index metrics | `metric` | `workspaceRoot`<br>`limit`<br>`symbol`<br>`depth`<br>`fileGlob`<br>`folderFilter` | `RustMetricsResponse` | `METRICS_SUCCESS`<br>`METRICS_FAILURE` |
+| `database/metrics` | `database` | sqlite | Query source-index metrics | `metric` | `workspaceRoot`<br>`limit`<br>`symbol`<br>`depth`<br>`fileGlob`<br>`folderFilter` | `RustMetricsResponse` | `METRICS_SUCCESS`<br>`METRICS_FAILURE` |
 
 #### Command field details
 
@@ -222,13 +222,13 @@ Result variants: `SYMBOL_QUERY_SUCCESS`, `SYMBOL_QUERY_FAILURE`.
 
 Notes:
 
-- Handled by the Rust CLI before daemon passthrough; JVM backends do not read this SQLite surface.
-- Hard filters are enforced by SQLite/compiler facts, never by semantic score.
+- Use this as the public source-index search surface before file reads or raw offset calls.
+- Hard filters are enforced by source-index and compiler facts, never by semantic score.
 - Nested filters include gradleProject, relativePathPrefix, productionOnly, excludePatterns, and usageFacets.
 - usageFacets is the supported public filter for computed declaration facets; symbol/query does not expose clusterKinds.
-- Token matching is computed by the Rust CLI from query text and indexed declaration fields without persisted token tables.
+- Token matching is computed from query text and indexed declaration fields.
 - Graph depth defaults to 1 and is capped at 2 in the first implementation.
-- Semantic discovery is represented in the response shape but reports available=false until a sidecar exists.
+- Semantic discovery reports available=false when no semantic candidate provider is configured.
 
 </details>
 
@@ -548,7 +548,7 @@ Response type: `CompletionsResult`.
 </details>
 
 <details markdown="1">
-<summary><code>database/metrics</code> - Query Rust-owned source-index metrics</summary>
+<summary><code>database/metrics</code> - Query source-index metrics</summary>
 
 | Field | Type | Required | Nullable | Values |
 | --- | --- | --- | --- | --- |
@@ -565,8 +565,8 @@ Result variants: `METRICS_SUCCESS`, `METRICS_FAILURE`.
 
 Notes:
 
-- Handled by the Rust CLI before daemon passthrough; JVM backends do not read this SQLite surface.
-- Use fanIn, fanOut, deadCode, impact, coupling, search, or graph for the v1 Rust metrics reader.
+- Use this as the public source-index database surface through kast agent call or kast inspect metrics.
+- Use fanIn, fanOut, deadCode, impact, coupling, search, or graph for supported metrics.
 
 </details>
 

--- a/cli-rs/resources/kast-skill/AGENTS.md
+++ b/cli-rs/resources/kast-skill/AGENTS.md
@@ -58,6 +58,7 @@ Run the catalog and docs checks after catalog changes:
 ```console
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- release generate contract --check
 python3 .github/scripts/render-rpc-contract-summary.py --check
+.github/scripts/test-kast-routing-evals.sh
 .github/scripts/test-kast-copilot-plugin.sh
 .github/scripts/test-lsp-pivot-gates.sh
 ```

--- a/cli-rs/resources/kast-skill/SKILL.md
+++ b/cli-rs/resources/kast-skill/SKILL.md
@@ -2,11 +2,11 @@
 name: kast
 description: >
   Use when an agent works in a Gradle project and needs the Rust `kast` CLI for
-  file discovery, Kotlin source reads or edits, symbol identity, references,
-  callers, hierarchy, diagnostics, source-index metrics, install/config/package
-  verification, file-backed Kast calls, or focused Gradle validation. Prefer
-  Kast before generic text or file tools for Kotlin and broad Gradle project
-  exploration.
+  file discovery, all Kotlin `.kt` and `.kts` source reads or edits, symbol
+  identity, references, callers, hierarchy, diagnostics, source-index metrics,
+  install/config/package verification, file-backed Kast calls, or focused
+  Gradle validation. Prefer Kast before generic text or file tools for Kotlin
+  and broad Gradle project exploration.
 ---
 
 # Kast
@@ -15,7 +15,10 @@ Kast is the installed Rust `kast` CLI semantic surface for Kotlin and Gradle
 repositories. When this skill is present, assume the binary installed it and use
 `kast` directly for file discovery, Kotlin context, symbol identity,
 relationships, diagnostics, edits, and focused validation. Default to Kast for
-Gradle project file operations that need semantic or install-state evidence.
+every `.kt` and `.kts` file and for Gradle project file operations that need
+semantic or install-state evidence. Treat Kast as the only navigation surface
+for Kotlin semantics until it returns a concrete blocker or a bounded
+non-semantic task remains.
 
 ## First Move
 
@@ -64,6 +67,10 @@ after this dynamic IDE warmup path has failed.
 ## Gradle File Routing
 
 - Use for Gradle project file work, not only direct Kotlin edits.
+- Any `.kt` or `.kts` file: start with `symbol/scaffold` when you need content
+  plus declaration context, or `raw/file-outline` when only structure is needed.
+  Do not open Kotlin files with generic readers before Kast has provided the
+  bounded target and semantic context.
 - Unknown symbol: start with `kast agent call symbol/query`; use tight `query`, `limit`,
   `modes`, and filters such as `relativePathPrefix`, `gradleProject`,
   `sourceSet`, or `kinds`.
@@ -84,6 +91,17 @@ after this dynamic IDE warmup path has failed.
   `database/metrics`, `kast inspect metrics fan-in`, other `kast inspect metrics` subcommands,
   `kast inspect demo --json`, `raw/workspace-refresh`, `raw/diagnostics`, then the
   narrowest Gradle task.
+
+## Public Surface
+
+Use the public agent surfaces first: `kast agent`, `kast agent tools`,
+`kast agent workflow`, `kast inspect metrics`, and the catalog method names in
+`references/commands.json`. Named tools such as `kast_symbol_query`,
+`kast_resolve`, `kast_references`, `kast_callers`, and `kast_metrics` are the
+host-facing way to expose navigation, relationships, source-index database
+access, and edits. Do not teach generated protocol paths, LSP capability
+internals, daemon routing details, or implementation class names as the public
+API for agents.
 
 ## Request Discipline
 

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/evals/routing.json
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/evals/routing.json
@@ -1,0 +1,293 @@
+{
+  "$schema": "./routing.schema.json",
+  "schemaVersion": 1,
+  "primitive": {
+    "type": "skill",
+    "name": "kast"
+  },
+  "description": "Sanitized routing evals for keeping the Kast skill usable as the primary Kotlin navigation surface.",
+  "cases": [
+    {
+      "id": "kotlin-file-trigger-all-kt-kts",
+      "type": "TRIGGER_MISS",
+      "source": {
+        "kind": "synthetic-regression",
+        "capturedAt": "2026-06-29",
+        "note": "Regression guard for Kotlin file prompts loading a generic file reader instead of the Kast skill."
+      },
+      "prompt": "Open app/src/main/kotlin/com/example/Widget.kt and summarize the declarations before editing it.",
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "observedRoute": {
+        "status": "prevent-regression",
+        "risk": "A provider may treat an exact Kotlin path as a generic file-read request and bypass Kast."
+      },
+      "allowedActions": [
+        {
+          "kind": "method",
+          "name": "symbol/scaffold"
+        },
+        {
+          "kind": "method",
+          "name": "raw/file-outline"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "generic file read before Kast",
+        "generated protocol endpoints"
+      ],
+      "recoveryExpectation": "If the backend is unavailable, report the concrete Kast setup or runtime recovery command before using a generic reader.",
+      "verificationEvidence": [
+        "SKILL.md explicitly covers every .kt and .kts file.",
+        "symbol/scaffold and raw/file-outline are catalog methods exposed through kast agent tools."
+      ],
+      "notes": "This case protects the all-Kotlin-file trigger and the sole-navigation rule."
+    },
+    {
+      "id": "unknown-symbol-navigation",
+      "type": "LOADED_BYPASSED",
+      "source": {
+        "kind": "synthetic-regression",
+        "capturedAt": "2026-06-29",
+        "note": "Regression guard for unknown symbol prompts falling back to workspace dumps or text search."
+      },
+      "prompt": "Find where EventBean is declared and show the best candidate before deciding which file to inspect.",
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "observedRoute": {
+        "status": "prevent-regression",
+        "risk": "The Kast skill may load but an agent may still choose raw workspace files or text search before symbol identity."
+      },
+      "allowedActions": [
+        {
+          "kind": "method",
+          "name": "symbol/query"
+        },
+        {
+          "kind": "method",
+          "name": "symbol/discover"
+        },
+        {
+          "kind": "method",
+          "name": "symbol/resolve"
+        },
+        {
+          "kind": "tool",
+          "name": "kast_symbol_query"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "workspace file dump",
+        "manual package inference"
+      ],
+      "recoveryExpectation": "If symbol/query returns INDEX_UNAVAILABLE, run the emitted Kast recovery or warmup path and retry the symbol-first route.",
+      "verificationEvidence": [
+        "symbol/query is a catalog method.",
+        "kast_symbol_query is exposed in kast agent tools.",
+        "SKILL.md names symbol/query as the first unknown-symbol step."
+      ],
+      "notes": "This case makes unknown-symbol navigation measurable without relying on raw file enumeration."
+    },
+    {
+      "id": "relationship-navigation",
+      "type": "LOADED_BYPASSED",
+      "source": {
+        "kind": "synthetic-regression",
+        "capturedAt": "2026-06-29",
+        "note": "Regression guard for usage and caller prompts being answered by textual call matching."
+      },
+      "prompt": "Before changing process, find every usage and the incoming calls that reach it.",
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "observedRoute": {
+        "status": "prevent-regression",
+        "risk": "The request may be answered through text matches instead of symbol identity and call hierarchy."
+      },
+      "allowedActions": [
+        {
+          "kind": "method",
+          "name": "symbol/resolve"
+        },
+        {
+          "kind": "method",
+          "name": "symbol/references"
+        },
+        {
+          "kind": "method",
+          "name": "symbol/callers"
+        },
+        {
+          "kind": "tool",
+          "name": "kast_callers"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "textual call graph",
+        "unresolved name matching"
+      ],
+      "recoveryExpectation": "If the name is ambiguous, use symbol/discover or symbol/resolve filters before references and callers.",
+      "verificationEvidence": [
+        "symbol/references and symbol/callers are catalog methods exposed as agent tools.",
+        "SKILL.md requires Kast for Kotlin usage sets and hierarchy."
+      ],
+      "notes": "This case protects relationship navigation through symbol calls instead of text."
+    },
+    {
+      "id": "source-index-database-access",
+      "type": "LOADED_BYPASSED",
+      "source": {
+        "kind": "synthetic-regression",
+        "capturedAt": "2026-06-29",
+        "note": "Regression guard for database-backed impact questions leaking implementation storage details."
+      },
+      "prompt": "Which public API declarations have the highest fan-in, and what would this change impact?",
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "observedRoute": {
+        "status": "prevent-regression",
+        "risk": "An agent may bypass the public metrics surface and ask for internal database paths or manual SQL."
+      },
+      "allowedActions": [
+        {
+          "kind": "method",
+          "name": "database/metrics"
+        },
+        {
+          "kind": "tool",
+          "name": "kast_metrics"
+        },
+        {
+          "kind": "command",
+          "name": "kast inspect metrics"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "manual SQLite queries",
+        "internal database paths"
+      ],
+      "recoveryExpectation": "If metrics are unavailable, report METRICS_DB_UNAVAILABLE and run the documented Kast index/runtime recovery before using another source.",
+      "verificationEvidence": [
+        "database/metrics is a catalog method exposed through kast_metrics.",
+        "SKILL.md lists database/metrics and kast inspect metrics as the public impact path."
+      ],
+      "notes": "This case verifies database access is public through Kast without exposing storage internals."
+    },
+    {
+      "id": "agent-workflow-public-surface",
+      "type": "ADAPTER_DRIFT",
+      "source": {
+        "kind": "synthetic-regression",
+        "capturedAt": "2026-06-29",
+        "note": "Regression guard for agents copying raw JSON-RPC snippets instead of using workflow commands."
+      },
+      "prompt": "Create a repeatable evidence bundle for a rename and diagnostics pass.",
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "observedRoute": {
+        "status": "prevent-regression",
+        "risk": "A host adapter may expose raw transport details while hiding high-level workflow commands."
+      },
+      "allowedActions": [
+        {
+          "kind": "command",
+          "name": "kast agent workflow rename-plan"
+        },
+        {
+          "kind": "command",
+          "name": "kast agent workflow write-validate"
+        },
+        {
+          "kind": "command",
+          "name": "kast agent workflow diagnostics"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "ad hoc JSON-RPC transport",
+        "manual edit without diagnostics"
+      ],
+      "recoveryExpectation": "If workflow help is unavailable, report active binary and skill incompatibility and require upgrade or reinstall.",
+      "verificationEvidence": [
+        "SKILL.md requires kast agent workflow for repeated semantic sequences.",
+        "kast agent workflow --help is part of the skill first-move checks."
+      ],
+      "notes": "This case keeps high-level workflow functionality visible in the public API."
+    },
+    {
+      "id": "public-api-boundary",
+      "type": "ADAPTER_DRIFT",
+      "source": {
+        "kind": "synthetic-regression",
+        "capturedAt": "2026-06-29",
+        "note": "Regression guard for public docs or tool descriptions leaking implementation-specific routes."
+      },
+      "prompt": "Document how an agent host should navigate Kotlin code with Kast without depending on implementation internals.",
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "observedRoute": {
+        "status": "prevent-regression",
+        "risk": "Public guidance may expose generated protocol endpoints, LSP capability internals, daemon routing, or backend implementation classes."
+      },
+      "allowedActions": [
+        {
+          "kind": "command",
+          "name": "kast agent"
+        },
+        {
+          "kind": "command",
+          "name": "kast agent tools"
+        },
+        {
+          "kind": "command",
+          "name": "kast agent workflow"
+        },
+        {
+          "kind": "command",
+          "name": "kast inspect metrics"
+        },
+        {
+          "kind": "tool",
+          "name": "kast_symbol_query"
+        },
+        {
+          "kind": "tool",
+          "name": "kast_metrics"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "generated protocol endpoints",
+        "capabilities.experimental.kastMethods",
+        "backend implementation classes"
+      ],
+      "recoveryExpectation": "If an adapter exposes only internal routes, prefer the canonical Kast skill and require adapter refresh rather than documenting the internals.",
+      "verificationEvidence": [
+        "SKILL.md public surface section names only kast agent, kast agent tools, kast agent workflow, kast inspect metrics, catalog methods, and named tools.",
+        "Tool descriptions for symbol/query, symbol/callers, and database/metrics do not mention protocol endpoint paths or LSP capability internals."
+      ],
+      "notes": "This case protects the public API boundary while still exposing database, symbol, and workflow capabilities."
+    }
+  ]
+}

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/evals/routing.schema.json
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/evals/routing.schema.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Kast skill routing eval corpus",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "primitive",
+    "description",
+    "cases"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "primitive": {
+      "$ref": "#/$defs/primitive"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/case"
+      }
+    }
+  },
+  "$defs": {
+    "primitive": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "skill"
+          ]
+        },
+        "name": {
+          "const": "kast"
+        }
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "source",
+        "prompt",
+        "expectedPrimitive",
+        "observedRoute",
+        "allowedActions",
+        "forbiddenActions",
+        "recoveryExpectation",
+        "verificationEvidence",
+        "notes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+        },
+        "type": {
+          "enum": [
+            "TRIGGER_MISS",
+            "WRONG_PRIMITIVE",
+            "LOADED_BYPASSED",
+            "ADAPTER_DRIFT",
+            "SCHEMA_FRICTION",
+            "SETUP_FRICTION"
+          ]
+        },
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "capturedAt",
+            "note"
+          ],
+          "properties": {
+            "kind": {
+              "enum": [
+                "synthetic-regression",
+                "sanitized-session",
+                "process-log"
+              ]
+            },
+            "capturedAt": {
+              "type": "string",
+              "format": "date"
+            },
+            "note": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "prompt": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expectedPrimitive": {
+          "$ref": "#/$defs/primitive"
+        },
+        "observedRoute": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "risk"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "prevent-regression",
+                "observed-miss"
+              ]
+            },
+            "risk": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "allowedActions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/action"
+          }
+        },
+        "forbiddenActions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "recoveryExpectation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verificationEvidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "method",
+            "command",
+            "tool"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/references/routing-improvement.md
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/references/routing-improvement.md
@@ -101,7 +101,8 @@ need to move together.
 
 After any routing change:
 
-1. Re-run `.github/scripts/test-kast-routing-evals.sh`.
+1. Re-run `.github/scripts/test-kast-routing-evals.sh`, which validates the
+   static routing corpus and the active `kast agent tools` envelope.
 2. When `plugin-eval` is available, run
    `plugin-eval analyze cli-rs/resources/kast-skill --metric-pack .github/plugin-eval/kast-routing/manifest.json`.
 3. Compare against the previous baseline.

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/references/routing-improvement.md
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/references/routing-improvement.md
@@ -101,9 +101,11 @@ need to move together.
 
 After any routing change:
 
-1. Re-run the skill routing/evaluation command for the current harness.
-2. Compare against the previous baseline.
-3. Re-run the corpus builder on fresh sessions
+1. Re-run `.github/scripts/test-kast-routing-evals.sh`.
+2. When `plugin-eval` is available, run
+   `plugin-eval analyze cli-rs/resources/kast-skill --metric-pack .github/plugin-eval/kast-routing/manifest.json`.
+3. Compare against the previous baseline.
+4. Re-run the corpus builder on fresh sessions.
 
 The goal is not only a better static score. The goal is fewer fresh cases in
 `trigger-miss` and `loaded-but-bypassed`.

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/references/routing-improvement.md
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/references/routing-improvement.md
@@ -65,7 +65,11 @@ Finally review `promotion-candidates.json`. These are suggested additions to
 
 When a prompt pattern recurs, add a sanitized entry to
 `fixtures/maintenance/evals/routing.json`.
-Use the existing examples in that file as the canonical schema.
+Validate it against `fixtures/maintenance/evals/routing.schema.json` and use
+the existing examples in that file as the canonical case shape.
+The packaged content smoke test validates that this corpus exists, routes every
+case to the `kast` skill, forbids text-search fallbacks for Kotlin semantics,
+and references catalog methods that are present in the public agent surface.
 
 Good routing evals:
 

--- a/cli-rs/resources/kast-skill/references/commands.json
+++ b/cli-rs/resources/kast-skill/references/commands.json
@@ -468,14 +468,18 @@
         "TIMEOUT"
       ],
       "notes": [
-        "Handled by the Rust CLI before daemon passthrough; JVM backends do not read this SQLite surface.",
-        "Hard filters are enforced by SQLite/compiler facts, never by semantic score.",
+        "Use this as the public source-index search surface before file reads or raw offset calls.",
+        "Hard filters are enforced by source-index and compiler facts, never by semantic score.",
         "Nested filters include gradleProject, relativePathPrefix, productionOnly, excludePatterns, and usageFacets.",
         "usageFacets is the supported public filter for computed declaration facets; symbol/query does not expose clusterKinds.",
-        "Token matching is computed by the Rust CLI from query text and indexed declaration fields without persisted token tables.",
+        "Token matching is computed from query text and indexed declaration fields.",
         "Graph depth defaults to 1 and is capped at 2 in the first implementation.",
-        "Semantic discovery is represented in the response shape but reports available=false until a sidecar exists."
-      ]
+        "Semantic discovery reports available=false when no semantic candidate provider is configured."
+      ],
+      "tool": {
+        "name": "kast_symbol_query",
+        "description": "Search the Kotlin source index for declarations by name, lexical text, graph evidence, and hard filters. Start here for unknown symbols, broad navigation, and .kt/.kts discovery before reading files or using raw offset tools."
+      }
     },
     "symbol/resolve": {
       "method": "symbol/resolve",
@@ -1479,7 +1483,7 @@
     "database/metrics": {
       "method": "database/metrics",
       "category": "database",
-      "summary": "Query Rust-owned source-index metrics",
+      "summary": "Query source-index metrics",
       "dataSource": "sqlite",
       "request": {
         "fields": {
@@ -1533,11 +1537,11 @@
       "failureType": "METRICS_FAILURE",
       "tool": {
         "name": "kast_metrics",
-        "description": "Query Rust-owned source-index metrics: fanIn, fanOut, deadCode, impact, coupling, search, graph. The CLI handles this before daemon passthrough."
+        "description": "Query source-index metrics: fanIn, fanOut, deadCode, impact, coupling, search, graph. Use this database-backed view for architecture, blast-radius, and impact questions before wider semantic traversal."
       },
       "notes": [
-        "Handled by the Rust CLI before daemon passthrough; JVM backends do not read this SQLite surface.",
-        "Use fanIn, fanOut, deadCode, impact, coupling, search, or graph for the v1 Rust metrics reader."
+        "Use this as the public source-index database surface through kast agent call or kast inspect metrics.",
+        "Use fanIn, fanOut, deadCode, impact, coupling, search, or graph for supported metrics."
       ]
     }
   }

--- a/cli-rs/resources/kast-skill/references/commands.yaml
+++ b/cli-rs/resources/kast-skill/references/commands.yaml
@@ -50,8 +50,8 @@ commands:
     failureType: METRICS_FAILURE
     method: database/metrics
     notes:
-    - Handled by the Rust CLI before daemon passthrough; JVM backends do not read this SQLite surface.
-    - Use fanIn, fanOut, deadCode, impact, coupling, search, or graph for the v1 Rust metrics reader.
+    - Use this as the public source-index database surface through kast agent call or kast inspect metrics.
+    - Use fanIn, fanOut, deadCode, impact, coupling, search, or graph for supported metrics.
     request:
       fields:
         depth:
@@ -90,9 +90,9 @@ commands:
       - metric
     responseType: RustMetricsResponse
     successType: METRICS_SUCCESS
-    summary: Query Rust-owned source-index metrics
+    summary: Query source-index metrics
     tool:
-      description: 'Query Rust-owned source-index metrics: fanIn, fanOut, deadCode, impact, coupling, search, graph. The CLI handles this before daemon passthrough.'
+      description: 'Query source-index metrics: fanIn, fanOut, deadCode, impact, coupling, search, graph. Use this database-backed view for architecture, blast-radius, and impact questions before wider semantic traversal.'
       name: kast_metrics
   health:
     category: system
@@ -677,13 +677,13 @@ commands:
     failureType: SYMBOL_QUERY_FAILURE
     method: symbol/query
     notes:
-    - Handled by the Rust CLI before daemon passthrough; JVM backends do not read this SQLite surface.
-    - Hard filters are enforced by SQLite/compiler facts, never by semantic score.
+    - Use this as the public source-index search surface before file reads or raw offset calls.
+    - Hard filters are enforced by source-index and compiler facts, never by semantic score.
     - Nested filters include gradleProject, relativePathPrefix, productionOnly, excludePatterns, and usageFacets.
     - usageFacets is the supported public filter for computed declaration facets; symbol/query does not expose clusterKinds.
-    - Token matching is computed by the Rust CLI from query text and indexed declaration fields without persisted token tables.
+    - Token matching is computed from query text and indexed declaration fields.
     - Graph depth defaults to 1 and is capped at 2 in the first implementation.
-    - Semantic discovery is represented in the response shape but reports available=false until a sidecar exists.
+    - Semantic discovery reports available=false when no semantic candidate provider is configured.
     request:
       fields:
         anchor:
@@ -865,6 +865,9 @@ commands:
     responseType: KastSymbolQueryResponse
     successType: SYMBOL_QUERY_SUCCESS
     summary: Query compiler-indexed declarations with symbolic hard filters, fielded lexical/name matching, bounded graph relationship evidence, and optional semantic discovery evidence
+    tool:
+      description: Search the Kotlin source index for declarations by name, lexical text, graph evidence, and hard filters. Start here for unknown symbols, broad navigation, and .kt/.kts discovery before reading files or using raw offset tools.
+      name: kast_symbol_query
   symbol/references:
     category: symbol
     dataSource: backend

--- a/cli-rs/resources/kast-skill/references/routing-improvement.md
+++ b/cli-rs/resources/kast-skill/references/routing-improvement.md
@@ -16,3 +16,8 @@ intentionally promotes sanitized outputs to a shipped reference.
 The package smoke tests validate the checked corpus against the catalog and
 agent tool metadata so promoted cases cannot drift away from the public
 navigation surface.
+
+Run `.github/scripts/test-kast-routing-evals.sh` after routing changes. When
+`plugin-eval` is available, run
+`plugin-eval analyze cli-rs/resources/kast-skill --metric-pack .github/plugin-eval/kast-routing/manifest.json`
+to include the Kast routing metric pack in the skill report.

--- a/cli-rs/resources/kast-skill/references/routing-improvement.md
+++ b/cli-rs/resources/kast-skill/references/routing-improvement.md
@@ -15,7 +15,9 @@ intentionally promotes sanitized outputs to a shipped reference.
 
 The package smoke tests validate the checked corpus against the catalog and
 agent tool metadata so promoted cases cannot drift away from the public
-navigation surface.
+navigation surface. The repository routing gate also captures the active
+`kast agent tools` envelope and scores that live public tool surface against
+the routing contract.
 
 Run `.github/scripts/test-kast-routing-evals.sh` after routing changes. When
 `plugin-eval` is available, run

--- a/cli-rs/resources/kast-skill/references/routing-improvement.md
+++ b/cli-rs/resources/kast-skill/references/routing-improvement.md
@@ -1,12 +1,18 @@
 # Kast routing improvement
 
-The packaged skill, `references/commands.json`, and
-`references/requests/` are the canonical shipped routing surface for the Kast
-skill. Keep maintenance routing cases centered on the Rust CLI:
-`expected_route` should be `rust-kast-cli`, `allowed_ops` should name `kast`
-subcommands, `kast agent` aliases, or catalog methods, and `forbidden_ops`
-should cover generic Kotlin tools such as `grep`, `rg`, and `view`.
+The packaged skill, `references/commands.json`, `references/requests/`, and
+`fixtures/maintenance/evals/routing.json` are the canonical shipped routing
+surface for the Kast skill. Validate routing cases against
+`fixtures/maintenance/evals/routing.schema.json`. Keep cases centered on the
+public agent surface: `expectedPrimitive.name` should be `kast`,
+`allowedActions` should name catalog methods, named tools, or `kast agent` /
+`kast inspect metrics` commands, and `forbiddenActions` should cover generic
+Kotlin tools such as `grep`, `rg`, and generic file reads.
 
 Keep session exports, benchmark runs, generated candidate corpora, and any
 local routing-analysis tools outside the installed skill tree unless a release
 intentionally promotes sanitized outputs to a shipped reference.
+
+The package smoke tests validate the checked corpus against the catalog and
+agent tool metadata so promoted cases cannot drift away from the public
+navigation surface.

--- a/cli-rs/src/agent/tools.rs
+++ b/cli-rs/src/agent/tools.rs
@@ -149,7 +149,7 @@ fn agent_tool_policy_prefix(method: &str) -> &'static str {
         return "Preferred Kotlin funnel tool. Use this before raw file or offset operations when a symbol name, target type, or intended refactor is known.";
     }
     if method.starts_with("database/") {
-        return "Preferred low-cost source-index tool. Use this before backend-wide traversal when index metrics can answer the question.";
+        return "Preferred low-cost source-index tool. Use this before wide semantic traversal when index metrics can answer the question.";
     }
     if method.starts_with("raw/workspace-files") {
         return "Secondary workspace inspection tool. Use only after symbol/query, workspace symbols, or workspace search cannot identify a bounded target.";

--- a/cli-rs/tests/cli_core_smoke.rs
+++ b/cli-rs/tests/cli_core_smoke.rs
@@ -114,6 +114,7 @@ fn smoke_core_cli_commands() {
             "kast_resolve",
             "kast_scaffold",
             "kast_symbol_discover",
+            "kast_symbol_query",
             "kast_workspace_files",
             "kast_workspace_search",
             "kast_workspace_symbol",

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -1,6 +1,32 @@
 mod support;
 
+use serde_json::Value;
+use std::collections::BTreeSet;
 use support::*;
+
+fn assert_no_local_paths(value: &Value, label: &str) {
+    match value {
+        Value::String(text) => {
+            for forbidden in ["/Users/", "/home/", "/private/", "C:\\"] {
+                assert!(
+                    !text.contains(forbidden),
+                    "{label} should not contain local absolute path marker {forbidden}: {text}"
+                );
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                assert_no_local_paths(item, label);
+            }
+        }
+        Value::Object(fields) => {
+            for value in fields.values() {
+                assert_no_local_paths(value, label);
+            }
+        }
+        _ => {}
+    }
+}
 
 #[test]
 fn packaged_skill_targets_rust_kast_only() {
@@ -80,7 +106,9 @@ fn packaged_skill_targets_rust_kast_only() {
     assert!(workflows.contains("--skill-target-dir"));
     assert!(workflows.contains("--instructions-target-dir"));
     assert!(workflows.contains("nextCommandArgv"));
-    assert!(routing_reference.contains("rust-kast-cli"));
+    assert!(routing_reference.contains("fixtures/maintenance/evals/routing.json"));
+    assert!(routing_reference.contains("fixtures/maintenance/evals/routing.schema.json"));
+    assert!(routing_reference.contains("allowedActions"));
     assert!(instruction_cli.contains("kast agent tools"));
     assert!(instruction_cli.contains("kast agent workflow --help"));
     assert!(instruction_cli.contains("stale instruction/binary install"));
@@ -99,6 +127,11 @@ fn packaged_skill_targets_rust_kast_only() {
         root.join("resources/kast-skill/references/workflows.md")
             .is_file(),
         "packaged skill must include workflow ownership reference"
+    );
+    assert!(
+        root.join("resources/kast-skill/fixtures/maintenance/evals/routing.schema.json")
+            .is_file(),
+        "packaged skill must include a schema for routing evals"
     );
     assert!(
         root.join("resources/kast-skill/scripts/verify-kast-state.py")
@@ -132,5 +165,191 @@ fn repo_local_copilot_plugin_content_is_generated_not_tracked() {
     assert!(
         root.join("cli-rs/resources/plugin/plugin.json").is_file(),
         "repo-local plugin source must live under cli-rs/resources/plugin"
+    );
+}
+
+#[test]
+fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let skill = std::fs::read_to_string(root.join("resources/kast-skill/SKILL.md"))
+        .expect("packaged skill");
+    let routing_eval_path =
+        root.join("resources/kast-skill/fixtures/maintenance/evals/routing.json");
+    let routing_eval: Value = serde_json::from_str(
+        &std::fs::read_to_string(&routing_eval_path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", routing_eval_path.display())),
+    )
+    .expect("routing eval json");
+    let routing_schema_path =
+        root.join("resources/kast-skill/fixtures/maintenance/evals/routing.schema.json");
+    let routing_schema: Value = serde_json::from_str(
+        &std::fs::read_to_string(&routing_schema_path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", routing_schema_path.display())),
+    )
+    .expect("routing eval schema json");
+    let routing_validator = jsonschema::validator_for(&routing_schema).expect("routing schema");
+    routing_validator
+        .validate(&routing_eval)
+        .unwrap_or_else(|error| panic!("routing eval schema validation failed: {error}"));
+    let catalog: Value = serde_json::from_str(include_str!(
+        "../resources/kast-skill/references/commands.json"
+    ))
+    .expect("commands catalog");
+    let commands = catalog["commands"].as_object().expect("catalog commands");
+    let tool_names = commands
+        .values()
+        .filter_map(|command| command.get("tool"))
+        .map(|tool| tool["name"].as_str().expect("tool name"))
+        .collect::<BTreeSet<_>>();
+    let cases = routing_eval["cases"]
+        .as_array()
+        .expect("routing eval cases");
+    assert!(
+        cases.len() >= 5,
+        "routing eval should cover Kotlin files, symbol calls, database access, workflows, and public API boundaries"
+    );
+
+    let case_ids = cases
+        .iter()
+        .map(|case| case["id"].as_str().expect("case id"))
+        .collect::<BTreeSet<_>>();
+    for required in [
+        "kotlin-file-trigger-all-kt-kts",
+        "unknown-symbol-navigation",
+        "relationship-navigation",
+        "source-index-database-access",
+        "agent-workflow-public-surface",
+        "public-api-boundary",
+    ] {
+        assert!(
+            case_ids.contains(required),
+            "routing eval should include {required}"
+        );
+    }
+
+    for case in cases {
+        assert_no_local_paths(case, case["id"].as_str().expect("case id"));
+        assert_eq!(
+            case["expectedPrimitive"]["name"], "kast",
+            "every case should route to the Kast skill: {case:#}"
+        );
+        let forbidden = case["forbiddenActions"]
+            .as_array()
+            .unwrap_or_else(|| panic!("case {} should list forbidden fallbacks", case["id"]));
+        assert!(
+            forbidden.iter().any(|value| value == "grep")
+                && forbidden.iter().any(|value| value == "rg"),
+            "case {} should forbid raw text search for Kotlin semantics",
+            case["id"]
+        );
+        assert!(
+            case["verificationEvidence"]
+                .as_array()
+                .expect("verification evidence")
+                .len()
+                >= 2,
+            "case {} should include concrete verification evidence",
+            case["id"]
+        );
+        for action in case["allowedActions"]
+            .as_array()
+            .unwrap_or_else(|| panic!("case {} should list allowed actions", case["id"]))
+        {
+            let kind = action["kind"].as_str().expect("action kind");
+            let name = action["name"].as_str().expect("action name");
+            match kind {
+                "method" => {
+                    let command = commands.get(name).unwrap_or_else(|| {
+                        panic!("eval case {} references missing method {name}", case["id"])
+                    });
+                    if matches!(
+                        name,
+                        "symbol/query"
+                            | "symbol/scaffold"
+                            | "symbol/resolve"
+                            | "symbol/references"
+                            | "symbol/callers"
+                            | "database/metrics"
+                            | "raw/file-outline"
+                    ) {
+                        assert!(
+                            command.get("tool").is_some(),
+                            "eval case {} expects {name} to be available through agent tools",
+                            case["id"]
+                        );
+                    }
+                }
+                "tool" => {
+                    assert!(
+                        tool_names.contains(name),
+                        "eval case {} references missing tool {name}",
+                        case["id"]
+                    );
+                }
+                "command" => {
+                    assert!(
+                        name.starts_with("kast agent") || name.starts_with("kast inspect metrics"),
+                        "eval case {} should use public Kast commands, got {name}",
+                        case["id"]
+                    );
+                }
+                other => panic!("unexpected action kind {other}"),
+            }
+        }
+    }
+    let action_names = cases
+        .iter()
+        .flat_map(|case| {
+            case["allowedActions"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .map(|action| action["name"].as_str().expect("action name"))
+        })
+        .collect::<BTreeSet<_>>();
+    for required in [
+        "symbol/query",
+        "symbol/callers",
+        "database/metrics",
+        "kast agent workflow diagnostics",
+        "kast agent tools",
+    ] {
+        assert!(
+            action_names.contains(required),
+            "routing eval should cover public action {required}"
+        );
+    }
+    let forbidden_names = cases
+        .iter()
+        .flat_map(|case| {
+            case["forbiddenActions"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .map(|action| action.as_str().expect("forbidden action"))
+        })
+        .collect::<BTreeSet<_>>();
+    for required in [
+        "generated protocol endpoints",
+        "capabilities.experimental.kastMethods",
+    ] {
+        assert!(
+            forbidden_names.contains(required),
+            "routing eval should reject public API leak {required}"
+        );
+    }
+
+    assert!(
+        (skill.contains(".kt") || skill.contains("`.kt`"))
+            && (skill.contains(".kts") || skill.contains("`.kts`")),
+        "skill trigger text must explicitly cover Kotlin source and script files"
+    );
+    assert!(
+        skill.contains("only navigation surface"),
+        "skill should state that Kast can be the sole navigation surface"
+    );
+    assert!(
+        !skill.contains("/rpc/") && !skill.contains("capabilities.experimental.kastMethods"),
+        "skill must not teach generated protocol endpoints or LSP internals as the public API"
     );
 }

--- a/cli-rs/tests/rpc_catalog_smoke.rs
+++ b/cli-rs/tests/rpc_catalog_smoke.rs
@@ -418,12 +418,56 @@ fn command_catalog_owns_copilot_tool_surface() {
         "kast_resolve",
         "kast_scaffold",
         "kast_symbol_discover",
+        "kast_symbol_query",
         "kast_workspace_files",
         "kast_workspace_search",
         "kast_workspace_symbol",
         "kast_write_and_validate",
     ]);
     assert_eq!(tool_names, expected);
+}
+
+#[test]
+fn agent_tool_surface_exposes_navigation_without_internal_transport_leaks() {
+    let catalog = catalog();
+    let commands = catalog["commands"].as_object().expect("commands object");
+    for (method, expected_name) in [
+        ("symbol/query", "kast_symbol_query"),
+        ("symbol/callers", "kast_callers"),
+        ("database/metrics", "kast_metrics"),
+    ] {
+        let tool = commands[method]
+            .get("tool")
+            .unwrap_or_else(|| panic!("{method} should be exposed as an agent tool"));
+        assert_eq!(tool["name"], expected_name);
+        let description = tool["description"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{method} tool description"));
+        assert!(
+            !description.contains("Rust-owned")
+                && !description.contains("daemon passthrough")
+                && !description.contains("JVM")
+                && !description.contains("/rpc/")
+                && !description.contains("capabilities.experimental.kastMethods"),
+            "{method} tool description should not expose implementation routing details: {description}"
+        );
+    }
+
+    let query_description = commands["symbol/query"]["tool"]["description"]
+        .as_str()
+        .expect("symbol/query tool description");
+    assert!(
+        query_description.contains("unknown symbols") && query_description.contains(".kt/.kts"),
+        "symbol/query should be disclosed as the first navigation step for Kotlin files: {query_description}"
+    );
+    let metrics_description = commands["database/metrics"]["tool"]["description"]
+        .as_str()
+        .expect("database/metrics tool description");
+    assert!(
+        metrics_description.contains("database-backed")
+            && metrics_description.contains("impact questions"),
+        "database/metrics should disclose source-index database access: {metrics_description}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds a schema-backed Kast routing eval corpus for Kotlin navigation, symbol calls, database metrics, high-level workflows, and public API boundary coverage.
- Tightens the packaged Kast skill and catalog/tool metadata so `.kt` and `.kts` work routes through Kast rather than generic text search.
- Adds a plugin-eval metric pack, a live `kast agent tools` envelope check, and wires the routing gate into CI.

## Validation
- `.github/scripts/test-kast-routing-evals.sh` -> `checks=10`, `score=100`
- `plugin-eval analyze cli-rs/resources/kast-skill --metric-pack .github/plugin-eval/kast-routing/manifest.json --format json` -> `checks=9`, `score=100`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke`
- `bash -n .github/scripts/test-kast-routing-evals.sh`
- `node --check .github/plugin-eval/kast-routing/emit-kast-routing-metrics.mjs`
- `python3 .../check_shell_safety.py .github/scripts/test-kast-routing-evals.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`

## Release impact
- Patch-release relevant: updates packaged skill/catalog behavior and CI validation for agent routing.