### PR TITLE
refactor: rename setup onboarding state

### DIFF
--- a/cli-rs/src/config/load.rs
+++ b/cli-rs/src/config/load.rs
@@ -95,8 +95,8 @@ impl KastConfig {
         Ok(config)
     }
 
-    pub fn can_run_agent_up_onboarding(&self) -> bool {
-        !self.onboarding.agent_up_completed
+    pub fn can_run_setup_onboarding(&self) -> bool {
+        !self.onboarding.setup_completed
             && self.runtime.is_default()
             && self.project_open.is_default()
     }
@@ -167,9 +167,9 @@ impl KastConfig {
             }
         }
         if let Some(onboarding) = partial.onboarding
-            && let Some(value) = onboarding.agent_up_completed
+            && let Some(value) = onboarding.setup_completed
         {
-            self.onboarding.agent_up_completed = value;
+            self.onboarding.setup_completed = value;
         }
         if let Some(indexing) = partial.indexing {
             if let Some(value) = indexing.phase2_enabled {

--- a/cli-rs/src/config/model.rs
+++ b/cli-rs/src/config/model.rs
@@ -130,12 +130,12 @@ impl Default for ProjectOpenConfig {
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OnboardingConfig {
-    pub agent_up_completed: bool,
+    pub setup_completed: bool,
 }
 
 impl OnboardingConfig {
     fn is_default(&self) -> bool {
-        !self.agent_up_completed
+        !self.setup_completed
     }
 }
 

--- a/cli-rs/src/config/partial.rs
+++ b/cli-rs/src/config/partial.rs
@@ -50,7 +50,8 @@ struct PartialProjectOpen {
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PartialOnboarding {
-    agent_up_completed: Option<bool>,
+    #[serde(alias = "agentUpCompleted")]
+    setup_completed: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/cli-rs/src/config/tests.rs
+++ b/cli-rs/src/config/tests.rs
@@ -534,8 +534,8 @@ dynamicOutput = false
         assert!(config.project_open.profile_auto_init);
         assert_eq!(config.project_open.profile, ProjectOpenProfile::CopilotLsp);
         assert!(config.project_open.auto_exclude_git);
-        assert!(!config.onboarding.agent_up_completed);
-        assert!(config.can_run_agent_up_onboarding());
+        assert!(!config.onboarding.setup_completed);
+        assert!(config.can_run_setup_onboarding());
     }
 
     #[test]
@@ -558,11 +558,30 @@ autoExcludeGit = false
         assert!(config.project_open.profile_auto_init);
         assert_eq!(config.project_open.profile, ProjectOpenProfile::CopilotLsp);
         assert!(!config.project_open.auto_exclude_git);
-        assert!(!config.can_run_agent_up_onboarding());
+        assert!(!config.can_run_setup_onboarding());
     }
 
     #[test]
-    fn parses_agent_up_onboarding_state() {
+    fn parses_setup_onboarding_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_file = temp.path().join("config.toml");
+        fs::write(
+            &config_file,
+            r#"[onboarding]
+setupCompleted = true
+"#,
+        )
+        .unwrap();
+
+        let mut config = KastConfig::defaults();
+        config.apply(read_partial_config(&config_file).unwrap());
+
+        assert!(config.onboarding.setup_completed);
+        assert!(!config.can_run_setup_onboarding());
+    }
+
+    #[test]
+    fn reads_legacy_agent_up_onboarding_state() {
         let temp = tempfile::tempdir().unwrap();
         let config_file = temp.path().join("config.toml");
         fs::write(
@@ -576,8 +595,8 @@ agentUpCompleted = true
         let mut config = KastConfig::defaults();
         config.apply(read_partial_config(&config_file).unwrap());
 
-        assert!(config.onboarding.agent_up_completed);
-        assert!(!config.can_run_agent_up_onboarding());
+        assert!(config.onboarding.setup_completed);
+        assert!(!config.can_run_setup_onboarding());
     }
 
     #[test]

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -572,6 +572,7 @@ fn root_setup_runtime_command(args: &cli::RuntimeArgs, no_open_ide: bool) -> Vec
     command
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct RemovedOperatorCommandEnvelope<'a> {
@@ -581,6 +582,7 @@ struct RemovedOperatorCommandEnvelope<'a> {
     schema_version: u32,
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct RemovedOperatorCommandError<'a> {
@@ -589,12 +591,14 @@ struct RemovedOperatorCommandError<'a> {
     details: RemovedOperatorCommandDetails<'a>,
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct RemovedOperatorCommandDetails<'a> {
     replacements: &'a [&'a str],
 }
 
+#[cfg(target_os = "macos")]
 fn removed_operator_command(
     method: &'static str,
     message: &'static str,

--- a/cli-rs/src/onboarding.rs
+++ b/cli-rs/src/onboarding.rs
@@ -69,7 +69,7 @@ pub fn maybe_run_setup_onboarding(
         no_onboard: args.no_open_ide,
         ci: env_flag("CI"),
         dumb_terminal: env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")),
-        config_allows: config.can_run_agent_up_onboarding(),
+        config_allows: config.can_run_setup_onboarding(),
         homebrew_idea_plugin_installable: true,
     };
     if !eligibility.allows_prompt() {
@@ -96,7 +96,7 @@ pub fn maybe_run_setup_onboarding(
         .map_err(|error| CliError::new("PROMPT_FAILED", error.to_string()))?;
 
     if !accepted {
-        mark_agent_up_onboarding_completed()?;
+        mark_setup_onboarding_completed()?;
         return Ok(SetupOnboardingOutcome::Declined);
     }
 
@@ -114,7 +114,7 @@ pub fn maybe_run_setup_onboarding(
         },
         &mut reporter,
     )?;
-    apply_agent_up_onboarding_config(scope, workspace_root)?;
+    apply_setup_onboarding_config(scope, workspace_root)?;
     prepare_current_invocation_for_idea(args);
     eprintln!();
     eprintln!(
@@ -155,38 +155,35 @@ fn prepare_current_invocation_for_idea(args: &mut SetupArgs) {
     }
 }
 
-fn mark_agent_up_onboarding_completed() -> Result<()> {
+fn mark_setup_onboarding_completed() -> Result<()> {
     self_mgmt::update_global_config(|document| {
-        table(document, "onboarding")?.insert("agentUpCompleted".to_string(), true.into());
+        table(document, "onboarding")?.insert("setupCompleted".to_string(), true.into());
         Ok(())
     })?;
     Ok(())
 }
 
-fn apply_agent_up_onboarding_config(
-    scope: SetupOnboardingScope,
-    workspace_root: &Path,
-) -> Result<()> {
+fn apply_setup_onboarding_config(scope: SetupOnboardingScope, workspace_root: &Path) -> Result<()> {
     match scope {
-        SetupOnboardingScope::Global => self_mgmt::update_global_config(|document| {
-            write_agent_up_onboarding_defaults(document)
-        })?,
+        SetupOnboardingScope::Global => {
+            self_mgmt::update_global_config(write_setup_onboarding_defaults)?
+        }
         SetupOnboardingScope::Repository => {
             self_mgmt::update_workspace_config(workspace_root, |document| {
-                write_agent_up_onboarding_defaults(document)
+                write_setup_onboarding_defaults(document)
             })?
         }
     };
     Ok(())
 }
 
-fn write_agent_up_onboarding_defaults(document: &mut toml::Table) -> Result<()> {
+fn write_setup_onboarding_defaults(document: &mut toml::Table) -> Result<()> {
     self_mgmt::write_developer_machine_idea_defaults(document)?;
 
     let project_open = table(document, "projectOpen")?;
     project_open.insert("profileAutoInit".to_string(), true.into());
 
-    table(document, "onboarding")?.insert("agentUpCompleted".to_string(), true.into());
+    table(document, "onboarding")?.insert("setupCompleted".to_string(), true.into());
     Ok(())
 }
 
@@ -292,7 +289,7 @@ mod tests {
     fn onboarding_defaults_configure_idea_agent_flow() {
         let mut document = toml::Table::new();
 
-        write_agent_up_onboarding_defaults(&mut document).expect("defaults");
+        write_setup_onboarding_defaults(&mut document).expect("defaults");
 
         assert_eq!(
             document
@@ -334,7 +331,7 @@ mod tests {
             document
                 .get("onboarding")
                 .and_then(toml::Value::as_table)
-                .and_then(|onboarding| onboarding.get("agentUpCompleted"))
+                .and_then(|onboarding| onboarding.get("setupCompleted"))
                 .and_then(toml::Value::as_bool),
             Some(true)
         );

--- a/cli-rs/src/output.rs
+++ b/cli-rs/src/output.rs
@@ -3,7 +3,7 @@ use crate::config::PathResolutionReport;
 use crate::error::{CliError, Result};
 use crate::install::{
     ActivateBundleResult, AgentGuidanceSetupPlan, AgentGuidanceSetupResult,
-    InstallIdeaPluginResult, InstallResult, InstallShellResult, InstallSkillResult,
+    InstallIdeaPluginResult, InstallResult, InstallShellResult,
 };
 use crate::orchestration::{SetupRuntimeNextAction, SetupRuntimeResult, SetupRuntimeStage};
 use crate::package::{PackageResult, UbuntuDebianBundlePackageResult};

--- a/cli-rs/src/output/install.rs
+++ b/cli-rs/src/output/install.rs
@@ -5,28 +5,6 @@ pub fn print_paths(result: &PathResolutionReport) -> Result<()> {
     print_markdown(&document.into_string())
 }
 
-fn print_skill_install(result: &InstallSkillResult) -> Result<()> {
-    let mut document = MarkdownDocument::default();
-    mdln!(document, "# Kast skill install");
-    mdln!(document);
-    mdln!(document, "- Installed at: `{}`", result.installed_at);
-    mdln!(document, "- Version: `{}`", result.version);
-    mdln!(
-        document,
-        "- Reused existing install: {}",
-        yes_no(result.skipped)
-    );
-    mdln!(document);
-    mdln!(document, "## Next steps");
-    mdln!(
-        document,
-        "- Read the installed skill entrypoint: `{}/SKILL.md`",
-        result.installed_at
-    );
-    mdln!(document, "- Read command help with: `kast help agent`");
-    print_markdown(&document.into_string())
-}
-
 fn print_idea_plugin_install(result: &InstallIdeaPluginResult) -> Result<()> {
     let mut document = MarkdownDocument::default();
     print_idea_plugin_install_summary(&mut document, result);

--- a/cli-rs/src/output/runtime_helpers.rs
+++ b/cli-rs/src/output/runtime_helpers.rs
@@ -129,12 +129,6 @@ fn runtime_state(state: RuntimeState) -> &'static str {
     }
 }
 
-fn print_optional(document: &mut MarkdownDocument, label: &str, value: Option<&str>) {
-    if let Some(value) = value.filter(|value| !value.trim().is_empty()) {
-        mdln!(document, "- {label}: `{value}`");
-    }
-}
-
 fn print_warnings(document: &mut MarkdownDocument, warnings: &[String]) {
     print_messages(document, "Warnings", warnings);
 }


### PR DESCRIPTION
## Summary
- rename current onboarding completion state from `agentUpCompleted` to `setupCompleted`
- rename internal helpers from `agent_up` wording to setup onboarding wording
- keep `agentUpCompleted` as a read alias so existing configs do not re-prompt users

Stacked on #321.

## Verification
- `cargo check --manifest-path cli-rs/Cargo.toml --locked`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked config::tests::`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked onboarding::tests::`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `.github/scripts/test-terminal-onboarding-contract.sh`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `git diff --check`