### PR TITLE
fix: default developer machines to IDEA backend

### DIFF
--- a/.github/scripts/test-development-cli-install-contract.sh
+++ b/.github/scripts/test-development-cli-install-contract.sh
@@ -52,7 +52,7 @@ dev_cli="${install_bin_dir}/kast-dev"
 profile="${tmp_root}/zshrc"
 shell_install_json="${tmp_root}/shell-install.json"
 HOME="$home_dir" KAST_CONFIG_HOME="$config_home" \
-  "$dev_cli" --output json machine shell --shell zsh --profile "$profile" >"$shell_install_json"
+  "$dev_cli" --output json developer machine shell --shell zsh --profile "$profile" >"$shell_install_json"
 
 grep -Fq '"commandName": "kast-dev"' "$shell_install_json" \
   || die "install shell should target the kast-dev command name"
@@ -65,7 +65,7 @@ grep -Fq "# >>> kast shell integration >>>" "$profile" \
 source_file="$(sed -n 's/.*"sourceFile": "\(.*\)",/\1/p' "$shell_install_json" | head -1)"
 [[ -n "$source_file" && -f "$source_file" ]] \
   || die "install shell should write the managed source file"
-grep -Fq "kast-dev machine completion zsh --command-name kast-dev" "$source_file" \
+grep -Fq "kast-dev developer machine completion zsh --command-name kast-dev" "$source_file" \
   || die "managed shell source should route completion through machine completion"
 
 gradle_profile="${tmp_root}/gradle-zshrc"
@@ -82,7 +82,7 @@ HOME="$home_dir" \
 
 grep -Fq "# >>> kast shell integration >>>" "$gradle_profile" \
   || die "installDevelopmentShell should patch the requested profile"
-grep -Fq "kast-dev machine completion zsh --command-name kast-dev" "${config_home}/shell/kast-dev.zsh" \
+grep -Fq "kast-dev developer machine completion zsh --command-name kast-dev" "${config_home}/shell/kast-dev.zsh" \
   || die "installDevelopmentShell should route completions through kast-dev"
 
 plugins_dir="${tmp_root}/jetbrains/plugins"
@@ -113,6 +113,20 @@ HOME="$home_dir" \
   KAST_CONFIG_HOME="$config_home" \
   PATH="$restricted_path" \
   "${repo_root}/gradlew" -q help --task installDevelopmentLocal >/dev/null
+
+HOME="$home_dir" \
+  CARGO_HOME="$cargo_home" \
+  RUSTUP_HOME="$rustup_home" \
+  GRADLE_USER_HOME="$gradle_user_home" \
+  KAST_CONFIG_HOME="$config_home" \
+  KAST_BIN_DIR="$install_bin_dir" \
+  PATH="$restricted_path" \
+  "${repo_root}/gradlew" -q configureDevelopmentMachineDefaults
+
+grep -Fq 'defaultBackend = "idea"' "${config_home}/config.toml" \
+  || die "configureDevelopmentMachineDefaults should set the IDEA plugin backend as the developer default"
+grep -Fq 'enabled = true' "${config_home}/config.toml" \
+  || die "configureDevelopmentMachineDefaults should enable IDEA launch policy"
 
 bin_config_home="${tmp_root}/config-bin-dir"
 custom_bin_dir="${tmp_root}/custom-bin"

--- a/.github/scripts/test-docs-content-contract.sh
+++ b/.github/scripts/test-docs-content-contract.sh
@@ -152,7 +152,8 @@ require_contains "$install_doc" "headless-linux.md" "Install docs must link the 
 require_contains "$headless_doc" 'scripts/install-ubuntu-debian.sh' "Headless docs must document the canonical Linux installer"
 require_contains "$headless_doc" 'kast developer release package ubuntu-debian-bundle' "Headless docs must document the release bundle packager"
 
-require_contains "$quickstart_doc" "kast setup --backend=headless" "Quickstart must start or warm a backend through setup"
+require_contains "$quickstart_doc" "kast setup --no-open-ide" "Quickstart must start or warm the developer-machine backend through setup"
+require_contains "$quickstart_doc" "kast setup --backend=headless" "Quickstart must keep explicit headless setup for Linux hosts"
 require_contains "$quickstart_doc" "kast agent call raw/resolve" "Quickstart must use agent resolve"
 require_contains "$quickstart_doc" "kast agent call raw/references" "Quickstart must use agent references"
 require_contains "$quickstart_doc" "kast agent call raw/workspace-symbol" "Quickstart must show name-to-offset bridge"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -209,6 +209,7 @@ val installDevelopmentShell: TaskProvider<Exec> by tasks.registering(Exec::class
             kastDevBinary.absolutePath,
             "--output",
             "json",
+            "developer",
             "machine",
             "shell",
             "--shell",
@@ -216,6 +217,20 @@ val installDevelopmentShell: TaskProvider<Exec> by tasks.registering(Exec::class
             "--command-name",
             "kast-dev",
         ) + developmentShellProfileArg()
+    )
+}
+
+val configureDevelopmentMachineDefaults: TaskProvider<Exec> by tasks.registering(Exec::class) {
+    group = "distribution"
+    description = "Configures developer-machine defaults to use the IDEA plugin backend."
+    dependsOn("installDevelopmentCli")
+    commandLine(
+        kastDevBinary.absolutePath,
+        "--output",
+        "json",
+        "developer",
+        "machine",
+        "defaults",
     )
 }
 
@@ -314,5 +329,5 @@ val installDevelopmentIdeaPlugin: TaskProvider<InstallDevelopmentIdeaPluginTask>
 tasks.register("installDevelopmentLocal") {
     group = "distribution"
     description = "Installs kast-dev shell integration and replaces the local IDEA plugin with the development build."
-    dependsOn(installDevelopmentShell, installDevelopmentIdeaPlugin)
+    dependsOn(installDevelopmentShell, installDevelopmentIdeaPlugin, configureDevelopmentMachineDefaults)
 }

--- a/cli-rs/src/cli/command_groups.rs
+++ b/cli-rs/src/cli/command_groups.rs
@@ -50,6 +50,8 @@ pub struct MachineArgs {
 pub enum MachineCommand {
     /// Install the Homebrew-managed IDEA plugin cask and link JetBrains profiles.
     Plugin(IdeaPluginInstallArgs),
+    /// Configure developer-machine defaults to use the IDEA plugin backend.
+    Defaults(DeveloperMachineDefaultsArgs),
     /// Install shell PATH and completion integration.
     Shell(ShellInstallArgs),
     /// Print shell completion scripts.

--- a/cli-rs/src/cli/install_machine.rs
+++ b/cli-rs/src/cli/install_machine.rs
@@ -112,6 +112,13 @@ pub struct ShellInstallArgs {
 }
 
 #[derive(Debug, Args, Clone)]
+pub struct DeveloperMachineDefaultsArgs {
+    /// Print the planned developer-machine config without writing it.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Args, Clone)]
 pub struct ResourceInstallArgs {
     /// Target root directory.
     #[arg(long)]

--- a/cli-rs/src/install/jetbrains_profiles.rs
+++ b/cli-rs/src/install/jetbrains_profiles.rs
@@ -135,6 +135,17 @@ fn install_idea_plugin_into_jetbrains_profiles(
             }
         }
     }
+    let developer_defaults = if args.dry_run {
+        self_mgmt::configure_developer_machine_defaults(true)?
+    } else {
+        reporter.idea_plugin_step_started("Configuring developer-machine IDEA defaults")?;
+        let defaults = self_mgmt::configure_developer_machine_defaults(false)?;
+        reporter.idea_plugin_step_finished(&format!(
+            "Configured IDEA plugin backend defaults at {}",
+            defaults.config_path
+        ))?;
+        defaults
+    };
 
     Ok(InstallIdeaPluginResult {
         cask_token,
@@ -154,6 +165,7 @@ fn install_idea_plugin_into_jetbrains_profiles(
             .map(|path| path.display().to_string())
             .collect(),
         dry_run: args.dry_run,
+        developer_defaults,
         warnings,
         schema_version: SCHEMA_VERSION,
     })

--- a/cli-rs/src/install/types.rs
+++ b/cli-rs/src/install/types.rs
@@ -154,6 +154,7 @@ pub struct InstallIdeaPluginResult {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub plugin_directories: Vec<String>,
     pub dry_run: bool,
+    pub developer_defaults: self_mgmt::DeveloperMachineDefaultsResult,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
     pub schema_version: u32,

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -762,6 +762,15 @@ fn run_machine(command: cli::MachineCommand, output_format: OutputFormat) -> Res
         cli::MachineCommand::Plugin(args) => {
             run_install(cli::InstallCommand::Plugin(args), output_format)
         }
+        cli::MachineCommand::Defaults(args) => {
+            let result = self_mgmt::configure_developer_machine_defaults(args.dry_run)?;
+            if output_format == OutputFormat::Json {
+                output::print_json(&result)?;
+            } else {
+                output::print_developer_machine_defaults(&result)?;
+            }
+            Ok(0)
+        }
         cli::MachineCommand::Shell(args) => {
             run_install(cli::InstallCommand::Shell(args), output_format)
         }

--- a/cli-rs/src/onboarding.rs
+++ b/cli-rs/src/onboarding.rs
@@ -171,11 +171,7 @@ fn apply_agent_up_onboarding_config(
 }
 
 fn write_agent_up_onboarding_defaults(document: &mut toml::Table) -> Result<()> {
-    table(document, "runtime")?.insert("defaultBackend".to_string(), "idea".into());
-    let idea_launch = nested_table(document, "runtime", "ideaLaunch")?;
-    idea_launch.insert("enabled".to_string(), true.into());
-    idea_launch.insert("command".to_string(), "idea".into());
-    idea_launch.insert("requireInstalledPlugin".to_string(), true.into());
+    self_mgmt::write_developer_machine_idea_defaults(document)?;
 
     let project_open = table(document, "projectOpen")?;
     project_open.insert("profileAutoInit".to_string(), true.into());
@@ -193,25 +189,6 @@ fn table<'a>(document: &'a mut toml::Table, key: &str) -> Result<&'a mut toml::T
             CliError::new(
                 "CONFIG_ERROR",
                 format!("Cannot write onboarding config because `{key}` is not a TOML table."),
-            )
-        })
-}
-
-fn nested_table<'a>(
-    document: &'a mut toml::Table,
-    first: &str,
-    second: &str,
-) -> Result<&'a mut toml::Table> {
-    table(document, first)?
-        .entry(second.to_string())
-        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
-        .as_table_mut()
-        .ok_or_else(|| {
-            CliError::new(
-                "CONFIG_ERROR",
-                format!(
-                    "Cannot write onboarding config because `{first}.{second}` is not a TOML table."
-                ),
             )
         })
 }

--- a/cli-rs/src/output.rs
+++ b/cli-rs/src/output.rs
@@ -12,7 +12,7 @@ use crate::runtime::{
     DaemonStopResult, RuntimeCandidateStatus, RuntimeState, WorkspaceEnsureResult,
     WorkspaceRestartResult, WorkspaceStatusResult,
 };
-use crate::self_mgmt::SelfDoctorResult;
+use crate::self_mgmt::{DeveloperMachineDefaultsResult, SelfDoctorResult};
 use glamour::{Renderer, Style as GlamourStyle};
 use serde::Serialize;
 use serde_json::Value;

--- a/cli-rs/src/output/install.rs
+++ b/cli-rs/src/output/install.rs
@@ -113,6 +113,14 @@ fn print_idea_plugin_install_summary(document: &mut MarkdownDocument, result: &I
             compact_path_for_output(jetbrains_config_root),
         ));
     }
+    rows.push((
+        "Developer default backend",
+        format!("{:?}", result.developer_defaults.default_backend).to_lowercase(),
+    ));
+    rows.push((
+        "Developer config",
+        compact_path_for_output(&result.developer_defaults.config_path),
+    ));
     for (item, value) in rows {
         mdln!(document, "- {item}: `{value}`");
     }
@@ -165,6 +173,41 @@ fn print_shell_install(result: &InstallShellResult) -> Result<()> {
         document,
         "- Open a fresh shell or run `{}`.",
         result.source_line
+    );
+    print_markdown(&document.into_string())
+}
+
+pub fn print_developer_machine_defaults(result: &DeveloperMachineDefaultsResult) -> Result<()> {
+    let mut document = MarkdownDocument::default();
+    mdln!(document, "# Kast developer-machine defaults");
+    mdln!(document);
+    mdln!(
+        document,
+        "- Status: {}",
+        if result.applied { "applied" } else { "planned" }
+    );
+    mdln!(document, "- Config path: `{}`", result.config_path);
+    mdln!(document, "- Default backend: `idea`");
+    mdln!(
+        document,
+        "- IDEA launch enabled: {}",
+        yes_no(result.idea_launch_enabled)
+    );
+    mdln!(document, "- IDEA launch command: `{}`", result.idea_launch_command);
+    mdln!(
+        document,
+        "- Require installed plugin: {}",
+        yes_no(result.require_installed_plugin)
+    );
+    mdln!(document);
+    mdln!(document, "## Next steps");
+    mdln!(
+        document,
+        "- Restart any open IntelliJ IDEA or Android Studio windows after updating the plugin."
+    );
+    mdln!(
+        document,
+        "- Reopen the project, then run `kast status` to verify the IDEA backend."
     );
     print_markdown(&document.into_string())
 }

--- a/cli-rs/src/output/tests.rs
+++ b/cli-rs/src/output/tests.rs
@@ -223,6 +223,15 @@ mod tests {
             jetbrains_config_root: Some("/tmp/JetBrains".to_string()),
             plugin_directories: vec!["/tmp/JetBrains/IntelliJIdea2026.1/plugins".to_string()],
             dry_run,
+            developer_defaults: DeveloperMachineDefaultsResult {
+                config_path: "/tmp/config.toml".to_string(),
+                default_backend: crate::config::RuntimeDefaultBackend::Idea,
+                idea_launch_enabled: true,
+                idea_launch_command: "idea".to_string(),
+                require_installed_plugin: true,
+                applied: !dry_run,
+                schema_version: 3,
+            },
             warnings: vec![],
             schema_version: 3,
         }

--- a/cli-rs/src/self_mgmt.rs
+++ b/cli-rs/src/self_mgmt.rs
@@ -55,6 +55,18 @@ pub struct DoctorBinaryDiagnostic {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DeveloperMachineDefaultsResult {
+    pub config_path: String,
+    pub default_backend: config::RuntimeDefaultBackend,
+    pub idea_launch_enabled: bool,
+    pub idea_launch_command: String,
+    pub require_installed_plugin: bool,
+    pub applied: bool,
+    pub schema_version: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SelfDoctorResult {
     pub target: ReadyTarget,
     pub installed: bool,
@@ -402,6 +414,33 @@ pub fn update_workspace_config(
     update_config_file(&path, mutator)
 }
 
+pub fn configure_developer_machine_defaults(
+    dry_run: bool,
+) -> Result<DeveloperMachineDefaultsResult> {
+    let config_path = config::global_config_path();
+    if !dry_run {
+        update_global_config(write_developer_machine_idea_defaults)?;
+    }
+    Ok(DeveloperMachineDefaultsResult {
+        config_path: config_path.display().to_string(),
+        default_backend: config::RuntimeDefaultBackend::Idea,
+        idea_launch_enabled: true,
+        idea_launch_command: "idea".to_string(),
+        require_installed_plugin: true,
+        applied: !dry_run,
+        schema_version: SCHEMA_VERSION,
+    })
+}
+
+pub(crate) fn write_developer_machine_idea_defaults(document: &mut toml::Table) -> Result<()> {
+    table(document, "runtime")?.insert("defaultBackend".to_string(), "idea".into());
+    let idea_launch = nested_table(document, "runtime", "ideaLaunch")?;
+    idea_launch.insert("enabled".to_string(), true.into());
+    idea_launch.insert("command".to_string(), "idea".into());
+    idea_launch.insert("requireInstalledPlugin".to_string(), true.into());
+    Ok(())
+}
+
 fn update_config_file(
     path: &Path,
     mutator: impl FnOnce(&mut toml::Table) -> Result<()>,
@@ -439,6 +478,40 @@ fn write_config_document(path: &Path, document: &toml::Table) -> Result<()> {
 
 fn default_config_document() -> Result<toml::Table> {
     Ok(config::default_config_template()?.parse::<toml::Table>()?)
+}
+
+fn table<'a>(document: &'a mut toml::Table, key: &str) -> Result<&'a mut toml::Table> {
+    document
+        .entry(key.to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| {
+            crate::error::CliError::new(
+                "CONFIG_ERROR",
+                format!(
+                    "Cannot write developer-machine config because `{key}` is not a TOML table."
+                ),
+            )
+        })
+}
+
+fn nested_table<'a>(
+    document: &'a mut toml::Table,
+    first: &str,
+    second: &str,
+) -> Result<&'a mut toml::Table> {
+    table(document, first)?
+        .entry(second.to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| {
+            crate::error::CliError::new(
+                "CONFIG_ERROR",
+                format!(
+                    "Cannot write developer-machine config because `{first}.{second}` is not a TOML table."
+                ),
+            )
+        })
 }
 
 fn merge_config_document(base: &mut toml::Table, overlay: toml::Table) {

--- a/cli-rs/tests/inspect_and_shell_smoke.rs
+++ b/cli-rs/tests/inspect_and_shell_smoke.rs
@@ -322,6 +322,70 @@ fn install_shell_writes_path_and_completion_profile_integration() {
 }
 
 #[test]
+fn developer_machine_defaults_configures_idea_plugin_backend() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let defaults = kast(&home, &config_home)
+        .args(["--output", "json", "developer", "machine", "defaults"])
+        .output()
+        .expect("developer machine defaults");
+
+    assert!(
+        defaults.status.success(),
+        "developer defaults should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&defaults.stdout),
+        String::from_utf8_lossy(&defaults.stderr)
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&defaults.stdout).expect("developer defaults json");
+    assert_eq!(stdout["defaultBackend"], "idea");
+    assert_eq!(stdout["ideaLaunchEnabled"], true);
+    assert_eq!(stdout["ideaLaunchCommand"], "idea");
+    assert_eq!(stdout["requireInstalledPlugin"], true);
+    assert_eq!(stdout["applied"], true);
+
+    let config = std::fs::read_to_string(config_home.join("config.toml")).expect("config");
+    assert!(config.contains("defaultBackend = \"idea\""), "{config}");
+    assert!(config.contains("[runtime.ideaLaunch]"), "{config}");
+    assert!(config.contains("enabled = true"), "{config}");
+    assert!(config.contains("command = \"idea\""), "{config}");
+    assert!(config.contains("requireInstalledPlugin = true"), "{config}");
+
+    let up = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "runtime",
+            "up",
+            "--workspace-root",
+            workspace.to_str().expect("workspace path"),
+            "--no-auto-start=true",
+        ])
+        .output()
+        .expect("runtime up");
+    assert!(
+        !up.status.success(),
+        "runtime up should fail without a live IDEA backend"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&up.stdout),
+        String::from_utf8_lossy(&up.stderr)
+    );
+    assert!(combined.contains("IDEA_PLUGIN_NOT_INSTALLED"), "{combined}");
+    assert!(
+        !combined.contains("Linux headless tarball"),
+        "developer defaults should not fall through to headless guidance: {combined}"
+    );
+}
+
+#[test]
 fn install_shell_prefers_running_cli_directory_over_stale_config_bin_dir() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/cli-rs/tests/machine_plugin_repair_smoke.rs
+++ b/cli-rs/tests/machine_plugin_repair_smoke.rs
@@ -58,6 +58,12 @@ fn idea_plugin_install_uses_profile_install_mode() {
             .display()
             .to_string()
     );
+    assert_eq!(stdout["developerDefaults"]["defaultBackend"], "idea");
+    assert_eq!(stdout["developerDefaults"]["applied"], false);
+    assert!(
+        !config_home.join("config.toml").exists(),
+        "dry-run plugin install must not write developer defaults"
+    );
     assert!(stdout.get("downloadDir").is_none(), "{stdout}");
 }
 

--- a/cli-rs/tests/machine_plugin_smoke.rs
+++ b/cli-rs/tests/machine_plugin_smoke.rs
@@ -93,6 +93,15 @@ fn plugin_install_gateway_installs_homebrew_cask_and_links_profiles() {
     );
     assert!(stdout.get("downloadDir").is_none(), "{stdout}");
     assert!(stdout.get("downloadedPath").is_none(), "{stdout}");
+    assert_eq!(stdout["developerDefaults"]["defaultBackend"], "idea");
+    assert_eq!(stdout["developerDefaults"]["ideaLaunchEnabled"], true);
+    assert_eq!(stdout["developerDefaults"]["applied"], true);
+    let config = std::fs::read_to_string(config_home.join("config.toml")).expect("config");
+    assert!(config.contains("defaultBackend = \"idea\""), "{config}");
+    assert!(config.contains("[runtime.ideaLaunch]"), "{config}");
+    assert!(config.contains("enabled = true"), "{config}");
+    assert!(config.contains("command = \"idea\""), "{config}");
+    assert!(config.contains("requireInstalledPlugin = true"), "{config}");
     #[cfg(unix)]
     assert_eq!(
         std::fs::read_link(jetbrains_root.join("IntelliJIdea2026.1/plugins/kast"))

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -40,7 +40,7 @@ flowchart LR
 | Agent automation | `agent tools`, `agent call <method>`, `agent workflow ...`, `agent lsp` | Discover tools, start LSP, and script semantic workflows |
 | Runtime | `status`, `developer runtime ...` | Inspect, start, refresh, or stop the workspace backend |
 | Inspect | `developer inspect paths`, `developer inspect metrics`, `developer inspect demo`, `developer inspect catalog` | Inspect paths, catalogs, demos, and source-index metrics |
-| Machine | `developer machine plugin`, `developer machine shell` | Manage local IDE plugin links and shell integration |
+| Machine | `developer machine plugin`, `developer machine defaults`, `developer machine shell` | Manage local IDE plugin links, developer defaults, and shell integration |
 | Release | `developer release package ...`, `developer release activate bundle`, `developer release generate`, `developer release validate` | Build, activate, or validate release artifacts |
 
 ## Output modes

--- a/docs/commands/install-repair.md
+++ b/docs/commands/install-repair.md
@@ -92,6 +92,13 @@ brew reinstall --cask kast-plugin
 kast developer machine plugin
 ```
 
+Use `kast developer machine defaults` to make developer-machine commands prefer
+the IDEA plugin backend unless a command explicitly passes another backend.
+
+```console title="Configure developer-machine backend defaults"
+kast developer machine defaults
+```
+
 Use `kast developer machine shell` to add the active shim directory to a shell profile
 and write managed completion integration.
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -200,7 +200,8 @@ For live Copilot CLI validation of the SDK extension tools, load the source
 package explicitly with `--plugin-dir cli-rs/resources/plugin`.
 
 Use the development Gradle task when you need a local debug CLI and IDEA plugin
-from the checkout:
+from the checkout. It also configures the developer-machine backend default to
+the IDEA plugin backend:
 
 ```console title="Install local development CLI and plugin"
 ./gradlew installDevelopmentLocal

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -38,28 +38,29 @@ it. Kast walks upward to the nearest Gradle or `.kast` marker when
 
 ## Step 1: start a backend
 
-Use the backend that matches the machine. The headless backend works well for
-servers and CI. The IDEA backend reuses an already-open IDEA or Android Studio
-project on developer machines.
+Use the backend that matches the machine. The developer-machine install
+configures the IDEA plugin backend as the default, so ordinary local commands
+do not need `--backend`. The headless backend stays explicit for Linux servers,
+CI, and hosted agents.
 
-=== "Headless"
+=== "Developer machine"
+
+    ```console title="Reuse an open IDEA or Android Studio project"
+    kast setup --no-open-ide
+    kast status
+    ```
+
+=== "Headless Linux"
 
     ```console title="Start or warm a headless backend"
     kast setup --backend=headless --no-open-ide
     kast status --backend=headless
     ```
 
-=== "IDEA"
-
-    ```console title="Reuse an open IDEA or Android Studio project"
-    kast setup --backend=idea --no-open-ide
-    kast status --backend=idea
-    ```
-
 Use JSON output for automation:
 
 ```console title="Machine-readable status"
-kast --output json status --backend=headless
+kast --output json status
 ```
 
 ## Step 2: resolve a symbol
@@ -71,8 +72,7 @@ returns one JSON object with the normalized request and result.
 APP_FILE="$PWD/src/main/kotlin/App.kt"
 
 kast agent call raw/resolve \
-  --params "{\"position\":{\"filePath\":\"$APP_FILE\",\"offset\":42}}" \
-  --backend=headless
+  --params "{\"position\":{\"filePath\":\"$APP_FILE\",\"offset\":42}}"
 ```
 
 The important fields are in `result`: fully qualified name, kind, signature,
@@ -92,8 +92,7 @@ you want one complete evidence list.
 
 ```console title="Find references"
 kast agent call raw/references \
-  --params "{\"position\":{\"filePath\":\"$APP_FILE\",\"offset\":42},\"includeDeclaration\":true}" \
-  --backend=headless
+  --params "{\"position\":{\"filePath\":\"$APP_FILE\",\"offset\":42},\"includeDeclaration\":true}"
 ```
 
 Read `result.searchScope.exhaustive` before claiming the list is complete. If
@@ -112,12 +111,14 @@ commands.
 
 ```console title="Find declarations by name"
 kast agent call raw/workspace-symbol \
-  --params '{"pattern":"OrderService","maxResults":20}' \
-  --backend=headless
+  --params '{"pattern":"OrderService","maxResults":20}'
 ```
 
 This keeps the workflow semantic. Use text search only when you are looking for
 plain text, comments, or literals.
+
+On a Linux headless install, add `--backend=headless` to the lifecycle and
+agent commands above.
 
 ## Step 5: stop when finished
 
@@ -125,7 +126,7 @@ Stop the backend when you want to free local resources. Long-lived developer
 machines can keep a warm backend running.
 
 ```console title="Stop the backend"
-kast developer runtime stop --backend=headless
+kast developer runtime stop
 ```
 
 ## Next commands


### PR DESCRIPTION
## Summary
- add `kast developer machine defaults` to persist IDEA plugin backend defaults on developer machines
- apply those defaults from `kast developer machine plugin` and `./gradlew installDevelopmentLocal`
- update development install contracts and docs so developer-machine examples use the configured IDEA/plugin default while headless stays explicit for Linux/server flows

## Validation
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `.github/scripts/test-development-cli-install-contract.sh`
- `.github/scripts/test-docs-content-contract.sh`
- `git diff --check`

## Stack
- Base: #305 (`feature/toon-agent-output`)
