### PR TITLE
docs: align agent guidance with current ADR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,37 +2,33 @@
 
 ## Project Structure & Module Organization
 
-Kast is a mixed Kotlin/Gradle and Rust project. Kotlin modules are declared in
-`settings.gradle.kts`: `analysis-api` owns shared contracts and models,
-`analysis-server` owns JSON-RPC dispatch, `index-store` owns SQLite-backed
-indexing, and `backend-headless`, `backend-shared`, and `backend-idea` own the
-runtime hosts. `build-logic` contains Gradle convention plugins. `cli-rs/` is
-the Rust CLI and installer. `docs/` plus `zensical.toml` are the documentation
-source; `site/` is generated output. Copilot and skill source lives under
-`cli-rs/resources/plugin/` and `cli-rs/resources/kast-skill/`.
+Kast is an agent-first, compiler-backed Kotlin and Gradle semantic control
+plane. Kotlin modules are declared in `settings.gradle.kts`: `analysis-api`
+owns the host-agnostic semantic contract and shared models, `analysis-server`
+owns JSON-RPC transport and dispatch, `index-store` owns the SQLite-backed
+source index, and `backend-headless`, `backend-shared`, and `backend-idea` own
+runtime hosts. `cli-rs/` owns the Rust AXI CLI, typed agent commands,
+installation, runtime orchestration, source-index CLI reads, release
+packaging, and repository agent assets. `build-logic` contains Gradle
+convention plugins. `docs/` plus `zensical.toml` are the documentation source;
+`site/` is generated output.
 
 Deeper `AGENTS.md` files narrow these rules for their subtrees. Follow the
 nearest guide when editing inside a scoped directory.
 
 ## Decision Records & Source Of Truth
 
-Use durable agent-only docs for product and agent-surface decisions instead of
-preserving conversation-only context. `.agents/adr/0001-agent-first-install-and-docs-operating-model.md`
-owns the global binary, repository Copilot, and docs operating model.
-`.agents/adr/0002-agent-resource-and-workflow-source-of-truth.md` owns
-manifest-backed agent resources, `kast agent workflow`, and the rule that stale
-binary/resource combinations fail loudly and require upgrade or reinstall.
-`.agents/adr/0005-axi-only-agent-cli-and-semantic-edit-dialect.md` owns the
-minimal v1 agent asset set and typed AXI CLI dialect.
+Use durable agent-only ADRs for product and agent-surface decisions.
 `.agents/adr/0006-forward-system-definition-and-audit-scope.md` owns the
-forward system definition and audit scope for evaluating current intent only.
-`.agents/adr/0004-repo-context-guidance-operating-model.md` owns repository
-root context-file selection, managed Kast guidance regions, clone-local Git
-filter behavior, and direct references to the installed skill path.
+current public product surface, system boundaries, supported workflows, AXI
+contract, extension points, audit assertions, validation gates, and future
+change rule.
 
-When a change alters source ownership, generated outputs, or validation gates,
-update the nearest scoped `AGENTS.md` in the same change. Agent-only ADRs stay
-under `.agents/adr/` and must not be added to the published docs nav.
+When a change expands or contracts the public product surface, add a
+superseding ADR before rewriting docs or generated assets. When a change alters
+source ownership, generated outputs, or validation gates, update the nearest
+scoped `AGENTS.md` in the same change. Agent-only ADRs stay under
+`.agents/adr/`; published docs navigation is owned by the docs source.
 
 ## Build, Test, and Development Commands
 
@@ -50,9 +46,9 @@ under `.agents/adr/` and must not be added to the published docs nav.
 
 ## Coding Style & Naming Conventions
 
-Prefer compiler-enforced invariants over runtime checks or casts. Do not work
-around type errors; model the missing state explicitly. Keep Kotlin package
-names under `io.github.amichne.kast`, use `*Test.kt` for JVM tests, and keep
+Prefer compiler-enforced invariants over runtime checks or casts. Model the
+missing state explicitly when types reveal a gap. Keep Kotlin package names
+under `io.github.amichne.kast`, use `*Test.kt` for JVM tests, and keep
 dependencies declared through `gradle/libs.versions.toml` where possible. Rust
 uses edition 2024; keep CLI modules small, typed, and covered by `cargo fmt`
 and `clippy`.
@@ -63,7 +59,7 @@ Use JUnit Jupiter for Kotlin tests under `src/test/kotlin`. Add focused tests
 before behavior changes, then broaden to integration or backend tests when a
 shared contract moves. Rust smoke and integration tests live in `cli-rs/tests`.
 Generated docs, RPC catalogs, and package manifests require their contract
-scripts, not just unit tests.
+scripts alongside unit tests.
 
 ## Commit & Pull Request Guidelines
 
@@ -75,6 +71,6 @@ docs, release, or packaging impact.
 ## Agent-Specific Instructions
 
 For Kotlin symbol identity, references, hierarchy, and safe edits, use Kast
-semantic tooling when available instead of text search. Treat `.github/`,
-`.agents/`, and `site/` package or site material as generated unless a scoped
-guide says otherwise; edit the source tree and regenerate.
+semantic tooling for compiler-backed evidence. Generated package, protocol,
+catalog, and site outputs come from their source owners and contract scripts;
+edit the source tree and regenerate.

--- a/analysis-api/AGENTS.md
+++ b/analysis-api/AGENTS.md
@@ -7,24 +7,24 @@ stay host-agnostic so the transport and runtime layers can share it.
 
 Keep this unit small, stable, and reusable across every runtime host.
 
-- Keep this module host-agnostic. Do not add Ktor, IDEA Platform, or other
-  runtime-specific dependencies here.
+- Keep this module host-agnostic. Runtime-specific dependencies belong in
+  runtime host modules.
 - Own `AnalysisBackend`, serializable request and response models,
   `AnalysisTransport`, JSON-RPC wire models, descriptor discovery helpers,
   `ServerLaunchOptions`, shared error types, capability enums,
   `ServerInstanceDescriptor`, and edit-plan validation semantics.
 - Keep shared startup helpers quiet for callers. `KastConfig.load`,
-  descriptor discovery, and similar shared entry points must not emit
-  incidental stdout or stderr because CLI JSON commands and IDEA startup
-  use these APIs inside machine-readable or UI-sensitive flows.
+  descriptor discovery, and similar shared entry points report through typed
+  results because CLI JSON commands and IDEA startup use these APIs inside
+  machine-readable or UI-sensitive flows.
 - Keep file-path rules explicit. Edit queries, rename hashes, workspace roots,
   and descriptor socket paths must stay absolute and normalized.
 - Treat `SCHEMA_VERSION`, serialized field changes, and descriptor transport
   fields as protocol changes. Update callers, tests, and docs together when
   the wire contract moves.
-- Keep edit application deterministic. Preserve conflict detection, non-
-  overlapping range validation, and partial-apply reporting unless you are
-  intentionally redesigning that behavior.
+- Keep edit application deterministic. Preserve conflict detection,
+  non-overlapping range validation, and partial-apply reporting through any
+  redesign.
 
 ## Verification
 

--- a/analysis-api/src/testFixtures/AGENTS.md
+++ b/analysis-api/src/testFixtures/AGENTS.md
@@ -11,16 +11,16 @@ Keep this unit deterministic so downstream tests stay readable and stable.
   `analysis-api` test-fixtures variant for reuse in downstream tests.
 - Own fake backends, deterministic fixture files, and helpers that make server
   and backend tests easier to read.
-- Do not add production-only behavior, network servers, or IDEA Platform
-  dependencies here.
+- Production host behavior, network servers, and IDEA Platform dependencies
+  live in production modules.
 - Keep fixtures small and explicit. Stable offsets, file contents, and
   capability sets matter because downstream tests depend on them.
-- Mirror the public API closely enough for tests to be meaningful, but avoid
-  simulating more behavior than the tests need.
+- Mirror the public API closely enough for meaningful tests. Keep simulation
+  bounded to the consuming tests.
 
 ## Verification
 
-Check the consumers of these fixtures, not just the fixture code itself.
+Check the consumers of these fixtures together with the fixture code.
 
 - Run the consuming tests that rely on this unit, starting with
   `./gradlew :analysis-server:test`.

--- a/analysis-server/AGENTS.md
+++ b/analysis-server/AGENTS.md
@@ -15,8 +15,8 @@ Keep this unit focused on transport concerns around the backend interface.
   descriptor directory; shutdown removes them.
 - Keep capability checks, truncation, and request-limit handling aligned with
   backend responses.
-- Do not move PSI logic, workspace discovery, or CLI parsing into this unit.
-  Those belong in `backend-headless` or `kast`.
+- PSI logic, workspace discovery, and CLI parsing stay in their runtime host
+  and Rust CLI owners.
 
 ## Verification
 

--- a/build-logic/AGENTS.md
+++ b/build-logic/AGENTS.md
@@ -11,18 +11,15 @@ Assume every edit in this unit can affect the whole repo.
   fat-jar packaging, runtime-lib syncing, wrapper generation, and reusable
   dependency bundles.
 - `kast.headless-app` is the shared packaging contract for app modules. Keep
-  task names and output layout stable unless every consumer is updated
-  together.
+  task names and output layout stable across every consumer.
 - `SyncRuntimeLibsTask` and `WriteWrapperScriptTask` define the runtime-libs
   and wrapper layout that `kast.sh`, `kast`, and portable dist packaging
   expect.
-- Do not put product behavior or workspace-specific runtime logic here. If a
-  change affects shipped analysis behavior, it probably belongs in an
-  application or backend module instead.
+- Product behavior and workspace-specific runtime logic belong in application,
+  backend, or CLI modules.
 - Treat version bumps and plugin changes as cross-repo work. A small edit here
   can alter every module's compile, test, or packaging behavior.
-- Preserve Java 21 and the shared version-catalog linkage unless the build is
-  being upgraded deliberately.
+- Java 21 and shared version-catalog linkage are the build baseline.
 
 ## Verification
 
@@ -31,8 +28,8 @@ Validate both the immediate target and the wider build impact.
 - For test-tag selection behavior, run
   `./gradlew -p build-logic test --tests DefaultTestTagSelectionTest`.
 - Convention plugin test filtering supports `-PincludeTags=<tag1,tag2>` and
-  `-PexcludeTags=<tag1,tag2>`. Default runs exclude `concurrency`,
-  `performance`, and `parity` unless include tags are set.
+  `-PexcludeTags=<tag1,tag2>`. Default runs skip `concurrency`,
+  `performance`, and `parity`; explicit include tags select those suites.
 - Run the affected module tasks that consume the changed convention, starting
   with `./gradlew :backend-headless:syncRuntimeLibs :backend-headless:portableDistZip`
   for runtime-lib or portable distribution changes.

--- a/cli-rs/AGENTS.md
+++ b/cli-rs/AGENTS.md
@@ -1,54 +1,51 @@
 # Rust CLI and agent resource guide
 
-This file applies to `cli-rs/` and descendants unless a deeper `AGENTS.md`
-narrows the rules. This tree owns the Rust CLI, installer, manifest-backed
-resource trust, agent command surface, and bundled agent resources.
+This file applies to `cli-rs/` and descendants. Deeper `AGENTS.md` files narrow
+the rules for their subtrees. This tree owns the Rust AXI CLI, typed agent
+command surface, installer, manifest-backed resource trust, runtime lifecycle
+orchestration, source-index CLI reads, release packaging, and bundled agent
+resources.
 
 ## Local purpose
 
-- `src/cli.rs` defines the public and hidden CLI command surface.
-- Public CLI families are intent-first: `kast ready`, `kast agent`,
-  `kast runtime`, `kast inspect`, `kast machine`, and `kast release`.
-- `src/agent.rs` owns `kast agent` aliases, `kast agent tools`,
-  `kast agent call`, and `kast agent workflow`; `kast agent up`,
-  `kast agent setup`, and `kast agent lsp` dispatch through operator handlers
-  before JSON-envelope execution.
-- `kast agent setup` installs harness-agnostic agent exposure: the packaged
-  skill under `.agents/skills/kast` plus a Kast-managed fenced region in the
-  ignored root `AGENTS.local.md` file, with `--agents-md` available for
-  explicit scoped guidance files. Its `--dry-run` mode must stay read-only and
-  explain skill and guidance targets.
-- `kast agent up` composes harness-agnostic setup with `kast runtime up`.
-  Its explicit `--workspace-root` must stay authoritative for setup targets,
-  and `--dry-run` must not write resources or start a backend.
+- `src/cli/root.rs` and `src/main.rs` define the root AXI CLI: compact context,
+  setup, readiness, repair, status, and developer operations.
+- `src/cli/agent.rs` and `src/agent/` own typed compiler-backed agent commands:
+  `verify`, `symbol`, `diagnostics`, `impact`, `rename`, and `lsp`.
+- `src/runtime/` owns backend lifecycle inspection and mutation for IDEA and
+  headless runtimes behind the same command dialect.
+- `src/install/` owns repository setup, managed guidance, machine install,
+  repair, bundle activation, shell integration, and IDEA plugin installation.
+- `src/symbol_query/` and `src/metrics_database/` own operational source-index
+  reads for the Rust CLI.
 - `src/install.rs`, `src/manifest.rs`, and `src/self_mgmt.rs` own install
   state, managed resource records, doctor checks, and repair behavior.
-- `resources/plugin/` owns the Copilot package source.
-- `resources/kast-skill/` owns the packaged skill and RPC/tool catalog.
-- `resources/kast-instructions/` owns installable Markdown instructions.
+- `resources/kast-skill/` owns the packaged `SKILL.md` and internal catalog
+  source material used by release checks and generated artifacts.
+- `resources/kast-instructions/` owns compact Markdown instruction source used
+  by resource validation.
+- `resources/plugin/` owns package source material used by release validation.
 - `protocol/` contains generated protocol artifacts for release and
-  integration consumers. It is not a docs site.
+  integration consumers.
 
-The durable decision record for agent resources and workflows is
-`.agents/adr/0002-agent-resource-and-workflow-source-of-truth.md`.
+The current public product surface, workflows, AXI contract, source ownership,
+and validation gates live in
+`.agents/adr/0006-forward-system-definition-and-audit-scope.md`.
 
 ## Edit rules
 
-- Keep command invariants in typed Rust structures. Do not bypass Clap, serde,
-  or catalog schema validation with ad hoc string handling.
+- Keep command invariants in typed Rust structures. Clap, serde, and catalog
+  schema validation own command parsing and structured data boundaries.
+- Agent-facing semantic workflows use typed `kast agent verify`, `symbol`,
+  `diagnostics`, `impact`, `rename`, and `lsp` commands.
+- Captured or agent-run commands default to compact structured output. Public
+  mutations are plan-first and gated: repair and rename require `--apply`;
+  setup supports `--dry-run`; forceful replacement requires `--force`.
 - Treat generated or installed resource copies as outputs. Edit the authored
   resource source, then regenerate or reinstall from the active binary.
-- Treat `AGENTS.md` files as authored guidance. Default Kast setup writes the
-  managed guidance block to ignored `AGENTS.local.md`; Kast may own only the
-  `<kast files="*.kt, *.kts" type="instructions" replaceTools="grep,search,write">`
-  region inside explicit guidance targets.
-- Do not maintain compatibility helpers only for older binaries. Missing
-  `kast agent` or `kast agent workflow` support is an incompatibility that
-  requires upgrade or reinstall.
-- Do not restore a shell `kast rpc` surface or older top-level developer
-  aliases. Agent and Copilot integrations use the root setup/readiness
-  commands, `kast developer ...`, `kast agent lsp`, `kast agent call`, and
-  `kast agent workflow`.
+- Treat `AGENTS.md` files as authored guidance. Repository setup writes one
+  managed `<kast>...</kast>` guidance region to the selected context file and
+  records one manifest-backed packaged skill install.
 - When install output shape changes, update manifest resource recording,
   doctor verification, package scripts, docs, and smoke tests in the same
   change.
@@ -57,12 +54,11 @@ The durable decision record for agent resources and workflows is
 
 - Command catalog truth lives in
   `resources/kast-skill/references/commands.json`.
-- Copilot package output shape lives in
-  `resources/plugin/primitive-manifest.json`.
+- Package artifact output shape lives in `resources/plugin/primitive-manifest.json`.
 - Installable skill source lives in `resources/kast-skill/`.
 - Installable instruction source lives in `resources/kast-instructions/`.
 - Generated request schemas and samples are derived from the catalog. Regenerate
-  them through the contract generator instead of hand-editing generated drift.
+  them through the contract generator.
 - Generated protocol markdown, OpenAPI YAML, and example fixtures live under
   `protocol/`; regenerate them through the Gradle docs generators.
 

--- a/cli-rs/resources/kast-instructions/AGENTS.md
+++ b/cli-rs/resources/kast-instructions/AGENTS.md
@@ -1,33 +1,28 @@
-# Installable instructions guide
+# Instruction source guide
 
 This file applies to `cli-rs/resources/kast-instructions/` and descendants.
-This tree is the authored source for Markdown instructions copied by
-manifest-backed resource installers.
+This tree is authored Markdown instruction source used by resource validation
+and package checks.
 
 ## Local purpose
 
-- `README.md` routes agents across the installed instruction files.
-- `cli.md` covers non-interactive CLI usage.
-- `tools.md` maps common agent tasks to portable `kast agent` commands and
-  workflows.
-- `tools.md` covers `kast agent`, file-backed request exchange, and catalog
-  calls through `kast agent call`.
-- `lsp.md` covers `kast agent lsp --stdio` and custom `kast/*` method discovery.
+- `README.md` routes agents across the instruction files.
+- `cli.md` covers AXI CLI usage, setup, readiness, repair, status, and output
+  formats.
+- `tools.md` maps semantic tasks to `kast agent verify`, `symbol`,
+  `diagnostics`, `impact`, and `rename`.
+- `lsp.md` covers `kast agent lsp --stdio` for editor integration.
 
-The durable source-of-truth contract for agent resources and workflows is
-`.agents/adr/0002-agent-resource-and-workflow-source-of-truth.md`.
+The current source-of-truth contract for public workflows and command dialect
+is `.agents/adr/0006-forward-system-definition-and-audit-scope.md`.
 
 ## Edit rules
 
-- Keep this tree lightweight and installable. Do not copy the full packaged
-  skill or generated request catalog into these files.
-- Prefer `kast agent` and `kast agent workflow` as the current agent surface.
-  If an active binary lacks those commands, instruct agents to upgrade or
-  reinstall Kast instead of preserving older-binary instructions.
-- Do not document a `kast rpc` shell flow; use `kast agent call` for catalog
-  request exchange.
-- When installed filenames or defaults change, update `src/install.rs`, docs,
-  and smoke tests that assert the installed instruction shape.
+- Keep this tree lightweight and aligned with root CLI plus typed agent
+  commands.
+- Use typed `kast agent` commands for compiler-backed semantic work.
+- When resource filenames or defaults change, update `src/install.rs`, docs,
+  and smoke tests that assert the instruction shape.
 
 ## Verify
 

--- a/cli-rs/resources/kast-skill/AGENTS.md
+++ b/cli-rs/resources/kast-skill/AGENTS.md
@@ -1,15 +1,14 @@
 # Kast skill and internal catalog guide
 
 This file applies to `cli-rs/resources/kast-skill/` and descendants. This tree
-contains the packaged skill entrypoint plus internal command catalog material
-used by docs, backend contracts, release checks, and generated LSP custom route
+contains the packaged skill entrypoint plus internal catalog material used by
+docs, backend contracts, release checks, and generated LSP custom route
 metadata.
 
 ## Local purpose
 
-- `SKILL.md` is the only file installed by v1 repository setup.
-- `references/commands.json` is the internal machine-readable RPC and tool
-  catalog.
+- `SKILL.md` is the packaged skill source installed by repository setup.
+- `references/commands.json` is the internal machine-readable command catalog.
 - `references/commands.yaml` and generated request schemas/samples are derived
   contract artifacts.
 - `references/quickstart.md` and `references/runbook.md` are agent-facing
@@ -17,30 +16,25 @@ metadata.
 - `references/workflows.md` owns install/config/package verification, project
   readiness, semantic workflow sequencing, and recovery ownership.
 - `scripts/verify-kast-state.py` is an internal deterministic helper for
-  read-only state checks. It must not advertise catalog, workflow, Copilot
-  package, portable instruction package, or hook surfaces as v1 setup assets.
+  read-only state checks.
 
-The durable decision record for package ownership, manifest-backed resource
-trust, and active-binary workflow support is
-`.agents/adr/0002-agent-resource-and-workflow-source-of-truth.md`.
+The current source-of-truth contract for the public product surface, workflows,
+AXI command dialect, and validation gates is
+`.agents/adr/0006-forward-system-definition-and-audit-scope.md`.
 
 ## Edit rules
 
 - Treat `references/commands.json` as the source catalog for internal methods,
   request fields, tool names, and flow grouping.
 - Regenerate derived contract artifacts after catalog changes.
-- Keep command and tool descriptions aligned with the current product story in
-  `.agents/adr/0001-agent-first-install-and-docs-operating-model.md`.
-- Do not add JVM-owned handlers for Rust-owned `database/*` or source-index
-  query methods.
-- Keep recovery guidance resolve-first and compiler-backed; do not route
-  Kotlin symbol work through text search.
-- Do not preserve public workflow, catalog-call, or tool-discovery helpers
-  solely for older binaries. Stale surfaces should return targeted replacement
-  guidance toward typed `kast agent` commands.
-- Prefer scripts only for internal verification. Keep them JSON-emitting, eager
-  about input validation, and read-only unless a future command explicitly
-  documents mutation.
+- Keep command and tool descriptions aligned with ADR 0006.
+- Rust CLI modules own operational source-index reads; JVM handlers own
+  API-backed semantic work.
+- Keep recovery guidance resolve-first and compiler-backed.
+- Skill guidance routes agents to `kast ready`, `kast repair`, and typed
+  `kast agent` commands.
+- Scripts are internal verification helpers. Keep them JSON-emitting, eager
+  about input validation, and read-only by default.
 
 ## Downstream surfaces
 

--- a/cli-rs/resources/plugin/AGENTS.md
+++ b/cli-rs/resources/plugin/AGENTS.md
@@ -1,39 +1,33 @@
-# Copilot package source guide
+# Package source guide
 
 This file applies to `cli-rs/resources/plugin/` and descendants. This tree is
-the authored source for the Kast Copilot package that repository setup and
-development install scripts copy into `.github`.
+the authored source for Kast package artifacts used by release validation and
+development packaging.
 
 ## Local purpose
 
-The package provides the repository-local Copilot integration:
+The package provides repository-local editor integration material:
 
 - `lsp.json` starts `kast agent lsp --stdio`.
 - `extensions/kast/extension.mjs` injects runtime tooling guidance for the typed
   `kast`, `kast help`, `kast ready`, and public `kast agent` command dialect.
-- `primitive-manifest.json` defines the files copied into a repository
-  `.github` directory.
+- `primitive-manifest.json` defines the package artifact shape.
 
-The durable decision record for the minimal v1 agent asset and command dialect
-is `.agents/adr/0005-axi-only-agent-cli-and-semantic-edit-dialect.md`.
+The current source-of-truth contract for public workflows and command dialect
+is `.agents/adr/0006-forward-system-definition-and-audit-scope.md`.
 
 ## Edit rules
 
-- Edit this source tree first for Copilot package changes.
+- Edit this source tree first for package changes.
 - Update `plugin.json` when entrypoints, package requirements, or package
   metadata change.
 - Update `primitive-manifest.json` when installed output files change.
 - Keep installed output paths relative and under the target `.github`
   package shape.
-- Do not edit generated `.github` package copies as the source of truth.
-  Regenerate or reinstall them from this tree.
-- Do not add package behavior that exists only to support older active
-  binaries. Missing typed `kast agent` support is an upgrade/reinstall
-  requirement.
-- Keep the package surface focused on LSP and runtime guidance. Do not add
-  package-specific custom agents, static instruction entrypoints,
-  `kast agent tools`, `kast agent call`, or `kast_*` tool registration unless
-  the public package shape is intentionally being expanded in a new ADR.
+- Generated `.github` package copies come from this source tree.
+- Keep package behavior aligned with `kast agent lsp --stdio`, `kast ready`,
+  `kast repair`, and typed `kast agent` commands.
+- Public package shape changes begin with a superseding ADR.
 
 ## Downstream surfaces
 
@@ -44,8 +38,7 @@ same change:
 - `docs/commands/agent.md`
 - `docs/commands/lsp.md`
 - `docs/troubleshooting.md`
-- `.agents/adr/0003-cli-command-documentation-operating-model.md` or a
-  superseding ADR when the product story changes
+- a superseding ADR when the product story changes
 - `.github/scripts/test-docs-content-contract.sh`
 
 ## Verify

--- a/cli-rs/src/AGENTS.md
+++ b/cli-rs/src/AGENTS.md
@@ -2,15 +2,13 @@
 
 This directory owns the Kast Rust CLI crate.
 
-Large command surfaces must be split by responsibility before they grow into
-catch-all files. Keep the crate root and module root files as facades: imports,
-constants, and explicit `include!` part ordering only. Domain behavior belongs
-in the named subdirectory next to the facade.
+Large command surfaces are split by responsibility. Keep the crate root and
+module root files as facades: imports, constants, and explicit `include!` part
+ordering. Domain behavior belongs in the named subdirectory next to the
+facade.
 
-When adding a new part file, name it for the contract it owns, not for a generic
-helper bucket. Avoid `util.rs`, `common.rs`, or broad shared modules unless the
-type itself is the contract.
+When adding a new part file, name it for the contract it owns. Shared modules
+use names tied to the typed contract they expose.
 
-Do not loosen types to make a split compile. If visibility or ownership becomes
-awkward, model the boundary explicitly and let the compiler force every caller
-through it.
+Keep visibility and ownership boundaries explicit so the compiler forces every
+caller through the modeled contract.

--- a/cli-rs/src/agent/AGENTS.md
+++ b/cli-rs/src/agent/AGENTS.md
@@ -1,13 +1,12 @@
 # Agent Module Instructions
 
-This directory owns pipe-friendly typed `kast agent` behavior and internal
-agent workflow contracts.
+This directory owns pipe-friendly typed `kast agent` behavior.
 
-Keep command dispatch, internal tool catalog projection, retained workflow
-execution, package verification, request input normalization, response
-envelopes, and alias expansion in separate part files. A new public agent
-command must be typed and must not expose arbitrary method dispatch.
+Keep command dispatch, internal catalog projection, package verification,
+request input normalization, response envelopes, and typed command execution
+in separate part files. Public agent commands are typed noun/verb operations
+with bounded flags and structured output.
 
-Do not add or route new behavior through a shell `kast rpc` surface.
-Agent-facing flows should prefer typed commands such as `kast agent symbol`,
-`kast agent diagnostics`, `kast agent impact`, and `kast agent rename`.
+Agent-facing semantic flows use `kast agent verify`, `kast agent symbol`,
+`kast agent diagnostics`, `kast agent impact`, `kast agent rename`, and
+`kast agent lsp`.

--- a/cli-rs/src/cli/AGENTS.md
+++ b/cli-rs/src/cli/AGENTS.md
@@ -3,8 +3,8 @@
 This directory owns Clap argument and command definitions.
 
 Keep command families split by the public surface they define: root commands,
-agent, runtime/LSP, inspect/metrics/demo/RPC, release/package/generate,
-machine/install, shared enums, conversions, and help/version helpers.
+agent, developer runtime, inspect, metrics, demo, release, package, generate,
+machine, install, shared enums, conversions, and help/version helpers.
 
-Do not encode runtime behavior in Clap DTOs. Argument types should describe
-operator input only; execution belongs in the command modules.
+Argument types describe operator input. Execution belongs in the command
+modules.

--- a/cli-rs/src/config/AGENTS.md
+++ b/cli-rs/src/config/AGENTS.md
@@ -7,5 +7,5 @@ Keep TOML DTOs separate from the normalized `KastConfig` model. Path resolution
 must explain ownership and source for every reported path. Workspace identity
 must prefer verifiable filesystem or Git facts over guessed strings.
 
-Do not hide install-owned configuration conflicts. Surface them through typed
-reports so repair code can make explicit decisions.
+Install-owned configuration conflicts surface through typed reports so repair
+code can make explicit decisions.

--- a/cli-rs/src/demo/AGENTS.md
+++ b/cli-rs/src/demo/AGENTS.md
@@ -6,4 +6,5 @@ Keep model types, entrypoints, SQLite access, symbol app state, compare app
 state, TUI event loops, rendering, and JSON/compare transformations separated.
 The database layer should return typed snapshots rather than UI-specific text.
 
-Do not let demo rendering rules leak into metrics or symbol-query contracts.
+Metrics and symbol-query contracts own their own result models and rendering
+boundaries.

--- a/cli-rs/src/install/AGENTS.md
+++ b/cli-rs/src/install/AGENTS.md
@@ -15,11 +15,11 @@ Each part file must own one install contract:
 - `bundle_install.rs` owns writing the activated bundle to disk.
 - `bundle_helpers.rs` owns local path, scratch-dir, copy, and shim helpers.
 - `repair.rs` owns doctor/repair state reconciliation.
-- `resource_installs.rs` owns skill, instruction, and Copilot package gateways.
+- `resource_installs.rs` owns skill, instruction, and package gateways.
 - `shell.rs` owns shell profile integration.
 - `embedded_resources.rs` owns packaged resource copying and checksums.
 - `homebrew_idea_plugin.rs` and `jetbrains_profiles.rs` own IDE plugin flows.
 - `resource_targets.rs` owns default resource target discovery.
 
-Do not add compatibility shims for stale binaries. Fail loudly when packaged
-resources, manifests, or generated outputs do not match the current contract.
+Packaged resources, manifests, and generated outputs match the current
+contract and report mismatches through typed install or repair reports.

--- a/cli-rs/src/lsp/AGENTS.md
+++ b/cli-rs/src/lsp/AGENTS.md
@@ -3,8 +3,8 @@
 This directory owns the `kast agent lsp` stdio adapter.
 
 Keep runtime transport, server state, capability routing, JSON-RPC framing,
-range/URI conversion, symbol mapping, and tests separated. The LSP adapter must
-fail closed when backend capabilities are missing or stale.
+range/URI conversion, symbol mapping, and tests separated. The LSP adapter
+reports missing or unsupported backend capabilities as typed errors.
 
-Do not mix protocol parsing with Kast semantic request construction unless a
-single function is the explicit boundary between the two.
+Protocol parsing and Kast semantic request construction meet at explicit
+boundary functions.

--- a/cli-rs/src/lsp/tests/AGENTS.md
+++ b/cli-rs/src/lsp/tests/AGENTS.md
@@ -6,5 +6,5 @@ Keep fake RPC support in `support.rs`. Group tests by protocol framing,
 initialization/routes, read operations, rename, hierarchy, and failure modes.
 Add new tests to the part that names the behavior under test.
 
-Do not add production code here. These files are included inside the
-`#[cfg(test)]` module declared by `../tests.rs`.
+Production code lives in the parent LSP module. These files are included
+inside the `#[cfg(test)]` module declared by `../tests.rs`.

--- a/cli-rs/src/metrics_database/AGENTS.md
+++ b/cli-rs/src/metrics_database/AGENTS.md
@@ -6,5 +6,4 @@ Keep query controls and result models separate from SQL execution and helper
 serialization. Public functions should return typed direct metrics results or
 typed direct metrics errors.
 
-Do not make UI output decisions here. Presentation belongs in `output` or the
-calling command.
+Presentation belongs in `output` or the calling command.

--- a/cli-rs/src/output/AGENTS.md
+++ b/cli-rs/src/output/AGENTS.md
@@ -2,9 +2,9 @@
 
 This directory owns human and JSON rendering for CLI command results.
 
-Keep rendering grouped by result family: core markdown/error output, agent-up,
-runtime/package output, readiness, tables, install output, and runtime helper
-formatting. Output code must not perform install, runtime, or config mutation.
+Keep rendering grouped by result family: core markdown/error output, typed
+agent commands, runtime, readiness, tables, install, package, and runtime
+helper formatting. Command modules own install, runtime, and config mutation.
 
-Do not bury behavior decisions in prose rendering. The command result type
-should already encode the state being displayed.
+Command result types encode the state being displayed; renderers project that
+state into human, TOON, or JSON output.

--- a/cli-rs/src/runtime/AGENTS.md
+++ b/cli-rs/src/runtime/AGENTS.md
@@ -1,11 +1,10 @@
 # Runtime Module Instructions
 
-This directory owns backend lifecycle, status inspection, RPC passthrough,
-descriptor management, workspace identity compatibility, and IDEA autolaunch.
+This directory owns backend lifecycle, status inspection, descriptor
+management, workspace identity, backend selection, and IDEA autolaunch.
 
 Keep lifecycle mutation separate from read-only inspection. Descriptor parsing,
 backend selection, workspace identity, and launch side effects must remain in
 named part files so callers can see the boundary they depend on.
 
-Do not silently choose an unsafe backend. If selection is ambiguous, return a
-typed error with the candidate evidence.
+Ambiguous backend selection returns a typed error with candidate evidence.

--- a/cli-rs/src/symbol_query/AGENTS.md
+++ b/cli-rs/src/symbol_query/AGENTS.md
@@ -1,11 +1,10 @@
 # Symbol Query Module Instructions
 
-This directory owns the JSON-RPC symbol query implementation backed by the
-source-index database.
+This directory owns source-index symbol query reads used by the Rust CLI.
 
-Keep RPC wrapping, request/response models, database reads, ranking/filtering,
-and tests separated. Ranking changes must remain explainable through typed
-signals in the response.
+Keep request/response models, database reads, ranking/filtering, and tests
+separated. Ranking changes remain explainable through typed signals in the
+response.
 
-Do not collapse semantic, lexical, graph, and structural signals into a single
-score without preserving their individual evidence.
+Semantic, lexical, graph, and structural signals stay visible as individual
+evidence.

--- a/cli-rs/tests/AGENTS.md
+++ b/cli-rs/tests/AGENTS.md
@@ -7,6 +7,5 @@ Keep each test file focused on one command family or contract surface. Shared
 fixtures belong in `support/`; individual tests should read like executable
 requirements for the surface named by the file.
 
-Do not create another monolithic smoke file. If a test needs unrelated fixture
-setup, move the fixture to `support` or split the assertion into the correct
-contract file.
+New coverage belongs in the test file for the command family or contract it
+proves. Shared setup belongs in `support/`.

--- a/cli-rs/tests/support/AGENTS.md
+++ b/cli-rs/tests/support/AGENTS.md
@@ -4,7 +4,7 @@ This directory owns shared integration-test fixtures only.
 
 Helpers here may create fake homes, bundles, archives, shell state, backend
 descriptors, or fake package-manager commands. They must stay deterministic and
-must not assert product behavior beyond fixture validity.
+assert fixture validity.
 
-Do not put command-contract assertions here. Assertions about CLI behavior
-belong in the integration test file for that command family.
+Assertions about CLI behavior belong in the integration test file for that
+command family.

--- a/index-store/AGENTS.md
+++ b/index-store/AGENTS.md
@@ -5,20 +5,19 @@ and headless/indexer hydration APIs shared across kast runtimes.
 
 ## Ownership
 
-Keep this unit focused on storage concerns and schema compatibility.
+Keep this unit focused on storage concerns and schema continuity.
 
 - Keep SQLite schema, migrations, interning codecs, and hydration helpers here.
   `SOURCE_INDEX_SCHEMA_VERSION`, table layouts, and query columns must stay
   aligned.
-- Bootstrap `sqlite-jdbc` inside this module before `DriverManager` access. Do
-  not rely on ambient JDBC registration from the host process because IDEA
-  and other plugin classloaders may not register the driver for you.
-- Keep this unit runtime-agnostic. Do not move IDEA PSI logic, CLI process
-  management, or JSON-RPC transport code here.
+- Bootstrap `sqlite-jdbc` inside this module before `DriverManager` access.
+  IDEA and other plugin classloaders require explicit driver registration.
+- Keep this unit runtime-agnostic. IDEA PSI logic, CLI process management, and
+  JSON-RPC transport code live in their runtime, CLI, and server owners.
 - Treat schema resets, additive migrations, and cache hydration changes as
-  compatibility-sensitive. Operational source-index reads belong in the Rust
-  CLI; Kotlin should only read SQLite for headless hydration or targeted
-  indexer/cache behavior.
+  contract-sensitive. Operational source-index reads belong in the Rust CLI;
+  Kotlin reads SQLite for headless hydration or targeted indexer/cache
+  behavior.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- Align every AGENTS.md file to ADR 0006 as the current source of truth
- Recast guidance around current public surfaces, typed AXI commands, and source-owner boundaries
- Remove older ADR/source-surface framing and backward-looking guidance

## Validation
- git diff --check
- rg scans over AGENTS.md for older ADR references, retired command-surface terms, and negation/backward-looking wording
- Confirmed 24 discovered AGENTS.md files and 24 changed AGENTS.md files

## Risk
- Documentation-only change; no runtime code changed