### PR TITLE
fix: preserve agent hook install config

### DIFF
--- a/.agents/adr/0004-repo-context-guidance-operating-model.md
+++ b/.agents/adr/0004-repo-context-guidance-operating-model.md
@@ -91,10 +91,11 @@ metadata only:
 - `.git/info/attributes`
 - `.git/tools/kast-context-region-filter`
 
-The clean and textconv modes remove only the managed `<kast>...</kast>` region.
-The smudge mode preserves an existing managed region and injects the current
-region when none is present. The attribute entry is scoped to the selected
-context file, not every matching filename in the tree.
+The clean and textconv modes remove only the managed `<kast>...</kast>` region
+from tracked content. The smudge mode preserves checked-out content unchanged;
+setup injects or repairs the current region in the working tree when none is
+present. The attribute entry is scoped to the selected context file, not every
+matching filename in the tree.
 
 `AGENTS.local.md` remains the fallback for repositories without a known context
 file. Because that file is intentionally local, setup keeps excluding it through
@@ -107,8 +108,9 @@ place. Existing `--agents-md` commands continue to work. Existing managed
 `<kast>` regions are replaced in place when current setup output changes.
 
 If the current managed region differs from the last recorded manifest checksum,
-setup fails unless `--force` is passed. `--force` replaces only the managed
-region and must not rewrite surrounding repository guidance.
+setup writes a timestamped backup, repairs only the managed region, and leaves
+surrounding repository guidance untouched. `--force` may be used to replace the
+managed region intentionally without changing the surrounding text.
 
 Stale active-binary/resource combinations continue to fail closed. The recovery
 path is to upgrade or reinstall Kast and rerun setup from the active binary.
@@ -148,7 +150,8 @@ Coverage must prove:
 - no known context file creates `AGENTS.local.md`
 - guidance points at the real installed `SKILL.md`
 - Git clean removes only the managed region
-- Git smudge injects the region when absent
+- Git clean removes only the managed region from tracked content
+- setup injects the region when absent
 - scoped Git attributes affect only the selected context file
 - `--agents-md` compatibility still works
 - `--context-file` accepts supported v1 filenames and rejects unsupported ones

--- a/.github/scripts/test-kast-copilot-plugin.sh
+++ b/.github/scripts/test-kast-copilot-plugin.sh
@@ -120,7 +120,7 @@ import { execFileSync } from "node:child_process";
 const pluginRoot = process.argv[2];
 const toolsModule = await import(`file://${pluginRoot}/extensions/kast/_shared/kast-tools.mjs`);
 const traceModule = await import(`file://${pluginRoot}/extensions/kast/_shared/kast-trace.mjs`);
-const agentTools = JSON.parse(execFileSync(process.env.KAST_BIN, ["agent", "tools"], { encoding: "utf8" }));
+const agentTools = JSON.parse(execFileSync(process.env.KAST_BIN, ["--output", "json", "agent", "tools", "--full"], { encoding: "utf8" }));
 if (!toolsModule.isKastAgentToolsEnvelope(agentTools)) {
   throw new Error("source plugin must accept the current KAST_AGENT_TOOLS envelope");
 }
@@ -254,7 +254,7 @@ node --input-type=module - "$tmp_dir" <<'NODE'
 import { execFileSync } from "node:child_process";
 const target = process.argv[2];
 const toolsModule = await import(`file://${target}/.github/extensions/kast/_shared/kast-tools.mjs`);
-const agentTools = JSON.parse(execFileSync(process.env.KAST_BIN, ["agent", "tools"], { encoding: "utf8" }));
+const agentTools = JSON.parse(execFileSync(process.env.KAST_BIN, ["--output", "json", "agent", "tools", "--full"], { encoding: "utf8" }));
 if (!toolsModule.isKastAgentToolsEnvelope(agentTools)) {
   throw new Error("installed plugin must accept the current KAST_AGENT_TOOLS envelope");
 }

--- a/.github/scripts/test-kast-routing-evals.sh
+++ b/.github/scripts/test-kast-routing-evals.sh
@@ -15,7 +15,7 @@ else
   kast_bin="${repo_root}/cli-rs/target/debug/kast"
 fi
 
-"$kast_bin" agent tools >"$tools_file"
+"$kast_bin" --output json agent tools --full >"$tools_file"
 KAST_AGENT_TOOLS_FILE="$tools_file" node "${metric_pack_dir}/emit-kast-routing-metrics.mjs" "$target" skill >"$tmp_file"
 
 node --input-type=module - "$tmp_file" <<'NODE'

--- a/cli-rs/resources/kast-skill/references/quickstart.md
+++ b/cli-rs/resources/kast-skill/references/quickstart.md
@@ -56,10 +56,11 @@ the setup target and runtime warmup command before writing files or launching a
 backend. In JSON dry runs, read `setup.targetDir`, `setup.installCommand`, and
 `runtimeCommand` before copying any command. Run `kast setup --workspace-root "$PWD"`
 when the repository should be prepared and warmed in one operator step.
-In a smart human terminal, the first eligible non-JSON `kast setup` may ask
-whether to apply IDEA/Copilot onboarding globally or for the repository only.
-Agents and scripts should use `kast --output json setup ...` or pass
-`--no-open-ide` so prompts cannot block execution.
+In a smart human terminal, the first eligible non-JSON `kast setup` from the
+Homebrew-installed binary may ask whether to apply IDEA/Copilot onboarding
+globally or for the repository only. Agents, scripts, and development aliases
+should use `kast --output json setup ...` or pass `--no-open-ide` so prompts
+cannot block execution.
 
 For shell pipelines, use the public `kast agent` surface instead of hand-written
 JSON-RPC plumbing. It emits one envelope with `ok`, `method`, `request`, and

--- a/cli-rs/resources/kast-skill/references/workflows.md
+++ b/cli-rs/resources/kast-skill/references/workflows.md
@@ -76,7 +76,8 @@ and `setup.installCommand` describe the guidance install, and `runtimeCommand`
 describes backend warmup. For agent-run flows, prefer
 `kast --output json setup --workspace-root "$PWD" --no-open-ide` when the
 command may inherit a human terminal; interactive onboarding is for operators
-choosing global or repository-scoped defaults, not unattended agents.
+using the Homebrew-installed binary to choose global or repository-scoped
+defaults, not unattended agents or development aliases.
 
 For `NO_BACKEND_AVAILABLE`, `INDEX_UNAVAILABLE`, `METRICS_DB_UNAVAILABLE`, or a
 missing source-index database, warm the runtime:

--- a/cli-rs/src/install/agent_guidance.rs
+++ b/cli-rs/src/install/agent_guidance.rs
@@ -335,9 +335,14 @@ fn update_context_git_filter(
         .unwrap_or_else(|| repo_root.join(".git/tools"));
     let filter_script = tools_dir.join("kast-context-region-filter");
     fs::create_dir_all(&tools_dir)?;
+    let filter_script_contents = format!(
+        "#!/usr/bin/env sh\nawk '\n  $0 == \"{}\" {{ in_kast = 1; next }}\n  in_kast && $0 == \"{}\" {{ in_kast = 0; next }}\n  !in_kast {{ print }}\n'\n",
+        KAST_MANAGED_FENCE_START.replace('"', "\\\""),
+        KAST_MANAGED_FENCE_END.replace('"', "\\\"")
+    );
     write_file_atomically(
         &filter_script,
-        b"#!/usr/bin/env sh\nsed '/<kast files=\"*.kt, *.kts\" type=\"instructions\" replaceTools=\"grep,search,write\">/,/<\\/kast>/d'\n",
+        filter_script_contents.as_bytes(),
     )?;
     set_context_filter_executable(&filter_script)?;
     let relative = target
@@ -353,9 +358,12 @@ fn update_context_git_filter(
     };
     let start_marker = "# >>> kast context filter >>>";
     let end_marker = "# <<< kast context filter <<<";
+    let mut lines = context_filter_lines(&original, start_marker, end_marker);
+    lines.insert(block.trim_end().to_string());
+    let block = lines.into_iter().collect::<Vec<_>>().join("\n");
     let updated_content = replace_managed_block_with_markers(
         &original,
-        &format!("{start_marker}\n{block}{end_marker}\n"),
+        &format!("{start_marker}\n{block}\n{end_marker}\n"),
         start_marker,
         end_marker,
     );
@@ -373,6 +381,23 @@ fn update_context_git_filter(
     })
 }
 
+fn context_filter_lines(original: &str, start_marker: &str, end_marker: &str) -> BTreeSet<String> {
+    let Some(start) = original.find(start_marker) else {
+        return BTreeSet::new();
+    };
+    let Some(end_offset) = original[start..].find(end_marker) else {
+        return BTreeSet::new();
+    };
+    let block_start = start + start_marker.len();
+    let block_end = start + end_offset;
+    original[block_start..block_end]
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
 fn git_info_attributes_path(repo_root: &Path) -> Option<PathBuf> {
     let output = ProcessCommand::new("git")
         .arg("-C")
@@ -388,24 +413,25 @@ fn git_info_attributes_path(repo_root: &Path) -> Option<PathBuf> {
 }
 
 fn configure_context_filter(repo_root: &Path, filter_script: &Path) -> Result<()> {
+    let filter_command = shell_command(&[filter_script.display().to_string()]);
     for args in [
         vec![
-            "config",
-            "--local",
-            "filter.kast-context-region.clean",
-            filter_script.to_str().unwrap_or(""),
+            "config".to_string(),
+            "--local".to_string(),
+            "filter.kast-context-region.clean".to_string(),
+            filter_command.clone(),
         ],
         vec![
-            "config",
-            "--local",
-            "filter.kast-context-region.smudge",
-            "cat",
+            "config".to_string(),
+            "--local".to_string(),
+            "filter.kast-context-region.smudge".to_string(),
+            "cat".to_string(),
         ],
         vec![
-            "config",
-            "--local",
-            "diff.kast-context-region.textconv",
-            filter_script.to_str().unwrap_or(""),
+            "config".to_string(),
+            "--local".to_string(),
+            "diff.kast-context-region.textconv".to_string(),
+            filter_command.clone(),
         ],
     ] {
         let output = ProcessCommand::new("git")
@@ -454,28 +480,8 @@ fn install_detected_hooks(
     let mut results = Vec::new();
     for target in detected_hook_targets(workspace_root) {
         let updated = match target.host {
-            "codex" => write_json_hook(
-                &target.path,
-                &json!({
-                    "hooks": [{
-                        "event": "SessionStart",
-                        "command": context_command(workspace_root)
-                    }]
-                }),
-            )?,
-            "claude-code" => write_json_hook(
-                &target.path,
-                &json!({
-                    "hooks": {
-                        "SessionStart": [{
-                            "hooks": [{
-                                "type": "command",
-                                "command": shell_command(&context_command(workspace_root))
-                            }]
-                        }]
-                    }
-                }),
-            )?,
+            "codex" => upsert_codex_hook(&target.path, workspace_root)?,
+            "claude-code" => upsert_claude_hook(&target.path, workspace_root)?,
             "opencode" => write_json_hook(
                 &target.path,
                 &json!({
@@ -544,6 +550,166 @@ fn detected_hook_targets(workspace_root: &Path) -> Vec<AgentHookTarget> {
         });
     }
     targets
+}
+
+fn upsert_codex_hook(path: &Path, workspace_root: &Path) -> Result<bool> {
+    let mut value = read_hook_config(path)?;
+    let hook = json!({
+        "event": "SessionStart",
+        "command": context_command(workspace_root)
+    });
+    let root = hook_config_object(&mut value, path)?;
+    let hooks = hook_config_array(root, "hooks", path)?;
+    let mut retained = Vec::with_capacity(hooks.len() + 1);
+    let mut kept_exact = false;
+    for hook_value in hooks.iter() {
+        if is_codex_kast_context_hook(hook_value) {
+            if !kept_exact && hook_value == &hook {
+                retained.push(hook_value.clone());
+                kept_exact = true;
+            }
+        } else {
+            retained.push(hook_value.clone());
+        }
+    }
+    if !kept_exact {
+        retained.push(hook);
+    }
+    *hooks = retained;
+    write_json_hook(path, &value)
+}
+
+fn upsert_claude_hook(path: &Path, workspace_root: &Path) -> Result<bool> {
+    let mut value = read_hook_config(path)?;
+    let command_hook = json!({
+        "type": "command",
+        "command": shell_command(&context_command(workspace_root))
+    });
+    let root = hook_config_object(&mut value, path)?;
+    let hooks_value = root
+        .entry("hooks".to_string())
+        .or_insert_with(|| json!({}));
+    let Some(hooks_object) = hooks_value.as_object_mut() else {
+        return Err(invalid_hook_config(path, "`hooks` must be a JSON object"));
+    };
+    let session_value = hooks_object
+        .entry("SessionStart".to_string())
+        .or_insert_with(|| json!([]));
+    let Some(session_hooks) = session_value.as_array_mut() else {
+        return Err(invalid_hook_config(
+            path,
+            "`hooks.SessionStart` must be a JSON array",
+        ));
+    };
+    remove_claude_kast_context_hooks(session_hooks, &command_hook);
+    if !session_hooks.iter().any(|entry| {
+        entry
+            .get("hooks")
+            .and_then(Value::as_array)
+            .is_some_and(|hooks| hooks.iter().any(|hook| hook == &command_hook))
+    }) {
+        session_hooks.push(json!({ "hooks": [command_hook] }));
+    }
+    write_json_hook(path, &value)
+}
+
+fn remove_claude_kast_context_hooks(session_hooks: &mut Vec<Value>, command_hook: &Value) {
+    let mut kept_exact = false;
+    session_hooks.retain_mut(|entry| {
+        let Some(object) = entry.as_object_mut() else {
+            return true;
+        };
+        let Some(hooks) = object.get_mut("hooks").and_then(Value::as_array_mut) else {
+            return true;
+        };
+        hooks.retain(|hook| {
+            if is_claude_kast_context_hook(hook) {
+                if !kept_exact && hook == command_hook {
+                    kept_exact = true;
+                    true
+                } else {
+                    false
+                }
+            } else {
+                true
+            }
+        });
+        !hooks.is_empty() || object.len() > 1
+    });
+}
+
+fn read_hook_config(path: &Path) -> Result<Value> {
+    match fs::read_to_string(path) {
+        Ok(content) if content.trim().is_empty() => Ok(json!({})),
+        Ok(content) => serde_json::from_str(&content)
+            .map_err(|error| invalid_hook_config(path, error.to_string())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(json!({})),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn hook_config_object<'a>(
+    value: &'a mut Value,
+    path: &Path,
+) -> Result<&'a mut serde_json::Map<String, Value>> {
+    value
+        .as_object_mut()
+        .ok_or_else(|| invalid_hook_config(path, "hook config must be a JSON object"))
+}
+
+fn hook_config_array<'a>(
+    object: &'a mut serde_json::Map<String, Value>,
+    key: &str,
+    path: &Path,
+) -> Result<&'a mut Vec<Value>> {
+    let value = object
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    value
+        .as_array_mut()
+        .ok_or_else(|| invalid_hook_config(path, format!("`{key}` must be a JSON array")))
+}
+
+fn invalid_hook_config(path: &Path, message: impl Into<String>) -> CliError {
+    CliError::new(
+        "HOOK_CONFIG_INVALID",
+        format!("Could not update {}: {}", path.display(), message.into()),
+    )
+}
+
+fn is_codex_kast_context_hook(value: &Value) -> bool {
+    value.get("event").and_then(Value::as_str) == Some("SessionStart")
+        && value
+            .get("command")
+            .is_some_and(command_value_mentions_kast_context)
+}
+
+fn is_claude_kast_context_hook(value: &Value) -> bool {
+    value.get("type").and_then(Value::as_str) == Some("command")
+        && value
+            .get("command")
+            .and_then(Value::as_str)
+            .is_some_and(command_string_mentions_kast_context)
+}
+
+fn command_value_mentions_kast_context(value: &Value) -> bool {
+    match value {
+        Value::Array(args) => {
+            let joined = args
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(" ");
+            command_string_mentions_kast_context(&joined)
+        }
+        Value::String(command) => command_string_mentions_kast_context(command),
+        _ => false,
+    }
+}
+
+fn command_string_mentions_kast_context(command: &str) -> bool {
+    command.contains("kast")
+        && (command.contains(" context ") || command.ends_with(" context"))
 }
 
 fn write_json_hook(path: &Path, value: &Value) -> Result<bool> {

--- a/cli-rs/src/install/homebrew_idea_plugin.rs
+++ b/cli-rs/src/install/homebrew_idea_plugin.rs
@@ -127,6 +127,12 @@ fn verify_homebrew_cli(homebrew: &HomebrewContext) -> Result<()> {
     Err(error)
 }
 
+pub(crate) fn current_cli_can_install_homebrew_idea_plugin() -> bool {
+    discover_homebrew_context()
+        .and_then(|homebrew| verify_homebrew_cli(&homebrew))
+        .is_ok()
+}
+
 fn homebrew_prefix(args: &[&str]) -> Result<PathBuf> {
     let output = run_brew(args)?;
     if !output.status.success() {

--- a/cli-rs/src/install/tests.rs
+++ b/cli-rs/src/install/tests.rs
@@ -272,4 +272,21 @@ mod tests {
             prefix
         ));
     }
+
+    #[test]
+    fn homebrew_cli_verification_rejects_development_binary() {
+        let context = HomebrewContext {
+            brew_prefix: PathBuf::from("/opt/homebrew"),
+            formula_prefix: PathBuf::from("/opt/homebrew/opt/kast"),
+            cli_path: PathBuf::from("/Users/example/.local/bin/kast-dev"),
+        };
+
+        let error = verify_homebrew_cli(&context).unwrap_err();
+
+        assert_eq!(error.code, "HOMEBREW_INSTALL_REQUIRED");
+        assert_eq!(
+            error.details.get("cliPath").map(String::as_str),
+            Some("/Users/example/.local/bin/kast-dev")
+        );
+    }
 }

--- a/cli-rs/src/onboarding.rs
+++ b/cli-rs/src/onboarding.rs
@@ -23,6 +23,7 @@ struct AgentUpOnboardingEligibility {
     ci: bool,
     dumb_terminal: bool,
     config_allows: bool,
+    homebrew_idea_plugin_installable: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,6 +51,7 @@ impl AgentUpOnboardingEligibility {
             && !self.ci
             && !self.dumb_terminal
             && self.config_allows
+            && self.homebrew_idea_plugin_installable
     }
 }
 
@@ -68,6 +70,14 @@ pub fn maybe_run_agent_up_onboarding(
         ci: env_flag("CI"),
         dumb_terminal: env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")),
         config_allows: config.can_run_agent_up_onboarding(),
+        homebrew_idea_plugin_installable: true,
+    };
+    if !eligibility.allows_prompt() {
+        return Ok(AgentUpOnboardingOutcome::NotEligible);
+    }
+    let eligibility = AgentUpOnboardingEligibility {
+        homebrew_idea_plugin_installable: install::current_cli_can_install_homebrew_idea_plugin(),
+        ..eligibility
     };
     if !eligibility.allows_prompt() {
         return Ok(AgentUpOnboardingOutcome::NotEligible);
@@ -207,6 +217,7 @@ mod tests {
             ci: false,
             dumb_terminal: false,
             config_allows: true,
+            homebrew_idea_plugin_installable: true,
         }
     }
 
@@ -257,6 +268,10 @@ mod tests {
             },
             AgentUpOnboardingEligibility {
                 config_allows: false,
+                ..eligible()
+            },
+            AgentUpOnboardingEligibility {
+                homebrew_idea_plugin_installable: false,
                 ..eligible()
             },
         ] {

--- a/cli-rs/tests/agent_setup_smoke.rs
+++ b/cli-rs/tests/agent_setup_smoke.rs
@@ -126,6 +126,95 @@ fn agent_setup_installs_skill_and_writes_ignored_local_guidance() {
 }
 
 #[test]
+fn agent_setup_context_git_filter_strips_managed_region_for_each_tracked_target() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let repo = temp.path().join("repo with spaces");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(&repo).expect("repo");
+    let init = Command::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .arg("init")
+        .output()
+        .expect("git init");
+    assert!(
+        init.status.success(),
+        "git init failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    std::fs::write(repo.join("AGENTS.md"), "# Agents\n").expect("agents");
+
+    let setup = kast(&home, &config_home)
+        .current_dir(&repo)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "setup",
+            "--context-file",
+            "CODEX.md",
+        ])
+        .output()
+        .expect("agent setup");
+    assert!(
+        setup.status.success(),
+        "setup should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&setup.stdout),
+        String::from_utf8_lossy(&setup.stderr)
+    );
+    let attributes =
+        std::fs::read_to_string(repo.join(".git/info/attributes")).expect("attributes");
+    assert!(
+        attributes.contains("AGENTS.md filter=kast-context-region"),
+        "{attributes}"
+    );
+    assert!(
+        attributes.contains("CODEX.md filter=kast-context-region"),
+        "{attributes}"
+    );
+
+    let add = Command::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["add", "AGENTS.md", "CODEX.md"])
+        .output()
+        .expect("git add context files");
+    assert!(
+        add.status.success(),
+        "git add failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&add.stdout),
+        String::from_utf8_lossy(&add.stderr)
+    );
+    for file in ["AGENTS.md", "CODEX.md"] {
+        let show = Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(["show", &format!(":{file}")])
+            .output()
+            .unwrap_or_else(|error| panic!("git show {file}: {error}"));
+        assert!(
+            show.status.success(),
+            "git show {file} failed: stdout={}, stderr={}",
+            String::from_utf8_lossy(&show.stdout),
+            String::from_utf8_lossy(&show.stderr)
+        );
+        let staged = String::from_utf8_lossy(&show.stdout);
+        assert!(
+            !staged.contains("<kast "),
+            "clean filter should remove managed region from staged {file}: {staged}"
+        );
+        assert!(
+            !staged.contains("</kast>"),
+            "clean filter should remove managed region from staged {file}: {staged}"
+        );
+    }
+}
+
+#[test]
 fn agent_setup_creates_local_guidance_without_root_agents_md() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -268,6 +357,112 @@ fn agent_setup_backs_up_and_repairs_modified_managed_region() {
     assert!(
         backup_exists,
         "setup should preserve a backup before repairing"
+    );
+}
+
+#[test]
+fn agent_setup_preserves_existing_hook_config_when_installing_detected_hooks() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::create_dir_all(repo.join(".codex")).expect("codex");
+    std::fs::create_dir_all(repo.join(".claude")).expect("claude");
+    std::fs::write(
+        repo.join(".codex/hooks.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "hooks": [{
+                "event": "SessionStart",
+                "command": ["existing-tool", "--flag"]
+            }]
+        }))
+        .expect("codex json"),
+    )
+    .expect("codex hooks");
+    std::fs::write(
+        repo.join(".claude/settings.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "permissions": {
+                "allow": ["Bash(./gradlew test)"]
+            },
+            "hooks": {
+                "SessionStart": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": "existing-tool --flag"
+                    }]
+                }]
+            }
+        }))
+        .expect("claude json"),
+    )
+    .expect("claude settings");
+
+    let setup = kast(&home, &config_home)
+        .current_dir(&repo)
+        .args(["--output", "json", "agent", "setup"])
+        .output()
+        .expect("agent setup");
+    assert!(
+        setup.status.success(),
+        "setup should preserve hook config: stdout={}, stderr={}",
+        String::from_utf8_lossy(&setup.stdout),
+        String::from_utf8_lossy(&setup.stderr)
+    );
+
+    let codex: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(repo.join(".codex/hooks.json")).unwrap())
+            .expect("codex hooks json");
+    let codex_hooks = codex["hooks"].as_array().expect("codex hooks array");
+    assert!(
+        codex_hooks
+            .iter()
+            .any(|hook| hook["command"] == serde_json::json!(["existing-tool", "--flag"])),
+        "{codex:#}"
+    );
+    assert!(
+        codex_hooks.iter().any(|hook| {
+            hook["event"] == "SessionStart"
+                && hook["command"]
+                    .as_array()
+                    .is_some_and(|argv| argv.iter().any(|arg| arg == "context"))
+        }),
+        "{codex:#}"
+    );
+
+    let claude: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(repo.join(".claude/settings.json")).unwrap())
+            .expect("claude settings json");
+    assert_eq!(
+        claude["permissions"]["allow"][0], "Bash(./gradlew test)",
+        "{claude:#}"
+    );
+    let session_hooks = claude["hooks"]["SessionStart"]
+        .as_array()
+        .expect("claude SessionStart hooks");
+    assert!(
+        session_hooks.iter().any(|entry| {
+            entry["hooks"].as_array().is_some_and(|hooks| {
+                hooks
+                    .iter()
+                    .any(|hook| hook["command"] == "existing-tool --flag")
+            })
+        }),
+        "{claude:#}"
+    );
+    assert!(
+        session_hooks.iter().any(|entry| {
+            entry["hooks"].as_array().is_some_and(|hooks| {
+                hooks.iter().any(|hook| {
+                    hook["command"]
+                        .as_str()
+                        .is_some_and(|command| command.contains(" context "))
+                })
+            })
+        }),
+        "{claude:#}"
     );
 }
 

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -71,14 +71,14 @@ kast setup --workspace-root "$PWD" --backend=headless
 kast setup --context-file "$PWD/cli-rs/AGENTS.md" --workspace-root "$PWD" --dry-run
 ```
 
-In a smart interactive terminal, the first eligible `kast setup` can offer
-automatic IDEA setup. If accepted, choose whether Kast saves IDEA as the
-default backend and automatic IDEA launch as global machine defaults or for
-this repository only. Project-open local guidance setup is enabled by default,
-so the JetBrains plugin is still installed or refreshed at machine scope and
-harness-agnostic guidance is still written under the workspace. Use
-`--no-open-ide` to skip that first-run prompt, and use `--output json` in
-scripts so onboarding never prompts.
+In a smart interactive terminal, the first eligible Homebrew-backed
+`kast setup` can offer automatic IDEA setup. If accepted, choose whether Kast
+saves IDEA as the default backend and automatic IDEA launch as global machine
+defaults or for this repository only. Project-open local guidance setup is
+enabled by default, so the JetBrains plugin is still installed or refreshed at
+machine scope and harness-agnostic guidance is still written under the
+workspace. Use `--no-open-ide` to skip that first-run prompt, and use
+`--output json` in scripts or development aliases so onboarding never prompts.
 
 When `--workspace-root` is supplied, setup targets that repository instead of
 the shell's current directory. The command reports the selected setup command

--- a/docs/commands/install-repair.md
+++ b/docs/commands/install-repair.md
@@ -32,13 +32,14 @@ the managed Kast region.
 Use `kast setup` when setup and runtime warmup should happen together. Start
 with `--dry-run` to inspect the skill target, guidance targets, and runtime
 command before writing files or starting a backend.
-In a smart interactive terminal, the first eligible non-JSON run can ask
-whether to apply automatic IDEA setup. Project-open local guidance setup is
-enabled by default; accepting lets the user save IDEA backend and launch
-defaults globally or for this repository only. The flow installs or refreshes
-the JetBrains plugin, prepares harness-agnostic agent guidance, then warms the
-repository runtime. Use
-`--no-open-ide` when an interactive terminal should behave like automation.
+In a smart interactive terminal, the first eligible non-JSON run from the
+Homebrew-installed `kast` can ask whether to apply automatic IDEA setup.
+Project-open local guidance setup is enabled by default; accepting lets the
+user save IDEA backend and launch defaults globally or for this repository
+only. The flow installs or refreshes the JetBrains plugin, prepares
+harness-agnostic agent guidance, then warms the repository runtime. Use
+`--no-open-ide` when an interactive terminal or development alias should behave
+like automation.
 In JSON dry-runs, both `setup.installCommand` and `runtimeCommand` start with
 the executable token used for the dry run, so copied binaries and absolute CLI
 paths remain directly callable.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -42,13 +42,15 @@ Homebrew links or refreshes the plugin, then restart after installing
 repository files so agents discover `.agents/skills/kast`, managed
 `AGENTS.local.md` guidance, runtime guidance, and catalog-backed tools at startup.
 
-On the first eligible run in a smart interactive terminal, `kast setup`
-offers automatic IDEA setup for IDEA-backed agent workflows. Accepting lets
-you save IDEA as the default backend and automatic IDEA launch either globally
-or for this repository only. Project-open local guidance setup is enabled by
-default. The flow also installs or refreshes the JetBrains plugin, installs
-repository agent guidance, and warms the workspace runtime. Scripts and repeatable setup
-should use `kast setup --no-open-ide` or `kast --output json setup ...`.
+On the first eligible run in a smart interactive terminal, the
+Homebrew-installed `kast setup` offers automatic IDEA setup for IDEA-backed
+agent workflows. Accepting lets you save IDEA as the default backend and
+automatic IDEA launch either globally or for this repository only. Project-open
+local guidance setup is enabled by default. The flow also installs or refreshes
+the JetBrains plugin, installs repository agent guidance, and warms the
+workspace runtime. Scripts, repeatable setup, and development aliases such as
+`kast-dev` should use `kast setup --no-open-ide` or
+`kast --output json setup ...`.
 
 ??? success "Homebrew machine install"
     `brew install kast` is machine-level. It installs one `kast` executable


### PR DESCRIPTION
## Summary
- preserve existing Codex and Claude hook config while upserting Kast hooks
- harden Git context clean/textconv filtering for exact sentinels, spaces in paths, and multiple tracked targets
- skip first-run Homebrew IDEA onboarding when setup is run from a development binary such as `kast-dev`
- align docs and packaged skill guidance with the Homebrew-backed onboarding contract
- make CI contract scripts request explicit full JSON agent-tool discovery

## Validation
- cargo fmt --manifest-path cli-rs/Cargo.toml --all
- git diff --check
- cargo test --manifest-path cli-rs/Cargo.toml --locked onboarding
- cargo test --manifest-path cli-rs/Cargo.toml --locked homebrew_cli_verification_rejects_development_binary
- cargo test --manifest-path cli-rs/Cargo.toml --locked --test machine_plugin_smoke
- .github/scripts/test-docs-content-contract.sh
- cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
- cargo test --manifest-path cli-rs/Cargo.toml --locked

## Remote CI
- Green on head bd27b7d8e16d52fb6c99eca2f8ce5aeb0f84791b
- gh pr checks evidence: 22 total, 19 passing, 3 skipped, no failures or pending

## Risk
- Low: changes are scoped to agent setup/install behavior, CI contract scripts, docs, and smoke coverage.