### PR TITLE
feat: add skill eval format comparison suites

### DIFF
--- a/.github/plugin-eval/kast-routing-format-impact/emit-kast-routing-format-impact-metrics.mjs
+++ b/.github/plugin-eval/kast-routing-format-impact/emit-kast-routing-format-impact-metrics.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const [, , rawTargetPath] = process.argv;
+const manifestDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(manifestDir, "../../..");
+const targetPath = rawTargetPath ? resolve(rawTargetPath) : join(repoRoot, "cli-rs/resources/kast-skill");
+const observedPath = process.env.KAST_ROUTING_FORMAT_IMPACT_OBSERVED_JSONL
+  ? resolve(process.env.KAST_ROUTING_FORMAT_IMPACT_OBSERVED_JSONL)
+  : null;
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function readJsonl(path) {
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function check(id, status, severity, message, evidence = [], remediation = []) {
+  return {
+    id,
+    category: "kast-routing-format-impact",
+    severity,
+    status,
+    message,
+    evidence,
+    remediation,
+  };
+}
+
+function metric(id, value, unit, band) {
+  return {
+    id,
+    category: "kast-routing-format-impact",
+    value,
+    unit,
+    band,
+  };
+}
+
+function failIf(condition, message, failures) {
+  if (condition) failures.push(message);
+}
+
+function collectStrings(value, strings = []) {
+  if (typeof value === "string") {
+    strings.push(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, strings);
+  } else if (value && typeof value === "object") {
+    for (const item of Object.values(value)) collectStrings(item, strings);
+  }
+  return strings;
+}
+
+const corpus = readJson(join(targetPath, "fixtures/maintenance/evals/routing.json"));
+const schema = readJson(join(targetPath, "fixtures/maintenance/evals/routing.schema.json"));
+const cases = Array.isArray(corpus.cases) ? corpus.cases : [];
+const checks = [];
+
+const schemaFailures = [];
+failIf(corpus.$schema !== "./routing.schema.json", "routing corpus must link ./routing.schema.json", schemaFailures);
+failIf(corpus.schemaVersion !== 1, "routing corpus schemaVersion must be 1", schemaFailures);
+failIf(corpus.primitive?.name !== "kast", "routing corpus primitive.name must be kast", schemaFailures);
+failIf(schema.properties?.cases?.items?.$ref !== "#/$defs/case", "routing schema must define typed case items", schemaFailures);
+checks.push(
+  check(
+    "routing-format-impact-schema-backed",
+    schemaFailures.length === 0 ? "pass" : "fail",
+    schemaFailures.length === 0 ? "info" : "error",
+    schemaFailures.length === 0 ? "Routing JSON/TOON comparison suite is backed by the routing corpus schema." : "Routing JSON/TOON comparison suite schema contract failed.",
+    schemaFailures.length === 0 ? [corpus.$schema] : schemaFailures,
+    ["Keep routing.json linked to routing.schema.json with schemaVersion 1."],
+  ),
+);
+
+const requiredCaseIds = new Set([
+  "kotlin-file-trigger-all-kt-kts",
+  "unknown-symbol-navigation",
+  "relationship-navigation",
+  "source-index-database-access",
+  "agent-workflow-public-surface",
+  "continuous-kast-use-after-first-call",
+  "source-override-skill-recovery",
+  "reference-budget-symbol-query",
+  "non-kotlin-docs-negative-case",
+  "public-api-boundary",
+]);
+const caseIds = new Set(cases.map((item) => item.id));
+const missingCaseIds = [...requiredCaseIds].filter((id) => !caseIds.has(id));
+checks.push(
+  check(
+    "routing-format-impact-required-cases",
+    missingCaseIds.length === 0 ? "pass" : "fail",
+    missingCaseIds.length === 0 ? "info" : "error",
+    missingCaseIds.length === 0
+      ? "Routing JSON/TOON comparison suite covers every routing eval case."
+      : "Routing JSON/TOON comparison suite is missing required cases.",
+    missingCaseIds.length === 0 ? [...caseIds].sort() : missingCaseIds,
+    ["Keep the routing comparison suite derived from every case in fixtures/maintenance/evals/routing.json."],
+  ),
+);
+
+const caseFailures = [];
+for (const item of cases) {
+  failIf(!item.prompt, `${item.id}: prompt is required`, caseFailures);
+  failIf(!item.expectedPrimitive?.name, `${item.id}: expectedPrimitive.name is required`, caseFailures);
+  failIf(!Array.isArray(item.allowedActions) || item.allowedActions.length === 0, `${item.id}: allowedActions are required`, caseFailures);
+  failIf(!Array.isArray(item.forbiddenActions) || item.forbiddenActions.length === 0, `${item.id}: forbiddenActions are required`, caseFailures);
+  failIf(!item.recoveryExpectation, `${item.id}: recoveryExpectation is required`, caseFailures);
+  failIf(!Array.isArray(item.verificationEvidence) || item.verificationEvidence.length < 2, `${item.id}: verificationEvidence needs at least two entries`, caseFailures);
+}
+checks.push(
+  check(
+    "routing-format-impact-case-evidence",
+    caseFailures.length === 0 ? "pass" : "fail",
+    caseFailures.length === 0 ? "info" : "error",
+    caseFailures.length === 0
+      ? "Every routing case has enough evidence to generate JSON/TOON answer requests."
+      : "One or more routing cases cannot generate scoreable JSON/TOON answer requests.",
+    caseFailures.length === 0 ? cases.map((item) => item.id) : caseFailures,
+    ["Keep routing cases prompt-bearing, action-bearing, and recovery-bearing so both encodings are scoreable."],
+  ),
+);
+
+const localPathNeedles = ["/Users/", "/home/", "/private/", "C:\\"];
+const localPathHits = collectStrings(corpus).filter((text) =>
+  localPathNeedles.some((needle) => text.includes(needle)),
+);
+checks.push(
+  check(
+    "routing-format-impact-corpus-sanitized",
+    localPathHits.length === 0 ? "pass" : "fail",
+    localPathHits.length === 0 ? "info" : "error",
+    localPathHits.length === 0 ? "Routing JSON/TOON comparison corpus contains no local absolute path markers." : "Routing JSON/TOON comparison corpus contains local absolute path markers.",
+    localPathHits.length === 0 ? [`cases=${cases.length}`] : localPathHits,
+    ["Sanitize durable routing cases before committing."],
+  ),
+);
+
+let observedRecords = [];
+if (observedPath) {
+  observedRecords = readJsonl(observedPath);
+}
+
+const observedFailures = [];
+const recordsByCase = new Map();
+for (const record of observedRecords) {
+  const key = record.caseId;
+  if (!recordsByCase.has(key)) recordsByCase.set(key, []);
+  recordsByCase.get(key).push(record);
+  failIf(record.decodedEquivalent !== true, `${record.caseId}/${record.format}: decodedEquivalent must be true`, observedFailures);
+}
+for (const item of cases) {
+  const records = recordsByCase.get(item.id) ?? [];
+  if (observedPath) {
+    const formats = new Set(records.map((record) => record.format));
+    failIf(!formats.has("json"), `${item.id}: missing json observed record`, observedFailures);
+    failIf(!formats.has("toon"), `${item.id}: missing toon observed record`, observedFailures);
+  }
+}
+checks.push(
+  check(
+    "routing-format-impact-observed-pairs",
+    observedFailures.length === 0 ? "pass" : "fail",
+    observedFailures.length === 0 ? "info" : "error",
+    observedPath
+      ? observedFailures.length === 0
+        ? "Observed JSONL includes complete routing JSON/TOON pairs with decoded-equivalent records."
+        : "Observed JSONL has incomplete routing pairs or semantic mismatches."
+      : "No observed JSONL supplied; routing JSON/TOON accuracy remains report-only and unmeasured.",
+    observedFailures.length === 0 ? [`records=${observedRecords.length}`] : observedFailures,
+    ["Run .github/scripts/run-kast-routing-format-impact-report.sh to generate observed JSONL."],
+  ),
+);
+
+const evaluated = observedRecords.filter((record) => record.answerVerdict && record.answerVerdict !== "not_evaluated");
+const answerFailures = [];
+const missingAnswerRecords = [];
+for (const record of observedRecords) {
+  if (!record.answerVerdict || record.answerVerdict === "not_evaluated") {
+    missingAnswerRecords.push(`${record.caseId}/${record.format}`);
+    continue;
+  }
+  if (record.answerVerdict !== "pass") {
+    const missing = (record.missingRequiredTerms ?? []).join(", ");
+    const forbidden = (record.forbiddenHits ?? []).join(", ");
+    answerFailures.push(`${record.caseId}/${record.format}: missing=[${missing}] forbidden=[${forbidden}]`);
+  }
+}
+const answerPassCount = evaluated.filter((record) => record.answerVerdict === "pass").length;
+const answerPassRate = evaluated.length > 0 ? Math.round((answerPassCount / evaluated.length) * 10000) / 100 : 0;
+let answerStatus = "warn";
+let answerSeverity = "warning";
+let answerMessage = "No captured routing answers were supplied; answer accuracy remains unmeasured.";
+let answerEvidence = missingAnswerRecords.length > 0 ? missingAnswerRecords : ["records=0"];
+if (evaluated.length > 0 && answerFailures.length === 0 && missingAnswerRecords.length === 0) {
+  answerStatus = "pass";
+  answerSeverity = "info";
+  answerMessage = "Captured routing answers satisfy every required term and avoid forbidden actions.";
+  answerEvidence = [`answers=${evaluated.length}`, `passRate=${answerPassRate}`];
+} else if (evaluated.length > 0 && answerFailures.length === 0) {
+  answerMessage = "Captured routing answer scoring is partial; some JSON/TOON pairs were not supplied.";
+  answerEvidence = missingAnswerRecords;
+} else if (answerFailures.length > 0) {
+  answerMessage = "Captured routing answers missed required terms or used forbidden actions.";
+  answerEvidence = answerFailures;
+}
+checks.push(
+  check(
+    "routing-format-impact-answer-scoring",
+    answerStatus,
+    answerSeverity,
+    answerMessage,
+    answerEvidence,
+    ["Generate answers from cli-rs/target/routing-format-impact/answer-requests.jsonl and set KAST_ROUTING_FORMAT_IMPACT_ANSWERS_JSONL before rerunning the report."],
+  ),
+);
+
+const jsonBytes = observedRecords
+  .filter((record) => record.format === "json")
+  .reduce((sum, record) => sum + (record.stdoutBytes ?? 0), 0);
+const toonBytes = observedRecords
+  .filter((record) => record.format === "toon")
+  .reduce((sum, record) => sum + (record.stdoutBytes ?? 0), 0);
+const byteReduction = jsonBytes > 0 ? Math.round(((jsonBytes - toonBytes) / jsonBytes) * 10000) / 100 : 0;
+const passCount = checks.filter((item) => item.status === "pass").length;
+const score = Math.round((passCount / checks.length) * 100);
+
+console.log(
+  JSON.stringify(
+    {
+      checks,
+      metrics: [
+        metric("kast-routing-format-impact-score", score, "percent", score === 100 ? "excellent" : score >= 85 ? "good" : "needs-work"),
+        metric("kast-routing-format-impact-cases", cases.length, "cases", cases.length >= requiredCaseIds.size ? "good" : "needs-work"),
+        metric("kast-routing-format-impact-observed-records", observedRecords.length, "records", observedRecords.length >= cases.length * 2 ? "good" : "report-only"),
+        metric("kast-routing-format-impact-byte-reduction", byteReduction, "percent", byteReduction > 0 ? "good" : "unmeasured"),
+        metric("kast-routing-format-impact-live-answers", evaluated.length, "records", evaluated.length > 0 ? "measured" : "report-only"),
+        metric("kast-routing-format-impact-answer-pass-rate", answerPassRate, "percent", evaluated.length > 0 ? answerPassRate === 100 ? "excellent" : answerPassRate >= 85 ? "good" : "needs-work" : "unmeasured"),
+        metric("kast-routing-format-impact-answer-failures", answerFailures.length, "records", answerFailures.length === 0 ? "good" : "needs-work"),
+      ],
+      artifacts: [
+        {
+          id: "kast-routing-format-impact-corpus",
+          type: "json",
+          label: "Kast routing JSON/TOON comparison corpus",
+          description: "Routing eval cases rendered as paired JSON and TOON model inputs for AXI comparison.",
+        },
+        {
+          id: "kast-routing-format-impact-observed-jsonl",
+          type: "jsonl",
+          label: "Kast routing JSON/TOON observed records",
+          description: "Paired routing JSON/TOON records with optional captured-answer verdicts.",
+        },
+        {
+          id: "kast-routing-format-impact-answer-requests",
+          type: "jsonl",
+          label: "Kast routing JSON/TOON answer requests",
+          description: "Prompt and input rows to feed an external agent/model runner before scoring captured routing answers.",
+        },
+      ],
+    },
+    null,
+    2,
+  ),
+);

--- a/.github/plugin-eval/kast-routing-format-impact/manifest.json
+++ b/.github/plugin-eval/kast-routing-format-impact/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "kast-routing-format-impact",
+  "version": "1.0.0",
+  "supportedTargetKinds": [
+    "skill",
+    "directory"
+  ],
+  "command": [
+    "node",
+    "./emit-kast-routing-format-impact-metrics.mjs"
+  ]
+}

--- a/.github/scripts/run-kast-routing-format-impact-report.sh
+++ b/.github/scripts/run-kast-routing-format-impact-report.sh
@@ -3,18 +3,18 @@ set -euo pipefail
 
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1 && pwd)"
 target="${repo_root}/cli-rs/resources/kast-skill"
-metric_pack_dir="${repo_root}/.github/plugin-eval/kast-format-impact"
-report_dir="${repo_root}/cli-rs/target/format-impact"
+metric_pack_dir="${repo_root}/.github/plugin-eval/kast-routing-format-impact"
+report_dir="${repo_root}/cli-rs/target/routing-format-impact"
 observed_jsonl="${report_dir}/observed.jsonl"
 answer_requests_jsonl="${report_dir}/answer-requests.jsonl"
 summary_json="${report_dir}/summary.json"
-agent_output_shape="${KAST_FORMAT_IMPACT_AGENT_OUTPUT_SHAPE:-${KAST_SKILL_EVAL_AGENT_OUTPUT_SHAPE:-text}}"
+agent_output_shape="${KAST_ROUTING_FORMAT_IMPACT_AGENT_OUTPUT_SHAPE:-${KAST_SKILL_EVAL_AGENT_OUTPUT_SHAPE:-text}}"
 
 case "$agent_output_shape" in
   text|json|toon) ;;
   *)
     printf 'Unsupported agent output shape: %s\n' "$agent_output_shape" >&2
-    printf 'Use text, json, or toon via KAST_FORMAT_IMPACT_AGENT_OUTPUT_SHAPE or KAST_SKILL_EVAL_AGENT_OUTPUT_SHAPE.\n' >&2
+    printf 'Use text, json, or toon via KAST_ROUTING_FORMAT_IMPACT_AGENT_OUTPUT_SHAPE or KAST_SKILL_EVAL_AGENT_OUTPUT_SHAPE.\n' >&2
     exit 64
     ;;
 esac
@@ -29,8 +29,8 @@ else
 fi
 
 answer_args=()
-if [[ -n "${KAST_FORMAT_IMPACT_ANSWERS_JSONL:-}" ]]; then
-  answer_args+=(--answers "$KAST_FORMAT_IMPACT_ANSWERS_JSONL")
+if [[ -n "${KAST_ROUTING_FORMAT_IMPACT_ANSWERS_JSONL:-}" ]]; then
+  answer_args+=(--answers "$KAST_ROUTING_FORMAT_IMPACT_ANSWERS_JSONL")
 fi
 
 cargo run \
@@ -40,17 +40,17 @@ cargo run \
   -- \
   --kast-bin "$kast_bin" \
   --target "$target" \
-  --suite format-impact \
+  --suite routing \
   --agent-output-shape "$agent_output_shape" \
   --output "$observed_jsonl" \
   --answer-requests "$answer_requests_jsonl" \
   "${answer_args[@]}" \
   >"$summary_json"
 
-KAST_FORMAT_IMPACT_OBSERVED_JSONL="$observed_jsonl" \
-  node "${metric_pack_dir}/emit-kast-format-impact-metrics.mjs" "$target" skill
+KAST_ROUTING_FORMAT_IMPACT_OBSERVED_JSONL="$observed_jsonl" \
+  node "${metric_pack_dir}/emit-kast-routing-format-impact-metrics.mjs" "$target" skill
 
-printf 'Kast format impact report written: %s\n' "$observed_jsonl"
-printf 'Kast format impact answer requests written: %s\n' "$answer_requests_jsonl"
-printf 'Kast format impact summary written: %s\n' "$summary_json"
-printf 'Kast format impact agent answer shape: %s\n' "$agent_output_shape"
+printf 'Kast routing format impact report written: %s\n' "$observed_jsonl"
+printf 'Kast routing format impact answer requests written: %s\n' "$answer_requests_jsonl"
+printf 'Kast routing format impact summary written: %s\n' "$summary_json"
+printf 'Kast routing format impact agent answer shape: %s\n' "$agent_output_shape"

--- a/.github/scripts/run-kast-skill-eval-format-comparison.sh
+++ b/.github/scripts/run-kast-skill-eval-format-comparison.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1 && pwd)"
+
+if [[ -z "${KAST_BIN:-}" ]]; then
+  cargo build --manifest-path "${repo_root}/cli-rs/Cargo.toml" --bin kast --locked
+  export KAST_BIN="${repo_root}/cli-rs/target/debug/kast"
+fi
+
+printf 'Kast skill eval agent answer shape: %s\n' "${KAST_SKILL_EVAL_AGENT_OUTPUT_SHAPE:-text}"
+"${repo_root}/.github/scripts/run-kast-format-impact-report.sh"
+"${repo_root}/.github/scripts/run-kast-routing-format-impact-report.sh"
+
+printf '%s\n' "Kast skill eval JSON/TOON comparison reports complete"

--- a/.github/scripts/test-kast-routing-evals.sh
+++ b/.github/scripts/test-kast-routing-evals.sh
@@ -15,7 +15,7 @@ else
   kast_bin="${repo_root}/cli-rs/target/debug/kast"
 fi
 
-"$kast_bin" agent tools >"$tools_file"
+"$kast_bin" --output json agent tools --full >"$tools_file"
 KAST_AGENT_TOOLS_FILE="$tools_file" node "${metric_pack_dir}/emit-kast-routing-metrics.mjs" "$target" skill >"$tmp_file"
 
 node --input-type=module - "$tmp_file" <<'NODE'

--- a/cli-rs/examples/format_impact_report.rs
+++ b/cli-rs/examples/format_impact_report.rs
@@ -16,6 +16,54 @@ struct Args {
     output: PathBuf,
     answer_requests: Option<PathBuf>,
     answers: Option<PathBuf>,
+    suite: Suite,
+    agent_output_shape: AgentOutputShape,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Suite {
+    FormatImpact,
+    Routing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AgentOutputShape {
+    Text,
+    Json,
+    Toon,
+}
+
+impl AgentOutputShape {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Json => "json",
+            Self::Toon => "toon",
+        }
+    }
+
+    fn answer_instructions(self) -> &'static str {
+        match self {
+            Self::Text => {
+                "Return concise plain text that names selected actions, summarizes facts and recovery, and states forbidden actions were avoided without listing them."
+            }
+            Self::Json => {
+                "Return one JSON object with selectedActions, facts, recovery, and forbiddenActionsAvoided fields; do not copy forbidden action names."
+            }
+            Self::Toon => {
+                "Return one TOON object with selectedActions, facts, recovery, and forbiddenActionsAvoided fields; do not copy forbidden action names."
+            }
+        }
+    }
+}
+
+impl Suite {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::FormatImpact => "format-impact",
+            Self::Routing => "routing",
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -33,6 +81,8 @@ struct ImpactCase {
     forbidden_actions: Vec<String>,
     gold_facts: Vec<String>,
     answer_scoring: AnswerScoring,
+    #[serde(default, skip_deserializing)]
+    model_input: Option<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -69,6 +119,8 @@ struct AnswerRequest {
     prompt: String,
     input: String,
     input_bytes: usize,
+    agent_output_shape: String,
+    answer_instructions: String,
     expected_actions: Vec<Action>,
     forbidden_actions: Vec<String>,
     gold_facts: Vec<String>,
@@ -99,6 +151,7 @@ struct ImpactRecord {
 #[serde(rename_all = "camelCase")]
 struct ImpactSummary {
     ok: bool,
+    suite: String,
     cases: usize,
     records: usize,
     decoded_equivalent: bool,
@@ -109,6 +162,7 @@ struct ImpactSummary {
     evaluated_answers: usize,
     passing_answers: usize,
     answer_accuracy_percent: Option<f64>,
+    agent_output_shape: String,
     output: PathBuf,
     answer_requests: Option<PathBuf>,
     answers: Option<PathBuf>,
@@ -132,9 +186,28 @@ struct AnswerScore {
     verdict: &'static str,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RoutingCase {
+    id: String,
+    #[serde(rename = "type")]
+    case_type: String,
+    prompt: String,
+    expected_primitive: Primitive,
+    allowed_actions: Vec<Action>,
+    forbidden_actions: Vec<String>,
+    recovery_expectation: String,
+    verification_evidence: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Primitive {
+    name: String,
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
-    let corpus = read_corpus(&args.target)?;
+    let corpus = read_corpus(&args.target, args.suite)?;
     let answers = match &args.answers {
         Some(path) => read_answer_records(path)?,
         None => BTreeMap::new(),
@@ -159,7 +232,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .get(&(case.id.clone(), output.format.to_string()))
                 .cloned();
             let answer_score = answer.as_deref().map(|answer| score_answer(case, answer));
-            answer_requests.push(answer_request(case, &output));
+            answer_requests.push(answer_request(case, &output, args.agent_output_shape));
             records.push(ImpactRecord {
                 case_id: case.id.clone(),
                 format: output.format.to_string(),
@@ -198,10 +271,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         write_jsonl(path, &answer_requests)?;
     }
     let summary = summarize(
+        args.suite,
         &records,
         args.output.clone(),
         args.answer_requests.clone(),
         args.answers.clone(),
+        args.agent_output_shape,
     );
     println!("{}", serde_json::to_string_pretty(&summary)?);
     let _ = fs::remove_dir_all(run_root);
@@ -214,6 +289,8 @@ fn parse_args() -> Result<Args, Box<dyn Error>> {
     let mut output = None;
     let mut answer_requests = None;
     let mut answers = None;
+    let mut suite = Suite::FormatImpact;
+    let mut agent_output_shape = AgentOutputShape::Text;
     let mut raw = std::env::args().skip(1);
 
     while let Some(arg) = raw.next() {
@@ -223,6 +300,33 @@ fn parse_args() -> Result<Args, Box<dyn Error>> {
             "--output" => output = raw.next().map(PathBuf::from),
             "--answer-requests" => answer_requests = raw.next().map(PathBuf::from),
             "--answers" => answers = raw.next().map(PathBuf::from),
+            "--suite" => {
+                suite = match raw.next().as_deref() {
+                    Some("format-impact") => Suite::FormatImpact,
+                    Some("routing") => Suite::Routing,
+                    Some(other) => {
+                        return Err(format!(
+                            "unsupported --suite `{other}`; expected format-impact or routing"
+                        )
+                        .into());
+                    }
+                    None => return Err("missing value for --suite".into()),
+                };
+            }
+            "--agent-output-shape" => {
+                agent_output_shape = match raw.next().as_deref() {
+                    Some("text") => AgentOutputShape::Text,
+                    Some("json") => AgentOutputShape::Json,
+                    Some("toon") => AgentOutputShape::Toon,
+                    Some(other) => {
+                        return Err(format!(
+                            "unsupported --agent-output-shape `{other}`; expected text, json, or toon"
+                        )
+                        .into());
+                    }
+                    None => return Err("missing value for --agent-output-shape".into()),
+                };
+            }
             other => return Err(format!("unexpected argument `{other}`").into()),
         }
     }
@@ -233,10 +337,23 @@ fn parse_args() -> Result<Args, Box<dyn Error>> {
         output: output.ok_or("missing --output")?,
         answer_requests,
         answers,
+        suite,
+        agent_output_shape,
     })
 }
 
-fn read_corpus(target: &Path) -> Result<Corpus, Box<dyn Error>> {
+fn read_corpus(target: &Path, suite: Suite) -> Result<Corpus, Box<dyn Error>> {
+    match suite {
+        Suite::FormatImpact => read_format_impact_corpus(target),
+        Suite::Routing => read_routing_corpus(target),
+    }
+}
+
+fn evals_dir(target: &Path) -> PathBuf {
+    target.join("fixtures").join("maintenance").join("evals")
+}
+
+fn read_format_impact_corpus(target: &Path) -> Result<Corpus, Box<dyn Error>> {
     let path = target
         .join("fixtures")
         .join("maintenance")
@@ -244,6 +361,22 @@ fn read_corpus(target: &Path) -> Result<Corpus, Box<dyn Error>> {
         .join("format-impact.json");
     let content = fs::read_to_string(&path)?;
     Ok(serde_json::from_str(&content)?)
+}
+
+fn read_routing_corpus(target: &Path) -> Result<Corpus, Box<dyn Error>> {
+    let path = evals_dir(target).join("routing.json");
+    let content = fs::read_to_string(&path)?;
+    let root: Value = serde_json::from_str(&content)?;
+    let raw_cases = root
+        .get("cases")
+        .and_then(Value::as_array)
+        .ok_or("routing corpus must contain cases array")?;
+    let mut cases = Vec::with_capacity(raw_cases.len());
+    for raw_case in raw_cases {
+        let routing_case: RoutingCase = serde_json::from_value(raw_case.clone())?;
+        cases.push(routing_case.into_impact_case(raw_case.clone()));
+    }
+    Ok(Corpus { cases })
 }
 
 fn read_answer_records(path: &Path) -> Result<BTreeMap<(String, String), String>, Box<dyn Error>> {
@@ -325,6 +458,8 @@ fn outputs_for_case(
                 kast_bin,
                 run_root,
                 &[
+                    "--output",
+                    "json",
                     "agent",
                     "workflow",
                     "symbol",
@@ -349,6 +484,7 @@ fn outputs_for_case(
             )
         }
         "synthetic-envelope" => synthetic_outputs(case),
+        "routing-case" => model_input_outputs(case),
         "prompt-only" => Ok(vec![
             FormatOutput {
                 format: "json",
@@ -365,6 +501,14 @@ fn outputs_for_case(
         ]),
         other => Err(format!("unsupported input artifact kind `{other}`").into()),
     }
+}
+
+fn model_input_outputs(case: &ImpactCase) -> Result<Vec<FormatOutput>, Box<dyn Error>> {
+    let value = case
+        .model_input
+        .clone()
+        .ok_or_else(|| format!("case {} missing model input", case.id))?;
+    encode_value_outputs(value)
 }
 
 fn command_outputs(
@@ -418,6 +562,10 @@ fn run_kast(kast_bin: &Path, run_root: &Path, args: &[&str]) -> Result<Vec<u8>, 
 
 fn synthetic_outputs(case: &ImpactCase) -> Result<Vec<FormatOutput>, Box<dyn Error>> {
     let value = synthetic_value(case);
+    encode_value_outputs(value)
+}
+
+fn encode_value_outputs(value: Value) -> Result<Vec<FormatOutput>, Box<dyn Error>> {
     let mut json_text = serde_json::to_string_pretty(&value)?;
     json_text.push('\n');
     let toon_text = toon_format::encode_default(&value)?;
@@ -498,13 +646,23 @@ fn extracted_facts(case: &ImpactCase, decoded: &Value) -> Vec<String> {
     facts
 }
 
-fn answer_request(case: &ImpactCase, output: &FormatOutput) -> AnswerRequest {
+fn answer_request(
+    case: &ImpactCase,
+    output: &FormatOutput,
+    agent_output_shape: AgentOutputShape,
+) -> AnswerRequest {
     AnswerRequest {
         case_id: case.id.clone(),
         format: output.format.to_string(),
-        prompt: case.prompt.clone(),
+        prompt: format!(
+            "{}\n\n{}",
+            case.prompt,
+            agent_output_shape.answer_instructions()
+        ),
         input: output.text.clone(),
         input_bytes: output.stdout_bytes,
+        agent_output_shape: agent_output_shape.as_str().to_string(),
+        answer_instructions: agent_output_shape.answer_instructions().to_string(),
         expected_actions: case.expected_actions.clone(),
         forbidden_actions: case.forbidden_actions.clone(),
         gold_facts: case.gold_facts.clone(),
@@ -596,10 +754,12 @@ fn write_jsonl<T: Serialize>(path: &Path, records: &[T]) -> Result<(), Box<dyn E
 }
 
 fn summarize(
+    suite: Suite,
     records: &[ImpactRecord],
     output: PathBuf,
     answer_requests: Option<PathBuf>,
     answers: Option<PathBuf>,
+    agent_output_shape: AgentOutputShape,
 ) -> ImpactSummary {
     let json_stdout_bytes = records
         .iter()
@@ -644,6 +804,7 @@ fn summarize(
 
     ImpactSummary {
         ok: true,
+        suite: suite.as_str().to_string(),
         cases: records.len() / 2,
         records: records.len(),
         decoded_equivalent: records.iter().all(|record| record.decoded_equivalent),
@@ -654,8 +815,54 @@ fn summarize(
         evaluated_answers,
         passing_answers,
         answer_accuracy_percent,
+        agent_output_shape: agent_output_shape.as_str().to_string(),
         output,
         answer_requests,
         answers,
+    }
+}
+
+impl RoutingCase {
+    fn into_impact_case(self, raw_case: Value) -> ImpactCase {
+        let mut required_terms = Vec::new();
+        required_terms.push(self.expected_primitive.name.clone());
+        for action in &self.allowed_actions {
+            if !required_terms.contains(&action.name) {
+                required_terms.push(action.name.clone());
+            }
+        }
+        required_terms.push("recovery".to_string());
+
+        let mut gold_facts = vec![
+            format!("The routing case type is {}.", self.case_type),
+            format!(
+                "The expected primitive is {}.",
+                self.expected_primitive.name
+            ),
+            format!("Recovery expectation: {}", self.recovery_expectation),
+        ];
+        gold_facts.extend(self.verification_evidence.iter().cloned());
+
+        ImpactCase {
+            id: self.id,
+            prompt: format!(
+                "Given this Kast routing eval case, identify the expected primitive, list every allowed public action, avoid forbidden fallbacks, and preserve the recovery expectation. Original prompt: {}",
+                self.prompt
+            ),
+            input_artifact: InputArtifact {
+                kind: "routing-case".to_string(),
+            },
+            expected_actions: self.allowed_actions,
+            forbidden_actions: self.forbidden_actions.clone(),
+            gold_facts,
+            answer_scoring: AnswerScoring {
+                required_terms,
+                forbidden_terms: self.forbidden_actions,
+            },
+            model_input: Some(json!({
+                "suite": "routing",
+                "case": raw_case,
+            })),
+        }
     }
 }

--- a/cli-rs/resources/kast-skill/AGENTS.md
+++ b/cli-rs/resources/kast-skill/AGENTS.md
@@ -60,9 +60,17 @@ cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- release generate contr
 python3 .github/scripts/render-rpc-contract-summary.py --check
 .github/scripts/test-kast-routing-evals.sh
 .github/scripts/run-kast-format-impact-report.sh
+.github/scripts/run-kast-routing-format-impact-report.sh
+.github/scripts/run-kast-skill-eval-format-comparison.sh
 .github/scripts/test-kast-copilot-plugin.sh
 .github/scripts/test-lsp-pivot-gates.sh
 ```
+
+For skill-eval format experiments, set `KAST_SKILL_EVAL_AGENT_OUTPUT_SHAPE`
+to `text`, `json`, or `toon` before running the comparison script. Suite-specific
+overrides are `KAST_FORMAT_IMPACT_AGENT_OUTPUT_SHAPE` and
+`KAST_ROUTING_FORMAT_IMPACT_AGENT_OUTPUT_SHAPE`; unset them to fall back to the
+shared value, and set `json` to switch captured answer requests back to JSON.
 
 Use `kast developer release validate --request-file <file>` for hand-authored request examples.
 Run the packaged helper dry run after script or workflow edits:

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -251,6 +251,15 @@ fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
             "routing eval should reject public API leak {required}"
         );
     }
+
+    let repo_root = root.parent().expect("repo root");
+    let routing_script_path = repo_root.join(".github/scripts/test-kast-routing-evals.sh");
+    let routing_script = std::fs::read_to_string(&routing_script_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", routing_script_path.display()));
+    assert!(
+        routing_script.contains("--output json agent tools --full"),
+        "routing metric-pack input should request JSON explicitly while agent defaults to TOON: {routing_script}"
+    );
 }
 
 #[test]
@@ -409,6 +418,17 @@ fn format_impact_metric_pack_and_runner_capture_scoreable_answers() {
         "runner should write answer request JSONL for external answer capture: {runner}"
     );
     assert!(
+        runner.contains("--suite format-impact"),
+        "runner should select the format-impact comparison suite explicitly: {runner}"
+    );
+    assert!(
+        runner.contains("--agent-output-shape")
+            && runner.contains("KAST_FORMAT_IMPACT_AGENT_OUTPUT_SHAPE")
+            && runner.contains("KAST_SKILL_EVAL_AGENT_OUTPUT_SHAPE")
+            && runner.contains("text|json|toon"),
+        "runner should make external agent answer shape configurable: {runner}"
+    );
+    assert!(
         runner.contains("KAST_FORMAT_IMPACT_ANSWERS_JSONL"),
         "runner should score captured answers when supplied: {runner}"
     );
@@ -482,6 +502,157 @@ fn format_impact_metric_pack_and_runner_capture_scoreable_answers() {
         .expect("metric list")
         .iter()
         .find(|metric| metric["id"] == "kast-format-impact-answer-pass-rate")
+        .expect("answer pass-rate metric");
+    assert_eq!(answer_pass_rate["value"], 100, "{metric_output:#}");
+}
+
+#[test]
+fn routing_format_impact_metric_pack_and_runner_capture_scoreable_answers() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repo root");
+    let manifest_path =
+        repo_root.join(".github/plugin-eval/kast-routing-format-impact/manifest.json");
+    let manifest: Value = serde_json::from_str(
+        &std::fs::read_to_string(&manifest_path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", manifest_path.display())),
+    )
+    .expect("routing format impact metric pack manifest");
+
+    assert_eq!(
+        manifest["name"], "kast-routing-format-impact",
+        "{manifest:#}"
+    );
+    assert_eq!(
+        manifest["command"],
+        serde_json::json!(["node", "./emit-kast-routing-format-impact-metrics.mjs"]),
+        "{manifest:#}"
+    );
+
+    let runner_path = repo_root.join(".github/scripts/run-kast-routing-format-impact-report.sh");
+    let runner = std::fs::read_to_string(&runner_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", runner_path.display()));
+    assert!(
+        runner.contains("format_impact_report"),
+        "runner should use the shared Rust JSON/TOON report generator: {runner}"
+    );
+    assert!(
+        runner.contains("--suite routing"),
+        "runner should select the routing comparison suite: {runner}"
+    );
+    assert!(
+        runner.contains("--agent-output-shape")
+            && runner.contains("KAST_ROUTING_FORMAT_IMPACT_AGENT_OUTPUT_SHAPE")
+            && runner.contains("KAST_SKILL_EVAL_AGENT_OUTPUT_SHAPE")
+            && runner.contains("text|json|toon"),
+        "runner should make routing agent answer shape configurable: {runner}"
+    );
+    assert!(
+        runner.contains("KAST_ROUTING_FORMAT_IMPACT_OBSERVED_JSONL"),
+        "runner should feed observed JSONL into the routing metric pack: {runner}"
+    );
+    assert!(
+        runner.contains("KAST_ROUTING_FORMAT_IMPACT_ANSWERS_JSONL"),
+        "runner should score captured routing answers when supplied: {runner}"
+    );
+
+    let combined_path = repo_root.join(".github/scripts/run-kast-skill-eval-format-comparison.sh");
+    let combined = std::fs::read_to_string(&combined_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", combined_path.display()));
+    assert!(
+        combined.contains("run-kast-format-impact-report.sh")
+            && combined.contains("run-kast-routing-format-impact-report.sh"),
+        "combined runner should execute both JSON/TOON comparison suites: {combined}"
+    );
+
+    let metric_pack_path = repo_root.join(
+        ".github/plugin-eval/kast-routing-format-impact/emit-kast-routing-format-impact-metrics.mjs",
+    );
+    let metric_pack = std::fs::read_to_string(&metric_pack_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", metric_pack_path.display()));
+    assert!(
+        metric_pack.contains("routing-format-impact-answer-scoring"),
+        "metric pack should expose answer scoring as a first-class check: {metric_pack}"
+    );
+    assert!(
+        metric_pack.contains("kast-routing-format-impact-answer-pass-rate"),
+        "metric pack should emit answer pass-rate metrics: {metric_pack}"
+    );
+
+    let target = repo_root.join("cli-rs/resources/kast-skill");
+    let routing_path = target.join("fixtures/maintenance/evals/routing.json");
+    let routing: Value = serde_json::from_str(
+        &std::fs::read_to_string(&routing_path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", routing_path.display())),
+    )
+    .expect("routing eval json");
+    let temp = tempfile::tempdir().expect("routing format impact metric tempdir");
+    let observed_path = temp.path().join("observed.jsonl");
+    let mut observed = String::new();
+    for case in routing["cases"].as_array().expect("routing cases") {
+        let case_id = case["id"].as_str().expect("case id");
+        let input = serde_json::json!({
+            "suite": "routing",
+            "case": case,
+        });
+        let mut json_input = serde_json::to_string_pretty(&input).expect("json input");
+        json_input.push('\n');
+        let toon_input = toon_format::encode_default(&input).expect("toon input");
+        assert!(
+            serde_json::from_str::<Value>(&toon_input).is_err(),
+            "routing TOON input should not parse as JSON for {case_id}"
+        );
+        let decoded: Value =
+            toon_format::decode_default(toon_input.trim()).expect("decode routing toon");
+        assert_eq!(
+            decoded, input,
+            "routing TOON should decode to JSON for {case_id}"
+        );
+
+        for (format, stdout_bytes) in [("json", json_input.len()), ("toon", toon_input.len())] {
+            observed.push_str(
+                &serde_json::to_string(&serde_json::json!({
+                    "caseId": case_id,
+                    "format": format,
+                    "decodedEquivalent": true,
+                    "answerVerdict": "pass",
+                    "stdoutBytes": stdout_bytes
+                }))
+                .expect("observed record json"),
+            );
+            observed.push('\n');
+        }
+    }
+    std::fs::write(&observed_path, observed)
+        .unwrap_or_else(|error| panic!("write {}: {error}", observed_path.display()));
+
+    let output = Command::new("node")
+        .arg(&metric_pack_path)
+        .arg(&target)
+        .arg("skill")
+        .env("KAST_ROUTING_FORMAT_IMPACT_OBSERVED_JSONL", &observed_path)
+        .output()
+        .unwrap_or_else(|error| panic!("run {}: {error}", metric_pack_path.display()));
+    assert!(
+        output.status.success(),
+        "metric pack should run: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let metric_output: Value =
+        serde_json::from_slice(&output.stdout).expect("metric pack output json");
+    let answer_check = metric_output["checks"]
+        .as_array()
+        .expect("metric checks")
+        .iter()
+        .find(|check| check["id"] == "routing-format-impact-answer-scoring")
+        .expect("answer scoring check");
+    assert_eq!(answer_check["status"], "pass", "{metric_output:#}");
+    let answer_pass_rate = metric_output["metrics"]
+        .as_array()
+        .expect("metric list")
+        .iter()
+        .find(|metric| metric["id"] == "kast-routing-format-impact-answer-pass-rate")
         .expect("answer pass-rate metric");
     assert_eq!(answer_pass_rate["value"], 100, "{metric_output:#}");
 }


### PR DESCRIPTION
## Summary
- add routing JSON/TOON format-impact metric pack and runner
- generalize the format-impact report generator across format-impact and routing suites
- add answer-request output-shape switching for eval capture without changing corpora

## Validation
- cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
- cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_output_format_smoke
- .github/scripts/test-kast-routing-evals.sh
- .github/scripts/run-kast-format-impact-report.sh
- .github/scripts/run-kast-routing-format-impact-report.sh
- plugin-eval analyze cli-rs/resources/kast-skill --metric-pack .github/plugin-eval/kast-format-impact/manifest.json
- plugin-eval analyze cli-rs/resources/kast-skill --metric-pack .github/plugin-eval/kast-routing-format-impact/manifest.json

## Notes
- Live answer accuracy remains report-only until external model answers are supplied.