### PR TITLE
fix: fail semantic analysis closed per file

### DIFF
--- a/.agents/superpowers/plans/2026-07-13-fail-closed-semantic-analysis.md
+++ b/.agents/superpowers/plans/2026-07-13-fail-closed-semantic-analysis.md
@@ -1,0 +1,642 @@
+# Fail-Closed Semantic Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every diagnostics response prove per-file semantic completeness and make incomplete evidence fail the typed CLI with exit status one.
+
+**Architecture:** `analysis-api` owns an invariant-checked per-file ledger and derived semantic outcome. The IDEA backend classifies each requested path and preserves ordinary compiler diagnostics, the server propagates completeness into mutation summaries, and the Rust response boundary converts incomplete semantic results into failed agent commands while promoting compact counts.
+
+**Tech Stack:** Kotlin 2.3/JVM 21, kotlinx.serialization, IntelliJ Platform analysis APIs, Rust 2024, serde/serde_json, Clap, JUnit Jupiter, Gradle, Cargo.
+
+## Global Constraints
+
+- Every requested file has one of `ANALYZED`, `PENDING_INDEX`, `OUTSIDE_SOURCE_MODULES`, `MISSING_ON_DISK`, or `BACKEND_FAILURE`.
+- Only skipped files or `ANALYSIS_FAILURE` diagnostics make semantic completeness fail; ordinary Kotlin compiler diagnostics remain analyzed evidence.
+- Runtime readiness and JSON-RPC transport success remain separate from semantic completeness.
+- Human, JSON, and TOON expose requested, analyzed, and skipped counts without parsing diagnostic messages.
+- Production Kotlin keeps one non-private top-level named type per same-named file.
+- `analysis-api` stays host-agnostic; IDEA PSI and indexing logic stays in `backend-idea`.
+- The public command surface and protocol schema version remain unchanged; generated protocol artifacts come from their source owners.
+- Use the isolated branch `feature/issue-332-fail-closed-analysis`; preserve unrelated worktree state.
+
+---
+
+### Task 1: Host-Agnostic Completeness Contract
+
+**Files:**
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/FileAnalysisState.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/FileAnalysisStatus.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/SemanticAnalysisOutcome.kt`
+- Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/DiagnosticsResult.kt`
+- Create: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/DiagnosticsResultTest.kt`
+- Modify: `analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt`
+- Modify: `analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/AnalysisBackendContractFixture.kt`
+- Modify: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/DocFieldCoverageTest.kt`
+- Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/OpenApiDocument.kt`
+- Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/DocsDocument.kt`
+
+**Interfaces:**
+- Consumes: `NormalizedPath`, `Diagnostic`, `PageableResult<Diagnostic>`, and parsed non-empty diagnostics paths.
+- Produces: `FileAnalysisStatus.analyzed(NormalizedPath)`, `FileAnalysisStatus.skipped(NormalizedPath, FileAnalysisState, String)`, and `DiagnosticsResult.of(List<Diagnostic>, List<FileAnalysisStatus>, PageInfo?)`.
+
+- [ ] **Step 1: Write failing completeness-contract tests**
+
+Create `DiagnosticsResultTest.kt` with these tests:
+
+```kotlin
+class DiagnosticsResultTest {
+    private val first = NormalizedPath.ofAbsolute(Path.of("/workspace/First.kt"))
+    private val second = NormalizedPath.ofAbsolute(Path.of("/workspace/Second.kt"))
+
+    @Test
+    fun `all analyzed files produce complete counts`() {
+        val result = DiagnosticsResult.of(
+            diagnostics = emptyList(),
+            fileStatuses = listOf(
+                FileAnalysisStatus.analyzed(first),
+                FileAnalysisStatus.analyzed(second),
+            ),
+        )
+
+        assertEquals(SemanticAnalysisOutcome.COMPLETE, result.semanticOutcome)
+        assertEquals(2, result.requestedFileCount)
+        assertEquals(2, result.analyzedFileCount)
+        assertEquals(0, result.skippedFileCount)
+    }
+
+    @Test
+    fun `a skipped file produces an incomplete result`() {
+        val result = DiagnosticsResult.of(
+            diagnostics = listOf(analysisFailure(second.value, "File not found")),
+            fileStatuses = listOf(
+                FileAnalysisStatus.analyzed(first),
+                FileAnalysisStatus.skipped(second, FileAnalysisState.MISSING_ON_DISK, "File not found"),
+            ),
+        )
+
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+        assertEquals(1, result.analyzedFileCount)
+        assertEquals(1, result.skippedFileCount)
+    }
+
+    @Test
+    fun `analysis failure cannot produce a complete result`() {
+        val result = DiagnosticsResult.of(
+            diagnostics = listOf(analysisFailure(first.value, "backend failed")),
+            fileStatuses = listOf(FileAnalysisStatus.analyzed(first)),
+        )
+
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+    }
+
+    private fun analysisFailure(filePath: String, message: String): Diagnostic = Diagnostic(
+        location = Location(
+            filePath = filePath,
+            startOffset = 0,
+            endOffset = 0,
+            startLine = 0,
+            startColumn = 0,
+            preview = "",
+        ),
+        severity = DiagnosticSeverity.ERROR,
+        message = message,
+        code = "ANALYSIS_FAILURE",
+    )
+}
+```
+
+Add shared-contract assertions that both the clean fixture and the syntactically broken fixture receive `ANALYZED`, with complete counts. The broken fixture must still contain ordinary compiler diagnostics rather than `ANALYSIS_FAILURE`.
+
+- [ ] **Step 2: Run the tests and verify the red state**
+
+Run:
+
+```bash
+./gradlew :analysis-api:test --tests io.github.amichne.kast.api.DiagnosticsResultTest --tests io.github.amichne.kast.testing.FakeAnalysisBackendContractTest
+```
+
+Expected: compilation fails because `FileAnalysisState`, `FileAnalysisStatus`, `SemanticAnalysisOutcome`, and `DiagnosticsResult.of` do not exist.
+
+- [ ] **Step 3: Add the typed result model**
+
+Create the three same-named production files. The core shapes are:
+
+```kotlin
+@Serializable
+enum class FileAnalysisState {
+    ANALYZED,
+    PENDING_INDEX,
+    OUTSIDE_SOURCE_MODULES,
+    MISSING_ON_DISK,
+    BACKEND_FAILURE,
+}
+```
+
+```kotlin
+@Serializable
+data class FileAnalysisStatus private constructor(
+    @DocField(description = "Normalized absolute path requested for semantic analysis.")
+    val filePath: String,
+    @DocField(description = "Typed semantic terminal state for the requested file.")
+    val state: FileAnalysisState,
+    @DocField(description = "Explanation when the file was not analyzed.", defaultValue = "null")
+    val message: String? = null,
+) {
+    companion object {
+        fun analyzed(filePath: NormalizedPath): FileAnalysisStatus =
+            FileAnalysisStatus(filePath.value, FileAnalysisState.ANALYZED)
+
+        fun skipped(
+            filePath: NormalizedPath,
+            state: FileAnalysisState,
+            message: String,
+        ): FileAnalysisStatus {
+            require(state != FileAnalysisState.ANALYZED)
+            require(message.isNotBlank())
+            return FileAnalysisStatus(filePath.value, state, message)
+        }
+    }
+}
+```
+
+```kotlin
+@Serializable
+enum class SemanticAnalysisOutcome {
+    COMPLETE,
+    INCOMPLETE,
+}
+```
+
+Replace direct construction of `DiagnosticsResult` with a private constructor plus `of`. `of` counts analyzed states, treats every other state as skipped, and also sets `INCOMPLETE` when any diagnostic code is `ANALYSIS_FAILURE`. Its `init` block verifies all derived counts and outcome facts. `withItems` constructs a new result with the same ledger and summary so pagination cannot erase completeness evidence.
+
+- [ ] **Step 4: Make the fake backend satisfy the stronger contract**
+
+Change `FakeAnalysisBackend.diagnostics` to:
+
+```kotlin
+override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult {
+    val filePaths = query.filePaths.value
+    filePaths.forEach { requireKnownFile(it.value) }
+    return DiagnosticsResult.of(
+        diagnostics = filePaths
+            .flatMap { filePath -> diagnosticsByFile[filePath.value].orEmpty() }
+            .sortedWith(compareBy({ it.location.filePath }, { it.location.startOffset })),
+        fileStatuses = filePaths.map(FileAnalysisStatus::analyzed),
+    )
+}
+```
+
+Register `FileAnalysisStatus` with the OpenAPI/document registries and `DocFieldCoverageTest`. Enums stay inline with existing enum handling.
+
+- [ ] **Step 5: Run the focused API tests and verify green**
+
+Run the Task 1 Gradle command again.
+
+Expected: `BUILD SUCCESSFUL`; clean and compiler-error fixtures are both semantically complete.
+
+- [ ] **Step 6: Commit the contract slice**
+
+```bash
+git add analysis-api
+git diff --cached --check
+git commit -m "feat: model per-file semantic completeness"
+```
+
+---
+
+### Task 2: IDEA Per-File Classification
+
+**Files:**
+- Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt:828`
+- Create: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastDiagnosticsCompletenessTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1 `FileAnalysisStatus` factories and `DiagnosticsResult.of`.
+- Produces: one ordered `FileAnalysisStatus` and zero or more diagnostics for each `ParsedDiagnosticsQuery.filePaths` entry.
+
+- [ ] **Step 1: Write failing IDEA regression tests**
+
+Use `@TestApplication`, `projectFixture`, `moduleFixture`, `sourceRootFixture`, and `psiFileFixture`. Add these scenarios:
+
+```kotlin
+@Test
+fun `ordinary compiler diagnostics are analyzed evidence`() = runBlocking {
+    ensureProjectReady()
+    val filePath = brokenFileFixture.get().virtualFile.path
+
+    val result = backend().diagnostics(DiagnosticsQuery(listOf(filePath)))
+
+    assertEquals(SemanticAnalysisOutcome.COMPLETE, result.semanticOutcome)
+    assertEquals(FileAnalysisState.ANALYZED, result.fileStatuses.single().state)
+    assertTrue(result.diagnostics.isNotEmpty())
+    assertTrue(result.diagnostics.none { it.code == "ANALYSIS_FAILURE" })
+}
+
+@Test
+fun `missing file is explicit incomplete evidence`() = runBlocking {
+    ensureProjectReady()
+    val missing = sourceRoot.resolve("Missing.kt").toString()
+
+    val result = backend().diagnostics(DiagnosticsQuery(listOf(missing)))
+
+    assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+    assertEquals(FileAnalysisState.MISSING_ON_DISK, result.fileStatuses.single().state)
+    assertEquals(0, result.analyzedFileCount)
+    assertEquals(1, result.skippedFileCount)
+    assertEquals("ANALYSIS_FAILURE", result.diagnostics.single().code)
+}
+```
+
+Also create an existing Kotlin file outside the source root and assert `OUTSIDE_SOURCE_MODULES`.
+Create a non-Kotlin file inside the source root and assert `BACKEND_FAILURE`.
+
+- [ ] **Step 2: Run the IDEA tests and verify the red state**
+
+Run:
+
+```bash
+./gradlew :backend-idea:test --tests io.github.amichne.kast.idea.KastDiagnosticsCompletenessTest
+```
+
+Expected: missing-file expectations fail because the current backend only returns a synthetic diagnostic and no file ledger.
+
+- [ ] **Step 3: Implement per-file analysis classification**
+
+Add a tightly owned private nested result:
+
+```kotlin
+private data class DiagnosticsFileAnalysis(
+    val status: FileAnalysisStatus,
+    val diagnostics: List<Diagnostic>,
+)
+```
+
+Split `diagnostics` into ordered concurrent calls to `analyzeDiagnosticsFile(NormalizedPath)`. The helper must:
+
+```kotlin
+private suspend fun analyzeDiagnosticsFile(filePath: NormalizedPath): DiagnosticsFileAnalysis {
+    if (Files.notExists(filePath.toJavaPath())) {
+        return skippedDiagnostics(filePath, FileAnalysisState.MISSING_ON_DISK, "File not found: ${filePath.value}")
+    }
+    return try {
+        timedReadAction(telemetry, IdeaTelemetryScope.DIAGNOSTICS, "kast.idea.diagnostics.file") {
+            if (!isWorkspaceFile(filePath.value)) {
+                return@timedReadAction skippedDiagnostics(filePath, FileAnalysisState.OUTSIDE_SOURCE_MODULES, "File is outside the active workspace: ${filePath.value}")
+            }
+            val virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath.value)
+                ?: return@timedReadAction skippedDiagnostics(filePath, FileAnalysisState.PENDING_INDEX, "File is not admitted to the IDEA virtual filesystem: ${filePath.value}")
+            if (!ProjectFileIndex.getInstance(project).isInSourceContent(virtualFile)) {
+                return@timedReadAction skippedDiagnostics(filePath, FileAnalysisState.OUTSIDE_SOURCE_MODULES, "File is outside IDEA source modules: ${filePath.value}")
+            }
+            if (DumbService.isDumb(project)) {
+                return@timedReadAction skippedDiagnostics(filePath, FileAnalysisState.PENDING_INDEX, "IDEA indexing is in progress: ${filePath.value}")
+            }
+            val file = PsiManager.getInstance(project).findFile(virtualFile) as? KtFile
+                ?: return@timedReadAction skippedDiagnostics(filePath, FileAnalysisState.BACKEND_FAILURE, "Cannot resolve Kotlin PSI: ${filePath.value}")
+            val diagnostics = analyze(file) {
+                file.collectDiagnostics(KaDiagnosticCheckerFilter.EXTENDED_AND_COMMON_CHECKERS)
+                    .flatMap { it.toApiDiagnostics() }
+            }
+            DiagnosticsFileAnalysis(FileAnalysisStatus.analyzed(filePath), diagnostics)
+        }
+    } catch (error: ProcessCanceledException) {
+        throw error
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        skippedDiagnostics(filePath, FileAnalysisState.BACKEND_FAILURE, error.message ?: error.toString())
+    }
+}
+```
+
+`skippedDiagnostics` returns the typed skipped status and one zero-offset `ANALYSIS_FAILURE` diagnostic. The outer method flattens diagnostics, preserves sorted diagnostic order, preserves request order for statuses, and calls `DiagnosticsResult.of`.
+
+- [ ] **Step 4: Run IDEA and API tests**
+
+Run:
+
+```bash
+./gradlew :backend-idea:test --tests io.github.amichne.kast.idea.KastDiagnosticsCompletenessTest :analysis-api:test
+```
+
+Expected: `BUILD SUCCESSFUL` and every test scenario has exactly one typed state per request.
+
+- [ ] **Step 5: Commit the backend slice**
+
+```bash
+git add backend-idea
+git diff --cached --check
+git commit -m "fix: classify incomplete IDEA diagnostics"
+```
+
+---
+
+### Task 3: Server and Mutation Completeness Propagation
+
+**Files:**
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastDiagnosticsSummary.kt`
+- Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt:686`
+- Modify: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt:579,878,1241`
+- Modify: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1 `DiagnosticsResult.semanticOutcome` and file counts.
+- Produces: `KastDiagnosticsSummary.from(DiagnosticsResult)` and `KastDiagnosticsSummary.completeWithoutFiles()`; mutation `clean` is false for incomplete evidence.
+
+- [ ] **Step 1: Write failing server tests**
+
+Add a raw dispatch assertion that `raw/diagnostics` returns complete counts for a known file. Add an `IncompleteDiagnosticsBackend` test delegate:
+
+```kotlin
+private class IncompleteDiagnosticsBackend(
+    private val delegate: AnalysisBackend,
+) : AnalysisBackend by delegate {
+    override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult {
+        val filePath = query.filePaths.value.single()
+        return DiagnosticsResult.of(
+            diagnostics = listOf(analysisFailure(filePath.value, "File not found")),
+            fileStatuses = listOf(
+                FileAnalysisStatus.skipped(filePath, FileAnalysisState.MISSING_ON_DISK, "File not found"),
+            ),
+        )
+    }
+}
+```
+
+Dispatch `symbol/rename` or `symbol/write-and-validate` through that backend and assert the returned success-shape response has `ok == false`, `diagnostics.semanticOutcome == INCOMPLETE`, `analyzedFileCount == 0`, and `skippedFileCount == 1`.
+
+- [ ] **Step 2: Run server tests and verify the red state**
+
+Run:
+
+```bash
+./gradlew :analysis-server:test --tests io.github.amichne.kast.server.AnalysisDispatcherTest
+```
+
+Expected: compilation fails because `KastDiagnosticsSummary` does not expose completeness evidence.
+
+- [ ] **Step 3: Move and strengthen the summary type**
+
+Move `KastDiagnosticsSummary` out of `SkillContracts.kt` into its same-named file and add:
+
+```kotlin
+@Serializable
+data class KastDiagnosticsSummary private constructor(
+    val clean: Boolean,
+    val semanticOutcome: SemanticAnalysisOutcome,
+    val requestedFileCount: Int,
+    val analyzedFileCount: Int,
+    val skippedFileCount: Int,
+    val errorCount: Int,
+    val warningCount: Int,
+    val errors: List<Diagnostic> = emptyList(),
+) {
+    companion object {
+        fun from(result: DiagnosticsResult): KastDiagnosticsSummary {
+            val errors = result.diagnostics.filter { it.severity == DiagnosticSeverity.ERROR }
+            return KastDiagnosticsSummary(
+                clean = result.semanticOutcome == SemanticAnalysisOutcome.COMPLETE && errors.isEmpty(),
+                semanticOutcome = result.semanticOutcome,
+                requestedFileCount = result.requestedFileCount,
+                analyzedFileCount = result.analyzedFileCount,
+                skippedFileCount = result.skippedFileCount,
+                errorCount = errors.size,
+                warningCount = result.diagnostics.count { it.severity == DiagnosticSeverity.WARNING },
+                errors = errors,
+            )
+        }
+
+        fun completeWithoutFiles(): KastDiagnosticsSummary = KastDiagnosticsSummary(
+            clean = true,
+            semanticOutcome = SemanticAnalysisOutcome.COMPLETE,
+            requestedFileCount = 0,
+            analyzedFileCount = 0,
+            skippedFileCount = 0,
+            errorCount = 0,
+            warningCount = 0,
+        )
+    }
+}
+```
+
+Replace manual summary construction and the private server `diagnosticsSummary` function with these factories.
+
+- [ ] **Step 4: Run API and server tests**
+
+Run:
+
+```bash
+./gradlew :analysis-api:test :analysis-server:test
+```
+
+Expected: `BUILD SUCCESSFUL`; pagination preserves counts and incomplete mutation validation is never clean.
+
+- [ ] **Step 5: Commit the propagation slice**
+
+```bash
+git add analysis-api analysis-server
+git diff --cached --check
+git commit -m "fix: propagate semantic completeness through validation"
+```
+
+---
+
+### Task 4: Rust Fail-Closed Agent Boundary and Output Summary
+
+**Files:**
+- Modify: `cli-rs/src/agent/response.rs`
+- Modify: `cli-rs/src/agent/dispatch.rs:437`
+- Create: `cli-rs/tests/agent_diagnostics_smoke.rs`
+
+**Interfaces:**
+- Consumes: JSON fields `semanticOutcome`, `requestedFileCount`, `analyzedFileCount`, `skippedFileCount`, and `diagnostics[].code`.
+- Produces: `SEMANTIC_ANALYSIS_INCOMPLETE` or `SEMANTIC_ANALYSIS_FAILED`, failed step/command envelopes, exit status one, and command-level `semanticAnalysis`.
+
+- [ ] **Step 1: Write the fake-daemon regression test**
+
+Create a fake IDEA descriptor/socket server that answers, in order as requested, `runtime/status`, `capabilities`, `raw/workspace-refresh`, and `raw/diagnostics`. Refresh returns success. Diagnostics returns:
+
+```json
+{
+  "diagnostics": [{
+    "location": {"filePath":"/workspace/Missing.kt","startOffset":0,"endOffset":0,"startLine":0,"startColumn":0,"preview":""},
+    "severity":"ERROR",
+    "message":"File not found",
+    "code":"ANALYSIS_FAILURE"
+  }],
+  "fileStatuses": [{"filePath":"/workspace/Missing.kt","state":"MISSING_ON_DISK","message":"File not found"}],
+  "semanticOutcome":"INCOMPLETE",
+  "requestedFileCount":1,
+  "analyzedFileCount":0,
+  "skippedFileCount":1,
+  "schemaVersion":3
+}
+```
+
+Invoke `kast --output json agent diagnostics --file-path <missing> --workspace-root <workspace>`. Assert exit failure, command `ok == false`, refresh step `ok == true`, diagnostics step `ok == false`, error code `SEMANTIC_ANALYSIS_INCOMPLETE`, and promoted counts.
+
+Run equivalent fake-server invocations with `--output toon` and `--output human`; assert both contain labels for analyzed `0` and skipped `1`.
+
+Run the fake server once more with an `ANALYZED` status, `COMPLETE` outcome,
+and one ordinary compiler `ERROR` whose code is not `ANALYSIS_FAILURE`.
+Assert the command exits zero, reports `ok == true`, and promotes analyzed `1`
+and skipped `0`.
+
+- [ ] **Step 2: Run the Rust integration test and verify red**
+
+Run:
+
+```bash
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_diagnostics_smoke
+```
+
+Expected: JSON invocation exits zero and reports `ok: true`, reproducing the issue.
+
+- [ ] **Step 3: Add semantic failure detection**
+
+Extend `result_failure` before the existing `ok == false` check:
+
+```rust
+if result.get("semanticOutcome").and_then(Value::as_str) == Some("INCOMPLETE") {
+    let mut error = agent_error(
+        "SEMANTIC_ANALYSIS_INCOMPLETE",
+        "The backend did not analyze every requested file.",
+    );
+    error.details.insert("semanticAnalysis".to_string(), semantic_analysis_summary(result));
+    return Some(error);
+}
+if result
+    .get("diagnostics")
+    .and_then(Value::as_array)
+    .is_some_and(|items| items.iter().any(|item| item.get("code").and_then(Value::as_str) == Some("ANALYSIS_FAILURE")))
+{
+    return Some(agent_error(
+        "SEMANTIC_ANALYSIS_FAILED",
+        "The backend returned an ANALYSIS_FAILURE diagnostic.",
+    ));
+}
+```
+
+`semantic_analysis_summary` copies only outcome and three counts into a bounded JSON object.
+
+- [ ] **Step 4: Promote the diagnostics summary**
+
+In `execute_agent_steps`, retain the diagnostics result summary before pushing the step result. Add `semanticAnalysis` to the final `KAST_AGENT_COMMAND` result only when those fields are present. The step keeps its full result and error, refresh remains independently successful, and `issues` still contains `AGENT_STEP_FAILED` for the diagnostics step.
+
+- [ ] **Step 5: Run focused Rust checks**
+
+Run:
+
+```bash
+cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_diagnostics_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_command_surface_smoke --test agent_output_format_smoke
+```
+
+Expected: all tests pass; incomplete evidence exits one and all formats expose counts.
+
+- [ ] **Step 6: Commit the CLI slice**
+
+```bash
+git add cli-rs/src/agent cli-rs/tests/agent_diagnostics_smoke.rs
+git diff --cached --check
+git commit -m "fix: fail agent diagnostics on incomplete evidence"
+```
+
+---
+
+### Task 5: Generated Contracts and Documentation Evidence
+
+**Files:**
+- Modify generated: `cli-rs/protocol/openapi.yaml`
+- Modify generated: `cli-rs/protocol/api-reference.md`
+- Modify generated: `cli-rs/protocol/api-specification.md`
+- Modify generated: `cli-rs/protocol/capabilities.md`
+- Modify generated: `cli-rs/protocol/examples/diagnostics-response.json`
+
+**Interfaces:**
+- Consumes: Task 1 registered Kotlin serializers and the fake backend example generator.
+- Produces: checked-in generated evidence documenting file states, outcome, and counts.
+
+- [ ] **Step 1: Regenerate protocol artifacts from source owners**
+
+Run:
+
+```bash
+./gradlew :analysis-api:generateOpenApiSpec :analysis-api:generateDocPages :analysis-server:generateDocExamples
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract
+```
+
+- [ ] **Step 2: Verify generated diagnostics evidence**
+
+Run:
+
+```bash
+rg -n "fileStatuses|semanticOutcome|requestedFileCount|analyzedFileCount|skippedFileCount" cli-rs/protocol
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+.github/scripts/test-docs-content-contract.sh
+```
+
+Expected: the diagnostics response schema and example contain all completeness fields; generation check and docs contract pass.
+
+- [ ] **Step 3: Commit generated evidence**
+
+```bash
+git add cli-rs/protocol
+git diff --cached --check
+git commit -m "docs: publish semantic completeness contract"
+```
+
+---
+
+### Task 6: Full Verification and Issue Handoff
+
+**Files:**
+- Review all branch changes from `origin/main...HEAD`
+- No new production files unless verification exposes a defect
+
+**Interfaces:**
+- Consumes: all prior tasks.
+- Produces: reproducible verification evidence, reviewed commits, pushed branch, PR, and closed issue after merge.
+
+- [ ] **Step 1: Run Kotlin and generated-contract verification**
+
+```bash
+./gradlew test
+.github/scripts/test-docs-content-contract.sh
+```
+
+Expected: `BUILD SUCCESSFUL` and the docs contract exits zero.
+
+- [ ] **Step 2: Run Rust verification**
+
+```bash
+cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
+cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
+cargo test --manifest-path cli-rs/Cargo.toml --locked
+```
+
+Expected: formatting is clean, Clippy reports no warnings, and every Rust test passes.
+
+- [ ] **Step 3: Review scope and invariants**
+
+```bash
+git status --short --branch
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+git log --oneline origin/main..HEAD
+```
+
+Confirm every #332 acceptance criterion has direct source/test evidence, every requested path gets one status, no unrelated file is staged, and ordinary compiler errors remain analyzed.
+
+- [ ] **Step 4: Perform code review and repair findings**
+
+Use the repository review workflow on `origin/main...HEAD`. For every finding, add a reproducing test or compiler proof, implement the minimal repair, rerun the affected focused checks, and commit with a conventional `fix:` message.
+
+- [ ] **Step 5: Publish #332**
+
+Push `feature/issue-332-fail-closed-analysis`, open a draft PR that includes `Closes #332`, list every verification command, mark ready once checks are green, and babysit GitHub Actions through terminal success. Merge only after required checks pass, verify `origin/main` contains the merge commit, and confirm issue #332 is closed.
+
+- [ ] **Step 6: Continue the parent queue**
+
+Refresh #331 relationships and open issues, select the next unblocked P0 child, and start its isolated design/implementation cycle without redefining completion of the parent goal.

--- a/.agents/superpowers/specs/2026-07-13-fail-closed-semantic-analysis-design.md
+++ b/.agents/superpowers/specs/2026-07-13-fail-closed-semantic-analysis-design.md
@@ -1,0 +1,166 @@
+# Fail-Closed Semantic Analysis Design
+
+Date: 2026-07-13
+
+Issue: [#332](https://github.com/amichne/kast/issues/332)
+
+Status: Approved for autonomous implementation
+
+## Objective
+
+Make a diagnostics response prove whether every requested file was analyzed.
+Backend reachability, workspace refresh acknowledgement, and JSON-RPC transport
+success must remain distinct from semantic completeness.
+
+The defining regression is a two-step `kast agent diagnostics` invocation in
+which workspace refresh succeeds, the backend returns an
+`ANALYSIS_FAILURE: File not found` diagnostic, and the command nevertheless
+reports `ok: true` with exit status zero.
+
+## Requirements
+
+1. Every requested file has one typed response state: `ANALYZED`,
+   `PENDING_INDEX`, `OUTSIDE_SOURCE_MODULES`, `MISSING_ON_DISK`, or
+   `BACKEND_FAILURE`.
+2. A diagnostics result is complete only when every requested file is
+   `ANALYZED` and no diagnostic has code `ANALYSIS_FAILURE`.
+3. An incomplete result produces a failed typed agent command and process exit
+   status one even when refresh and JSON-RPC transport succeeded.
+4. Ordinary Kotlin compiler errors remain successful semantic analysis. They
+   may make a mutation validation dirty, but they do not mean the file was
+   skipped.
+5. Diagnostics responses expose requested, analyzed, and skipped file counts
+   plus a typed semantic outcome in human, JSON, and TOON output.
+6. Mutation validation summaries preserve the same completeness evidence and
+   cannot report clean when semantic analysis was incomplete.
+7. Existing raw diagnostics, typed agent diagnostics, and mutation command
+   names remain unchanged.
+
+## Considered Approaches
+
+### Parse diagnostics in the CLI
+
+The CLI could scan diagnostic codes and fail if it sees `ANALYSIS_FAILURE`.
+This is a useful defensive check but is insufficient as the primary contract:
+it cannot distinguish missing, pending, outside-module, and backend-failure
+states, and it cannot prove a file was omitted without any diagnostic.
+
+### Fail the whole RPC request
+
+The backend could throw as soon as one file cannot be analyzed. This fails
+closed but discards useful evidence for the other files in a batch and cannot
+report per-file terminal states or counts.
+
+### Per-file completeness ledger
+
+The selected approach adds a typed per-file ledger to `DiagnosticsResult` and
+derives a summary from it. The backend returns evidence for every requested
+file, the server preserves it, and the CLI converts an incomplete semantic
+outcome into a failed agent step. A defensive CLI check also rejects any
+`ANALYSIS_FAILURE` diagnostic even if a malformed backend claims completeness.
+
+## Contract Model
+
+`analysis-api` will own three host-agnostic types:
+
+- `FileAnalysisState`, the closed state enumeration;
+- `FileAnalysisStatus`, the normalized absolute file path, state, and optional
+  explanation for one request entry;
+- `SemanticAnalysisOutcome`, with `COMPLETE` and `INCOMPLETE` variants.
+
+`DiagnosticsResult` retains its existing `diagnostics` and pagination fields
+and adds:
+
+- ordered `fileStatuses`;
+- `semanticOutcome`;
+- `requestedFileCount`;
+- `analyzedFileCount`;
+- `skippedFileCount`.
+
+Construction validates that counts match the ledger, analyzed plus skipped
+equals requested, the outcome matches skipped-file evidence, and an
+`ANALYSIS_FAILURE` diagnostic can never coexist with `COMPLETE`. Pagination may
+truncate diagnostic items but never changes completeness evidence.
+
+The public wire-model change is additive and stays on the current protocol
+schema version. Generated OpenAPI, protocol reference pages, and examples are
+regenerated from the Kotlin model owners. This avoids redefining unrelated
+schema-versioned surfaces while making new backends and the version-coupled CLI
+emit the stronger evidence.
+
+## IDEA Backend Classification
+
+The IDEA backend evaluates requested paths independently and preserves request
+order. Classification precedence is:
+
+1. absent on the filesystem: `MISSING_ON_DISK`;
+2. outside the active workspace or an IDEA source module:
+   `OUTSIDE_SOURCE_MODULES`;
+3. present but not admitted to VFS/PSI, or project indexing still in progress:
+   `PENDING_INDEX`;
+4. admitted Kotlin source successfully analyzed, with or without ordinary
+   compiler diagnostics: `ANALYZED`;
+5. unexpected analysis exception: `BACKEND_FAILURE`.
+
+Every non-analyzed state also emits an error diagnostic with code
+`ANALYSIS_FAILURE` for compatibility with existing consumers. Cancellation and
+IDE process-cancellation exceptions remain operation cancellation; they are not
+misreported as per-file backend failures.
+
+Issue #335 will later add bounded waiting for VFS/PSI admission. This issue
+only makes the current lack of admission explicit and fail-closed.
+
+## Server and Mutation Flow
+
+`raw/diagnostics` continues to serialize `DiagnosticsResult`. Pagination is
+applied only to diagnostic items, leaving the file ledger and counts intact.
+
+The internal mutation validation summary gains the semantic outcome and file
+counts. Its `clean` flag is true only when semantic analysis is complete and no
+ordinary compiler error is present. Zero affected files produce a complete
+zero-count summary.
+
+## CLI Flow
+
+The Rust response boundary recognizes two semantic failure signals:
+
+- `semanticOutcome == INCOMPLETE`;
+- any diagnostic with `code == ANALYSIS_FAILURE`.
+
+Either signal makes the diagnostics step fail with a stable semantic-analysis
+error. `execute_agent_steps` then sets command `ok` to false and `run` returns
+exit status one. Refresh success remains visible as its own successful step.
+
+For diagnostics, the agent command promotes the typed outcome and requested,
+analyzed, and skipped counts into a command-level `semanticAnalysis` summary.
+The shared structured renderer makes the same fields available in human, JSON,
+and TOON modes.
+
+## Testing
+
+Tests will prove:
+
+- contract construction and serialization enforce count/outcome invariants;
+- the fake backend returns complete ledgers for clean and broken Kotlin files;
+- IDEA returns `ANALYZED` for ordinary compiler diagnostics and a typed
+  non-analyzed state for missing or unavailable files;
+- server dispatch preserves completeness evidence through pagination;
+- mutation summaries are not clean when semantic evidence is incomplete;
+- a fake daemon can acknowledge refresh, return a missing-file analysis
+  result, and cause `kast agent diagnostics` to emit `ok: false` with exit one;
+- command-level counts appear in JSON, TOON, and human output;
+- existing clean and ordinary compiler-diagnostic paths retain their behavior.
+
+Focused validation covers `analysis-api`, `analysis-server`, `backend-idea`,
+and Rust agent tests. Final validation runs the full Gradle and locked Rust
+suites, formatting, Clippy with warnings denied, generated-contract checks, and
+diff hygiene.
+
+## Non-Goals
+
+- waiting for newly created files to enter IDEA semantic scope (#335);
+- persistent observable mutation operations (#333);
+- changing runtime readiness or daemon lifecycle models;
+- adding or restoring arbitrary public JSON-RPC command surfaces;
+- treating ordinary Kotlin compiler errors as transport or completeness
+  failures.

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/DiagnosticsResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/DiagnosticsResult.kt
@@ -12,19 +12,83 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class DiagnosticsResult(
+class DiagnosticsResult private constructor(
     @DocField(description = "List of compilation diagnostics found in the requested files.")
     val diagnostics: List<Diagnostic>,
+    @DocField(description = "Typed semantic terminal state for every requested file.")
+    val fileStatuses: List<FileAnalysisStatus>,
+    @DocField(description = "Whether semantic evidence is complete for every requested file.")
+    val semanticOutcome: SemanticAnalysisOutcome,
+    @DocField(description = "Number of files requested for semantic analysis.")
+    val requestedFileCount: Int,
+    @DocField(description = "Number of requested files successfully analyzed.")
+    val analyzedFileCount: Int,
+    @DocField(description = "Number of requested files not analyzed.")
+    val skippedFileCount: Int,
     @DocField(description = "Pagination metadata when results are truncated.")
     override val page: PageInfo? = null,
     @DocField(description = "Protocol schema version for forward compatibility.", serverManaged = true)
     val schemaVersion: Int = SCHEMA_VERSION,
 ) : PageableResult<Diagnostic> {
+    init {
+        require(requestedFileCount == fileStatuses.size) {
+            "requestedFileCount must match fileStatuses"
+        }
+        require(analyzedFileCount == fileStatuses.count { it.state == FileAnalysisState.ANALYZED }) {
+            "analyzedFileCount must match analyzed file statuses"
+        }
+        require(skippedFileCount == requestedFileCount - analyzedFileCount) {
+            "skippedFileCount must match non-analyzed file statuses"
+        }
+        require(
+            semanticOutcome != SemanticAnalysisOutcome.COMPLETE ||
+                (skippedFileCount == 0 && diagnostics.none { it.code == ANALYSIS_FAILURE_CODE }),
+        ) {
+            "Complete semantic analysis cannot contain skipped files or ANALYSIS_FAILURE diagnostics"
+        }
+    }
+
     override val items: List<Diagnostic>
         get() = diagnostics
 
-    override fun withItems(items: List<Diagnostic>, page: PageInfo?): PageableResult<Diagnostic> = copy(
-        diagnostics = items,
-        page = page,
-    )
+    override fun withItems(items: List<Diagnostic>, page: PageInfo?): PageableResult<Diagnostic> =
+        DiagnosticsResult(
+            diagnostics = items,
+            fileStatuses = fileStatuses,
+            semanticOutcome = semanticOutcome,
+            requestedFileCount = requestedFileCount,
+            analyzedFileCount = analyzedFileCount,
+            skippedFileCount = skippedFileCount,
+            page = page,
+            schemaVersion = schemaVersion,
+        )
+
+    companion object {
+        private const val ANALYSIS_FAILURE_CODE = "ANALYSIS_FAILURE"
+
+        fun of(
+            diagnostics: List<Diagnostic>,
+            fileStatuses: List<FileAnalysisStatus>,
+            page: PageInfo? = null,
+        ): DiagnosticsResult {
+            val analyzedFileCount = fileStatuses.count { it.state == FileAnalysisState.ANALYZED }
+            val skippedFileCount = fileStatuses.size - analyzedFileCount
+            val semanticOutcome = if (
+                skippedFileCount == 0 && diagnostics.none { it.code == ANALYSIS_FAILURE_CODE }
+            ) {
+                SemanticAnalysisOutcome.COMPLETE
+            } else {
+                SemanticAnalysisOutcome.INCOMPLETE
+            }
+            return DiagnosticsResult(
+                diagnostics = diagnostics,
+                fileStatuses = fileStatuses,
+                semanticOutcome = semanticOutcome,
+                requestedFileCount = fileStatuses.size,
+                analyzedFileCount = analyzedFileCount,
+                skippedFileCount = skippedFileCount,
+                page = page,
+            )
+        }
+    }
 }

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/FileAnalysisState.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/FileAnalysisState.kt
@@ -1,0 +1,12 @@
+package io.github.amichne.kast.api.contract.result
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class FileAnalysisState {
+    ANALYZED,
+    PENDING_INDEX,
+    OUTSIDE_SOURCE_MODULES,
+    MISSING_ON_DISK,
+    BACKEND_FAILURE,
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/FileAnalysisStatus.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/FileAnalysisStatus.kt
@@ -1,0 +1,43 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package io.github.amichne.kast.api.contract.result
+
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.Serializable
+
+@Serializable
+class FileAnalysisStatus private constructor(
+    @DocField(description = "Normalized absolute path requested for semantic analysis.")
+    val filePath: String,
+    @DocField(description = "Typed semantic terminal state for the requested file.")
+    val state: FileAnalysisState,
+    @DocField(description = "Explanation when the file was not analyzed.", defaultValue = "null")
+    val message: String? = null,
+) {
+    init {
+        require(filePath.isNotBlank()) { "filePath must not be blank" }
+        require(state == FileAnalysisState.ANALYZED || !message.isNullOrBlank()) {
+            "A skipped file requires a non-blank explanation"
+        }
+        require(state != FileAnalysisState.ANALYZED || message == null) {
+            "An analyzed file cannot carry a skip explanation"
+        }
+    }
+
+    companion object {
+        fun analyzed(filePath: NormalizedPath): FileAnalysisStatus =
+            FileAnalysisStatus(filePath.value, FileAnalysisState.ANALYZED)
+
+        fun skipped(
+            filePath: NormalizedPath,
+            state: FileAnalysisState,
+            message: String,
+        ): FileAnalysisStatus {
+            require(state != FileAnalysisState.ANALYZED) {
+                "Use analyzed() for an analyzed file"
+            }
+            return FileAnalysisStatus(filePath.value, state, message)
+        }
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/SemanticAnalysisOutcome.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/SemanticAnalysisOutcome.kt
@@ -1,0 +1,9 @@
+package io.github.amichne.kast.api.contract.result
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class SemanticAnalysisOutcome {
+    COMPLETE,
+    INCOMPLETE,
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastDiagnosticsSummary.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastDiagnosticsSummary.kt
@@ -1,0 +1,60 @@
+package io.github.amichne.kast.api.contract.skill
+
+import io.github.amichne.kast.api.contract.Diagnostic
+import io.github.amichne.kast.api.contract.DiagnosticSeverity
+import io.github.amichne.kast.api.contract.result.DiagnosticsResult
+import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
+import kotlinx.serialization.Serializable
+
+@Serializable
+class KastDiagnosticsSummary private constructor(
+    val clean: Boolean,
+    val errorCount: Int,
+    val warningCount: Int,
+    val semanticOutcome: SemanticAnalysisOutcome,
+    val requestedFileCount: Int,
+    val analyzedFileCount: Int,
+    val skippedFileCount: Int,
+    val errors: List<Diagnostic> = emptyList(),
+) {
+    init {
+        require(errorCount >= 0) { "errorCount must not be negative" }
+        require(warningCount >= 0) { "warningCount must not be negative" }
+        require(requestedFileCount == analyzedFileCount + skippedFileCount) {
+            "requestedFileCount must equal analyzedFileCount plus skippedFileCount"
+        }
+        require(errorCount == errors.size) { "errorCount must match errors" }
+        require(errors.all { it.severity == DiagnosticSeverity.ERROR }) {
+            "errors must contain only error diagnostics"
+        }
+        require(clean == (semanticOutcome == SemanticAnalysisOutcome.COMPLETE && errorCount == 0)) {
+            "clean requires complete semantic evidence without error diagnostics"
+        }
+    }
+
+    companion object {
+        fun from(result: DiagnosticsResult): KastDiagnosticsSummary {
+            val errors = result.diagnostics.filter { it.severity == DiagnosticSeverity.ERROR }
+            return KastDiagnosticsSummary(
+                clean = result.semanticOutcome == SemanticAnalysisOutcome.COMPLETE && errors.isEmpty(),
+                errorCount = errors.size,
+                warningCount = result.diagnostics.count { it.severity == DiagnosticSeverity.WARNING },
+                semanticOutcome = result.semanticOutcome,
+                requestedFileCount = result.requestedFileCount,
+                analyzedFileCount = result.analyzedFileCount,
+                skippedFileCount = result.skippedFileCount,
+                errors = errors,
+            )
+        }
+
+        fun completeWithoutFiles(): KastDiagnosticsSummary = KastDiagnosticsSummary(
+            clean = true,
+            errorCount = 0,
+            warningCount = 0,
+            semanticOutcome = SemanticAnalysisOutcome.COMPLETE,
+            requestedFileCount = 0,
+            analyzedFileCount = 0,
+            skippedFileCount = 0,
+        )
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastDiagnosticsSummary.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastDiagnosticsSummary.kt
@@ -2,6 +2,7 @@ package io.github.amichne.kast.api.contract.skill
 
 import io.github.amichne.kast.api.contract.Diagnostic
 import io.github.amichne.kast.api.contract.DiagnosticSeverity
+import io.github.amichne.kast.api.contract.PositiveInt
 import io.github.amichne.kast.api.contract.result.DiagnosticsResult
 import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
 import kotlinx.serialization.Serializable
@@ -23,7 +24,7 @@ class KastDiagnosticsSummary private constructor(
         require(requestedFileCount == analyzedFileCount + skippedFileCount) {
             "requestedFileCount must equal analyzedFileCount plus skippedFileCount"
         }
-        require(errorCount == errors.size) { "errorCount must match errors" }
+        require(errorCount >= errors.size) { "errorCount must include every returned error" }
         require(errors.all { it.severity == DiagnosticSeverity.ERROR }) {
             "errors must contain only error diagnostics"
         }
@@ -33,7 +34,13 @@ class KastDiagnosticsSummary private constructor(
     }
 
     companion object {
-        fun from(result: DiagnosticsResult): KastDiagnosticsSummary {
+        fun from(result: DiagnosticsResult): KastDiagnosticsSummary =
+            from(result, PositiveInt(Int.MAX_VALUE))
+
+        fun from(
+            result: DiagnosticsResult,
+            maxReturnedErrors: PositiveInt,
+        ): KastDiagnosticsSummary {
             val errors = result.diagnostics.filter { it.severity == DiagnosticSeverity.ERROR }
             return KastDiagnosticsSummary(
                 clean = result.semanticOutcome == SemanticAnalysisOutcome.COMPLETE && errors.isEmpty(),
@@ -43,7 +50,7 @@ class KastDiagnosticsSummary private constructor(
                 requestedFileCount = result.requestedFileCount,
                 analyzedFileCount = result.analyzedFileCount,
                 skippedFileCount = result.skippedFileCount,
-                errors = errors,
+                errors = errors.take(maxReturnedErrors.value),
             )
         }
 

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt
@@ -683,14 +683,6 @@ data class KastScaffoldTypeHierarchy(
 )
 
 @Serializable
-data class KastDiagnosticsSummary(
-    val clean: Boolean,
-    val errorCount: Int,
-    val warningCount: Int,
-    val errors: List<Diagnostic> = emptyList(),
-)
-
-@Serializable
 sealed interface KastResolveResponse
 
 @Serializable

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/DocsDocument.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/DocsDocument.kt
@@ -28,6 +28,7 @@ import io.github.amichne.kast.api.contract.result.CompletionItem
 import io.github.amichne.kast.api.contract.result.CompletionsResult
 import io.github.amichne.kast.api.contract.result.DiagnosticsResult
 import io.github.amichne.kast.api.contract.result.FileOutlineResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
 import io.github.amichne.kast.api.contract.result.ImplementationsResult
 import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
 import io.github.amichne.kast.api.contract.result.ReferencesResult
@@ -109,6 +110,7 @@ object DocsDocument {
         "SemanticInsertionResult" to SemanticInsertionResult.serializer(),
         "DiagnosticsQuery" to DiagnosticsQuery.serializer(),
         "DiagnosticsResult" to DiagnosticsResult.serializer(),
+        "FileAnalysisStatus" to FileAnalysisStatus.serializer(),
         "Diagnostic" to Diagnostic.serializer(),
         "FileOutlineQuery" to FileOutlineQuery.serializer(),
         "FileOutlineResult" to FileOutlineResult.serializer(),

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/OpenApiDocument.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/OpenApiDocument.kt
@@ -47,6 +47,7 @@ import io.github.amichne.kast.api.contract.result.CompletionItem
 import io.github.amichne.kast.api.contract.result.CompletionsResult
 import io.github.amichne.kast.api.contract.result.DiagnosticsResult
 import io.github.amichne.kast.api.contract.result.FileOutlineResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
 import io.github.amichne.kast.api.contract.result.ImplementationsResult
 import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
 import io.github.amichne.kast.api.contract.result.ReferencesResult
@@ -215,6 +216,7 @@ object OpenApiDocument {
         registry.register("SemanticInsertionResult", SemanticInsertionResult.serializer())
         registry.register("DiagnosticsQuery", DiagnosticsQuery.serializer())
         registry.register("DiagnosticsResult", DiagnosticsResult.serializer())
+        registry.register("FileAnalysisStatus", FileAnalysisStatus.serializer())
         registry.register("Diagnostic", Diagnostic.serializer())
         registry.register("FileOutlineQuery", FileOutlineQuery.serializer())
         registry.register("FileOutlineResult", FileOutlineResult.serializer())

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DiagnosticsResultTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DiagnosticsResultTest.kt
@@ -1,0 +1,78 @@
+package io.github.amichne.kast.api
+
+import io.github.amichne.kast.api.contract.Diagnostic
+import io.github.amichne.kast.api.contract.DiagnosticSeverity
+import io.github.amichne.kast.api.contract.Location
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.result.DiagnosticsResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisState
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
+import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+class DiagnosticsResultTest {
+    private val first = NormalizedPath.ofAbsolute(Path.of("/workspace/First.kt"))
+    private val second = NormalizedPath.ofAbsolute(Path.of("/workspace/Second.kt"))
+
+    @Test
+    fun `all analyzed files produce complete counts`() {
+        val result = DiagnosticsResult.of(
+            diagnostics = emptyList(),
+            fileStatuses = listOf(
+                FileAnalysisStatus.analyzed(first),
+                FileAnalysisStatus.analyzed(second),
+            ),
+        )
+
+        assertEquals(SemanticAnalysisOutcome.COMPLETE, result.semanticOutcome)
+        assertEquals(2, result.requestedFileCount)
+        assertEquals(2, result.analyzedFileCount)
+        assertEquals(0, result.skippedFileCount)
+    }
+
+    @Test
+    fun `a skipped file produces an incomplete result`() {
+        val result = DiagnosticsResult.of(
+            diagnostics = listOf(analysisFailure(second.value, "File not found")),
+            fileStatuses = listOf(
+                FileAnalysisStatus.analyzed(first),
+                FileAnalysisStatus.skipped(
+                    second,
+                    FileAnalysisState.MISSING_ON_DISK,
+                    "File not found",
+                ),
+            ),
+        )
+
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+        assertEquals(2, result.requestedFileCount)
+        assertEquals(1, result.analyzedFileCount)
+        assertEquals(1, result.skippedFileCount)
+    }
+
+    @Test
+    fun `analysis failure cannot produce a complete result`() {
+        val result = DiagnosticsResult.of(
+            diagnostics = listOf(analysisFailure(first.value, "backend failed")),
+            fileStatuses = listOf(FileAnalysisStatus.analyzed(first)),
+        )
+
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+    }
+
+    private fun analysisFailure(filePath: String, message: String): Diagnostic = Diagnostic(
+        location = Location(
+            filePath = filePath,
+            startOffset = 0,
+            endOffset = 0,
+            startLine = 0,
+            startColumn = 0,
+            preview = "",
+        ),
+        severity = DiagnosticSeverity.ERROR,
+        message = message,
+        code = "ANALYSIS_FAILURE",
+    )
+}

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DocFieldCoverageTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DocFieldCoverageTest.kt
@@ -28,6 +28,7 @@ import io.github.amichne.kast.api.contract.result.CompletionItem
 import io.github.amichne.kast.api.contract.result.CompletionsResult
 import io.github.amichne.kast.api.contract.result.DiagnosticsResult
 import io.github.amichne.kast.api.contract.result.FileOutlineResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
 import io.github.amichne.kast.api.contract.result.ImplementationsResult
 import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
 import io.github.amichne.kast.api.contract.result.ReferencesResult
@@ -107,6 +108,7 @@ class DocFieldCoverageTest {
         "SemanticInsertionResult" to SemanticInsertionResult.serializer(),
         "DiagnosticsQuery" to DiagnosticsQuery.serializer(),
         "DiagnosticsResult" to DiagnosticsResult.serializer(),
+        "FileAnalysisStatus" to FileAnalysisStatus.serializer(),
         "Diagnostic" to Diagnostic.serializer(),
         "FileOutlineQuery" to FileOutlineQuery.serializer(),
         "FileOutlineResult" to FileOutlineResult.serializer(),

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastDiagnosticsSummaryTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastDiagnosticsSummaryTest.kt
@@ -1,0 +1,73 @@
+package io.github.amichne.kast.api
+
+import io.github.amichne.kast.api.contract.Diagnostic
+import io.github.amichne.kast.api.contract.DiagnosticSeverity
+import io.github.amichne.kast.api.contract.Location
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.result.DiagnosticsResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisState
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
+import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
+import io.github.amichne.kast.api.contract.skill.KastDiagnosticsSummary
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+class KastDiagnosticsSummaryTest {
+    private val filePath = NormalizedPath.ofAbsolute(Path.of("/workspace/Sample.kt"))
+
+    @Test
+    fun `incomplete evidence is not clean even without compiler errors`() {
+        val result = DiagnosticsResult.of(
+            diagnostics = emptyList(),
+            fileStatuses = listOf(
+                FileAnalysisStatus.skipped(
+                    filePath,
+                    FileAnalysisState.PENDING_INDEX,
+                    "IDEA is indexing",
+                ),
+            ),
+        )
+
+        val summary = KastDiagnosticsSummary.from(result)
+
+        assertFalse(summary.clean)
+        assertEquals(0, summary.errorCount)
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, summary.semanticOutcome)
+        assertEquals(1, summary.requestedFileCount)
+        assertEquals(0, summary.analyzedFileCount)
+        assertEquals(1, summary.skippedFileCount)
+    }
+
+    @Test
+    fun `ordinary compiler error remains complete but not clean`() {
+        val result = DiagnosticsResult.of(
+            diagnostics = listOf(compilerError()),
+            fileStatuses = listOf(FileAnalysisStatus.analyzed(filePath)),
+        )
+
+        val summary = KastDiagnosticsSummary.from(result)
+
+        assertFalse(summary.clean)
+        assertEquals(1, summary.errorCount)
+        assertEquals(SemanticAnalysisOutcome.COMPLETE, summary.semanticOutcome)
+        assertEquals(1, summary.requestedFileCount)
+        assertEquals(1, summary.analyzedFileCount)
+        assertEquals(0, summary.skippedFileCount)
+    }
+
+    private fun compilerError(): Diagnostic = Diagnostic(
+        location = Location(
+            filePath = filePath.value,
+            startOffset = 0,
+            endOffset = 1,
+            startLine = 0,
+            startColumn = 0,
+            preview = "x",
+        ),
+        severity = DiagnosticSeverity.ERROR,
+        message = "Type mismatch",
+        code = "TYPE_MISMATCH",
+    )
+}

--- a/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/AnalysisBackendContractFixture.kt
+++ b/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/AnalysisBackendContractFixture.kt
@@ -3,6 +3,9 @@ package io.github.amichne.kast.testing
 import io.github.amichne.kast.api.contract.AnalysisBackend
 import io.github.amichne.kast.api.contract.CallDirection
 import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
+import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
+import io.github.amichne.kast.api.contract.result.FileAnalysisState
+import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
 import io.github.amichne.kast.api.validation.FileHashing
 import io.github.amichne.kast.api.validation.parsed
 import io.github.amichne.kast.api.contract.query.FileOutlineQuery
@@ -62,6 +65,10 @@ data class AnalysisBackendContractFixture(
         depth = 1,
         maxTotalCalls = 16,
         maxChildrenPerNode = 16,
+    )
+
+    val diagnosticsQuery: DiagnosticsQuery = DiagnosticsQuery(
+        filePaths = listOf(declarationFile.toString(), brokenFile.toString()),
     )
 
     val typeHierarchyQuery: TypeHierarchyQuery = TypeHierarchyQuery(
@@ -245,6 +252,7 @@ object AnalysisBackendContractAssertions {
         assertFileOutline(backend, fixture)
         assertWorkspaceSymbolSearch(backend, fixture)
         assertWorkspaceSearch(backend, fixture)
+        assertDiagnostics(backend, fixture)
         assertRename(backend, fixture)
     }
 
@@ -360,6 +368,29 @@ object AnalysisBackendContractAssertions {
             "workspace search expected a preview containing greet but had <${result.matches.map { it.preview }}>"
         }
         expectEquals(false, result.truncated, "workspace search truncated")
+    }
+
+    private suspend fun assertDiagnostics(
+        backend: AnalysisBackend,
+        fixture: AnalysisBackendContractFixture,
+    ) {
+        val result = backend.diagnostics(fixture.diagnosticsQuery.parsed())
+
+        expectEquals(SemanticAnalysisOutcome.COMPLETE, result.semanticOutcome, "diagnostics semantic outcome")
+        expectEquals(2, result.requestedFileCount, "diagnostics requested files")
+        expectEquals(2, result.analyzedFileCount, "diagnostics analyzed files")
+        expectEquals(0, result.skippedFileCount, "diagnostics skipped files")
+        expectEquals(
+            listOf(FileAnalysisState.ANALYZED, FileAnalysisState.ANALYZED),
+            result.fileStatuses.map { it.state },
+            "diagnostics file states",
+        )
+        check(result.diagnostics.any { it.code == "FAKE_PARSE_ERROR" }) {
+            "ordinary compiler diagnostics must remain analyzed evidence"
+        }
+        check(result.diagnostics.none { it.code == "ANALYSIS_FAILURE" }) {
+            "ordinary compiler diagnostics must not be reported as analysis failures"
+        }
     }
 
     private suspend fun assertRename(

--- a/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
+++ b/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
@@ -15,6 +15,7 @@ import io.github.amichne.kast.api.contract.result.CompletionsResult
 import io.github.amichne.kast.api.contract.Diagnostic
 import io.github.amichne.kast.api.contract.DiagnosticSeverity
 import io.github.amichne.kast.api.contract.result.DiagnosticsResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
 import io.github.amichne.kast.api.contract.FileHash
 import io.github.amichne.kast.api.contract.result.FileOutlineResult
 import io.github.amichne.kast.api.contract.FilePosition
@@ -246,12 +247,13 @@ class FakeAnalysisBackend private constructor(
     }
 
     override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult {
-        val filePaths = query.filePaths.value.map { it.value }
-        filePaths.forEach(::requireKnownFile)
-        return DiagnosticsResult(
+        val filePaths = query.filePaths.value
+        filePaths.forEach { requireKnownFile(it.value) }
+        return DiagnosticsResult.of(
             diagnostics = filePaths
-                .flatMap { filePath -> diagnosticsByFile[filePath].orEmpty() }
+                .flatMap { filePath -> diagnosticsByFile[filePath.value].orEmpty() }
                 .sortedWith(compareBy({ it.location.filePath }, { it.location.startOffset })),
+            fileStatuses = filePaths.map(FileAnalysisStatus::analyzed),
         )
     }
 

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
@@ -2,13 +2,13 @@ package io.github.amichne.kast.server
 
 import io.github.amichne.kast.api.contract.AnalysisBackend
 import io.github.amichne.kast.api.contract.CallDirection
-import io.github.amichne.kast.api.contract.Diagnostic
 import io.github.amichne.kast.api.contract.FileHash
 import io.github.amichne.kast.api.contract.FileOperation
 import io.github.amichne.kast.api.contract.FilePosition
 import io.github.amichne.kast.api.contract.Location
 import io.github.amichne.kast.api.contract.PageInfo
 import io.github.amichne.kast.api.contract.PageableResult
+import io.github.amichne.kast.api.contract.PositiveInt
 import io.github.amichne.kast.api.contract.OutlineSymbol
 import io.github.amichne.kast.api.contract.ReadCapability
 import io.github.amichne.kast.api.contract.MutationCapability
@@ -579,8 +579,8 @@ internal class SkillRpcOrchestrator(
         } else {
             requireReadCapability(ReadCapability.DIAGNOSTICS)
             KastDiagnosticsSummary.from(
-                backend.diagnostics(DiagnosticsQuery(filePaths = renameResult.affectedFiles).parsed())
-                    .withLimit(config.maxResults, ::diagnosticPageToken),
+                result = backend.diagnostics(DiagnosticsQuery(filePaths = renameResult.affectedFiles).parsed()),
+                maxReturnedErrors = PositiveInt(config.maxResults),
             )
         }
         return KastRenameSuccessResponse(
@@ -880,7 +880,8 @@ internal class SkillRpcOrchestrator(
     private suspend fun validateFiles(filePaths: List<String>): KastDiagnosticsSummary {
         requireReadCapability(ReadCapability.DIAGNOSTICS)
         return KastDiagnosticsSummary.from(
-            backend.diagnostics(DiagnosticsQuery(filePaths = filePaths).parsed()).withLimit(config.maxResults, ::diagnosticPageToken),
+            result = backend.diagnostics(DiagnosticsQuery(filePaths = filePaths).parsed()),
+            maxReturnedErrors = PositiveInt(config.maxResults),
         )
     }
 
@@ -1322,8 +1323,6 @@ private fun WrapperScaffoldMode.toInsertionTarget(): SemanticInsertionTarget = w
 private fun placeholderLogFile(): String = "/dev/null"
 
 private fun referencePageToken(location: Location): String = location.startOffset.toString()
-
-private fun diagnosticPageToken(diagnostic: Diagnostic): String = diagnostic.location.startOffset.toString()
 
 private fun workspaceSymbolPageToken(limit: Int): String = limit.toString()
 

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
@@ -3,7 +3,6 @@ package io.github.amichne.kast.server
 import io.github.amichne.kast.api.contract.AnalysisBackend
 import io.github.amichne.kast.api.contract.CallDirection
 import io.github.amichne.kast.api.contract.Diagnostic
-import io.github.amichne.kast.api.contract.DiagnosticSeverity
 import io.github.amichne.kast.api.contract.FileHash
 import io.github.amichne.kast.api.contract.FileOperation
 import io.github.amichne.kast.api.contract.FilePosition
@@ -576,10 +575,13 @@ internal class SkillRpcOrchestrator(
             ).parsed(),
         )
         val diagnosticsSummary = if (renameResult.affectedFiles.isEmpty()) {
-            KastDiagnosticsSummary(clean = true, errorCount = 0, warningCount = 0)
+            KastDiagnosticsSummary.completeWithoutFiles()
         } else {
             requireReadCapability(ReadCapability.DIAGNOSTICS)
-            diagnosticsSummary(backend.diagnostics(DiagnosticsQuery(filePaths = renameResult.affectedFiles).parsed()).withLimit(config.maxResults, ::diagnosticPageToken))
+            KastDiagnosticsSummary.from(
+                backend.diagnostics(DiagnosticsQuery(filePaths = renameResult.affectedFiles).parsed())
+                    .withLimit(config.maxResults, ::diagnosticPageToken),
+            )
         }
         return KastRenameSuccessResponse(
             ok = diagnosticsSummary.clean,
@@ -877,7 +879,7 @@ internal class SkillRpcOrchestrator(
 
     private suspend fun validateFiles(filePaths: List<String>): KastDiagnosticsSummary {
         requireReadCapability(ReadCapability.DIAGNOSTICS)
-        return diagnosticsSummary(
+        return KastDiagnosticsSummary.from(
             backend.diagnostics(DiagnosticsQuery(filePaths = filePaths).parsed()).withLimit(config.maxResults, ::diagnosticPageToken),
         )
     }
@@ -1237,14 +1239,6 @@ internal class SkillRpcOrchestrator(
             )
         }
     }
-
-    private fun diagnosticsSummary(result: io.github.amichne.kast.api.contract.result.DiagnosticsResult): KastDiagnosticsSummary =
-        KastDiagnosticsSummary(
-            clean = result.diagnostics.none { it.severity == DiagnosticSeverity.ERROR },
-            errorCount = result.diagnostics.count { it.severity == DiagnosticSeverity.ERROR },
-            warningCount = result.diagnostics.count { it.severity == DiagnosticSeverity.WARNING },
-            errors = result.diagnostics.filter { it.severity == DiagnosticSeverity.ERROR },
-        )
 
     private fun resolveContent(content: String?, contentFile: String?): String {
         if (content != null) {

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
@@ -12,6 +12,11 @@ import io.github.amichne.kast.api.contract.result.CodeActionsResult
 import io.github.amichne.kast.api.contract.query.CompletionsQuery
 import io.github.amichne.kast.api.contract.result.CompletionsResult
 import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
+import io.github.amichne.kast.api.contract.Diagnostic
+import io.github.amichne.kast.api.contract.DiagnosticSeverity
+import io.github.amichne.kast.api.contract.result.DiagnosticsResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisState
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
 import io.github.amichne.kast.api.contract.FileHash
 import io.github.amichne.kast.api.validation.FileHashing
 import io.github.amichne.kast.api.contract.FileOperation
@@ -20,6 +25,7 @@ import io.github.amichne.kast.api.contract.result.FileOutlineResult
 import io.github.amichne.kast.api.contract.FilePosition
 import io.github.amichne.kast.api.contract.NonBlankString
 import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.Location
 import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
 import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
 import io.github.amichne.kast.api.contract.query.ImplementationsQuery
@@ -41,6 +47,7 @@ import io.github.amichne.kast.api.contract.RuntimeLifecycleResponse
 import io.github.amichne.kast.api.contract.SemanticInsertionQuery
 import io.github.amichne.kast.api.contract.SemanticInsertionResult
 import io.github.amichne.kast.api.contract.SemanticInsertionTarget
+import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
 import io.github.amichne.kast.api.contract.query.SymbolQuery
 import io.github.amichne.kast.api.contract.result.SymbolResult
 import io.github.amichne.kast.api.contract.TextEdit
@@ -55,6 +62,7 @@ import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
 import io.github.amichne.kast.api.contract.skill.*
 import io.github.amichne.kast.api.contract.result.WorkspaceSymbolResult
 import io.github.amichne.kast.api.validation.ParsedApplyEditsQuery
+import io.github.amichne.kast.api.validation.ParsedDiagnosticsQuery
 import io.github.amichne.kast.testing.FakeAnalysisBackend
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -373,6 +381,67 @@ class AnalysisDispatcherTest {
             backend.appliedFileHashes,
         )
         assertTrue(file.readText().endsWith(content))
+    }
+
+    @Test
+    fun `raw diagnostics preserves incomplete semantic evidence`() {
+        val file = sampleFile()
+        val backend = IncompleteDiagnosticsBackend(FakeAnalysisBackend.sample(tempDir))
+        val dispatcher = RpcAnalysisDispatcher(backend = backend, config = AnalysisServerConfig())
+        val raw = runBlocking {
+            dispatcher.dispatch(
+                JsonRpcRequest(
+                    id = JsonPrimitive(1),
+                    method = "raw/diagnostics",
+                    params = json.encodeToJsonElement(
+                        DiagnosticsQuery.serializer(),
+                        DiagnosticsQuery(filePaths = listOf(file.toString())),
+                    ),
+                ),
+            )
+        }
+        val response = json.decodeFromString(JsonRpcSuccessResponse.serializer(), raw)
+        val result = json.decodeFromJsonElement(DiagnosticsResult.serializer(), response.result)
+
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+        assertEquals(FileAnalysisState.BACKEND_FAILURE, result.fileStatuses.single().state)
+        assertEquals(1, result.requestedFileCount)
+        assertEquals(0, result.analyzedFileCount)
+        assertEquals(1, result.skippedFileCount)
+    }
+
+    @Test
+    fun `mutation summary fails closed when post edit analysis is incomplete`() {
+        val file = sampleFile()
+        val backend = IncompleteDiagnosticsBackend(FakeAnalysisBackend.sample(tempDir))
+        val dispatcher = RpcAnalysisDispatcher(backend = backend, config = AnalysisServerConfig())
+        val raw = runBlocking {
+            dispatcher.dispatch(
+                JsonRpcRequest(
+                    id = JsonPrimitive(1),
+                    method = "symbol/write-and-validate",
+                    params = json.encodeToJsonElement(
+                        KastWriteAndValidateRequest.serializer(),
+                        KastWriteAndValidateInsertAtOffsetRequest(
+                            workspaceRoot = tempDir.toString(),
+                            filePath = file.toString(),
+                            offset = file.readText().length,
+                            content = "\nfun added() = Unit\n",
+                        ),
+                    ),
+                ),
+            )
+        }
+        val response = json.decodeFromString(JsonRpcSuccessResponse.serializer(), raw)
+        val result = json.decodeFromJsonElement(KastWriteAndValidateResponse.serializer(), response.result)
+
+        val success = result as KastWriteAndValidateSuccessResponse
+        assertFalse(success.ok)
+        assertFalse(success.diagnostics.clean)
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, success.diagnostics.semanticOutcome)
+        assertEquals(1, success.diagnostics.requestedFileCount)
+        assertEquals(0, success.diagnostics.analyzedFileCount)
+        assertEquals(1, success.diagnostics.skippedFileCount)
     }
 
     @Test
@@ -1166,5 +1235,35 @@ private class CapturingApplyEditsBackend(
             fileHash.filePath.value to fileHash.hash
         }
         return delegate.applyEdits(query)
+    }
+}
+
+private class IncompleteDiagnosticsBackend(
+    private val delegate: AnalysisBackend,
+) : AnalysisBackend by delegate {
+    override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult {
+        val fileStatuses = query.filePaths.value.map { filePath ->
+            FileAnalysisStatus.skipped(
+                filePath = filePath,
+                state = FileAnalysisState.BACKEND_FAILURE,
+                message = "Semantic analysis was unavailable after the operation",
+            )
+        }
+        val diagnostics = query.filePaths.value.map { filePath ->
+            Diagnostic(
+                location = Location(
+                    filePath = filePath.value,
+                    startOffset = 0,
+                    endOffset = 0,
+                    startLine = 0,
+                    startColumn = 0,
+                    preview = "",
+                ),
+                severity = DiagnosticSeverity.ERROR,
+                message = "Semantic analysis was unavailable after the operation",
+                code = "ANALYSIS_FAILURE",
+            )
+        }
+        return DiagnosticsResult.of(diagnostics = diagnostics, fileStatuses = fileStatuses)
     }
 }

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
@@ -445,6 +445,42 @@ class AnalysisDispatcherTest {
     }
 
     @Test
+    fun `mutation summary remains dirty when an error is beyond the returned diagnostic limit`() {
+        val file = sampleFile()
+        val backend = CompilerDiagnosticsBeyondLimitBackend(FakeAnalysisBackend.sample(tempDir))
+        val dispatcher = RpcAnalysisDispatcher(
+            backend = backend,
+            config = AnalysisServerConfig(maxResults = 1),
+        )
+        val raw = runBlocking {
+            dispatcher.dispatch(
+                JsonRpcRequest(
+                    id = JsonPrimitive(1),
+                    method = "symbol/write-and-validate",
+                    params = json.encodeToJsonElement(
+                        KastWriteAndValidateRequest.serializer(),
+                        KastWriteAndValidateInsertAtOffsetRequest(
+                            workspaceRoot = tempDir.toString(),
+                            filePath = file.toString(),
+                            offset = file.readText().length,
+                            content = "\nfun added() = Unit\n",
+                        ),
+                    ),
+                ),
+            )
+        }
+        val response = json.decodeFromString(JsonRpcSuccessResponse.serializer(), raw)
+        val result = json.decodeFromJsonElement(KastWriteAndValidateResponse.serializer(), response.result)
+
+        val success = result as KastWriteAndValidateSuccessResponse
+        assertFalse(success.ok)
+        assertFalse(success.diagnostics.clean)
+        assertEquals(1, success.diagnostics.errorCount)
+        assertEquals(1, success.diagnostics.warningCount)
+        assertEquals(listOf("LATE_COMPILER_ERROR"), success.diagnostics.errors.map(Diagnostic::code))
+    }
+
+    @Test
     fun `symbol add file dispatches file creation and diagnostics`() {
         FakeAnalysisBackend.sample(tempDir)
         val targetFile = tempDir.resolve("src").resolve("Added.kt")
@@ -1265,5 +1301,37 @@ private class IncompleteDiagnosticsBackend(
             )
         }
         return DiagnosticsResult.of(diagnostics = diagnostics, fileStatuses = fileStatuses)
+    }
+}
+
+private class CompilerDiagnosticsBeyondLimitBackend(
+    private val delegate: AnalysisBackend,
+) : AnalysisBackend by delegate {
+    override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult {
+        val filePath = query.filePaths.value.single()
+        fun diagnostic(
+            severity: DiagnosticSeverity,
+            offset: Int,
+            code: String,
+        ): Diagnostic = Diagnostic(
+            location = Location(
+                filePath = filePath.value,
+                startOffset = offset,
+                endOffset = offset,
+                startLine = 0,
+                startColumn = 0,
+                preview = "",
+            ),
+            severity = severity,
+            message = code,
+            code = code,
+        )
+        return DiagnosticsResult.of(
+            diagnostics = listOf(
+                diagnostic(DiagnosticSeverity.WARNING, 0, "EARLY_WARNING"),
+                diagnostic(DiagnosticSeverity.ERROR, 1, "LATE_COMPILER_ERROR"),
+            ),
+            fileStatuses = listOf(FileAnalysisStatus.analyzed(filePath)),
+        )
     }
 }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
@@ -850,18 +850,18 @@ internal class KastPluginBackend(
     }
 
     private suspend fun analyzeDiagnosticsFile(filePath: NormalizedPath): DiagnosticsFileAnalysis {
-        if (!isWorkspaceFile(filePath.value)) {
-            return skippedDiagnostics(
-                filePath = filePath,
-                state = FileAnalysisState.OUTSIDE_SOURCE_MODULES,
-                message = "File is outside the active workspace: ${filePath.value}",
-            )
-        }
         if (Files.notExists(Path.of(filePath.value))) {
             return skippedDiagnostics(
                 filePath = filePath,
                 state = FileAnalysisState.MISSING_ON_DISK,
                 message = "File not found: ${filePath.value}",
+            )
+        }
+        if (!isWorkspaceFile(filePath.value)) {
+            return skippedDiagnostics(
+                filePath = filePath,
+                state = FileAnalysisState.OUTSIDE_SOURCE_MODULES,
+                message = "File is outside the active workspace: ${filePath.value}",
             )
         }
 
@@ -877,18 +877,18 @@ internal class KastPluginBackend(
                         state = FileAnalysisState.PENDING_INDEX,
                         message = "File exists on disk but is not available in the IDEA virtual file system",
                     )
-                if (DumbService.isDumb(project)) {
-                    return@timedReadAction skippedDiagnostics(
-                        filePath = filePath,
-                        state = FileAnalysisState.PENDING_INDEX,
-                        message = "IDEA indexing is still in progress",
-                    )
-                }
                 if (!ProjectFileIndex.getInstance(project).isInSourceContent(virtualFile)) {
                     return@timedReadAction skippedDiagnostics(
                         filePath = filePath,
                         state = FileAnalysisState.OUTSIDE_SOURCE_MODULES,
                         message = "File is not contained in an IDEA source module",
+                    )
+                }
+                if (DumbService.isDumb(project)) {
+                    return@timedReadAction skippedDiagnostics(
+                        filePath = filePath,
+                        state = FileAnalysisState.PENDING_INDEX,
+                        message = "IDEA indexing is still in progress",
                     )
                 }
                 val psiFile = PsiManager.getInstance(project).findFile(virtualFile)

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
@@ -40,13 +40,16 @@ import io.github.amichne.kast.api.contract.result.CompletionsResult
 import io.github.amichne.kast.api.contract.Diagnostic
 import io.github.amichne.kast.api.contract.DiagnosticSeverity
 import io.github.amichne.kast.api.contract.result.DiagnosticsResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisState
 import io.github.amichne.kast.api.contract.result.FileOutlineResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
 import io.github.amichne.kast.api.contract.HealthResponse
 import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
 import io.github.amichne.kast.api.contract.result.ImplementationsResult
 
 import io.github.amichne.kast.api.contract.Location
 import io.github.amichne.kast.api.contract.MutationCapability
+import io.github.amichne.kast.api.contract.NormalizedPath
 import io.github.amichne.kast.api.protocol.NotFoundException
 import io.github.amichne.kast.api.contract.ReadCapability
 import io.github.amichne.kast.api.contract.result.ReferencesResult
@@ -104,6 +107,7 @@ import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import java.nio.file.FileSystems
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CancellationException
 
@@ -827,41 +831,122 @@ internal class KastPluginBackend(
 
     override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult = withContext(readDispatcher) {
         telemetry.inSpan(IdeaTelemetryScope.DIAGNOSTICS, "kast.idea.diagnostics") {
-            val diagnostics = coroutineScope {
-                query.filePaths.value.map { it.value }.sorted().map { filePath ->
+            val fileAnalyses = coroutineScope {
+                query.filePaths.value.map { filePath ->
                     async(readDispatcher) {
-                        runCatching {
-                            timedReadAction(telemetry, IdeaTelemetryScope.DIAGNOSTICS, "kast.idea.diagnostics.file") {
-                                val file = findKtFile(filePath)
-                                analyze(file) {
-                                    file.collectDiagnostics(KaDiagnosticCheckerFilter.EXTENDED_AND_COMMON_CHECKERS)
-                                        .flatMap { diagnostic -> diagnostic.toApiDiagnostics() }
-                                }
-                            }
-                        }.getOrElse { ex ->
-                            listOf(
-                                Diagnostic(
-                                    location = Location(
-                                        filePath = filePath,
-                                        startOffset = 0,
-                                        endOffset = 0,
-                                        startLine = 0,
-                                        startColumn = 0,
-                                        preview = "",
-                                    ),
-                                    severity = DiagnosticSeverity.ERROR,
-                                    message = ex.message ?: ex.toString(),
-                                    code = "ANALYSIS_FAILURE",
-                                ),
-                            )
-                        }
+                        analyzeDiagnosticsFile(filePath)
                     }
-                }.awaitAll().flatten()
-            }.sortedWith(compareBy({ it.location.filePath }, { it.location.startOffset }, { it.code ?: "" }))
+                }.awaitAll()
+            }
+            val diagnostics = fileAnalyses
+                .flatMap(DiagnosticsFileAnalysis::diagnostics)
+                .sortedWith(compareBy({ it.location.filePath }, { it.location.startOffset }, { it.code ?: "" }))
 
-            DiagnosticsResult(diagnostics = diagnostics)
+            DiagnosticsResult.of(
+                diagnostics = diagnostics,
+                fileStatuses = fileAnalyses.map(DiagnosticsFileAnalysis::status),
+            )
         }
     }
+
+    private suspend fun analyzeDiagnosticsFile(filePath: NormalizedPath): DiagnosticsFileAnalysis {
+        if (!isWorkspaceFile(filePath.value)) {
+            return skippedDiagnostics(
+                filePath = filePath,
+                state = FileAnalysisState.OUTSIDE_SOURCE_MODULES,
+                message = "File is outside the active workspace: ${filePath.value}",
+            )
+        }
+        if (Files.notExists(Path.of(filePath.value))) {
+            return skippedDiagnostics(
+                filePath = filePath,
+                state = FileAnalysisState.MISSING_ON_DISK,
+                message = "File not found: ${filePath.value}",
+            )
+        }
+
+        return try {
+            timedReadAction(
+                telemetry,
+                IdeaTelemetryScope.DIAGNOSTICS,
+                "kast.idea.diagnostics.file",
+            ) {
+                val virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath.value)
+                    ?: return@timedReadAction skippedDiagnostics(
+                        filePath = filePath,
+                        state = FileAnalysisState.PENDING_INDEX,
+                        message = "File exists on disk but is not available in the IDEA virtual file system",
+                    )
+                if (DumbService.isDumb(project)) {
+                    return@timedReadAction skippedDiagnostics(
+                        filePath = filePath,
+                        state = FileAnalysisState.PENDING_INDEX,
+                        message = "IDEA indexing is still in progress",
+                    )
+                }
+                if (!ProjectFileIndex.getInstance(project).isInSourceContent(virtualFile)) {
+                    return@timedReadAction skippedDiagnostics(
+                        filePath = filePath,
+                        state = FileAnalysisState.OUTSIDE_SOURCE_MODULES,
+                        message = "File is not contained in an IDEA source module",
+                    )
+                }
+                val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
+                    ?: return@timedReadAction skippedDiagnostics(
+                        filePath = filePath,
+                        state = FileAnalysisState.PENDING_INDEX,
+                        message = "IDEA has not created PSI for the file yet",
+                    )
+                val file = psiFile as? KtFile
+                    ?: return@timedReadAction skippedDiagnostics(
+                        filePath = filePath,
+                        state = FileAnalysisState.BACKEND_FAILURE,
+                        message = "Semantic diagnostics require a Kotlin source file",
+                    )
+                val fileDiagnostics = analyze(file) {
+                    file.collectDiagnostics(KaDiagnosticCheckerFilter.EXTENDED_AND_COMMON_CHECKERS)
+                        .flatMap { diagnostic -> diagnostic.toApiDiagnostics() }
+                }
+                DiagnosticsFileAnalysis(
+                    status = FileAnalysisStatus.analyzed(filePath),
+                    diagnostics = fileDiagnostics,
+                )
+            }
+        } catch (ex: ProcessCanceledException) {
+            throw ex
+        } catch (ex: CancellationException) {
+            throw ex
+        } catch (ex: Throwable) {
+            skippedDiagnostics(
+                filePath = filePath,
+                state = FileAnalysisState.BACKEND_FAILURE,
+                message = ex.message?.takeIf(String::isNotBlank) ?: ex.toString(),
+            )
+        }
+    }
+
+    private fun skippedDiagnostics(
+        filePath: NormalizedPath,
+        state: FileAnalysisState,
+        message: String,
+    ): DiagnosticsFileAnalysis = DiagnosticsFileAnalysis(
+        status = FileAnalysisStatus.skipped(filePath, state, message),
+        diagnostics = listOf(
+            Diagnostic(
+                location = Location(
+                    filePath = filePath.value,
+                    startOffset = 0,
+                    endOffset = 0,
+                    startLine = 0,
+                    startColumn = 0,
+                    preview = "",
+                ),
+                severity = DiagnosticSeverity.ERROR,
+                message = message,
+                code = "ANALYSIS_FAILURE",
+            ),
+        ),
+    )
 
     // Note: Unlike the headless backend, IDEA's ReferencesSearch.search() resolves
     // import directives as reference sites, so explicit import FQN handling is not needed here.
@@ -1195,6 +1280,11 @@ internal class KastPluginBackend(
         val visibility: SymbolVisibility,
         val scopeKind: SearchScopeKind,
         val candidateFileCount: Int,
+    )
+
+    private data class DiagnosticsFileAnalysis(
+        val status: FileAnalysisStatus,
+        val diagnostics: List<Diagnostic>,
     )
 
     companion object {

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastDiagnosticsCompletenessTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastDiagnosticsCompletenessTest.kt
@@ -96,6 +96,21 @@ class KastDiagnosticsCompletenessTest {
     }
 
     @Test
+    fun `missing file takes precedence over workspace classification`() = runBlocking {
+        ensureProjectReady()
+        val missingOutsideWorkspace = workspaceRoot.parent.resolve("MissingOutsideWorkspace.kt")
+        Files.deleteIfExists(missingOutsideWorkspace)
+
+        val result = backend().diagnostics(
+            DiagnosticsQuery(filePaths = listOf(missingOutsideWorkspace.toString())),
+        )
+
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+        assertEquals(FileAnalysisState.MISSING_ON_DISK, result.fileStatuses.single().state)
+        assertEquals("ANALYSIS_FAILURE", result.diagnostics.single().code)
+    }
+
+    @Test
     fun `ordinary compiler diagnostics retain complete semantic evidence`() = runBlocking {
         ensureProjectReady()
         val brokenFile = Path.of(brokenFileFixture.get().virtualFile.path)
@@ -150,6 +165,30 @@ class KastDiagnosticsCompletenessTest {
             assertEquals(FileAnalysisState.OUTSIDE_SOURCE_MODULES, result.fileStatuses.single().state)
             assertEquals(0, result.analyzedFileCount)
             assertEquals(1, result.skippedFileCount)
+            assertEquals("ANALYSIS_FAILURE", result.diagnostics.single().code)
+        } finally {
+            Files.deleteIfExists(outsideSourceFile)
+        }
+    }
+
+    @Test
+    fun `outside source modules takes precedence over indexing`() {
+        ensureProjectReady()
+        val outsideSourceFile = workspaceRoot.resolve("OutsideSourceDuringIndexing.kt")
+        Files.writeString(outsideSourceFile, validSource)
+        LocalFileSystem.getInstance().refreshAndFindFileByNioFile(outsideSourceFile)
+
+        try {
+            val result = DumbModeTestUtils.computeInDumbModeSynchronously(project) {
+                runBlocking {
+                    backend().diagnostics(
+                        DiagnosticsQuery(filePaths = listOf(outsideSourceFile.toString())),
+                    )
+                }
+            }
+
+            assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+            assertEquals(FileAnalysisState.OUTSIDE_SOURCE_MODULES, result.fileStatuses.single().state)
             assertEquals("ANALYSIS_FAILURE", result.diagnostics.single().code)
         } finally {
             Files.deleteIfExists(outsideSourceFile)

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastDiagnosticsCompletenessTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastDiagnosticsCompletenessTest.kt
@@ -1,0 +1,174 @@
+package io.github.amichne.kast.idea
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiFile
+import com.intellij.testFramework.DumbModeTestUtils
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.fixture.TestFixture
+import com.intellij.testFramework.junit5.fixture.moduleFixture
+import com.intellij.testFramework.junit5.fixture.projectFixture
+import com.intellij.testFramework.junit5.fixture.psiFileFixture
+import com.intellij.testFramework.junit5.fixture.sourceRootFixture
+import io.github.amichne.kast.api.contract.RuntimeState
+import io.github.amichne.kast.api.contract.ServerLimits
+import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
+import io.github.amichne.kast.api.contract.result.FileAnalysisState
+import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+@TestApplication
+class KastDiagnosticsCompletenessTest {
+    companion object {
+        private val defaultLimits = ServerLimits(
+            maxResults = 500,
+            requestTimeoutMillis = 30_000L,
+            maxConcurrentRequests = 4,
+        )
+
+        private const val validSource = """
+            package diagnostics
+
+            fun valid(): Int = 42
+        """
+
+        private const val brokenSource = """
+            package diagnostics
+
+            fun broken(): Int = "not an integer"
+        """
+    }
+
+    private val projectFixture: TestFixture<Project> = projectFixture()
+    private val moduleFixture: TestFixture<Module> = projectFixture.moduleFixture("main")
+    private val sourceRootFixture: TestFixture<PsiDirectory> = moduleFixture.sourceRootFixture()
+    private val validFileFixture: TestFixture<PsiFile> =
+        sourceRootFixture.psiFileFixture("Valid.kt", validSource)
+    private val brokenFileFixture: TestFixture<PsiFile> =
+        sourceRootFixture.psiFileFixture("Broken.kt", brokenSource)
+    private val nonKotlinFileFixture: TestFixture<PsiFile> =
+        sourceRootFixture.psiFileFixture("Notes.txt", "Semantic analysis requires Kotlin source.")
+
+    private val project: Project
+        get() = projectFixture.get()
+
+    private val sourceRoot: Path
+        get() = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+
+    private val workspaceRoot: Path
+        get() = sourceRoot.parent
+
+    private fun backend(): KastPluginBackend = KastPluginBackend(
+        project = project,
+        workspaceRoot = workspaceRoot,
+        limits = defaultLimits,
+    )
+
+    private fun ensureProjectReady() {
+        moduleFixture.get()
+        validFileFixture.get()
+        brokenFileFixture.get()
+        nonKotlinFileFixture.get()
+        waitUntilIndexesAreReady(project)
+    }
+
+    @Test
+    fun `missing file is explicit incomplete evidence`() = runBlocking {
+        ensureProjectReady()
+        val missingFile = sourceRoot.resolve("Missing.kt")
+
+        val result = backend().diagnostics(
+            DiagnosticsQuery(filePaths = listOf(missingFile.toString())),
+        )
+
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+        assertEquals(FileAnalysisState.MISSING_ON_DISK, result.fileStatuses.single().state)
+        assertEquals(0, result.analyzedFileCount)
+        assertEquals(1, result.skippedFileCount)
+        assertEquals("ANALYSIS_FAILURE", result.diagnostics.single().code)
+    }
+
+    @Test
+    fun `ordinary compiler diagnostics retain complete semantic evidence`() = runBlocking {
+        ensureProjectReady()
+        val brokenFile = Path.of(brokenFileFixture.get().virtualFile.path)
+
+        val result = backend().diagnostics(
+            DiagnosticsQuery(filePaths = listOf(brokenFile.toString())),
+        )
+
+        assertEquals(SemanticAnalysisOutcome.COMPLETE, result.semanticOutcome)
+        assertEquals(FileAnalysisState.ANALYZED, result.fileStatuses.single().state)
+        assertEquals(1, result.analyzedFileCount)
+        assertEquals(0, result.skippedFileCount)
+        assertTrue(result.diagnostics.isNotEmpty())
+        assertTrue(result.diagnostics.none { it.code == "ANALYSIS_FAILURE" })
+    }
+
+    @Test
+    fun `indexing produces pending semantic evidence independently of runtime health`() {
+        ensureProjectReady()
+        val validFile = Path.of(validFileFixture.get().virtualFile.path)
+
+        val (runtime, diagnostics) = DumbModeTestUtils.computeInDumbModeSynchronously(project) {
+            runBlocking {
+                backend().runtimeStatus() to backend().diagnostics(
+                    DiagnosticsQuery(filePaths = listOf(validFile.toString())),
+                )
+            }
+        }
+
+        assertEquals(RuntimeState.INDEXING, runtime.state)
+        assertTrue(runtime.healthy)
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, diagnostics.semanticOutcome)
+        assertEquals(FileAnalysisState.PENDING_INDEX, diagnostics.fileStatuses.single().state)
+        assertEquals(0, diagnostics.analyzedFileCount)
+        assertEquals(1, diagnostics.skippedFileCount)
+        assertEquals("ANALYSIS_FAILURE", diagnostics.diagnostics.single().code)
+    }
+
+    @Test
+    fun `Kotlin file outside source modules is explicit incomplete evidence`() = runBlocking {
+        ensureProjectReady()
+        val outsideSourceFile = workspaceRoot.resolve("OutsideSource.kt")
+        Files.writeString(outsideSourceFile, validSource)
+        LocalFileSystem.getInstance().refreshAndFindFileByNioFile(outsideSourceFile)
+
+        try {
+            val result = backend().diagnostics(
+                DiagnosticsQuery(filePaths = listOf(outsideSourceFile.toString())),
+            )
+
+            assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+            assertEquals(FileAnalysisState.OUTSIDE_SOURCE_MODULES, result.fileStatuses.single().state)
+            assertEquals(0, result.analyzedFileCount)
+            assertEquals(1, result.skippedFileCount)
+            assertEquals("ANALYSIS_FAILURE", result.diagnostics.single().code)
+        } finally {
+            Files.deleteIfExists(outsideSourceFile)
+        }
+    }
+
+    @Test
+    fun `non Kotlin source file is explicit backend failure evidence`() = runBlocking {
+        ensureProjectReady()
+        val nonKotlinFile = Path.of(nonKotlinFileFixture.get().virtualFile.path)
+
+        val result = backend().diagnostics(
+            DiagnosticsQuery(filePaths = listOf(nonKotlinFile.toString())),
+        )
+
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, result.semanticOutcome)
+        assertEquals(FileAnalysisState.BACKEND_FAILURE, result.fileStatuses.single().state)
+        assertEquals(0, result.analyzedFileCount)
+        assertEquals(1, result.skippedFileCount)
+        assertEquals("ANALYSIS_FAILURE", result.diagnostics.single().code)
+    }
+}

--- a/cli-rs/protocol/api-reference.md
+++ b/cli-rs/protocol/api-reference.md
@@ -826,6 +826,11 @@ daemon, including input/output schemas, examples, and behavioral notes.
             | Signature | Description |
             |-----------|-------------|
             | `#!kotlin diagnostics: List<Diagnostic>` | List of compilation diagnostics found in the requested files. |
+            | `#!kotlin fileStatuses: List<FileAnalysisStatus>` | Typed semantic terminal state for every requested file. |
+            | `#!kotlin semanticOutcome: SemanticAnalysisOutcome` | Whether semantic evidence is complete for every requested file. |
+            | `#!kotlin requestedFileCount: Int` | Number of files requested for semantic analysis. |
+            | `#!kotlin analyzedFileCount: Int` | Number of requested files successfully analyzed. |
+            | `#!kotlin skippedFileCount: Int` | Number of requested files not analyzed. |
             | `#!kotlin page: PageInfo?` | Pagination metadata when results are truncated. |
             | `#!kotlin schemaVersion: Int` | Protocol schema version for forward compatibility. |
         === "Internal protocol"
@@ -854,6 +859,16 @@ daemon, including input/output schemas, examples, and behavioral notes.
             {
                 "result": {
                     "diagnostics": [],
+                    "fileStatuses": [
+                        {
+                            "filePath": "/workspace/src/Sample.kt",
+                            "state": "ANALYZED"
+                        }
+                    ],
+                    "semanticOutcome": "COMPLETE",
+                    "requestedFileCount": 1,
+                    "analyzedFileCount": 1,
+                    "skippedFileCount": 0,
                     "schemaVersion": 3
                 },
                 "id": 1,

--- a/cli-rs/protocol/capabilities.md
+++ b/cli-rs/protocol/capabilities.md
@@ -224,6 +224,11 @@ category. Expand any operation to see its input and output schemas.
             | Signature | Description |
             |-----------|-------------|
             | `#!kotlin diagnostics: List<Diagnostic>` | List of compilation diagnostics found in the requested files. |
+            | `#!kotlin fileStatuses: List<FileAnalysisStatus>` | Typed semantic terminal state for every requested file. |
+            | `#!kotlin semanticOutcome: SemanticAnalysisOutcome` | Whether semantic evidence is complete for every requested file. |
+            | `#!kotlin requestedFileCount: Int` | Number of files requested for semantic analysis. |
+            | `#!kotlin analyzedFileCount: Int` | Number of requested files successfully analyzed. |
+            | `#!kotlin skippedFileCount: Int` | Number of requested files not analyzed. |
             | `#!kotlin page: PageInfo?` | Pagination metadata when results are truncated. |
             | `#!kotlin schemaVersion: Int` | Protocol schema version for forward compatibility. |
 

--- a/cli-rs/protocol/examples/diagnostics-response.json
+++ b/cli-rs/protocol/examples/diagnostics-response.json
@@ -1,6 +1,16 @@
 {
     "result": {
         "diagnostics": [],
+        "fileStatuses": [
+            {
+                "filePath": "/workspace/src/Sample.kt",
+                "state": "ANALYZED"
+            }
+        ],
+        "semanticOutcome": "COMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 1,
+        "skippedFileCount": 0,
         "schemaVersion": 3
     },
     "id": 1,

--- a/cli-rs/protocol/openapi.yaml
+++ b/cli-rs/protocol/openapi.yaml
@@ -1431,6 +1431,21 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/Diagnostic"
+        fileStatuses:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FileAnalysisStatus"
+        semanticOutcome:
+          "$ref": "#/components/schemas/SemanticAnalysisOutcome"
+        requestedFileCount:
+          type: integer
+          format: int32
+        analyzedFileCount:
+          type: integer
+          format: int32
+        skippedFileCount:
+          type: integer
+          format: int32
         page:
           anyOf:
             - "$ref": "#/components/schemas/PageInfo"
@@ -1441,6 +1456,11 @@ components:
       additionalProperties: false
       required:
         - diagnostics
+        - fileStatuses
+        - semanticOutcome
+        - requestedFileCount
+        - analyzedFileCount
+        - skippedFileCount
     Diagnostic:
       type: object
       properties:
@@ -1465,6 +1485,34 @@ components:
         - ERROR
         - WARNING
         - INFO
+    FileAnalysisStatus:
+      type: object
+      properties:
+        filePath:
+          type: string
+        state:
+          "$ref": "#/components/schemas/FileAnalysisState"
+        message:
+          anyOf:
+            - type: string
+            - type: "null"
+      additionalProperties: false
+      required:
+        - filePath
+        - state
+    FileAnalysisState:
+      type: string
+      enum:
+        - ANALYZED
+        - PENDING_INDEX
+        - OUTSIDE_SOURCE_MODULES
+        - MISSING_ON_DISK
+        - BACKEND_FAILURE
+    SemanticAnalysisOutcome:
+      type: string
+      enum:
+        - COMPLETE
+        - INCOMPLETE
     FileOutlineQuery:
       type: object
       properties:

--- a/cli-rs/src/agent.rs
+++ b/cli-rs/src/agent.rs
@@ -9,7 +9,7 @@ use crate::cli::{
 };
 use crate::error::{CliError, Result};
 use crate::{output, runtime, validate};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 

--- a/cli-rs/src/agent.rs
+++ b/cli-rs/src/agent.rs
@@ -12,6 +12,7 @@ use crate::{output, runtime, validate};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
+use std::path::{Component, Path, PathBuf};
 
 include!("agent/types.rs");
 include!("agent/dispatch.rs");
@@ -19,3 +20,52 @@ include!("agent/request.rs");
 include!("agent/envelope.rs");
 include!("agent/input.rs");
 include!("agent/response.rs");
+
+#[cfg(test)]
+mod semantic_analysis_evidence_tests {
+    use super::*;
+
+    #[test]
+    fn normalized_requested_file_path_matches_normalized_status_path() {
+        let request = json!({
+            "params": {
+                "filePaths": ["/workspace/src/../src/Sample.kt"]
+            }
+        });
+        let result = json!({
+            "diagnostics": [],
+            "fileStatuses": [{
+                "filePath": "/workspace/src/Sample.kt",
+                "state": "ANALYZED"
+            }],
+            "semanticOutcome": "COMPLETE",
+            "requestedFileCount": 1,
+            "analyzedFileCount": 1,
+            "skippedFileCount": 0
+        });
+
+        assert!(matches!(
+            AgentSemanticAnalysisEvidence::from_result("raw/diagnostics", &request, Some(&result),),
+            AgentSemanticAnalysisEvidence::Valid(_),
+        ));
+    }
+
+    #[test]
+    fn unrelated_command_result_does_not_require_diagnostics_evidence() {
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "runtime/status",
+            "params": {}
+        });
+        let result = json!({
+            "semanticOutcome": "not a diagnostics outcome",
+            "schemaVersion": 3
+        });
+
+        assert!(matches!(
+            AgentSemanticAnalysisEvidence::from_result("runtime/status", &request, Some(&result),),
+            AgentSemanticAnalysisEvidence::NotDiagnostics,
+        ));
+    }
+}

--- a/cli-rs/src/agent/dispatch.rs
+++ b/cli-rs/src/agent/dispatch.rs
@@ -470,10 +470,13 @@ fn execute_agent_steps(
             step_session,
         );
         if step.method == "raw/diagnostics" {
-            semantic_analysis = envelope
-                .result
-                .as_ref()
-                .and_then(AgentSemanticAnalysisSummary::from_result);
+            semantic_analysis = envelope.result.as_ref().and_then(|result| {
+                match AgentSemanticAnalysisEvidence::from_result(result) {
+                    AgentSemanticAnalysisEvidence::Valid(summary) => Some(summary),
+                    AgentSemanticAnalysisEvidence::Absent
+                    | AgentSemanticAnalysisEvidence::Invalid => None,
+                }
+            });
         }
         if !envelope.ok {
             issues.push(json!({

--- a/cli-rs/src/agent/dispatch.rs
+++ b/cli-rs/src/agent/dispatch.rs
@@ -470,13 +470,14 @@ fn execute_agent_steps(
             step_session,
         );
         if step.method == "raw/diagnostics" {
-            semantic_analysis = envelope.result.as_ref().and_then(|result| {
-                match AgentSemanticAnalysisEvidence::from_result(result) {
-                    AgentSemanticAnalysisEvidence::Valid(summary) => Some(summary),
-                    AgentSemanticAnalysisEvidence::Absent
-                    | AgentSemanticAnalysisEvidence::Invalid => None,
-                }
-            });
+            let evidence_is_invalid = envelope
+                .error
+                .as_ref()
+                .is_some_and(|error| error.code == "SEMANTIC_ANALYSIS_INVALID");
+            semantic_analysis = (!evidence_is_invalid)
+                .then_some(envelope.result.as_ref())
+                .flatten()
+                .and_then(AgentSemanticAnalysisSummary::from_result);
         }
         if !envelope.ok {
             issues.push(json!({

--- a/cli-rs/src/agent/dispatch.rs
+++ b/cli-rs/src/agent/dispatch.rs
@@ -455,6 +455,7 @@ fn execute_agent_steps(
     };
     let mut step_results = Vec::with_capacity(steps.len());
     let mut issues = Vec::new();
+    let mut semantic_analysis = None;
     for step in steps {
         let step_session = session
             .as_ref()
@@ -468,6 +469,12 @@ fn execute_agent_steps(
             },
             step_session,
         );
+        if step.method == "raw/diagnostics" {
+            semantic_analysis = envelope
+                .result
+                .as_ref()
+                .and_then(AgentSemanticAnalysisSummary::from_result);
+        }
         if !envelope.ok {
             issues.push(json!({
                 "code": "AGENT_STEP_FAILED",
@@ -488,13 +495,16 @@ fn execute_agent_steps(
         }
     }
     let ok = issues.is_empty();
-    let result = json!({
+    let mut result = json!({
         "type": "KAST_AGENT_COMMAND",
         "ok": ok,
         "steps": step_results,
         "issues": issues,
         "schemaVersion": SCHEMA_VERSION,
     });
+    if let (Some(summary), Some(result)) = (semantic_analysis, result.as_object_mut()) {
+        result.insert("semanticAnalysis".to_string(), json!(summary));
+    }
     let error = (!ok).then(|| {
         let mut error = agent_error("AGENT_COMMAND_FAILED", "Agent command failed.");
         error

--- a/cli-rs/src/agent/response.rs
+++ b/cli-rs/src/agent/response.rs
@@ -103,26 +103,38 @@ fn response_error(response: &Value) -> Option<AgentError> {
 
 fn result_failure(result: &Option<Value>) -> Option<AgentError> {
     let result = result.as_ref()?;
-    if let Some(summary) = AgentSemanticAnalysisSummary::from_result(result)
-        && summary.is_incomplete()
-    {
-        let mut agent_error = AgentError {
-            code: "SEMANTIC_ANALYSIS_INCOMPLETE".to_string(),
-            message: format!(
-                "Semantic analysis was incomplete: analyzed {} of {} requested files; skipped {}.",
-                summary.analyzed_file_count,
-                summary.requested_file_count,
-                summary.skipped_file_count,
-            ),
-            details: BTreeMap::new(),
-        };
-        agent_error
-            .details
-            .insert("semanticAnalysis".to_string(), json!(summary));
-        agent_error
-            .details
-            .insert("result".to_string(), result.clone());
-        return Some(agent_error);
+    match AgentSemanticAnalysisEvidence::from_result(result) {
+        AgentSemanticAnalysisEvidence::Valid(summary) if summary.is_incomplete() => {
+            let mut agent_error = AgentError {
+                code: "SEMANTIC_ANALYSIS_INCOMPLETE".to_string(),
+                message: format!(
+                    "Semantic analysis was incomplete: analyzed {} of {} requested files; skipped {}.",
+                    summary.analyzed_file_count,
+                    summary.requested_file_count,
+                    summary.skipped_file_count,
+                ),
+                details: BTreeMap::new(),
+            };
+            agent_error
+                .details
+                .insert("semanticAnalysis".to_string(), json!(summary));
+            agent_error
+                .details
+                .insert("result".to_string(), result.clone());
+            return Some(agent_error);
+        }
+        AgentSemanticAnalysisEvidence::Invalid => {
+            let mut agent_error = agent_error(
+                "SEMANTIC_ANALYSIS_INVALID",
+                "The backend returned malformed semantic completeness evidence.",
+            );
+            agent_error
+                .details
+                .insert("result".to_string(), result.clone());
+            return Some(agent_error);
+        }
+        AgentSemanticAnalysisEvidence::Absent
+        | AgentSemanticAnalysisEvidence::Valid(_) => {}
     }
     if result
         .get("diagnostics")

--- a/cli-rs/src/agent/response.rs
+++ b/cli-rs/src/agent/response.rs
@@ -25,11 +25,17 @@ fn response_envelope(
             };
         }
     };
+    let semantic_evidence = AgentSemanticAnalysisEvidence::from_result(
+        &method,
+        &request,
+        response.get("result"),
+    );
     if !full_response {
         preview_large_strings(&mut response, AXI_PREVIEW_LIMIT);
     }
     let result = response.get("result").cloned();
-    let error = response_error(&response).or_else(|| result_failure(&result));
+    let error = response_error(&response)
+        .or_else(|| result_failure(semantic_evidence, &result));
     AgentEnvelope {
         ok: error.is_none() && result.is_some(),
         method,
@@ -101,9 +107,11 @@ fn response_error(response: &Value) -> Option<AgentError> {
     Some(agent_error)
 }
 
-fn result_failure(result: &Option<Value>) -> Option<AgentError> {
-    let result = result.as_ref()?;
-    match AgentSemanticAnalysisEvidence::from_result(result) {
+fn result_failure(
+    semantic_evidence: AgentSemanticAnalysisEvidence,
+    result: &Option<Value>,
+) -> Option<AgentError> {
+    match semantic_evidence {
         AgentSemanticAnalysisEvidence::Valid(summary) if summary.is_incomplete() => {
             let mut agent_error = AgentError {
                 code: "SEMANTIC_ANALYSIS_INCOMPLETE".to_string(),
@@ -118,9 +126,11 @@ fn result_failure(result: &Option<Value>) -> Option<AgentError> {
             agent_error
                 .details
                 .insert("semanticAnalysis".to_string(), json!(summary));
-            agent_error
-                .details
-                .insert("result".to_string(), result.clone());
+            if let Some(result) = result {
+                agent_error
+                    .details
+                    .insert("result".to_string(), result.clone());
+            }
             return Some(agent_error);
         }
         AgentSemanticAnalysisEvidence::Invalid => {
@@ -128,32 +138,17 @@ fn result_failure(result: &Option<Value>) -> Option<AgentError> {
                 "SEMANTIC_ANALYSIS_INVALID",
                 "The backend returned malformed semantic completeness evidence.",
             );
-            agent_error
-                .details
-                .insert("result".to_string(), result.clone());
+            if let Some(result) = result {
+                agent_error
+                    .details
+                    .insert("result".to_string(), result.clone());
+            }
             return Some(agent_error);
         }
-        AgentSemanticAnalysisEvidence::Absent
+        AgentSemanticAnalysisEvidence::NotDiagnostics
         | AgentSemanticAnalysisEvidence::Valid(_) => {}
     }
-    if result
-        .get("diagnostics")
-        .and_then(Value::as_array)
-        .is_some_and(|diagnostics| {
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.get("code").and_then(Value::as_str) == Some("ANALYSIS_FAILURE"))
-        })
-    {
-        let mut agent_error = agent_error(
-            "SEMANTIC_ANALYSIS_FAILED",
-            "The backend reported an ANALYSIS_FAILURE diagnostic.",
-        );
-        agent_error
-            .details
-            .insert("result".to_string(), result.clone());
-        return Some(agent_error);
-    }
+    let result = result.as_ref()?;
     if result.get("ok").and_then(Value::as_bool) != Some(false) {
         return None;
     }

--- a/cli-rs/src/agent/response.rs
+++ b/cli-rs/src/agent/response.rs
@@ -103,6 +103,45 @@ fn response_error(response: &Value) -> Option<AgentError> {
 
 fn result_failure(result: &Option<Value>) -> Option<AgentError> {
     let result = result.as_ref()?;
+    if let Some(summary) = AgentSemanticAnalysisSummary::from_result(result)
+        && summary.is_incomplete()
+    {
+        let mut agent_error = AgentError {
+            code: "SEMANTIC_ANALYSIS_INCOMPLETE".to_string(),
+            message: format!(
+                "Semantic analysis was incomplete: analyzed {} of {} requested files; skipped {}.",
+                summary.analyzed_file_count,
+                summary.requested_file_count,
+                summary.skipped_file_count,
+            ),
+            details: BTreeMap::new(),
+        };
+        agent_error
+            .details
+            .insert("semanticAnalysis".to_string(), json!(summary));
+        agent_error
+            .details
+            .insert("result".to_string(), result.clone());
+        return Some(agent_error);
+    }
+    if result
+        .get("diagnostics")
+        .and_then(Value::as_array)
+        .is_some_and(|diagnostics| {
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.get("code").and_then(Value::as_str) == Some("ANALYSIS_FAILURE"))
+        })
+    {
+        let mut agent_error = agent_error(
+            "SEMANTIC_ANALYSIS_FAILED",
+            "The backend reported an ANALYSIS_FAILURE diagnostic.",
+        );
+        agent_error
+            .details
+            .insert("result".to_string(), result.clone());
+        return Some(agent_error);
+    }
     if result.get("ok").and_then(Value::as_bool) != Some(false) {
         return None;
     }

--- a/cli-rs/src/agent/types.rs
+++ b/cli-rs/src/agent/types.rs
@@ -25,6 +25,37 @@ pub struct AgentError {
     pub details: BTreeMap<String, Value>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentSemanticAnalysisSummary {
+    semantic_outcome: AgentSemanticAnalysisOutcome,
+    requested_file_count: usize,
+    analyzed_file_count: usize,
+    skipped_file_count: usize,
+}
+
+impl AgentSemanticAnalysisSummary {
+    fn from_result(result: &Value) -> Option<Self> {
+        let summary = serde_json::from_value::<Self>(result.clone()).ok()?;
+        (summary.requested_file_count
+            == summary
+                .analyzed_file_count
+                .checked_add(summary.skipped_file_count)?)
+        .then_some(summary)
+    }
+
+    fn is_incomplete(&self) -> bool {
+        self.semantic_outcome == AgentSemanticAnalysisOutcome::Incomplete
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum AgentSemanticAnalysisOutcome {
+    Complete,
+    Incomplete,
+}
+
 struct AgentRequest {
     method: String,
     request: Value,

--- a/cli-rs/src/agent/types.rs
+++ b/cli-rs/src/agent/types.rs
@@ -35,17 +35,42 @@ struct AgentSemanticAnalysisSummary {
 }
 
 impl AgentSemanticAnalysisSummary {
-    fn from_result(result: &Value) -> Option<Self> {
-        let summary = serde_json::from_value::<Self>(result.clone()).ok()?;
-        (summary.requested_file_count
-            == summary
-                .analyzed_file_count
-                .checked_add(summary.skipped_file_count)?)
-        .then_some(summary)
-    }
-
     fn is_incomplete(&self) -> bool {
         self.semantic_outcome == AgentSemanticAnalysisOutcome::Incomplete
+    }
+}
+
+enum AgentSemanticAnalysisEvidence {
+    Absent,
+    Valid(AgentSemanticAnalysisSummary),
+    Invalid,
+}
+
+impl AgentSemanticAnalysisEvidence {
+    fn from_result(result: &Value) -> Self {
+        const FIELDS: [&str; 4] = [
+            "semanticOutcome",
+            "requestedFileCount",
+            "analyzedFileCount",
+            "skippedFileCount",
+        ];
+        if FIELDS.iter().all(|field| result.get(field).is_none()) {
+            return Self::Absent;
+        }
+        let Ok(summary) = serde_json::from_value::<AgentSemanticAnalysisSummary>(result.clone())
+        else {
+            return Self::Invalid;
+        };
+        let Some(classified_file_count) = summary
+            .analyzed_file_count
+            .checked_add(summary.skipped_file_count)
+        else {
+            return Self::Invalid;
+        };
+        if summary.requested_file_count != classified_file_count {
+            return Self::Invalid;
+        }
+        Self::Valid(summary)
     }
 }
 

--- a/cli-rs/src/agent/types.rs
+++ b/cli-rs/src/agent/types.rs
@@ -35,43 +35,211 @@ struct AgentSemanticAnalysisSummary {
 }
 
 impl AgentSemanticAnalysisSummary {
+    fn from_result(result: &Value) -> Option<Self> {
+        serde_json::from_value(result.clone()).ok()
+    }
+
     fn is_incomplete(&self) -> bool {
         self.semantic_outcome == AgentSemanticAnalysisOutcome::Incomplete
     }
 }
 
 enum AgentSemanticAnalysisEvidence {
-    Absent,
+    NotDiagnostics,
     Valid(AgentSemanticAnalysisSummary),
     Invalid,
 }
 
 impl AgentSemanticAnalysisEvidence {
-    fn from_result(result: &Value) -> Self {
-        const FIELDS: [&str; 4] = [
-            "semanticOutcome",
-            "requestedFileCount",
-            "analyzedFileCount",
-            "skippedFileCount",
-        ];
-        if FIELDS.iter().all(|field| result.get(field).is_none()) {
-            return Self::Absent;
+    fn from_result(method: &str, request: &Value, result: Option<&Value>) -> Self {
+        if method != "raw/diagnostics" {
+            return Self::NotDiagnostics;
         }
-        let Ok(summary) = serde_json::from_value::<AgentSemanticAnalysisSummary>(result.clone())
-        else {
+        let Some(result) = result else {
             return Self::Invalid;
         };
-        let Some(classified_file_count) = summary
-            .analyzed_file_count
-            .checked_add(summary.skipped_file_count)
-        else {
+        let Ok(request) = serde_json::from_value::<AgentDiagnosticsRequest>(request.clone()) else {
             return Self::Invalid;
         };
-        if summary.requested_file_count != classified_file_count {
+        let Ok(evidence) = serde_json::from_value::<AgentDiagnosticsResult>(result.clone()) else {
             return Self::Invalid;
-        }
-        Self::Valid(summary)
+        };
+        evidence
+            .validated_summary(&request.params.file_paths)
+            .map_or(Self::Invalid, Self::Valid)
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentDiagnosticsRequest {
+    params: AgentDiagnosticsRequestParams,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentDiagnosticsRequestParams {
+    file_paths: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentDiagnosticsResult {
+    diagnostics: Vec<AgentDiagnostic>,
+    file_statuses: Vec<AgentFileAnalysisStatus>,
+    #[serde(flatten)]
+    summary: AgentSemanticAnalysisSummary,
+}
+
+impl AgentDiagnosticsResult {
+    fn validated_summary(
+        self,
+        requested_file_paths: &[String],
+    ) -> Option<AgentSemanticAnalysisSummary> {
+        let requested_file_paths = requested_file_paths
+            .iter()
+            .map(|file_path| normalized_absolute_path(file_path))
+            .collect::<Option<Vec<_>>>()?;
+        let status_file_paths = self
+            .file_statuses
+            .iter()
+            .map(|status| normalized_absolute_path(&status.file_path))
+            .collect::<Option<Vec<_>>>()?;
+        let status_file_paths_match = status_file_paths == requested_file_paths;
+        if !status_file_paths_match
+            || self
+                .file_statuses
+                .iter()
+                .any(|status| !status.is_valid())
+            || self
+                .diagnostics
+                .iter()
+                .any(|diagnostic| !diagnostic.is_valid())
+        {
+            return None;
+        }
+
+        let analyzed_file_count = self
+            .file_statuses
+            .iter()
+            .filter(|status| status.state == AgentFileAnalysisState::Analyzed)
+            .count();
+        let skipped_file_count = self.file_statuses.len().checked_sub(analyzed_file_count)?;
+        let has_analysis_failure = self
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code.as_deref() == Some("ANALYSIS_FAILURE"));
+        let expected_outcome = if skipped_file_count == 0 && !has_analysis_failure {
+            AgentSemanticAnalysisOutcome::Complete
+        } else {
+            AgentSemanticAnalysisOutcome::Incomplete
+        };
+
+        if self.summary.requested_file_count != requested_file_paths.len()
+            || self.summary.requested_file_count != self.file_statuses.len()
+            || self.summary.analyzed_file_count != analyzed_file_count
+            || self.summary.skipped_file_count != skipped_file_count
+            || self.summary.semantic_outcome != expected_outcome
+        {
+            return None;
+        }
+        Some(self.summary)
+    }
+}
+
+fn normalized_absolute_path(raw: &str) -> Option<PathBuf> {
+    let path = Path::new(raw);
+    if !path.is_absolute() {
+        return None;
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+        }
+    }
+    Some(normalized)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentFileAnalysisStatus {
+    file_path: String,
+    state: AgentFileAnalysisState,
+    message: Option<String>,
+}
+
+impl AgentFileAnalysisStatus {
+    fn is_valid(&self) -> bool {
+        if self.file_path.trim().is_empty() {
+            return false;
+        }
+        match self.state {
+            AgentFileAnalysisState::Analyzed => self.message.is_none(),
+            AgentFileAnalysisState::PendingIndex
+            | AgentFileAnalysisState::OutsideSourceModules
+            | AgentFileAnalysisState::MissingOnDisk
+            | AgentFileAnalysisState::BackendFailure => self
+                .message
+                .as_deref()
+                .is_some_and(|message| !message.trim().is_empty()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum AgentFileAnalysisState {
+    Analyzed,
+    PendingIndex,
+    OutsideSourceModules,
+    MissingOnDisk,
+    BackendFailure,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentDiagnostic {
+    location: AgentDiagnosticLocation,
+    severity: AgentDiagnosticSeverity,
+    message: String,
+    code: Option<String>,
+}
+
+impl AgentDiagnostic {
+    fn is_valid(&self) -> bool {
+        self.location.is_valid()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentDiagnosticLocation {
+    file_path: String,
+    start_offset: usize,
+    end_offset: usize,
+    start_line: usize,
+    start_column: usize,
+    preview: String,
+}
+
+impl AgentDiagnosticLocation {
+    fn is_valid(&self) -> bool {
+        !self.file_path.trim().is_empty() && self.start_offset <= self.end_offset
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum AgentDiagnosticSeverity {
+    Error,
+    Warning,
+    Info,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/cli-rs/src/agent/types.rs
+++ b/cli-rs/src/agent/types.rs
@@ -86,8 +86,16 @@ struct AgentDiagnosticsRequestParams {
 struct AgentDiagnosticsResult {
     diagnostics: Vec<AgentDiagnostic>,
     file_statuses: Vec<AgentFileAnalysisStatus>,
+    page: Option<AgentDiagnosticsPage>,
     #[serde(flatten)]
     summary: AgentSemanticAnalysisSummary,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentDiagnosticsPage {
+    truncated: bool,
+    next_page_token: Option<String>,
 }
 
 impl AgentDiagnosticsResult {
@@ -128,17 +136,20 @@ impl AgentDiagnosticsResult {
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code.as_deref() == Some("ANALYSIS_FAILURE"));
-        let expected_outcome = if skipped_file_count == 0 && !has_analysis_failure {
-            AgentSemanticAnalysisOutcome::Complete
-        } else {
-            AgentSemanticAnalysisOutcome::Incomplete
+        let visible_evidence_is_incomplete = skipped_file_count > 0 || has_analysis_failure;
+        let semantic_outcome_is_valid = match self.summary.semantic_outcome {
+            AgentSemanticAnalysisOutcome::Complete => !visible_evidence_is_incomplete,
+            AgentSemanticAnalysisOutcome::Incomplete => {
+                visible_evidence_is_incomplete
+                    || self.page.as_ref().is_some_and(|page| page.truncated)
+            }
         };
 
         if self.summary.requested_file_count != requested_file_paths.len()
             || self.summary.requested_file_count != self.file_statuses.len()
             || self.summary.analyzed_file_count != analyzed_file_count
             || self.summary.skipped_file_count != skipped_file_count
-            || self.summary.semantic_outcome != expected_outcome
+            || !semantic_outcome_is_valid
         {
             return None;
         }

--- a/cli-rs/tests/agent_diagnostics_smoke.rs
+++ b/cli-rs/tests/agent_diagnostics_smoke.rs
@@ -153,6 +153,32 @@ fn analysis_failure_diagnostic_fails_closed_without_completeness_fields() {
     );
 }
 
+#[test]
+fn malformed_completeness_evidence_fails_closed() {
+    let (output, methods) = run_single_json_scenario(
+        "Malformed.kt",
+        "fun malformed(): Int = 42\n",
+        malformed_completeness_evidence,
+    );
+    let document = decode_json(&output);
+
+    assert_eq!(
+        methods,
+        [
+            "runtime/status",
+            "capabilities",
+            "raw/workspace-refresh",
+            "raw/diagnostics"
+        ],
+    );
+    assert!(!output.status.success(), "{document:#}");
+    assert_eq!(document["ok"], false, "{document:#}");
+    assert_eq!(
+        document["result"]["steps"][1]["error"]["code"], "SEMANTIC_ANALYSIS_INVALID",
+        "{document:#}",
+    );
+}
+
 fn run_single_json_scenario(
     file_name: &str,
     source: &str,
@@ -431,6 +457,21 @@ fn legacy_analysis_failure(file: &Path) -> Value {
             "message": "Backend failed before completeness fields were produced",
             "code": "ANALYSIS_FAILURE"
         }],
+        "schemaVersion": 3
+    })
+}
+
+fn malformed_completeness_evidence(file: &Path) -> Value {
+    json!({
+        "diagnostics": [],
+        "fileStatuses": [{
+            "filePath": file.display().to_string(),
+            "state": "ANALYZED"
+        }],
+        "semanticOutcome": "COMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 0,
+        "skippedFileCount": 0,
         "schemaVersion": 3
     })
 }

--- a/cli-rs/tests/agent_diagnostics_smoke.rs
+++ b/cli-rs/tests/agent_diagnostics_smoke.rs
@@ -128,38 +128,48 @@ fn clean_file_remains_a_successful_complete_analysis() {
 }
 
 #[test]
-fn analysis_failure_diagnostic_fails_closed_without_completeness_fields() {
-    let (output, methods) = run_single_json_scenario(
-        "Legacy.kt",
-        "fun legacy(): Int = 42\n",
-        legacy_analysis_failure,
-    );
-    let document = decode_json(&output);
+fn omitted_completeness_proof_fails_closed() {
+    assert_invalid_semantic_evidence("Omitted.kt", omitted_completeness_proof);
+}
 
-    assert_eq!(
-        methods,
-        [
-            "runtime/status",
-            "capabilities",
-            "raw/workspace-refresh",
-            "raw/diagnostics"
-        ],
-    );
-    assert!(!output.status.success(), "{document:#}");
-    assert_eq!(document["ok"], false, "{document:#}");
-    assert_eq!(
-        document["result"]["steps"][1]["error"]["code"], "SEMANTIC_ANALYSIS_FAILED",
-        "{document:#}",
-    );
+#[test]
+fn complete_outcome_with_a_skipped_file_fails_closed() {
+    assert_invalid_semantic_evidence("Skipped.kt", complete_outcome_with_skipped_file);
+}
+
+#[test]
+fn missing_file_status_ledger_fails_closed() {
+    assert_invalid_semantic_evidence("MissingLedger.kt", missing_file_status_ledger);
+}
+
+#[test]
+fn mismatched_file_status_ledger_fails_closed() {
+    assert_invalid_semantic_evidence("MismatchedLedger.kt", mismatched_file_status_ledger);
+}
+
+#[test]
+fn unknown_file_analysis_state_fails_closed() {
+    assert_invalid_semantic_evidence("UnknownState.kt", unknown_file_analysis_state);
+}
+
+#[test]
+fn malformed_diagnostic_code_fails_closed() {
+    assert_invalid_semantic_evidence("MalformedCode.kt", malformed_diagnostic_code);
+}
+
+#[test]
+fn malformed_diagnostic_structure_fails_closed() {
+    assert_invalid_semantic_evidence("MalformedDiagnostic.kt", malformed_diagnostic_structure);
 }
 
 #[test]
 fn malformed_completeness_evidence_fails_closed() {
-    let (output, methods) = run_single_json_scenario(
-        "Malformed.kt",
-        "fun malformed(): Int = 42\n",
-        malformed_completeness_evidence,
-    );
+    assert_invalid_semantic_evidence("Malformed.kt", malformed_completeness_evidence);
+}
+
+fn assert_invalid_semantic_evidence(file_name: &str, diagnostics: fn(&Path) -> Value) {
+    let (output, methods) =
+        run_single_json_scenario(file_name, "fun valid(): Int = 42\n", diagnostics);
     let document = decode_json(&output);
 
     assert_eq!(
@@ -449,14 +459,105 @@ fn complete_clean_diagnostics(file: &Path) -> Value {
     })
 }
 
-fn legacy_analysis_failure(file: &Path) -> Value {
+fn omitted_completeness_proof(_file: &Path) -> Value {
+    json!({
+        "diagnostics": [],
+        "schemaVersion": 3
+    })
+}
+
+fn complete_outcome_with_skipped_file(file: &Path) -> Value {
+    json!({
+        "diagnostics": [],
+        "fileStatuses": [{
+            "filePath": file.display().to_string(),
+            "state": "MISSING_ON_DISK",
+            "message": "File not found"
+        }],
+        "semanticOutcome": "COMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 0,
+        "skippedFileCount": 1,
+        "schemaVersion": 3
+    })
+}
+
+fn missing_file_status_ledger(_file: &Path) -> Value {
+    json!({
+        "diagnostics": [],
+        "semanticOutcome": "COMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 1,
+        "skippedFileCount": 0,
+        "schemaVersion": 3
+    })
+}
+
+fn mismatched_file_status_ledger(file: &Path) -> Value {
+    json!({
+        "diagnostics": [],
+        "fileStatuses": [{
+            "filePath": file.display().to_string(),
+            "state": "ANALYZED"
+        }],
+        "semanticOutcome": "INCOMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 0,
+        "skippedFileCount": 1,
+        "schemaVersion": 3
+    })
+}
+
+fn unknown_file_analysis_state(file: &Path) -> Value {
+    json!({
+        "diagnostics": [],
+        "fileStatuses": [{
+            "filePath": file.display().to_string(),
+            "state": "NOT_A_STATE"
+        }],
+        "semanticOutcome": "COMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 1,
+        "skippedFileCount": 0,
+        "schemaVersion": 3
+    })
+}
+
+fn malformed_diagnostic_code(file: &Path) -> Value {
     json!({
         "diagnostics": [{
             "location": diagnostic_location(file),
             "severity": "ERROR",
-            "message": "Backend failed before completeness fields were produced",
-            "code": "ANALYSIS_FAILURE"
+            "message": "Malformed code",
+            "code": 42
         }],
+        "fileStatuses": [{
+            "filePath": file.display().to_string(),
+            "state": "ANALYZED"
+        }],
+        "semanticOutcome": "COMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 1,
+        "skippedFileCount": 0,
+        "schemaVersion": 3
+    })
+}
+
+fn malformed_diagnostic_structure(file: &Path) -> Value {
+    json!({
+        "diagnostics": [{
+            "severity": "ERROR",
+            "message": "Missing location",
+            "code": "TYPE_MISMATCH"
+        }],
+        "fileStatuses": [{
+            "filePath": file.display().to_string(),
+            "state": "ANALYZED"
+        }],
+        "semanticOutcome": "COMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 1,
+        "skippedFileCount": 0,
         "schemaVersion": 3
     })
 }

--- a/cli-rs/tests/agent_diagnostics_smoke.rs
+++ b/cli-rs/tests/agent_diagnostics_smoke.rs
@@ -1,0 +1,447 @@
+mod support;
+
+use serde_json::{Value, json};
+use std::process::Output;
+use std::time::{Duration, Instant};
+use support::*;
+
+#[test]
+fn incomplete_semantic_analysis_fails_closed_in_every_output_format() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let file = workspace.join("src/Missing.kt");
+    std::fs::create_dir_all(file.parent().expect("source parent")).expect("source dir");
+    std::fs::create_dir_all(&home).expect("home");
+    write_macos_plugin_workspace_metadata(&workspace);
+
+    let socket_path = workspace_socket_path(&workspace, temp.path());
+    write_descriptor(&home, &workspace, &socket_path);
+    let listener = bind_listener(&socket_path);
+    let backend = spawn_fake_backend(
+        listener,
+        workspace.clone(),
+        incomplete_diagnostics(&file),
+        12,
+    );
+
+    let json_output = run_diagnostics(&home, &config_home, &workspace, &file, "json");
+    let human_output = run_diagnostics(&home, &config_home, &workspace, &file, "human");
+    let toon_output = run_diagnostics(&home, &config_home, &workspace, &file, "toon");
+    let methods = backend.join().expect("fake diagnostics backend");
+
+    assert_eq!(
+        methods,
+        [
+            "runtime/status",
+            "capabilities",
+            "raw/workspace-refresh",
+            "raw/diagnostics"
+        ]
+        .repeat(3),
+    );
+    for (format, output, document) in [
+        ("json", &json_output, decode_json(&json_output)),
+        ("human", &human_output, decode_json(&human_output)),
+        ("toon", &toon_output, decode_toon(&toon_output)),
+    ] {
+        assert!(
+            !output.status.success(),
+            "{format} diagnostics must fail closed: stdout={}, stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(document["ok"], false, "{format}: {document:#}");
+        assert_eq!(document["result"]["ok"], false, "{format}: {document:#}");
+        assert_eq!(
+            document["result"]["steps"][0]["name"], "workspace-refresh",
+            "{format}: {document:#}",
+        );
+        assert_eq!(
+            document["result"]["steps"][0]["ok"], true,
+            "{format}: {document:#}",
+        );
+        assert_eq!(
+            document["result"]["steps"][1]["error"]["code"], "SEMANTIC_ANALYSIS_INCOMPLETE",
+            "{format}: {document:#}",
+        );
+        assert_semantic_counts(&document, "INCOMPLETE", 1, 0, 1, format);
+    }
+}
+
+#[test]
+fn ordinary_compiler_diagnostic_remains_a_successful_complete_analysis() {
+    let (output, methods) = run_single_json_scenario(
+        "Broken.kt",
+        "fun broken(): Int = \"nope\"\n",
+        complete_compiler_diagnostics,
+    );
+    let document = decode_json(&output);
+
+    assert_eq!(
+        methods,
+        [
+            "runtime/status",
+            "capabilities",
+            "raw/workspace-refresh",
+            "raw/diagnostics"
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "ordinary compiler diagnostics retain successful semantic analysis: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(document["ok"], true, "{document:#}");
+    assert_eq!(document["result"]["steps"][1]["ok"], true, "{document:#}");
+    assert_semantic_counts(&document, "COMPLETE", 1, 1, 0, "json");
+}
+
+#[test]
+fn clean_file_remains_a_successful_complete_analysis() {
+    let (output, methods) = run_single_json_scenario(
+        "Clean.kt",
+        "fun clean(): Int = 42\n",
+        complete_clean_diagnostics,
+    );
+    let document = decode_json(&output);
+
+    assert_eq!(
+        methods,
+        [
+            "runtime/status",
+            "capabilities",
+            "raw/workspace-refresh",
+            "raw/diagnostics"
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "clean analysis should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(document["ok"], true, "{document:#}");
+    assert_semantic_counts(&document, "COMPLETE", 1, 1, 0, "json");
+}
+
+#[test]
+fn analysis_failure_diagnostic_fails_closed_without_completeness_fields() {
+    let (output, methods) = run_single_json_scenario(
+        "Legacy.kt",
+        "fun legacy(): Int = 42\n",
+        legacy_analysis_failure,
+    );
+    let document = decode_json(&output);
+
+    assert_eq!(
+        methods,
+        [
+            "runtime/status",
+            "capabilities",
+            "raw/workspace-refresh",
+            "raw/diagnostics"
+        ],
+    );
+    assert!(!output.status.success(), "{document:#}");
+    assert_eq!(document["ok"], false, "{document:#}");
+    assert_eq!(
+        document["result"]["steps"][1]["error"]["code"], "SEMANTIC_ANALYSIS_FAILED",
+        "{document:#}",
+    );
+}
+
+fn run_single_json_scenario(
+    file_name: &str,
+    source: &str,
+    diagnostics: fn(&Path) -> Value,
+) -> (Output, Vec<String>) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let file = workspace.join("src").join(file_name);
+    std::fs::create_dir_all(file.parent().expect("source parent")).expect("source dir");
+    std::fs::write(&file, source).expect("scenario source");
+    std::fs::create_dir_all(&home).expect("home");
+    write_macos_plugin_workspace_metadata(&workspace);
+
+    let socket_path = workspace_socket_path(&workspace, temp.path());
+    write_descriptor(&home, &workspace, &socket_path);
+    let listener = bind_listener(&socket_path);
+    let backend = spawn_fake_backend(listener, workspace.clone(), diagnostics(&file), 4);
+    let output = run_diagnostics(&home, &config_home, &workspace, &file, "json");
+    let methods = backend.join().expect("fake diagnostics backend");
+    (output, methods)
+}
+
+fn run_diagnostics(
+    home: &Path,
+    config_home: &Path,
+    workspace: &Path,
+    file: &Path,
+    output_format: &str,
+) -> Output {
+    kast(home, config_home)
+        .args([
+            "--output",
+            output_format,
+            "agent",
+            "diagnostics",
+            "--workspace-root",
+            workspace.to_str().expect("workspace path"),
+            "--file-path",
+            file.to_str().expect("file path"),
+        ])
+        .output()
+        .expect("agent diagnostics")
+}
+
+fn decode_json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "decode JSON output: {error}; stdout={}",
+            String::from_utf8_lossy(&output.stdout),
+        )
+    })
+}
+
+fn decode_toon(output: &Output) -> Value {
+    let text = std::str::from_utf8(&output.stdout).expect("TOON output is UTF-8");
+    toon_format::decode_default(text.trim()).expect("decode TOON output")
+}
+
+fn assert_semantic_counts(
+    document: &Value,
+    outcome: &str,
+    requested: u64,
+    analyzed: u64,
+    skipped: u64,
+    format: &str,
+) {
+    let summary = &document["result"]["semanticAnalysis"];
+    assert_eq!(
+        summary["semanticOutcome"], outcome,
+        "{format}: {document:#}"
+    );
+    assert_eq!(
+        summary["requestedFileCount"], requested,
+        "{format}: {document:#}"
+    );
+    assert_eq!(
+        summary["analyzedFileCount"], analyzed,
+        "{format}: {document:#}"
+    );
+    assert_eq!(
+        summary["skippedFileCount"], skipped,
+        "{format}: {document:#}"
+    );
+}
+
+fn workspace_socket_path(workspace: &Path, _temp_root: &Path) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        let metadata = std::fs::read_to_string(workspace.join(".kast/setup/workspace.json"))
+            .expect("plugin workspace metadata");
+        let metadata: Value = serde_json::from_str(&metadata).expect("workspace metadata JSON");
+        PathBuf::from(
+            metadata["socketPath"]
+                .as_str()
+                .expect("metadata socketPath"),
+        )
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = workspace;
+        _temp_root.join("diagnostics.sock")
+    }
+}
+
+fn write_descriptor(home: &Path, workspace: &Path, socket_path: &Path) {
+    let descriptor_dir = default_descriptor_dir(home);
+    std::fs::create_dir_all(&descriptor_dir).expect("descriptor dir");
+    std::fs::write(
+        descriptor_dir.join("daemons.json"),
+        serde_json::to_vec_pretty(&json!([{
+            "workspaceRoot": workspace.display().to_string(),
+            "backendName": "idea",
+            "backendVersion": "diagnostics-test",
+            "transport": "uds",
+            "socketPath": socket_path.display().to_string(),
+            "pid": std::process::id(),
+            "schemaVersion": 3
+        }]))
+        .expect("descriptor JSON"),
+    )
+    .expect("descriptor");
+}
+
+fn bind_listener(socket_path: &Path) -> UnixListener {
+    if socket_path.exists() {
+        std::fs::remove_file(socket_path).expect("remove stale test socket");
+    }
+    UnixListener::bind(socket_path).expect("bind fake diagnostics socket")
+}
+
+fn spawn_fake_backend(
+    listener: UnixListener,
+    workspace: PathBuf,
+    diagnostics: Value,
+    expected_requests: usize,
+) -> std::thread::JoinHandle<Vec<String>> {
+    listener
+        .set_nonblocking(true)
+        .expect("nonblocking listener");
+    thread::spawn(move || {
+        let mut methods = Vec::with_capacity(expected_requests);
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while methods.len() < expected_requests && Instant::now() < deadline {
+            let (mut stream, _) = match listener.accept() {
+                Ok(connection) => connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                    continue;
+                }
+                Err(error) => panic!("accept fake diagnostics client: {error}"),
+            };
+            let mut reader = BufReader::new(stream.try_clone().expect("clone diagnostics stream"));
+            let mut request_line = String::new();
+            reader
+                .read_line(&mut request_line)
+                .expect("read diagnostics request");
+            let request: Value =
+                serde_json::from_str(&request_line).expect("diagnostics request JSON");
+            let method = request["method"]
+                .as_str()
+                .expect("request method")
+                .to_string();
+            methods.push(method.clone());
+            let result = match method.as_str() {
+                "runtime/status" => json!({
+                    "state": "READY",
+                    "healthy": true,
+                    "active": true,
+                    "indexing": false,
+                    "backendName": "idea",
+                    "backendVersion": "diagnostics-test",
+                    "workspaceRoot": workspace.display().to_string(),
+                    "schemaVersion": 3
+                }),
+                "capabilities" => json!({
+                    "backendName": "idea",
+                    "backendVersion": "diagnostics-test",
+                    "workspaceRoot": workspace.display().to_string(),
+                    "readCapabilities": ["DIAGNOSTICS"],
+                    "mutationCapabilities": ["REFRESH_WORKSPACE"],
+                    "limits": {
+                        "requestTimeoutMillis": 60000,
+                        "maxResults": 1000,
+                        "maxConcurrentRequests": 4
+                    },
+                    "schemaVersion": 3
+                }),
+                "raw/workspace-refresh" => json!({
+                    "refreshedFiles": request["params"]["filePaths"],
+                    "removedFiles": [],
+                    "fullRefresh": false,
+                    "schemaVersion": 3
+                }),
+                "raw/diagnostics" => diagnostics.clone(),
+                other => panic!("unexpected fake diagnostics method: {other}"),
+            };
+            writeln!(
+                stream,
+                "{}",
+                json!({"jsonrpc": "2.0", "id": request["id"], "result": result}),
+            )
+            .expect("write diagnostics response");
+        }
+        assert_eq!(
+            methods.len(),
+            expected_requests,
+            "fake backend request timeout"
+        );
+        methods
+    })
+}
+
+fn incomplete_diagnostics(file: &Path) -> Value {
+    json!({
+        "diagnostics": [{
+            "location": diagnostic_location(file),
+            "severity": "ERROR",
+            "message": "File not found after refresh",
+            "code": "ANALYSIS_FAILURE"
+        }],
+        "fileStatuses": [{
+            "filePath": file.display().to_string(),
+            "state": "MISSING_ON_DISK",
+            "message": "File not found after refresh"
+        }],
+        "semanticOutcome": "INCOMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 0,
+        "skippedFileCount": 1,
+        "schemaVersion": 3
+    })
+}
+
+fn complete_compiler_diagnostics(file: &Path) -> Value {
+    json!({
+        "diagnostics": [{
+            "location": diagnostic_location(file),
+            "severity": "ERROR",
+            "message": "Type mismatch",
+            "code": "TYPE_MISMATCH"
+        }],
+        "fileStatuses": [{
+            "filePath": file.display().to_string(),
+            "state": "ANALYZED"
+        }],
+        "semanticOutcome": "COMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 1,
+        "skippedFileCount": 0,
+        "schemaVersion": 3
+    })
+}
+
+fn complete_clean_diagnostics(file: &Path) -> Value {
+    json!({
+        "diagnostics": [],
+        "fileStatuses": [{
+            "filePath": file.display().to_string(),
+            "state": "ANALYZED"
+        }],
+        "semanticOutcome": "COMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 1,
+        "skippedFileCount": 0,
+        "schemaVersion": 3
+    })
+}
+
+fn legacy_analysis_failure(file: &Path) -> Value {
+    json!({
+        "diagnostics": [{
+            "location": diagnostic_location(file),
+            "severity": "ERROR",
+            "message": "Backend failed before completeness fields were produced",
+            "code": "ANALYSIS_FAILURE"
+        }],
+        "schemaVersion": 3
+    })
+}
+
+fn diagnostic_location(file: &Path) -> Value {
+    json!({
+        "filePath": file.display().to_string(),
+        "startOffset": 0,
+        "endOffset": 0,
+        "startLine": 0,
+        "startColumn": 0,
+        "preview": ""
+    })
+}

--- a/cli-rs/tests/agent_diagnostics_smoke.rs
+++ b/cli-rs/tests/agent_diagnostics_smoke.rs
@@ -128,6 +128,54 @@ fn clean_file_remains_a_successful_complete_analysis() {
 }
 
 #[test]
+fn truncated_page_can_hide_analysis_failure_without_invalidating_evidence() {
+    let (output, methods) = run_single_json_scenario(
+        "Truncated.kt",
+        "fun truncated(): Int = 42\n",
+        incomplete_diagnostics_with_truncated_page,
+    );
+    let document = decode_json(&output);
+
+    assert_eq!(
+        methods,
+        [
+            "runtime/status",
+            "capabilities",
+            "raw/workspace-refresh",
+            "raw/diagnostics"
+        ],
+    );
+    assert!(!output.status.success(), "{document:#}");
+    assert_eq!(document["ok"], false, "{document:#}");
+    assert_eq!(
+        document["result"]["steps"][1]["error"]["code"], "SEMANTIC_ANALYSIS_INCOMPLETE",
+        "{document:#}",
+    );
+    assert_semantic_counts(&document, "INCOMPLETE", 1, 1, 0, "json");
+}
+
+#[test]
+fn untruncated_page_cannot_explain_incomplete_outcome() {
+    assert_invalid_semantic_evidence(
+        "Untruncated.kt",
+        incomplete_diagnostics_with_untruncated_page,
+    );
+}
+
+#[test]
+fn absent_page_cannot_explain_incomplete_outcome() {
+    assert_invalid_semantic_evidence("NoPage.kt", incomplete_diagnostics_without_page);
+}
+
+#[test]
+fn malformed_page_cannot_explain_incomplete_outcome() {
+    assert_invalid_semantic_evidence(
+        "MalformedPage.kt",
+        incomplete_diagnostics_with_malformed_page,
+    );
+}
+
+#[test]
 fn omitted_completeness_proof_fails_closed() {
     assert_invalid_semantic_evidence("Omitted.kt", omitted_completeness_proof);
 }
@@ -457,6 +505,63 @@ fn complete_clean_diagnostics(file: &Path) -> Value {
         "skippedFileCount": 0,
         "schemaVersion": 3
     })
+}
+
+fn incomplete_diagnostics_with_truncated_page(file: &Path) -> Value {
+    incomplete_diagnostics_with_page(
+        file,
+        Some(json!({
+            "truncated": true,
+            "nextPageToken": "0"
+        })),
+    )
+}
+
+fn incomplete_diagnostics_with_untruncated_page(file: &Path) -> Value {
+    incomplete_diagnostics_with_page(
+        file,
+        Some(json!({
+            "truncated": false
+        })),
+    )
+}
+
+fn incomplete_diagnostics_without_page(file: &Path) -> Value {
+    incomplete_diagnostics_with_page(file, None)
+}
+
+fn incomplete_diagnostics_with_malformed_page(file: &Path) -> Value {
+    incomplete_diagnostics_with_page(
+        file,
+        Some(json!({
+            "truncated": true,
+            "nextPageToken": 0
+        })),
+    )
+}
+
+fn incomplete_diagnostics_with_page(file: &Path, page: Option<Value>) -> Value {
+    let mut result = json!({
+        "diagnostics": [{
+            "location": diagnostic_location(file),
+            "severity": "WARNING",
+            "message": "Visible warning before hidden analysis failure",
+            "code": "VISIBLE_WARNING"
+        }],
+        "fileStatuses": [{
+            "filePath": file.display().to_string(),
+            "state": "ANALYZED"
+        }],
+        "semanticOutcome": "INCOMPLETE",
+        "requestedFileCount": 1,
+        "analyzedFileCount": 1,
+        "skippedFileCount": 0,
+        "schemaVersion": 3
+    });
+    if let Some(page) = page {
+        result["page"] = page;
+    }
+    result
 }
 
 fn omitted_completeness_proof(_file: &Path) -> Value {


### PR DESCRIPTION
## What changed

- model per-file semantic analysis completeness as typed API outcomes
- classify IDEA diagnostics queries as analyzed, pending index, outside source modules, missing on disk, or backend failure
- propagate aggregate completeness and file-state counts through JSON-RPC and mutation responses
- make `kast agent diagnostics` fail closed with a non-zero exit for incomplete, failed, or malformed semantic evidence
- expose the same completeness counts in human, JSON, and TOON output
- regenerate diagnostics examples, API reference content, capabilities, and OpenAPI schema

## Why

Runtime readiness and request-specific semantic completeness were previously conflated. A reachable backend could return partial or failed analysis while the CLI still appeared successful, leaving agents unable to distinguish complete evidence from missing proof.

This change makes completeness explicit at every boundary and treats absent or malformed proof as a typed failure.

## Validation

- `./gradlew test`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check`
- `.github/scripts/test-docs-content-contract.sh`
- `zensical build --clean`

Closes #332
