### PR TITLE
fix: keep Kast skill installs entrypoint-only

### DIFF
--- a/.github/plugin-eval/kast-routing/emit-kast-routing-metrics.mjs
+++ b/.github/plugin-eval/kast-routing/emit-kast-routing-metrics.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -189,23 +189,16 @@ const actionNames = new Set();
 for (const item of cases) {
   for (const action of item.allowedActions ?? []) {
     actionNames.add(action.name);
-    if (action.kind === "method" && !commands[action.name]) {
-      actionFailures.push(`${item.id}: missing method ${action.name}`);
-    } else if (action.kind === "tool" && !toolNames.has(action.name)) {
-      actionFailures.push(`${item.id}: missing tool ${action.name}`);
-    } else if (
-      action.kind === "command" &&
-      !action.name.startsWith("kast agent") &&
-      !action.name.startsWith("kast inspect metrics")
-    ) {
+    if (action.kind === "method") {
+      actionFailures.push(`${item.id}: allowedActions must use kast agent commands, not method ${action.name}`);
+    } else if (action.kind === "tool") {
+      actionFailures.push(`${item.id}: allowedActions must use kast agent commands, not tool ${action.name}`);
+    } else if (action.kind === "command" && !action.name.startsWith("kast agent")) {
       actionFailures.push(`${item.id}: non-public command ${action.name}`);
-    } else if (action.kind === "script") {
-      const scriptPath = join(targetPath, action.name);
-      if (!existsSync(scriptPath)) {
-        actionFailures.push(`${item.id}: missing script ${action.name}`);
-      }
     } else if (action.kind === "generic" && !isNegativeCase(item)) {
       actionFailures.push(`${item.id}: generic action is only valid for negative routing cases`);
+    } else if (!["method", "tool", "command", "generic"].includes(action.kind)) {
+      actionFailures.push(`${item.id}: unsupported public action kind ${action.kind}`);
     }
   }
 }
@@ -215,18 +208,19 @@ checks.push(
     actionFailures.length === 0 ? "pass" : "fail",
     actionFailures.length === 0 ? "info" : "error",
     actionFailures.length === 0
-      ? "All routing actions resolve to public Kast methods, tools, commands, packaged scripts, or negative generic actions."
+      ? "All routing actions resolve to kast agent commands or negative generic actions."
       : "Some routing actions do not resolve.",
     actionFailures.length === 0 ? [...actionNames].sort() : actionFailures,
-    ["Keep allowedActions aligned with references/commands.json, kast agent tools, and packaged scripts."],
+    ["Keep allowedActions aligned with the public kast agent command surface."],
   ),
 );
 
 const triggerEvidence = [
-  "all Kotlin `.kt` and `.kts`",
-  "every `.kt` and `.kts` file",
-  "only navigation surface",
-  "Any `.kt` or `.kts` file",
+  "Use when working on Kotlin or Gradle semantics",
+  "`.kt`",
+  "`.kts`",
+  "Route all Kast work through",
+  "only first-class Kast",
 ];
 checks.push(
   check(
@@ -242,8 +236,8 @@ checks.push(
 );
 
 const continuityEvidence = [
-  "Keep using Kast after the first successful call",
-  "A first Kast result is not a handoff back to generic file reads",
+  "Keep using `kast agent` after the first successful call",
+  "not a handoff back to generic file reads",
 ];
 checks.push(
   check(
@@ -259,9 +253,11 @@ checks.push(
 );
 
 const referenceRouterEvidence = [
-  "Normal use loads only SKILL.md",
-  "Do not pre-load the full catalog",
-  "Load `references/runbook.md` only",
+  "Normal installed use loads only `SKILL.md`",
+  "Do not pre-load the full source catalog",
+  "Discover method schemas",
+  "`kast agent tools`",
+  "`kast agent workflow --help`",
 ];
 checks.push(
   check(
@@ -269,10 +265,10 @@ checks.push(
     includesAll(skill, referenceRouterEvidence) ? "pass" : "fail",
     includesAll(skill, referenceRouterEvidence) ? "info" : "error",
     includesAll(skill, referenceRouterEvidence)
-      ? "Skill routes reference loading by need instead of encouraging eager reference reads."
-      : "Skill does not provide a strict enough reference-loading router.",
+      ? "Skill routes option discovery through the CLI instead of encouraging eager source-reference reads."
+      : "Skill does not provide a strict enough progressive-disclosure router.",
     referenceRouterEvidence,
-    ["Keep SKILL.md as trigger/router text and push detail into references only when needed."],
+    ["Keep installed SKILL.md as trigger/router text and push detail discovery through kast agent tools."],
   ),
 );
 
@@ -327,16 +323,17 @@ checks.push(
 );
 
 const requiredActions = [
-  "symbol/query",
-  "symbol/callers",
-  "database/metrics",
-  "kast_symbol_query",
-  "kast_callers",
-  "kast_metrics",
+  "kast agent scaffold",
+  "kast agent file-outline",
+  "kast agent call symbol/query",
+  "kast agent references",
+  "kast agent callers",
+  "kast agent raw-diagnostics",
+  "kast agent call database/metrics",
   "kast agent workflow diagnostics",
+  "kast agent workflow package-verify",
   "kast agent setup skill --source-dir",
   "kast agent tools",
-  "scripts/verify-kast-state.py",
 ];
 const missingActions = requiredActions.filter((name) => !actionNames.has(name));
 checks.push(
@@ -345,10 +342,10 @@ checks.push(
     missingActions.length === 0 ? "pass" : "fail",
     missingActions.length === 0 ? "info" : "error",
     missingActions.length === 0
-      ? "Routing eval exposes symbol calls, database metrics, high-level workflows, source-override recovery, and agent tool discovery."
+      ? "Routing eval exposes symbol calls, database metrics, high-level workflows, package verification, source-override recovery, and agent tool discovery through kast agent commands."
       : "Routing eval is missing required public action coverage.",
     missingActions.length === 0 ? requiredActions : missingActions,
-    ["Add allowedActions for missing public methods, tools, or workflow commands."],
+    ["Add allowedActions for missing public kast agent commands."],
   ),
 );
 
@@ -361,9 +358,9 @@ for (const item of referenceCases) {
   const forbiddenReferences = new Set(expectation.forbiddenReferences ?? []);
   failIf(!alwaysLoaded.has("SKILL.md"), `${item.id}: referenceExpectation.alwaysLoaded must include SKILL.md`, referenceFailures);
   for (const required of [
-    "references/commands.json before exact field lookup",
-    "references/requests/ before sample need",
-    "references/runbook.md for ordinary symbol lookup",
+    "static references/commands.json lookup before tool discovery",
+    "static references/requests/ lookup before tool discovery",
+    "source-only runbook for ordinary symbol lookup",
   ]) {
     failIf(!forbiddenReferences.has(required), `${item.id}: referenceExpectation must forbid ${required}`, referenceFailures);
   }

--- a/cli-rs/resources/kast-skill/SKILL.md
+++ b/cli-rs/resources/kast-skill/SKILL.md
@@ -1,143 +1,101 @@
 ---
 name: kast
 description: >
-  Use when an agent works in a Gradle project and needs the Rust `kast` CLI for
-  file discovery, all Kotlin `.kt` and `.kts` source reads or edits, symbol
-  identity, references, callers, hierarchy, diagnostics, source-index metrics,
-  install/config/package verification, file-backed Kast calls, or focused
-  Gradle validation. Prefer Kast before generic text or file tools for Kotlin
-  and broad Gradle project exploration.
+  Use when working on Kotlin or Gradle semantics in a repository: `.kt` and
+  `.kts` source reads or edits, symbol identity, references, callers,
+  hierarchy, diagnostics, source-index metrics, semantic mutation, package
+  readiness, or focused Gradle validation. Route all Kast work through
+  `kast agent`.
 ---
 
-# Kast
+# Kast Agent
 
-Kast is the installed Rust `kast` CLI semantic surface for Kotlin and Gradle
-repositories. When this skill is present, assume the binary installed it and use
-`kast` directly for file discovery, Kotlin context, symbol identity,
-relationships, diagnostics, edits, and focused validation. Default to Kast for
-every `.kt` and `.kts` file and for Gradle project file operations that need
-semantic or install-state evidence. Treat Kast as the only navigation surface
-for Kotlin semantics until it returns a concrete blocker or a bounded
-non-semantic task remains.
+Kotlin work uses the agent route: `kast agent ...` is the only first-class Kast
+path. Do not use raw transport, generated protocol routes, LSP internals, or
+source-only helper scripts as the agent workflow. If the active binary lacks
+`kast agent`, report stale Kast installation and require upgrade or reinstall;
+do not replace the missing compiler-backed path with text search.
 
-## Continuity Rule
+## Operating Loop
 
-Keep using Kast after the first successful call for the same Kotlin or Gradle
-task. A first Kast result is not a handoff back to generic file reads; continue
-with `symbol/scaffold`, `symbol/references`, `symbol/callers`,
-`raw/diagnostics`, `raw/workspace-refresh`, or the matching
-`kast agent workflow ...` command until the task leaves Kotlin semantics or
-Kast reports a concrete blocker.
+1. Route to the narrowest Kotlin-aware `kast agent` surface before reading
+   files, searching text, or guessing project structure.
+2. Keep using `kast agent` after the first successful call. A first result is
+   not a handoff back to generic file reads; stay on `kast agent` until the work
+   leaves Kotlin semantics or it reports a concrete blocker.
+3. Mutate through `kast agent` when the target is semantic or compiler-owned.
+   Validate with `kast agent` diagnostics and then the narrowest Gradle task
+   that proves the change.
 
-## First Move
+Completion criterion: every Kotlin semantic claim, edit target, relationship
+set, and completion proof is backed by `kast agent` evidence, or the remaining
+work is an exact non-Kotlin path that does not depend on semantic facts.
 
-Confirm the command surface, then use Kast before ordinary text tools for
-Kotlin or Gradle project facts:
+## Usage Routes
+
+Use direct `kast agent` subcommands first. Use `kast agent workflow ...` for
+repeated sequences. Use `kast agent call <method>` only when no direct
+subcommand or workflow fits.
+
+| Need | Use |
+| --- | --- |
+| Kotlin file content with declaration context | `kast agent scaffold` |
+| File structure only | `kast agent file-outline` |
+| Unknown symbol | `kast agent discover`, then `kast agent resolve` |
+| Exact symbol identity | `kast agent resolve` |
+| Usages and incoming calls | `kast agent references`, `kast agent callers` |
+| Offset-owned relationships | `kast agent raw-resolve`, `kast agent raw-references`, `kast agent raw-call-hierarchy`, `kast agent raw-type-hierarchy`, `kast agent raw-implementations` |
+| Workspace files, symbols, or text | `kast agent workspace-files`, `kast agent workspace-symbol`, `kast agent workspace-search` |
+| Diagnostics | `kast agent raw-diagnostics` |
+| Source-index impact | `kast agent metrics` or `kast agent workflow impact` |
+| Rename or write | `kast agent raw-rename`, `kast agent workflow rename-plan`, or `kast agent workflow write-validate` |
+| Imports, completions, code actions, insertion points | `kast agent raw-optimize-imports`, `kast agent raw-completions`, `kast agent raw-code-actions`, `kast agent raw-semantic-insertion-point` |
+| Repeated semantic sequence | `kast agent workflow symbol`, `kast agent workflow diagnostics`, `kast agent workflow rename-plan`, or `kast agent workflow write-validate` |
+
+Use `kast agent workspace-search` only for Kotlin comments, string literals, or
+other text that is not a symbol. Use ordinary file tools for exact non-Kotlin
+paths, generated text, docs, skill maintenance, and final absence checks after
+`kast agent` finds no candidates.
+
+## Disclosure
+
+Normal installed use loads only `SKILL.md`. Discover method schemas, field
+names, default arguments, mutation metadata, and invocation argv through
+`kast agent tools`; use `kast agent workflow --help` for supported multi-step
+operations. Do not pre-load the full source catalog, generated request samples,
+or raw transport runbook before a concrete command needs exact fields.
+
+## Catalog Calls
+
+For one nontrivial catalog call, keep parameters in a file:
 
 ```console
-command -v kast
-kast --help
-kast agent --help
-kast agent tools
-kast agent workflow --help
+kast agent --output json call <method> --params-file "$KAST_PARAMS" --workspace-root "$PWD"
 ```
 
-When the installed skill exposes `scripts/`, prefer the read-only verifier for
-install, package, config, active-binary, and project-readiness evidence:
+Use camelCase fields and absolute paths. A call succeeds only when the outer
+`ok` field and the nested result status are clean. Validation errors,
+`ok=false`, dirty diagnostics, hash mismatches, and failed Gradle tasks fail the
+operation.
 
-```console
-python3 scripts/verify-kast-state.py --workspace-root "$PWD" --require-gradle-project
-```
+## Health Reference
 
-If the binary is missing or does not expose the expected agent tool/workflow
-surface, report that the installed skill and active binary are incompatible and
-require a CLI upgrade/reinstall. Do not replace the missing compiler-backed path
-with non-semantic Kotlin search.
+Use this section only when a `kast agent` command fails, the user asks for
+readiness evidence, or backend state is part of the task. Do not make these
+commands the first move for normal Kotlin work.
 
-If a command reports `NO_BACKEND_AVAILABLE`, `INDEX_UNAVAILABLE`,
-`METRICS_DB_UNAVAILABLE`, or a missing source-index database, warm the
-repository with `kast agent up` when setup state may also be stale, or warm the
-IDE-hosted backend directly when only runtime state is missing:
+| Symptom or need | Command |
+| --- | --- |
+| Agent readiness or safe repair | `kast agent --output json ready --for agent --fix` |
+| Kotlin backend readiness | `kast agent --output json ready --for kotlin --fix` |
+| Resource setup plus runtime warmup | `kast agent --output json up --workspace-root "$PWD" --no-onboard` |
+| Backend health/capabilities sweep | `kast agent --output json workflow verify --workspace-root "$PWD"` |
+| Direct health RPC | `kast agent --output json health --workspace-root "$PWD"` |
+| Detailed runtime state | `kast agent --output json runtime-status --workspace-root "$PWD"` |
+| Advertised backend capabilities | `kast agent --output json capabilities --workspace-root "$PWD"` |
+| Repo-local package/resource state | `kast agent --output json workflow package-verify --workspace-root "$PWD" --require-skill` |
 
-```console
-kast agent up --workspace-root "$PWD" --dry-run
-kast --output json agent up --workspace-root "$PWD" --no-onboard
-kast runtime up --workspace-root "$PWD" --backend idea
-```
-
-Interactive human `kast agent up` may offer first-run IDEA/Copilot onboarding
-with global or repository-scoped defaults. Agents should use JSON output or
-`--no-onboard` so prompts cannot block execution. Runtime warmup may open IDEA
-or Android Studio only when
-`runtime.ideaLaunch.enabled` is set in Kast config; otherwise it reports that
-the project must be opened in the IDE. Treat the failure as a blocker only
-after this dynamic IDE warmup path has failed.
-
-## Gradle File Routing
-
-- Use for Gradle project file work, not only direct Kotlin edits.
-- Any `.kt` or `.kts` file: start with `symbol/scaffold` when you need content
-  plus declaration context, or `raw/file-outline` when only structure is needed.
-  Do not open Kotlin files with generic readers before Kast has provided the
-  bounded target and semantic context.
-- Unknown symbol: start with `kast agent call symbol/query`; use tight `query`, `limit`,
-  `modes`, and filters such as `relativePathPrefix`, `gradleProject`,
-  `sourceSet`, or `kinds`.
-- Ambiguous symbol: escalate through `raw/workspace-symbol`, `symbol/discover`,
-  then `symbol/resolve`; inspect with `symbol/scaffold`, `raw/file-outline`,
-  `symbol/references`, or `symbol/callers`.
-- Unknown file/module: use `raw/workspace-files includeFiles=false`; request
-  paths only with `moduleName` and a small `maxFilesPerModule`.
-- Unknown Kotlin text, comments, or literals: use `raw/workspace-search`.
-- Known non-Kotlin path (`build.gradle.kts`, docs, YAML, JSON, shell): normal
-  file tools are fine. Use Kast to discover the owning module or likely path
-  when the path is not already exact.
-- Kotlin edits: `symbol/rename`, `symbol/write-and-validate`,
-  `raw/semantic-insertion-point`, `raw/completions`, `raw/code-actions`,
-  `raw/apply-edits`, `raw/optimize-imports`; still run Kast before external
-  patches and diagnostics after.
-- Impact/proof: `raw/type-hierarchy`, `raw/implementations`,
-  `database/metrics`, `kast inspect metrics fan-in`, other `kast inspect metrics` subcommands,
-  `kast inspect demo --json`, `raw/workspace-refresh`, `raw/diagnostics`, then the
-  narrowest Gradle task.
-
-## Public Surface
-
-Use the public agent surfaces first: `kast agent`, `kast agent tools`,
-`kast agent workflow`, `kast inspect metrics`, and the catalog method names in
-`references/commands.json`. Named tools such as `kast_symbol_query`,
-`kast_resolve`, `kast_references`, `kast_callers`, and `kast_metrics` are the
-host-facing way to expose navigation, relationships, source-index database
-access, and edits. Do not teach generated protocol paths, LSP capability
-internals, daemon routing details, or implementation class names as the public
-API for agents.
-
-## Request Discipline
-
-For repeated semantic sequences, use `kast agent workflow ...`; the active CLI
-must provide this command. For one nontrivial catalog call, use
-`scripts/kast-agent-call.py` so params, stdout, and stderr are preserved as
-files. Send catalog methods through `kast agent call <method> --params-file
-"$KAST_PARAMS"` with `--workspace-root "$PWD"` when scripting manually. Use
-camelCase fields, absolute paths, and check the agent envelope `ok` plus the
-nested result status; validation errors, `ok=false`, dirty diagnostics, hash
-mismatches, and failed Gradle tasks fail the operation.
-Normal use loads only SKILL.md. Do not pre-load the full catalog, generated
-request samples, or raw transport runbook before a concrete call needs them.
-Load `references/workflows.md` for install/refresh/verify ownership, project
-readiness gates, file-backed request exchange, semantic request sequences, and
-failure recovery. Load `references/commands.yaml`, `references/commands.json`,
-or `references/requests/` only for exact fields, variants, enum values, or
-samples. Load `references/runbook.md` only when debugging raw transport or
-preserving a full JSON-RPC envelope matters.
-
-## Boundaries
-
-Do not use `grep`, `rg`, `ast-grep`, manual parsing, or ordinary file reads for
-Kotlin symbol identity, usage sets, hierarchy, insertion points, or rename
-scope. Use them for exact non-Kotlin paths, generated text, docs, skill
-maintenance, and final absence verification after Kast finds no candidates.
-
-When a Kotlin request names only a symbol, resolve it with Kast before reading
-or editing. For exact Kotlin-file textual cleanup, read only what is needed and
-run Kast diagnostics before claiming completion.
+If `NO_BACKEND_AVAILABLE`, `INDEX_UNAVAILABLE`, `METRICS_DB_UNAVAILABLE`, or a
+missing source-index database appears, run `kast agent --output json up` or
+`kast agent --output json workflow verify`, then retry the original Kotlin
+route.

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/evals/routing.json
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/evals/routing.json
@@ -26,12 +26,12 @@
       },
       "allowedActions": [
         {
-          "kind": "method",
-          "name": "symbol/scaffold"
+          "kind": "command",
+          "name": "kast agent scaffold"
         },
         {
-          "kind": "method",
-          "name": "raw/file-outline"
+          "kind": "command",
+          "name": "kast agent file-outline"
         }
       ],
       "forbiddenActions": [
@@ -43,7 +43,7 @@
       "recoveryExpectation": "If the backend is unavailable, report the concrete Kast setup or runtime recovery command before using a generic reader.",
       "verificationEvidence": [
         "SKILL.md explicitly covers every .kt and .kts file.",
-        "symbol/scaffold and raw/file-outline are catalog methods exposed through kast agent tools."
+        "SKILL.md routes Kotlin file inspection through kast agent scaffold and kast agent file-outline."
       ],
       "notes": "This case protects the all-Kotlin-file trigger and the sole-navigation rule."
     },
@@ -66,20 +66,16 @@
       },
       "allowedActions": [
         {
-          "kind": "method",
-          "name": "symbol/query"
+          "kind": "command",
+          "name": "kast agent call symbol/query"
         },
         {
-          "kind": "method",
-          "name": "symbol/discover"
+          "kind": "command",
+          "name": "kast agent discover"
         },
         {
-          "kind": "method",
-          "name": "symbol/resolve"
-        },
-        {
-          "kind": "tool",
-          "name": "kast_symbol_query"
+          "kind": "command",
+          "name": "kast agent resolve"
         }
       ],
       "forbiddenActions": [
@@ -90,9 +86,8 @@
       ],
       "recoveryExpectation": "If symbol/query returns INDEX_UNAVAILABLE, run the emitted Kast recovery or warmup path and retry the symbol-first route.",
       "verificationEvidence": [
-        "symbol/query is a catalog method.",
-        "kast_symbol_query is exposed in kast agent tools.",
-        "SKILL.md names symbol/query as the first unknown-symbol step."
+        "symbol/query is reachable through kast agent call.",
+        "SKILL.md names kast agent discover and kast agent resolve for unknown symbols."
       ],
       "notes": "This case makes unknown-symbol navigation measurable without relying on raw file enumeration."
     },
@@ -115,20 +110,16 @@
       },
       "allowedActions": [
         {
-          "kind": "method",
-          "name": "symbol/resolve"
+          "kind": "command",
+          "name": "kast agent resolve"
         },
         {
-          "kind": "method",
-          "name": "symbol/references"
+          "kind": "command",
+          "name": "kast agent references"
         },
         {
-          "kind": "method",
-          "name": "symbol/callers"
-        },
-        {
-          "kind": "tool",
-          "name": "kast_callers"
+          "kind": "command",
+          "name": "kast agent callers"
         }
       ],
       "forbiddenActions": [
@@ -137,10 +128,10 @@
         "textual call graph",
         "unresolved name matching"
       ],
-      "recoveryExpectation": "If the name is ambiguous, use symbol/discover or symbol/resolve filters before references and callers.",
+      "recoveryExpectation": "If the name is ambiguous, use kast agent discover or kast agent resolve filters before references and callers.",
       "verificationEvidence": [
-        "symbol/references and symbol/callers are catalog methods exposed as agent tools.",
-        "SKILL.md requires Kast for Kotlin usage sets and hierarchy."
+        "SKILL.md routes usage sets through kast agent references.",
+        "SKILL.md routes caller expansion through kast agent callers."
       ],
       "notes": "This case protects relationship navigation through symbol calls instead of text."
     },
@@ -163,16 +154,16 @@
       },
       "allowedActions": [
         {
-          "kind": "method",
-          "name": "database/metrics"
-        },
-        {
-          "kind": "tool",
-          "name": "kast_metrics"
+          "kind": "command",
+          "name": "kast agent metrics"
         },
         {
           "kind": "command",
-          "name": "kast inspect metrics"
+          "name": "kast agent workflow impact"
+        },
+        {
+          "kind": "command",
+          "name": "kast agent call database/metrics"
         }
       ],
       "forbiddenActions": [
@@ -183,8 +174,8 @@
       ],
       "recoveryExpectation": "If metrics are unavailable, report METRICS_DB_UNAVAILABLE and run the documented Kast index/runtime recovery before using another source.",
       "verificationEvidence": [
-        "database/metrics is a catalog method exposed through kast_metrics.",
-        "SKILL.md lists database/metrics and kast inspect metrics as the public impact path."
+        "database/metrics is reachable through kast agent call.",
+        "SKILL.md lists kast agent metrics and kast agent workflow impact as the public impact path."
       ],
       "notes": "This case verifies database access is public through Kast without exposing storage internals."
     },
@@ -194,7 +185,7 @@
       "source": {
         "kind": "synthetic-regression",
         "capturedAt": "2026-06-29",
-        "note": "Regression guard for agents copying raw JSON-RPC snippets instead of using workflow commands."
+        "note": "Regression guard for agents copying raw protocol snippets instead of using workflow commands."
       },
       "prompt": "Create a repeatable evidence bundle for a rename and diagnostics pass.",
       "expectedPrimitive": {
@@ -222,7 +213,8 @@
       "forbiddenActions": [
         "grep",
         "rg",
-        "ad hoc JSON-RPC transport",
+        "kast rpc",
+        "ad hoc protocol transport",
         "manual edit without diagnostics"
       ],
       "recoveryExpectation": "If workflow help is unavailable, report active binary and skill incompatibility and require upgrade or reinstall.",
@@ -251,16 +243,16 @@
       },
       "allowedActions": [
         {
-          "kind": "method",
-          "name": "symbol/scaffold"
+          "kind": "command",
+          "name": "kast agent scaffold"
         },
         {
-          "kind": "method",
-          "name": "symbol/references"
+          "kind": "command",
+          "name": "kast agent references"
         },
         {
-          "kind": "method",
-          "name": "raw/diagnostics"
+          "kind": "command",
+          "name": "kast agent raw-diagnostics"
         },
         {
           "kind": "command",
@@ -276,7 +268,7 @@
       ],
       "recoveryExpectation": "If a follow-up Kast call fails with backend or index state, run the documented Kast recovery and retry the same semantic route before falling back.",
       "verificationEvidence": [
-        "symbol/scaffold, symbol/references, and raw/diagnostics are catalog methods.",
+        "SKILL.md routes continued declaration, reference, and diagnostics work through kast agent commands.",
         "kast agent workflow diagnostics is a public workflow command for continued validation."
       ],
       "notes": "This case protects sustained Kast use across a multi-step Kotlin task, not just initial pickup."
@@ -300,10 +292,6 @@
       },
       "allowedActions": [
         {
-          "kind": "script",
-          "name": "scripts/verify-kast-state.py"
-        },
-        {
           "kind": "command",
           "name": "kast agent setup skill --source-dir"
         },
@@ -321,8 +309,8 @@
       ],
       "recoveryExpectation": "Run the emitted `kast agent setup skill --target-dir ... --source-dir <skill-root> --force` recovery, then rerun the verifier or package-verify gate.",
       "verificationEvidence": [
-        "verify-kast-state.py emits stale skill recovery with --source-dir when --skill-root is provided.",
-        "package_verifier_smoke covers source-root recovery for tampered manifest-backed skills."
+        "kast agent workflow package-verify emits stale skill recovery for manifest-backed package drift.",
+        "package_verifier_smoke covers recovery for tampered manifest-backed skills."
       ],
       "notes": "This case keeps stale installed skill recovery tied to the verified source tree."
     },
@@ -345,24 +333,20 @@
       },
       "allowedActions": [
         {
-          "kind": "method",
-          "name": "symbol/query"
-        },
-        {
-          "kind": "tool",
-          "name": "kast_symbol_query"
+          "kind": "command",
+          "name": "kast agent call symbol/query"
         }
       ],
       "forbiddenActions": [
         "grep",
         "rg",
-        "references/commands.json before exact field lookup",
-        "references/requests/ before sample need",
-        "references/runbook.md for ordinary symbol lookup"
+        "static references/commands.json lookup before tool discovery",
+        "static references/requests/ lookup before tool discovery",
+        "source-only runbook for ordinary symbol lookup"
       ],
       "recoveryExpectation": "If symbol/query needs exact request fields, load only the relevant catalog or request sample instead of the full reference tree.",
       "verificationEvidence": [
-        "symbol/query and kast_symbol_query are public symbol lookup surfaces.",
+        "symbol/query is reachable through kast agent call.",
         "SKILL.md routes detailed references by need instead of pre-loading all references."
       ],
       "referenceExpectation": {
@@ -370,13 +354,12 @@
           "SKILL.md"
         ],
         "allowedReferences": [
-          "references/commands.yaml",
-          "references/requests/symbol/query/minimal.json"
+          "kast agent tools"
         ],
         "forbiddenReferences": [
-          "references/commands.json before exact field lookup",
-          "references/requests/ before sample need",
-          "references/runbook.md for ordinary symbol lookup"
+          "static references/commands.json lookup before tool discovery",
+          "static references/requests/ lookup before tool discovery",
+          "source-only runbook for ordinary symbol lookup"
         ]
       },
       "notes": "This case makes reference-loading efficiency part of the shipped routing contract."
@@ -449,28 +432,21 @@
         },
         {
           "kind": "command",
-          "name": "kast inspect metrics"
-        },
-        {
-          "kind": "tool",
-          "name": "kast_symbol_query"
-        },
-        {
-          "kind": "tool",
-          "name": "kast_metrics"
+          "name": "kast agent call"
         }
       ],
       "forbiddenActions": [
         "grep",
         "rg",
+        "kast rpc",
         "generated protocol endpoints",
         "capabilities.experimental.kastMethods",
         "backend implementation classes"
       ],
       "recoveryExpectation": "If an adapter exposes only internal routes, prefer the canonical Kast skill and require adapter refresh rather than documenting the internals.",
       "verificationEvidence": [
-        "SKILL.md public surface section names only kast agent, kast agent tools, kast agent workflow, kast inspect metrics, catalog methods, and named tools.",
-        "Tool descriptions for symbol/query, symbol/callers, and database/metrics do not mention protocol endpoint paths or LSP capability internals."
+        "SKILL.md public surface section names kast agent as the only first-class path.",
+        "Catalog method descriptions for symbol/query, symbol/callers, and database/metrics do not mention protocol endpoint paths or LSP capability internals."
       ],
       "notes": "This case protects the public API boundary while still exposing database, symbol, and workflow capabilities."
     }

--- a/cli-rs/resources/kast-skill/references/routing-improvement.md
+++ b/cli-rs/resources/kast-skill/references/routing-improvement.md
@@ -1,20 +1,21 @@
 # Kast routing improvement
 
-The packaged skill, `references/commands.json`, `references/requests/`, and
-`fixtures/maintenance/evals/routing.json` are the canonical shipped routing
-surface for the Kast skill. Validate routing cases against
+The installed skill entrypoint, source catalog, and
+`fixtures/maintenance/evals/routing.json` are the canonical routing surface for
+the Kast skill. Validate routing cases against
 `fixtures/maintenance/evals/routing.schema.json`. Keep positive cases centered
 on the public agent surface: `expectedPrimitive.name` should be `kast`,
-`allowedActions` should name catalog methods, named tools, packaged scripts, or
-`kast agent` / `kast inspect metrics` commands, and `forbiddenActions` should
-cover generic Kotlin tools such as `grep`, `rg`, and generic file reads.
+`allowedActions` should name `kast agent ...` commands, and
+`forbiddenActions` should cover generic Kotlin tools such as `grep`, `rg`, and
+generic file reads.
 Negative over-trigger cases should set `expectedPrimitive.name` to `none`, use
 only generic allowed actions, and forbid Kast semantic actions that should not
 run for unrelated work.
 
-Keep session exports, benchmark runs, generated candidate corpora, and any
-local routing-analysis tools outside the installed skill tree unless a release
-intentionally promotes sanitized outputs to a shipped reference.
+Keep session exports, benchmark runs, generated candidate corpora, source-only
+catalog fixtures, and any local routing-analysis tools outside the installed
+skill tree unless a release intentionally promotes sanitized output into
+`SKILL.md`.
 
 The package smoke tests validate the checked corpus against the catalog and
 agent tool metadata so promoted cases cannot drift away from the public

--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -32,7 +32,6 @@ use std::thread;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-static KAST_SKILL: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/resources/kast-skill");
 static KAST_INSTRUCTIONS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/resources/kast-instructions");
 static COPILOT_PLUGIN: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/resources/plugin");
 const KAST_FORMULA_NAME: &str = "kast";

--- a/cli-rs/src/install/embedded_resources.rs
+++ b/cli-rs/src/install/embedded_resources.rs
@@ -11,6 +11,11 @@ enum ResourceReplaceMode {
     ManagedFilesOnly,
 }
 
+const THIN_SKILL_OUTPUTS: &[&str] = &["SKILL.md"];
+const THIN_INSTRUCTION_OUTPUTS: &[&str] = &["README.md", "cli.md", "tools.md", "lsp.md"];
+const RETIRED_SKILL_PACKAGE_OUTPUTS: &[&str] = &["AGENTS.md", "fixtures", "references", "scripts"];
+const RETIRED_INSTRUCTION_OUTPUTS: &[&str] = &["AGENTS.md", "rpc.md"];
+
 #[derive(Debug)]
 struct EmbeddedResourceInstallOutcome {
     skipped: bool,
@@ -38,8 +43,8 @@ fn install_embedded_resource(
         .collect::<Vec<_>>();
     let outputs_match = resource_outputs_match(target, files)?;
     let markers_present = retired_marker_paths.iter().any(|path| path.exists());
-    let retired_outputs_present = matches!(kind, ManagedResourceKind::CopilotPackage)
-        && retired_copilot_package_outputs_present(target);
+    let retired_outputs_present = retired_resource_outputs_present(kind, target);
+    let manifest_managed = manifest_has_resource(kind, target)?;
     if !force && outputs_match && !markers_present && !retired_outputs_present {
         return Ok(EmbeddedResourceInstallOutcome {
             skipped: true,
@@ -49,8 +54,26 @@ fn install_embedded_resource(
         });
     }
 
-    let manifest_managed = manifest_has_resource(kind, target)?;
     let retired_marker_managed = markers_present;
+    if target.exists()
+        && !force
+        && retired_outputs_present
+        && matches!(
+            kind,
+            ManagedResourceKind::Skill | ManagedResourceKind::Instructions
+        )
+        && !manifest_managed
+        && !retired_marker_managed
+    {
+        return Err(CliError::new(
+            "INSTALL_TARGET_EXISTS",
+            format!(
+                "{} contains unmanaged retired Kast {} files. Pass --force to replace them.",
+                target.display(),
+                kind
+            ),
+        ));
+    }
     if target.exists()
         && !force
         && !outputs_match
@@ -106,6 +129,69 @@ fn resource_install_files(
         Some(source_dir) => filesystem_resource_files(source_dir),
         None => embedded_dir_resource_files(embedded_dir),
     }
+}
+
+fn thin_skill_install_files(
+    source_dir: Option<&Path>,
+) -> Result<Vec<EmbeddedResourceFile>> {
+    let files = match source_dir {
+        Some(source_dir) => filesystem_resource_files(source_dir).map(|files| {
+            filter_resource_install_files(files, |relative| {
+                relative_matches_any(relative, THIN_SKILL_OUTPUTS)
+            })
+        })?,
+        None => vec![EmbeddedResourceFile {
+            relative: PathBuf::from("SKILL.md"),
+            contents: include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/resources/kast-skill/SKILL.md"
+            ))
+            .to_vec(),
+            executable: false,
+        }],
+    };
+    require_resource_outputs(files, THIN_SKILL_OUTPUTS)
+}
+
+fn thin_instruction_install_files(
+    source_dir: Option<&Path>,
+    embedded_dir: &'static Dir<'static>,
+) -> Result<Vec<EmbeddedResourceFile>> {
+    let files = resource_install_files(source_dir, embedded_dir).map(|files| {
+        filter_resource_install_files(files, |relative| {
+            relative_matches_any(relative, THIN_INSTRUCTION_OUTPUTS)
+        })
+    })?;
+    require_resource_outputs(files, THIN_INSTRUCTION_OUTPUTS)
+}
+
+fn filter_resource_install_files(
+    files: Vec<EmbeddedResourceFile>,
+    include: impl Fn(&Path) -> bool,
+) -> Vec<EmbeddedResourceFile> {
+    files
+        .into_iter()
+        .filter(|file| include(&file.relative))
+        .collect()
+}
+
+fn relative_matches_any(path: &Path, candidates: &[&str]) -> bool {
+    candidates.iter().any(|candidate| path == Path::new(candidate))
+}
+
+fn require_resource_outputs(
+    files: Vec<EmbeddedResourceFile>,
+    required: &[&str],
+) -> Result<Vec<EmbeddedResourceFile>> {
+    for relative in required {
+        if !files.iter().any(|file| file.relative == Path::new(relative)) {
+            return Err(CliError::new(
+                "RESOURCE_SOURCE_INCOMPLETE",
+                format!("Resource source is missing required installed file: {relative}"),
+            ));
+        }
+    }
+    Ok(files)
 }
 
 fn filesystem_resource_files(source_dir: &Path) -> Result<Vec<EmbeddedResourceFile>> {
@@ -318,6 +404,19 @@ fn retired_copilot_package_outputs_present(github_dir: &Path) -> bool {
     RETIRED_COPILOT_PACKAGE_OUTPUTS
         .iter()
         .any(|relative| github_dir.join(relative).exists())
+}
+
+fn retired_resource_outputs_present(kind: ManagedResourceKind, target: &Path) -> bool {
+    match kind {
+        ManagedResourceKind::CopilotPackage => retired_copilot_package_outputs_present(target),
+        ManagedResourceKind::Skill => RETIRED_SKILL_PACKAGE_OUTPUTS
+            .iter()
+            .any(|relative| target.join(relative).exists()),
+        ManagedResourceKind::Instructions => RETIRED_INSTRUCTION_OUTPUTS
+            .iter()
+            .any(|relative| target.join(relative).exists()),
+        ManagedResourceKind::AgentGuidance => false,
+    }
 }
 
 fn record_managed_resource(

--- a/cli-rs/src/install/resource_installs.rs
+++ b/cli-rs/src/install/resource_installs.rs
@@ -8,7 +8,7 @@ pub fn install_skill(args: ResourceInstallArgs) -> Result<InstallSkillResult> {
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| "kast".to_string());
     let target = target_root.join(name);
-    let files = resource_install_files(args.source_dir.as_deref(), &KAST_SKILL)?;
+    let files = thin_skill_install_files(args.source_dir.as_deref())?;
     let outcome = install_embedded_resource(
         ManagedResourceKind::Skill,
         &target,
@@ -55,7 +55,7 @@ pub fn install_instructions(args: ResourceInstallArgs) -> Result<InstallInstruct
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| "kast".to_string());
     let target = target_root.join(name);
-    let files = resource_install_files(args.source_dir.as_deref(), &KAST_INSTRUCTIONS)?;
+    let files = thin_instruction_install_files(args.source_dir.as_deref(), &KAST_INSTRUCTIONS)?;
     let outcome = install_embedded_resource(
         ManagedResourceKind::Instructions,
         &target,

--- a/cli-rs/src/install/tests.rs
+++ b/cli-rs/src/install/tests.rs
@@ -37,8 +37,8 @@ mod tests {
         assert!(temp.path().join("kast/README.md").is_file());
         assert!(temp.path().join("kast/cli.md").is_file());
         assert!(temp.path().join("kast/tools.md").is_file());
-        assert!(temp.path().join("kast/rpc.md").is_file());
         assert!(temp.path().join("kast/lsp.md").is_file());
+        assert!(!temp.path().join("kast/rpc.md").exists());
         assert!(!temp.path().join("kast/.kast-version").exists());
         let second = install_instructions(args).unwrap();
         assert!(second.skipped);

--- a/cli-rs/tests/agent_target_detection_smoke.rs
+++ b/cli-rs/tests/agent_target_detection_smoke.rs
@@ -113,7 +113,8 @@ agentHarness = "skill"
         expected_codex_skill.display().to_string()
     );
     assert!(codex_skills.join("kast/SKILL.md").is_file());
-    assert!(codex_skills.join("kast/references/commands.json").is_file());
+    assert!(!codex_skills.join("kast/references").exists());
+    assert!(!codex_skills.join("kast/scripts").exists());
 
     let up = kast(&home, &config_home)
         .current_dir(&workspace)
@@ -277,11 +278,8 @@ fn explicit_host_skill_target_is_manifest_backed_outside_workspace_repo() {
         .expect("canonical installed host skill");
     assert_eq!(installed_at, expected_host_skill);
     assert!(expected_host_skill.join("SKILL.md").is_file());
-    assert!(
-        expected_host_skill
-            .join("references/commands.json")
-            .is_file()
-    );
+    assert!(!expected_host_skill.join("references").exists());
+    assert!(!expected_host_skill.join("scripts").exists());
 
     let verifier = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("resources/kast-skill/scripts/verify-kast-state.py");
@@ -345,6 +343,8 @@ fn agent_setup_skill_can_override_packaged_skill_source() {
     std::fs::create_dir_all(&config_home).expect("config home");
     std::fs::create_dir_all(&workspace).expect("workspace");
     std::fs::create_dir_all(source_root.join("references")).expect("source references");
+    std::fs::create_dir_all(source_root.join("fixtures/maintenance/evals"))
+        .expect("source eval fixtures");
     std::fs::create_dir_all(source_root.join("scripts/__pycache__")).expect("source cache");
     std::fs::write(source_root.join("SKILL.md"), "override skill\n").expect("source skill");
     std::fs::write(
@@ -352,6 +352,11 @@ fn agent_setup_skill_can_override_packaged_skill_source() {
         r#"{"commands":{}}"#,
     )
     .expect("source commands");
+    std::fs::write(
+        source_root.join("fixtures/maintenance/evals/routing.json"),
+        r#"{"cases":[]}"#,
+    )
+    .expect("source routing eval");
     std::fs::write(source_root.join(".kast-version"), "retired marker\n").expect("source marker");
     std::fs::write(
         source_root.join("scripts/helper.py"),
@@ -391,14 +396,10 @@ fn agent_setup_skill_can_override_packaged_skill_source() {
         std::fs::read_to_string(installed.join("SKILL.md")).expect("installed skill"),
         "override skill\n"
     );
-    assert_eq!(
-        std::fs::read_to_string(installed.join("references/commands.json"))
-            .expect("installed commands"),
-        r#"{"commands":{}}"#
-    );
-    assert!(installed.join("scripts/helper.py").is_file());
+    assert!(!installed.join("references").exists());
+    assert!(!installed.join("fixtures").exists());
+    assert!(!installed.join("scripts").exists());
     assert!(!installed.join(".kast-version").exists());
-    assert!(!installed.join("scripts/__pycache__").exists());
 }
 
 #[test]
@@ -459,7 +460,8 @@ fn codex_instruction_roots_are_first_class_agent_targets() {
     assert!(codex_instructions.join("kast/README.md").is_file());
     assert!(codex_instructions.join("kast/cli.md").is_file());
     assert!(codex_instructions.join("kast/tools.md").is_file());
-    assert!(codex_instructions.join("kast/rpc.md").is_file());
+    assert!(codex_instructions.join("kast/lsp.md").is_file());
+    assert!(!codex_instructions.join("kast/rpc.md").exists());
 
     let up = kast(&home, &config_home)
         .current_dir(&workspace)

--- a/cli-rs/tests/cli_core_smoke.rs
+++ b/cli-rs/tests/cli_core_smoke.rs
@@ -316,26 +316,10 @@ fn smoke_core_cli_commands() {
         .expect("install skill");
     assert!(skill.status.success());
     assert!(skill_dir.join("kast/SKILL.md").is_file());
-    assert!(skill_dir.join("kast/references/commands.json").is_file());
-    assert!(skill_dir.join("kast/references/quickstart.md").is_file());
-    assert!(skill_dir.join("kast/references/runbook.md").is_file());
-    assert!(skill_dir.join("kast/references/workflows.md").is_file());
-    assert!(
-        skill_dir
-            .join("kast/scripts/verify-kast-state.py")
-            .is_file()
-    );
-    assert!(skill_dir.join("kast/scripts/kast-agent-call.py").is_file());
-    assert!(
-        !skill_dir
-            .join("kast/scripts/kast-semantic-workflow.py")
-            .exists()
-    );
-    assert!(
-        skill_dir
-            .join("kast/references/requests/symbol/query/request.schema.json")
-            .is_file()
-    );
+    assert!(!skill_dir.join("kast/AGENTS.md").exists());
+    assert!(!skill_dir.join("kast/references").exists());
+    assert!(!skill_dir.join("kast/scripts").exists());
+
     let instructions_dir = temp.path().join("instructions");
     let instructions = kast(&home, &config_home)
         .args([
@@ -352,8 +336,8 @@ fn smoke_core_cli_commands() {
     assert!(instructions_dir.join("kast/README.md").is_file());
     assert!(instructions_dir.join("kast/cli.md").is_file());
     assert!(instructions_dir.join("kast/tools.md").is_file());
-    assert!(instructions_dir.join("kast/rpc.md").is_file());
     assert!(instructions_dir.join("kast/lsp.md").is_file());
+    assert!(!instructions_dir.join("kast/rpc.md").exists());
 
     let github_dir = temp.path().join(".github");
     let copilot = kast(&home, &config_home)

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -29,134 +29,60 @@ fn assert_no_local_paths(value: &Value, label: &str) {
 }
 
 #[test]
-fn packaged_skill_targets_rust_kast_only() {
+fn packaged_skill_teaches_kast_agent_as_exclusive_route() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let skill = std::fs::read_to_string(root.join("resources/kast-skill/SKILL.md"))
         .expect("packaged skill");
-    let quickstart =
-        std::fs::read_to_string(root.join("resources/kast-skill/references/quickstart.md"))
-            .expect("packaged skill quickstart");
-    let workflows =
-        std::fs::read_to_string(root.join("resources/kast-skill/references/workflows.md"))
-            .expect("packaged skill workflows");
-    let routing_reference = std::fs::read_to_string(
-        root.join("resources/kast-skill/references/routing-improvement.md"),
-    )
-    .expect("routing reference");
-    let instruction_cli = std::fs::read_to_string(root.join("resources/kast-instructions/cli.md"))
-        .expect("portable CLI instructions");
-    let instruction_tools =
-        std::fs::read_to_string(root.join("resources/kast-instructions/tools.md"))
-            .expect("portable tool instructions");
-    let instruction_rpc = std::fs::read_to_string(root.join("resources/kast-instructions/rpc.md"))
-        .expect("portable RPC instructions");
 
-    assert!(skill.contains("Rust `kast` CLI"));
-    assert!(skill.contains("command -v kast"));
-    assert!(skill.contains("kast agent --help"));
-    assert!(skill.contains("kast agent tools"));
-    assert!(skill.contains("kast agent workflow --help"));
-    assert!(skill.contains("scripts/verify-kast-state.py"));
-    assert!(skill.contains("scripts/kast-agent-call.py"));
-    assert!(!skill.contains("scripts/kast-semantic-workflow.py"));
-    assert!(skill.contains("kast agent workflow ..."));
-    assert!(skill.contains("Use for Gradle project file work"));
-    assert!(skill.contains("assume the binary installed it"));
-    assert!(skill.contains("`kast` directly"));
-    assert!(skill.contains("active binary are incompatible"));
-    assert!(skill.contains("project file operations"));
-    assert!(skill.contains("Use Kast to discover the owning module"));
-    assert!(skill.contains("when the path is not already exact"));
-    assert!(skill.contains("Unknown symbol"));
-    assert!(skill.contains("symbol/query"));
-    assert!(skill.contains("raw/workspace-files"));
-    assert!(skill.contains("includeFiles=false"));
-    assert!(skill.contains("kast inspect metrics fan-in"));
-    assert!(skill.contains("kast inspect demo"));
-    assert!(skill.contains("raw/type-hierarchy"));
-    assert!(skill.contains("raw/semantic-insertion-point"));
-    assert!(skill.contains("raw/completions"));
-    assert!(skill.contains("raw/apply-edits"));
-    assert!(skill.contains("kast runtime up --workspace-root \"$PWD\" --backend idea"));
-    assert!(quickstart.contains("command -v kast"));
-    assert!(quickstart.contains("kast agent --help"));
-    assert!(quickstart.contains("kast agent tools"));
-    assert!(quickstart.contains("kast agent workflow --help"));
-    assert!(quickstart.contains("kast agent call"));
-    assert!(quickstart.contains("result.invocation.argv"));
-    assert!(quickstart.contains("schemaVersion >= 3"));
-    assert!(quickstart.contains("matching `toolCount`"));
-    assert!(quickstart.contains("scripts/verify-kast-state.py"));
-    assert!(quickstart.contains("scripts/kast-agent-call.py"));
-    assert!(!quickstart.contains("scripts/kast-semantic-workflow.py"));
-    assert!(quickstart.contains("active binary are incompatible"));
-    assert!(quickstart.contains("incompatible. Upgrade or reinstall Kast"));
-    assert!(quickstart.contains("raw transport/debug escape hatch"));
-    assert!(quickstart.contains("kast inspect metrics impact"));
-    assert!(quickstart.contains("kast inspect demo"));
-    assert!(quickstart.contains("INDEX_UNAVAILABLE"));
-    assert!(quickstart.contains("kast runtime up --workspace-root \"$PWD\" --backend idea"));
-    assert!(quickstart.contains("follow its recovery commands exactly"));
-    assert!(quickstart.contains("preserve the selected executable token"));
-    assert!(quickstart.contains("--skill-target-dir"));
-    assert!(quickstart.contains("--instructions-target-dir"));
-    assert!(workflows.contains("Execute recovery commands exactly as emitted"));
-    assert!(workflows.contains("selected executable token"));
-    assert!(workflows.contains("--copilot-target-dir"));
-    assert!(workflows.contains("--skill-target-dir"));
-    assert!(workflows.contains("--instructions-target-dir"));
-    assert!(workflows.contains("nextCommandArgv"));
-    assert!(routing_reference.contains("fixtures/maintenance/evals/routing.json"));
-    assert!(routing_reference.contains("fixtures/maintenance/evals/routing.schema.json"));
-    assert!(routing_reference.contains("allowedActions"));
-    assert!(instruction_cli.contains("kast agent tools"));
-    assert!(instruction_cli.contains("kast agent workflow --help"));
-    assert!(instruction_cli.contains("stale instruction/binary install"));
-    assert!(instruction_cli.contains("every `.kt` and `.kts` file"));
-    assert!(instruction_cli.contains("Do not invoke Kast for unrelated docs/text work"));
-    assert!(instruction_tools.contains("kast agent tools"));
-    assert!(instruction_tools.contains("--copilot-target-dir"));
-    assert!(instruction_tools.contains("nextCommandArgv"));
-    assert!(instruction_tools.contains("result.invocation.argv"));
-    assert!(instruction_tools.contains("schemaVersion >= 3"));
-    assert!(instruction_tools.contains("matching `toolCount`"));
-    assert!(instruction_tools.contains("Keep using Kast after the first successful call"));
-    assert!(instruction_rpc.contains("kast agent tools"));
-    assert!(instruction_rpc.contains("catalog-backed tool names"));
-    assert!(instruction_rpc.contains("result.invocation.argv"));
-    assert!(instruction_rpc.contains("schemaVersion >= 3"));
-    assert!(instruction_rpc.contains("matching `toolCount`"));
-    assert!(
-        root.join("resources/kast-skill/references/workflows.md")
-            .is_file(),
-        "packaged skill must include workflow ownership reference"
-    );
-    assert!(
-        root.join("resources/kast-skill/fixtures/maintenance/evals/routing.schema.json")
-            .is_file(),
-        "packaged skill must include a schema for routing evals"
-    );
-    assert!(
-        root.join("resources/kast-skill/scripts/verify-kast-state.py")
-            .is_file(),
-        "packaged skill must include state verifier"
-    );
-    assert!(
-        root.join("resources/kast-skill/scripts/kast-agent-call.py")
-            .is_file(),
-        "packaged skill must include file-backed call harness"
-    );
-    assert!(
-        !root
-            .join("resources/kast-skill/scripts/kast-semantic-workflow.py")
-            .exists(),
-        "semantic workflow runner must live in the active kast binary"
-    );
+    for required in [
+        "Use when working on Kotlin or Gradle semantics",
+        "Route all Kast work through",
+        "`kast agent ...` is the only first-class Kast",
+        "Do not use raw transport",
+        "If the active binary lacks",
+        "require upgrade or reinstall",
+        "do not replace the missing compiler-backed path with text search",
+        "Route to the narrowest Kotlin-aware `kast agent` surface",
+        "Keep using `kast agent` after the first successful call",
+        "Normal installed use loads only `SKILL.md`",
+        "Discover method schemas",
+        "Do not pre-load the full source catalog",
+        "Use direct `kast agent` subcommands first",
+        "`kast agent workflow ...`",
+        "`kast agent call <method>`",
+        "`kast agent tools`",
+        "`kast agent workflow --help`",
+        "`kast agent scaffold`",
+        "`kast agent file-outline`",
+        "`kast agent discover`",
+        "`kast agent resolve`",
+        "`kast agent references`",
+        "`kast agent callers`",
+        "`kast agent metrics`",
+        "`kast agent workflow impact`",
+        "`kast agent raw-diagnostics`",
+        "`kast agent workspace-search`",
+        "workflow package-verify",
+        "Use ordinary file tools for exact non-Kotlin",
+    ] {
+        assert!(
+            skill.contains(required),
+            "packaged skill should teach {required}"
+        );
+    }
 
-    assert!(
-        root.join("resources/plugin/lsp.json").is_file(),
-        "packaged Copilot LSP plugin source must live under cli-rs/resources/plugin"
-    );
+    for forbidden in [
+        "kast rpc",
+        "capabilities.experimental.kastMethods",
+        "scripts/verify-kast-state.py",
+        "scripts/kast-agent-call.py",
+        "scripts/kast-semantic-workflow.py",
+    ] {
+        assert!(
+            !skill.contains(forbidden),
+            "packaged skill should not teach {forbidden}"
+        );
+    }
 }
 
 #[test]
@@ -174,8 +100,6 @@ fn repo_local_copilot_plugin_content_is_generated_not_tracked() {
 #[test]
 fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let skill = std::fs::read_to_string(root.join("resources/kast-skill/SKILL.md"))
-        .expect("packaged skill");
     let routing_eval_path =
         root.join("resources/kast-skill/fixtures/maintenance/evals/routing.json");
     let routing_eval: Value = serde_json::from_str(
@@ -194,16 +118,6 @@ fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
     routing_validator
         .validate(&routing_eval)
         .unwrap_or_else(|error| panic!("routing eval schema validation failed: {error}"));
-    let catalog: Value = serde_json::from_str(include_str!(
-        "../resources/kast-skill/references/commands.json"
-    ))
-    .expect("commands catalog");
-    let commands = catalog["commands"].as_object().expect("catalog commands");
-    let tool_names = commands
-        .values()
-        .filter_map(|command| command.get("tool"))
-        .map(|tool| tool["name"].as_str().expect("tool name"))
-        .collect::<BTreeSet<_>>();
     let cases = routing_eval["cases"]
         .as_array()
         .expect("routing eval cases");
@@ -281,44 +195,21 @@ fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
             let name = action["name"].as_str().expect("action name");
             match kind {
                 "method" => {
-                    let command = commands.get(name).unwrap_or_else(|| {
-                        panic!("eval case {} references missing method {name}", case["id"])
-                    });
-                    if matches!(
-                        name,
-                        "symbol/query"
-                            | "symbol/scaffold"
-                            | "symbol/resolve"
-                            | "symbol/references"
-                            | "symbol/callers"
-                            | "database/metrics"
-                            | "raw/file-outline"
-                    ) {
-                        assert!(
-                            command.get("tool").is_some(),
-                            "eval case {} expects {name} to be available through agent tools",
-                            case["id"]
-                        );
-                    }
+                    panic!(
+                        "eval case {} should name a kast agent command instead of method {name}",
+                        case["id"]
+                    );
                 }
                 "tool" => {
-                    assert!(
-                        tool_names.contains(name),
-                        "eval case {} references missing tool {name}",
+                    panic!(
+                        "eval case {} should name a kast agent command instead of tool {name}",
                         case["id"]
                     );
                 }
                 "command" => {
                     assert!(
-                        name.starts_with("kast agent") || name.starts_with("kast inspect metrics"),
-                        "eval case {} should use public Kast commands, got {name}",
-                        case["id"]
-                    );
-                }
-                "script" => {
-                    assert!(
-                        root.join("resources/kast-skill").join(name).is_file(),
-                        "eval case {} references missing packaged script {name}",
+                        name.starts_with("kast agent"),
+                        "eval case {} should use kast agent commands, got {name}",
                         case["id"]
                     );
                 }
@@ -344,13 +235,17 @@ fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
         })
         .collect::<BTreeSet<_>>();
     for required in [
-        "symbol/query",
-        "symbol/callers",
-        "database/metrics",
+        "kast agent scaffold",
+        "kast agent file-outline",
+        "kast agent call symbol/query",
+        "kast agent references",
+        "kast agent callers",
+        "kast agent raw-diagnostics",
+        "kast agent call database/metrics",
         "kast agent workflow diagnostics",
+        "kast agent workflow package-verify",
         "kast agent setup skill --source-dir",
         "kast agent tools",
-        "scripts/verify-kast-state.py",
     ] {
         assert!(
             action_names.contains(required),
@@ -368,6 +263,7 @@ fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
         })
         .collect::<BTreeSet<_>>();
     for required in [
+        "kast rpc",
         "generated protocol endpoints",
         "capabilities.experimental.kastMethods",
     ] {
@@ -376,29 +272,4 @@ fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
             "routing eval should reject public API leak {required}"
         );
     }
-
-    assert!(
-        (skill.contains(".kt") || skill.contains("`.kt`"))
-            && (skill.contains(".kts") || skill.contains("`.kts`")),
-        "skill trigger text must explicitly cover Kotlin source and script files"
-    );
-    assert!(
-        skill.contains("only navigation surface"),
-        "skill should state that Kast can be the sole navigation surface"
-    );
-    assert!(
-        !skill.contains("/rpc/") && !skill.contains("capabilities.experimental.kastMethods"),
-        "skill must not teach generated protocol endpoints or LSP internals as the public API"
-    );
-    assert!(
-        skill.contains("Keep using Kast after the first successful call")
-            && skill.contains("A first Kast result is not a handoff back to generic file reads"),
-        "skill should keep follow-up Kotlin work on Kast after initial pickup"
-    );
-    assert!(
-        skill.contains("Normal use loads only SKILL.md")
-            && skill.contains("Do not pre-load the full catalog")
-            && skill.contains("Load `references/runbook.md` only"),
-        "skill should route reference loading by need"
-    );
 }

--- a/cli-rs/tests/resource_install_gateway_smoke.rs
+++ b/cli-rs/tests/resource_install_gateway_smoke.rs
@@ -121,8 +121,8 @@ fn install_resource_gateways_support_force_and_current_versions() {
     assert!(stale_instructions.join("README.md").is_file());
     assert!(stale_instructions.join("cli.md").is_file());
     assert!(stale_instructions.join("tools.md").is_file());
-    assert!(stale_instructions.join("rpc.md").is_file());
     assert!(stale_instructions.join("lsp.md").is_file());
+    assert!(!stale_instructions.join("rpc.md").exists());
     assert_eq!(
         instructions_stdout["sourceBundleSha256"]
             .as_str()


### PR DESCRIPTION
## Summary
- keep consumer Kast skill installs to the SKILL.md entrypoint instead of embedding/installing the full skill source tree
- preserve routing evals as source-side validation and update routing checks around kast agent commands
- update install/resource tests for thin skill and instruction payloads

## Validation
- cargo test --manifest-path cli-rs/Cargo.toml install_skill --locked
- cargo test --manifest-path cli-rs/Cargo.toml --test agent_target_detection_smoke agent_setup_skill_can_override_packaged_skill_source --locked
- cargo test --manifest-path cli-rs/Cargo.toml --test resource_install_gateway_smoke --locked
- cargo test --manifest-path cli-rs/Cargo.toml --test packaged_content_smoke --locked
- .github/scripts/test-kast-routing-evals.sh
- node --check .github/plugin-eval/kast-routing/emit-kast-routing-metrics.mjs
- git diff --cached --check
- plugin-eval analyze cli-rs/resources/kast-skill/SKILL.md --format markdown

## Risk
- plugin-eval still reports deferred source-tree budget because it counts source-only catalog/eval/helper files; consumer installs now avoid embedding and installing those files.