### PR TITLE
refactor: drop stale agent harness config

### DIFF
--- a/cli-rs/src/cli/agent.rs
+++ b/cli-rs/src/cli/agent.rs
@@ -55,21 +55,6 @@ pub struct AgentGuidanceSetupArgs {
     pub dry_run: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum AgentSetupHarness {
-    Auto,
-    Copilot,
-    Skill,
-    Instructions,
-}
-
-impl AgentSetupHarness {
-    pub fn is_auto(self) -> bool {
-        matches!(self, Self::Auto)
-    }
-}
-
 #[derive(Debug, Args, Clone, Default)]
 pub struct AgentRuntimeArgs {
     /// Absolute workspace root for daemon lifecycle and RPC commands.

--- a/cli-rs/src/config.rs
+++ b/cli-rs/src/config.rs
@@ -1,5 +1,5 @@
 use crate::SCHEMA_VERSION;
-use crate::cli::{AgentSetupHarness, BackendName, DaemonStartArgs};
+use crate::cli::{BackendName, DaemonStartArgs};
 use crate::error::{CliError, Result};
 use crate::manifest;
 use serde::{Deserialize, Serialize};

--- a/cli-rs/src/config/load.rs
+++ b/cli-rs/src/config/load.rs
@@ -162,9 +162,6 @@ impl KastConfig {
             if let Some(value) = project_open.profile {
                 self.project_open.profile = value;
             }
-            if let Some(value) = project_open.agent_harness {
-                self.project_open.agent_harness = value;
-            }
             if let Some(value) = project_open.auto_exclude_git {
                 self.project_open.auto_exclude_git = value;
             }

--- a/cli-rs/src/config/load.rs
+++ b/cli-rs/src/config/load.rs
@@ -95,8 +95,8 @@ impl KastConfig {
         Ok(config)
     }
 
-    pub fn can_run_agent_up_onboarding(&self) -> bool {
-        !self.onboarding.agent_up_completed
+    pub fn can_run_setup_onboarding(&self) -> bool {
+        !self.onboarding.setup_completed
             && self.runtime.is_default()
             && self.project_open.is_default()
     }
@@ -167,9 +167,9 @@ impl KastConfig {
             }
         }
         if let Some(onboarding) = partial.onboarding
-            && let Some(value) = onboarding.agent_up_completed
+            && let Some(value) = onboarding.setup_completed
         {
-            self.onboarding.agent_up_completed = value;
+            self.onboarding.setup_completed = value;
         }
         if let Some(indexing) = partial.indexing {
             if let Some(value) = indexing.phase2_enabled {

--- a/cli-rs/src/config/model.rs
+++ b/cli-rs/src/config/model.rs
@@ -106,7 +106,6 @@ impl Default for IdeaLaunchConfig {
 pub struct ProjectOpenConfig {
     pub profile_auto_init: bool,
     pub profile: ProjectOpenProfile,
-    pub agent_harness: AgentSetupHarness,
     pub auto_exclude_git: bool,
 }
 
@@ -114,7 +113,6 @@ impl ProjectOpenConfig {
     fn is_default(&self) -> bool {
         self.profile_auto_init
             && self.profile == ProjectOpenProfile::CopilotLsp
-            && self.agent_harness.is_auto()
             && self.auto_exclude_git
     }
 }
@@ -124,7 +122,6 @@ impl Default for ProjectOpenConfig {
         Self {
             profile_auto_init: true,
             profile: ProjectOpenProfile::CopilotLsp,
-            agent_harness: AgentSetupHarness::Auto,
             auto_exclude_git: true,
         }
     }

--- a/cli-rs/src/config/model.rs
+++ b/cli-rs/src/config/model.rs
@@ -130,12 +130,12 @@ impl Default for ProjectOpenConfig {
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OnboardingConfig {
-    pub agent_up_completed: bool,
+    pub setup_completed: bool,
 }
 
 impl OnboardingConfig {
     fn is_default(&self) -> bool {
-        !self.agent_up_completed
+        !self.setup_completed
     }
 }
 

--- a/cli-rs/src/config/partial.rs
+++ b/cli-rs/src/config/partial.rs
@@ -50,7 +50,8 @@ struct PartialProjectOpen {
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PartialOnboarding {
-    agent_up_completed: Option<bool>,
+    #[serde(alias = "agentUpCompleted")]
+    setup_completed: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/cli-rs/src/config/partial.rs
+++ b/cli-rs/src/config/partial.rs
@@ -44,7 +44,6 @@ struct PartialIdeaLaunch {
 struct PartialProjectOpen {
     profile_auto_init: Option<bool>,
     profile: Option<ProjectOpenProfile>,
-    agent_harness: Option<AgentSetupHarness>,
     auto_exclude_git: Option<bool>,
 }
 

--- a/cli-rs/src/config/tests.rs
+++ b/cli-rs/src/config/tests.rs
@@ -533,7 +533,6 @@ dynamicOutput = false
 
         assert!(config.project_open.profile_auto_init);
         assert_eq!(config.project_open.profile, ProjectOpenProfile::CopilotLsp);
-        assert_eq!(config.project_open.agent_harness, AgentSetupHarness::Auto);
         assert!(config.project_open.auto_exclude_git);
         assert!(!config.onboarding.agent_up_completed);
         assert!(config.can_run_agent_up_onboarding());
@@ -548,7 +547,6 @@ dynamicOutput = false
             r#"[projectOpen]
 profileAutoInit = true
 profile = "copilot-lsp"
-agentHarness = "instructions"
 autoExcludeGit = false
 "#,
         )
@@ -559,10 +557,6 @@ autoExcludeGit = false
 
         assert!(config.project_open.profile_auto_init);
         assert_eq!(config.project_open.profile, ProjectOpenProfile::CopilotLsp);
-        assert_eq!(
-            config.project_open.agent_harness,
-            AgentSetupHarness::Instructions
-        );
         assert!(!config.project_open.auto_exclude_git);
         assert!(!config.can_run_agent_up_onboarding());
     }
@@ -584,25 +578,6 @@ agentUpCompleted = true
 
         assert!(config.onboarding.agent_up_completed);
         assert!(!config.can_run_agent_up_onboarding());
-    }
-
-    #[test]
-    fn rejects_invalid_project_open_agent_harness() {
-        let temp = tempfile::tempdir().unwrap();
-        let config_file = temp.path().join("config.toml");
-        fs::write(
-            &config_file,
-            r#"[projectOpen]
-agentHarness = "mcp"
-"#,
-        )
-        .unwrap();
-
-        let error = read_partial_config(&config_file).unwrap_err();
-
-        assert_eq!(error.code, "CONFIG_ERROR");
-        assert!(error.message.contains("mcp"), "{}", error.message);
-        assert!(error.message.contains("instructions"), "{}", error.message);
     }
 
     #[test]

--- a/cli-rs/src/config/tests.rs
+++ b/cli-rs/src/config/tests.rs
@@ -534,8 +534,8 @@ dynamicOutput = false
         assert!(config.project_open.profile_auto_init);
         assert_eq!(config.project_open.profile, ProjectOpenProfile::CopilotLsp);
         assert!(config.project_open.auto_exclude_git);
-        assert!(!config.onboarding.agent_up_completed);
-        assert!(config.can_run_agent_up_onboarding());
+        assert!(!config.onboarding.setup_completed);
+        assert!(config.can_run_setup_onboarding());
     }
 
     #[test]
@@ -558,11 +558,30 @@ autoExcludeGit = false
         assert!(config.project_open.profile_auto_init);
         assert_eq!(config.project_open.profile, ProjectOpenProfile::CopilotLsp);
         assert!(!config.project_open.auto_exclude_git);
-        assert!(!config.can_run_agent_up_onboarding());
+        assert!(!config.can_run_setup_onboarding());
     }
 
     #[test]
-    fn parses_agent_up_onboarding_state() {
+    fn parses_setup_onboarding_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_file = temp.path().join("config.toml");
+        fs::write(
+            &config_file,
+            r#"[onboarding]
+setupCompleted = true
+"#,
+        )
+        .unwrap();
+
+        let mut config = KastConfig::defaults();
+        config.apply(read_partial_config(&config_file).unwrap());
+
+        assert!(config.onboarding.setup_completed);
+        assert!(!config.can_run_setup_onboarding());
+    }
+
+    #[test]
+    fn reads_legacy_agent_up_onboarding_state() {
         let temp = tempfile::tempdir().unwrap();
         let config_file = temp.path().join("config.toml");
         fs::write(
@@ -576,8 +595,8 @@ agentUpCompleted = true
         let mut config = KastConfig::defaults();
         config.apply(read_partial_config(&config_file).unwrap());
 
-        assert!(config.onboarding.agent_up_completed);
-        assert!(!config.can_run_agent_up_onboarding());
+        assert!(config.onboarding.setup_completed);
+        assert!(!config.can_run_setup_onboarding());
     }
 
     #[test]

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -572,6 +572,7 @@ fn root_setup_runtime_command(args: &cli::RuntimeArgs, no_open_ide: bool) -> Vec
     command
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct RemovedOperatorCommandEnvelope<'a> {
@@ -581,6 +582,7 @@ struct RemovedOperatorCommandEnvelope<'a> {
     schema_version: u32,
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct RemovedOperatorCommandError<'a> {
@@ -589,12 +591,14 @@ struct RemovedOperatorCommandError<'a> {
     details: RemovedOperatorCommandDetails<'a>,
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct RemovedOperatorCommandDetails<'a> {
     replacements: &'a [&'a str],
 }
 
+#[cfg(target_os = "macos")]
 fn removed_operator_command(
     method: &'static str,
     message: &'static str,

--- a/cli-rs/src/onboarding.rs
+++ b/cli-rs/src/onboarding.rs
@@ -322,17 +322,11 @@ mod tests {
                 .and_then(toml::Value::as_bool),
             Some(true)
         );
-        let project_open = document
-            .get("projectOpen")
-            .and_then(toml::Value::as_table)
-            .expect("project open");
-        assert!(
-            !project_open.contains_key("agentHarness"),
-            "onboarding must not force a harness-specific setup path"
-        );
         assert_eq!(
-            project_open
-                .get("profileAutoInit")
+            document
+                .get("projectOpen")
+                .and_then(toml::Value::as_table)
+                .and_then(|project_open| project_open.get("profileAutoInit"))
                 .and_then(toml::Value::as_bool),
             Some(true)
         );

--- a/cli-rs/src/onboarding.rs
+++ b/cli-rs/src/onboarding.rs
@@ -69,7 +69,7 @@ pub fn maybe_run_setup_onboarding(
         no_onboard: args.no_open_ide,
         ci: env_flag("CI"),
         dumb_terminal: env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")),
-        config_allows: config.can_run_agent_up_onboarding(),
+        config_allows: config.can_run_setup_onboarding(),
         homebrew_idea_plugin_installable: true,
     };
     if !eligibility.allows_prompt() {
@@ -96,7 +96,7 @@ pub fn maybe_run_setup_onboarding(
         .map_err(|error| CliError::new("PROMPT_FAILED", error.to_string()))?;
 
     if !accepted {
-        mark_agent_up_onboarding_completed()?;
+        mark_setup_onboarding_completed()?;
         return Ok(SetupOnboardingOutcome::Declined);
     }
 
@@ -114,7 +114,7 @@ pub fn maybe_run_setup_onboarding(
         },
         &mut reporter,
     )?;
-    apply_agent_up_onboarding_config(scope, workspace_root)?;
+    apply_setup_onboarding_config(scope, workspace_root)?;
     prepare_current_invocation_for_idea(args);
     eprintln!();
     eprintln!(
@@ -155,38 +155,35 @@ fn prepare_current_invocation_for_idea(args: &mut SetupArgs) {
     }
 }
 
-fn mark_agent_up_onboarding_completed() -> Result<()> {
+fn mark_setup_onboarding_completed() -> Result<()> {
     self_mgmt::update_global_config(|document| {
-        table(document, "onboarding")?.insert("agentUpCompleted".to_string(), true.into());
+        table(document, "onboarding")?.insert("setupCompleted".to_string(), true.into());
         Ok(())
     })?;
     Ok(())
 }
 
-fn apply_agent_up_onboarding_config(
-    scope: SetupOnboardingScope,
-    workspace_root: &Path,
-) -> Result<()> {
+fn apply_setup_onboarding_config(scope: SetupOnboardingScope, workspace_root: &Path) -> Result<()> {
     match scope {
-        SetupOnboardingScope::Global => self_mgmt::update_global_config(|document| {
-            write_agent_up_onboarding_defaults(document)
-        })?,
+        SetupOnboardingScope::Global => {
+            self_mgmt::update_global_config(write_setup_onboarding_defaults)?
+        }
         SetupOnboardingScope::Repository => {
             self_mgmt::update_workspace_config(workspace_root, |document| {
-                write_agent_up_onboarding_defaults(document)
+                write_setup_onboarding_defaults(document)
             })?
         }
     };
     Ok(())
 }
 
-fn write_agent_up_onboarding_defaults(document: &mut toml::Table) -> Result<()> {
+fn write_setup_onboarding_defaults(document: &mut toml::Table) -> Result<()> {
     self_mgmt::write_developer_machine_idea_defaults(document)?;
 
     let project_open = table(document, "projectOpen")?;
     project_open.insert("profileAutoInit".to_string(), true.into());
 
-    table(document, "onboarding")?.insert("agentUpCompleted".to_string(), true.into());
+    table(document, "onboarding")?.insert("setupCompleted".to_string(), true.into());
     Ok(())
 }
 
@@ -292,7 +289,7 @@ mod tests {
     fn onboarding_defaults_configure_idea_agent_flow() {
         let mut document = toml::Table::new();
 
-        write_agent_up_onboarding_defaults(&mut document).expect("defaults");
+        write_setup_onboarding_defaults(&mut document).expect("defaults");
 
         assert_eq!(
             document
@@ -334,7 +331,7 @@ mod tests {
             document
                 .get("onboarding")
                 .and_then(toml::Value::as_table)
-                .and_then(|onboarding| onboarding.get("agentUpCompleted"))
+                .and_then(|onboarding| onboarding.get("setupCompleted"))
                 .and_then(toml::Value::as_bool),
             Some(true)
         );

--- a/cli-rs/src/output.rs
+++ b/cli-rs/src/output.rs
@@ -3,7 +3,7 @@ use crate::config::PathResolutionReport;
 use crate::error::{CliError, Result};
 use crate::install::{
     ActivateBundleResult, AgentGuidanceSetupPlan, AgentGuidanceSetupResult,
-    InstallIdeaPluginResult, InstallResult, InstallShellResult, InstallSkillResult,
+    InstallIdeaPluginResult, InstallResult, InstallShellResult,
 };
 use crate::orchestration::{SetupRuntimeNextAction, SetupRuntimeResult, SetupRuntimeStage};
 use crate::package::{PackageResult, UbuntuDebianBundlePackageResult};

--- a/cli-rs/src/output/install.rs
+++ b/cli-rs/src/output/install.rs
@@ -5,28 +5,6 @@ pub fn print_paths(result: &PathResolutionReport) -> Result<()> {
     print_markdown(&document.into_string())
 }
 
-fn print_skill_install(result: &InstallSkillResult) -> Result<()> {
-    let mut document = MarkdownDocument::default();
-    mdln!(document, "# Kast skill install");
-    mdln!(document);
-    mdln!(document, "- Installed at: `{}`", result.installed_at);
-    mdln!(document, "- Version: `{}`", result.version);
-    mdln!(
-        document,
-        "- Reused existing install: {}",
-        yes_no(result.skipped)
-    );
-    mdln!(document);
-    mdln!(document, "## Next steps");
-    mdln!(
-        document,
-        "- Read the installed skill entrypoint: `{}/SKILL.md`",
-        result.installed_at
-    );
-    mdln!(document, "- Read command help with: `kast help agent`");
-    print_markdown(&document.into_string())
-}
-
 fn print_idea_plugin_install(result: &InstallIdeaPluginResult) -> Result<()> {
     let mut document = MarkdownDocument::default();
     print_idea_plugin_install_summary(&mut document, result);

--- a/cli-rs/src/output/runtime_helpers.rs
+++ b/cli-rs/src/output/runtime_helpers.rs
@@ -129,12 +129,6 @@ fn runtime_state(state: RuntimeState) -> &'static str {
     }
 }
 
-fn print_optional(document: &mut MarkdownDocument, label: &str, value: Option<&str>) {
-    if let Some(value) = value.filter(|value| !value.trim().is_empty()) {
-        mdln!(document, "- {label}: `{value}`");
-    }
-}
-
 fn print_warnings(document: &mut MarkdownDocument, warnings: &[String]) {
     print_messages(document, "Warnings", warnings);
 }


### PR DESCRIPTION
## Summary
- remove the stale `projectOpen.agentHarness` config field and the now-unused `AgentSetupHarness` enum
- stop parsing/applying harness-specific setup config now that setup is harness-agnostic
- delete config/onboarding tests that only covered the retired setting

Stacked on #320.

## Verification
- `cargo check --manifest-path cli-rs/Cargo.toml --locked`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked config::tests::`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked onboarding::tests::`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `.github/scripts/test-terminal-onboarding-contract.sh`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `git diff --check`