### PR TITLE
Align CLI output defaults with AXI

### DIFF
--- a/cli-rs/resources/kast-instructions/cli.md
+++ b/cli-rs/resources/kast-instructions/cli.md
@@ -13,8 +13,9 @@ kast agent tools
 kast agent workflow --help
 ```
 
-For agent automation, prefer machine-readable output and explicit workspace
-roots:
+Kast defaults to compact TOON when stdout is not an interactive human terminal
+or when it detects an agent process. For agent automation, keep explicit
+workspace roots and use JSON only when a JSON consumer requires it:
 
 ```sh
 kast --output json setup --workspace-root "$PWD" --dry-run
@@ -24,16 +25,18 @@ kast --output json developer runtime up --workspace-root "$PWD" --backend idea
 ```
 
 Use human output only for operator-facing summaries. Use `--output json` when a
-result will be parsed, stored, or used as evidence. `kast agent` defaults to
-compact TOON; add `--full` to `agent call` when exact large response fields are
-needed. For `setup` dry-runs, `setup.targetDir` is the resolved package target,
-`setup.installCommand` is the install-only command for the selected guidance
-package, and `runtimeCommand` shows the backend warmup that a real setup will
-attempt.
+result will be parsed by a JSON-only consumer, stored, or used as evidence. Add
+`--full` to `agent call` when exact large response fields are needed. Set
+`[cli] dynamicOutput = false` in `config.toml` to disable the interactive-human
+fallback and keep implicit output TOON. For `setup` dry-runs, `setup.targetDir`
+is the resolved package target, `setup.installCommand` is the install-only
+command for the selected guidance package, and `runtimeCommand` shows the
+backend warmup that a real setup will attempt.
 
 ## Non-Interactive Rules
 
-- Prefer `--output json` for agent-run operator commands.
+- Prefer implicit TOON for agent-run operator commands; pass `--output json`
+  only for JSON consumers.
 - Pass `--no-open-ide` to `kast setup` when a human TTY may be present but
   automation must not prompt.
 - Pass command-specific mutation controls explicitly, such as `--dry-run` or

--- a/cli-rs/resources/kast-instructions/tools.md
+++ b/cli-rs/resources/kast-instructions/tools.md
@@ -26,7 +26,8 @@ until the task leaves Kotlin semantics or Kast reports a concrete blocker.
 
 ## Readiness Tools
 
-Use JSON output when a result will drive later steps:
+Kast defaults to compact TOON outside interactive human terminals. Use JSON
+output when a JSON-only result will drive later steps:
 
 ```sh
 kast --output json setup --workspace-root "$PWD" --dry-run

--- a/cli-rs/resources/kast-skill/SKILL.md
+++ b/cli-rs/resources/kast-skill/SKILL.md
@@ -18,7 +18,7 @@ first-class path.
 
 1. Use `kast agent workflow ...` when a workflow fits, or `kast agent call <method>` for the narrowest single catalog method.
 2. Keep nontrivial params in a JSON file and pass `--params-file`; use `kast agent tools --full` only when exact fields, variants, or mutation metadata are needed.
-3. `kast agent` defaults to compact TOON; use `--output json` for parsed scripts and add `--full` to `agent call` when exact large response fields are needed.
+3. Kast defaults to compact TOON outside interactive human terminals; use `--output json` for JSON-only parsed scripts and add `--full` to `agent call` when exact large response fields are needed.
 4. Stay on `kast agent` after the first successful call. Switch to generic file reads or text search only when the work leaves Kotlin semantics or Kast reports a concrete blocker.
 5. Mutate through `kast agent` for semantic or compiler-owned targets, then validate with Kast diagnostics/workflows and the narrowest Gradle task.
 

--- a/cli-rs/resources/kast-skill/references/quickstart.md
+++ b/cli-rs/resources/kast-skill/references/quickstart.md
@@ -64,12 +64,12 @@ cannot block execution.
 
 For shell pipelines, use the public `kast agent` surface instead of hand-written
 JSON-RPC plumbing. It emits one envelope with `ok`, `method`, `request`, and
-either `result` or `error`; `kast agent` defaults to compact TOON and
-`--output json` selects JSON for parsed scripts. `kast agent call <method>`
-accepts params, full JSON-RPC requests, previous envelopes, and `nextRequest`
-objects through stdin or `--params-file`. Add `--full` when exact large
-response fields are needed. Do not use a shell RPC command; preserve envelopes
-through `kast agent call <method>` instead.
+either `result` or `error`. Kast defaults to compact TOON outside interactive
+human terminals, and `--output json` selects JSON for JSON-only parsed scripts.
+`kast agent call <method>` accepts params, full JSON-RPC requests, previous
+envelopes, and `nextRequest` objects through stdin or `--params-file`. Add
+`--full` when exact large response fields are needed. Do not use a shell RPC
+command; preserve envelopes through `kast agent call <method>` instead.
 
 JSON-RPC request schemas, response types, discriminated variants, and
 field-level notes live in `references/commands.yaml` for reading and

--- a/cli-rs/src/config/load.rs
+++ b/cli-rs/src/config/load.rs
@@ -70,6 +70,7 @@ impl KastConfig {
             },
             cli: CliConfig {
                 binary_path: paths.shim_path.clone(),
+                dynamic_output: true,
             },
         }
     }
@@ -267,6 +268,11 @@ impl KastConfig {
             {
                 self.backends.idea.enabled = value;
             }
+        }
+        if let Some(cli) = partial.cli
+            && let Some(value) = cli.dynamic_output
+        {
+            self.cli.dynamic_output = value;
         }
     }
 }

--- a/cli-rs/src/config/model.rs
+++ b/cli-rs/src/config/model.rs
@@ -244,6 +244,7 @@ pub struct IdeaBackendConfig {
 #[serde(rename_all = "camelCase")]
 pub struct CliConfig {
     pub binary_path: PathBuf,
+    pub dynamic_output: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/cli-rs/src/config/partial.rs
+++ b/cli-rs/src/config/partial.rs
@@ -12,6 +12,7 @@ struct PartialConfig {
     telemetry: Option<PartialTelemetry>,
     profiling: Option<PartialProfiling>,
     backends: Option<PartialBackends>,
+    cli: Option<PartialCli>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -128,4 +129,10 @@ struct PartialHeadless {
 #[serde(rename_all = "camelCase")]
 struct PartialIdea {
     enabled: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PartialCli {
+    dynamic_output: Option<bool>,
 }

--- a/cli-rs/src/config/path_resolution.rs
+++ b/cli-rs/src/config/path_resolution.rs
@@ -275,7 +275,7 @@ fn idea_ignored_workspace_key(key: &str) -> bool {
 fn install_owned_config_key(key: &str) -> bool {
     let key = normalize_config_key(key);
     key.starts_with("paths.")
-        || key.starts_with("cli.")
+        || key == "cli.binarypath"
         || key.starts_with("install.")
         || key == "backends.headless.runtimelibsdir"
         || key == "backends.headless.ideahome"

--- a/cli-rs/src/config/tests.rs
+++ b/cli-rs/src/config/tests.rs
@@ -473,6 +473,12 @@ installRoot = "{}"
     }
 
     #[test]
+    fn cli_dynamic_output_is_behavior_config_not_install_owned() {
+        assert!(install_owned_config_key("cli.binaryPath"));
+        assert!(!install_owned_config_key("cli.dynamicOutput"));
+    }
+
+    #[test]
     fn parses_runtime_idea_launch() {
         let temp = tempfile::tempdir().unwrap();
         let config_file = temp.path().join("config.toml");
@@ -501,6 +507,24 @@ requireInstalledPlugin = false
         );
         assert_eq!(config.runtime.idea_launch.wait_timeout_millis.get(), 45_678);
         assert!(!config.runtime.idea_launch.require_installed_plugin);
+    }
+
+    #[test]
+    fn parses_cli_dynamic_output_policy() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_file = temp.path().join("config.toml");
+        fs::write(
+            &config_file,
+            r#"[cli]
+dynamicOutput = false
+"#,
+        )
+        .unwrap();
+
+        let mut config = KastConfig::defaults();
+        config.apply(read_partial_config(&config_file).unwrap());
+
+        assert!(!config.cli.dynamic_output);
     }
 
     #[test]

--- a/cli-rs/src/install/repair.rs
+++ b/cli-rs/src/install/repair.rs
@@ -96,7 +96,10 @@ fn repair_install_config_state(
     let config_path = config::global_config_path();
     let document = read_toml_document(&config_path)?;
     let remove_paths_table = document.contains_key("paths");
-    let remove_cli_table = document.contains_key("cli");
+    let remove_cli_binary_path = document
+        .get("cli")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|cli| cli.contains_key("binaryPath"));
     let remove_install_table = document.contains_key("install");
     let remove_headless_runtime_paths = document
         .get("backends")
@@ -108,7 +111,7 @@ fn repair_install_config_state(
         });
 
     if remove_paths_table
-        || remove_cli_table
+        || remove_cli_binary_path
         || remove_install_table
         || remove_headless_runtime_paths
     {
@@ -122,7 +125,7 @@ fn repair_install_config_state(
     }
     if args.apply
         && (remove_paths_table
-            || remove_cli_table
+            || remove_cli_binary_path
             || remove_install_table
             || remove_headless_runtime_paths)
     {
@@ -131,8 +134,13 @@ fn repair_install_config_state(
             if remove_paths_table {
                 document.remove("paths");
             }
-            if remove_cli_table {
-                document.remove("cli");
+            if remove_cli_binary_path
+                && let Some(toml::Value::Table(cli)) = document.get_mut("cli")
+            {
+                cli.remove("binaryPath");
+                if cli.is_empty() {
+                    document.remove("cli");
+                }
             }
             if remove_install_table {
                 document.remove("install");

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -30,7 +30,7 @@ use cli::{Cli, Command, GenerateCommand, OutputFormat, ShellKind};
 use error::{CliError, Result};
 use serde::Serialize;
 use std::env;
-use std::io;
+use std::io::{self, IsTerminal};
 use std::path::{Path, PathBuf};
 
 const SCHEMA_VERSION: u32 = 3;
@@ -69,7 +69,6 @@ fn parse_cli() -> Result<Option<Cli>> {
 
 fn requested_output_format() -> OutputFormat {
     let mut args = std::env::args().skip(1);
-    let mut saw_agent = false;
     while let Some(arg) = args.next() {
         if arg == "--output" {
             return match args.next().as_deref() {
@@ -85,33 +84,88 @@ fn requested_output_format() -> OutputFormat {
                 _ => OutputFormat::Human,
             };
         }
-        if arg == "agent" {
-            saw_agent = true;
-        }
     }
-    if saw_agent {
-        OutputFormat::Toon
-    } else {
-        OutputFormat::Human
-    }
+    implicit_output_format()
 }
 
 fn effective_output_format(
     requested: Option<OutputFormat>,
-    command: Option<&Command>,
+    _command: Option<&Command>,
 ) -> OutputFormat {
     if let Some(requested) = requested {
         return requested;
     }
-    if matches!(command, Some(Command::Agent(_))) {
-        OutputFormat::Toon
-    } else {
+    implicit_output_format()
+}
+
+fn implicit_output_format() -> OutputFormat {
+    if dynamic_output_enabled() && OutputEnvironment::current().allows_human_output() {
         OutputFormat::Human
+    } else {
+        OutputFormat::Toon
     }
 }
 
 fn error_exit_code(error: &CliError) -> i32 {
     if error.code == "CLI_USAGE" { 2 } else { 1 }
+}
+
+fn dynamic_output_enabled() -> bool {
+    config::KastConfig::load_global()
+        .map(|config| config.cli.dynamic_output)
+        .unwrap_or(true)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutputEnvironment {
+    stdin_terminal: bool,
+    stdout_terminal: bool,
+    ci: bool,
+    dumb_terminal: bool,
+    agent_process: bool,
+}
+
+impl OutputEnvironment {
+    fn current() -> Self {
+        Self {
+            stdin_terminal: io::stdin().is_terminal(),
+            stdout_terminal: io::stdout().is_terminal(),
+            ci: env_flag("CI"),
+            dumb_terminal: env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")),
+            agent_process: agent_process_environment_present(),
+        }
+    }
+
+    fn allows_human_output(self) -> bool {
+        self.stdin_terminal
+            && self.stdout_terminal
+            && !self.ci
+            && !self.dumb_terminal
+            && !self.agent_process
+    }
+}
+
+fn env_flag(name: &str) -> bool {
+    env::var(name)
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty() && value != "0")
+}
+
+fn agent_process_environment_present() -> bool {
+    const AGENT_PROCESS_ENV_KEYS: &[&str] = &[
+        "CODEX_SANDBOX",
+        "CODEX_SESSION_ID",
+        "CODEX_TASK_ID",
+        "CODEX_RUN_ID",
+        "CLAUDECODE",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "CLAUDE_CODE_SSE_PORT",
+        "OPENCODE",
+        "OPENCODE_SESSION",
+        "CURSOR_AGENT",
+        "GITHUB_COPILOT_AGENT",
+    ];
+    AGENT_PROCESS_ENV_KEYS.iter().any(|key| env_flag(key))
 }
 
 fn default_runtime_args() -> cli::RuntimeArgs {
@@ -192,7 +246,7 @@ fn run_context(args: cli::RuntimeArgs, output_format: OutputFormat) -> Result<i3
         bin: display_current_executable(),
         description: "Compiler-backed Kotlin semantic navigation, editing, diagnostics, and repository agent setup.",
         workspace_root: workspace_root.display().to_string(),
-        output_default: "kast agent defaults to TOON; pass --output json when a JSON consumer requires it.",
+        output_default: "Kast defaults to TOON outside interactive human terminals; pass --output json when a JSON consumer requires it.",
         commands: vec![
             ContextCommandHint {
                 command: "kast setup --workspace-root <repo>".to_string(),
@@ -1179,5 +1233,50 @@ fn completion_shell(shell: ShellKind) -> clap_complete::Shell {
     match shell {
         ShellKind::Bash => clap_complete::Shell::Bash,
         ShellKind::Zsh => clap_complete::Shell::Zsh,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn interactive_human_environment() -> OutputEnvironment {
+        OutputEnvironment {
+            stdin_terminal: true,
+            stdout_terminal: true,
+            ci: false,
+            dumb_terminal: false,
+            agent_process: false,
+        }
+    }
+
+    #[test]
+    fn output_environment_allows_human_only_for_interactive_non_agent_terminal() {
+        assert!(interactive_human_environment().allows_human_output());
+
+        for environment in [
+            OutputEnvironment {
+                stdin_terminal: false,
+                ..interactive_human_environment()
+            },
+            OutputEnvironment {
+                stdout_terminal: false,
+                ..interactive_human_environment()
+            },
+            OutputEnvironment {
+                ci: true,
+                ..interactive_human_environment()
+            },
+            OutputEnvironment {
+                dumb_terminal: true,
+                ..interactive_human_environment()
+            },
+            OutputEnvironment {
+                agent_process: true,
+                ..interactive_human_environment()
+            },
+        ] {
+            assert!(!environment.allows_human_output(), "{environment:?}");
+        }
     }
 }

--- a/cli-rs/tests/agent_output_format_smoke.rs
+++ b/cli-rs/tests/agent_output_format_smoke.rs
@@ -53,6 +53,38 @@ fn agent_tools_default_toon_matches_explicit_json() {
 }
 
 #[test]
+fn operator_commands_default_to_toon_when_stdout_is_not_interactive() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let status = kast(&home, &config_home)
+        .args([
+            "status",
+            "--workspace-root",
+            workspace.to_str().expect("workspace path"),
+        ])
+        .output()
+        .expect("status toon");
+    assert!(
+        status.status.success(),
+        "status toon should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&status.stderr)
+    );
+    assert!(
+        serde_json::from_slice::<serde_json::Value>(&status.stdout).is_err(),
+        "default noninteractive status output should not be JSON"
+    );
+    let output = decode_toon(&status.stdout);
+
+    assert_eq!(output["candidates"], serde_json::json!([]), "{output:#}");
+}
+
+#[test]
 fn agent_call_validation_errors_can_emit_toon() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/cli-rs/tests/machine_plugin_smoke.rs
+++ b/cli-rs/tests/machine_plugin_smoke.rs
@@ -127,6 +127,8 @@ fn plugin_install_human_output_reports_progress_and_summary_tables() {
     let install = kast(&home, &config_home)
         .env("PATH", &brew_bin)
         .args([
+            "--output",
+            "human",
             "developer",
             "machine",
             "plugin",

--- a/cli-rs/tests/metrics_direct_smoke.rs
+++ b/cli-rs/tests/metrics_direct_smoke.rs
@@ -16,6 +16,8 @@ fn reads_metrics_directly_from_source_index_db() {
 
     let fan_in = kast(&home, &config_home)
         .args([
+            "--output",
+            "human",
             "developer",
             "inspect",
             "metrics",

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -51,7 +51,7 @@ fn packaged_skill_stays_usage_first_and_public_agent_only() {
     assert!(skill.contains("`kast agent call <method>`"), "{skill}");
     assert!(skill.contains("`kast agent workflow ...`"), "{skill}");
     assert!(
-        skill.contains("`--output json` for parsed scripts"),
+        skill.contains("`--output json` for JSON-only parsed scripts"),
         "{skill}"
     );
     assert!(skill.contains("raw catalog methods only after"), "{skill}");
@@ -258,7 +258,7 @@ fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
         .unwrap_or_else(|error| panic!("read {}: {error}", routing_script_path.display()));
     assert!(
         routing_script.contains("--output json agent tools --full"),
-        "routing metric-pack input should request JSON explicitly while agent defaults to TOON: {routing_script}"
+        "routing metric-pack input should request JSON explicitly while implicit noninteractive output defaults to TOON: {routing_script}"
     );
 }
 

--- a/cli-rs/tests/ready_repair_smoke.rs
+++ b/cli-rs/tests/ready_repair_smoke.rs
@@ -26,6 +26,7 @@ runtimeLibsDir = "{}"
 ideaHome = "{}"
 
 [cli]
+dynamicOutput = false
 binaryPath = "{}"
 
 [install]
@@ -87,7 +88,8 @@ version = "0.7.35"
     let config_after =
         std::fs::read_to_string(config_home.join("config.toml")).expect("config after repair");
     assert!(!config_after.contains("[paths]"));
-    assert!(!config_after.contains("[cli]"));
+    assert!(config_after.contains("[cli]"));
+    assert!(config_after.contains("dynamicOutput = false"));
     assert!(!config_after.contains("[install]"));
     assert!(!config_after.contains("binaryPath"));
     assert!(!config_after.contains("runtimeLibsDir"));

--- a/cli-rs/tests/runtime_backend_smoke.rs
+++ b/cli-rs/tests/runtime_backend_smoke.rs
@@ -13,6 +13,8 @@ fn up_without_installed_backend_reports_supported_headless_distribution() {
 
     let up = kast(&home, &config_home)
         .args([
+            "--output",
+            "human",
             "developer",
             "runtime",
             "up",
@@ -53,6 +55,8 @@ fn runtime_commands_use_configured_default_backend_when_backend_flag_is_absent()
 
     let up = kast(&home, &config_home)
         .args([
+            "--output",
+            "human",
             "developer",
             "runtime",
             "up",
@@ -91,6 +95,8 @@ fn runtime_backend_flag_overrides_configured_default_backend() {
 
     let up = kast(&home, &config_home)
         .args([
+            "--output",
+            "human",
             "developer",
             "runtime",
             "up",

--- a/cli-rs/tests/runtime_lifecycle_smoke.rs
+++ b/cli-rs/tests/runtime_lifecycle_smoke.rs
@@ -3,7 +3,7 @@ mod support;
 use support::*;
 
 #[test]
-fn lifecycle_commands_render_human_text_by_default_and_json_when_selected() {
+fn lifecycle_commands_render_human_text_when_selected_and_json_when_selected() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let config_home = temp.path().join("config");
@@ -13,6 +13,8 @@ fn lifecycle_commands_render_human_text_by_default_and_json_when_selected() {
 
     let human = kast(&home, &config_home)
         .args([
+            "--output",
+            "human",
             "developer",
             "runtime",
             "status",
@@ -31,7 +33,7 @@ fn lifecycle_commands_render_human_text_by_default_and_json_when_selected() {
     let stdout = String::from_utf8_lossy(&human.stdout);
     assert!(
         stdout.starts_with("Kast status\n===========\n"),
-        "status should default to a rendered readable summary: {stdout}"
+        "status should render a readable summary when human output is selected: {stdout}"
     );
     assert!(
         stdout.contains("No runtime candidates were found."),
@@ -47,7 +49,7 @@ fn lifecycle_commands_render_human_text_by_default_and_json_when_selected() {
     );
     assert!(
         serde_json::from_slice::<serde_json::Value>(&human.stdout).is_err(),
-        "default status output should not be JSON"
+        "human status output should not be JSON"
     );
 
     let json = kast(&home, &config_home)

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -12,11 +12,12 @@ machine-oriented command path.
 
 ## Agent Envelope
 
-Every `kast agent` command emits one envelope on stdout. Agent commands default
-to compact TOON for prompt-friendly shell use. Use `--output json` when a
-script needs to parse the envelope, and add `--full` to `agent call` when the
-caller needs exact large response fields instead of AXI previews. Treat
-`ok: false` as a failed operation even when the process exited cleanly.
+Every `kast agent` command emits one envelope on stdout. Kast defaults to
+compact TOON outside interactive human terminals for prompt-friendly shell use.
+Use `--output json` when a JSON-only script needs to parse the envelope, and
+add `--full` to `agent call` when the caller needs exact large response fields
+instead of AXI previews. Treat `ok: false` as a failed operation even when the
+process exited cleanly.
 
 ```json title="Envelope shape"
 {

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -6,9 +6,10 @@ icon: lucide/list-tree
 
 # Commands
 
-Kast keeps the public CLI small. Human operator commands default to readable
-text and accept `--output json` when scripts need structured payloads. Advanced
-agent commands emit one JSON object on stdout so they can be chained in tools.
+Kast keeps the public CLI small. Commands default to compact TOON outside
+interactive human terminals and switch to readable text only when Kast can see
+an interactive non-agent terminal. Pass `--output json` when scripts need JSON
+payloads.
 
 ## Command groups
 
@@ -45,31 +46,32 @@ flowchart LR
 
 ## Output modes
 
-Operator commands are designed for humans first. They render readable summaries
-in terminals and plain text in captured logs. Add `--output json` to preserve
-the structured payload for automation.
+Commands are AXI-oriented by default: captured, piped, CI, and agent-process
+invocations use compact TOON on stdout. Interactive non-agent terminals get the
+most readable human output unless `[cli] dynamicOutput = false` is set in
+`config.toml`. Add `--output json` for JSON-only automation.
 
 === "Human terminal"
 
-    ```console title="Readable by default"
+    ```console title="Readable when interactive"
     kast status
     ```
 
 === "Script"
 
-    ```console title="Structured output"
+    ```console title="JSON output"
     kast --output json status
     ```
 
-`kast agent` is different by design. It always emits a single JSON envelope
-with `ok`, `method`, `request`, and either `result` or `error`. Use it when a
-script, agent, or CI step needs stable machine output.
+`kast agent` always emits a single envelope with `ok`, `method`, `request`, and
+either `result` or `error`. Use it when a script, agent, or CI step needs
+stable machine output.
 
 | Surface | Output default | Use it for |
 |---------|----------------|------------|
-| `kast ready` and `kast developer runtime ...` | Human-readable text | Operator inspection and repair loops |
-| `kast --output json ...` | Structured JSON for supported operator commands | CI and scripts that still use high-level operator commands |
-| `kast agent ...` | One JSON envelope on stdout | Agent tools, command chaining, and stable semantic evidence |
+| `kast ready` and `kast developer runtime ...` | TOON outside interactive human terminals; readable text in interactive human terminals | Operator inspection and repair loops |
+| `kast --output json ...` | Structured JSON for supported commands | CI and scripts that require JSON |
+| `kast agent ...` | One TOON envelope on stdout unless `--output json` is selected | Agent tools, command chaining, and stable semantic evidence |
 
 ## Workspace selection
 

--- a/docs/commands/lifecycle.md
+++ b/docs/commands/lifecycle.md
@@ -29,8 +29,10 @@ IntelliJ IDEA or Android Studio profile when the launcher is not on `PATH`.
 
 ## Inspect runtime state
 
-Use `kast developer runtime status` for a human-readable state summary. Add `--output json` when
-a script needs resolved paths, daemon state, logs, warnings, or backend details.
+Use `kast developer runtime status` for a human-readable state summary in an
+interactive non-agent terminal. Captured and agent-run invocations default to
+compact TOON. Add `--output json` when a JSON-only script needs resolved paths,
+daemon state, logs, warnings, or backend details.
 
 ```console title="Check runtime state"
 kast developer runtime status

--- a/docs/commands/metrics.md
+++ b/docs/commands/metrics.md
@@ -11,9 +11,11 @@ not require a running JVM backend when the database already exists.
 
 ## Direct metrics
 
-Use `kast developer inspect metrics ...` for human-readable summaries or `--output json` for
-automation. Pass `--database` only when you need to read a specific index file
-instead of the current workspace cache.
+Use `kast developer inspect metrics ...` for human-readable summaries in an
+interactive non-agent terminal. Captured and agent-run invocations default to
+compact TOON; pass `--output json` for JSON-only automation. Pass `--database`
+only when you need to read a specific index file instead of the current
+workspace cache.
 
 ```console title="Source-index metrics"
 kast developer inspect metrics fan-in --limit 20

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -130,10 +130,11 @@ profile needs repair.
 Kast 1.0 resolves every install-owned path from the install manifest at
 `$HOME/.local/share/kast/install.json`. The user config file remains
 `$HOME/.config/kast/config.toml`, but it only owns behavior settings such as
-backend selection, indexing policy, launch policy, telemetry, and profiling.
-Do not put install roots, CLI paths, daemon paths, socket paths, runtime
-library paths, or managed install state in `config.toml`; those values come
-from the manifest-backed resolver.
+backend selection, indexing policy, launch policy, telemetry, profiling, and
+`[cli] dynamicOutput = false` when implicit output should stay TOON even in an
+interactive human terminal. Do not put install roots, CLI paths, daemon paths,
+socket paths, runtime library paths, or managed install state in `config.toml`;
+those values come from the manifest-backed resolver.
 
 ??? question "Inspect the active path model"
     Use `kast developer inspect paths` when you need the exact resolved paths that the CLI,

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -57,7 +57,8 @@ CI, and hosted agents.
     kast status --backend=headless
     ```
 
-Use JSON output for automation:
+Captured and agent-run commands default to compact TOON. Use JSON output when
+automation specifically needs JSON:
 
 ```console title="Machine-readable status"
 kast --output json status

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,6 +126,6 @@ hierarchy evidence was complete or bounded, and plan mutations with file hashes
 before applying edits.
 
 !!! tip "Automation boundary"
-    Use `--output json` on operator commands when automation needs structured
-    payloads. Use `kast agent call <method>` for pipe-friendly advanced catalog
-    calls.
+    Captured and agent-run commands default to compact TOON. Use
+    `--output json` when automation specifically needs JSON payloads, and use
+    `kast agent call <method>` for pipe-friendly advanced catalog calls.


### PR DESCRIPTION
## Summary
- default non-interactive and agent-process CLI output to TOON unless an output format is explicitly requested
- keep human output for interactive non-agent terminals through the new [cli] dynamicOutput setting
- preserve dynamicOutput during install repair and update docs/packaged skill guidance

## Verification
- cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
- cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
- cargo test --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features
- KAST_VERSION=0.0.0-ci cargo build --manifest-path cli-rs/Cargo.toml --release --locked
- .github/scripts/test-docs-navigation-contract.sh
- .github/scripts/test-docs-content-contract.sh
- zensical build --clean
- .github/scripts/test-release-workflow-contract.sh
- .github/scripts/test-kast-build-contract.sh
- .github/scripts/test-terminal-onboarding-contract.sh
- .github/scripts/test-kast-routing-evals.sh
- .github/scripts/test-kast-copilot-plugin.sh