### PR TITLE
[codex] Score TOON format impact answers

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -70,5 +70,5 @@ For terminal onboarding and executable command examples, run:
 
 For plugin-eval metric pack changes, run the script that owns the changed pack,
 such as `.github/scripts/test-kast-routing-evals.sh` for routing checks or
-`.github/scripts/run-kast-format-impact-report.sh` for the report-only TOON
-format impact pack.
+`.github/scripts/run-kast-format-impact-report.sh` for the TOON format impact,
+answer-request capture, and optional scored-answer pack.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -67,3 +67,8 @@ For terminal onboarding and executable command examples, run:
 ```console
 .github/scripts/test-terminal-onboarding-contract.sh
 ```
+
+For plugin-eval metric pack changes, run the script that owns the changed pack,
+such as `.github/scripts/test-kast-routing-evals.sh` for routing checks or
+`.github/scripts/run-kast-format-impact-report.sh` for the report-only TOON
+format impact pack.

--- a/.github/plugin-eval/kast-format-impact/emit-kast-format-impact-metrics.mjs
+++ b/.github/plugin-eval/kast-format-impact/emit-kast-format-impact-metrics.mjs
@@ -106,6 +106,8 @@ for (const item of cases) {
   failIf(JSON.stringify(item.pairedFormats) !== JSON.stringify(corpus.formats), `${item.id}: pairedFormats must match corpus formats`, caseFailures);
   failIf(item.reportOnly !== true, `${item.id}: live accuracy cases must stay report-only`, caseFailures);
   failIf(!Array.isArray(item.goldFacts) || item.goldFacts.length < 2, `${item.id}: goldFacts needs at least two entries`, caseFailures);
+  failIf(!Array.isArray(item.answerScoring?.requiredTerms) || item.answerScoring.requiredTerms.length < 1, `${item.id}: answerScoring.requiredTerms needs at least one entry`, caseFailures);
+  failIf(!Array.isArray(item.answerScoring?.forbiddenTerms), `${item.id}: answerScoring.forbiddenTerms must be present`, caseFailures);
   failIf(!isPositiveCase(item) && !isNegativeCase(item), `${item.id}: expectedPrimitive must be kast or none`, caseFailures);
 
   const forbidden = new Set(item.forbiddenActions ?? []);
@@ -124,7 +126,7 @@ checks.push(
     caseFailures.length === 0 ? "pass" : "fail",
     caseFailures.length === 0 ? "info" : "error",
     caseFailures.length === 0
-      ? "Every format impact case is paired, report-only, and has gold facts plus forbidden-action expectations."
+      ? "Every format impact case is paired, report-only, and has gold facts, forbidden-action expectations, plus deterministic answer scoring terms."
       : "One or more format impact cases are incomplete.",
     caseFailures.length === 0 ? cases.map((item) => `${item.id}:${item.scenario}`) : caseFailures,
     ["Keep JSON/TOON case pairs explicit and report-only until live accuracy thresholds stabilize."],
@@ -143,7 +145,6 @@ for (const record of observedRecords) {
   if (!recordsByCase.has(key)) recordsByCase.set(key, []);
   recordsByCase.get(key).push(record);
   failIf(record.decodedEquivalent !== true, `${record.caseId}/${record.format}: decodedEquivalent must be true`, observedFailures);
-  failIf((record.forbiddenHits ?? []).length > 0, `${record.caseId}/${record.format}: forbidden hits ${record.forbiddenHits.join(", ")}`, observedFailures);
 }
 for (const item of cases) {
   const records = recordsByCase.get(item.id) ?? [];
@@ -168,6 +169,49 @@ checks.push(
   ),
 );
 
+const evaluated = observedRecords.filter((record) => record.answerVerdict && record.answerVerdict !== "not_evaluated");
+const answerFailures = [];
+const missingAnswerRecords = [];
+for (const record of observedRecords) {
+  if (!record.answerVerdict || record.answerVerdict === "not_evaluated") {
+    missingAnswerRecords.push(`${record.caseId}/${record.format}`);
+    continue;
+  }
+  if (record.answerVerdict !== "pass") {
+    const missing = (record.missingRequiredTerms ?? []).join(", ");
+    const forbidden = (record.forbiddenHits ?? []).join(", ");
+    answerFailures.push(`${record.caseId}/${record.format}: missing=[${missing}] forbidden=[${forbidden}]`);
+  }
+}
+const answerPassCount = evaluated.filter((record) => record.answerVerdict === "pass").length;
+const answerPassRate = evaluated.length > 0 ? Math.round((answerPassCount / evaluated.length) * 10000) / 100 : 0;
+let answerStatus = "warn";
+let answerSeverity = "warning";
+let answerMessage = "No captured answers were supplied; answer accuracy remains unmeasured.";
+let answerEvidence = missingAnswerRecords.length > 0 ? missingAnswerRecords : ["records=0"];
+if (evaluated.length > 0 && answerFailures.length === 0 && missingAnswerRecords.length === 0) {
+  answerStatus = "pass";
+  answerSeverity = "info";
+  answerMessage = "Captured answers satisfy every required term and avoid forbidden actions.";
+  answerEvidence = [`answers=${evaluated.length}`, `passRate=${answerPassRate}`];
+} else if (evaluated.length > 0 && answerFailures.length === 0) {
+  answerMessage = "Captured answer scoring is partial; some JSON/TOON pairs were not supplied.";
+  answerEvidence = missingAnswerRecords;
+} else if (answerFailures.length > 0) {
+  answerMessage = "Captured answers missed required terms or used forbidden actions.";
+  answerEvidence = answerFailures;
+}
+checks.push(
+  check(
+    "format-impact-answer-scoring",
+    answerStatus,
+    answerSeverity,
+    answerMessage,
+    answerEvidence,
+    ["Generate answers from cli-rs/target/format-impact/answer-requests.jsonl and set KAST_FORMAT_IMPACT_ANSWERS_JSONL before rerunning the report."],
+  ),
+);
+
 const jsonBytes = observedRecords
   .filter((record) => record.format === "json")
   .reduce((sum, record) => sum + (record.stdoutBytes ?? 0), 0);
@@ -175,7 +219,6 @@ const toonBytes = observedRecords
   .filter((record) => record.format === "toon")
   .reduce((sum, record) => sum + (record.stdoutBytes ?? 0), 0);
 const byteReduction = jsonBytes > 0 ? Math.round(((jsonBytes - toonBytes) / jsonBytes) * 10000) / 100 : 0;
-const evaluated = observedRecords.filter((record) => record.answerVerdict && record.answerVerdict !== "not_evaluated");
 const passCount = checks.filter((item) => item.status === "pass").length;
 const score = Math.round((passCount / checks.length) * 100);
 
@@ -189,6 +232,8 @@ console.log(
         metric("kast-format-impact-observed-records", observedRecords.length, "records", observedRecords.length >= cases.length * 2 ? "good" : "report-only"),
         metric("kast-format-impact-byte-reduction", byteReduction, "percent", byteReduction > 0 ? "good" : "unmeasured"),
         metric("kast-format-impact-live-answers", evaluated.length, "records", evaluated.length > 0 ? "measured" : "report-only"),
+        metric("kast-format-impact-answer-pass-rate", answerPassRate, "percent", evaluated.length > 0 ? answerPassRate === 100 ? "excellent" : answerPassRate >= 85 ? "good" : "needs-work" : "unmeasured"),
+        metric("kast-format-impact-answer-failures", answerFailures.length, "records", answerFailures.length === 0 ? "good" : "needs-work"),
       ],
       artifacts: [
         {
@@ -201,7 +246,13 @@ console.log(
           id: "kast-format-impact-observed-jsonl",
           type: "jsonl",
           label: "Kast TOON format impact observed records",
-          description: "Report-only paired JSON/TOON fixture records and optional live-agent verdicts.",
+          description: "Paired JSON/TOON fixture records with optional captured-answer verdicts.",
+        },
+        {
+          id: "kast-format-impact-answer-requests",
+          type: "jsonl",
+          label: "Kast TOON format impact answer requests",
+          description: "Prompt and input rows to feed an external agent/model runner before scoring captured answers.",
         },
       ],
     },

--- a/.github/plugin-eval/kast-format-impact/emit-kast-format-impact-metrics.mjs
+++ b/.github/plugin-eval/kast-format-impact/emit-kast-format-impact-metrics.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const [, , rawTargetPath] = process.argv;
+const manifestDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(manifestDir, "../../..");
+const targetPath = rawTargetPath ? resolve(rawTargetPath) : join(repoRoot, "cli-rs/resources/kast-skill");
+const observedPath = process.env.KAST_FORMAT_IMPACT_OBSERVED_JSONL
+  ? resolve(process.env.KAST_FORMAT_IMPACT_OBSERVED_JSONL)
+  : null;
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function readJsonl(path) {
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function check(id, status, severity, message, evidence = [], remediation = []) {
+  return {
+    id,
+    category: "kast-format-impact",
+    severity,
+    status,
+    message,
+    evidence,
+    remediation,
+  };
+}
+
+function metric(id, value, unit, band) {
+  return {
+    id,
+    category: "kast-format-impact",
+    value,
+    unit,
+    band,
+  };
+}
+
+function failIf(condition, message, failures) {
+  if (condition) failures.push(message);
+}
+
+function isPositiveCase(item) {
+  return item.expectedPrimitive?.type === "skill" && item.expectedPrimitive?.name === "kast";
+}
+
+function isNegativeCase(item) {
+  return item.expectedPrimitive?.type === "none" && item.expectedPrimitive?.name === "none";
+}
+
+const corpus = readJson(join(targetPath, "fixtures/maintenance/evals/format-impact.json"));
+const schema = readJson(join(targetPath, "fixtures/maintenance/evals/format-impact.schema.json"));
+const cases = Array.isArray(corpus.cases) ? corpus.cases : [];
+const checks = [];
+
+const schemaFailures = [];
+failIf(corpus.$schema !== "./format-impact.schema.json", "format impact corpus must link ./format-impact.schema.json", schemaFailures);
+failIf(corpus.schemaVersion !== 1, "format impact corpus schemaVersion must be 1", schemaFailures);
+failIf(JSON.stringify(corpus.formats) !== JSON.stringify(["json", "toon"]), "format impact corpus formats must be [json, toon]", schemaFailures);
+failIf(schema.properties?.cases?.items?.$ref !== "#/$defs/case", "format impact schema must define typed case items", schemaFailures);
+checks.push(
+  check(
+    "format-impact-schema-backed",
+    schemaFailures.length === 0 ? "pass" : "fail",
+    schemaFailures.length === 0 ? "info" : "error",
+    schemaFailures.length === 0 ? "Format impact corpus is schema-backed." : "Format impact corpus schema contract failed.",
+    schemaFailures.length === 0 ? [corpus.$schema] : schemaFailures,
+    ["Keep format-impact.json linked to format-impact.schema.json with schemaVersion 1."],
+  ),
+);
+
+const requiredCaseIds = new Set([
+  "tool-catalog-comprehension",
+  "symbol-result-extraction",
+  "relationship-navigation-continuation",
+  "validation-error-recovery",
+  "workflow-evidence-json-artifacts",
+  "non-kotlin-negative-routing",
+  "large-read-only-catalog-efficiency",
+]);
+const caseIds = new Set(cases.map((item) => item.id));
+const missingCaseIds = [...requiredCaseIds].filter((id) => !caseIds.has(id));
+checks.push(
+  check(
+    "format-impact-required-cases",
+    missingCaseIds.length === 0 ? "pass" : "fail",
+    missingCaseIds.length === 0 ? "info" : "error",
+    missingCaseIds.length === 0
+      ? "Format impact corpus covers catalog comprehension, extraction, relationship continuation, validation recovery, workflow evidence, negative routing, and large read-only output."
+      : "Format impact corpus is missing required coverage cases.",
+    missingCaseIds.length === 0 ? [...caseIds].sort() : missingCaseIds,
+    ["Add missing cases to fixtures/maintenance/evals/format-impact.json."],
+  ),
+);
+
+const caseFailures = [];
+for (const item of cases) {
+  failIf(JSON.stringify(item.pairedFormats) !== JSON.stringify(corpus.formats), `${item.id}: pairedFormats must match corpus formats`, caseFailures);
+  failIf(item.reportOnly !== true, `${item.id}: live accuracy cases must stay report-only`, caseFailures);
+  failIf(!Array.isArray(item.goldFacts) || item.goldFacts.length < 2, `${item.id}: goldFacts needs at least two entries`, caseFailures);
+  failIf(!isPositiveCase(item) && !isNegativeCase(item), `${item.id}: expectedPrimitive must be kast or none`, caseFailures);
+
+  const forbidden = new Set(item.forbiddenActions ?? []);
+  if (isPositiveCase(item)) {
+    failIf(!forbidden.has("grep"), `${item.id}: positive case must forbid grep`, caseFailures);
+    failIf(!forbidden.has("rg"), `${item.id}: positive case must forbid rg`, caseFailures);
+  }
+  if (isNegativeCase(item)) {
+    failIf(!(item.expectedActions ?? []).every((action) => action.kind === "generic"), `${item.id}: negative expected actions must be generic`, caseFailures);
+    failIf(!forbidden.has("kast agent call"), `${item.id}: negative case must forbid kast agent call`, caseFailures);
+  }
+}
+checks.push(
+  check(
+    "format-impact-case-evidence",
+    caseFailures.length === 0 ? "pass" : "fail",
+    caseFailures.length === 0 ? "info" : "error",
+    caseFailures.length === 0
+      ? "Every format impact case is paired, report-only, and has gold facts plus forbidden-action expectations."
+      : "One or more format impact cases are incomplete.",
+    caseFailures.length === 0 ? cases.map((item) => `${item.id}:${item.scenario}`) : caseFailures,
+    ["Keep JSON/TOON case pairs explicit and report-only until live accuracy thresholds stabilize."],
+  ),
+);
+
+let observedRecords = [];
+if (observedPath) {
+  observedRecords = readJsonl(observedPath);
+}
+
+const observedFailures = [];
+const recordsByCase = new Map();
+for (const record of observedRecords) {
+  const key = record.caseId;
+  if (!recordsByCase.has(key)) recordsByCase.set(key, []);
+  recordsByCase.get(key).push(record);
+  failIf(record.decodedEquivalent !== true, `${record.caseId}/${record.format}: decodedEquivalent must be true`, observedFailures);
+  failIf((record.forbiddenHits ?? []).length > 0, `${record.caseId}/${record.format}: forbidden hits ${record.forbiddenHits.join(", ")}`, observedFailures);
+}
+for (const item of cases) {
+  const records = recordsByCase.get(item.id) ?? [];
+  if (observedPath) {
+    const formats = new Set(records.map((record) => record.format));
+    failIf(!formats.has("json"), `${item.id}: missing json observed record`, observedFailures);
+    failIf(!formats.has("toon"), `${item.id}: missing toon observed record`, observedFailures);
+  }
+}
+checks.push(
+  check(
+    "format-impact-observed-pairs",
+    observedFailures.length === 0 ? "pass" : "fail",
+    observedFailures.length === 0 ? "info" : "error",
+    observedPath
+      ? observedFailures.length === 0
+        ? "Observed JSONL includes complete JSON/TOON pairs with decoded-equivalent records."
+        : "Observed JSONL has incomplete pairs or semantic mismatches."
+      : "No observed JSONL supplied; live accuracy remains report-only and unmeasured.",
+    observedFailures.length === 0 ? [`records=${observedRecords.length}`] : observedFailures,
+    ["Run .github/scripts/run-kast-format-impact-report.sh to generate observed JSONL."],
+  ),
+);
+
+const jsonBytes = observedRecords
+  .filter((record) => record.format === "json")
+  .reduce((sum, record) => sum + (record.stdoutBytes ?? 0), 0);
+const toonBytes = observedRecords
+  .filter((record) => record.format === "toon")
+  .reduce((sum, record) => sum + (record.stdoutBytes ?? 0), 0);
+const byteReduction = jsonBytes > 0 ? Math.round(((jsonBytes - toonBytes) / jsonBytes) * 10000) / 100 : 0;
+const evaluated = observedRecords.filter((record) => record.answerVerdict && record.answerVerdict !== "not_evaluated");
+const passCount = checks.filter((item) => item.status === "pass").length;
+const score = Math.round((passCount / checks.length) * 100);
+
+console.log(
+  JSON.stringify(
+    {
+      checks,
+      metrics: [
+        metric("kast-format-impact-score", score, "percent", score === 100 ? "excellent" : score >= 85 ? "good" : "needs-work"),
+        metric("kast-format-impact-cases", cases.length, "cases", cases.length >= requiredCaseIds.size ? "good" : "needs-work"),
+        metric("kast-format-impact-observed-records", observedRecords.length, "records", observedRecords.length >= cases.length * 2 ? "good" : "report-only"),
+        metric("kast-format-impact-byte-reduction", byteReduction, "percent", byteReduction > 0 ? "good" : "unmeasured"),
+        metric("kast-format-impact-live-answers", evaluated.length, "records", evaluated.length > 0 ? "measured" : "report-only"),
+      ],
+      artifacts: [
+        {
+          id: "kast-format-impact-corpus",
+          type: "json",
+          label: "Kast TOON format impact corpus",
+          description: "Paired JSON versus TOON cases for agent output comprehension and cost checks.",
+        },
+        {
+          id: "kast-format-impact-observed-jsonl",
+          type: "jsonl",
+          label: "Kast TOON format impact observed records",
+          description: "Report-only paired JSON/TOON fixture records and optional live-agent verdicts.",
+        },
+      ],
+    },
+    null,
+    2,
+  ),
+);

--- a/.github/plugin-eval/kast-format-impact/manifest.json
+++ b/.github/plugin-eval/kast-format-impact/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "kast-format-impact",
+  "version": "1.0.0",
+  "supportedTargetKinds": [
+    "skill",
+    "directory"
+  ],
+  "command": [
+    "node",
+    "./emit-kast-format-impact-metrics.mjs"
+  ]
+}

--- a/.github/scripts/run-kast-format-impact-report.sh
+++ b/.github/scripts/run-kast-format-impact-report.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1 && pwd)"
+target="${repo_root}/cli-rs/resources/kast-skill"
+metric_pack_dir="${repo_root}/.github/plugin-eval/kast-format-impact"
+report_dir="${repo_root}/cli-rs/target/format-impact"
+observed_jsonl="${report_dir}/observed.jsonl"
+summary_json="${report_dir}/summary.json"
+
+mkdir -p "$report_dir"
+
+if [[ -n "${KAST_BIN:-}" ]]; then
+  kast_bin="${KAST_BIN}"
+else
+  cargo build --manifest-path "${repo_root}/cli-rs/Cargo.toml" --bin kast --locked
+  kast_bin="${repo_root}/cli-rs/target/debug/kast"
+fi
+
+cargo run \
+  --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
+  --locked \
+  --example format_impact_report \
+  -- \
+  --kast-bin "$kast_bin" \
+  --target "$target" \
+  --output "$observed_jsonl" \
+  >"$summary_json"
+
+KAST_FORMAT_IMPACT_OBSERVED_JSONL="$observed_jsonl" \
+  node "${metric_pack_dir}/emit-kast-format-impact-metrics.mjs" "$target" skill
+
+printf 'Kast format impact report written: %s\n' "$observed_jsonl"
+printf 'Kast format impact summary written: %s\n' "$summary_json"

--- a/.github/scripts/run-kast-format-impact-report.sh
+++ b/.github/scripts/run-kast-format-impact-report.sh
@@ -6,6 +6,7 @@ target="${repo_root}/cli-rs/resources/kast-skill"
 metric_pack_dir="${repo_root}/.github/plugin-eval/kast-format-impact"
 report_dir="${repo_root}/cli-rs/target/format-impact"
 observed_jsonl="${report_dir}/observed.jsonl"
+answer_requests_jsonl="${report_dir}/answer-requests.jsonl"
 summary_json="${report_dir}/summary.json"
 
 mkdir -p "$report_dir"
@@ -17,6 +18,11 @@ else
   kast_bin="${repo_root}/cli-rs/target/debug/kast"
 fi
 
+answer_args=()
+if [[ -n "${KAST_FORMAT_IMPACT_ANSWERS_JSONL:-}" ]]; then
+  answer_args+=(--answers "$KAST_FORMAT_IMPACT_ANSWERS_JSONL")
+fi
+
 cargo run \
   --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
   --locked \
@@ -25,10 +31,13 @@ cargo run \
   --kast-bin "$kast_bin" \
   --target "$target" \
   --output "$observed_jsonl" \
+  --answer-requests "$answer_requests_jsonl" \
+  "${answer_args[@]}" \
   >"$summary_json"
 
 KAST_FORMAT_IMPACT_OBSERVED_JSONL="$observed_jsonl" \
   node "${metric_pack_dir}/emit-kast-format-impact-metrics.mjs" "$target" skill
 
 printf 'Kast format impact report written: %s\n' "$observed_jsonl"
+printf 'Kast format impact answer requests written: %s\n' "$answer_requests_jsonl"
 printf 'Kast format impact summary written: %s\n' "$summary_json"

--- a/.github/scripts/test-development-cli-install-contract.sh
+++ b/.github/scripts/test-development-cli-install-contract.sh
@@ -52,7 +52,7 @@ dev_cli="${install_bin_dir}/kast-dev"
 profile="${tmp_root}/zshrc"
 shell_install_json="${tmp_root}/shell-install.json"
 HOME="$home_dir" KAST_CONFIG_HOME="$config_home" \
-  "$dev_cli" --output json machine shell --shell zsh --profile "$profile" >"$shell_install_json"
+  "$dev_cli" --output json developer machine shell --shell zsh --profile "$profile" >"$shell_install_json"
 
 grep -Fq '"commandName": "kast-dev"' "$shell_install_json" \
   || die "install shell should target the kast-dev command name"
@@ -65,7 +65,7 @@ grep -Fq "# >>> kast shell integration >>>" "$profile" \
 source_file="$(sed -n 's/.*"sourceFile": "\(.*\)",/\1/p' "$shell_install_json" | head -1)"
 [[ -n "$source_file" && -f "$source_file" ]] \
   || die "install shell should write the managed source file"
-grep -Fq "kast-dev machine completion zsh --command-name kast-dev" "$source_file" \
+grep -Fq "kast-dev developer machine completion zsh --command-name kast-dev" "$source_file" \
   || die "managed shell source should route completion through machine completion"
 
 gradle_profile="${tmp_root}/gradle-zshrc"
@@ -82,7 +82,7 @@ HOME="$home_dir" \
 
 grep -Fq "# >>> kast shell integration >>>" "$gradle_profile" \
   || die "installDevelopmentShell should patch the requested profile"
-grep -Fq "kast-dev machine completion zsh --command-name kast-dev" "${config_home}/shell/kast-dev.zsh" \
+grep -Fq "kast-dev developer machine completion zsh --command-name kast-dev" "${config_home}/shell/kast-dev.zsh" \
   || die "installDevelopmentShell should route completions through kast-dev"
 
 plugins_dir="${tmp_root}/jetbrains/plugins"
@@ -113,6 +113,20 @@ HOME="$home_dir" \
   KAST_CONFIG_HOME="$config_home" \
   PATH="$restricted_path" \
   "${repo_root}/gradlew" -q help --task installDevelopmentLocal >/dev/null
+
+HOME="$home_dir" \
+  CARGO_HOME="$cargo_home" \
+  RUSTUP_HOME="$rustup_home" \
+  GRADLE_USER_HOME="$gradle_user_home" \
+  KAST_CONFIG_HOME="$config_home" \
+  KAST_BIN_DIR="$install_bin_dir" \
+  PATH="$restricted_path" \
+  "${repo_root}/gradlew" -q configureDevelopmentMachineDefaults
+
+grep -Fq 'defaultBackend = "idea"' "${config_home}/config.toml" \
+  || die "configureDevelopmentMachineDefaults should set the IDEA plugin backend as the developer default"
+grep -Fq 'enabled = true' "${config_home}/config.toml" \
+  || die "configureDevelopmentMachineDefaults should enable IDEA launch policy"
 
 bin_config_home="${tmp_root}/config-bin-dir"
 custom_bin_dir="${tmp_root}/custom-bin"

--- a/.github/scripts/test-docs-content-contract.sh
+++ b/.github/scripts/test-docs-content-contract.sh
@@ -152,7 +152,8 @@ require_contains "$install_doc" "headless-linux.md" "Install docs must link the 
 require_contains "$headless_doc" 'scripts/install-ubuntu-debian.sh' "Headless docs must document the canonical Linux installer"
 require_contains "$headless_doc" 'kast developer release package ubuntu-debian-bundle' "Headless docs must document the release bundle packager"
 
-require_contains "$quickstart_doc" "kast setup --backend=headless" "Quickstart must start or warm a backend through setup"
+require_contains "$quickstart_doc" "kast setup --no-open-ide" "Quickstart must start or warm the developer-machine backend through setup"
+require_contains "$quickstart_doc" "kast setup --backend=headless" "Quickstart must keep explicit headless setup for Linux hosts"
 require_contains "$quickstart_doc" "kast agent call raw/resolve" "Quickstart must use agent resolve"
 require_contains "$quickstart_doc" "kast agent call raw/references" "Quickstart must use agent references"
 require_contains "$quickstart_doc" "kast agent call raw/workspace-symbol" "Quickstart must show name-to-offset bridge"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -209,6 +209,7 @@ val installDevelopmentShell: TaskProvider<Exec> by tasks.registering(Exec::class
             kastDevBinary.absolutePath,
             "--output",
             "json",
+            "developer",
             "machine",
             "shell",
             "--shell",
@@ -216,6 +217,20 @@ val installDevelopmentShell: TaskProvider<Exec> by tasks.registering(Exec::class
             "--command-name",
             "kast-dev",
         ) + developmentShellProfileArg()
+    )
+}
+
+val configureDevelopmentMachineDefaults: TaskProvider<Exec> by tasks.registering(Exec::class) {
+    group = "distribution"
+    description = "Configures developer-machine defaults to use the IDEA plugin backend."
+    dependsOn("installDevelopmentCli")
+    commandLine(
+        kastDevBinary.absolutePath,
+        "--output",
+        "json",
+        "developer",
+        "machine",
+        "defaults",
     )
 }
 
@@ -314,5 +329,5 @@ val installDevelopmentIdeaPlugin: TaskProvider<InstallDevelopmentIdeaPluginTask>
 tasks.register("installDevelopmentLocal") {
     group = "distribution"
     description = "Installs kast-dev shell integration and replaces the local IDEA plugin with the development build."
-    dependsOn(installDevelopmentShell, installDevelopmentIdeaPlugin)
+    dependsOn(installDevelopmentShell, installDevelopmentIdeaPlugin, configureDevelopmentMachineDefaults)
 }

--- a/cli-rs/Cargo.lock
+++ b/cli-rs/Cargo.lock
@@ -1172,6 +1172,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
+ "toon-format",
  "uuid",
  "zip",
 ]
@@ -2000,6 +2001,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2448,6 +2450,18 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "toon-format"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f89570c1a68d73941f728cca32a4345b2ffca36667ad921af336c60309a3e7e"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "tracing"

--- a/cli-rs/Cargo.toml
+++ b/cli-rs/Cargo.toml
@@ -22,6 +22,7 @@ serde_yaml = "0.9"
 sha2 = "0.11"
 tar = "0.4"
 thiserror = "2.0"
+toon-format = { version = "0.5.0", default-features = false }
 toml = "1.1"
 uuid = { version = "1.18", features = ["v4"] }
 zip = { version = "6.0", default-features = false, features = ["deflate"] }

--- a/cli-rs/examples/format_impact_report.rs
+++ b/cli-rs/examples/format_impact_report.rs
@@ -1,0 +1,383 @@
+use std::error::Error;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Debug)]
+struct Args {
+    kast_bin: PathBuf,
+    target: PathBuf,
+    output: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct Corpus {
+    cases: Vec<ImpactCase>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ImpactCase {
+    id: String,
+    prompt: String,
+    input_artifact: InputArtifact,
+    gold_facts: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct InputArtifact {
+    kind: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ImpactRecord {
+    case_id: String,
+    format: String,
+    prompt: String,
+    observed_actions: Vec<String>,
+    forbidden_hits: Vec<String>,
+    extracted_facts: Vec<String>,
+    answer_verdict: String,
+    stdout_bytes: usize,
+    decoded_equivalent: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ImpactSummary {
+    ok: bool,
+    cases: usize,
+    records: usize,
+    decoded_equivalent: bool,
+    json_stdout_bytes: usize,
+    toon_stdout_bytes: usize,
+    byte_reduction_percent: Option<f64>,
+    answer_verdict: String,
+    output: PathBuf,
+}
+
+#[derive(Debug)]
+struct FormatOutput {
+    format: &'static str,
+    stdout_bytes: usize,
+    decoded: Value,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = parse_args()?;
+    let corpus = read_corpus(&args.target)?;
+    let run_root = make_run_root()?;
+    let mut records = Vec::new();
+
+    for case in &corpus.cases {
+        let outputs = outputs_for_case(&args.kast_bin, &run_root, case)?;
+        let decoded_equivalent = outputs
+            .first()
+            .zip(outputs.get(1))
+            .is_some_and(|(left, right)| left.decoded == right.decoded);
+        if !decoded_equivalent {
+            return Err(format!("decoded JSON and TOON differ for case {}", case.id).into());
+        }
+
+        for output in outputs {
+            records.push(ImpactRecord {
+                case_id: case.id.clone(),
+                format: output.format.to_string(),
+                prompt: case.prompt.clone(),
+                observed_actions: Vec::new(),
+                forbidden_hits: Vec::new(),
+                extracted_facts: extracted_facts(case, &output.decoded),
+                answer_verdict: "not_evaluated".to_string(),
+                stdout_bytes: output.stdout_bytes,
+                decoded_equivalent,
+            });
+        }
+    }
+
+    write_jsonl(&args.output, &records)?;
+    let summary = summarize(&records, args.output.clone());
+    println!("{}", serde_json::to_string_pretty(&summary)?);
+    let _ = fs::remove_dir_all(run_root);
+    Ok(())
+}
+
+fn parse_args() -> Result<Args, Box<dyn Error>> {
+    let mut kast_bin = None;
+    let mut target = None;
+    let mut output = None;
+    let mut raw = std::env::args().skip(1);
+
+    while let Some(arg) = raw.next() {
+        match arg.as_str() {
+            "--kast-bin" => kast_bin = raw.next().map(PathBuf::from),
+            "--target" => target = raw.next().map(PathBuf::from),
+            "--output" => output = raw.next().map(PathBuf::from),
+            other => return Err(format!("unexpected argument `{other}`").into()),
+        }
+    }
+
+    Ok(Args {
+        kast_bin: kast_bin.ok_or("missing --kast-bin")?,
+        target: target.unwrap_or_else(|| PathBuf::from("cli-rs/resources/kast-skill")),
+        output: output.ok_or("missing --output")?,
+    })
+}
+
+fn read_corpus(target: &Path) -> Result<Corpus, Box<dyn Error>> {
+    let path = target
+        .join("fixtures")
+        .join("maintenance")
+        .join("evals")
+        .join("format-impact.json");
+    let content = fs::read_to_string(&path)?;
+    Ok(serde_json::from_str(&content)?)
+}
+
+fn make_run_root() -> Result<PathBuf, Box<dyn Error>> {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let root =
+        std::env::temp_dir().join(format!("kast-format-impact-{}-{now}", std::process::id()));
+    fs::create_dir_all(root.join("home"))?;
+    fs::create_dir_all(root.join("config"))?;
+    Ok(root)
+}
+
+fn outputs_for_case(
+    kast_bin: &Path,
+    run_root: &Path,
+    case: &ImpactCase,
+) -> Result<Vec<FormatOutput>, Box<dyn Error>> {
+    match case.input_artifact.kind.as_str() {
+        "agent-tools" => command_outputs(
+            kast_bin,
+            run_root,
+            &["agent", "tools"],
+            &["agent", "--format", "toon", "tools"],
+        ),
+        "validation-error" => command_outputs(
+            kast_bin,
+            run_root,
+            &["agent", "call", "symbol/resolve"],
+            &["agent", "--format", "toon", "call", "symbol/resolve"],
+        ),
+        "workflow-dry-run" => {
+            let out_dir = run_root.join("workflow").join(&case.id);
+            let out_dir = out_dir.to_str().ok_or("workflow path must be utf-8")?;
+            command_outputs(
+                kast_bin,
+                run_root,
+                &[
+                    "agent",
+                    "workflow",
+                    "symbol",
+                    "--dry-run",
+                    "--out-dir",
+                    out_dir,
+                    "--symbol",
+                    "Kast",
+                    "--references",
+                ],
+                &[
+                    "agent",
+                    "--format",
+                    "toon",
+                    "workflow",
+                    "symbol",
+                    "--dry-run",
+                    "--out-dir",
+                    out_dir,
+                    "--symbol",
+                    "Kast",
+                    "--references",
+                ],
+            )
+        }
+        "synthetic-envelope" => synthetic_outputs(case),
+        "prompt-only" => Ok(vec![
+            FormatOutput {
+                format: "json",
+                stdout_bytes: 0,
+                decoded: Value::Null,
+            },
+            FormatOutput {
+                format: "toon",
+                stdout_bytes: 0,
+                decoded: Value::Null,
+            },
+        ]),
+        other => Err(format!("unsupported input artifact kind `{other}`").into()),
+    }
+}
+
+fn command_outputs(
+    kast_bin: &Path,
+    run_root: &Path,
+    json_args: &[&str],
+    toon_args: &[&str],
+) -> Result<Vec<FormatOutput>, Box<dyn Error>> {
+    let json_stdout = run_kast(kast_bin, run_root, json_args)?;
+    let toon_stdout = run_kast(kast_bin, run_root, toon_args)?;
+    let json_decoded = serde_json::from_slice(&json_stdout)?;
+    let toon_text = std::str::from_utf8(&toon_stdout)?;
+    let toon_decoded = toon_format::decode_default(toon_text.trim())?;
+
+    Ok(vec![
+        FormatOutput {
+            format: "json",
+            stdout_bytes: json_stdout.len(),
+            decoded: json_decoded,
+        },
+        FormatOutput {
+            format: "toon",
+            stdout_bytes: toon_stdout.len(),
+            decoded: toon_decoded,
+        },
+    ])
+}
+
+fn run_kast(kast_bin: &Path, run_root: &Path, args: &[&str]) -> Result<Vec<u8>, Box<dyn Error>> {
+    let output = Command::new(kast_bin)
+        .args(args)
+        .env("HOME", run_root.join("home"))
+        .env("KAST_CONFIG_HOME", run_root.join("config"))
+        .output()?;
+    if output.stdout.is_empty() {
+        return Err(format!(
+            "kast produced empty stdout for {:?}: status={}, stderr={}",
+            args,
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    Ok(output.stdout)
+}
+
+fn synthetic_outputs(case: &ImpactCase) -> Result<Vec<FormatOutput>, Box<dyn Error>> {
+    let value = synthetic_value(case);
+    let mut json_text = serde_json::to_string_pretty(&value)?;
+    json_text.push('\n');
+    let toon_text = toon_format::encode_default(&value)?;
+    let toon_decoded = toon_format::decode_default(toon_text.trim())?;
+
+    Ok(vec![
+        FormatOutput {
+            format: "json",
+            stdout_bytes: json_text.len(),
+            decoded: serde_json::from_str(&json_text)?,
+        },
+        FormatOutput {
+            format: "toon",
+            stdout_bytes: toon_text.len(),
+            decoded: toon_decoded,
+        },
+    ])
+}
+
+fn synthetic_value(case: &ImpactCase) -> Value {
+    json!({
+        "ok": true,
+        "method": "symbol/resolve",
+        "request": {
+            "method": "symbol/resolve",
+            "params": {
+                "symbol": "EventBean",
+                "kind": "class"
+            }
+        },
+        "result": {
+            "type": "SYMBOL_RESOLVE_SUCCESS",
+            "symbol": {
+                "name": "EventBean",
+                "kind": "CLASS",
+                "fqName": "com.example.EventBean",
+                "location": {
+                    "filePath": "src/main/kotlin/com/example/EventBean.kt",
+                    "offset": 128
+                }
+            },
+            "nextActions": if case.id.contains("relationship") {
+                json!(["symbol/references", "symbol/callers"])
+            } else {
+                json!(["symbol/scaffold"])
+            }
+        }
+    })
+}
+
+fn extracted_facts(case: &ImpactCase, decoded: &Value) -> Vec<String> {
+    if decoded.is_null() {
+        return case.gold_facts.clone();
+    }
+
+    let mut facts = Vec::new();
+    if let Some(method) = decoded.get("method").and_then(Value::as_str) {
+        facts.push(format!("method={method}"));
+    }
+    if let Some(result_type) = decoded.pointer("/result/type").and_then(Value::as_str) {
+        facts.push(format!("result.type={result_type}"));
+    }
+    if let Some(error_code) = decoded.pointer("/error/code").and_then(Value::as_str) {
+        facts.push(format!("error.code={error_code}"));
+    }
+    if let Some(symbol) = decoded
+        .pointer("/result/symbol/name")
+        .and_then(Value::as_str)
+    {
+        facts.push(format!("symbol.name={symbol}"));
+    }
+    if facts.is_empty() {
+        facts.extend(case.gold_facts.iter().take(2).cloned());
+    }
+    facts
+}
+
+fn write_jsonl(path: &Path, records: &[ImpactRecord]) -> Result<(), Box<dyn Error>> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = File::create(path)?;
+    for record in records {
+        writeln!(file, "{}", serde_json::to_string(record)?)?;
+    }
+    Ok(())
+}
+
+fn summarize(records: &[ImpactRecord], output: PathBuf) -> ImpactSummary {
+    let json_stdout_bytes = records
+        .iter()
+        .filter(|record| record.format == "json")
+        .map(|record| record.stdout_bytes)
+        .sum::<usize>();
+    let toon_stdout_bytes = records
+        .iter()
+        .filter(|record| record.format == "toon")
+        .map(|record| record.stdout_bytes)
+        .sum::<usize>();
+    let byte_reduction_percent = if json_stdout_bytes > 0 {
+        Some(
+            ((json_stdout_bytes as f64 - toon_stdout_bytes as f64) / json_stdout_bytes as f64)
+                * 100.0,
+        )
+    } else {
+        None
+    };
+
+    ImpactSummary {
+        ok: true,
+        cases: records.len() / 2,
+        records: records.len(),
+        decoded_equivalent: records.iter().all(|record| record.decoded_equivalent),
+        json_stdout_bytes,
+        toon_stdout_bytes,
+        byte_reduction_percent,
+        answer_verdict: "not_evaluated".to_string(),
+        output,
+    }
+}

--- a/cli-rs/examples/format_impact_report.rs
+++ b/cli-rs/examples/format_impact_report.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fs::{self, File};
 use std::io::Write;
@@ -13,6 +14,8 @@ struct Args {
     kast_bin: PathBuf,
     target: PathBuf,
     output: PathBuf,
+    answer_requests: Option<PathBuf>,
+    answers: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -26,12 +29,50 @@ struct ImpactCase {
     id: String,
     prompt: String,
     input_artifact: InputArtifact,
+    expected_actions: Vec<Action>,
+    forbidden_actions: Vec<String>,
     gold_facts: Vec<String>,
+    answer_scoring: AnswerScoring,
 }
 
 #[derive(Debug, Deserialize)]
 struct InputArtifact {
     kind: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct Action {
+    kind: String,
+    name: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AnswerScoring {
+    required_terms: Vec<String>,
+    forbidden_terms: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AnswerRecord {
+    case_id: String,
+    format: String,
+    answer: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AnswerRequest {
+    case_id: String,
+    format: String,
+    prompt: String,
+    input: String,
+    input_bytes: usize,
+    expected_actions: Vec<Action>,
+    forbidden_actions: Vec<String>,
+    gold_facts: Vec<String>,
+    answer_scoring: AnswerScoring,
 }
 
 #[derive(Debug, Serialize)]
@@ -42,8 +83,14 @@ struct ImpactRecord {
     prompt: String,
     observed_actions: Vec<String>,
     forbidden_hits: Vec<String>,
+    matched_required_terms: Vec<String>,
+    missing_required_terms: Vec<String>,
     extracted_facts: Vec<String>,
     answer_verdict: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    answer_score: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    answer: Option<String>,
     stdout_bytes: usize,
     decoded_equivalent: bool,
 }
@@ -59,21 +106,43 @@ struct ImpactSummary {
     toon_stdout_bytes: usize,
     byte_reduction_percent: Option<f64>,
     answer_verdict: String,
+    evaluated_answers: usize,
+    passing_answers: usize,
+    answer_accuracy_percent: Option<f64>,
     output: PathBuf,
+    answer_requests: Option<PathBuf>,
+    answers: Option<PathBuf>,
 }
 
 #[derive(Debug)]
 struct FormatOutput {
     format: &'static str,
     stdout_bytes: usize,
+    text: String,
     decoded: Value,
+}
+
+#[derive(Debug)]
+struct AnswerScore {
+    observed_actions: Vec<String>,
+    forbidden_hits: Vec<String>,
+    matched_required_terms: Vec<String>,
+    missing_required_terms: Vec<String>,
+    score: f64,
+    verdict: &'static str,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
     let corpus = read_corpus(&args.target)?;
+    let answers = match &args.answers {
+        Some(path) => read_answer_records(path)?,
+        None => BTreeMap::new(),
+    };
+    validate_answer_records(&corpus, &answers)?;
     let run_root = make_run_root()?;
     let mut records = Vec::new();
+    let mut answer_requests = Vec::new();
 
     for case in &corpus.cases {
         let outputs = outputs_for_case(&args.kast_bin, &run_root, case)?;
@@ -86,14 +155,38 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
 
         for output in outputs {
+            let answer = answers
+                .get(&(case.id.clone(), output.format.to_string()))
+                .cloned();
+            let answer_score = answer.as_deref().map(|answer| score_answer(case, answer));
+            answer_requests.push(answer_request(case, &output));
             records.push(ImpactRecord {
                 case_id: case.id.clone(),
                 format: output.format.to_string(),
                 prompt: case.prompt.clone(),
-                observed_actions: Vec::new(),
-                forbidden_hits: Vec::new(),
+                observed_actions: answer_score
+                    .as_ref()
+                    .map(|score| score.observed_actions.clone())
+                    .unwrap_or_default(),
+                forbidden_hits: answer_score
+                    .as_ref()
+                    .map(|score| score.forbidden_hits.clone())
+                    .unwrap_or_default(),
+                matched_required_terms: answer_score
+                    .as_ref()
+                    .map(|score| score.matched_required_terms.clone())
+                    .unwrap_or_default(),
+                missing_required_terms: answer_score
+                    .as_ref()
+                    .map(|score| score.missing_required_terms.clone())
+                    .unwrap_or_default(),
                 extracted_facts: extracted_facts(case, &output.decoded),
-                answer_verdict: "not_evaluated".to_string(),
+                answer_verdict: answer_score
+                    .as_ref()
+                    .map(|score| score.verdict.to_string())
+                    .unwrap_or_else(|| "not_evaluated".to_string()),
+                answer_score: answer_score.as_ref().map(|score| score.score),
+                answer,
                 stdout_bytes: output.stdout_bytes,
                 decoded_equivalent,
             });
@@ -101,7 +194,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     write_jsonl(&args.output, &records)?;
-    let summary = summarize(&records, args.output.clone());
+    if let Some(path) = &args.answer_requests {
+        write_jsonl(path, &answer_requests)?;
+    }
+    let summary = summarize(
+        &records,
+        args.output.clone(),
+        args.answer_requests.clone(),
+        args.answers.clone(),
+    );
     println!("{}", serde_json::to_string_pretty(&summary)?);
     let _ = fs::remove_dir_all(run_root);
     Ok(())
@@ -111,6 +212,8 @@ fn parse_args() -> Result<Args, Box<dyn Error>> {
     let mut kast_bin = None;
     let mut target = None;
     let mut output = None;
+    let mut answer_requests = None;
+    let mut answers = None;
     let mut raw = std::env::args().skip(1);
 
     while let Some(arg) = raw.next() {
@@ -118,6 +221,8 @@ fn parse_args() -> Result<Args, Box<dyn Error>> {
             "--kast-bin" => kast_bin = raw.next().map(PathBuf::from),
             "--target" => target = raw.next().map(PathBuf::from),
             "--output" => output = raw.next().map(PathBuf::from),
+            "--answer-requests" => answer_requests = raw.next().map(PathBuf::from),
+            "--answers" => answers = raw.next().map(PathBuf::from),
             other => return Err(format!("unexpected argument `{other}`").into()),
         }
     }
@@ -126,6 +231,8 @@ fn parse_args() -> Result<Args, Box<dyn Error>> {
         kast_bin: kast_bin.ok_or("missing --kast-bin")?,
         target: target.unwrap_or_else(|| PathBuf::from("cli-rs/resources/kast-skill")),
         output: output.ok_or("missing --output")?,
+        answer_requests,
+        answers,
     })
 }
 
@@ -137,6 +244,51 @@ fn read_corpus(target: &Path) -> Result<Corpus, Box<dyn Error>> {
         .join("format-impact.json");
     let content = fs::read_to_string(&path)?;
     Ok(serde_json::from_str(&content)?)
+}
+
+fn read_answer_records(path: &Path) -> Result<BTreeMap<(String, String), String>, Box<dyn Error>> {
+    let content = fs::read_to_string(path)?;
+    let mut answers = BTreeMap::new();
+    for (index, line) in content.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: AnswerRecord = serde_json::from_str(line)
+            .map_err(|error| format!("{}:{}: {error}", path.display(), index + 1))?;
+        let key = (record.case_id, record.format);
+        if answers.insert(key.clone(), record.answer).is_some() {
+            return Err(format!(
+                "{}:{}: duplicate answer for {}/{}",
+                path.display(),
+                index + 1,
+                key.0,
+                key.1
+            )
+            .into());
+        }
+    }
+    Ok(answers)
+}
+
+fn validate_answer_records(
+    corpus: &Corpus,
+    answers: &BTreeMap<(String, String), String>,
+) -> Result<(), Box<dyn Error>> {
+    let expected_keys = corpus
+        .cases
+        .iter()
+        .flat_map(|case| ["json", "toon"].map(move |format| (case.id.clone(), format.to_string())))
+        .collect::<BTreeSet<_>>();
+    for key in answers.keys() {
+        if !expected_keys.contains(key) {
+            return Err(format!(
+                "answer supplied for unknown case/format {}/{}",
+                key.0, key.1
+            )
+            .into());
+        }
+    }
+    Ok(())
 }
 
 fn make_run_root() -> Result<PathBuf, Box<dyn Error>> {
@@ -203,11 +355,13 @@ fn outputs_for_case(
             FormatOutput {
                 format: "json",
                 stdout_bytes: 0,
+                text: String::new(),
                 decoded: Value::Null,
             },
             FormatOutput {
                 format: "toon",
                 stdout_bytes: 0,
+                text: String::new(),
                 decoded: Value::Null,
             },
         ]),
@@ -224,18 +378,23 @@ fn command_outputs(
     let json_stdout = run_kast(kast_bin, run_root, json_args)?;
     let toon_stdout = run_kast(kast_bin, run_root, toon_args)?;
     let json_decoded = serde_json::from_slice(&json_stdout)?;
-    let toon_text = std::str::from_utf8(&toon_stdout)?;
+    let json_stdout_bytes = json_stdout.len();
+    let json_text = String::from_utf8(json_stdout)?;
+    let toon_stdout_bytes = toon_stdout.len();
+    let toon_text = String::from_utf8(toon_stdout)?;
     let toon_decoded = toon_format::decode_default(toon_text.trim())?;
 
     Ok(vec![
         FormatOutput {
             format: "json",
-            stdout_bytes: json_stdout.len(),
+            stdout_bytes: json_stdout_bytes,
+            text: json_text,
             decoded: json_decoded,
         },
         FormatOutput {
             format: "toon",
-            stdout_bytes: toon_stdout.len(),
+            stdout_bytes: toon_stdout_bytes,
+            text: toon_text,
             decoded: toon_decoded,
         },
     ])
@@ -265,16 +424,19 @@ fn synthetic_outputs(case: &ImpactCase) -> Result<Vec<FormatOutput>, Box<dyn Err
     json_text.push('\n');
     let toon_text = toon_format::encode_default(&value)?;
     let toon_decoded = toon_format::decode_default(toon_text.trim())?;
+    let json_decoded = serde_json::from_str(&json_text)?;
 
     Ok(vec![
         FormatOutput {
             format: "json",
             stdout_bytes: json_text.len(),
-            decoded: serde_json::from_str(&json_text)?,
+            text: json_text,
+            decoded: json_decoded,
         },
         FormatOutput {
             format: "toon",
             stdout_bytes: toon_text.len(),
+            text: toon_text,
             decoded: toon_decoded,
         },
     ])
@@ -338,7 +500,93 @@ fn extracted_facts(case: &ImpactCase, decoded: &Value) -> Vec<String> {
     facts
 }
 
-fn write_jsonl(path: &Path, records: &[ImpactRecord]) -> Result<(), Box<dyn Error>> {
+fn answer_request(case: &ImpactCase, output: &FormatOutput) -> AnswerRequest {
+    AnswerRequest {
+        case_id: case.id.clone(),
+        format: output.format.to_string(),
+        prompt: case.prompt.clone(),
+        input: output.text.clone(),
+        input_bytes: output.stdout_bytes,
+        expected_actions: case.expected_actions.clone(),
+        forbidden_actions: case.forbidden_actions.clone(),
+        gold_facts: case.gold_facts.clone(),
+        answer_scoring: case.answer_scoring.clone(),
+    }
+}
+
+fn score_answer(case: &ImpactCase, answer: &str) -> AnswerScore {
+    let matched_required_terms = case
+        .answer_scoring
+        .required_terms
+        .iter()
+        .filter(|term| contains_term(answer, term))
+        .cloned()
+        .collect::<Vec<_>>();
+    let missing_required_terms = case
+        .answer_scoring
+        .required_terms
+        .iter()
+        .filter(|term| !contains_term(answer, term))
+        .cloned()
+        .collect::<Vec<_>>();
+    let forbidden_hits = case
+        .answer_scoring
+        .forbidden_terms
+        .iter()
+        .filter(|term| contains_term(answer, term))
+        .cloned()
+        .collect::<Vec<_>>();
+    let observed_actions = case
+        .expected_actions
+        .iter()
+        .filter(|action| contains_term(answer, &action.name))
+        .map(|action| action.name.clone())
+        .collect::<Vec<_>>();
+    let required_score = if case.answer_scoring.required_terms.is_empty() {
+        100.0
+    } else {
+        (matched_required_terms.len() as f64 / case.answer_scoring.required_terms.len() as f64)
+            * 100.0
+    };
+    let score = if forbidden_hits.is_empty() {
+        required_score
+    } else {
+        0.0
+    };
+    let verdict = if missing_required_terms.is_empty() && forbidden_hits.is_empty() {
+        "pass"
+    } else {
+        "fail"
+    };
+
+    AnswerScore {
+        observed_actions,
+        forbidden_hits,
+        matched_required_terms,
+        missing_required_terms,
+        score,
+        verdict,
+    }
+}
+
+fn contains_term(answer: &str, term: &str) -> bool {
+    let answer = answer.to_ascii_lowercase();
+    let term = term.to_ascii_lowercase();
+    if is_token_term(&term) {
+        return answer
+            .split(|character: char| !character.is_ascii_alphanumeric())
+            .any(|token| token == term);
+    }
+    answer.contains(&term)
+}
+
+fn is_token_term(term: &str) -> bool {
+    term.chars()
+        .all(|character| character.is_ascii_alphanumeric())
+        && term.len() <= 4
+}
+
+fn write_jsonl<T: Serialize>(path: &Path, records: &[T]) -> Result<(), Box<dyn Error>> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -349,7 +597,12 @@ fn write_jsonl(path: &Path, records: &[ImpactRecord]) -> Result<(), Box<dyn Erro
     Ok(())
 }
 
-fn summarize(records: &[ImpactRecord], output: PathBuf) -> ImpactSummary {
+fn summarize(
+    records: &[ImpactRecord],
+    output: PathBuf,
+    answer_requests: Option<PathBuf>,
+    answers: Option<PathBuf>,
+) -> ImpactSummary {
     let json_stdout_bytes = records
         .iter()
         .filter(|record| record.format == "json")
@@ -368,6 +621,28 @@ fn summarize(records: &[ImpactRecord], output: PathBuf) -> ImpactSummary {
     } else {
         None
     };
+    let evaluated_answers = records
+        .iter()
+        .filter(|record| record.answer_verdict != "not_evaluated")
+        .count();
+    let passing_answers = records
+        .iter()
+        .filter(|record| record.answer_verdict == "pass")
+        .count();
+    let answer_accuracy_percent = if evaluated_answers > 0 {
+        Some((passing_answers as f64 / evaluated_answers as f64) * 100.0)
+    } else {
+        None
+    };
+    let answer_verdict = if evaluated_answers == 0 {
+        "not_evaluated"
+    } else if passing_answers == evaluated_answers {
+        "pass"
+    } else if passing_answers == 0 {
+        "fail"
+    } else {
+        "partial"
+    };
 
     ImpactSummary {
         ok: true,
@@ -377,7 +652,12 @@ fn summarize(records: &[ImpactRecord], output: PathBuf) -> ImpactSummary {
         json_stdout_bytes,
         toon_stdout_bytes,
         byte_reduction_percent,
-        answer_verdict: "not_evaluated".to_string(),
+        answer_verdict: answer_verdict.to_string(),
+        evaluated_answers,
+        passing_answers,
+        answer_accuracy_percent,
         output,
+        answer_requests,
+        answers,
     }
 }

--- a/cli-rs/resources/kast-skill/AGENTS.md
+++ b/cli-rs/resources/kast-skill/AGENTS.md
@@ -59,6 +59,7 @@ Run the catalog and docs checks after catalog changes:
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- release generate contract --check
 python3 .github/scripts/render-rpc-contract-summary.py --check
 .github/scripts/test-kast-routing-evals.sh
+.github/scripts/run-kast-format-impact-report.sh
 .github/scripts/test-kast-copilot-plugin.sh
 .github/scripts/test-lsp-pivot-gates.sh
 ```

--- a/cli-rs/resources/kast-skill/SKILL.md
+++ b/cli-rs/resources/kast-skill/SKILL.md
@@ -18,8 +18,9 @@ first-class path.
 
 1. Use `kast agent workflow ...` when a workflow fits, or `kast agent call <method>` for the narrowest single catalog method.
 2. Keep nontrivial params in a JSON file and pass `--params-file`; use `kast agent tools` only when exact fields, variants, or mutation metadata are needed.
-3. Stay on `kast agent` after the first successful call. Switch to generic file reads or text search only when the work leaves Kotlin semantics or Kast reports a concrete blocker.
-4. Mutate through `kast agent` for semantic or compiler-owned targets, then validate with Kast diagnostics/workflows and the narrowest Gradle task.
+3. Keep response output JSON by default; use `--format toon` only for large read-only outputs when the host can consume TOON.
+4. Stay on `kast agent` after the first successful call. Switch to generic file reads or text search only when the work leaves Kotlin semantics or Kast reports a concrete blocker.
+5. Mutate through `kast agent` for semantic or compiler-owned targets, then validate with Kast diagnostics/workflows and the narrowest Gradle task.
 
 Completion criterion: every Kotlin semantic claim, edit target, relationship set, and completion proof is backed by `kast agent` evidence, or the remaining work is an exact non-Kotlin path.
 

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/evals/format-impact.json
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/evals/format-impact.json
@@ -40,6 +40,19 @@
         "The result type is KAST_AGENT_TOOLS.",
         "The selected route is symbol/query, not text search."
       ],
+      "answerScoring": {
+        "requiredTerms": [
+          "agent/tools",
+          "KAST_AGENT_TOOLS",
+          "symbol/query"
+        ],
+        "forbiddenTerms": [
+          "grep",
+          "rg",
+          "workspace file dump",
+          "manual package inference"
+        ]
+      },
       "metrics": [
         "routeAccuracy",
         "fieldAccuracy",
@@ -82,6 +95,20 @@
         "The declaration is EventBean.",
         "The file path must be read from result data, not inferred from the package name."
       ],
+      "answerScoring": {
+        "requiredTerms": [
+          "symbol/resolve",
+          "EventBean",
+          "src/main/kotlin/com/example/EventBean.kt",
+          "symbol/scaffold"
+        ],
+        "forbiddenTerms": [
+          "grep",
+          "rg",
+          "invented response fields",
+          "generic file read before Kast"
+        ]
+      },
       "metrics": [
         "fieldAccuracy",
         "answerVerdict",
@@ -127,6 +154,19 @@
         "The action must preserve the resolved symbol identity.",
         "Text matching is not an acceptable replacement."
       ],
+      "answerScoring": {
+        "requiredTerms": [
+          "EventBean",
+          "symbol/references",
+          "symbol/callers"
+        ],
+        "forbiddenTerms": [
+          "grep",
+          "rg",
+          "textual call graph",
+          "unresolved name matching"
+        ]
+      },
       "metrics": [
         "routeAccuracy",
         "fieldAccuracy",
@@ -168,6 +208,20 @@
         "Request params remain JSON even when stdout was TOON.",
         "The retry method remains symbol/resolve."
       ],
+      "answerScoring": {
+        "requiredTerms": [
+          "AGENT_REQUEST_INVALID",
+          "JSON",
+          "symbol/resolve",
+          "--params-file"
+        ],
+        "forbiddenTerms": [
+          "grep",
+          "rg",
+          "TOON params",
+          "changing methods instead of repairing params"
+        ]
+      },
       "metrics": [
         "routeAccuracy",
         "fieldAccuracy",
@@ -209,6 +263,21 @@
         "workflow.json remains JSON.",
         "Step input and stdout files remain JSON."
       ],
+      "answerScoring": {
+        "requiredTerms": [
+          "agent/workflow/symbol",
+          "dryRun",
+          "workflow.json",
+          "stdout.json",
+          "JSON"
+        ],
+        "forbiddenTerms": [
+          "grep",
+          "rg",
+          "TOON workflow files",
+          "treating dry-run as mutation proof"
+        ]
+      },
       "metrics": [
         "fieldAccuracy",
         "answerVerdict",
@@ -249,6 +318,18 @@
         "The task is docs-only.",
         "No Kotlin semantic route should be selected."
       ],
+      "answerScoring": {
+        "requiredTerms": [
+          "docs/commands/install.md",
+          "docs content contract"
+        ],
+        "forbiddenTerms": [
+          "kast agent call",
+          "kast agent workflow",
+          "symbol/query",
+          "semantic backend warmup"
+        ]
+      },
       "metrics": [
         "routeAccuracy",
         "forbiddenFallbacks",
@@ -289,6 +370,21 @@
         "TOON stdout bytes are lower than pretty JSON bytes.",
         "The agent tools schemaVersion and catalogSha256 are preserved."
       ],
+      "answerScoring": {
+        "requiredTerms": [
+          "TOON",
+          "same JSON value",
+          "lower",
+          "schemaVersion",
+          "catalogSha256"
+        ],
+        "forbiddenTerms": [
+          "grep",
+          "rg",
+          "tokenizer dependency",
+          "schema change"
+        ]
+      },
       "metrics": [
         "stdoutBytes",
         "decodedEquivalent",

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/evals/format-impact.json
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/evals/format-impact.json
@@ -1,0 +1,301 @@
+{
+  "$schema": "./format-impact.schema.json",
+  "schemaVersion": 1,
+  "description": "Report-only paired JSON versus TOON cases for measuring Kast agent output comprehension, route accuracy, and byte cost without making live model results a CI gate.",
+  "formats": [
+    "json",
+    "toon"
+  ],
+  "cases": [
+    {
+      "id": "tool-catalog-comprehension",
+      "scenario": "TOOL_CATALOG_COMPREHENSION",
+      "prompt": "Given the agent tool catalog, choose the first Kast action for finding where EventBean is declared in a Kotlin workspace.",
+      "pairedFormats": [
+        "json",
+        "toon"
+      ],
+      "inputArtifact": {
+        "kind": "agent-tools",
+        "description": "Use the current kast agent tools envelope in JSON and TOON forms."
+      },
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "expectedActions": [
+        {
+          "kind": "command",
+          "name": "kast agent call symbol/query"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "workspace file dump",
+        "manual package inference"
+      ],
+      "goldFacts": [
+        "The envelope method is agent/tools.",
+        "The result type is KAST_AGENT_TOOLS.",
+        "The selected route is symbol/query, not text search."
+      ],
+      "metrics": [
+        "routeAccuracy",
+        "fieldAccuracy",
+        "forbiddenFallbacks",
+        "stdoutBytes",
+        "decodedEquivalent"
+      ],
+      "reportOnly": true
+    },
+    {
+      "id": "symbol-result-extraction",
+      "scenario": "SYMBOL_RESULT_EXTRACTION",
+      "prompt": "Given a symbol resolve envelope, extract the method, resolved declaration identity, file path, and the next inspection action without inventing fields.",
+      "pairedFormats": [
+        "json",
+        "toon"
+      ],
+      "inputArtifact": {
+        "kind": "synthetic-envelope",
+        "description": "Use a stable symbol/resolve-style envelope encoded as JSON and TOON."
+      },
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "expectedActions": [
+        {
+          "kind": "command",
+          "name": "kast agent call symbol/scaffold"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "invented response fields",
+        "generic file read before Kast"
+      ],
+      "goldFacts": [
+        "The envelope method is symbol/resolve.",
+        "The declaration is EventBean.",
+        "The file path must be read from result data, not inferred from the package name."
+      ],
+      "metrics": [
+        "fieldAccuracy",
+        "answerVerdict",
+        "forbiddenFallbacks",
+        "decodedEquivalent"
+      ],
+      "reportOnly": true
+    },
+    {
+      "id": "relationship-navigation-continuation",
+      "scenario": "RELATIONSHIP_NAVIGATION",
+      "prompt": "Continue from a resolved Kotlin declaration by finding usages and incoming callers, preserving symbol identity across the next Kast calls.",
+      "pairedFormats": [
+        "json",
+        "toon"
+      ],
+      "inputArtifact": {
+        "kind": "synthetic-envelope",
+        "description": "Use a resolved symbol envelope that contains enough identity to request references and callers."
+      },
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "expectedActions": [
+        {
+          "kind": "command",
+          "name": "kast agent call symbol/references"
+        },
+        {
+          "kind": "command",
+          "name": "kast agent call symbol/callers"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "textual call graph",
+        "unresolved name matching"
+      ],
+      "goldFacts": [
+        "The continuation must use symbol/references or symbol/callers.",
+        "The action must preserve the resolved symbol identity.",
+        "Text matching is not an acceptable replacement."
+      ],
+      "metrics": [
+        "routeAccuracy",
+        "fieldAccuracy",
+        "forbiddenFallbacks",
+        "decodedEquivalent"
+      ],
+      "reportOnly": true
+    },
+    {
+      "id": "validation-error-recovery",
+      "scenario": "VALIDATION_RECOVERY",
+      "prompt": "Given an AGENT_REQUEST_INVALID envelope for symbol/resolve, repair the request using JSON params and retry the same method.",
+      "pairedFormats": [
+        "json",
+        "toon"
+      ],
+      "inputArtifact": {
+        "kind": "validation-error",
+        "description": "Use the current validation error envelope from kast agent call symbol/resolve."
+      },
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "expectedActions": [
+        {
+          "kind": "command",
+          "name": "kast agent call symbol/resolve --params-file"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "TOON params",
+        "changing methods instead of repairing params"
+      ],
+      "goldFacts": [
+        "The error code is AGENT_REQUEST_INVALID.",
+        "Request params remain JSON even when stdout was TOON.",
+        "The retry method remains symbol/resolve."
+      ],
+      "metrics": [
+        "routeAccuracy",
+        "fieldAccuracy",
+        "answerVerdict",
+        "decodedEquivalent"
+      ],
+      "reportOnly": true
+    },
+    {
+      "id": "workflow-evidence-json-artifacts",
+      "scenario": "WORKFLOW_EVIDENCE",
+      "prompt": "Given TOON workflow stdout, identify the workflow result and inspect the emitted workflow evidence files as JSON artifacts.",
+      "pairedFormats": [
+        "json",
+        "toon"
+      ],
+      "inputArtifact": {
+        "kind": "workflow-dry-run",
+        "description": "Use a dry-run symbol workflow stdout envelope plus its generated workflow files."
+      },
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "expectedActions": [
+        {
+          "kind": "command",
+          "name": "kast agent workflow symbol --dry-run"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "TOON workflow files",
+        "treating dry-run as mutation proof"
+      ],
+      "goldFacts": [
+        "Only stdout changes format.",
+        "workflow.json remains JSON.",
+        "Step input and stdout files remain JSON."
+      ],
+      "metrics": [
+        "fieldAccuracy",
+        "answerVerdict",
+        "stdoutBytes",
+        "decodedEquivalent"
+      ],
+      "reportOnly": true
+    },
+    {
+      "id": "non-kotlin-negative-routing",
+      "scenario": "NEGATIVE_ROUTING",
+      "prompt": "Update docs/commands/install.md copy and run the docs content contract. No Kotlin or Kast package-state question is involved.",
+      "pairedFormats": [
+        "json",
+        "toon"
+      ],
+      "inputArtifact": {
+        "kind": "prompt-only",
+        "description": "No Kast output should be needed for this unrelated docs task."
+      },
+      "expectedPrimitive": {
+        "type": "none",
+        "name": "none"
+      },
+      "expectedActions": [
+        {
+          "kind": "generic",
+          "name": "normal file read"
+        }
+      ],
+      "forbiddenActions": [
+        "kast agent call",
+        "kast agent workflow",
+        "symbol/query",
+        "semantic backend warmup"
+      ],
+      "goldFacts": [
+        "The task is docs-only.",
+        "No Kotlin semantic route should be selected."
+      ],
+      "metrics": [
+        "routeAccuracy",
+        "forbiddenFallbacks",
+        "answerVerdict"
+      ],
+      "reportOnly": true
+    },
+    {
+      "id": "large-read-only-catalog-efficiency",
+      "scenario": "LARGE_READ_ONLY_OUTPUT",
+      "prompt": "Compare JSON and TOON agent tool catalog output and report whether the denser form preserves semantics while reducing stdout bytes.",
+      "pairedFormats": [
+        "json",
+        "toon"
+      ],
+      "inputArtifact": {
+        "kind": "agent-tools",
+        "description": "Use the current agent tools catalog because it is a large read-only response."
+      },
+      "expectedPrimitive": {
+        "type": "skill",
+        "name": "kast"
+      },
+      "expectedActions": [
+        {
+          "kind": "command",
+          "name": "kast agent --format toon tools"
+        }
+      ],
+      "forbiddenActions": [
+        "grep",
+        "rg",
+        "tokenizer dependency",
+        "schema change"
+      ],
+      "goldFacts": [
+        "TOON decodes to the same JSON value as default output.",
+        "TOON stdout bytes are lower than pretty JSON bytes.",
+        "The agent tools schemaVersion and catalogSha256 are preserved."
+      ],
+      "metrics": [
+        "stdoutBytes",
+        "decodedEquivalent",
+        "fieldAccuracy",
+        "answerVerdict"
+      ],
+      "reportOnly": true
+    }
+  ]
+}

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/evals/format-impact.schema.json
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/evals/format-impact.schema.json
@@ -56,6 +56,7 @@
         "expectedActions",
         "forbiddenActions",
         "goldFacts",
+        "answerScoring",
         "metrics",
         "reportOnly"
       ],
@@ -141,6 +142,9 @@
             "minLength": 1
           }
         },
+        "answerScoring": {
+          "$ref": "#/$defs/answerScoring"
+        },
         "metrics": {
           "type": "array",
           "minItems": 1,
@@ -213,6 +217,31 @@
         "name": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "answerScoring": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requiredTerms",
+        "forbiddenTerms"
+      ],
+      "properties": {
+        "requiredTerms": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "forbiddenTerms": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     }

--- a/cli-rs/resources/kast-skill/fixtures/maintenance/evals/format-impact.schema.json
+++ b/cli-rs/resources/kast-skill/fixtures/maintenance/evals/format-impact.schema.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Kast TOON format impact eval corpus",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "description",
+    "formats",
+    "cases"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "formats": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "json"
+        },
+        {
+          "const": "toon"
+        }
+      ],
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/case"
+      }
+    }
+  },
+  "$defs": {
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "scenario",
+        "prompt",
+        "pairedFormats",
+        "inputArtifact",
+        "expectedPrimitive",
+        "expectedActions",
+        "forbiddenActions",
+        "goldFacts",
+        "metrics",
+        "reportOnly"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+        },
+        "scenario": {
+          "enum": [
+            "TOOL_CATALOG_COMPREHENSION",
+            "SYMBOL_RESULT_EXTRACTION",
+            "RELATIONSHIP_NAVIGATION",
+            "VALIDATION_RECOVERY",
+            "WORKFLOW_EVIDENCE",
+            "NEGATIVE_ROUTING",
+            "LARGE_READ_ONLY_OUTPUT"
+          ]
+        },
+        "prompt": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pairedFormats": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "json"
+            },
+            {
+              "const": "toon"
+            }
+          ],
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "inputArtifact": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "description"
+          ],
+          "properties": {
+            "kind": {
+              "enum": [
+                "agent-tools",
+                "synthetic-envelope",
+                "validation-error",
+                "workflow-dry-run",
+                "prompt-only"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "expectedPrimitive": {
+          "$ref": "#/$defs/expectedPrimitive"
+        },
+        "expectedActions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/action"
+          }
+        },
+        "forbiddenActions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "goldFacts": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "metrics": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": [
+              "routeAccuracy",
+              "fieldAccuracy",
+              "forbiddenFallbacks",
+              "answerVerdict",
+              "stdoutBytes",
+              "decodedEquivalent"
+            ]
+          }
+        },
+        "reportOnly": {
+          "const": true
+        }
+      }
+    },
+    "expectedPrimitive": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "skill"
+            },
+            "name": {
+              "const": "kast"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "none"
+            },
+            "name": {
+              "const": "none"
+            }
+          }
+        }
+      ]
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "command",
+            "generic"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/cli-rs/src/agent/dispatch.rs
+++ b/cli-rs/src/agent/dispatch.rs
@@ -1,7 +1,8 @@
 pub fn run(args: AgentArgs) -> Result<i32> {
+    let format = args.format;
     let envelope = execute(args.command);
     let exit_code = if envelope.ok { 0 } else { 1 };
-    output::print_json(&envelope)?;
+    output::print_agent_output(&envelope, format)?;
     Ok(exit_code)
 }
 

--- a/cli-rs/src/catalog_schema.rs
+++ b/cli-rs/src/catalog_schema.rs
@@ -57,7 +57,9 @@ fn params_schema(command: &Value, method: &str) -> Result<Value> {
     match command.get("variants").and_then(Value::as_object) {
         Some(variants) if !variants.is_empty() => {
             let mut schemas = Vec::with_capacity(variants.len());
-            for (variant_name, variant_request) in variants {
+            let mut sorted_variants = variants.iter().collect::<Vec<_>>();
+            sorted_variants.sort_by_key(|(name, _)| *name);
+            for (variant_name, variant_request) in sorted_variants {
                 schemas.push(variant_schema(
                     command,
                     variant_name,
@@ -403,5 +405,45 @@ mod tests {
         });
         assert!(validator.validate(&valid).is_ok());
         assert!(validator.validate(&invalid).is_err());
+    }
+
+    #[test]
+    fn variant_schema_order_is_canonical() {
+        let catalog = json!({
+            "commands": {
+                "symbol/rename": {
+                    "request": {
+                        "fields": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["BY_SYMBOL", "BY_OFFSET"]
+                            }
+                        },
+                        "required": ["type"]
+                    },
+                    "variants": {
+                        "BY_SYMBOL": {
+                            "fields": {
+                                "symbol": { "type": "string" }
+                            },
+                            "required": ["symbol"]
+                        },
+                        "BY_OFFSET": {
+                            "fields": {
+                                "filePath": { "type": "string" }
+                            },
+                            "required": ["filePath"]
+                        }
+                    }
+                }
+            }
+        });
+        let schema = request_schema(&catalog, "symbol/rename").expect("schema");
+        let variants = schema["properties"]["params"]["oneOf"]
+            .as_array()
+            .expect("oneOf variants");
+        let first_type = &variants[0]["properties"]["type"]["const"];
+
+        assert_eq!(first_type, "BY_OFFSET");
     }
 }

--- a/cli-rs/src/cli/agent.rs
+++ b/cli-rs/src/cli/agent.rs
@@ -7,6 +7,9 @@ pub enum AgentOutputFormat {
 #[derive(Debug, Args, Clone)]
 #[command(disable_help_subcommand = true)]
 pub struct AgentArgs {
+    /// Select JSON or TOON for agent envelope stdout.
+    #[arg(long, value_enum, default_value = "json")]
+    pub format: AgentOutputFormat,
     #[command(subcommand)]
     pub command: AgentCommand,
 }

--- a/cli-rs/src/cli/agent.rs
+++ b/cli-rs/src/cli/agent.rs
@@ -1,3 +1,9 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum AgentOutputFormat {
+    Json,
+    Toon,
+}
+
 #[derive(Debug, Args, Clone)]
 #[command(disable_help_subcommand = true)]
 pub struct AgentArgs {

--- a/cli-rs/src/cli/command_groups.rs
+++ b/cli-rs/src/cli/command_groups.rs
@@ -50,6 +50,8 @@ pub struct MachineArgs {
 pub enum MachineCommand {
     /// Install the Homebrew-managed IDEA plugin cask and link JetBrains profiles.
     Plugin(IdeaPluginInstallArgs),
+    /// Configure developer-machine defaults to use the IDEA plugin backend.
+    Defaults(DeveloperMachineDefaultsArgs),
     /// Install shell PATH and completion integration.
     Shell(ShellInstallArgs),
     /// Print shell completion scripts.

--- a/cli-rs/src/cli/install_machine.rs
+++ b/cli-rs/src/cli/install_machine.rs
@@ -112,6 +112,13 @@ pub struct ShellInstallArgs {
 }
 
 #[derive(Debug, Args, Clone)]
+pub struct DeveloperMachineDefaultsArgs {
+    /// Print the planned developer-machine config without writing it.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Args, Clone)]
 pub struct ResourceInstallArgs {
     /// Target root directory.
     #[arg(long)]

--- a/cli-rs/src/contract_gen.rs
+++ b/cli-rs/src/contract_gen.rs
@@ -82,7 +82,10 @@ pub fn generated_files_from_catalog(
     samples_root: &Path,
 ) -> Result<BTreeMap<PathBuf, String>> {
     let mut files = BTreeMap::new();
-    files.insert(yaml_path.to_path_buf(), serde_yaml::to_string(catalog)?);
+    files.insert(
+        yaml_path.to_path_buf(),
+        serde_yaml::to_string(&canonical_json_value(catalog))?,
+    );
     let schemas = catalog_schema::request_schemas(catalog)?;
     for (method, command) in commands(catalog)? {
         let category = command
@@ -260,9 +263,27 @@ fn request_path(samples_root: &Path, category: &str, method: &str) -> PathBuf {
 }
 
 fn json_file_content(value: &Value) -> Result<String> {
-    let mut content = serde_json::to_string_pretty(value)?;
+    let mut content = serde_json::to_string_pretty(&canonical_json_value(value))?;
     content.push('\n');
     Ok(content)
+}
+
+fn canonical_json_value(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(items.iter().map(canonical_json_value).collect()),
+        Value::Object(fields) => {
+            let mut sorted = Map::new();
+            let mut entries = BTreeMap::new();
+            for (key, value) in fields {
+                entries.insert(key, value);
+            }
+            for (key, value) in entries {
+                sorted.insert(key.clone(), canonical_json_value(value));
+            }
+            Value::Object(sorted)
+        }
+        _ => value.clone(),
+    }
 }
 
 fn request_payload(method: &str, params: Value) -> Result<Value> {
@@ -539,6 +560,52 @@ mod tests {
         assert!(files.contains_key(Path::new(
             "/tmp/requests/symbol/example/request.schema.json"
         )));
+    }
+
+    #[test]
+    fn generated_files_keep_canonical_object_order() {
+        let catalog = json!({
+            "version": "dev",
+            "commands": {
+                "symbol/example": {
+                    "summary": "Example command",
+                    "method": "symbol/example",
+                    "request": {
+                        "required": ["query"],
+                        "fields": {
+                            "query": { "type": "string" }
+                        }
+                    },
+                    "category": "symbol"
+                }
+            },
+            "$schema": "./commands.schema.json",
+            "categories": {
+                "symbol": ["symbol/example"]
+            }
+        });
+        let files = generated_files_from_catalog(
+            &catalog,
+            Path::new("/tmp/commands.yaml"),
+            Path::new("/tmp/requests"),
+        )
+        .expect("generated files");
+
+        let yaml = files
+            .get(Path::new("/tmp/commands.yaml"))
+            .expect("commands yaml");
+        assert!(
+            yaml.starts_with("$schema: ./commands.schema.json\ncategories:\n"),
+            "{yaml}"
+        );
+
+        let minimal = files
+            .get(Path::new("/tmp/requests/symbol/example/minimal.json"))
+            .expect("minimal sample");
+        assert_eq!(
+            minimal,
+            "{\n  \"id\": 1,\n  \"jsonrpc\": \"2.0\",\n  \"method\": \"symbol/example\",\n  \"params\": {\n    \"query\": \"Widget\"\n  }\n}\n"
+        );
     }
 
     #[test]

--- a/cli-rs/src/install/jetbrains_profiles.rs
+++ b/cli-rs/src/install/jetbrains_profiles.rs
@@ -135,6 +135,17 @@ fn install_idea_plugin_into_jetbrains_profiles(
             }
         }
     }
+    let developer_defaults = if args.dry_run {
+        self_mgmt::configure_developer_machine_defaults(true)?
+    } else {
+        reporter.idea_plugin_step_started("Configuring developer-machine IDEA defaults")?;
+        let defaults = self_mgmt::configure_developer_machine_defaults(false)?;
+        reporter.idea_plugin_step_finished(&format!(
+            "Configured IDEA plugin backend defaults at {}",
+            defaults.config_path
+        ))?;
+        defaults
+    };
 
     Ok(InstallIdeaPluginResult {
         cask_token,
@@ -154,6 +165,7 @@ fn install_idea_plugin_into_jetbrains_profiles(
             .map(|path| path.display().to_string())
             .collect(),
         dry_run: args.dry_run,
+        developer_defaults,
         warnings,
         schema_version: SCHEMA_VERSION,
     })

--- a/cli-rs/src/install/types.rs
+++ b/cli-rs/src/install/types.rs
@@ -154,6 +154,7 @@ pub struct InstallIdeaPluginResult {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub plugin_directories: Vec<String>,
     pub dry_run: bool,
+    pub developer_defaults: self_mgmt::DeveloperMachineDefaultsResult,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
     pub schema_version: u32,

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -762,6 +762,15 @@ fn run_machine(command: cli::MachineCommand, output_format: OutputFormat) -> Res
         cli::MachineCommand::Plugin(args) => {
             run_install(cli::InstallCommand::Plugin(args), output_format)
         }
+        cli::MachineCommand::Defaults(args) => {
+            let result = self_mgmt::configure_developer_machine_defaults(args.dry_run)?;
+            if output_format == OutputFormat::Json {
+                output::print_json(&result)?;
+            } else {
+                output::print_developer_machine_defaults(&result)?;
+            }
+            Ok(0)
+        }
         cli::MachineCommand::Shell(args) => {
             run_install(cli::InstallCommand::Shell(args), output_format)
         }

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -151,6 +151,7 @@ fn run_ready(args: cli::ReadyArgs, output_format: OutputFormat) -> Result<i32> {
 }
 
 fn run_agent(args: cli::AgentArgs, output_format: OutputFormat) -> Result<i32> {
+    let agent_format = args.format;
     match args.command {
         cli::AgentCommand::Up(args) => {
             run_agent_up_with_surface(args, output_format, AgentUpCommandSurface::AgentUp)
@@ -158,7 +159,10 @@ fn run_agent(args: cli::AgentArgs, output_format: OutputFormat) -> Result<i32> {
         cli::AgentCommand::Ready(args) => run_ready(args, output_format),
         cli::AgentCommand::Setup(args) => run_agent_setup(args, output_format),
         cli::AgentCommand::Lsp(args) => lsp::run(args),
-        command => agent::run(cli::AgentArgs { command }),
+        command => agent::run(cli::AgentArgs {
+            format: agent_format,
+            command,
+        }),
     }
 }
 

--- a/cli-rs/src/onboarding.rs
+++ b/cli-rs/src/onboarding.rs
@@ -171,11 +171,7 @@ fn apply_agent_up_onboarding_config(
 }
 
 fn write_agent_up_onboarding_defaults(document: &mut toml::Table) -> Result<()> {
-    table(document, "runtime")?.insert("defaultBackend".to_string(), "idea".into());
-    let idea_launch = nested_table(document, "runtime", "ideaLaunch")?;
-    idea_launch.insert("enabled".to_string(), true.into());
-    idea_launch.insert("command".to_string(), "idea".into());
-    idea_launch.insert("requireInstalledPlugin".to_string(), true.into());
+    self_mgmt::write_developer_machine_idea_defaults(document)?;
 
     let project_open = table(document, "projectOpen")?;
     project_open.insert("profileAutoInit".to_string(), true.into());
@@ -193,25 +189,6 @@ fn table<'a>(document: &'a mut toml::Table, key: &str) -> Result<&'a mut toml::T
             CliError::new(
                 "CONFIG_ERROR",
                 format!("Cannot write onboarding config because `{key}` is not a TOML table."),
-            )
-        })
-}
-
-fn nested_table<'a>(
-    document: &'a mut toml::Table,
-    first: &str,
-    second: &str,
-) -> Result<&'a mut toml::Table> {
-    table(document, first)?
-        .entry(second.to_string())
-        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
-        .as_table_mut()
-        .ok_or_else(|| {
-            CliError::new(
-                "CONFIG_ERROR",
-                format!(
-                    "Cannot write onboarding config because `{first}.{second}` is not a TOML table."
-                ),
             )
         })
 }

--- a/cli-rs/src/output.rs
+++ b/cli-rs/src/output.rs
@@ -12,7 +12,7 @@ use crate::runtime::{
     DaemonStopResult, RuntimeCandidateStatus, RuntimeState, WorkspaceEnsureResult,
     WorkspaceRestartResult, WorkspaceStatusResult,
 };
-use crate::self_mgmt::SelfDoctorResult;
+use crate::self_mgmt::{DeveloperMachineDefaultsResult, SelfDoctorResult};
 use glamour::{Renderer, Style as GlamourStyle};
 use serde::Serialize;
 use serde_json::Value;

--- a/cli-rs/src/output.rs
+++ b/cli-rs/src/output.rs
@@ -1,4 +1,4 @@
-use crate::cli::{AgentSetupHarness, OutputFormat, ReadyTarget};
+use crate::cli::{AgentOutputFormat, AgentSetupHarness, OutputFormat, ReadyTarget};
 use crate::config::PathResolutionReport;
 use crate::error::{CliError, Result};
 use crate::install::{

--- a/cli-rs/src/output/core.rs
+++ b/cli-rs/src/output/core.rs
@@ -1,5 +1,9 @@
 pub fn print_json(value: &impl Serialize) -> Result<()> {
-    io::stdout().write_all(render_agent_output(value, AgentOutputFormat::Json)?.as_bytes())?;
+    print_agent_output(value, AgentOutputFormat::Json)
+}
+
+pub(crate) fn print_agent_output(value: &impl Serialize, format: AgentOutputFormat) -> Result<()> {
+    io::stdout().write_all(render_agent_output(value, format)?.as_bytes())?;
     Ok(())
 }
 

--- a/cli-rs/src/output/core.rs
+++ b/cli-rs/src/output/core.rs
@@ -1,7 +1,26 @@
 pub fn print_json(value: &impl Serialize) -> Result<()> {
-    serde_json::to_writer_pretty(io::stdout(), value)?;
-    println!();
+    io::stdout().write_all(render_agent_output(value, AgentOutputFormat::Json)?.as_bytes())?;
     Ok(())
+}
+
+pub(crate) fn render_agent_output(
+    value: &impl Serialize,
+    format: AgentOutputFormat,
+) -> Result<String> {
+    match format {
+        AgentOutputFormat::Json => {
+            let mut rendered = serde_json::to_string_pretty(value)?;
+            rendered.push('\n');
+            Ok(rendered)
+        }
+        AgentOutputFormat::Toon => {
+            let value = serde_json::to_value(value)?;
+            let mut rendered = toon_format::encode_default(&value)
+                .map_err(|error| CliError::new("TOON_ENCODE_ERROR", error.to_string()))?;
+            rendered.push('\n');
+            Ok(rendered)
+        }
+    }
 }
 
 pub fn print_error(error: &CliError, output: OutputFormat) -> Result<()> {

--- a/cli-rs/src/output/install.rs
+++ b/cli-rs/src/output/install.rs
@@ -113,6 +113,14 @@ fn print_idea_plugin_install_summary(document: &mut MarkdownDocument, result: &I
             compact_path_for_output(jetbrains_config_root),
         ));
     }
+    rows.push((
+        "Developer default backend",
+        format!("{:?}", result.developer_defaults.default_backend).to_lowercase(),
+    ));
+    rows.push((
+        "Developer config",
+        compact_path_for_output(&result.developer_defaults.config_path),
+    ));
     for (item, value) in rows {
         mdln!(document, "- {item}: `{value}`");
     }
@@ -165,6 +173,41 @@ fn print_shell_install(result: &InstallShellResult) -> Result<()> {
         document,
         "- Open a fresh shell or run `{}`.",
         result.source_line
+    );
+    print_markdown(&document.into_string())
+}
+
+pub fn print_developer_machine_defaults(result: &DeveloperMachineDefaultsResult) -> Result<()> {
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast developer-machine defaults");
+    mdln!(document);
+    mdln!(
+        document,
+        "- Status: {}",
+        if result.applied { "applied" } else { "planned" }
+    );
+    mdln!(document, "- Config path: `{}`", result.config_path);
+    mdln!(document, "- Default backend: `idea`");
+    mdln!(
+        document,
+        "- IDEA launch enabled: {}",
+        yes_no(result.idea_launch_enabled)
+    );
+    mdln!(document, "- IDEA launch command: `{}`", result.idea_launch_command);
+    mdln!(
+        document,
+        "- Require installed plugin: {}",
+        yes_no(result.require_installed_plugin)
+    );
+    mdln!(document);
+    mdln!(document, "## Next steps");
+    mdln!(
+        document,
+        "- Restart any open IntelliJ IDEA or Android Studio windows after updating the plugin."
+    );
+    mdln!(
+        document,
+        "- Reopen the project, then run `kast status` to verify the IDEA backend."
     );
     print_markdown(&document.into_string())
 }

--- a/cli-rs/src/output/tests.rs
+++ b/cli-rs/src/output/tests.rs
@@ -223,6 +223,15 @@ mod tests {
             jetbrains_config_root: Some("/tmp/JetBrains".to_string()),
             plugin_directories: vec!["/tmp/JetBrains/IntelliJIdea2026.1/plugins".to_string()],
             dry_run,
+            developer_defaults: DeveloperMachineDefaultsResult {
+                config_path: "/tmp/config.toml".to_string(),
+                default_backend: crate::config::RuntimeDefaultBackend::Idea,
+                idea_launch_enabled: true,
+                idea_launch_command: "idea".to_string(),
+                require_installed_plugin: true,
+                applied: !dry_run,
+                schema_version: 3,
+            },
             warnings: vec![],
             schema_version: 3,
         }

--- a/cli-rs/src/output/tests.rs
+++ b/cli-rs/src/output/tests.rs
@@ -1,6 +1,83 @@
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn agent_output_renderer_defaults_to_pretty_json() {
+        let value = json!({
+            "ok": true,
+            "method": "agent/tools",
+            "result": {
+                "type": "KAST_AGENT_TOOLS",
+                "tools": [
+                    {"name": "kast_resolve", "method": "symbol/resolve"},
+                    {"name": "kast_references", "method": "symbol/references"}
+                ]
+            },
+            "schemaVersion": 3
+        });
+
+        let rendered = render_agent_output(&value, AgentOutputFormat::Json)
+            .expect("render default json agent output");
+
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&rendered).expect("rendered json"),
+            value
+        );
+        assert!(
+            rendered.ends_with('\n'),
+            "agent output should keep the existing trailing newline contract"
+        );
+    }
+
+    #[test]
+    fn agent_output_renderer_can_emit_round_trippable_toon() {
+        let value = json!({
+            "ok": true,
+            "method": "agent/tools",
+            "result": {
+                "type": "KAST_AGENT_TOOLS",
+                "tools": [
+                    {"name": "kast_resolve", "method": "symbol/resolve", "mutates": false},
+                    {"name": "kast_references", "method": "symbol/references", "mutates": false},
+                    {"name": "kast_rename", "method": "symbol/rename", "mutates": true}
+                ]
+            },
+            "schemaVersion": 3
+        });
+
+        let rendered = render_agent_output(&value, AgentOutputFormat::Toon)
+            .expect("render toon agent output");
+        let decoded: serde_json::Value =
+            toon_format::decode_default(rendered.trim()).expect("decode toon output");
+
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn agent_output_renderer_toon_is_smaller_for_uniform_agent_rows() {
+        let value = json!({
+            "tools": [
+                {"name": "kast_resolve", "method": "symbol/resolve", "mutates": false},
+                {"name": "kast_references", "method": "symbol/references", "mutates": false},
+                {"name": "kast_rename", "method": "symbol/rename", "mutates": true},
+                {"name": "kast_workspace_search", "method": "raw/workspace-search", "mutates": false}
+            ]
+        });
+
+        let json_output = render_agent_output(&value, AgentOutputFormat::Json)
+            .expect("render json agent output");
+        let toon_output = render_agent_output(&value, AgentOutputFormat::Toon)
+            .expect("render toon agent output");
+
+        assert!(
+            toon_output.len() < json_output.len(),
+            "TOON should reduce repeated field names for uniform rows: json={}, toon={}",
+            json_output.len(),
+            toon_output.len()
+        );
+    }
 
     #[test]
     fn rendered_human_output_plain_text_does_not_dump_raw_markdown_tokens() {

--- a/cli-rs/src/self_mgmt.rs
+++ b/cli-rs/src/self_mgmt.rs
@@ -340,10 +340,30 @@ pub fn write_install_state(install: &InstallState) -> Result<PathBuf> {
     manifest::write_install_manifest(install)
 }
 
-pub fn record_repo_resource(repo_root: &Path, mut resource: ManagedRepoResource) -> Result<()> {
+pub fn record_repo_resource(repo_root: &Path, resource: ManagedRepoResource) -> Result<()> {
+    let paths = manifest::default_resolved_paths();
+    manifest::with_install_lock(&paths, || {
+        let mut install =
+            manifest::read_install_manifest()?.unwrap_or_else(manifest::fresh_manifest);
+        upsert_repo_resource(&mut install, repo_root, resource);
+        install.version = install.version.trim().to_string();
+        if install.version.is_empty() {
+            install.version = cli::version().to_string();
+        }
+        install.active_version = cli::version().to_string();
+        install.updated_at = manifest::current_timestamp();
+        let paths = manifest::paths_from_manifest(&install)?;
+        manifest::write_manifest_atomic(&paths.manifest_file, &install)
+    })
+}
+
+fn upsert_repo_resource(
+    install: &mut InstallState,
+    repo_root: &Path,
+    mut resource: ManagedRepoResource,
+) {
     let normalized_repo = config::normalize(repo_root.to_path_buf());
     let repo_path = normalized_repo.display().to_string();
-    let mut install = read_global_install_state()?.unwrap_or_else(manifest::fresh_manifest);
     let repo_index = install
         .repos
         .iter()
@@ -385,14 +405,6 @@ pub fn record_repo_resource(repo_root: &Path, mut resource: ManagedRepoResource)
             .cmp(&right.kind)
             .then_with(|| left.target_path.cmp(&right.target_path))
     });
-    install.version = install.version.trim().to_string();
-    if install.version.is_empty() {
-        install.version = cli::version().to_string();
-    }
-    install.active_version = cli::version().to_string();
-    install.updated_at = manifest::current_timestamp();
-    write_install_state(&install)?;
-    Ok(())
 }
 
 pub fn read_global_install_state() -> Result<Option<InstallState>> {
@@ -557,6 +569,23 @@ fn parse_version_triplet(value: &str) -> Option<(u64, u64, u64)> {
 mod tests {
     use super::*;
 
+    fn test_repo_resource(
+        kind: ManagedResourceKind,
+        target_path: &str,
+        version: &str,
+    ) -> ManagedRepoResource {
+        ManagedRepoResource {
+            kind,
+            target_path: target_path.to_string(),
+            primitive_version: version.to_string(),
+            source_bundle_sha256: format!("source-{version}"),
+            output_paths: vec![format!("{target_path}/output.md")],
+            output_checksums: vec![],
+            installed_at: format!("installed-{version}"),
+            history: vec![],
+        }
+    }
+
     #[test]
     fn configured_binary_match_accepts_manifest_active_binary() {
         let configured_binary = Path::new("/example/bin/kast");
@@ -574,5 +603,53 @@ mod tests {
             Path::new("/other/bin/kast"),
             Some(&install)
         ));
+    }
+
+    #[test]
+    fn repo_resource_upsert_preserves_resources_and_records_history() {
+        let mut install = manifest::fresh_manifest();
+        let repo_root = Path::new("/workspace/kast");
+        let skill_target = "/workspace/kast/.agents/skills/kast";
+        let instructions_target = "/workspace/kast/.agents/instructions/kast";
+
+        upsert_repo_resource(
+            &mut install,
+            repo_root,
+            test_repo_resource(ManagedResourceKind::Skill, skill_target, "1.0.0"),
+        );
+        upsert_repo_resource(
+            &mut install,
+            repo_root,
+            test_repo_resource(
+                ManagedResourceKind::Instructions,
+                instructions_target,
+                "1.0.0",
+            ),
+        );
+        upsert_repo_resource(
+            &mut install,
+            repo_root,
+            test_repo_resource(ManagedResourceKind::Skill, skill_target, "1.0.1"),
+        );
+
+        let repo = install
+            .repos
+            .iter()
+            .find(|repo| repo.path == repo_root.display().to_string())
+            .expect("repo resource entry");
+        assert_eq!(repo.resources.len(), 2);
+        let skill = repo
+            .resources
+            .iter()
+            .find(|resource| resource.kind == ManagedResourceKind::Skill)
+            .expect("skill resource");
+        assert_eq!(skill.primitive_version, "1.0.1");
+        assert_eq!(skill.history.len(), 1);
+        assert_eq!(skill.history[0].primitive_version, "1.0.0");
+        assert!(
+            repo.resources
+                .iter()
+                .any(|resource| resource.kind == ManagedResourceKind::Instructions)
+        );
     }
 }

--- a/cli-rs/src/self_mgmt.rs
+++ b/cli-rs/src/self_mgmt.rs
@@ -55,6 +55,18 @@ pub struct DoctorBinaryDiagnostic {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DeveloperMachineDefaultsResult {
+    pub config_path: String,
+    pub default_backend: config::RuntimeDefaultBackend,
+    pub idea_launch_enabled: bool,
+    pub idea_launch_command: String,
+    pub require_installed_plugin: bool,
+    pub applied: bool,
+    pub schema_version: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SelfDoctorResult {
     pub target: ReadyTarget,
     pub installed: bool,
@@ -402,6 +414,33 @@ pub fn update_workspace_config(
     update_config_file(&path, mutator)
 }
 
+pub fn configure_developer_machine_defaults(
+    dry_run: bool,
+) -> Result<DeveloperMachineDefaultsResult> {
+    let config_path = config::global_config_path();
+    if !dry_run {
+        update_global_config(write_developer_machine_idea_defaults)?;
+    }
+    Ok(DeveloperMachineDefaultsResult {
+        config_path: config_path.display().to_string(),
+        default_backend: config::RuntimeDefaultBackend::Idea,
+        idea_launch_enabled: true,
+        idea_launch_command: "idea".to_string(),
+        require_installed_plugin: true,
+        applied: !dry_run,
+        schema_version: SCHEMA_VERSION,
+    })
+}
+
+pub(crate) fn write_developer_machine_idea_defaults(document: &mut toml::Table) -> Result<()> {
+    table(document, "runtime")?.insert("defaultBackend".to_string(), "idea".into());
+    let idea_launch = nested_table(document, "runtime", "ideaLaunch")?;
+    idea_launch.insert("enabled".to_string(), true.into());
+    idea_launch.insert("command".to_string(), "idea".into());
+    idea_launch.insert("requireInstalledPlugin".to_string(), true.into());
+    Ok(())
+}
+
 fn update_config_file(
     path: &Path,
     mutator: impl FnOnce(&mut toml::Table) -> Result<()>,
@@ -439,6 +478,40 @@ fn write_config_document(path: &Path, document: &toml::Table) -> Result<()> {
 
 fn default_config_document() -> Result<toml::Table> {
     Ok(config::default_config_template()?.parse::<toml::Table>()?)
+}
+
+fn table<'a>(document: &'a mut toml::Table, key: &str) -> Result<&'a mut toml::Table> {
+    document
+        .entry(key.to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| {
+            crate::error::CliError::new(
+                "CONFIG_ERROR",
+                format!(
+                    "Cannot write developer-machine config because `{key}` is not a TOML table."
+                ),
+            )
+        })
+}
+
+fn nested_table<'a>(
+    document: &'a mut toml::Table,
+    first: &str,
+    second: &str,
+) -> Result<&'a mut toml::Table> {
+    table(document, first)?
+        .entry(second.to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| {
+            crate::error::CliError::new(
+                "CONFIG_ERROR",
+                format!(
+                    "Cannot write developer-machine config because `{first}.{second}` is not a TOML table."
+                ),
+            )
+        })
 }
 
 fn merge_config_document(base: &mut toml::Table, overlay: toml::Table) {

--- a/cli-rs/tests/agent_output_format_smoke.rs
+++ b/cli-rs/tests/agent_output_format_smoke.rs
@@ -1,0 +1,136 @@
+mod support;
+
+use support::*;
+
+fn decode_toon(bytes: &[u8]) -> serde_json::Value {
+    let output = std::str::from_utf8(bytes).expect("toon output should be utf-8");
+    toon_format::decode_default(output.trim()).expect("toon output should decode")
+}
+
+#[test]
+fn agent_tools_can_emit_toon_equivalent_to_default_json() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    std::fs::create_dir_all(&home).expect("home");
+
+    let json = kast(&home, &config_home)
+        .args(["agent", "tools"])
+        .output()
+        .expect("agent tools json");
+    assert!(
+        json.status.success(),
+        "agent tools json should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&json.stdout),
+        String::from_utf8_lossy(&json.stderr)
+    );
+    let json_value: serde_json::Value =
+        serde_json::from_slice(&json.stdout).expect("agent tools json");
+
+    let toon = kast(&home, &config_home)
+        .args(["agent", "--format", "toon", "tools"])
+        .output()
+        .expect("agent tools toon");
+    assert!(
+        toon.status.success(),
+        "agent tools toon should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&toon.stdout),
+        String::from_utf8_lossy(&toon.stderr)
+    );
+    assert!(
+        serde_json::from_slice::<serde_json::Value>(&toon.stdout).is_err(),
+        "toon output should not be parseable as JSON"
+    );
+    let toon_value = decode_toon(&toon.stdout);
+
+    assert_eq!(toon_value, json_value);
+    assert!(
+        toon.stdout.len() < json.stdout.len(),
+        "toon agent tools output should be smaller than pretty JSON: json={}, toon={}",
+        json.stdout.len(),
+        toon.stdout.len()
+    );
+}
+
+#[test]
+fn agent_call_validation_errors_can_emit_toon() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    std::fs::create_dir_all(&home).expect("home");
+
+    let call = kast(&home, &config_home)
+        .args(["agent", "--format", "toon", "call", "symbol/resolve"])
+        .output()
+        .expect("agent call toon validation");
+    assert!(
+        !call.status.success(),
+        "invalid agent call should fail validation"
+    );
+    assert!(
+        serde_json::from_slice::<serde_json::Value>(&call.stdout).is_err(),
+        "toon validation output should not be parseable as JSON"
+    );
+    let output = decode_toon(&call.stdout);
+
+    assert_eq!(output["ok"], false, "{output:#}");
+    assert_eq!(output["method"], "symbol/resolve", "{output:#}");
+    assert_eq!(
+        output["error"]["code"], "AGENT_REQUEST_INVALID",
+        "{output:#}"
+    );
+}
+
+#[test]
+fn agent_workflow_toon_stdout_keeps_step_files_json() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let out_dir = temp.path().join("workflow");
+    std::fs::create_dir_all(&home).expect("home");
+
+    let workflow = kast(&home, &config_home)
+        .args([
+            "agent",
+            "--format",
+            "toon",
+            "workflow",
+            "symbol",
+            "--dry-run",
+            "--out-dir",
+            out_dir.to_str().expect("workflow path"),
+            "--symbol",
+            "Kast",
+            "--references",
+        ])
+        .output()
+        .expect("agent workflow toon dry-run");
+    assert!(
+        workflow.status.success(),
+        "workflow dry-run should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&workflow.stdout),
+        String::from_utf8_lossy(&workflow.stderr)
+    );
+    assert!(
+        serde_json::from_slice::<serde_json::Value>(&workflow.stdout).is_err(),
+        "toon workflow stdout should not be parseable as JSON"
+    );
+    let output = decode_toon(&workflow.stdout);
+
+    assert_eq!(output["ok"], true, "{output:#}");
+    assert_eq!(output["method"], "agent/workflow/symbol", "{output:#}");
+    assert_eq!(output["result"]["dryRun"], true, "{output:#}");
+
+    for path in [
+        out_dir.join("workflow.json"),
+        out_dir.join("symbol-query/input.json"),
+        out_dir.join("symbol-query/stdout.json"),
+        out_dir.join("symbol-resolve/input.json"),
+        out_dir.join("symbol-references/input.json"),
+    ] {
+        let content = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+        serde_json::from_str::<serde_json::Value>(&content)
+            .unwrap_or_else(|error| panic!("{} should remain JSON: {error}", path.display()));
+    }
+}

--- a/cli-rs/tests/inspect_and_shell_smoke.rs
+++ b/cli-rs/tests/inspect_and_shell_smoke.rs
@@ -322,6 +322,70 @@ fn install_shell_writes_path_and_completion_profile_integration() {
 }
 
 #[test]
+fn developer_machine_defaults_configures_idea_plugin_backend() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let defaults = kast(&home, &config_home)
+        .args(["--output", "json", "developer", "machine", "defaults"])
+        .output()
+        .expect("developer machine defaults");
+
+    assert!(
+        defaults.status.success(),
+        "developer defaults should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&defaults.stdout),
+        String::from_utf8_lossy(&defaults.stderr)
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&defaults.stdout).expect("developer defaults json");
+    assert_eq!(stdout["defaultBackend"], "idea");
+    assert_eq!(stdout["ideaLaunchEnabled"], true);
+    assert_eq!(stdout["ideaLaunchCommand"], "idea");
+    assert_eq!(stdout["requireInstalledPlugin"], true);
+    assert_eq!(stdout["applied"], true);
+
+    let config = std::fs::read_to_string(config_home.join("config.toml")).expect("config");
+    assert!(config.contains("defaultBackend = \"idea\""), "{config}");
+    assert!(config.contains("[runtime.ideaLaunch]"), "{config}");
+    assert!(config.contains("enabled = true"), "{config}");
+    assert!(config.contains("command = \"idea\""), "{config}");
+    assert!(config.contains("requireInstalledPlugin = true"), "{config}");
+
+    let up = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "runtime",
+            "up",
+            "--workspace-root",
+            workspace.to_str().expect("workspace path"),
+            "--no-auto-start=true",
+        ])
+        .output()
+        .expect("runtime up");
+    assert!(
+        !up.status.success(),
+        "runtime up should fail without a live IDEA backend"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&up.stdout),
+        String::from_utf8_lossy(&up.stderr)
+    );
+    assert!(combined.contains("IDEA_PLUGIN_NOT_INSTALLED"), "{combined}");
+    assert!(
+        !combined.contains("Linux headless tarball"),
+        "developer defaults should not fall through to headless guidance: {combined}"
+    );
+}
+
+#[test]
 fn install_shell_prefers_running_cli_directory_over_stale_config_bin_dir() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/cli-rs/tests/machine_plugin_repair_smoke.rs
+++ b/cli-rs/tests/machine_plugin_repair_smoke.rs
@@ -58,6 +58,12 @@ fn idea_plugin_install_uses_profile_install_mode() {
             .display()
             .to_string()
     );
+    assert_eq!(stdout["developerDefaults"]["defaultBackend"], "idea");
+    assert_eq!(stdout["developerDefaults"]["applied"], false);
+    assert!(
+        !config_home.join("config.toml").exists(),
+        "dry-run plugin install must not write developer defaults"
+    );
     assert!(stdout.get("downloadDir").is_none(), "{stdout}");
 }
 

--- a/cli-rs/tests/machine_plugin_smoke.rs
+++ b/cli-rs/tests/machine_plugin_smoke.rs
@@ -93,6 +93,15 @@ fn plugin_install_gateway_installs_homebrew_cask_and_links_profiles() {
     );
     assert!(stdout.get("downloadDir").is_none(), "{stdout}");
     assert!(stdout.get("downloadedPath").is_none(), "{stdout}");
+    assert_eq!(stdout["developerDefaults"]["defaultBackend"], "idea");
+    assert_eq!(stdout["developerDefaults"]["ideaLaunchEnabled"], true);
+    assert_eq!(stdout["developerDefaults"]["applied"], true);
+    let config = std::fs::read_to_string(config_home.join("config.toml")).expect("config");
+    assert!(config.contains("defaultBackend = \"idea\""), "{config}");
+    assert!(config.contains("[runtime.ideaLaunch]"), "{config}");
+    assert!(config.contains("enabled = true"), "{config}");
+    assert!(config.contains("command = \"idea\""), "{config}");
+    assert!(config.contains("requireInstalledPlugin = true"), "{config}");
     #[cfg(unix)]
     assert_eq!(
         std::fs::read_link(jetbrains_root.join("IntelliJIdea2026.1/plugins/kast"))

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -50,6 +50,10 @@ fn packaged_skill_stays_usage_first_and_public_agent_only() {
     assert!(skill.contains("Kotlin work uses `kast agent`."), "{skill}");
     assert!(skill.contains("`kast agent call <method>`"), "{skill}");
     assert!(skill.contains("`kast agent workflow ...`"), "{skill}");
+    assert!(
+        skill.contains("`--format toon` only for large read-only outputs"),
+        "{skill}"
+    );
     assert!(skill.contains("raw catalog methods only after"), "{skill}");
     assert!(
         !skill.contains("`kast agent scaffold`"),

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -252,3 +252,150 @@ fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
         );
     }
 }
+
+#[test]
+fn packaged_skill_format_impact_eval_covers_toon_accuracy_surface() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let eval_path = root.join("resources/kast-skill/fixtures/maintenance/evals/format-impact.json");
+    let eval: Value = serde_json::from_str(
+        &std::fs::read_to_string(&eval_path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", eval_path.display())),
+    )
+    .expect("format impact eval json");
+    let schema_path =
+        root.join("resources/kast-skill/fixtures/maintenance/evals/format-impact.schema.json");
+    let schema: Value = serde_json::from_str(
+        &std::fs::read_to_string(&schema_path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", schema_path.display())),
+    )
+    .expect("format impact eval schema json");
+    let validator = jsonschema::validator_for(&schema).expect("format impact schema");
+    validator
+        .validate(&eval)
+        .unwrap_or_else(|error| panic!("format impact eval schema validation failed: {error}"));
+
+    assert_eq!(eval["schemaVersion"], 1, "{eval:#}");
+    assert_eq!(
+        eval["formats"],
+        serde_json::json!(["json", "toon"]),
+        "{eval:#}"
+    );
+
+    let cases = eval["cases"].as_array().expect("format impact eval cases");
+    assert!(
+        cases.len() >= 7,
+        "format impact eval should cover tool catalog, symbol extraction, relationship navigation, validation recovery, workflow evidence, negative routing, and large read-only output"
+    );
+
+    let case_ids = cases
+        .iter()
+        .map(|case| case["id"].as_str().expect("case id"))
+        .collect::<BTreeSet<_>>();
+    for required in [
+        "tool-catalog-comprehension",
+        "symbol-result-extraction",
+        "relationship-navigation-continuation",
+        "validation-error-recovery",
+        "workflow-evidence-json-artifacts",
+        "non-kotlin-negative-routing",
+        "large-read-only-catalog-efficiency",
+    ] {
+        assert!(
+            case_ids.contains(required),
+            "format impact eval should include {required}"
+        );
+    }
+
+    for case in cases {
+        assert_no_local_paths(case, case["id"].as_str().expect("case id"));
+        assert_eq!(case["pairedFormats"], eval["formats"], "{case:#}");
+        assert!(
+            case["prompt"]
+                .as_str()
+                .is_some_and(|prompt| !prompt.is_empty()),
+            "case should include a prompt: {case:#}"
+        );
+        assert!(
+            case["goldFacts"]
+                .as_array()
+                .is_some_and(|facts| facts.len() >= 2),
+            "case should include gold facts: {case:#}"
+        );
+        assert!(
+            case["reportOnly"].as_bool() == Some(true),
+            "format impact live accuracy cases must stay report-only: {case:#}"
+        );
+
+        let expected_actions = case["expectedActions"]
+            .as_array()
+            .unwrap_or_else(|| panic!("case {} should list expected actions", case["id"]));
+        let forbidden_actions = case["forbiddenActions"]
+            .as_array()
+            .unwrap_or_else(|| panic!("case {} should list forbidden actions", case["id"]));
+        if case["expectedPrimitive"]["name"] == "none" {
+            assert!(
+                expected_actions
+                    .iter()
+                    .all(|action| action["kind"] == "generic"),
+                "negative format-impact cases should not expect Kast actions: {case:#}"
+            );
+            assert!(
+                forbidden_actions
+                    .iter()
+                    .any(|action| action == "kast agent call"),
+                "negative format-impact cases should forbid Kast calls: {case:#}"
+            );
+        } else {
+            assert!(
+                expected_actions.iter().any(|action| {
+                    action["kind"] == "command"
+                        && action["name"]
+                            .as_str()
+                            .is_some_and(|name| name.starts_with("kast agent"))
+                }),
+                "positive format-impact cases should expect a kast agent command: {case:#}"
+            );
+            assert!(
+                forbidden_actions.iter().any(|action| action == "grep")
+                    && forbidden_actions.iter().any(|action| action == "rg"),
+                "positive format-impact cases should forbid text-search fallbacks: {case:#}"
+            );
+        }
+    }
+}
+
+#[test]
+fn format_impact_metric_pack_and_runner_are_report_only() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repo root");
+    let manifest_path = repo_root.join(".github/plugin-eval/kast-format-impact/manifest.json");
+    let manifest: Value = serde_json::from_str(
+        &std::fs::read_to_string(&manifest_path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", manifest_path.display())),
+    )
+    .expect("format impact metric pack manifest");
+
+    assert_eq!(manifest["name"], "kast-format-impact", "{manifest:#}");
+    assert_eq!(
+        manifest["command"],
+        serde_json::json!(["node", "./emit-kast-format-impact-metrics.mjs"]),
+        "{manifest:#}"
+    );
+
+    let runner_path = repo_root.join(".github/scripts/run-kast-format-impact-report.sh");
+    let runner = std::fs::read_to_string(&runner_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", runner_path.display()));
+    assert!(
+        runner.contains("format_impact_report"),
+        "runner should use the Rust TOON-aware report generator: {runner}"
+    );
+    assert!(
+        runner.contains("KAST_FORMAT_IMPACT_OBSERVED_JSONL"),
+        "runner should feed observed JSONL into the metric pack: {runner}"
+    );
+    assert!(
+        !runner.contains("exit 1 # accuracy"),
+        "report-only accuracy deltas should not be hard CI failures: {runner}"
+    );
+}

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -322,6 +322,16 @@ fn packaged_skill_format_impact_eval_covers_toon_accuracy_surface() {
             "case should include gold facts: {case:#}"
         );
         assert!(
+            case["answerScoring"]["requiredTerms"]
+                .as_array()
+                .is_some_and(|terms| !terms.is_empty()),
+            "case should include deterministic answer scoring terms: {case:#}"
+        );
+        assert!(
+            case["answerScoring"]["forbiddenTerms"].is_array(),
+            "case should include deterministic forbidden answer terms: {case:#}"
+        );
+        assert!(
             case["reportOnly"].as_bool() == Some(true),
             "format impact live accuracy cases must stay report-only: {case:#}"
         );
@@ -365,7 +375,7 @@ fn packaged_skill_format_impact_eval_covers_toon_accuracy_surface() {
 }
 
 #[test]
-fn format_impact_metric_pack_and_runner_are_report_only() {
+fn format_impact_metric_pack_and_runner_capture_scoreable_answers() {
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("repo root");
@@ -395,7 +405,83 @@ fn format_impact_metric_pack_and_runner_are_report_only() {
         "runner should feed observed JSONL into the metric pack: {runner}"
     );
     assert!(
-        !runner.contains("exit 1 # accuracy"),
-        "report-only accuracy deltas should not be hard CI failures: {runner}"
+        runner.contains("--answer-requests"),
+        "runner should write answer request JSONL for external answer capture: {runner}"
     );
+    assert!(
+        runner.contains("KAST_FORMAT_IMPACT_ANSWERS_JSONL"),
+        "runner should score captured answers when supplied: {runner}"
+    );
+
+    let metric_pack_path = repo_root
+        .join(".github/plugin-eval/kast-format-impact/emit-kast-format-impact-metrics.mjs");
+    let metric_pack = std::fs::read_to_string(&metric_pack_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", metric_pack_path.display()));
+    assert!(
+        metric_pack.contains("format-impact-answer-scoring"),
+        "metric pack should expose answer scoring as a first-class check: {metric_pack}"
+    );
+    assert!(
+        metric_pack.contains("kast-format-impact-answer-pass-rate"),
+        "metric pack should emit answer pass-rate metrics: {metric_pack}"
+    );
+
+    let target = repo_root.join("cli-rs/resources/kast-skill");
+    let eval_path = target.join("fixtures/maintenance/evals/format-impact.json");
+    let eval: Value = serde_json::from_str(
+        &std::fs::read_to_string(&eval_path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", eval_path.display())),
+    )
+    .expect("format impact eval json");
+    let temp = tempfile::tempdir().expect("format impact metric tempdir");
+    let observed_path = temp.path().join("observed.jsonl");
+    let mut observed = String::new();
+    for case in eval["cases"].as_array().expect("format impact cases") {
+        let case_id = case["id"].as_str().expect("case id");
+        for format in ["json", "toon"] {
+            observed.push_str(
+                &serde_json::to_string(&serde_json::json!({
+                    "caseId": case_id,
+                    "format": format,
+                    "decodedEquivalent": true,
+                    "answerVerdict": "pass",
+                    "stdoutBytes": 1
+                }))
+                .expect("observed record json"),
+            );
+            observed.push('\n');
+        }
+    }
+    std::fs::write(&observed_path, observed)
+        .unwrap_or_else(|error| panic!("write {}: {error}", observed_path.display()));
+
+    let output = Command::new("node")
+        .arg(&metric_pack_path)
+        .arg(&target)
+        .arg("skill")
+        .env("KAST_FORMAT_IMPACT_OBSERVED_JSONL", &observed_path)
+        .output()
+        .unwrap_or_else(|error| panic!("run {}: {error}", metric_pack_path.display()));
+    assert!(
+        output.status.success(),
+        "metric pack should run: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let metric_output: Value =
+        serde_json::from_slice(&output.stdout).expect("metric pack output json");
+    let answer_check = metric_output["checks"]
+        .as_array()
+        .expect("metric checks")
+        .iter()
+        .find(|check| check["id"] == "format-impact-answer-scoring")
+        .expect("answer scoring check");
+    assert_eq!(answer_check["status"], "pass", "{metric_output:#}");
+    let answer_pass_rate = metric_output["metrics"]
+        .as_array()
+        .expect("metric list")
+        .iter()
+        .find(|metric| metric["id"] == "kast-format-impact-answer-pass-rate")
+        .expect("answer pass-rate metric");
+    assert_eq!(answer_pass_rate["value"], 100, "{metric_output:#}");
 }

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -10,10 +10,13 @@ icon: lucide/bot
 agents. It is part of the public command tree because it is the preferred
 machine-oriented command path.
 
-## JSON envelope
+## Agent Envelope
 
-Every `kast agent` command emits one JSON object on stdout. Treat `ok: false`
-as a failed operation even when the process exited cleanly.
+Every `kast agent` command emits one envelope on stdout. JSON is the default
+and remains the canonical script format. Use `kast agent --format toon ...`
+only when the host can consume TOON and needs a denser, prompt-friendly
+encoding for large read-only responses. Treat `ok: false` as a failed
+operation even when the process exited cleanly.
 
 ```json title="Envelope shape"
 {
@@ -24,13 +27,18 @@ as a failed operation even when the process exited cleanly.
 }
 ```
 
-Stderr may contain human-readable startup or progress messages. Scripts should
-parse stdout and keep stderr for diagnostics.
+The envelope fields are the same for JSON and TOON output. Stderr may contain
+human-readable startup or progress messages. Scripts should parse stdout and
+keep stderr for diagnostics.
+
+Request inputs stay JSON regardless of stdout encoding. Keep `--params`,
+`--params-file`, and `--request-file` payloads as JSON, and keep workflow files
+as JSON artifacts.
 
 ```mermaid
 flowchart LR
     command["kast agent ..."]
-    envelope["JSON envelope"]
+    envelope["agent envelope"]
     ok["ok: true<br/>result"]
     error["ok: false<br/>error"]
     next["nextRequest or workflow files"]
@@ -122,6 +130,7 @@ mutation metadata, and params JSON Schemas.
 
 ```console title="List catalog-backed tools"
 kast agent tools
+kast agent --format toon tools
 ```
 
 Invoke one of the returned specs through the returned
@@ -152,13 +161,14 @@ sequenceDiagram
     Host->>CLI: kast agent call <method>
     CLI->>Backend: Normalized request
     Backend-->>CLI: Semantic result or typed error
-    CLI-->>Host: JSON envelope
+    CLI-->>Host: agent envelope
 ```
 
 ## Catalog calls
 
 Use catalog calls for method-specific requests. They prepare the request object
-and return a stable JSON envelope.
+and return a stable agent envelope: JSON by default, or TOON when requested
+with `kast agent --format toon ...`.
 
 ```console title="Resolve and trace from a file offset"
 APP_FILE="$PWD/src/main/kotlin/App.kt"
@@ -230,5 +240,5 @@ dry-run workflow as proof that files changed.
 
 Use `kast agent call <method>` when a workflow does not fit and the task needs a
 specific catalog method. The input may be a params object, a full JSON-RPC
-request, or a prior agent envelope with `nextRequest`; the output is always the
-agent envelope.
+request, or a prior agent envelope with `nextRequest`; the output is the agent
+envelope, using JSON unless `--format toon` is requested.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -40,7 +40,7 @@ flowchart LR
 | Agent automation | `agent tools`, `agent call <method>`, `agent workflow ...`, `agent lsp` | Discover tools, start LSP, and script semantic workflows |
 | Runtime | `status`, `developer runtime ...` | Inspect, start, refresh, or stop the workspace backend |
 | Inspect | `developer inspect paths`, `developer inspect metrics`, `developer inspect demo`, `developer inspect catalog` | Inspect paths, catalogs, demos, and source-index metrics |
-| Machine | `developer machine plugin`, `developer machine shell` | Manage local IDE plugin links and shell integration |
+| Machine | `developer machine plugin`, `developer machine defaults`, `developer machine shell` | Manage local IDE plugin links, developer defaults, and shell integration |
 | Release | `developer release package ...`, `developer release activate bundle`, `developer release generate`, `developer release validate` | Build, activate, or validate release artifacts |
 
 ## Output modes

--- a/docs/commands/install-repair.md
+++ b/docs/commands/install-repair.md
@@ -92,6 +92,13 @@ brew reinstall --cask kast-plugin
 kast developer machine plugin
 ```
 
+Use `kast developer machine defaults` to make developer-machine commands prefer
+the IDEA plugin backend unless a command explicitly passes another backend.
+
+```console title="Configure developer-machine backend defaults"
+kast developer machine defaults
+```
+
 Use `kast developer machine shell` to add the active shim directory to a shell profile
 and write managed completion integration.
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -200,7 +200,8 @@ For live Copilot CLI validation of the SDK extension tools, load the source
 package explicitly with `--plugin-dir cli-rs/resources/plugin`.
 
 Use the development Gradle task when you need a local debug CLI and IDEA plugin
-from the checkout:
+from the checkout. It also configures the developer-machine backend default to
+the IDEA plugin backend:
 
 ```console title="Install local development CLI and plugin"
 ./gradlew installDevelopmentLocal

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -38,28 +38,29 @@ it. Kast walks upward to the nearest Gradle or `.kast` marker when
 
 ## Step 1: start a backend
 
-Use the backend that matches the machine. The headless backend works well for
-servers and CI. The IDEA backend reuses an already-open IDEA or Android Studio
-project on developer machines.
+Use the backend that matches the machine. The developer-machine install
+configures the IDEA plugin backend as the default, so ordinary local commands
+do not need `--backend`. The headless backend stays explicit for Linux servers,
+CI, and hosted agents.
 
-=== "Headless"
+=== "Developer machine"
+
+    ```console title="Reuse an open IDEA or Android Studio project"
+    kast setup --no-open-ide
+    kast status
+    ```
+
+=== "Headless Linux"
 
     ```console title="Start or warm a headless backend"
     kast setup --backend=headless --no-open-ide
     kast status --backend=headless
     ```
 
-=== "IDEA"
-
-    ```console title="Reuse an open IDEA or Android Studio project"
-    kast setup --backend=idea --no-open-ide
-    kast status --backend=idea
-    ```
-
 Use JSON output for automation:
 
 ```console title="Machine-readable status"
-kast --output json status --backend=headless
+kast --output json status
 ```
 
 ## Step 2: resolve a symbol
@@ -71,8 +72,7 @@ returns one JSON object with the normalized request and result.
 APP_FILE="$PWD/src/main/kotlin/App.kt"
 
 kast agent call raw/resolve \
-  --params "{\"position\":{\"filePath\":\"$APP_FILE\",\"offset\":42}}" \
-  --backend=headless
+  --params "{\"position\":{\"filePath\":\"$APP_FILE\",\"offset\":42}}"
 ```
 
 The important fields are in `result`: fully qualified name, kind, signature,
@@ -92,8 +92,7 @@ you want one complete evidence list.
 
 ```console title="Find references"
 kast agent call raw/references \
-  --params "{\"position\":{\"filePath\":\"$APP_FILE\",\"offset\":42},\"includeDeclaration\":true}" \
-  --backend=headless
+  --params "{\"position\":{\"filePath\":\"$APP_FILE\",\"offset\":42},\"includeDeclaration\":true}"
 ```
 
 Read `result.searchScope.exhaustive` before claiming the list is complete. If
@@ -112,12 +111,14 @@ commands.
 
 ```console title="Find declarations by name"
 kast agent call raw/workspace-symbol \
-  --params '{"pattern":"OrderService","maxResults":20}' \
-  --backend=headless
+  --params '{"pattern":"OrderService","maxResults":20}'
 ```
 
 This keeps the workflow semantic. Use text search only when you are looking for
 plain text, comments, or literals.
+
+On a Linux headless install, add `--backend=headless` to the lifecycle and
+agent commands above.
 
 ## Step 5: stop when finished
 
@@ -125,7 +126,7 @@ Stop the backend when you want to free local resources. Long-lived developer
 machines can keep a warm backend running.
 
 ```console title="Stop the backend"
-kast developer runtime stop --backend=headless
+kast developer runtime stop
 ```
 
 ## Next commands


### PR DESCRIPTION
## Summary

- Add deterministic answer-scoring terms to the TOON format-impact corpus and schema.
- Extend the format-impact report generator to write answer request JSONL, accept captured answer JSONL, and emit per-answer verdicts and pass-rate summary fields.
- Update the plugin-eval metric pack and runner script so answer scoring is report-only when absent and measured when `KAST_FORMAT_IMPACT_ANSWERS_JSONL` is supplied.
- Add packaged-content coverage for the capture/scoring contract.

## Validation

- `.github/scripts/run-kast-format-impact-report.sh`
  - 14 observed JSON/TOON records
  - 37.63% TOON byte reduction
  - answer scoring reported as unmeasured when no captured answers were supplied
- `KAST_FORMAT_IMPACT_ANSWERS_JSONL="$PWD/cli-rs/target/format-impact/generated-answers.jsonl" .github/scripts/run-kast-format-impact-report.sh`
  - 14 measured answers
  - 100% answer pass rate
  - metric pack score 100
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke -- --nocapture`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `git diff --check`

## Notes

Captured answer quality remains report-only unless a caller supplies answer JSONL through `KAST_FORMAT_IMPACT_ANSWERS_JSONL`. The deterministic gate still checks corpus shape, JSON/TOON pair completeness, and decoded equivalence.