### PR TITLE
Use JSON agent tools output in routing evals

### DIFF
--- a/.github/scripts/test-kast-copilot-plugin.sh
+++ b/.github/scripts/test-kast-copilot-plugin.sh
@@ -120,7 +120,7 @@ import { execFileSync } from "node:child_process";
 const pluginRoot = process.argv[2];
 const toolsModule = await import(`file://${pluginRoot}/extensions/kast/_shared/kast-tools.mjs`);
 const traceModule = await import(`file://${pluginRoot}/extensions/kast/_shared/kast-trace.mjs`);
-const agentTools = JSON.parse(execFileSync(process.env.KAST_BIN, ["agent", "tools"], { encoding: "utf8" }));
+const agentTools = JSON.parse(execFileSync(process.env.KAST_BIN, ["--output", "json", "agent", "tools", "--full"], { encoding: "utf8" }));
 if (!toolsModule.isKastAgentToolsEnvelope(agentTools)) {
   throw new Error("source plugin must accept the current KAST_AGENT_TOOLS envelope");
 }
@@ -254,7 +254,7 @@ node --input-type=module - "$tmp_dir" <<'NODE'
 import { execFileSync } from "node:child_process";
 const target = process.argv[2];
 const toolsModule = await import(`file://${target}/.github/extensions/kast/_shared/kast-tools.mjs`);
-const agentTools = JSON.parse(execFileSync(process.env.KAST_BIN, ["agent", "tools"], { encoding: "utf8" }));
+const agentTools = JSON.parse(execFileSync(process.env.KAST_BIN, ["--output", "json", "agent", "tools", "--full"], { encoding: "utf8" }));
 if (!toolsModule.isKastAgentToolsEnvelope(agentTools)) {
   throw new Error("installed plugin must accept the current KAST_AGENT_TOOLS envelope");
 }

--- a/.github/scripts/test-kast-routing-evals.sh
+++ b/.github/scripts/test-kast-routing-evals.sh
@@ -15,7 +15,7 @@ else
   kast_bin="${repo_root}/cli-rs/target/debug/kast"
 fi
 
-"$kast_bin" agent tools >"$tools_file"
+"$kast_bin" --output json agent tools --full >"$tools_file"
 KAST_AGENT_TOOLS_FILE="$tools_file" node "${metric_pack_dir}/emit-kast-routing-metrics.mjs" "$target" skill >"$tmp_file"
 
 node --input-type=module - "$tmp_file" <<'NODE'


### PR DESCRIPTION
## Summary
- Update the kast routing eval script to request the full agent tools listing in JSON form.
- Update the Kast Copilot plugin package contract to parse the same full JSON `agent tools --full` envelope.
- Keep both metrics and plugin contract pipelines aligned with the structured output expected by their evaluators.

## Testing
- `.github/scripts/test-kast-routing-evals.sh`
- `.github/scripts/test-kast-copilot-plugin.sh`
- GitHub checks: 18 passing, 2 skipped on PR #308

## Callouts
- The change assumes the JSON `agent tools --full` output remains the stable contract for parsed CI scripts.