### PR TITLE
Install thin Kast agent resources

### DIFF
--- a/.agents/adr/0002-agent-resource-and-workflow-source-of-truth.md
+++ b/.agents/adr/0002-agent-resource-and-workflow-source-of-truth.md
@@ -33,9 +33,9 @@ commands as the current source-of-truth model.
 | Surface | Source of truth | Installed or generated output | Verification |
 |---------|-----------------|-------------------------------|--------------|
 | Copilot package | `cli-rs/resources/plugin/` and `primitive-manifest.json` | `.github/lsp.json`, `.github/extensions/kast/**` | `.github/scripts/test-kast-copilot-plugin.sh`, `.github/scripts/test-lsp-pivot-gates.sh` |
-| RPC and tool catalog | `cli-rs/resources/kast-skill/references/commands.json` | request schemas, samples, LSP custom route metadata, `kast agent tools` specs | `cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- release generate contract --check`, `cargo test --manifest-path cli-rs/Cargo.toml --locked --test rpc_catalog_smoke` |
-| Packaged skill | `cli-rs/resources/kast-skill/` | installed `kast` skill directories | `python3 cli-rs/resources/kast-skill/scripts/verify-kast-state.py`, CLI smoke tests |
-| Installable instructions | `cli-rs/resources/kast-instructions/` | installed instruction directories | `kast agent setup instructions --force`, docs content contract |
+| RPC and tool catalog | `cli-rs/resources/kast-skill/references/commands.json` | internal request schemas, samples, LSP custom route metadata, `kast agent tools` specs | `cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- release generate contract --check`, `cargo test --manifest-path cli-rs/Cargo.toml --locked --test rpc_catalog_smoke` |
+| Packaged skill | `cli-rs/resources/kast-skill/SKILL.md` | thin installed `kast` skill entrypoint only | `kast agent workflow package-verify`, CLI smoke tests |
+| Installable instructions | `cli-rs/resources/kast-instructions/` | thin installed instruction directories: `README.md`, `cli.md`, `tools.md`, `lsp.md` | `kast agent setup instructions --force`, docs content contract |
 | Harness selection | `projectOpen.agentHarness` and `kast agent setup auto --harness ...` | Copilot, skill, or instruction resource installs | CLI smoke tests |
 | Repo resource trust | `$HOME/.local/share/kast/install.json` | managed repo resource records with output checksums | `kast --output json ready`, verifier script |
 | Tool discovery | `cli-rs/resources/kast-skill/references/commands.json` | `kast agent tools` JSON specs for CLI-capable hosts and Copilot adapter loading | CLI smoke tests, Copilot package tests |
@@ -67,11 +67,15 @@ Agent-facing changes must keep these requirements true:
   invoke the returned `result.invocation.argv` so alternate binary names and
   absolute binary paths keep working.
 - Raw `kast rpc` remains a hidden debug escape hatch, not the public agent
-  integration contract.
+  integration contract or installable instruction topic.
 - Repo-installed resources are recorded in `install.json` with kind, target,
   primitive version, source bundle checksum, output paths, and output checksums.
-- `kast ready` and `verify-kast-state.py` fail closed on missing, stale, or
-  tampered manifest-backed resources.
+- `kast ready`, `kast agent workflow package-verify`, and the source-tree
+  verifier fail closed on missing, stale, or tampered manifest-backed
+  resources.
+- `kast agent setup skill` installs only `SKILL.md`; source-only references,
+  generated request samples, routing fixtures, and helper scripts stay under
+  `cli-rs/resources/kast-skill/` for CLI, docs, tests, and validation.
 - Mutating workflows require explicit mutation opt-in; dry runs only create
   evidence files.
 - Stale active-binary/resource combinations report incompatibility and require

--- a/cli-rs/resources/kast-instructions/lsp.md
+++ b/cli-rs/resources/kast-instructions/lsp.md
@@ -31,8 +31,9 @@ kast setup --workspace-root "$PWD" --backend headless --no-open-ide
 ## Capabilities
 
 During initialization, Kast exposes normal LSP capabilities plus custom
-`kast/*` methods under `capabilities.experimental.kastMethods`. Those custom
-methods are generated from `cli-rs/resources/kast-skill/references/commands.json`.
+`kast/*` methods under `capabilities.experimental.kastMethods`. CLI-capable
+hosts should prefer `kast agent tools` for the same catalog-backed method
+metadata unless they specifically need LSP transport.
 
 Use the built-in LSP methods for standard editor flows such as definition,
 references, hover, document symbols, implementations, call hierarchy, type

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/evals/routing.schema.json
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/evals/routing.schema.json
@@ -209,7 +209,6 @@
             "method",
             "command",
             "tool",
-            "script",
             "generic"
           ]
         },

--- a/cli-rs/resources/kast-skill/references/workflows.md
+++ b/cli-rs/resources/kast-skill/references/workflows.md
@@ -1,33 +1,32 @@
 # Kast workflow ownership
 
 Use this file when a task needs an install/config/package check, a project
-readiness gate, or a repeatable semantic request sequence. Keep exact request
-fields in `commands.json` and `references/requests/`; this file owns the
-decision points.
+readiness gate, or a repeatable semantic request sequence. Discover exact
+request fields with `kast agent tools`; this file owns the decision points.
 
 ## Install and package verification
 
-Run the read-only verifier before claiming the active package, skill,
-instructions, config, or binary are current:
+Run the native package verification workflow before claiming the active
+package, skill, instructions, config, or binary are current:
 
 ```sh
-python3 scripts/verify-kast-state.py --workspace-root "$PWD" \
+kast agent --output json workflow package-verify --workspace-root "$PWD" \
   --require-gradle-project
 ```
 
-Hosts that can only call the CLI can run the equivalent manifest-backed
-workflow gate:
+Pass explicit require and target-root flags when a host-specific resource must
+be checked:
 
 ```sh
-kast --output json agent workflow package-verify --workspace-root "$PWD" \
+kast agent --output json workflow package-verify --workspace-root "$PWD" \
   --require-copilot --copilot-target-dir "$PWD/.github" \
   --require-skill --skill-target-dir "$PWD/.codex/skills" \
   --require-instructions --instructions-target-dir "$PWD/.codex/instructions"
 ```
 
 Add `--require-copilot`, `--require-skill`, or `--require-instructions` only
-when that repository-local artifact is required for the task. The script emits
-JSON with command-surface evidence, readiness, paths, manifest-backed
+when that repository-local artifact is required for the task. The workflow
+emits JSON with command-surface evidence, readiness, paths, manifest-backed
 resource state, catalog hash comparisons, and recovery commands.
 When a package was installed into a nonstandard host root, pass the same setup
 target root with `--copilot-target-dir`, `--skill-target-dir`, or
@@ -39,18 +38,14 @@ manifest-backed. Failed required resource checks include
 `requiredResources.issues[].recoveryArgv` with the exact recovery invocation to run.
 In `--dry-run` mode, catalog-backed workflow steps report `nextRequest`;
 `package-verify` reports `nextCommandArgv` because it is native CLI
-verification, not a backend JSON-RPC method.
+verification, not a backend method.
 
-Execute recovery commands exactly as emitted. When the verifier is run with
-`--kast-bin` or another absolute executable, recovery strings preserve the
-selected executable token. Stale skill and instruction recovery also preserves
-the target resource root when the verifier can identify one; the owner table
-below names the state owner, not a command to rewrite back to bare `kast`.
-When the verifier is run with `--skill-root`, stale skill recovery also includes
-`--source-dir <skill-root>` so the selected binary installs the same skill tree
-that was verified instead of only its embedded skill bundle.
+Execute recovery commands exactly as emitted. Stale skill and instruction
+recovery preserves the target resource root when package verification can
+identify one; the owner table below names the state owner, not a command to
+rewrite back to bare `kast`.
 
-If the verifier reports stale state, use the one owner for that state:
+If package verification reports stale state, use the one owner for that state:
 
 | Symptom | Owner |
 | --- | --- |
@@ -99,27 +94,29 @@ quote runtime evidence.
 For any nontrivial call, build the params file and preserve stdout/stderr:
 
 ```sh
-python3 scripts/kast-agent-call.py symbol/query \
-  --params-json '{"query":"EventBean","modes":["exact","lexical"],"limit":10}' \
-  --workspace-root "$PWD"
+KAST_TMP="$(mktemp -d)"
+trap 'rm -rf "$KAST_TMP"' EXIT
+KAST_PARAMS="$KAST_TMP/params.json"
+KAST_RESULT="$KAST_TMP/stdout.json"
+KAST_STDERR="$KAST_TMP/stderr.txt"
+printf '%s\n' '{"query":"EventBean","modes":["exact","lexical"],"limit":10}' >"$KAST_PARAMS"
+kast agent call symbol/query --params-file "$KAST_PARAMS" \
+  --workspace-root "$PWD" >"$KAST_RESULT" 2>"$KAST_STDERR"
 ```
 
-For large payloads, put JSON in a file and pass `--params-file`. The script
-validates that the method exists in the shipped catalog, checks that the active
-binary exposes a valid `kast agent tools` envelope, writes `params.json`,
-`stdout.json`, and `stderr.txt`, and fails if the agent envelope or nested
-result reports failure.
+For large payloads, put JSON in a file and pass `--params-file`. Check
+`kast agent tools` first when the method or params shape is unknown. The call
+fails the operation if the agent envelope or nested result reports failure.
 
-Use `--dry-run` to construct and validate the params file without contacting a
-backend. Mutating methods such as `symbol/write-and-validate`, `symbol/rename`,
-`raw/rename`, `raw/optimize-imports`, and `raw/apply-edits` require
-`--allow-mutation`.
+Mutating methods such as `symbol/write-and-validate`, `symbol/rename`,
+`raw/rename`, `raw/optimize-imports`, and `raw/apply-edits` require explicit
+mutation controls on their workflow or command surface.
 
 ## Semantic workflow patterns
 
 Use `kast agent workflow ...` for common identity-first sequences. For catalog
-methods outside these patterns, use `scripts/kast-agent-call.py` as the
-file-backed request harness:
+methods outside these patterns, use `kast agent call <method> --params-file`
+as the file-backed request harness:
 
 ```sh
 kast agent workflow symbol --workspace-root "$PWD" \
@@ -148,13 +145,12 @@ have:
 | rename | prefer `symbol/rename` or `raw/rename` dry-run evidence before applying edits |
 | structured edit | `symbol/write-and-validate` when it can express the change; otherwise `raw/apply-edits` with hashes, then diagnostics |
 
-Read `references/requests/<category>/<method>/minimal.json` and
-`maximal.json` for sample payloads. Read `commands.yaml` for field names and
-variant discriminators.
+Use `kast agent tools` for sample schema shape, field names, and variant
+discriminators.
 
 ## Hook candidate
 
 No hook ships in the compact skill. If a host supports hooks, use
-`scripts/verify-kast-state.py --require-gradle-project` as the read-only gate
-before Kotlin semantic tasks and add `--require-copilot` only for Copilot
+`kast agent workflow package-verify --require-gradle-project` as the read-only
+gate before Kotlin semantic tasks and add `--require-copilot` only for Copilot
 package publication checks.

--- a/cli-rs/resources/kast-skill/scripts/verify-kast-state.py
+++ b/cli-rs/resources/kast-skill/scripts/verify-kast-state.py
@@ -775,10 +775,7 @@ def main() -> int:
     result["checks"]["sourceSkill"] = {
         "catalog": str(source_catalog),
         "catalogExists": source_catalog.is_file(),
-        "scripts": {
-            "verifyKastState": str(skill_root / "scripts/verify-kast-state.py"),
-            "kastAgentCall": str(skill_root / "scripts/kast-agent-call.py"),
-        },
+        "installedContent": ["SKILL.md"],
         "explicitOverride": explicit_skill_root is not None,
     }
     if not source_catalog.is_file():
@@ -820,15 +817,7 @@ def main() -> int:
         "skills",
         args.require_skill,
         skill_root,
-        [
-            "SKILL.md",
-            "references/commands.json",
-            "references/quickstart.md",
-            "references/runbook.md",
-            "references/workflows.md",
-            "scripts/verify-kast-state.py",
-            "scripts/kast-agent-call.py",
-        ],
+        ["SKILL.md"],
         ready_json,
         kast_bin,
         skill_target_dirs,

--- a/cli-rs/src/install/tests.rs
+++ b/cli-rs/src/install/tests.rs
@@ -16,6 +16,10 @@ mod tests {
         let first = install_skill(args.clone()).unwrap();
         assert!(!first.skipped);
         assert!(temp.path().join("kast/SKILL.md").is_file());
+        assert!(!temp.path().join("kast/AGENTS.md").exists());
+        assert!(!temp.path().join("kast/references").exists());
+        assert!(!temp.path().join("kast/scripts").exists());
+        assert!(!temp.path().join("kast/fixtures").exists());
         assert!(!temp.path().join("kast/.kast-version").exists());
         let second = install_skill(args).unwrap();
         assert!(second.skipped);
@@ -38,10 +42,118 @@ mod tests {
         assert!(temp.path().join("kast/cli.md").is_file());
         assert!(temp.path().join("kast/tools.md").is_file());
         assert!(temp.path().join("kast/lsp.md").is_file());
+        assert!(!temp.path().join("kast/AGENTS.md").exists());
         assert!(!temp.path().join("kast/rpc.md").exists());
         assert!(!temp.path().join("kast/.kast-version").exists());
         let second = install_instructions(args).unwrap();
         assert!(second.skipped);
+    }
+
+    #[test]
+    fn install_skill_replaces_retired_heavy_outputs_when_managed() {
+        let temp = tempfile::tempdir().unwrap();
+        let args = ResourceInstallArgs {
+            target_dir: Some(temp.path().to_path_buf()),
+            name: Some("kast".to_string()),
+            source_dir: None,
+            force: false,
+            no_auto_exclude_git: false,
+            dry_run: false,
+        };
+        let first = install_skill(args.clone()).unwrap();
+        assert!(!first.skipped);
+
+        let target = temp.path().join("kast");
+        fs::create_dir_all(target.join("references")).unwrap();
+        fs::create_dir_all(target.join("scripts")).unwrap();
+        fs::create_dir_all(target.join("fixtures")).unwrap();
+        fs::write(target.join("AGENTS.md"), "old source guide\n").unwrap();
+        fs::write(target.join("references/commands.json"), "{}\n").unwrap();
+        fs::write(target.join("scripts/verify-kast-state.py"), "#!/usr/bin/env python3\n")
+            .unwrap();
+
+        let second = install_skill(args.clone()).unwrap();
+        assert!(!second.skipped);
+        assert!(target.join("SKILL.md").is_file());
+        assert!(!target.join("AGENTS.md").exists());
+        assert!(!target.join("references").exists());
+        assert!(!target.join("scripts").exists());
+        assert!(!target.join("fixtures").exists());
+
+        let third = install_skill(args).unwrap();
+        assert!(third.skipped);
+    }
+
+    #[test]
+    fn install_instructions_replaces_retired_rpc_output_when_managed() {
+        let temp = tempfile::tempdir().unwrap();
+        let args = ResourceInstallArgs {
+            target_dir: Some(temp.path().to_path_buf()),
+            name: Some("kast".to_string()),
+            source_dir: None,
+            force: false,
+            no_auto_exclude_git: false,
+            dry_run: false,
+        };
+        let first = install_instructions(args.clone()).unwrap();
+        assert!(!first.skipped);
+
+        let target = temp.path().join("kast");
+        fs::write(target.join("AGENTS.md"), "old source guide\n").unwrap();
+        fs::write(target.join("rpc.md"), "old raw rpc guide\n").unwrap();
+
+        let second = install_instructions(args.clone()).unwrap();
+        assert!(!second.skipped);
+        assert!(target.join("README.md").is_file());
+        assert!(target.join("cli.md").is_file());
+        assert!(target.join("tools.md").is_file());
+        assert!(target.join("lsp.md").is_file());
+        assert!(!target.join("AGENTS.md").exists());
+        assert!(!target.join("rpc.md").exists());
+
+        let third = install_instructions(args).unwrap();
+        assert!(third.skipped);
+    }
+
+    #[test]
+    fn install_skill_source_override_requires_entrypoint() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("source");
+        fs::create_dir_all(&source).unwrap();
+        let args = ResourceInstallArgs {
+            target_dir: Some(temp.path().join("target")),
+            name: Some("kast".to_string()),
+            source_dir: Some(source),
+            force: false,
+            no_auto_exclude_git: false,
+            dry_run: false,
+        };
+
+        let error = install_skill(args).unwrap_err();
+
+        assert_eq!(error.code, "RESOURCE_SOURCE_INCOMPLETE");
+        assert!(error.message.contains("SKILL.md"));
+    }
+
+    #[test]
+    fn install_instructions_source_override_requires_thin_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("source");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("README.md"), "# Guide\n").unwrap();
+        let args = ResourceInstallArgs {
+            target_dir: Some(temp.path().join("target")),
+            name: Some("kast".to_string()),
+            source_dir: Some(source),
+            force: false,
+            no_auto_exclude_git: false,
+            dry_run: false,
+        };
+
+        let error = install_instructions(args).unwrap_err();
+
+        assert_eq!(error.code, "RESOURCE_SOURCE_INCOMPLETE");
+        assert!(error.message.contains("cli.md"));
     }
 
     #[test]

--- a/cli-rs/src/output/install.rs
+++ b/cli-rs/src/output/install.rs
@@ -20,9 +20,10 @@ fn print_skill_install(result: &InstallSkillResult) -> Result<()> {
     mdln!(document, "## Next steps");
     mdln!(
         document,
-        "- Read the installed quickstart: `{}/references/quickstart.md`",
+        "- Read the installed skill entrypoint: `{}/SKILL.md`",
         result.installed_at
     );
+    mdln!(document, "- Discover callable tools with: `kast agent tools`");
     print_markdown(&document.into_string())
 }
 

--- a/cli-rs/tests/cli_core_smoke.rs
+++ b/cli-rs/tests/cli_core_smoke.rs
@@ -382,7 +382,7 @@ fn smoke_core_cli_commands() {
     assert!(!skill_dir.join("kast/AGENTS.md").exists());
     assert!(!skill_dir.join("kast/references").exists());
     assert!(!skill_dir.join("kast/scripts").exists());
-
+    assert!(!skill_dir.join("kast/fixtures").exists());
     let instructions_dir = temp.path().join("instructions");
     let instructions = kast(&home, &config_home)
         .args([
@@ -400,6 +400,7 @@ fn smoke_core_cli_commands() {
     assert!(instructions_dir.join("kast/cli.md").is_file());
     assert!(instructions_dir.join("kast/tools.md").is_file());
     assert!(instructions_dir.join("kast/lsp.md").is_file());
+    assert!(!instructions_dir.join("kast/AGENTS.md").exists());
     assert!(!instructions_dir.join("kast/rpc.md").exists());
 
     let github_dir = temp.path().join(".github");

--- a/cli-rs/tests/resource_install_gateway_smoke.rs
+++ b/cli-rs/tests/resource_install_gateway_smoke.rs
@@ -53,6 +53,10 @@ fn install_resource_gateways_support_force_and_current_versions() {
     let skill_stdout: serde_json::Value =
         serde_json::from_slice(&skill.stdout).expect("skill install json");
     assert!(stale_skill.join("SKILL.md").is_file());
+    assert!(!stale_skill.join("AGENTS.md").exists());
+    assert!(!stale_skill.join("references").exists());
+    assert!(!stale_skill.join("scripts").exists());
+    assert!(!stale_skill.join("fixtures").exists());
     assert_eq!(
         skill_stdout["sourceBundleSha256"]
             .as_str()
@@ -122,6 +126,7 @@ fn install_resource_gateways_support_force_and_current_versions() {
     assert!(stale_instructions.join("cli.md").is_file());
     assert!(stale_instructions.join("tools.md").is_file());
     assert!(stale_instructions.join("lsp.md").is_file());
+    assert!(!stale_instructions.join("AGENTS.md").exists());
     assert!(!stale_instructions.join("rpc.md").exists());
     assert_eq!(
         instructions_stdout["sourceBundleSha256"]


### PR DESCRIPTION
## Summary
- Install only the Kast skill entrypoint and lean instruction files as managed agent resources.
- Retire source-only skill references, fixtures, helper scripts, and the raw RPC instruction file from installed payloads.
- Update routing guidance, package verification docs, eval fixtures, and Rust smoke coverage for the thin resource contract.

## Validation
- `cargo fmt --manifest-path cli-rs/Cargo.toml --check`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked install::tests`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_target_detection_smoke --test cli_core_smoke --test packaged_content_smoke --test resource_install_gateway_smoke`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test package_verifier_smoke`
- `.github/scripts/test-docs-content-contract.sh`

## Notes
- Rebased from `b7e86bd6ee1b008e3a22bb1bf40abb2c86053e4c` onto current `origin/main`.
- Branch contains one commit: `98483dea feat: install thin Kast agent resources`.