### PR TITLE
docs: permit useful sub-agent delegation

### DIFF
--- a/.agents/superpowers/plans/2026-07-13-sub-agent-delegation-policy.md
+++ b/.agents/superpowers/plans/2026-07-13-sub-agent-delegation-policy.md
@@ -1,0 +1,98 @@
+# Sub-Agent Delegation Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permit and encourage useful sub-agent delegation across the repository without making delegation mandatory.
+
+**Architecture:** The root `AGENTS.md` owns the single repo-wide delegation policy. Nested instruction files remain unchanged and may narrow the root policy only when a subtree later develops a concrete coordination constraint.
+
+**Tech Stack:** Markdown repository instructions, Git verification
+
+## Global Constraints
+
+- Delegation is permitted and encouraged when it is useful, but never mandatory.
+- Delegate only concrete, bounded work that can proceed independently.
+- The primary agent retains responsibility for scope, coordination, integration, review, and final verification.
+- Avoid delegated work that would collide in the shared workspace or depend on unfinished shared state.
+- Do not change nested `AGENTS.md` files or public documentation.
+
+---
+
+### Task 1: Add the repo-wide delegation policy
+
+**Files:**
+- Modify: `AGENTS.md:82-89`
+- Verify: `AGENTS.md`
+
+**Interfaces:**
+- Consumes: `.agents/superpowers/specs/2026-07-13-sub-agent-delegation-policy-design.md`
+- Produces: the root `## Sub-Agent Delegation` instruction section inherited by every repository subtree
+
+- [ ] **Step 1: Verify the policy is absent at baseline**
+
+Run:
+
+```bash
+rg -n '^## Sub-Agent Delegation$' AGENTS.md
+```
+
+Expected: exit status `1` with no output because the heading does not yet
+exist.
+
+- [ ] **Step 2: Add the delegation policy**
+
+Insert the following block immediately before the `<kast>` routing block:
+
+```markdown
+## Sub-Agent Delegation
+
+Agents may delegate concrete, bounded tasks to sub-agents when doing so is
+useful. Delegation is encouraged for independent investigation,
+implementation, testing, or review work that can proceed safely in parallel,
+but it is never mandatory.
+
+The primary agent remains responsible for scope, coordination, integration,
+reviewing delegated results, and final verification. Account for the shared
+workspace: do not delegate parallel work that would edit the same files,
+depend on unfinished shared state, or otherwise be tightly coupled.
+```
+
+- [ ] **Step 3: Verify the operative policy**
+
+Run:
+
+```bash
+rg -n -A10 '^## Sub-Agent Delegation$' AGENTS.md
+git diff --check
+git diff --name-only HEAD -- ':(glob)**/AGENTS.md'
+```
+
+Expected: the search prints the complete approved policy, `git diff --check`
+exits `0`, and the changed-file query prints only `AGENTS.md`.
+
+- [ ] **Step 4: Review and commit the instruction change**
+
+Run:
+
+```bash
+git diff -- AGENTS.md
+git add AGENTS.md
+git diff --cached --check
+git commit -m "docs: permit useful sub-agent delegation"
+```
+
+Expected: the diff contains only the approved root policy, the staged check
+exits `0`, and the commit succeeds.
+
+- [ ] **Step 5: Confirm the repository state**
+
+Run:
+
+```bash
+git status --short --branch
+git log -3 --oneline
+```
+
+Expected: the worktree is clean, the branch is ahead of `origin/main` only by
+the approved design, plan, and implementation commits, and the newest commit
+is `docs: permit useful sub-agent delegation`.

--- a/.agents/superpowers/specs/2026-07-13-sub-agent-delegation-policy-design.md
+++ b/.agents/superpowers/specs/2026-07-13-sub-agent-delegation-policy-design.md
@@ -1,0 +1,63 @@
+# Sub-Agent Delegation Policy Design
+
+**Status:** Approved
+
+**Date:** 2026-07-13
+
+## Context
+
+The repository instructions do not currently state whether an agent may
+delegate work to sub-agents. The repository should make that permission
+explicit without requiring delegation or duplicating a repo-wide policy across
+scoped `AGENTS.md` files.
+
+## Decision
+
+Add one concise, repo-wide delegation section to the root `AGENTS.md`:
+
+- Agents may delegate concrete, bounded tasks to sub-agents when doing so is
+  useful.
+- Delegation is encouraged for independent investigation, implementation,
+  testing, or review work that can proceed safely in parallel, but it is never
+  mandatory.
+- The primary agent remains responsible for task scope, coordination,
+  integration, review of delegated results, and final verification.
+- Agents must account for the shared workspace and avoid parallel delegation
+  when tasks would edit the same files, depend on unfinished shared state, or
+  are otherwise tightly coupled.
+
+The policy grants repository-level permission to use an available delegation
+facility. It does not require every execution environment to provide one.
+
+## Placement
+
+Place the new section in the root `AGENTS.md` under agent-specific guidance.
+Do not repeat it in nested instruction files. Scoped guides may narrow the
+policy later if a subtree has a concrete coordination constraint.
+
+## Considered alternatives
+
+### Mandate delegation for parallelizable work
+
+Rejected. Delegation overhead can exceed its benefit for small tasks, and
+availability differs between agent environments.
+
+### Repeat the policy in every scoped guide
+
+Rejected. Duplication would make the permission harder to maintain and allow
+scoped copies to drift.
+
+### Record the policy in an ADR
+
+Rejected. This changes an internal agent workflow rule, not the public product
+surface, source ownership, generated outputs, or validation gates.
+
+## Acceptance criteria
+
+1. The root `AGENTS.md` explicitly permits and encourages useful sub-agent
+   delegation without making it mandatory.
+2. Responsibility for coordination, integration, review, and verification
+   remains with the primary agent.
+3. Shared-workspace collision and task-coupling constraints are explicit.
+4. Nested `AGENTS.md` files and public documentation remain unchanged.
+5. `git diff --check` passes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,18 @@ semantic tooling for compiler-backed evidence. Generated package, protocol,
 catalog, and site outputs come from their source owners and contract scripts;
 edit the source tree and regenerate.
 
+## Sub-Agent Delegation
+
+Agents may delegate concrete, bounded tasks to sub-agents when doing so is
+useful. Delegation is encouraged for independent investigation,
+implementation, testing, or review work that can proceed safely in parallel,
+but it is never mandatory.
+
+The primary agent remains responsible for scope, coordination, integration,
+reviewing delegated results, and final verification. Account for the shared
+workspace: do not delegate parallel work that would edit the same files,
+depend on unfinished shared state, or otherwise be tightly coupled.
+
 <kast>
 ## Kast routing
 Use `/Users/amichne/code/kast/.agents/skills/kast/SKILL.md` before Kotlin or Gradle semantic work.


### PR DESCRIPTION
## What changed

- record the approved design and implementation plan for repository-wide sub-agent delegation
- add the root `AGENTS.md` policy permitting useful, bounded delegation
- keep integration, review, and final verification with the primary agent
- explicitly prevent shared-workspace collisions and tightly coupled parallel edits

## Why

The repository did not state whether agents could delegate independent work. This makes the permission and its safety constraints explicit without duplicating policy in scoped guides or public documentation.

## Validation

- `rg -n -A10 '^## Sub-Agent Delegation$' AGENTS.md`
- `git diff --check origin/main..HEAD`
- confirmed only the approved design, plan, and root guidance differ from `origin/main`
