### PR TITLE
feat: make semantic mutations observable

### DIFF
--- a/.agents/adr/0015-observable-semantic-mutation-lifecycle.md
+++ b/.agents/adr/0015-observable-semantic-mutation-lifecycle.md
@@ -1,0 +1,99 @@
+# ADR 0015: Observable semantic mutation lifecycle
+
+Status: Accepted
+
+Date: 2026-07-13
+
+This ADR supersedes ADR 0006 and ADR 0009 only for execution of public typed
+semantic mutations. Their plan-first command boundary, hidden raw transport,
+and remaining product rules stay authoritative.
+
+## Decision
+
+Every public `kast agent` semantic mutation that crosses the `--apply` gate is
+an asynchronous, server-owned operation. Submission requires a caller-chosen
+idempotency key and immediately returns a stable operation ID. The backend
+continues execution independently of the submitting shell process, and callers
+can reconnect to query status, retrieve the retained terminal result, or
+request cancellation.
+
+The contract covers rename, add-file, add-declaration, add-implementation,
+add-statement, and replace-declaration. Planning remains read-only and does not
+require an idempotency key.
+
+`kast agent operation status` and `kast agent operation cancel` accept exactly
+one stable selector: an operation ID or its idempotency key. Status and cancel
+requests are idempotent. A successful submission, retry, status response, and
+cancellation acknowledgement expose both identifiers.
+
+## Idempotency binding
+
+The server binds an idempotency key atomically to a canonical fingerprint made
+from the JSON-RPC method and normalized typed request payload after removing
+the idempotency key. Repeating the same key and fingerprint always returns the
+same operation ID and retained state or result. Reusing the key for a different
+fingerprint is a typed conflict and never starts another mutation.
+
+The registry is authoritative for the lifetime of the backend daemon. This
+decision does not add persistence across daemon restart. If the daemon loses
+its registry, prior operation state is ambiguous rather than assumed failed or
+safe to replay.
+
+## Lifecycle and progress
+
+Operation status is a closed set: queued, applying, validating, completed,
+failed, or cancelled. Progress uses typed stages for identity resolution, edit
+application, workspace refresh, import optimization, and diagnostics.
+
+The server records the latest entered stage before invoking that stage. It
+also records whether edit application began and whether it completed, so a
+later validation failure or cancellation cannot imply that no write occurred.
+Completed and failed outcomes retain the typed mutation result or typed error.
+
+Cancellation is request and acknowledgement based. A cancellation request
+sets a cancellation-requested fact and signals the running coroutine. The
+operation becomes terminal `cancelled` only after execution cooperatively
+stops. If edit application completed before cancellation was observed, the
+terminal outcome retains that fact. The server never publishes cancellation as
+proof that the workspace was untouched.
+
+## Filesystem fallback
+
+Filesystem fallback is safe only when a successfully queried operation state
+proves edit application never began. Completed operations, operations that
+entered edit application, missing operation state after daemon restart, and
+unreachable operation state after disconnect are not safe fallback signals.
+In those cases callers must recover the backend state and inspect the retained
+result or workspace before deciding on another mutation.
+
+## Source of truth
+
+| Layer | Owner |
+| --- | --- |
+| Identifiers, lifecycle, progress, selectors, receipts, and terminal outcomes | `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/` |
+| Atomic key binding, operation execution, status, cancellation, and result retention | `analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/` |
+| Public `--idempotency-key` and operation commands | `cli-rs/src/cli/agent.rs`, `cli-rs/src/agent/` |
+| Public recovery and fallback guidance | `docs/reference/agent-commands.md`, `docs/reference/mutation-selectors.md`, `cli-rs/resources/kast-skill/` |
+
+## Validation
+
+```console
+./gradlew :analysis-api:test :analysis-server:test
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_command_surface_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked
+.github/scripts/test-docs-content-contract.sh
+.github/scripts/test-docs-navigation-contract.sh
+git diff --check
+```
+
+The server tests must cover an operation longer than ten seconds, disconnect
+and reconnect, same-key retry, different-payload conflict, cancellation before
+and after edit application, idempotent status and cancellation, progress
+transitions, and terminal result retrieval.
+
+## Change rule
+
+Further mutation-lifecycle expansion must preserve atomic key binding, truthful
+edit-application facts, typed terminal outcomes, and plan-first `--apply`
+gating. Adding daemon-restart durability requires a superseding ADR that owns
+the persistence, retention, schema migration, and crash-recovery contract.

--- a/.agents/superpowers/plans/2026-07-13-observable-semantic-mutations.md
+++ b/.agents/superpowers/plans/2026-07-13-observable-semantic-mutations.md
@@ -1,0 +1,479 @@
+# Observable Semantic Mutations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This issue explicitly forbids subagent delegation, so execution stays inline.
+
+**Goal:** Give every public applied semantic mutation a stable idempotent operation lifecycle that remains queryable and cancellable after the submitting client disconnects.
+
+**Architecture:** Add host-agnostic sealed mutation lifecycle contracts in `analysis-api`, then run typed mutation variants through an atomic daemon-resident registry in `analysis-server`. The Rust CLI keeps read-only plans unchanged, requires a caller key at the `--apply` boundary, submits work asynchronously, and exposes typed operation status and cancellation commands; authored catalog and guidance sources then regenerate their owned artifacts.
+
+**Tech Stack:** Kotlin, kotlinx.serialization, kotlinx.coroutines, JUnit Jupiter, Gradle, Rust 2024, Clap, Serde, Cargo, Zensical.
+
+## Global Constraints
+
+- Cover rename, add-file, add-declaration, add-implementation, add-statement, and replace-declaration.
+- A key binds atomically to the actual symbol method plus canonical normalized payload excluding the key.
+- Same key and fingerprint returns one operation ID and retained state; another fingerprint returns typed conflict before mutation.
+- Cancellation becomes terminal only after the worker cooperatively stops.
+- Preserve edit-application started/completed facts through validation failure and cancellation.
+- Status and cancel are idempotent and accept exactly one operation ID or idempotency-key selector.
+- Retain typed terminal results for the backend daemon lifetime; daemon-restart durability remains unsupported and ambiguous.
+- Filesystem fallback is safe only when successfully retrieved terminal state proves edit application never began.
+- Keep one non-private top-level production Kotlin type per same-named file; direct sealed variants stay with their root.
+- Treat `cli-rs/resources/kast-skill/references/commands.json` as catalog source and regenerate YAML/request schemas/samples.
+- Do not push or open a pull request.
+
+---
+
+### Task 1: Add the host-agnostic lifecycle contract
+
+**Files:**
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationId.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationIdempotencyKey.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastSemanticMutationKind.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastSemanticMutation.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationSelector.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationProgressStage.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationEditApplicationState.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationExecutionTrace.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastSemanticMutationResult.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationFailure.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationState.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationSnapshot.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationSubmissionReceipt.kt`
+- Test: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationContractTest.kt`
+
+**Interfaces:**
+- Produces a UUID-shaped serializable `KastMutationOperationId` and a
+  serializable `KastMutationIdempotencyKey` whose trimmed length is 1 through
+  128 characters.
+- Produces `KastSemanticMutation` with nested `Rename`, `AddFile`, `AddDeclaration`, `AddImplementation`, `AddStatement`, and `ReplaceDeclaration` request variants.
+- Produces `KastMutationOperationSelector.ByOperationId` and `.ByIdempotencyKey`.
+- Produces a sealed state machine whose direct variants are `Queued`, `Applying`, `Validating`, `Completed`, `Failed`, and `Cancelled`.
+- Produces typed `KastSemanticMutationResult` and `KastMutationFailure` variants rather than string-tagged payloads.
+
+- [ ] **Step 1: Write failing serialization and invariant tests**
+
+Add tests that construct all six mutation variants, serialize their stable type discriminators, round-trip both selectors, reject blank/oversized idempotency keys and malformed operation IDs, and assert that terminal states require a typed result, failure, or cancelled outcome.
+
+Representative assertions:
+
+```kotlin
+val encoded = json.encodeToJsonElement(
+    KastSemanticMutation.serializer(),
+    KastSemanticMutation.AddFile(
+        idempotencyKey = KastMutationIdempotencyKey("issue-333-add-file"),
+        request = KastAddFileRequest(filePath = "/workspace/Added.kt", contentFile = "/tmp/Added.kt"),
+    ),
+).jsonObject
+assertEquals(JsonPrimitive("ADD_FILE"), encoded["type"])
+assertFailsWith<IllegalArgumentException> { KastMutationIdempotencyKey(" ") }
+assertFailsWith<IllegalArgumentException> { KastMutationOperationId("not-a-uuid") }
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```console
+./gradlew :analysis-api:test --tests io.github.amichne.kast.api.contract.mutation.KastMutationContractTest
+```
+
+Expected: test compilation fails because the mutation lifecycle package does not exist.
+
+- [ ] **Step 3: Implement the minimal sealed contract**
+
+Use serializable value classes and sealed roots. `KastMutationOperationState` carries a `KastMutationExecutionTrace` in every variant and no nullable terminal payload:
+
+```kotlin
+@Serializable
+sealed interface KastMutationOperationState {
+    val trace: KastMutationExecutionTrace
+    val cancellationRequested: Boolean
+
+    @Serializable @SerialName("QUEUED")
+    data class Queued(
+        override val trace: KastMutationExecutionTrace = KastMutationExecutionTrace(),
+        override val cancellationRequested: Boolean = false,
+    ) : KastMutationOperationState
+
+    @Serializable @SerialName("COMPLETED")
+    data class Completed(
+        val result: KastSemanticMutationResult,
+        override val trace: KastMutationExecutionTrace,
+        override val cancellationRequested: Boolean,
+    ) : KastMutationOperationState
+}
+```
+
+`Applying` and `Validating` require the active progress stage plus a trace.
+`Failed` requires a `KastMutationFailure`; `Cancelled` requires the last
+truthful trace; and both retain `cancellationRequested`. No active variant can
+carry a terminal result, and no terminal variant can omit its typed outcome.
+`KastMutationExecutionTrace` owns entered stages and one enum value
+`NOT_STARTED`, `STARTED`, or `COMPLETED`; it never exposes contradictory
+booleans.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the same Gradle command. Expected: all `KastMutationContractTest` cases pass.
+
+- [ ] **Step 5: Commit the contract slice**
+
+```console
+git add analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/mutation
+git diff --cached --check
+git commit -m "feat: model semantic mutation lifecycles"
+```
+
+### Task 2: Execute and retain operations in the backend daemon
+
+**Files:**
+- Create: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationFingerprint.kt`
+- Create: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationProgressEvent.kt`
+- Create: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationProgressReporter.kt`
+- Create: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistry.kt`
+- Create: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationOperationService.kt`
+- Modify: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt`
+- Modify: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt`
+- Test: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistryTest.kt`
+- Test: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationLifecycleTest.kt`
+- Modify: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt`
+
+**Interfaces:**
+- `MutationOperationRegistry.submit(mutation, fingerprint, execute)` atomically returns one `KastMutationSubmissionReceipt` per key/fingerprint.
+- `MutationOperationRegistry.status(selector)` and `.cancel(selector)` return the same immutable snapshot shape and are safe to retry.
+- `MutationProgressReporter.report(event)` receives `StageEntered` and `EditApplicationCompleted` events.
+- `MutationOperationService` canonicalizes decoded typed payloads, executes each mutation variant through `SkillRpcOrchestrator`, and converts reported failures and exceptions into typed terminal states.
+- JSON-RPC methods are `mutation/submit`, `mutation/status`, and `mutation/cancel`.
+
+- [ ] **Step 1: Write registry tests for atomic idempotency and truthful cancellation**
+
+Use `CompletableDeferred` gates and an injected operation-ID factory. Tests prove:
+
+```kotlin
+val first = registry.submit(mutation, fingerprint, execute)
+val retry = registry.submit(mutation, fingerprint, execute)
+assertEquals(first.operation.operationId, retry.operation.operationId)
+assertEquals(1, executionCount.get())
+assertFailsWith<MutationIdempotencyConflictException> {
+    registry.submit(otherMutationWithSameKey, otherFingerprint, execute)
+}
+```
+
+Cancellation tests block before edit application and after
+`EditApplicationCompleted`, call cancel twice, release or cancel the worker,
+await terminal state, and assert `Cancelled.trace.editApplicationState` is
+respectively `NOT_STARTED` or `COMPLETED`. The immediate cancel response may
+remain active with `cancellationRequested=true`; terminal cancellation is
+asserted only after the job completion callback runs.
+
+- [ ] **Step 2: Run registry tests and verify RED**
+
+```console
+./gradlew :analysis-server:test --tests io.github.amichne.kast.server.mutation.MutationOperationRegistryTest
+```
+
+Expected: test compilation fails because the registry does not exist.
+
+- [ ] **Step 3: Implement the atomic registry**
+
+Confine mutable entries to a private nested registry type and guard both maps
+and every state transition with one lock. Build the worker with a dispatcher-
+owned `CoroutineScope(SupervisorJob() + Dispatchers.Default)`. Start it once
+after the entry and job are installed. Register `invokeOnCompletion` so a
+cancelled job transitions to terminal `Cancelled` only after cooperative
+completion.
+
+Canonical fingerprint creation recursively sorts JSON object keys and hashes:
+
+```text
+<symbol-method>\n<normalized-typed-payload-without-idempotencyKey>
+```
+
+with SHA-256. A different fingerprint for an existing key throws a typed
+conflict before a job is created.
+
+- [ ] **Step 4: Run registry tests and verify GREEN**
+
+Run the same focused registry test. Expected: all idempotency, status,
+cancellation, and retention cases pass.
+
+- [ ] **Step 5: Write failing dispatcher/orchestrator lifecycle tests**
+
+Add tests that submit an add-file and a rename, poll by both selectors, and
+assert terminal typed results. A stage-gated backend verifies the retained
+stage order:
+
+```kotlin
+listOf(
+    KastMutationProgressStage.IDENTITY_RESOLUTION,
+    KastMutationProgressStage.EDIT_APPLICATION,
+    KastMutationProgressStage.WORKSPACE_REFRESH,
+    KastMutationProgressStage.IMPORT_OPTIMIZATION,
+    KastMutationProgressStage.DIAGNOSTICS,
+)
+```
+
+File creation omits identity resolution. A delayed backend blocks one
+operation for at least `10_100` milliseconds; submission must return in less
+than one second, and a later status call must retrieve the terminal result.
+
+- [ ] **Step 6: Run lifecycle tests and verify RED**
+
+```console
+./gradlew :analysis-server:test --tests io.github.amichne.kast.server.mutation.MutationOperationLifecycleTest
+```
+
+Expected: JSON-RPC methods are unknown and no progress reporter exists.
+
+- [ ] **Step 7: Wire the service, RPC methods, and actual progress boundaries**
+
+Add `mutation/submit`, `mutation/status`, and `mutation/cancel` to the
+dispatcher. The service passes a reporter into every public mutation path.
+`SkillRpcOrchestrator` reports identity resolution before named symbol/scope
+resolution, edit application immediately before the backend edit, edit
+completion immediately after it returns, explicit workspace refresh before
+import optimization, and diagnostics before terminal response construction.
+Call `ensureActive()` after recording edit completion so a cancellation that
+arrived during a non-cooperative backend write retains `COMPLETED` before the
+worker stops.
+
+- [ ] **Step 8: Verify lifecycle GREEN and socket reconnect behavior**
+
+Run the lifecycle test, then add and run a UDS test that submits without
+reading the response, reconnects, queries by idempotency key, releases the
+gated backend, and retrieves the terminal result:
+
+```console
+./gradlew :analysis-server:test --tests io.github.amichne.kast.server.mutation.MutationOperationLifecycleTest
+./gradlew :analysis-server:test --tests io.github.amichne.kast.server.AnalysisServerSocketTest
+```
+
+Expected: both classes pass, including the greater-than-ten-second and
+disconnect/reconnect scenarios.
+
+- [ ] **Step 9: Commit the daemon lifecycle slice**
+
+```console
+git add analysis-server analysis-api
+git diff --cached --check
+git commit -m "feat: retain observable mutation operations"
+```
+
+### Task 3: Expose idempotent apply, status, and cancellation in the AXI CLI
+
+**Files:**
+- Modify: `cli-rs/src/cli/agent.rs`
+- Modify: `cli-rs/src/agent.rs`
+- Modify: `cli-rs/src/agent/dispatch.rs`
+- Test: `cli-rs/tests/agent_command_surface_smoke.rs`
+- Create: `cli-rs/tests/agent_operation_surface_smoke.rs`
+- Modify: `cli-rs/resources/kast-skill/references/commands.json`
+- Generate: `cli-rs/resources/kast-skill/references/commands.yaml`
+- Generate: `cli-rs/resources/kast-skill/references/requests/mutation/submit/`
+- Generate: `cli-rs/resources/kast-skill/references/requests/mutation/status/`
+- Generate: `cli-rs/resources/kast-skill/references/requests/mutation/cancel/`
+- Modify/Generate: `cli-rs/protocol/api-specification.md`
+
+**Interfaces:**
+- Every public mutation args type flattens `AgentMutationApplyArgs { apply, idempotency_key }`.
+- `AgentCommand::Operation(AgentOperationArgs)` owns `Status` and `Cancel` subcommands.
+- The apply path sends a typed `mutation/submit` variant; the plan path retains its original typed `symbol/*` request.
+- Operation selector argument groups require exactly one `--operation-id` or `--idempotency-key`.
+
+- [ ] **Step 1: Write failing CLI command and request-shape tests**
+
+Extend the plan tests to prove plans remain read-only. Add tests that:
+
+- run every mutation with `--apply` but without `--idempotency-key` and receive
+  structured `AGENT_USAGE` before runtime discovery;
+- parse `kast agent operation status|cancel` with each selector and reject zero
+  or two selectors;
+- use a fake Unix socket backend to capture the request and assert apply emits
+  `mutation/submit` with the expected variant, key, and nested typed request;
+- assert status and cancel retries return backend-provided snapshots unchanged.
+
+- [ ] **Step 2: Run focused CLI tests and verify RED**
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_command_surface_smoke --test agent_operation_surface_smoke
+```
+
+Expected: `operation` is unknown and apply reaches runtime discovery instead
+of rejecting the missing idempotency key.
+
+- [ ] **Step 3: Implement the typed CLI boundary**
+
+Add `AgentMutationApplyArgs` and require a nonblank key inside dispatch only
+when `apply` is true. Build submission JSON in one owner:
+
+```rust
+json!({
+    "type": mutation_kind,
+    "idempotencyKey": idempotency_key,
+    "request": mutation_params,
+})
+```
+
+Use `mutation/submit`, `mutation/status`, and `mutation/cancel` only behind the
+typed public commands. Keep progress off stdout and preserve the existing
+structured `AgentEnvelope` output path for JSON and TOON.
+
+- [ ] **Step 4: Verify CLI GREEN**
+
+Run the same focused Cargo command. Expected: all plan, apply validation,
+request capture, status, cancellation, and selector cases pass.
+
+- [ ] **Step 5: Add catalog source entries and regenerate owned outputs**
+
+Add a `mutation` category with the three lifecycle methods. Define top-level
+variants for all six submit requests and both selector forms. Then run:
+
+```console
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract
+python3 .github/scripts/render-rpc-contract-summary.py --write
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+```
+
+Expected: YAML, schemas, samples, and generated summary match the authored JSON
+catalog.
+
+- [ ] **Step 6: Commit the CLI and generated contract slice**
+
+```console
+git add cli-rs/src cli-rs/tests cli-rs/resources/kast-skill/references cli-rs/protocol/api-specification.md
+git diff --cached --check
+git commit -m "feat: expose mutation operation controls"
+```
+
+### Task 4: Publish safe recovery and filesystem fallback guidance
+
+**Files:**
+- Modify: `docs/reference/agent-commands.md`
+- Modify: `docs/reference/mutation-selectors.md`
+- Modify: `docs/use/automate-with-agents.md`
+- Modify: `cli-rs/resources/kast-skill/SKILL.md`
+- Modify: `cli-rs/resources/kast-skill/references/quickstart.md`
+- Test: `cli-rs/tests/packaged_content_smoke.rs`
+
+**Interfaces:**
+- Public docs teach the typed command surface, not raw lifecycle RPC methods.
+- Packaged guidance requires a stable caller key, status before retry, and the
+  exact fallback safety boundary.
+
+- [ ] **Step 1: Add a failing packaged-content contract**
+
+Assert the packaged skill includes `kast agent operation status`,
+`--idempotency-key`, cancellation, and the rule that filesystem fallback is
+unsafe after edit application began or when daemon-restart state is missing.
+
+- [ ] **Step 2: Verify RED**
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
+```
+
+Expected: assertions fail because current skill guidance has no lifecycle or
+fallback contract.
+
+- [ ] **Step 3: Update authored public and packaged guidance**
+
+Document this recovery sequence without exposing raw methods:
+
+```console
+kast agent add-file ... --apply --idempotency-key <stable-key> --workspace-root "$PWD"
+kast agent operation status --idempotency-key <stable-key> --workspace-root "$PWD"
+kast agent operation cancel --operation-id <operation-id> --workspace-root "$PWD"
+```
+
+State that filesystem fallback requires a retrieved terminal failed/cancelled
+state with edit application `NOT_STARTED`; all active, completed,
+edit-started, unreachable, and post-restart-unknown states are unsafe or
+ambiguous.
+
+- [ ] **Step 4: Verify docs and packaged guidance GREEN**
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
+.github/scripts/test-docs-content-contract.sh
+.github/scripts/test-docs-navigation-contract.sh
+zensical build --clean
+```
+
+- [ ] **Step 5: Commit the guidance slice**
+
+```console
+git add docs cli-rs/resources/kast-skill cli-rs/tests/packaged_content_smoke.rs
+git diff --cached --check
+git commit -m "docs: define safe mutation recovery"
+```
+
+### Task 5: Review, validate, report, and hand off the committed branch
+
+**Files:**
+- Modify: `.agent-turn/issue-333-report.md`
+- Write: `.agent-turn/kotlin-agentic-correctness/<session>/scorecard.json`
+- Write: `.agent-turn/kotlin-agentic-correctness/<session>/evidence.jsonl`
+
+- [ ] **Step 1: Run Kotlin semantic diagnostics or retain the exact blocker**
+
+```console
+kast agent verify --workspace-root "$PWD"
+```
+
+If the plugin-owned isolated-worktree metadata remains unavailable, record
+`MACOS_PLUGIN_WORKSPACE_REQUIRED` and use focused/full Gradle compilation as
+the authoritative proof; do not run `kast setup`.
+
+- [ ] **Step 2: Run focused and full Kotlin validation**
+
+```console
+./gradlew :analysis-api:test :analysis-server:test
+./gradlew test
+```
+
+- [ ] **Step 3: Run full Rust and generated-contract validation**
+
+```console
+cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
+cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
+cargo test --manifest-path cli-rs/Cargo.toml --locked
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+python3 .github/scripts/render-rpc-contract-summary.py --check
+```
+
+- [ ] **Step 4: Run documentation, package, and diff gates**
+
+```console
+.github/scripts/test-kast-copilot-plugin.sh
+.github/scripts/test-lsp-pivot-gates.sh
+.github/scripts/test-docs-content-contract.sh
+.github/scripts/test-docs-navigation-contract.sh
+zensical build --clean
+git diff --check
+```
+
+- [ ] **Step 5: Review requirements and Kotlin scorecard**
+
+Re-read issue #333, ADR 0015, and this plan. Self-review the complete diff for
+double-apply races, cancellation timing, retained edit facts, selector
+validation, public/raw boundary leakage, one-type-per-file compliance, and
+generated ownership. Write the nine-dimension Kotlin Engineering scorecard;
+no dimension may be `Fail`.
+
+- [ ] **Step 6: Write the durable turn report**
+
+Write `.agent-turn/issue-333-report.md` with status, commit SHAs, commands and
+results, exact Kast blocker if present, acceptance-criterion evidence, and
+remaining concerns. The report stays untracked as requested.
+
+- [ ] **Step 7: Commit any final scoped corrections and verify clean handoff**
+
+```console
+git status --short --branch
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+```
+
+Do not push or create a pull request. Preserve the isolated worktree and branch
+for the parent agent's handoff.

--- a/.agents/superpowers/specs/2026-07-13-observable-semantic-mutations-design.md
+++ b/.agents/superpowers/specs/2026-07-13-observable-semantic-mutations-design.md
@@ -1,0 +1,209 @@
+# Observable Semantic Mutations Design
+
+**Status:** Approved
+
+**Date:** 2026-07-13
+
+## Purpose
+
+Make every public applied semantic mutation recoverable when the invoking
+agent process yields or disconnects before the mutation finishes. A caller
+must be able to distinguish latency from completion, failure, and cancellation
+without risking a duplicate edit.
+
+The design covers all current public `--apply` mutations: rename, add-file,
+add-declaration, add-implementation, add-statement, and replace-declaration.
+Read-only planning remains unchanged.
+
+## Considered approaches
+
+### Server-owned asynchronous operation registry
+
+The selected approach submits a typed mutation to the long-lived backend,
+atomically binds its idempotency key, and returns an operation receipt before
+execution proceeds. The backend owns execution, progress, cancellation, and
+terminal-result retention. Any later CLI process can reconnect to the same
+daemon and query by operation ID or idempotency key.
+
+This is the only option that decouples mutation lifetime from both the CLI
+process and the original transport connection while keeping compiler-backed
+execution in its existing owner.
+
+### CLI-owned background process and state files
+
+This approach would fork a CLI worker and persist state locally. It was
+rejected because shell yield, client death, and process supervision become
+part of the correctness boundary, while backend lifecycle and IDEA write
+access remain elsewhere.
+
+### Synchronous mutation plus a progress ledger
+
+This approach would record progress while retaining the current blocking RPC.
+It was rejected because request timeout and connection lifetime would still
+control execution. A disconnected caller could observe a ledger only if the
+original request coroutine survived, which is the failure this issue removes.
+
+## Trusted domain model
+
+The untrusted boundaries are CLI strings and JSON-RPC payloads. They parse
+once into constrained operation IDs, constrained idempotency keys, typed
+mutation variants, typed operation selectors, lifecycle states, progress
+stages, and terminal outcomes.
+
+The shared contract owns:
+
+- `KastMutationOperationId` and `KastMutationIdempotencyKey` value types;
+- a sealed public mutation request variant for each applied command;
+- operation selectors by ID or idempotency key;
+- `KastMutationOperationStatus`: queued, applying, validating, completed,
+  failed, or cancelled;
+- `KastMutationProgressStage`: identity resolution, edit application,
+  workspace refresh, import optimization, or diagnostics;
+- an immutable operation snapshot containing both identifiers, mutation kind,
+  status, current progress, cancellation request state, and edit-application
+  facts;
+- a submission receipt; and
+- sealed completed, failed, and cancelled terminal outcomes carrying the
+  typed mutation result or error.
+
+Each non-private production Kotlin type gets a same-named file. Direct sealed
+variants remain with their root. Raw strings and nullable flag combinations do
+not cross from transport parsing into the operation registry.
+
+## Submission and idempotency
+
+Applied command requests include a required caller-chosen idempotency key. The
+CLI requires the key only with `--apply`; mutation planning remains usable
+without it and shows the key placeholder in the apply command.
+
+The server normalizes the decoded request, excludes the idempotency key, and
+hashes the JSON-RPC method plus canonical typed payload. Under one registry
+lock it either:
+
+1. returns the existing receipt when key and fingerprint match;
+2. returns a typed conflict when the key already names another fingerprint; or
+3. creates exactly one operation ID, stores the queued entry, and schedules
+   exactly one worker.
+
+The receipt returned for a retry contains the original operation ID. A retry
+after completion returns retained state rather than starting another edit.
+Different JSON object ordering cannot alter the fingerprint because hashing
+uses the server's normalized typed serialization.
+
+## Execution and progress
+
+The dispatcher owns a supervisor coroutine scope independent of request
+coroutines. Submission schedules work in that scope and returns immediately,
+so the normal request timeout applies only to submission, status, and cancel
+calls—not to mutation execution.
+
+The worker publishes stage entry before invoking each stage. Lifecycle status
+is `applying` through identity resolution and edit application, then
+`validating` through workspace refresh, import optimization, and diagnostics.
+The registry separately records `editApplicationBegan` and
+`editApplicationCompleted`.
+
+The semantic orchestrator reports progress at the actual boundaries:
+
+- resolve a named symbol or placement identity;
+- calculate and apply the edit plan;
+- refresh affected workspace files;
+- optimize imports when the mutation supports it; and
+- retrieve diagnostics and build the terminal result.
+
+File creation has no declaration identity to resolve, so its first entered
+stage is edit application. Stages are not fabricated for work that does not
+occur.
+
+## Cancellation
+
+Cancellation is idempotent and request based. The first request records
+`cancellationRequested=true` and signals the worker job. Later requests return
+the same evolving or terminal snapshot.
+
+The operation becomes terminal cancelled only when the worker has
+cooperatively stopped and the registry has recorded its last truthful stage.
+If cancellation arrives before edit application begins, the terminal outcome
+proves no semantic edit started. If edit application began or completed, those
+facts remain true in the cancelled outcome. If a non-cancellable backend call
+finishes despite the request, execution observes cancellation at the next
+cooperative boundary and never rewrites history to claim the mutation did not
+run.
+
+Cancellation after any terminal state is a successful no-op returning the
+same terminal state and result.
+
+## Status and result retrieval
+
+The CLI adds:
+
+```console
+kast agent operation status --operation-id <id> --workspace-root "$PWD"
+kast agent operation status --idempotency-key <key> --workspace-root "$PWD"
+kast agent operation cancel --operation-id <id> --workspace-root "$PWD"
+```
+
+Each command accepts exactly one selector. Status includes the retained typed
+terminal outcome when present, so a reconnecting caller needs no hidden raw
+RPC or separate result command. Both status and cancel are read-safe to retry.
+
+The registry retains state only for the life of the backend daemon. Persistence
+across daemon restart is deliberately out of scope; a lost registry is an
+ambiguous outcome, not permission to retry a filesystem edit.
+
+## Failure behavior
+
+Expected failures are typed and observable:
+
+- an unknown operation selector returns not found without mutation;
+- a reused idempotency key with another fingerprint returns conflict without
+  mutation;
+- a mutation response with `ok=false` becomes a failed operation with its
+  typed mutation response retained;
+- an exception becomes a failed terminal outcome with a structured API error;
+  and
+- cooperative cancellation becomes a cancelled terminal outcome with stage
+  and edit-application facts.
+
+Internal raw edit methods remain transport implementation details. The public
+agent mutation surface is the lifecycle contract governed here.
+
+## Filesystem fallback
+
+Filesystem fallback is safe only after a successful status query proves
+`editApplicationBegan=false` in a terminal failed or cancelled outcome. It is
+unsafe when:
+
+- the operation completed;
+- edit application began, even if validation later failed or cancellation was
+  requested;
+- the operation is still queued, applying, or validating;
+- the daemon is unreachable; or
+- the daemon restarted and no longer knows the operation.
+
+In unsafe or ambiguous states the caller first recovers backend visibility,
+retrieves the operation result when available, and inspects the workspace.
+
+## Testing
+
+Development follows red-green TDD in vertical slices:
+
+1. shared serialization and invariant tests for IDs, selectors, lifecycle,
+   stages, and terminal outcomes;
+2. registry tests for atomic same-key retry, different-payload conflict,
+   truthful cancellation, status idempotence, and result retention;
+3. dispatcher/orchestrator tests for all five progress stages and typed
+   mutation results;
+4. a real operation delayed beyond ten seconds whose submission returns
+   immediately and whose terminal result is retrieved later;
+5. a Unix-domain-socket test that disconnects after submission, reconnects,
+   and queries by idempotency key; and
+6. Rust CLI tests for required apply keys, typed request shape, status/cancel
+   selectors, structured output, and help.
+
+Focused analysis API, analysis server, and CLI tests run throughout. Final
+verification includes full Gradle and Cargo suites, Clippy, formatting,
+contract generation checks, documentation contracts, Zensical rendering, and
+diff hygiene. Kast semantic diagnostics are attempted first; in this isolated
+worktree the plugin-owned workspace metadata may be unavailable, in which case
+the exact failure is retained and Gradle compilation is authoritative.

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationEditApplicationState.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationEditApplicationState.kt
@@ -1,0 +1,10 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class KastMutationEditApplicationState {
+    NOT_STARTED,
+    STARTED,
+    COMPLETED,
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationExecutionTrace.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationExecutionTrace.kt
@@ -1,0 +1,49 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KastMutationExecutionTrace(
+    val enteredStages: List<KastMutationProgressStage> = emptyList(),
+    val editApplicationState: KastMutationEditApplicationState = KastMutationEditApplicationState.NOT_STARTED,
+) {
+    init {
+        require(enteredStages.distinct() == enteredStages) { "Mutation progress stages must not repeat" }
+        require(enteredStages.zipWithNext().all { (left, right) -> left.ordinal < right.ordinal }) {
+            "Mutation progress stages must follow lifecycle order"
+        }
+        val enteredEditApplication = KastMutationProgressStage.EDIT_APPLICATION in enteredStages
+        require(enteredEditApplication == (editApplicationState != KastMutationEditApplicationState.NOT_STARTED)) {
+            "Mutation edit state must agree with entered progress stages"
+        }
+    }
+
+    val currentStage: KastMutationProgressStage?
+        get() = enteredStages.lastOrNull()
+
+    val safeForFilesystemFallback: Boolean
+        get() = editApplicationState == KastMutationEditApplicationState.NOT_STARTED
+
+    fun entering(stage: KastMutationProgressStage): KastMutationExecutionTrace {
+        val previousStage = currentStage
+        require(stage !in enteredStages) { "Mutation progress stage $stage was already entered" }
+        require(previousStage == null || previousStage.ordinal < stage.ordinal) {
+            "Mutation progress stage $stage cannot follow $previousStage"
+        }
+        return copy(
+            enteredStages = enteredStages + stage,
+            editApplicationState = if (stage == KastMutationProgressStage.EDIT_APPLICATION) {
+                KastMutationEditApplicationState.STARTED
+            } else {
+                editApplicationState
+            },
+        )
+    }
+
+    fun editApplicationCompleted(): KastMutationExecutionTrace {
+        require(editApplicationState == KastMutationEditApplicationState.STARTED) {
+            "Mutation edit application can complete only after it starts"
+        }
+        return copy(editApplicationState = KastMutationEditApplicationState.COMPLETED)
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationExecutionTrace.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationExecutionTrace.kt
@@ -21,9 +21,6 @@ data class KastMutationExecutionTrace(
     val currentStage: KastMutationProgressStage?
         get() = enteredStages.lastOrNull()
 
-    val safeForFilesystemFallback: Boolean
-        get() = editApplicationState == KastMutationEditApplicationState.NOT_STARTED
-
     fun entering(stage: KastMutationProgressStage): KastMutationExecutionTrace {
         val previousStage = currentStage
         require(stage !in enteredStages) { "Mutation progress stage $stage was already entered" }

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationFailure.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationFailure.kt
@@ -1,7 +1,9 @@
 package io.github.amichne.kast.api.contract.mutation
 
 import io.github.amichne.kast.api.contract.skill.KastRenameFailureResponse
+import io.github.amichne.kast.api.contract.skill.KastRenameSuccessResponse
 import io.github.amichne.kast.api.contract.skill.KastScopeMutationFailureResponse
+import io.github.amichne.kast.api.contract.skill.KastScopeMutationSuccessResponse
 import io.github.amichne.kast.api.protocol.ApiErrorResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -18,6 +20,18 @@ sealed interface KastMutationFailure {
     @SerialName("SCOPE_MUTATION_FAILURE")
     data class Scope(
         val response: KastScopeMutationFailureResponse,
+    ) : KastMutationFailure
+
+    @Serializable
+    @SerialName("APPLIED_INVALID_RENAME")
+    data class AppliedInvalidRename(
+        val response: KastRenameSuccessResponse,
+    ) : KastMutationFailure
+
+    @Serializable
+    @SerialName("APPLIED_INVALID_SCOPE")
+    data class AppliedInvalidScope(
+        val response: KastScopeMutationSuccessResponse,
     ) : KastMutationFailure
 
     @Serializable

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationFailure.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationFailure.kt
@@ -1,0 +1,28 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import io.github.amichne.kast.api.contract.skill.KastRenameFailureResponse
+import io.github.amichne.kast.api.contract.skill.KastScopeMutationFailureResponse
+import io.github.amichne.kast.api.protocol.ApiErrorResponse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface KastMutationFailure {
+    @Serializable
+    @SerialName("RENAME_FAILURE")
+    data class Rename(
+        val response: KastRenameFailureResponse,
+    ) : KastMutationFailure
+
+    @Serializable
+    @SerialName("SCOPE_MUTATION_FAILURE")
+    data class Scope(
+        val response: KastScopeMutationFailureResponse,
+    ) : KastMutationFailure
+
+    @Serializable
+    @SerialName("THROWN_FAILURE")
+    data class Thrown(
+        val error: ApiErrorResponse,
+    ) : KastMutationFailure
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationIdempotencyKey.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationIdempotencyKey.kt
@@ -1,0 +1,22 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+@JvmInline
+value class KastMutationIdempotencyKey(
+    val value: String,
+) {
+    init {
+        require(value == value.trim()) { "Mutation idempotency key must not have surrounding whitespace" }
+        require(value.length in 1..MAX_LENGTH) {
+            "Mutation idempotency key length must be between 1 and $MAX_LENGTH characters"
+        }
+    }
+
+    override fun toString(): String = value
+
+    companion object {
+        const val MAX_LENGTH: Int = 128
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationId.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationId.kt
@@ -1,0 +1,22 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+@Serializable
+@JvmInline
+value class KastMutationOperationId(
+    val value: String,
+) {
+    init {
+        require(runCatching { UUID.fromString(value) }.isSuccess) {
+            "Mutation operation ID must be a UUID"
+        }
+    }
+
+    override fun toString(): String = value
+
+    companion object {
+        fun random(): KastMutationOperationId = KastMutationOperationId(UUID.randomUUID().toString())
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationSelector.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationSelector.kt
@@ -1,0 +1,19 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface KastMutationOperationSelector {
+    @Serializable
+    @SerialName("BY_OPERATION_ID")
+    data class ByOperationId(
+        val operationId: KastMutationOperationId,
+    ) : KastMutationOperationSelector
+
+    @Serializable
+    @SerialName("BY_IDEMPOTENCY_KEY")
+    data class ByIdempotencyKey(
+        val idempotencyKey: KastMutationIdempotencyKey,
+    ) : KastMutationOperationSelector
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationSnapshot.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationSnapshot.kt
@@ -1,0 +1,11 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KastMutationOperationSnapshot(
+    val operationId: KastMutationOperationId,
+    val idempotencyKey: KastMutationIdempotencyKey,
+    val mutationKind: KastSemanticMutationKind,
+    val state: KastMutationOperationState,
+)

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationSnapshot.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationSnapshot.kt
@@ -8,4 +8,17 @@ data class KastMutationOperationSnapshot(
     val idempotencyKey: KastMutationIdempotencyKey,
     val mutationKind: KastSemanticMutationKind,
     val state: KastMutationOperationState,
-)
+) {
+    val safeForFilesystemFallback: Boolean
+        get() = when (state) {
+            is KastMutationOperationState.Failed,
+            is KastMutationOperationState.Cancelled,
+            -> state.trace.editApplicationState == KastMutationEditApplicationState.NOT_STARTED
+
+            is KastMutationOperationState.Queued,
+            is KastMutationOperationState.Applying,
+            is KastMutationOperationState.Validating,
+            is KastMutationOperationState.Completed,
+            -> false
+        }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationState.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationOperationState.kt
@@ -1,0 +1,84 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface KastMutationOperationState {
+    val trace: KastMutationExecutionTrace
+    val cancellationRequested: Boolean
+
+    @Serializable
+    @SerialName("QUEUED")
+    data class Queued(
+        override val trace: KastMutationExecutionTrace = KastMutationExecutionTrace(),
+        override val cancellationRequested: Boolean = false,
+    ) : KastMutationOperationState
+
+    @Serializable
+    @SerialName("APPLYING")
+    data class Applying(
+        val stage: KastMutationProgressStage,
+        override val trace: KastMutationExecutionTrace,
+        override val cancellationRequested: Boolean,
+    ) : KastMutationOperationState {
+        init {
+            require(stage in APPLYING_STAGES) { "$stage is not an applying stage" }
+            require(trace.currentStage == stage) { "Applying stage must match the trace current stage" }
+        }
+    }
+
+    @Serializable
+    @SerialName("VALIDATING")
+    data class Validating(
+        val stage: KastMutationProgressStage,
+        override val trace: KastMutationExecutionTrace,
+        override val cancellationRequested: Boolean,
+    ) : KastMutationOperationState {
+        init {
+            require(stage in VALIDATING_STAGES) { "$stage is not a validating stage" }
+            require(trace.currentStage == stage) { "Validating stage must match the trace current stage" }
+        }
+    }
+
+    @Serializable
+    @SerialName("COMPLETED")
+    data class Completed(
+        val result: KastSemanticMutationResult,
+        override val trace: KastMutationExecutionTrace,
+        override val cancellationRequested: Boolean,
+    ) : KastMutationOperationState
+
+    @Serializable
+    @SerialName("FAILED")
+    data class Failed(
+        val failure: KastMutationFailure,
+        override val trace: KastMutationExecutionTrace,
+        override val cancellationRequested: Boolean,
+    ) : KastMutationOperationState
+
+    @Serializable
+    @SerialName("CANCELLED")
+    data class Cancelled(
+        val message: String,
+        override val trace: KastMutationExecutionTrace,
+        override val cancellationRequested: Boolean = true,
+    ) : KastMutationOperationState {
+        init {
+            require(message.isNotBlank()) { "Mutation cancellation outcome requires a message" }
+            require(cancellationRequested) { "Cancelled mutation must retain its cancellation request" }
+        }
+    }
+
+    companion object {
+        private val APPLYING_STAGES = setOf(
+            KastMutationProgressStage.IDENTITY_RESOLUTION,
+            KastMutationProgressStage.EDIT_APPLICATION,
+        )
+        private val VALIDATING_STAGES = setOf(
+            KastMutationProgressStage.WORKSPACE_REFRESH,
+            KastMutationProgressStage.IMPORT_OPTIMIZATION,
+            KastMutationProgressStage.DIAGNOSTICS,
+        )
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationProgressStage.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationProgressStage.kt
@@ -1,0 +1,12 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class KastMutationProgressStage {
+    IDENTITY_RESOLUTION,
+    EDIT_APPLICATION,
+    WORKSPACE_REFRESH,
+    IMPORT_OPTIMIZATION,
+    DIAGNOSTICS,
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationSubmissionReceipt.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationSubmissionReceipt.kt
@@ -1,0 +1,9 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KastMutationSubmissionReceipt(
+    val operation: KastMutationOperationSnapshot,
+    val deduplicated: Boolean,
+)

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastSemanticMutation.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastSemanticMutation.kt
@@ -1,0 +1,89 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import io.github.amichne.kast.api.contract.skill.KastAddDeclarationRequest
+import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
+import io.github.amichne.kast.api.contract.skill.KastAddImplementationRequest
+import io.github.amichne.kast.api.contract.skill.KastAddStatementRequest
+import io.github.amichne.kast.api.contract.skill.KastRenameBySymbolRequest
+import io.github.amichne.kast.api.contract.skill.KastReplaceDeclarationRequest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface KastSemanticMutation {
+    val idempotencyKey: KastMutationIdempotencyKey
+    val kind: KastSemanticMutationKind
+    val symbolMethod: String
+
+    @Serializable
+    @SerialName("RENAME")
+    data class Rename(
+        override val idempotencyKey: KastMutationIdempotencyKey,
+        val request: KastRenameBySymbolRequest,
+    ) : KastSemanticMutation {
+        override val kind: KastSemanticMutationKind
+            get() = KastSemanticMutationKind.RENAME
+        override val symbolMethod: String
+            get() = "symbol/rename"
+    }
+
+    @Serializable
+    @SerialName("ADD_FILE")
+    data class AddFile(
+        override val idempotencyKey: KastMutationIdempotencyKey,
+        val request: KastAddFileRequest,
+    ) : KastSemanticMutation {
+        override val kind: KastSemanticMutationKind
+            get() = KastSemanticMutationKind.ADD_FILE
+        override val symbolMethod: String
+            get() = "symbol/add-file"
+    }
+
+    @Serializable
+    @SerialName("ADD_DECLARATION")
+    data class AddDeclaration(
+        override val idempotencyKey: KastMutationIdempotencyKey,
+        val request: KastAddDeclarationRequest,
+    ) : KastSemanticMutation {
+        override val kind: KastSemanticMutationKind
+            get() = KastSemanticMutationKind.ADD_DECLARATION
+        override val symbolMethod: String
+            get() = "symbol/add-declaration"
+    }
+
+    @Serializable
+    @SerialName("ADD_IMPLEMENTATION")
+    data class AddImplementation(
+        override val idempotencyKey: KastMutationIdempotencyKey,
+        val request: KastAddImplementationRequest,
+    ) : KastSemanticMutation {
+        override val kind: KastSemanticMutationKind
+            get() = KastSemanticMutationKind.ADD_IMPLEMENTATION
+        override val symbolMethod: String
+            get() = "symbol/add-implementation"
+    }
+
+    @Serializable
+    @SerialName("ADD_STATEMENT")
+    data class AddStatement(
+        override val idempotencyKey: KastMutationIdempotencyKey,
+        val request: KastAddStatementRequest,
+    ) : KastSemanticMutation {
+        override val kind: KastSemanticMutationKind
+            get() = KastSemanticMutationKind.ADD_STATEMENT
+        override val symbolMethod: String
+            get() = "symbol/add-statement"
+    }
+
+    @Serializable
+    @SerialName("REPLACE_DECLARATION")
+    data class ReplaceDeclaration(
+        override val idempotencyKey: KastMutationIdempotencyKey,
+        val request: KastReplaceDeclarationRequest,
+    ) : KastSemanticMutation {
+        override val kind: KastSemanticMutationKind
+            get() = KastSemanticMutationKind.REPLACE_DECLARATION
+        override val symbolMethod: String
+            get() = "symbol/replace-declaration"
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastSemanticMutationKind.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastSemanticMutationKind.kt
@@ -1,0 +1,13 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class KastSemanticMutationKind {
+    RENAME,
+    ADD_FILE,
+    ADD_DECLARATION,
+    ADD_IMPLEMENTATION,
+    ADD_STATEMENT,
+    REPLACE_DECLARATION,
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastSemanticMutationResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/mutation/KastSemanticMutationResult.kt
@@ -1,0 +1,21 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import io.github.amichne.kast.api.contract.skill.KastRenameSuccessResponse
+import io.github.amichne.kast.api.contract.skill.KastScopeMutationSuccessResponse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface KastSemanticMutationResult {
+    @Serializable
+    @SerialName("RENAME_RESULT")
+    data class Rename(
+        val response: KastRenameSuccessResponse,
+    ) : KastSemanticMutationResult
+
+    @Serializable
+    @SerialName("SCOPE_MUTATION_RESULT")
+    data class Scope(
+        val response: KastScopeMutationSuccessResponse,
+    ) : KastSemanticMutationResult
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastDiagnosticsSummary.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastDiagnosticsSummary.kt
@@ -33,6 +33,35 @@ class KastDiagnosticsSummary private constructor(
         }
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (other !is KastDiagnosticsSummary) {
+            return false
+        }
+        return clean == other.clean &&
+            errorCount == other.errorCount &&
+            warningCount == other.warningCount &&
+            semanticOutcome == other.semanticOutcome &&
+            requestedFileCount == other.requestedFileCount &&
+            analyzedFileCount == other.analyzedFileCount &&
+            skippedFileCount == other.skippedFileCount &&
+            errors == other.errors
+    }
+
+    override fun hashCode(): Int {
+        var result = clean.hashCode()
+        result = 31 * result + errorCount
+        result = 31 * result + warningCount
+        result = 31 * result + semanticOutcome.hashCode()
+        result = 31 * result + requestedFileCount
+        result = 31 * result + analyzedFileCount
+        result = 31 * result + skippedFileCount
+        result = 31 * result + errors.hashCode()
+        return result
+    }
+
     companion object {
         fun from(result: DiagnosticsResult): KastDiagnosticsSummary =
             from(result, PositiveInt(Int.MAX_VALUE))

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastDiagnosticsSummaryTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastDiagnosticsSummaryTest.kt
@@ -57,6 +57,20 @@ class KastDiagnosticsSummaryTest {
         assertEquals(0, summary.skippedFileCount)
     }
 
+    @Test
+    fun `independently derived summaries retain value identity`() {
+        val result = DiagnosticsResult.of(
+            diagnostics = listOf(compilerError()),
+            fileStatuses = listOf(FileAnalysisStatus.analyzed(filePath)),
+        )
+
+        val first = KastDiagnosticsSummary.from(result)
+        val second = KastDiagnosticsSummary.from(result)
+
+        assertEquals(first, second)
+        assertEquals(first.hashCode(), second.hashCode())
+    }
+
     private fun compilerError(): Diagnostic = Diagnostic(
         location = Location(
             filePath = filePath.value,

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationContractTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationContractTest.kt
@@ -123,19 +123,7 @@ class KastMutationContractTest {
             ),
             editApplicationState = KastMutationEditApplicationState.COMPLETED,
         )
-        val success = KastSemanticMutationResult.Scope(
-            KastScopeMutationSuccessResponse(
-                ok = true,
-                operation = KastScopeMutationOperation.ADD_FILE,
-                applied = true,
-                affectedFiles = listOf("/workspace/Added.kt"),
-                createdFiles = listOf("/workspace/Added.kt"),
-                editCount = 1,
-                importChanges = 0,
-                diagnostics = KastDiagnosticsSummary(clean = true, errorCount = 0, warningCount = 0),
-                logFile = "",
-            ),
-        )
+        val success = scopeSuccess()
         val completed = KastMutationOperationState.Completed(
             result = success,
             trace = trace,
@@ -162,6 +150,90 @@ class KastMutationContractTest {
         assertEquals(success, completed.result)
         assertEquals(KastMutationEditApplicationState.COMPLETED, failed.trace.editApplicationState)
         assertTrue(cancelled.cancellationRequested)
-        assertFalse(cancelled.trace.safeForFilesystemFallback)
     }
+
+    @Test
+    fun `filesystem fallback requires terminal no-write failure or cancellation`() {
+        val operationId = KastMutationOperationId(UUID.randomUUID().toString())
+        val key = KastMutationIdempotencyKey("issue-333-fallback")
+        val noWriteTrace = KastMutationExecutionTrace()
+        val identityTrace = noWriteTrace.entering(KastMutationProgressStage.IDENTITY_RESOLUTION)
+        val completedTrace = KastMutationExecutionTrace()
+            .entering(KastMutationProgressStage.EDIT_APPLICATION)
+            .editApplicationCompleted()
+        val thrown = KastMutationFailure.Thrown(
+            ApiErrorResponse(
+                requestId = operationId.value,
+                code = "TEST_FAILURE",
+                message = "failed",
+                retryable = false,
+            ),
+        )
+        fun snapshot(state: KastMutationOperationState) = KastMutationOperationSnapshot(
+            operationId = operationId,
+            idempotencyKey = key,
+            mutationKind = KastSemanticMutationKind.ADD_FILE,
+            state = state,
+        )
+
+        assertFalse(snapshot(KastMutationOperationState.Queued()).safeForFilesystemFallback)
+        assertFalse(
+            snapshot(
+                KastMutationOperationState.Applying(
+                    stage = KastMutationProgressStage.IDENTITY_RESOLUTION,
+                    trace = identityTrace,
+                    cancellationRequested = false,
+                ),
+            ).safeForFilesystemFallback,
+        )
+        assertFalse(
+            snapshot(
+                KastMutationOperationState.Completed(
+                    result = scopeSuccess(),
+                    trace = completedTrace,
+                    cancellationRequested = false,
+                ),
+            ).safeForFilesystemFallback,
+        )
+        assertTrue(
+            snapshot(
+                KastMutationOperationState.Failed(
+                    failure = thrown,
+                    trace = noWriteTrace,
+                    cancellationRequested = false,
+                ),
+            ).safeForFilesystemFallback,
+        )
+        assertTrue(
+            snapshot(
+                KastMutationOperationState.Cancelled(
+                    message = "Stopped before edit application.",
+                    trace = noWriteTrace,
+                ),
+            ).safeForFilesystemFallback,
+        )
+        assertFalse(
+            snapshot(
+                KastMutationOperationState.Failed(
+                    failure = thrown,
+                    trace = completedTrace,
+                    cancellationRequested = false,
+                ),
+            ).safeForFilesystemFallback,
+        )
+    }
+
+    private fun scopeSuccess(): KastSemanticMutationResult.Scope = KastSemanticMutationResult.Scope(
+            KastScopeMutationSuccessResponse(
+                ok = true,
+                operation = KastScopeMutationOperation.ADD_FILE,
+                applied = true,
+                affectedFiles = listOf("/workspace/Added.kt"),
+                createdFiles = listOf("/workspace/Added.kt"),
+                editCount = 1,
+                importChanges = 0,
+                diagnostics = KastDiagnosticsSummary(clean = true, errorCount = 0, warningCount = 0),
+                logFile = "",
+            ),
+        )
 }

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationContractTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationContractTest.kt
@@ -1,5 +1,8 @@
 package io.github.amichne.kast.api.contract.mutation
 
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.result.DiagnosticsResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
 import io.github.amichne.kast.api.contract.skill.KastAddDeclarationRequest
 import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
 import io.github.amichne.kast.api.contract.skill.KastAddImplementationRequest
@@ -24,6 +27,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.nio.file.Path
 import java.util.UUID
 
 class KastMutationContractTest {
@@ -232,7 +236,16 @@ class KastMutationContractTest {
                 createdFiles = listOf("/workspace/Added.kt"),
                 editCount = 1,
                 importChanges = 0,
-                diagnostics = KastDiagnosticsSummary(clean = true, errorCount = 0, warningCount = 0),
+                diagnostics = KastDiagnosticsSummary.from(
+                    DiagnosticsResult.of(
+                        diagnostics = emptyList(),
+                        fileStatuses = listOf(
+                            FileAnalysisStatus.analyzed(
+                                NormalizedPath.ofAbsolute(Path.of("/workspace/Added.kt")),
+                            ),
+                        ),
+                    ),
+                ),
                 logFile = "",
             ),
         )

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationContractTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/mutation/KastMutationContractTest.kt
@@ -1,0 +1,167 @@
+package io.github.amichne.kast.api.contract.mutation
+
+import io.github.amichne.kast.api.contract.skill.KastAddDeclarationRequest
+import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
+import io.github.amichne.kast.api.contract.skill.KastAddImplementationRequest
+import io.github.amichne.kast.api.contract.skill.KastAddStatementRequest
+import io.github.amichne.kast.api.contract.skill.KastAtPlacementAnchor
+import io.github.amichne.kast.api.contract.skill.KastDiagnosticsSummary
+import io.github.amichne.kast.api.contract.skill.KastFilePlacementScope
+import io.github.amichne.kast.api.contract.skill.KastPlacementAnchor
+import io.github.amichne.kast.api.contract.skill.KastPlacementSelector
+import io.github.amichne.kast.api.contract.skill.KastRenameBySymbolRequest
+import io.github.amichne.kast.api.contract.skill.KastReplaceDeclarationRequest
+import io.github.amichne.kast.api.contract.skill.KastScopeMutationOperation
+import io.github.amichne.kast.api.contract.skill.KastScopeMutationSuccessResponse
+import io.github.amichne.kast.api.contract.skill.KastStatementPlacementAnchor
+import io.github.amichne.kast.api.protocol.ApiErrorResponse
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class KastMutationContractTest {
+    private val json = Json {
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `operation identifiers reject malformed boundary values`() {
+        val operationId = KastMutationOperationId(UUID.randomUUID().toString())
+        val idempotencyKey = KastMutationIdempotencyKey("issue-333-add-file")
+
+        assertEquals(operationId.value, operationId.toString())
+        assertEquals(idempotencyKey.value, idempotencyKey.toString())
+        assertThrows<IllegalArgumentException> { KastMutationOperationId("not-a-uuid") }
+        assertThrows<IllegalArgumentException> { KastMutationIdempotencyKey(" ") }
+        assertThrows<IllegalArgumentException> { KastMutationIdempotencyKey("x".repeat(129)) }
+    }
+
+    @Test
+    fun `all public semantic mutation variants have stable wire identities`() {
+        val key = KastMutationIdempotencyKey("issue-333")
+        val placement = KastPlacementSelector(
+            scope = KastFilePlacementScope("/workspace/Sample.kt"),
+            anchor = KastAtPlacementAnchor(KastPlacementAnchor.FILE_BOTTOM),
+        )
+        val mutations = listOf(
+            "RENAME" to KastSemanticMutation.Rename(
+                idempotencyKey = key,
+                request = KastRenameBySymbolRequest(symbol = "sample.greet", newName = "welcome"),
+            ),
+            "ADD_FILE" to KastSemanticMutation.AddFile(
+                idempotencyKey = key,
+                request = KastAddFileRequest(
+                    filePath = "/workspace/Added.kt",
+                    contentFile = "/tmp/Added.kt",
+                ),
+            ),
+            "ADD_DECLARATION" to KastSemanticMutation.AddDeclaration(
+                idempotencyKey = key,
+                request = KastAddDeclarationRequest(placement = placement, contentFile = "/tmp/declaration.kt"),
+            ),
+            "ADD_IMPLEMENTATION" to KastSemanticMutation.AddImplementation(
+                idempotencyKey = key,
+                request = KastAddImplementationRequest(placement = placement, contentFile = "/tmp/implementation.kt"),
+            ),
+            "ADD_STATEMENT" to KastSemanticMutation.AddStatement(
+                idempotencyKey = key,
+                request = KastAddStatementRequest(
+                    insideScope = "sample.greet",
+                    anchor = KastStatementPlacementAnchor.BODY_END,
+                    contentFile = "/tmp/statement.kt",
+                ),
+            ),
+            "REPLACE_DECLARATION" to KastSemanticMutation.ReplaceDeclaration(
+                idempotencyKey = key,
+                request = KastReplaceDeclarationRequest(
+                    symbol = "sample.greet",
+                    contentFile = "/tmp/replacement.kt",
+                ),
+            ),
+        )
+
+        mutations.forEach { (expectedType, mutation) ->
+            val encoded = json.encodeToJsonElement(KastSemanticMutation.serializer(), mutation).jsonObject
+            assertEquals(JsonPrimitive(expectedType), encoded["type"])
+            assertEquals(JsonPrimitive(key.value), encoded["idempotencyKey"])
+            assertTrue(encoded["request"] != null)
+            assertEquals(mutation, json.decodeFromJsonElement(KastSemanticMutation.serializer(), encoded))
+        }
+    }
+
+    @Test
+    fun `operation selectors round trip without nullable selector fields`() {
+        val operationId = KastMutationOperationId(UUID.randomUUID().toString())
+        val key = KastMutationIdempotencyKey("issue-333-selector")
+        val selectors = listOf(
+            KastMutationOperationSelector.ByOperationId(operationId),
+            KastMutationOperationSelector.ByIdempotencyKey(key),
+        )
+
+        selectors.forEach { selector ->
+            val encoded = json.encodeToString(KastMutationOperationSelector.serializer(), selector)
+            assertEquals(selector, json.decodeFromString(KastMutationOperationSelector.serializer(), encoded))
+        }
+    }
+
+    @Test
+    fun `terminal operation states retain typed outcomes and edit facts`() {
+        val trace = KastMutationExecutionTrace(
+            enteredStages = listOf(
+                KastMutationProgressStage.EDIT_APPLICATION,
+                KastMutationProgressStage.WORKSPACE_REFRESH,
+                KastMutationProgressStage.IMPORT_OPTIMIZATION,
+                KastMutationProgressStage.DIAGNOSTICS,
+            ),
+            editApplicationState = KastMutationEditApplicationState.COMPLETED,
+        )
+        val success = KastSemanticMutationResult.Scope(
+            KastScopeMutationSuccessResponse(
+                ok = true,
+                operation = KastScopeMutationOperation.ADD_FILE,
+                applied = true,
+                affectedFiles = listOf("/workspace/Added.kt"),
+                createdFiles = listOf("/workspace/Added.kt"),
+                editCount = 1,
+                importChanges = 0,
+                diagnostics = KastDiagnosticsSummary(clean = true, errorCount = 0, warningCount = 0),
+                logFile = "",
+            ),
+        )
+        val completed = KastMutationOperationState.Completed(
+            result = success,
+            trace = trace,
+            cancellationRequested = false,
+        )
+        val failed = KastMutationOperationState.Failed(
+            failure = KastMutationFailure.Thrown(
+                ApiErrorResponse(
+                    requestId = "operation",
+                    code = "TEST_FAILURE",
+                    message = "failed",
+                    retryable = false,
+                ),
+            ),
+            trace = trace,
+            cancellationRequested = false,
+        )
+        val cancelled = KastMutationOperationState.Cancelled(
+            message = "Cancellation acknowledged after execution stopped.",
+            trace = trace,
+            cancellationRequested = true,
+        )
+
+        assertEquals(success, completed.result)
+        assertEquals(KastMutationEditApplicationState.COMPLETED, failed.trace.editApplicationState)
+        assertTrue(cancelled.cancellationRequested)
+        assertFalse(cancelled.trace.safeForFilesystemFallback)
+    }
+}

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisDispatcher.kt
@@ -66,6 +66,11 @@ import kotlinx.serialization.json.JsonNull
 import java.util.UUID
 import io.github.amichne.kast.api.validation.parsed
 import io.github.amichne.kast.api.contract.skill.*
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSelector
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSnapshot
+import io.github.amichne.kast.api.contract.mutation.KastMutationSubmissionReceipt
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
+import io.github.amichne.kast.server.mutation.MutationOperationService
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
@@ -83,6 +88,7 @@ class RpcAnalysisDispatcher(
     },
 ) {
     private val skillRpc = SkillRpcOrchestrator(backend, config, json)
+    private val mutationRpc = MutationOperationService(skillRpc, json)
     private val afterResponseActions = ConcurrentLinkedQueue<() -> Unit>()
 
     suspend fun dispatch(request: JsonRpcRequest): String {
@@ -386,6 +392,21 @@ class RpcAnalysisDispatcher(
             "symbol/replace-declaration" -> encode(
                 KastScopeMutationResponse.serializer(),
                 skillRpc.replaceDeclaration(decodeParams(KastReplaceDeclarationRequest.serializer(), params)),
+            )
+
+            "mutation/submit" -> encode(
+                KastMutationSubmissionReceipt.serializer(),
+                mutationRpc.submit(decodeParams(KastSemanticMutation.serializer(), params)),
+            )
+
+            "mutation/status" -> encode(
+                KastMutationOperationSnapshot.serializer(),
+                mutationRpc.status(decodeParams(KastMutationOperationSelector.serializer(), params)),
+            )
+
+            "mutation/cancel" -> encode(
+                KastMutationOperationSnapshot.serializer(),
+                mutationRpc.cancel(decodeParams(KastMutationOperationSelector.serializer(), params)),
             )
 
             "raw/implementations" -> encode(

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisServer.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisServer.kt
@@ -5,7 +5,6 @@ import io.github.amichne.kast.api.contract.AnalysisTransport
 import io.github.amichne.kast.api.client.ServerInstanceDescriptor
 import io.github.amichne.kast.api.client.defaultDescriptorDirectory
 import kotlinx.coroutines.runBlocking
-import java.io.Closeable
 
 class AnalysisServer(
     private val backend: AnalysisBackend,
@@ -63,25 +62,9 @@ class AnalysisServer(
 
         return RunningAnalysisServer(
             server = transportServer,
+            dispatcher = dispatcher,
             descriptor = descriptor,
             descriptorStore = descriptorStore,
         )
-    }
-}
-
-class RunningAnalysisServer internal constructor(
-    private val server: LocalRpcServer,
-    val descriptor: ServerInstanceDescriptor?,
-    private val descriptorStore: DescriptorStore?,
-) : Closeable {
-    fun await() {
-        server.await()
-    }
-
-    override fun close() {
-        descriptorStore?.let { store ->
-            descriptor?.let(store::delete)
-        }
-        server.close()
     }
 }

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/RpcAnalysisDispatcher.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/RpcAnalysisDispatcher.kt
@@ -74,6 +74,7 @@ import io.github.amichne.kast.server.mutation.MutationOperationService
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
+import java.io.Closeable
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CancellationException
 
@@ -86,7 +87,7 @@ class RpcAnalysisDispatcher(
         explicitNulls = false
         prettyPrint = false
     },
-) {
+) : Closeable {
     private val skillRpc = SkillRpcOrchestrator(backend, config, json)
     private val mutationRpc = MutationOperationService(skillRpc, json)
     private val afterResponseActions = ConcurrentLinkedQueue<() -> Unit>()
@@ -449,6 +450,10 @@ class RpcAnalysisDispatcher(
         }
     }
 
+    override fun close() {
+        mutationRpc.close()
+    }
+
     private suspend fun requestLifecycle(action: RuntimeLifecycleAction): RuntimeLifecycleResponse {
         val afterResponseAction = lifecycleController.afterResponseAction(action)
             ?: throw CapabilityNotSupportedException(
@@ -497,14 +502,6 @@ class RpcAnalysisDispatcher(
         serializer: KSerializer<T>,
         value: T,
     ): JsonElement = json.encodeToJsonElement(serializer, value)
-}
-
-fun interface RuntimeLifecycleController {
-    fun afterResponseAction(action: RuntimeLifecycleAction): (() -> Unit)?
-
-    object Unavailable : RuntimeLifecycleController {
-        override fun afterResponseAction(action: RuntimeLifecycleAction): (() -> Unit)? = null
-    }
 }
 
 private class UnknownRpcMethodException(

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/RunningAnalysisServer.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/RunningAnalysisServer.kt
@@ -1,0 +1,29 @@
+package io.github.amichne.kast.server
+
+import io.github.amichne.kast.api.client.ServerInstanceDescriptor
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicBoolean
+
+class RunningAnalysisServer internal constructor(
+    private val server: LocalRpcServer,
+    private val dispatcher: RpcAnalysisDispatcher,
+    val descriptor: ServerInstanceDescriptor?,
+    private val descriptorStore: DescriptorStore?,
+) : Closeable {
+    private val closed = AtomicBoolean(false)
+
+    fun await() {
+        server.await()
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) {
+            return
+        }
+        server.close()
+        dispatcher.close()
+        descriptorStore?.let { store ->
+            descriptor?.let(store::delete)
+        }
+    }
+}

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/RuntimeLifecycleController.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/RuntimeLifecycleController.kt
@@ -1,0 +1,11 @@
+package io.github.amichne.kast.server
+
+import io.github.amichne.kast.api.contract.RuntimeLifecycleAction
+
+fun interface RuntimeLifecycleController {
+    fun afterResponseAction(action: RuntimeLifecycleAction): (() -> Unit)?
+
+    object Unavailable : RuntimeLifecycleController {
+        override fun afterResponseAction(action: RuntimeLifecycleAction): (() -> Unit)? = null
+    }
+}

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
@@ -24,6 +24,7 @@ import io.github.amichne.kast.api.contract.query.FileOutlineQuery
 import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
 import io.github.amichne.kast.api.contract.query.ReferencesQuery
 import io.github.amichne.kast.api.contract.query.RenameQuery
+import io.github.amichne.kast.api.contract.query.RefreshQuery
 import io.github.amichne.kast.api.contract.query.SymbolQuery
 import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
@@ -94,6 +95,11 @@ import io.github.amichne.kast.api.protocol.CapabilityNotSupportedException
 import io.github.amichne.kast.api.protocol.ValidationException
 import io.github.amichne.kast.api.validation.FileHashing
 import io.github.amichne.kast.api.validation.parsed
+import io.github.amichne.kast.api.contract.mutation.KastMutationProgressStage
+import io.github.amichne.kast.server.mutation.MutationProgressEvent
+import io.github.amichne.kast.server.mutation.MutationProgressReporter
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.serialization.json.Json
 import java.nio.file.Files
 import java.nio.file.Path
@@ -380,9 +386,15 @@ internal class SkillRpcOrchestrator(
         )
     }
 
-    suspend fun rename(request: KastRenameRequest): KastRenameResponse = when (request) {
-        is KastRenameBySymbolRequest -> renameBySymbol(request)
-        is KastRenameByOffsetRequest -> renameByOffset(request)
+    suspend fun rename(
+        request: KastRenameRequest,
+        progress: MutationProgressReporter = MutationProgressReporter.NONE,
+    ): KastRenameResponse {
+        progress.enter(KastMutationProgressStage.IDENTITY_RESOLUTION)
+        return when (request) {
+            is KastRenameBySymbolRequest -> renameBySymbol(request, progress)
+            is KastRenameByOffsetRequest -> renameByOffset(request, progress)
+        }
     }
 
     suspend fun writeAndValidate(request: KastWriteAndValidateRequest): KastWriteAndValidateResponse = when (request) {
@@ -391,7 +403,10 @@ internal class SkillRpcOrchestrator(
         is KastWriteAndValidateReplaceRangeRequest -> writeAndValidateReplace(request)
     }
 
-    suspend fun addFile(request: KastAddFileRequest): KastScopeMutationResponse {
+    suspend fun addFile(
+        request: KastAddFileRequest,
+        progress: MutationProgressReporter = MutationProgressReporter.NONE,
+    ): KastScopeMutationResponse {
         val filePath = request.targetFilePath.value
         return writeAndValidateCreate(
             KastWriteAndValidateCreateFileRequest(
@@ -399,6 +414,7 @@ internal class SkillRpcOrchestrator(
                 filePath = filePath,
                 contentFile = request.contentFilePath.value,
             ),
+            progress,
         ).toScopeMutationResponse(
             operation = request.operation,
             affectedFiles = listOf(filePath),
@@ -407,13 +423,20 @@ internal class SkillRpcOrchestrator(
         )
     }
 
-    suspend fun addDeclaration(request: KastAddDeclarationRequest): KastScopeMutationResponse =
-        addPlacedContent(request)
+    suspend fun addDeclaration(
+        request: KastAddDeclarationRequest,
+        progress: MutationProgressReporter = MutationProgressReporter.NONE,
+    ): KastScopeMutationResponse = addPlacedContent(request, progress)
 
-    suspend fun addImplementation(request: KastAddImplementationRequest): KastScopeMutationResponse =
-        addPlacedContent(request)
+    suspend fun addImplementation(
+        request: KastAddImplementationRequest,
+        progress: MutationProgressReporter = MutationProgressReporter.NONE,
+    ): KastScopeMutationResponse = addPlacedContent(request, progress)
 
-    suspend fun addStatement(request: KastAddStatementRequest): KastScopeMutationResponse {
+    suspend fun addStatement(
+        request: KastAddStatementRequest,
+        progress: MutationProgressReporter = MutationProgressReporter.NONE,
+    ): KastScopeMutationResponse {
         val placement = KastPlacementSelector(
             scope = KastNamedPlacementScope(
                 insideScope = request.requestedInsideScope.value,
@@ -427,13 +450,18 @@ internal class SkillRpcOrchestrator(
             placement = placement,
             contentFile = request.contentFilePath.value,
             statementBody = true,
+            progress = progress,
         )
     }
 
-    suspend fun replaceDeclaration(request: KastReplaceDeclarationRequest): KastScopeMutationResponse {
+    suspend fun replaceDeclaration(
+        request: KastReplaceDeclarationRequest,
+        progress: MutationProgressReporter = MutationProgressReporter.NONE,
+    ): KastScopeMutationResponse {
         val workspaceRoot = request.requestedWorkspaceRoot?.value
         val symbol = request.requestedSymbol.value
         workspaceRootFor(workspaceRoot)
+        progress.enter(KastMutationProgressStage.IDENTITY_RESOLUTION)
         val resolved = resolveNamedSymbol(
             symbolName = symbol,
             fileHint = request.fileHint,
@@ -469,6 +497,7 @@ internal class SkillRpcOrchestrator(
                 startOffset = declarationScope.startOffset,
                 endOffset = declarationScope.endOffset,
             ),
+            progress = progress,
         )
         return response.toScopeMutationResponse(
             operation = request.operation,
@@ -477,7 +506,10 @@ internal class SkillRpcOrchestrator(
         )
     }
 
-    private suspend fun renameBySymbol(request: KastRenameBySymbolRequest): KastRenameResponse {
+    private suspend fun renameBySymbol(
+        request: KastRenameBySymbolRequest,
+        progress: MutationProgressReporter,
+    ): KastRenameResponse {
         val workspaceRoot = workspaceRootFor(request.workspaceRoot)
         val resolved = resolveNamedSymbol(
             symbolName = request.symbol,
@@ -523,10 +555,14 @@ internal class SkillRpcOrchestrator(
                     newName = request.newName,
                 )
             },
+            progress = progress,
         )
     }
 
-    private suspend fun renameByOffset(request: KastRenameByOffsetRequest): KastRenameResponse {
+    private suspend fun renameByOffset(
+        request: KastRenameByOffsetRequest,
+        progress: MutationProgressReporter,
+    ): KastRenameResponse {
         val workspaceRoot = workspaceRootFor(request.workspaceRoot)
         val filePath = request.filePath.normalizedAbsolutePath()
         return performRename(
@@ -549,6 +585,7 @@ internal class SkillRpcOrchestrator(
                     newName = request.newName,
                 )
             },
+            progress = progress,
         )
     }
 
@@ -558,6 +595,7 @@ internal class SkillRpcOrchestrator(
         newName: String,
         queryBuilder: () -> KastRenameQuery,
         failureQueryBuilder: () -> KastRenameFailureQuery,
+        progress: MutationProgressReporter,
     ): KastRenameResponse {
         requireMutationCapability(MutationCapability.RENAME)
         val renameResult = backend.rename(
@@ -568,12 +606,18 @@ internal class SkillRpcOrchestrator(
             ).parsed(),
         )
         requireMutationCapability(MutationCapability.APPLY_EDITS)
+        progress.enter(KastMutationProgressStage.EDIT_APPLICATION)
         val applyResult = backend.applyEdits(
             ApplyEditsQuery(
                 edits = renameResult.edits,
                 fileHashes = renameResult.fileHashes,
             ).parsed(),
         )
+        progress.editApplicationCompleted()
+        currentCoroutineContext().ensureActive()
+        progress.enter(KastMutationProgressStage.WORKSPACE_REFRESH)
+        refreshFiles(renameResult.affectedFiles)
+        progress.enter(KastMutationProgressStage.DIAGNOSTICS)
         val diagnosticsSummary = if (renameResult.affectedFiles.isEmpty()) {
             KastDiagnosticsSummary.completeWithoutFiles()
         } else {
@@ -594,12 +638,16 @@ internal class SkillRpcOrchestrator(
         )
     }
 
-    private suspend fun writeAndValidateCreate(request: KastWriteAndValidateCreateFileRequest): KastWriteAndValidateResponse {
+    private suspend fun writeAndValidateCreate(
+        request: KastWriteAndValidateCreateFileRequest,
+        progress: MutationProgressReporter = MutationProgressReporter.NONE,
+    ): KastWriteAndValidateResponse {
         val workspaceRoot = workspaceRootFor(request.workspaceRoot)
         val filePath = request.filePath.normalizedAbsolutePath()
         val content = resolveContent(request.content, request.contentFile)
         requireMutationCapability(MutationCapability.APPLY_EDITS)
         requireMutationCapability(MutationCapability.FILE_OPERATIONS)
+        progress.enter(KastMutationProgressStage.EDIT_APPLICATION)
         val applyResult = backend.applyEdits(
             ApplyEditsQuery(
                 edits = emptyList(),
@@ -607,7 +655,13 @@ internal class SkillRpcOrchestrator(
                 fileOperations = listOf(FileOperation.CreateFile(filePath = filePath, content = content)),
             ).parsed(),
         )
+        progress.editApplicationCompleted()
+        currentCoroutineContext().ensureActive()
+        progress.enter(KastMutationProgressStage.WORKSPACE_REFRESH)
+        refreshFiles(listOf(filePath))
+        progress.enter(KastMutationProgressStage.IMPORT_OPTIMIZATION)
         val optimized = optimizeImports(filePath)
+        progress.enter(KastMutationProgressStage.DIAGNOSTICS)
         val diagnostics = validateFiles(listOf(filePath))
         return KastWriteAndValidateSuccessResponse(
             ok = diagnostics.clean,
@@ -669,15 +723,23 @@ internal class SkillRpcOrchestrator(
         filePath: String,
         edits: List<TextEdit>,
         query: KastWriteAndValidateQuery,
+        progress: MutationProgressReporter = MutationProgressReporter.NONE,
     ): KastWriteAndValidateResponse {
         requireMutationCapability(MutationCapability.APPLY_EDITS)
+        progress.enter(KastMutationProgressStage.EDIT_APPLICATION)
         val applyResult = backend.applyEdits(
             ApplyEditsQuery(
                 edits = edits,
                 fileHashes = currentFileHashes(edits.map(TextEdit::filePath)),
             ).parsed(),
         )
+        progress.editApplicationCompleted()
+        currentCoroutineContext().ensureActive()
+        progress.enter(KastMutationProgressStage.WORKSPACE_REFRESH)
+        refreshFiles(listOf(filePath))
+        progress.enter(KastMutationProgressStage.IMPORT_OPTIMIZATION)
         val optimized = optimizeImports(filePath)
+        progress.enter(KastMutationProgressStage.DIAGNOSTICS)
         val diagnostics = validateFiles(listOf(filePath))
         return KastWriteAndValidateSuccessResponse(
             ok = diagnostics.clean,
@@ -689,13 +751,17 @@ internal class SkillRpcOrchestrator(
         )
     }
 
-    private suspend fun addPlacedContent(request: KastPlacedScopeMutationRequest): KastScopeMutationResponse =
+    private suspend fun addPlacedContent(
+        request: KastPlacedScopeMutationRequest,
+        progress: MutationProgressReporter,
+    ): KastScopeMutationResponse =
         addContentAtPlacement(
             operation = request.operation,
             workspaceRoot = request.requestedWorkspaceRoot?.value,
             placement = request.placement,
             contentFile = request.contentFilePath.value,
             statementBody = false,
+            progress = progress,
         )
 
     private suspend fun addContentAtPlacement(
@@ -704,8 +770,10 @@ internal class SkillRpcOrchestrator(
         placement: KastPlacementSelector,
         contentFile: String,
         statementBody: Boolean,
+        progress: MutationProgressReporter,
     ): KastScopeMutationResponse {
         workspaceRootFor(workspaceRoot)
+        progress.enter(KastMutationProgressStage.IDENTITY_RESOLUTION)
         val resolvedPlacement = resolvePlacement(placement, statementBody)
         val content = resolveContent(null, contentFile)
         val response = applyEditsAndValidate(
@@ -723,6 +791,7 @@ internal class SkillRpcOrchestrator(
                 filePath = resolvedPlacement.filePath,
                 offset = resolvedPlacement.offset,
             ),
+            progress = progress,
         )
         return response.toScopeMutationResponse(
             operation = operation,
@@ -875,6 +944,11 @@ internal class SkillRpcOrchestrator(
     private suspend fun optimizeImports(filePath: String) = run {
         requireMutationCapability(MutationCapability.OPTIMIZE_IMPORTS)
         backend.optimizeImports(ImportOptimizeQuery(filePaths = listOf(filePath)).parsed())
+    }
+
+    private suspend fun refreshFiles(filePaths: List<String>) {
+        requireMutationCapability(MutationCapability.REFRESH_WORKSPACE)
+        backend.refresh(RefreshQuery(filePaths = filePaths.distinct()).parsed())
     }
 
     private suspend fun validateFiles(filePaths: List<String>): KastDiagnosticsSummary {
@@ -1269,6 +1343,14 @@ internal class SkillRpcOrchestrator(
         val reasons: List<String>,
     )
 
+}
+
+private fun MutationProgressReporter.enter(stage: KastMutationProgressStage) {
+    report(MutationProgressEvent.StageEntered(stage))
+}
+
+private fun MutationProgressReporter.editApplicationCompleted() {
+    report(MutationProgressEvent.EditApplicationCompleted)
 }
 
 private fun String.normalizedAbsolutePath(): String = Path.of(this).toAbsolutePath().normalize().toString()

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationFingerprint.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationFingerprint.kt
@@ -1,0 +1,10 @@
+package io.github.amichne.kast.server.mutation
+
+@JvmInline
+internal value class MutationFingerprint(
+    val value: String,
+) {
+    init {
+        require(value.isNotBlank()) { "Mutation fingerprint must not be blank" }
+    }
+}

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistry.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistry.kt
@@ -16,83 +16,78 @@ import io.github.amichne.kast.api.protocol.ApiErrorResponse
 import io.github.amichne.kast.api.protocol.ConflictException
 import io.github.amichne.kast.api.protocol.NotFoundException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.io.Closeable
 
 internal class MutationOperationRegistry(
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    private val scope: CoroutineScope,
     private val operationIdFactory: () -> KastMutationOperationId = KastMutationOperationId::random,
-) {
+) : Closeable {
     private val lock = Any()
     private val operationsById = mutableMapOf<KastMutationOperationId, OperationEntry>()
     private val operationsByKey = mutableMapOf<KastMutationIdempotencyKey, OperationEntry>()
+    private var closed = false
 
     fun submit(
         mutation: KastSemanticMutation,
         fingerprint: MutationFingerprint,
         execute: suspend (MutationProgressReporter) -> ExecutionOutcome,
     ): KastMutationSubmissionReceipt {
-        val existing = synchronized(lock) { operationsByKey[mutation.idempotencyKey] }
-        if (existing != null) {
-            if (existing.fingerprint != fingerprint) {
-                throw ConflictException(
-                    message = "Mutation idempotency key is already bound to another request",
-                    details = mapOf(
-                        "idempotencyKey" to mutation.idempotencyKey.value,
-                        "operationId" to existing.operationId.value,
-                    ),
-                )
+        val submission = synchronized(lock) {
+            if (closed) {
+                throw ConflictException("Mutation operation registry is shutting down")
             }
-            return synchronized(lock) {
-                KastMutationSubmissionReceipt(operation = existing.snapshot(), deduplicated = true)
-            }
-        }
-
-        val entry = synchronized(lock) {
-            operationsByKey[mutation.idempotencyKey]?.let { raced ->
-                if (raced.fingerprint != fingerprint) {
+            operationsByKey[mutation.idempotencyKey]?.let { existing ->
+                if (existing.fingerprint != fingerprint) {
                     throw ConflictException(
                         message = "Mutation idempotency key is already bound to another request",
                         details = mapOf(
                             "idempotencyKey" to mutation.idempotencyKey.value,
-                            "operationId" to raced.operationId.value,
+                            "operationId" to existing.operationId.value,
                         ),
                     )
                 }
-                return KastMutationSubmissionReceipt(operation = raced.snapshot(), deduplicated = true)
+                return@synchronized Submission.Existing(
+                    KastMutationSubmissionReceipt(operation = existing.snapshot(), deduplicated = true),
+                )
             }
-            OperationEntry(
+
+            lateinit var entry: OperationEntry
+            val job = scope.launch(start = CoroutineStart.LAZY) {
+                runOperation(entry, execute)
+            }
+            entry = OperationEntry(
                 operationId = uniqueOperationId(),
                 mutation = mutation,
                 fingerprint = fingerprint,
-            ).also { created ->
-                operationsById[created.operationId] = created
-                operationsByKey[mutation.idempotencyKey] = created
-            }
-        }
-
-        val queuedReceipt = synchronized(lock) {
-            KastMutationSubmissionReceipt(operation = entry.snapshot(), deduplicated = false)
-        }
-        val job = scope.launch {
-            runOperation(entry, execute)
-        }
-        synchronized(lock) {
-            entry.job = job
-        }
-        job.invokeOnCompletion { cause ->
-            if (cause is CancellationException) {
-                synchronized(lock) {
-                    entry.transitionToCancelledAfterStop()
+                job = job,
+            )
+            job.invokeOnCompletion { cause ->
+                if (cause is CancellationException) {
+                    synchronized(lock) {
+                        entry.transitionToCancelledAfterStop()
+                    }
                 }
             }
+            operationsById[entry.operationId] = entry
+            operationsByKey[mutation.idempotencyKey] = entry
+            Submission.New(
+                receipt = KastMutationSubmissionReceipt(operation = entry.snapshot(), deduplicated = false),
+                job = job,
+            )
         }
-        return queuedReceipt
+
+        if (submission is Submission.New) {
+            submission.job.start()
+        }
+        return submission.receipt
     }
 
     fun status(selector: KastMutationOperationSelector): KastMutationOperationSnapshot =
@@ -106,8 +101,29 @@ internal class MutationOperationRegistry(
             }
             entry.snapshot() to entry.job
         }
-        job?.cancel(CancellationException("Semantic mutation cancellation requested"))
+        job.cancel(CancellationException("Semantic mutation cancellation requested"))
         return snapshot
+    }
+
+    override fun close() {
+        val jobs = synchronized(lock) {
+            if (closed) {
+                return
+            }
+            closed = true
+            operationsById.values
+                .filterNot { it.state.isTerminal() }
+                .onEach { entry ->
+                    entry.state = entry.state.withCancellationRequested()
+                }
+                .map(OperationEntry::job)
+        }
+        jobs.forEach { job ->
+            job.cancel(CancellationException("Semantic mutation server is shutting down"))
+        }
+        runBlocking {
+            jobs.joinAll()
+        }
     }
 
     private suspend fun runOperation(
@@ -190,12 +206,25 @@ internal class MutationOperationRegistry(
         ) : ExecutionOutcome
     }
 
+    private sealed interface Submission {
+        val receipt: KastMutationSubmissionReceipt
+
+        data class Existing(
+            override val receipt: KastMutationSubmissionReceipt,
+        ) : Submission
+
+        data class New(
+            override val receipt: KastMutationSubmissionReceipt,
+            val job: Job,
+        ) : Submission
+    }
+
     private class OperationEntry(
         val operationId: KastMutationOperationId,
         val mutation: KastSemanticMutation,
         val fingerprint: MutationFingerprint,
         var state: KastMutationOperationState = KastMutationOperationState.Queued(),
-        var job: Job? = null,
+        val job: Job,
     ) {
         fun snapshot(): KastMutationOperationSnapshot = KastMutationOperationSnapshot(
             operationId = operationId,

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistry.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistry.kt
@@ -1,0 +1,279 @@
+package io.github.amichne.kast.server.mutation
+
+import io.github.amichne.kast.api.contract.mutation.KastMutationExecutionTrace
+import io.github.amichne.kast.api.contract.mutation.KastMutationFailure
+import io.github.amichne.kast.api.contract.mutation.KastMutationIdempotencyKey
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationId
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSelector
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSnapshot
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationState
+import io.github.amichne.kast.api.contract.mutation.KastMutationProgressStage
+import io.github.amichne.kast.api.contract.mutation.KastMutationSubmissionReceipt
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutationResult
+import io.github.amichne.kast.api.protocol.AnalysisException
+import io.github.amichne.kast.api.protocol.ApiErrorResponse
+import io.github.amichne.kast.api.protocol.ConflictException
+import io.github.amichne.kast.api.protocol.NotFoundException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+
+internal class MutationOperationRegistry(
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    private val operationIdFactory: () -> KastMutationOperationId = KastMutationOperationId::random,
+) {
+    private val lock = Any()
+    private val operationsById = mutableMapOf<KastMutationOperationId, OperationEntry>()
+    private val operationsByKey = mutableMapOf<KastMutationIdempotencyKey, OperationEntry>()
+
+    fun submit(
+        mutation: KastSemanticMutation,
+        fingerprint: MutationFingerprint,
+        execute: suspend (MutationProgressReporter) -> ExecutionOutcome,
+    ): KastMutationSubmissionReceipt {
+        val existing = synchronized(lock) { operationsByKey[mutation.idempotencyKey] }
+        if (existing != null) {
+            if (existing.fingerprint != fingerprint) {
+                throw ConflictException(
+                    message = "Mutation idempotency key is already bound to another request",
+                    details = mapOf(
+                        "idempotencyKey" to mutation.idempotencyKey.value,
+                        "operationId" to existing.operationId.value,
+                    ),
+                )
+            }
+            return synchronized(lock) {
+                KastMutationSubmissionReceipt(operation = existing.snapshot(), deduplicated = true)
+            }
+        }
+
+        val entry = synchronized(lock) {
+            operationsByKey[mutation.idempotencyKey]?.let { raced ->
+                if (raced.fingerprint != fingerprint) {
+                    throw ConflictException(
+                        message = "Mutation idempotency key is already bound to another request",
+                        details = mapOf(
+                            "idempotencyKey" to mutation.idempotencyKey.value,
+                            "operationId" to raced.operationId.value,
+                        ),
+                    )
+                }
+                return KastMutationSubmissionReceipt(operation = raced.snapshot(), deduplicated = true)
+            }
+            OperationEntry(
+                operationId = uniqueOperationId(),
+                mutation = mutation,
+                fingerprint = fingerprint,
+            ).also { created ->
+                operationsById[created.operationId] = created
+                operationsByKey[mutation.idempotencyKey] = created
+            }
+        }
+
+        val queuedReceipt = synchronized(lock) {
+            KastMutationSubmissionReceipt(operation = entry.snapshot(), deduplicated = false)
+        }
+        val job = scope.launch {
+            runOperation(entry, execute)
+        }
+        synchronized(lock) {
+            entry.job = job
+        }
+        job.invokeOnCompletion { cause ->
+            if (cause is CancellationException) {
+                synchronized(lock) {
+                    entry.transitionToCancelledAfterStop()
+                }
+            }
+        }
+        return queuedReceipt
+    }
+
+    fun status(selector: KastMutationOperationSelector): KastMutationOperationSnapshot =
+        synchronized(lock) { requireEntry(selector).snapshot() }
+
+    fun cancel(selector: KastMutationOperationSelector): KastMutationOperationSnapshot {
+        val (snapshot, job) = synchronized(lock) {
+            val entry = requireEntry(selector)
+            if (!entry.state.isTerminal()) {
+                entry.state = entry.state.withCancellationRequested()
+            }
+            entry.snapshot() to entry.job
+        }
+        job?.cancel(CancellationException("Semantic mutation cancellation requested"))
+        return snapshot
+    }
+
+    private suspend fun runOperation(
+        entry: OperationEntry,
+        execute: suspend (MutationProgressReporter) -> ExecutionOutcome,
+    ) {
+        try {
+            val outcome = execute(reporterFor(entry))
+            currentCoroutineContext().ensureActive()
+            synchronized(lock) {
+                val trace = entry.state.trace
+                val cancellationRequested = entry.state.cancellationRequested
+                entry.state = when (outcome) {
+                    is ExecutionOutcome.Succeeded -> KastMutationOperationState.Completed(
+                        result = outcome.result,
+                        trace = trace,
+                        cancellationRequested = cancellationRequested,
+                    )
+
+                    is ExecutionOutcome.Failed -> KastMutationOperationState.Failed(
+                        failure = outcome.failure,
+                        trace = trace,
+                        cancellationRequested = cancellationRequested,
+                    )
+                }
+            }
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Throwable) {
+            synchronized(lock) {
+                entry.state = KastMutationOperationState.Failed(
+                    failure = KastMutationFailure.Thrown(exception.toApiError(entry.operationId)),
+                    trace = entry.state.trace,
+                    cancellationRequested = entry.state.cancellationRequested,
+                )
+            }
+        }
+    }
+
+    private fun reporterFor(entry: OperationEntry): MutationProgressReporter = MutationProgressReporter { event ->
+        synchronized(lock) {
+            if (entry.state.isTerminal()) {
+                return@synchronized
+            }
+            entry.state = when (event) {
+                is MutationProgressEvent.StageEntered -> entry.state.entering(event.stage)
+                MutationProgressEvent.EditApplicationCompleted -> entry.state.editApplicationCompleted()
+            }
+        }
+    }
+
+    private fun requireEntry(selector: KastMutationOperationSelector): OperationEntry = when (selector) {
+        is KastMutationOperationSelector.ByOperationId -> operationsById[selector.operationId]
+        is KastMutationOperationSelector.ByIdempotencyKey -> operationsByKey[selector.idempotencyKey]
+    } ?: throw NotFoundException(
+        message = "Mutation operation was not found",
+        details = when (selector) {
+            is KastMutationOperationSelector.ByOperationId -> mapOf("operationId" to selector.operationId.value)
+            is KastMutationOperationSelector.ByIdempotencyKey -> mapOf("idempotencyKey" to selector.idempotencyKey.value)
+        },
+    )
+
+    private fun uniqueOperationId(): KastMutationOperationId {
+        repeat(MAX_OPERATION_ID_ATTEMPTS) {
+            val candidate = operationIdFactory()
+            if (candidate !in operationsById) {
+                return candidate
+            }
+        }
+        error("Mutation operation ID factory produced repeated collisions")
+    }
+
+    internal sealed interface ExecutionOutcome {
+        data class Succeeded(
+            val result: KastSemanticMutationResult,
+        ) : ExecutionOutcome
+
+        data class Failed(
+            val failure: KastMutationFailure,
+        ) : ExecutionOutcome
+    }
+
+    private class OperationEntry(
+        val operationId: KastMutationOperationId,
+        val mutation: KastSemanticMutation,
+        val fingerprint: MutationFingerprint,
+        var state: KastMutationOperationState = KastMutationOperationState.Queued(),
+        var job: Job? = null,
+    ) {
+        fun snapshot(): KastMutationOperationSnapshot = KastMutationOperationSnapshot(
+            operationId = operationId,
+            idempotencyKey = mutation.idempotencyKey,
+            mutationKind = mutation.kind,
+            state = state,
+        )
+
+        fun transitionToCancelledAfterStop() {
+            if (state.isTerminal()) {
+                return
+            }
+            state = KastMutationOperationState.Cancelled(
+                message = "Cancellation acknowledged after semantic mutation execution stopped.",
+                trace = state.trace,
+                cancellationRequested = true,
+            )
+        }
+    }
+
+    private companion object {
+        const val MAX_OPERATION_ID_ATTEMPTS = 8
+    }
+}
+
+private fun KastMutationOperationState.isTerminal(): Boolean =
+    this is KastMutationOperationState.Completed ||
+        this is KastMutationOperationState.Failed ||
+        this is KastMutationOperationState.Cancelled
+
+private fun KastMutationOperationState.withCancellationRequested(): KastMutationOperationState = when (this) {
+    is KastMutationOperationState.Queued -> copy(cancellationRequested = true)
+    is KastMutationOperationState.Applying -> copy(cancellationRequested = true)
+    is KastMutationOperationState.Validating -> copy(cancellationRequested = true)
+    is KastMutationOperationState.Completed,
+    is KastMutationOperationState.Failed,
+    is KastMutationOperationState.Cancelled,
+    -> this
+}
+
+private fun KastMutationOperationState.entering(stage: KastMutationProgressStage): KastMutationOperationState {
+    val nextTrace = trace.entering(stage)
+    return if (stage <= KastMutationProgressStage.EDIT_APPLICATION) {
+        KastMutationOperationState.Applying(
+            stage = stage,
+            trace = nextTrace,
+            cancellationRequested = cancellationRequested,
+        )
+    } else {
+        KastMutationOperationState.Validating(
+            stage = stage,
+            trace = nextTrace,
+            cancellationRequested = cancellationRequested,
+        )
+    }
+}
+
+private fun KastMutationOperationState.editApplicationCompleted(): KastMutationOperationState {
+    val nextTrace = trace.editApplicationCompleted()
+    return when (this) {
+        is KastMutationOperationState.Applying -> copy(trace = nextTrace)
+        else -> error("Mutation edit completion was reported outside the applying state")
+    }
+}
+
+private fun Throwable.toApiError(operationId: KastMutationOperationId): ApiErrorResponse = when (this) {
+    is AnalysisException -> ApiErrorResponse(
+        requestId = operationId.value,
+        code = errorCode,
+        message = message,
+        retryable = retryable,
+        details = details,
+    )
+
+    else -> ApiErrorResponse(
+        requestId = operationId.value,
+        code = "MUTATION_EXECUTION_FAILED",
+        message = message ?: this::class.java.simpleName,
+        retryable = false,
+    )
+}

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationOperationService.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationOperationService.kt
@@ -11,19 +11,28 @@ import io.github.amichne.kast.api.contract.skill.KastRenameSuccessResponse
 import io.github.amichne.kast.api.contract.skill.KastScopeMutationFailureResponse
 import io.github.amichne.kast.api.contract.skill.KastScopeMutationSuccessResponse
 import io.github.amichne.kast.server.SkillRpcOrchestrator
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import java.io.Closeable
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 
 internal class MutationOperationService(
     private val skillRpc: SkillRpcOrchestrator,
     private val json: Json,
-    private val registry: MutationOperationRegistry = MutationOperationRegistry(),
-) {
+) : Closeable {
+    private val operationJob: CompletableJob = SupervisorJob()
+    private val registry = MutationOperationRegistry(
+        CoroutineScope(operationJob + Dispatchers.Default),
+    )
+
     fun submit(mutation: KastSemanticMutation): KastMutationSubmissionReceipt = registry.submit(
         mutation = mutation,
         fingerprint = mutation.fingerprint(),
@@ -41,6 +50,11 @@ internal class MutationOperationService(
     fun status(selector: KastMutationOperationSelector): KastMutationOperationSnapshot = registry.status(selector)
 
     fun cancel(selector: KastMutationOperationSelector): KastMutationOperationSnapshot = registry.cancel(selector)
+
+    override fun close() {
+        registry.close()
+        operationJob.cancel()
+    }
 
     private fun KastSemanticMutation.fingerprint(): MutationFingerprint {
         val request = when (this) {
@@ -70,7 +84,11 @@ private fun JsonElement.canonical(): JsonElement = when (this) {
 }
 
 private fun KastRenameSuccessResponse.toOutcome(): MutationOperationRegistry.ExecutionOutcome =
-    MutationOperationRegistry.ExecutionOutcome.Succeeded(KastSemanticMutationResult.Rename(this))
+    if (ok) {
+        MutationOperationRegistry.ExecutionOutcome.Succeeded(KastSemanticMutationResult.Rename(this))
+    } else {
+        MutationOperationRegistry.ExecutionOutcome.Failed(KastMutationFailure.AppliedInvalidRename(this))
+    }
 
 private fun KastRenameFailureResponse.toOutcome(): MutationOperationRegistry.ExecutionOutcome =
     MutationOperationRegistry.ExecutionOutcome.Failed(KastMutationFailure.Rename(this))
@@ -83,8 +101,11 @@ private fun io.github.amichne.kast.api.contract.skill.KastRenameResponse.toOutco
 
 private fun io.github.amichne.kast.api.contract.skill.KastScopeMutationResponse.toOutcome(): MutationOperationRegistry.ExecutionOutcome =
     when (this) {
-        is KastScopeMutationSuccessResponse ->
+        is KastScopeMutationSuccessResponse -> if (ok) {
             MutationOperationRegistry.ExecutionOutcome.Succeeded(KastSemanticMutationResult.Scope(this))
+        } else {
+            MutationOperationRegistry.ExecutionOutcome.Failed(KastMutationFailure.AppliedInvalidScope(this))
+        }
 
         is KastScopeMutationFailureResponse ->
             MutationOperationRegistry.ExecutionOutcome.Failed(KastMutationFailure.Scope(this))

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationOperationService.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationOperationService.kt
@@ -1,0 +1,95 @@
+package io.github.amichne.kast.server.mutation
+
+import io.github.amichne.kast.api.contract.mutation.KastMutationFailure
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSelector
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSnapshot
+import io.github.amichne.kast.api.contract.mutation.KastMutationSubmissionReceipt
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutationResult
+import io.github.amichne.kast.api.contract.skill.KastRenameFailureResponse
+import io.github.amichne.kast.api.contract.skill.KastRenameSuccessResponse
+import io.github.amichne.kast.api.contract.skill.KastScopeMutationFailureResponse
+import io.github.amichne.kast.api.contract.skill.KastScopeMutationSuccessResponse
+import io.github.amichne.kast.server.SkillRpcOrchestrator
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+internal class MutationOperationService(
+    private val skillRpc: SkillRpcOrchestrator,
+    private val json: Json,
+    private val registry: MutationOperationRegistry = MutationOperationRegistry(),
+) {
+    fun submit(mutation: KastSemanticMutation): KastMutationSubmissionReceipt = registry.submit(
+        mutation = mutation,
+        fingerprint = mutation.fingerprint(),
+    ) { reporter ->
+        when (mutation) {
+            is KastSemanticMutation.Rename -> skillRpc.rename(mutation.request, reporter).toOutcome()
+            is KastSemanticMutation.AddFile -> skillRpc.addFile(mutation.request, reporter).toOutcome()
+            is KastSemanticMutation.AddDeclaration -> skillRpc.addDeclaration(mutation.request, reporter).toOutcome()
+            is KastSemanticMutation.AddImplementation -> skillRpc.addImplementation(mutation.request, reporter).toOutcome()
+            is KastSemanticMutation.AddStatement -> skillRpc.addStatement(mutation.request, reporter).toOutcome()
+            is KastSemanticMutation.ReplaceDeclaration -> skillRpc.replaceDeclaration(mutation.request, reporter).toOutcome()
+        }
+    }
+
+    fun status(selector: KastMutationOperationSelector): KastMutationOperationSnapshot = registry.status(selector)
+
+    fun cancel(selector: KastMutationOperationSelector): KastMutationOperationSnapshot = registry.cancel(selector)
+
+    private fun KastSemanticMutation.fingerprint(): MutationFingerprint {
+        val request = when (this) {
+            is KastSemanticMutation.Rename -> canonicalRequest(mutationRequestSerializer(), request)
+            is KastSemanticMutation.AddFile -> canonicalRequest(mutationRequestSerializer(), request)
+            is KastSemanticMutation.AddDeclaration -> canonicalRequest(mutationRequestSerializer(), request)
+            is KastSemanticMutation.AddImplementation -> canonicalRequest(mutationRequestSerializer(), request)
+            is KastSemanticMutation.AddStatement -> canonicalRequest(mutationRequestSerializer(), request)
+            is KastSemanticMutation.ReplaceDeclaration -> canonicalRequest(mutationRequestSerializer(), request)
+        }
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest("$symbolMethod\n$request".toByteArray(StandardCharsets.UTF_8))
+            .joinToString(separator = "") { byte -> "%02x".format(byte) }
+        return MutationFingerprint(digest)
+    }
+
+    private fun <T> canonicalRequest(serializer: KSerializer<T>, request: T): String =
+        json.encodeToJsonElement(serializer, request).canonical().toString()
+}
+
+private fun JsonElement.canonical(): JsonElement = when (this) {
+    is JsonArray -> JsonArray(map(JsonElement::canonical))
+    is JsonObject -> JsonObject(entries.sortedBy(Map.Entry<String, JsonElement>::key).associate { (key, value) ->
+        key to value.canonical()
+    })
+    else -> this
+}
+
+private fun KastRenameSuccessResponse.toOutcome(): MutationOperationRegistry.ExecutionOutcome =
+    MutationOperationRegistry.ExecutionOutcome.Succeeded(KastSemanticMutationResult.Rename(this))
+
+private fun KastRenameFailureResponse.toOutcome(): MutationOperationRegistry.ExecutionOutcome =
+    MutationOperationRegistry.ExecutionOutcome.Failed(KastMutationFailure.Rename(this))
+
+private fun io.github.amichne.kast.api.contract.skill.KastRenameResponse.toOutcome(): MutationOperationRegistry.ExecutionOutcome =
+    when (this) {
+        is KastRenameSuccessResponse -> toOutcome()
+        is KastRenameFailureResponse -> toOutcome()
+    }
+
+private fun io.github.amichne.kast.api.contract.skill.KastScopeMutationResponse.toOutcome(): MutationOperationRegistry.ExecutionOutcome =
+    when (this) {
+        is KastScopeMutationSuccessResponse ->
+            MutationOperationRegistry.ExecutionOutcome.Succeeded(KastSemanticMutationResult.Scope(this))
+
+        is KastScopeMutationFailureResponse ->
+            MutationOperationRegistry.ExecutionOutcome.Failed(KastMutationFailure.Scope(this))
+    }
+
+@Suppress("UNCHECKED_CAST")
+private inline fun <reified T> mutationRequestSerializer(): KSerializer<T> =
+    kotlinx.serialization.serializer<T>()

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationProgressEvent.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationProgressEvent.kt
@@ -1,0 +1,11 @@
+package io.github.amichne.kast.server.mutation
+
+import io.github.amichne.kast.api.contract.mutation.KastMutationProgressStage
+
+internal sealed interface MutationProgressEvent {
+    data class StageEntered(
+        val stage: KastMutationProgressStage,
+    ) : MutationProgressEvent
+
+    data object EditApplicationCompleted : MutationProgressEvent
+}

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationProgressReporter.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/mutation/MutationProgressReporter.kt
@@ -1,0 +1,9 @@
+package io.github.amichne.kast.server.mutation
+
+internal fun interface MutationProgressReporter {
+    fun report(event: MutationProgressEvent)
+
+    companion object {
+        val NONE: MutationProgressReporter = MutationProgressReporter { }
+    }
+}

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt
@@ -5,6 +5,12 @@ import io.github.amichne.kast.api.protocol.JsonRpcRequest
 import io.github.amichne.kast.api.protocol.JsonRpcSuccessResponse
 import io.github.amichne.kast.api.contract.RuntimeLifecycleAction
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
+import io.github.amichne.kast.api.contract.mutation.KastMutationIdempotencyKey
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSelector
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSnapshot
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationState
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
+import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
 import io.github.amichne.kast.testing.FakeAnalysisBackend
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -22,6 +28,7 @@ import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
 import java.nio.channels.SocketChannel
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.io.path.exists
@@ -192,6 +199,47 @@ class AnalysisServerSocketTest {
     }
 
     @Test
+    fun `mutation status remains retrievable by idempotency key after client disconnect`() {
+        val socketPath = tempDir.resolve("run").resolve("m.sock")
+        val target = tempDir.resolve("src/Reconnected.kt")
+        val contentFile = tempDir.resolve("reconnected-content.kt")
+        Files.writeString(contentFile, "package sample\n\nclass Reconnected\n")
+        val idempotencyKey = KastMutationIdempotencyKey("issue-333-reconnect")
+        val mutation = KastSemanticMutation.AddFile(
+            idempotencyKey = idempotencyKey,
+            request = KastAddFileRequest(
+                workspaceRoot = tempDir.toString(),
+                filePath = target.toString(),
+                contentFile = contentFile.toString(),
+            ),
+        )
+
+        AnalysisServer(
+            backend = FakeAnalysisBackend.sample(tempDir),
+            config = AnalysisServerConfig(
+                transport = AnalysisTransport.UnixDomainSocket(socketPath),
+                descriptorDirectory = tempDir.resolve("instances"),
+            ),
+        ).start().use {
+            sendWithoutReadingResponse(
+                socketPath = socketPath,
+                request = JsonRpcRequest(
+                    id = JsonPrimitive(1),
+                    method = "mutation/submit",
+                    params = json.encodeToJsonElement(KastSemanticMutation.serializer(), mutation),
+                ),
+            )
+            Thread.sleep(25)
+
+            val selector = KastMutationOperationSelector.ByIdempotencyKey(idempotencyKey)
+            val terminal = awaitMutationTerminal(socketPath, selector)
+
+            assertTrue(terminal.state is KastMutationOperationState.Completed)
+            assertEquals("package sample\n\nclass Reconnected\n", Files.readString(target))
+        }
+    }
+
+    @Test
     fun `expected client disconnects include macOS disconnected socket errors`() {
         assertTrue(isExpectedClientDisconnect(IOException("Socket is not connected")))
     }
@@ -222,6 +270,33 @@ class AnalysisServerSocketTest {
             writer.newLine()
             writer.flush()
         }
+    }
+
+    private fun awaitMutationTerminal(
+        socketPath: Path,
+        selector: KastMutationOperationSelector,
+    ): KastMutationOperationSnapshot {
+        repeat(200) {
+            val response = callSocket(
+                socketPath = socketPath,
+                request = JsonRpcRequest(
+                    id = JsonPrimitive(2),
+                    method = "mutation/status",
+                    params = json.encodeToJsonElement(KastMutationOperationSelector.serializer(), selector),
+                ),
+            )
+            val success = json.decodeFromString(JsonRpcSuccessResponse.serializer(), response)
+            val snapshot = json.decodeFromJsonElement(KastMutationOperationSnapshot.serializer(), success.result)
+            if (
+                snapshot.state is KastMutationOperationState.Completed ||
+                snapshot.state is KastMutationOperationState.Failed ||
+                snapshot.state is KastMutationOperationState.Cancelled
+            ) {
+                return snapshot
+            }
+            Thread.sleep(5)
+        }
+        error("Mutation operation did not become terminal after reconnect")
     }
 
     private fun awaitClientHandlerCompletion() {

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt
@@ -1,8 +1,7 @@
 package io.github.amichne.kast.server
 
+import io.github.amichne.kast.api.contract.AnalysisBackend
 import io.github.amichne.kast.api.contract.AnalysisTransport
-import io.github.amichne.kast.api.protocol.JsonRpcRequest
-import io.github.amichne.kast.api.protocol.JsonRpcSuccessResponse
 import io.github.amichne.kast.api.contract.RuntimeLifecycleAction
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.contract.mutation.KastMutationIdempotencyKey
@@ -10,8 +9,16 @@ import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSelecto
 import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSnapshot
 import io.github.amichne.kast.api.contract.mutation.KastMutationOperationState
 import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
+import io.github.amichne.kast.api.contract.result.ApplyEditsResult
 import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
+import io.github.amichne.kast.api.protocol.JsonRpcRequest
+import io.github.amichne.kast.api.protocol.JsonRpcSuccessResponse
+import io.github.amichne.kast.api.validation.ParsedApplyEditsQuery
 import io.github.amichne.kast.testing.FakeAnalysisBackend
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -31,6 +38,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.exists
 
 class AnalysisServerSocketTest {
@@ -240,6 +248,64 @@ class AnalysisServerSocketTest {
     }
 
     @Test
+    fun `server close cancels and joins mutation before removing descriptor authority`() {
+        val socketPath = tempDir.resolve("run").resolve("c.sock")
+        val descriptorDirectory = tempDir.resolve("close-instances")
+        val descriptorFile = descriptorDirectory.resolve("daemons.json")
+        val target = tempDir.resolve("src/AfterClose.kt")
+        val contentFile = tempDir.resolve("after-close-content.kt")
+        Files.writeString(contentFile, "package sample\n\nclass AfterClose\n")
+        val applyStarted = CompletableDeferred<Unit>()
+        val applyStopped = CompletableDeferred<Unit>()
+        val descriptorRetainedDuringStop = AtomicBoolean(false)
+        val backend = ClosingApplyBackend(
+            delegate = FakeAnalysisBackend.sample(tempDir),
+            applyStarted = applyStarted,
+            applyStopped = applyStopped,
+            descriptorFile = descriptorFile,
+            descriptorIdentity = socketPath.toString(),
+            descriptorRetainedDuringStop = descriptorRetainedDuringStop,
+        )
+        val server = AnalysisServer(
+            backend = backend,
+            config = AnalysisServerConfig(
+                transport = AnalysisTransport.UnixDomainSocket(socketPath),
+                descriptorDirectory = descriptorDirectory,
+            ),
+        ).start()
+        val mutation = KastSemanticMutation.AddFile(
+            idempotencyKey = KastMutationIdempotencyKey("issue-333-server-close"),
+            request = KastAddFileRequest(
+                workspaceRoot = tempDir.toString(),
+                filePath = target.toString(),
+                contentFile = contentFile.toString(),
+            ),
+        )
+        callSocket(
+            socketPath = socketPath,
+            request = JsonRpcRequest(
+                id = JsonPrimitive(1),
+                method = "mutation/submit",
+                params = json.encodeToJsonElement(KastSemanticMutation.serializer(), mutation),
+            ),
+        )
+        runBlocking { withTimeout(1_000) { applyStarted.await() } }
+
+        server.close()
+        runBlocking { withTimeout(1_000) { applyStopped.await() } }
+        Thread.sleep(300)
+
+        assertFalse(Files.exists(target), "mutation wrote after server authority closed")
+        assertTrue(
+            descriptorRetainedDuringStop.get(),
+            "descriptor authority was removed before the mutation worker stopped",
+        )
+        assertFalse(
+            Files.exists(descriptorFile) && Files.readString(descriptorFile).contains(socketPath.toString()),
+        )
+    }
+
+    @Test
     fun `expected client disconnects include macOS disconnected socket errors`() {
         assertTrue(isExpectedClientDisconnect(IOException("Socket is not connected")))
     }
@@ -302,6 +368,28 @@ class AnalysisServerSocketTest {
     private fun awaitClientHandlerCompletion() {
         repeat(50) {
             Thread.sleep(10)
+        }
+    }
+}
+
+private class ClosingApplyBackend(
+    private val delegate: AnalysisBackend,
+    private val applyStarted: CompletableDeferred<Unit>,
+    private val applyStopped: CompletableDeferred<Unit>,
+    private val descriptorFile: Path,
+    private val descriptorIdentity: String,
+    private val descriptorRetainedDuringStop: AtomicBoolean,
+) : AnalysisBackend by delegate {
+    override suspend fun applyEdits(query: ParsedApplyEditsQuery): ApplyEditsResult {
+        applyStarted.complete(Unit)
+        return try {
+            delay(250)
+            delegate.applyEdits(query)
+        } finally {
+            descriptorRetainedDuringStop.set(
+                Files.exists(descriptorFile) && Files.readString(descriptorFile).contains(descriptorIdentity),
+            )
+            applyStopped.complete(Unit)
         }
     }
 }

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationLifecycleTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationLifecycleTest.kt
@@ -1,0 +1,243 @@
+package io.github.amichne.kast.server.mutation
+
+import io.github.amichne.kast.api.contract.AnalysisBackend
+import io.github.amichne.kast.api.contract.mutation.KastMutationEditApplicationState
+import io.github.amichne.kast.api.contract.mutation.KastMutationIdempotencyKey
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSelector
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSnapshot
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationState
+import io.github.amichne.kast.api.contract.mutation.KastMutationProgressStage
+import io.github.amichne.kast.api.contract.mutation.KastMutationSubmissionReceipt
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutationResult
+import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
+import io.github.amichne.kast.api.contract.skill.KastAddDeclarationRequest
+import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
+import io.github.amichne.kast.api.contract.skill.KastAtPlacementAnchor
+import io.github.amichne.kast.api.contract.skill.KastFilePlacementScope
+import io.github.amichne.kast.api.contract.skill.KastPlacementAnchor
+import io.github.amichne.kast.api.contract.skill.KastPlacementSelector
+import io.github.amichne.kast.api.protocol.JsonRpcRequest
+import io.github.amichne.kast.api.protocol.JsonRpcSuccessResponse
+import io.github.amichne.kast.api.validation.ParsedApplyEditsQuery
+import io.github.amichne.kast.server.AnalysisServerConfig
+import io.github.amichne.kast.server.RpcAnalysisDispatcher
+import io.github.amichne.kast.testing.FakeAnalysisBackend
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+class MutationOperationLifecycleTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    private val json = Json {
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `retry applies once and terminal status retains all progress and result`() = runBlocking {
+        val backend = FakeAnalysisBackend.sample(tempDir)
+        val dispatcher = RpcAnalysisDispatcher(backend, AnalysisServerConfig())
+        val target = tempDir.resolve("src/Sample.kt")
+        val contentFile = tempDir.resolve("declaration.kt")
+        Files.writeString(contentFile, "\nfun added() = Unit\n")
+        val mutation = KastSemanticMutation.AddDeclaration(
+            idempotencyKey = KastMutationIdempotencyKey("issue-333-lifecycle"),
+            request = KastAddDeclarationRequest(
+                workspaceRoot = tempDir.toString(),
+                placement = KastPlacementSelector(
+                    scope = KastFilePlacementScope(target.toString()),
+                    anchor = KastAtPlacementAnchor(KastPlacementAnchor.FILE_BOTTOM),
+                ),
+                contentFile = contentFile.toString(),
+            ),
+        )
+
+        val first = submit(dispatcher, mutation)
+        val retry = submit(dispatcher, mutation)
+        val terminal = awaitTerminal(
+            dispatcher,
+            KastMutationOperationSelector.ByOperationId(first.operation.operationId),
+        )
+
+        assertEquals(first.operation.operationId, retry.operation.operationId)
+        assertTrue(retry.deduplicated)
+        assertEquals(1, target.readText().split("fun added() = Unit").size - 1)
+        assertEquals(
+            listOf(
+                KastMutationProgressStage.IDENTITY_RESOLUTION,
+                KastMutationProgressStage.EDIT_APPLICATION,
+                KastMutationProgressStage.WORKSPACE_REFRESH,
+                KastMutationProgressStage.IMPORT_OPTIMIZATION,
+                KastMutationProgressStage.DIAGNOSTICS,
+            ),
+            terminal.state.trace.enteredStages,
+        )
+        val completed = terminal.state as KastMutationOperationState.Completed
+        assertTrue(completed.result is KastSemanticMutationResult.Scope)
+        assertEquals(
+            terminal,
+            status(dispatcher, KastMutationOperationSelector.ByIdempotencyKey(mutation.idempotencyKey)),
+        )
+    }
+
+    @Test
+    fun `operation longer than ten seconds returns receipt before terminal result`() = runBlocking {
+        val backend = DelayedApplyBackend(FakeAnalysisBackend.sample(tempDir), 10_100)
+        val dispatcher = RpcAnalysisDispatcher(backend, AnalysisServerConfig(requestTimeoutMillis = 500))
+        val contentFile = tempDir.resolve("slow-content.kt")
+        val target = tempDir.resolve("src/Slow.kt")
+        Files.writeString(contentFile, "package sample\n\nclass Slow\n")
+        val mutation = KastSemanticMutation.AddFile(
+            idempotencyKey = KastMutationIdempotencyKey("issue-333-slow"),
+            request = KastAddFileRequest(
+                workspaceRoot = tempDir.toString(),
+                filePath = target.toString(),
+                contentFile = contentFile.toString(),
+            ),
+        )
+        val clock = TimeSource.Monotonic
+        val operationStart = clock.markNow()
+
+        val receipt = submit(dispatcher, mutation)
+        val submissionElapsed = operationStart.elapsedNow()
+        val terminal = awaitTerminal(
+            dispatcher,
+            KastMutationOperationSelector.ByOperationId(receipt.operation.operationId),
+            attempts = 3_000,
+        )
+
+        assertTrue(submissionElapsed < 1.seconds, "submission took $submissionElapsed")
+        assertTrue(operationStart.elapsedNow() > 10.seconds)
+        assertTrue(terminal.state is KastMutationOperationState.Completed)
+        assertEquals("package sample\n\nclass Slow\n", target.readText())
+    }
+
+    @Test
+    fun `cancellation request retrieves typed terminal cancelled outcome`() = runBlocking {
+        val applyStarted = CompletableDeferred<Unit>()
+        val backend = CancellableApplyBackend(FakeAnalysisBackend.sample(tempDir), applyStarted)
+        val dispatcher = RpcAnalysisDispatcher(backend, AnalysisServerConfig())
+        val contentFile = tempDir.resolve("cancel-content.kt")
+        val target = tempDir.resolve("src/Cancelled.kt")
+        Files.writeString(contentFile, "package sample\n\nclass Cancelled\n")
+        val mutation = KastSemanticMutation.AddFile(
+            idempotencyKey = KastMutationIdempotencyKey("issue-333-cancel"),
+            request = KastAddFileRequest(
+                workspaceRoot = tempDir.toString(),
+                filePath = target.toString(),
+                contentFile = contentFile.toString(),
+            ),
+        )
+        val receipt = submit(dispatcher, mutation)
+        applyStarted.await()
+        val selector = KastMutationOperationSelector.ByOperationId(receipt.operation.operationId)
+
+        val acknowledged = dispatch(
+            dispatcher = dispatcher,
+            method = "mutation/cancel",
+            params = json.encodeToJsonElement(KastMutationOperationSelector.serializer(), selector),
+            serializer = KastMutationOperationSnapshot.serializer(),
+        )
+        val terminal = awaitTerminal(dispatcher, selector)
+
+        assertTrue(acknowledged.state.cancellationRequested)
+        val cancelled = terminal.state as KastMutationOperationState.Cancelled
+        assertEquals(KastMutationEditApplicationState.STARTED, cancelled.trace.editApplicationState)
+        assertFalse(cancelled.trace.safeForFilesystemFallback)
+        assertFalse(Files.exists(target))
+    }
+
+    private suspend fun submit(
+        dispatcher: RpcAnalysisDispatcher,
+        mutation: KastSemanticMutation,
+    ): KastMutationSubmissionReceipt = dispatch(
+        dispatcher = dispatcher,
+        method = "mutation/submit",
+        params = json.encodeToJsonElement(KastSemanticMutation.serializer(), mutation),
+        serializer = KastMutationSubmissionReceipt.serializer(),
+    )
+
+    private suspend fun status(
+        dispatcher: RpcAnalysisDispatcher,
+        selector: KastMutationOperationSelector,
+    ): KastMutationOperationSnapshot = dispatch(
+        dispatcher = dispatcher,
+        method = "mutation/status",
+        params = json.encodeToJsonElement(KastMutationOperationSelector.serializer(), selector),
+        serializer = KastMutationOperationSnapshot.serializer(),
+    )
+
+    private suspend fun awaitTerminal(
+        dispatcher: RpcAnalysisDispatcher,
+        selector: KastMutationOperationSelector,
+        attempts: Int = 400,
+    ): KastMutationOperationSnapshot {
+        repeat(attempts) {
+            val snapshot = status(dispatcher, selector)
+            if (
+                snapshot.state is KastMutationOperationState.Completed ||
+                snapshot.state is KastMutationOperationState.Failed ||
+                snapshot.state is KastMutationOperationState.Cancelled
+            ) {
+                return snapshot
+            }
+            delay(5)
+        }
+        error("Mutation operation did not become terminal")
+    }
+
+    private suspend fun <T> dispatch(
+        dispatcher: RpcAnalysisDispatcher,
+        method: String,
+        params: JsonElement,
+        serializer: KSerializer<T>,
+    ): T {
+        val raw = dispatcher.dispatch(
+            JsonRpcRequest(
+                id = JsonPrimitive(1),
+                method = method,
+                params = params,
+            ),
+        )
+        val response = json.decodeFromString(JsonRpcSuccessResponse.serializer(), raw)
+        return json.decodeFromJsonElement(serializer, response.result)
+    }
+}
+
+private class DelayedApplyBackend(
+    private val delegate: AnalysisBackend,
+    private val delayMillis: Long,
+) : AnalysisBackend by delegate {
+    override suspend fun applyEdits(query: ParsedApplyEditsQuery) = run {
+        delay(delayMillis)
+        delegate.applyEdits(query)
+    }
+}
+
+private class CancellableApplyBackend(
+    delegate: AnalysisBackend,
+    private val applyStarted: CompletableDeferred<Unit>,
+) : AnalysisBackend by delegate {
+    override suspend fun applyEdits(query: ParsedApplyEditsQuery) = run {
+        applyStarted.complete(Unit)
+        awaitCancellation()
+    }
+}

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationLifecycleTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationLifecycleTest.kt
@@ -16,6 +16,9 @@ import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
 import io.github.amichne.kast.api.contract.mutation.KastSemanticMutationResult
 import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
 import io.github.amichne.kast.api.contract.result.DiagnosticsResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisState
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
+import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
 import io.github.amichne.kast.api.contract.skill.KastAddDeclarationRequest
 import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
 import io.github.amichne.kast.api.contract.skill.KastAtPlacementAnchor
@@ -203,6 +206,39 @@ class MutationOperationLifecycleTest {
     }
 
     @Test
+    fun `applied mutation with incomplete semantic evidence fails closed and remains observable`() = runBlocking {
+        val backend = IncompleteMutationDiagnosticsBackend(FakeAnalysisBackend.sample(tempDir))
+        val dispatcher = RpcAnalysisDispatcher(backend, AnalysisServerConfig())
+        val contentFile = tempDir.resolve("incomplete-scope-content.kt")
+        val target = tempDir.resolve("src/IncompleteScope.kt")
+        Files.writeString(contentFile, "package sample\n\nclass IncompleteScope\n")
+        val mutation = KastSemanticMutation.AddFile(
+            idempotencyKey = KastMutationIdempotencyKey("issue-333-incomplete-scope"),
+            request = KastAddFileRequest(
+                workspaceRoot = tempDir.toString(),
+                filePath = target.toString(),
+                contentFile = contentFile.toString(),
+            ),
+        )
+
+        val receipt = submit(dispatcher, mutation)
+        val terminal = awaitTerminal(
+            dispatcher,
+            KastMutationOperationSelector.ByOperationId(receipt.operation.operationId),
+        )
+
+        val failed = terminal.state as KastMutationOperationState.Failed
+        val incomplete = failed.failure as KastMutationFailure.AppliedInvalidScope
+        assertFalse(incomplete.response.ok)
+        assertTrue(incomplete.response.applied)
+        assertEquals(SemanticAnalysisOutcome.INCOMPLETE, incomplete.response.diagnostics.semanticOutcome)
+        assertEquals(1, incomplete.response.diagnostics.skippedFileCount)
+        assertEquals(KastMutationEditApplicationState.COMPLETED, failed.trace.editApplicationState)
+        assertFalse(terminal.safeForFilesystemFallback)
+        assertTrue(Files.exists(target))
+    }
+
+    @Test
     fun `applied rename response with invalid diagnostics is a typed failed operation`() = runBlocking {
         val backend = InvalidDiagnosticsBackend(FakeAnalysisBackend.sample(tempDir))
         val dispatcher = RpcAnalysisDispatcher(backend, AnalysisServerConfig())
@@ -312,7 +348,7 @@ private class InvalidDiagnosticsBackend(
 ) : AnalysisBackend by delegate {
     override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult {
         val filePath = query.filePaths.value.first().value
-        return DiagnosticsResult(
+        return DiagnosticsResult.of(
             diagnostics = listOf(
                 Diagnostic(
                     location = Location(
@@ -327,6 +363,22 @@ private class InvalidDiagnosticsBackend(
                     message = "Synthetic invalid mutation diagnostic",
                 ),
             ),
+            fileStatuses = listOf(FileAnalysisStatus.analyzed(query.filePaths.value.first())),
         )
     }
+}
+
+private class IncompleteMutationDiagnosticsBackend(
+    private val delegate: AnalysisBackend,
+) : AnalysisBackend by delegate {
+    override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult = DiagnosticsResult.of(
+        diagnostics = emptyList(),
+        fileStatuses = query.filePaths.value.map { filePath ->
+            FileAnalysisStatus.skipped(
+                filePath = filePath,
+                state = FileAnalysisState.BACKEND_FAILURE,
+                message = "Semantic analysis was unavailable after the mutation",
+            )
+        },
+    )
 }

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationLifecycleTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationLifecycleTest.kt
@@ -1,6 +1,10 @@
 package io.github.amichne.kast.server.mutation
 
 import io.github.amichne.kast.api.contract.AnalysisBackend
+import io.github.amichne.kast.api.contract.Diagnostic
+import io.github.amichne.kast.api.contract.DiagnosticSeverity
+import io.github.amichne.kast.api.contract.Location
+import io.github.amichne.kast.api.contract.mutation.KastMutationFailure
 import io.github.amichne.kast.api.contract.mutation.KastMutationEditApplicationState
 import io.github.amichne.kast.api.contract.mutation.KastMutationIdempotencyKey
 import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSelector
@@ -11,15 +15,18 @@ import io.github.amichne.kast.api.contract.mutation.KastMutationSubmissionReceip
 import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
 import io.github.amichne.kast.api.contract.mutation.KastSemanticMutationResult
 import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
+import io.github.amichne.kast.api.contract.result.DiagnosticsResult
 import io.github.amichne.kast.api.contract.skill.KastAddDeclarationRequest
 import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
 import io.github.amichne.kast.api.contract.skill.KastAtPlacementAnchor
 import io.github.amichne.kast.api.contract.skill.KastFilePlacementScope
 import io.github.amichne.kast.api.contract.skill.KastPlacementAnchor
 import io.github.amichne.kast.api.contract.skill.KastPlacementSelector
+import io.github.amichne.kast.api.contract.skill.KastRenameBySymbolRequest
 import io.github.amichne.kast.api.protocol.JsonRpcRequest
 import io.github.amichne.kast.api.protocol.JsonRpcSuccessResponse
 import io.github.amichne.kast.api.validation.ParsedApplyEditsQuery
+import io.github.amichne.kast.api.validation.ParsedDiagnosticsQuery
 import io.github.amichne.kast.server.AnalysisServerConfig
 import io.github.amichne.kast.server.RpcAnalysisDispatcher
 import io.github.amichne.kast.testing.FakeAnalysisBackend
@@ -161,8 +168,66 @@ class MutationOperationLifecycleTest {
         assertTrue(acknowledged.state.cancellationRequested)
         val cancelled = terminal.state as KastMutationOperationState.Cancelled
         assertEquals(KastMutationEditApplicationState.STARTED, cancelled.trace.editApplicationState)
-        assertFalse(cancelled.trace.safeForFilesystemFallback)
+        assertFalse(terminal.safeForFilesystemFallback)
         assertFalse(Files.exists(target))
+    }
+
+    @Test
+    fun `applied scope response with invalid diagnostics is a typed failed operation`() = runBlocking {
+        val backend = InvalidDiagnosticsBackend(FakeAnalysisBackend.sample(tempDir))
+        val dispatcher = RpcAnalysisDispatcher(backend, AnalysisServerConfig())
+        val contentFile = tempDir.resolve("invalid-scope-content.kt")
+        val target = tempDir.resolve("src/InvalidScope.kt")
+        Files.writeString(contentFile, "package sample\n\nclass InvalidScope\n")
+        val mutation = KastSemanticMutation.AddFile(
+            idempotencyKey = KastMutationIdempotencyKey("issue-333-invalid-scope"),
+            request = KastAddFileRequest(
+                workspaceRoot = tempDir.toString(),
+                filePath = target.toString(),
+                contentFile = contentFile.toString(),
+            ),
+        )
+
+        val receipt = submit(dispatcher, mutation)
+        val terminal = awaitTerminal(
+            dispatcher,
+            KastMutationOperationSelector.ByOperationId(receipt.operation.operationId),
+        )
+
+        val failed = terminal.state as KastMutationOperationState.Failed
+        val invalid = failed.failure as KastMutationFailure.AppliedInvalidScope
+        assertFalse(invalid.response.ok)
+        assertTrue(invalid.response.applied)
+        assertEquals(KastMutationEditApplicationState.COMPLETED, failed.trace.editApplicationState)
+        assertTrue(Files.exists(target))
+    }
+
+    @Test
+    fun `applied rename response with invalid diagnostics is a typed failed operation`() = runBlocking {
+        val backend = InvalidDiagnosticsBackend(FakeAnalysisBackend.sample(tempDir))
+        val dispatcher = RpcAnalysisDispatcher(backend, AnalysisServerConfig())
+        val target = tempDir.resolve("src/Sample.kt")
+        val mutation = KastSemanticMutation.Rename(
+            idempotencyKey = KastMutationIdempotencyKey("issue-333-invalid-rename"),
+            request = KastRenameBySymbolRequest(
+                workspaceRoot = tempDir.toString(),
+                symbol = "greet",
+                fileHint = target.toString(),
+                newName = "hello",
+            ),
+        )
+
+        val receipt = submit(dispatcher, mutation)
+        val terminal = awaitTerminal(
+            dispatcher,
+            KastMutationOperationSelector.ByOperationId(receipt.operation.operationId),
+        )
+
+        val failed = terminal.state as KastMutationOperationState.Failed
+        val invalid = failed.failure as KastMutationFailure.AppliedInvalidRename
+        assertFalse(invalid.response.ok)
+        assertEquals(KastMutationEditApplicationState.COMPLETED, failed.trace.editApplicationState)
+        assertTrue(target.readText().contains("fun hello()"))
     }
 
     private suspend fun submit(
@@ -239,5 +304,29 @@ private class CancellableApplyBackend(
     override suspend fun applyEdits(query: ParsedApplyEditsQuery) = run {
         applyStarted.complete(Unit)
         awaitCancellation()
+    }
+}
+
+private class InvalidDiagnosticsBackend(
+    private val delegate: AnalysisBackend,
+) : AnalysisBackend by delegate {
+    override suspend fun diagnostics(query: ParsedDiagnosticsQuery): DiagnosticsResult {
+        val filePath = query.filePaths.value.first().value
+        return DiagnosticsResult(
+            diagnostics = listOf(
+                Diagnostic(
+                    location = Location(
+                        filePath = filePath,
+                        startOffset = 0,
+                        endOffset = 1,
+                        startLine = 1,
+                        startColumn = 1,
+                        preview = "invalid",
+                    ),
+                    severity = DiagnosticSeverity.ERROR,
+                    message = "Synthetic invalid mutation diagnostic",
+                ),
+            ),
+        )
     }
 }

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistryTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistryTest.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.server.mutation
 
+import io.github.amichne.kast.api.contract.NormalizedPath
 import io.github.amichne.kast.api.contract.mutation.KastMutationEditApplicationState
 import io.github.amichne.kast.api.contract.mutation.KastMutationIdempotencyKey
 import io.github.amichne.kast.api.contract.mutation.KastMutationOperationId
@@ -8,6 +9,8 @@ import io.github.amichne.kast.api.contract.mutation.KastMutationOperationState
 import io.github.amichne.kast.api.contract.mutation.KastMutationProgressStage
 import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
 import io.github.amichne.kast.api.contract.mutation.KastSemanticMutationResult
+import io.github.amichne.kast.api.contract.result.DiagnosticsResult
+import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
 import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
 import io.github.amichne.kast.api.contract.skill.KastDiagnosticsSummary
 import io.github.amichne.kast.api.contract.skill.KastScopeMutationOperation
@@ -27,6 +30,7 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -227,7 +231,16 @@ class MutationOperationRegistryTest {
             createdFiles = listOf("/workspace/Added.kt"),
             editCount = 1,
             importChanges = 0,
-            diagnostics = KastDiagnosticsSummary(clean = true, errorCount = 0, warningCount = 0),
+            diagnostics = KastDiagnosticsSummary.from(
+                DiagnosticsResult.of(
+                    diagnostics = emptyList(),
+                    fileStatuses = listOf(
+                        FileAnalysisStatus.analyzed(
+                            NormalizedPath.ofAbsolute(Path.of("/workspace/Added.kt")),
+                        ),
+                    ),
+                ),
+            ),
             logFile = "",
         ),
     )

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistryTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistryTest.kt
@@ -1,0 +1,172 @@
+package io.github.amichne.kast.server.mutation
+
+import io.github.amichne.kast.api.contract.mutation.KastMutationEditApplicationState
+import io.github.amichne.kast.api.contract.mutation.KastMutationIdempotencyKey
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationId
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSelector
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationState
+import io.github.amichne.kast.api.contract.mutation.KastMutationProgressStage
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutationResult
+import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
+import io.github.amichne.kast.api.contract.skill.KastDiagnosticsSummary
+import io.github.amichne.kast.api.contract.skill.KastScopeMutationOperation
+import io.github.amichne.kast.api.contract.skill.KastScopeMutationSuccessResponse
+import io.github.amichne.kast.api.protocol.ConflictException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.atomic.AtomicInteger
+
+class MutationOperationRegistryTest {
+    private val firstOperationId = KastMutationOperationId("00000000-0000-0000-0000-000000000001")
+
+    @Test
+    fun `same key and fingerprint execute once while different fingerprint conflicts`() = runBlocking {
+        val executionCount = AtomicInteger()
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        val registry = registry()
+        val mutation = addFileMutation("issue-333-retry", "/workspace/Added.kt")
+        val fingerprint = MutationFingerprint("same-request")
+
+        val first = registry.submit(mutation, fingerprint) {
+            executionCount.incrementAndGet()
+            started.complete(Unit)
+            release.await()
+            MutationOperationRegistry.ExecutionOutcome.Succeeded(scopeSuccess())
+        }
+        started.await()
+        val retry = registry.submit(mutation, fingerprint) {
+            error("A deduplicated operation must not install another worker")
+        }
+
+        assertEquals(firstOperationId, first.operation.operationId)
+        assertEquals(first.operation.operationId, retry.operation.operationId)
+        assertFalse(first.deduplicated)
+        assertTrue(retry.deduplicated)
+        assertEquals(1, executionCount.get())
+        assertThrows<ConflictException> {
+            registry.submit(
+                addFileMutation("issue-333-retry", "/workspace/Different.kt"),
+                MutationFingerprint("different-request"),
+            ) { MutationOperationRegistry.ExecutionOutcome.Succeeded(scopeSuccess()) }
+        }
+
+        release.complete(Unit)
+        val terminal = awaitTerminal(registry, KastMutationOperationSelector.ByOperationId(firstOperationId))
+        assertTrue(terminal.state is KastMutationOperationState.Completed)
+        assertEquals(
+            terminal,
+            registry.status(KastMutationOperationSelector.ByIdempotencyKey(mutation.idempotencyKey)),
+        )
+    }
+
+    @Test
+    fun `cancellation becomes terminal only after worker stops and is idempotent`() = runBlocking {
+        val enteredIdentity = CompletableDeferred<Unit>()
+        val workerStopped = CompletableDeferred<Unit>()
+        val registry = registry()
+        val mutation = addFileMutation("issue-333-cancel-before-edit", "/workspace/Added.kt")
+        val receipt = registry.submit(mutation, MutationFingerprint("cancel-before-edit")) { reporter ->
+            reporter.report(MutationProgressEvent.StageEntered(KastMutationProgressStage.IDENTITY_RESOLUTION))
+            enteredIdentity.complete(Unit)
+            try {
+                awaitCancellation()
+            } finally {
+                workerStopped.complete(Unit)
+            }
+        }
+        enteredIdentity.await()
+        val selector = KastMutationOperationSelector.ByOperationId(receipt.operation.operationId)
+
+        val firstCancel = registry.cancel(selector)
+        val secondCancel = registry.cancel(selector)
+
+        assertTrue(firstCancel.state.cancellationRequested)
+        assertTrue(secondCancel.state.cancellationRequested)
+        workerStopped.await()
+        val terminal = awaitTerminal(registry, selector)
+        val cancelled = terminal.state as KastMutationOperationState.Cancelled
+        assertEquals(KastMutationEditApplicationState.NOT_STARTED, cancelled.trace.editApplicationState)
+        assertTrue(cancelled.trace.safeForFilesystemFallback)
+        assertEquals(terminal, registry.cancel(selector))
+        assertEquals(terminal, registry.status(selector))
+    }
+
+    @Test
+    fun `cancellation after edit application retains completed edit fact`() = runBlocking {
+        val editCompleted = CompletableDeferred<Unit>()
+        val registry = registry()
+        val mutation = addFileMutation("issue-333-cancel-after-edit", "/workspace/Added.kt")
+        val receipt = registry.submit(mutation, MutationFingerprint("cancel-after-edit")) { reporter ->
+            reporter.report(MutationProgressEvent.StageEntered(KastMutationProgressStage.EDIT_APPLICATION))
+            reporter.report(MutationProgressEvent.EditApplicationCompleted)
+            editCompleted.complete(Unit)
+            awaitCancellation()
+        }
+        editCompleted.await()
+        val selector = KastMutationOperationSelector.ByOperationId(receipt.operation.operationId)
+
+        registry.cancel(selector)
+
+        val terminal = awaitTerminal(registry, selector)
+        val cancelled = terminal.state as KastMutationOperationState.Cancelled
+        assertEquals(KastMutationEditApplicationState.COMPLETED, cancelled.trace.editApplicationState)
+        assertFalse(cancelled.trace.safeForFilesystemFallback)
+        assertNotEquals(KastMutationOperationState.Queued(), cancelled)
+    }
+
+    private fun registry(): MutationOperationRegistry = MutationOperationRegistry(
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+        operationIdFactory = { firstOperationId },
+    )
+
+    private fun addFileMutation(key: String, filePath: String): KastSemanticMutation.AddFile =
+        KastSemanticMutation.AddFile(
+            idempotencyKey = KastMutationIdempotencyKey(key),
+            request = KastAddFileRequest(filePath = filePath, contentFile = "/tmp/content.kt"),
+        )
+
+    private fun scopeSuccess(): KastSemanticMutationResult.Scope = KastSemanticMutationResult.Scope(
+        KastScopeMutationSuccessResponse(
+            ok = true,
+            operation = KastScopeMutationOperation.ADD_FILE,
+            applied = true,
+            affectedFiles = listOf("/workspace/Added.kt"),
+            createdFiles = listOf("/workspace/Added.kt"),
+            editCount = 1,
+            importChanges = 0,
+            diagnostics = KastDiagnosticsSummary(clean = true, errorCount = 0, warningCount = 0),
+            logFile = "",
+        ),
+    )
+
+    private suspend fun awaitTerminal(
+        registry: MutationOperationRegistry,
+        selector: KastMutationOperationSelector,
+    ) = buildList {
+        repeat(200) {
+            val snapshot = registry.status(selector)
+            if (
+                snapshot.state is KastMutationOperationState.Completed ||
+                snapshot.state is KastMutationOperationState.Failed ||
+                snapshot.state is KastMutationOperationState.Cancelled
+            ) {
+                add(snapshot)
+                return@buildList
+            }
+            delay(5)
+        }
+    }.single()
+}

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistryTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/mutation/MutationOperationRegistryTest.kt
@@ -14,6 +14,7 @@ import io.github.amichne.kast.api.contract.skill.KastScopeMutationOperation
 import io.github.amichne.kast.api.contract.skill.KastScopeMutationSuccessResponse
 import io.github.amichne.kast.api.protocol.ConflictException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -26,7 +27,11 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import kotlin.coroutines.CoroutineContext
 
 class MutationOperationRegistryTest {
     private val firstOperationId = KastMutationOperationId("00000000-0000-0000-0000-000000000001")
@@ -99,7 +104,7 @@ class MutationOperationRegistryTest {
         val terminal = awaitTerminal(registry, selector)
         val cancelled = terminal.state as KastMutationOperationState.Cancelled
         assertEquals(KastMutationEditApplicationState.NOT_STARTED, cancelled.trace.editApplicationState)
-        assertTrue(cancelled.trace.safeForFilesystemFallback)
+        assertTrue(terminal.safeForFilesystemFallback)
         assertEquals(terminal, registry.cancel(selector))
         assertEquals(terminal, registry.status(selector))
     }
@@ -123,8 +128,83 @@ class MutationOperationRegistryTest {
         val terminal = awaitTerminal(registry, selector)
         val cancelled = terminal.state as KastMutationOperationState.Cancelled
         assertEquals(KastMutationEditApplicationState.COMPLETED, cancelled.trace.editApplicationState)
-        assertFalse(cancelled.trace.safeForFilesystemFallback)
+        assertFalse(terminal.safeForFilesystemFallback)
         assertNotEquals(KastMutationOperationState.Queued(), cancelled)
+    }
+
+    @Test
+    fun `same-key cancellation cannot race worker attachment and start execution`() = runBlocking {
+        val blockingDispatcher = BlockingLaunchDispatcher()
+        val executionCount = AtomicInteger()
+        val submission = CompletableDeferred<Unit>()
+        val registry = MutationOperationRegistry(
+            scope = CoroutineScope(SupervisorJob() + blockingDispatcher),
+            operationIdFactory = { firstOperationId },
+        )
+        val mutation = addFileMutation("issue-333-attachment-race", "/workspace/Race.kt")
+        val fingerprint = MutationFingerprint("attachment-race")
+        val submitter = thread(name = "mutation-submit-race") {
+            registry.submit(mutation, fingerprint) {
+                executionCount.incrementAndGet()
+                MutationOperationRegistry.ExecutionOutcome.Succeeded(scopeSuccess())
+            }
+            submission.complete(Unit)
+        }
+        assertTrue(blockingDispatcher.awaitDispatch(), "worker launch never reached dispatcher")
+
+        val retry = registry.submit(mutation, fingerprint) {
+            error("same-key retry must not install another worker")
+        }
+        val cancelled = registry.cancel(
+            KastMutationOperationSelector.ByOperationId(retry.operation.operationId),
+        )
+        blockingDispatcher.release()
+        submission.await()
+        submitter.join()
+
+        val terminal = awaitTerminal(
+            registry,
+            KastMutationOperationSelector.ByOperationId(firstOperationId),
+        )
+        assertTrue(cancelled.state.cancellationRequested)
+        assertTrue(terminal.state is KastMutationOperationState.Cancelled)
+        assertEquals(0, executionCount.get())
+    }
+
+    @Test
+    fun `close cancels and joins workers while retaining truthful terminal trace`() = runBlocking {
+        val editStarted = CompletableDeferred<Unit>()
+        val workerStopped = CompletableDeferred<Unit>()
+        val registry = registry()
+        val receipt = registry.submit(
+            addFileMutation("issue-333-close", "/workspace/Close.kt"),
+            MutationFingerprint("close"),
+        ) { reporter ->
+            reporter.report(MutationProgressEvent.StageEntered(KastMutationProgressStage.EDIT_APPLICATION))
+            editStarted.complete(Unit)
+            try {
+                awaitCancellation()
+            } finally {
+                workerStopped.complete(Unit)
+            }
+        }
+        editStarted.await()
+
+        registry.close()
+
+        assertTrue(workerStopped.isCompleted)
+        val terminal = registry.status(
+            KastMutationOperationSelector.ByOperationId(receipt.operation.operationId),
+        )
+        val cancelled = terminal.state as KastMutationOperationState.Cancelled
+        assertEquals(KastMutationEditApplicationState.STARTED, cancelled.trace.editApplicationState)
+        assertTrue(cancelled.cancellationRequested)
+        assertThrows<ConflictException> {
+            registry.submit(
+                addFileMutation("issue-333-after-close", "/workspace/AfterClose.kt"),
+                MutationFingerprint("after-close"),
+            ) { MutationOperationRegistry.ExecutionOutcome.Succeeded(scopeSuccess()) }
+        }
     }
 
     private fun registry(): MutationOperationRegistry = MutationOperationRegistry(
@@ -169,4 +249,21 @@ class MutationOperationRegistryTest {
             delay(5)
         }
     }.single()
+}
+
+private class BlockingLaunchDispatcher : CoroutineDispatcher() {
+    private val dispatchEntered = CountDownLatch(1)
+    private val dispatchRelease = CountDownLatch(1)
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        dispatchEntered.countDown()
+        check(dispatchRelease.await(5, TimeUnit.SECONDS)) { "Timed out waiting to release worker dispatch" }
+        Dispatchers.Default.dispatch(context, block)
+    }
+
+    fun awaitDispatch(): Boolean = dispatchEntered.await(5, TimeUnit.SECONDS)
+
+    fun release() {
+        dispatchRelease.countDown()
+    }
 }

--- a/cli-rs/protocol/api-specification.md
+++ b/cli-rs/protocol/api-specification.md
@@ -44,7 +44,7 @@ so the page exposes the internal JSON-RPC catalog used by typed
 families, flow-oriented building blocks, and request fields that
 callers compose into larger automation flows.
 
-Catalog version: `dev`. Methods: `36`.
+Catalog version: `dev`. Methods: `39`.
 
 #### Method families
 
@@ -53,6 +53,7 @@ The families below are internal JSON-RPC namespaces, not public CLI commands.
 | Family | Role | Source | Methods |
 | --- | --- | --- | --- |
 | `system` | Runtime readiness, backend state, and capability discovery. | backend | `health`<br>`runtime/status`<br>`runtime/shutdown`<br>`runtime/restart`<br>`capabilities` |
+| `mutation` | Cataloged JSON-RPC methods. | backend | `mutation/submit`<br>`mutation/status`<br>`mutation/cancel` |
 | `symbol` | Name-based orchestration for agent and script workflows. | backend, sqlite | `symbol/scaffold`<br>`symbol/discover`<br>`symbol/query`<br>`symbol/resolve`<br>`symbol/references`<br>`symbol/callers`<br>`symbol/rename`<br>`symbol/write-and-validate`<br>`symbol/add-file`<br>`symbol/add-declaration`<br>`symbol/add-implementation`<br>`symbol/add-statement`<br>`symbol/replace-declaration` |
 | `raw` | Position- and file-based backend primitives. | backend | `raw/resolve`<br>`raw/references`<br>`raw/call-hierarchy`<br>`raw/type-hierarchy`<br>`raw/semantic-insertion-point`<br>`raw/diagnostics`<br>`raw/rename`<br>`raw/optimize-imports`<br>`raw/apply-edits`<br>`raw/workspace-refresh`<br>`raw/file-outline`<br>`raw/workspace-symbol`<br>`raw/workspace-search`<br>`raw/workspace-files`<br>`raw/implementations`<br>`raw/code-actions`<br>`raw/completions` |
 | `database` | Source-index queries for metrics and impact views. | sqlite | `database/metrics` |
@@ -85,6 +86,9 @@ uses a discriminated response envelope.
 | `runtime/shutdown` | `system` | backend | Ask the runtime host to shut down after this response is flushed | none | none | `RuntimeLifecycleResponse` | single result |
 | `runtime/restart` | `system` | backend | Ask the runtime host to restart after this response is flushed | none | none | `RuntimeLifecycleResponse` | single result |
 | `capabilities` | `system` | backend | Advertised read and mutation capabilities | none | none | `BackendCapabilities` | single result |
+| `mutation/submit` | `mutation` | backend | Submit an idempotent semantic mutation and return its stable operation identity | `type` | none | `KastMutationSubmissionReceipt` | single result |
+| `mutation/status` | `mutation` | backend | Retrieve retained semantic mutation state by operation identity or idempotency key | `type` | none | `KastMutationOperationSnapshot` | single result |
+| `mutation/cancel` | `mutation` | backend | Request cooperative cancellation and retrieve the latest semantic mutation state | `type` | none | `KastMutationOperationSnapshot` | single result |
 | `symbol/scaffold` | `symbol` | backend | Gather structural generation context for a Kotlin file | `targetFile` | `workspaceRoot`<br>`targetSymbol`<br>`mode`<br>`kind` | `KastScaffoldResponse` | `SCAFFOLD_SUCCESS`<br>`SCAFFOLD_FAILURE` |
 | `symbol/discover` | `symbol` | backend | Rank candidate declarations for a simple symbol name | `symbol` | `workspaceRoot`<br>`fileHint`<br>`line`<br>`codeSnippet`<br>`kind`<br>`containingType`<br>`maxResults`<br>`includeDeclarationScope` | `KastDiscoverResponse` | `DISCOVER_SUCCESS`<br>`DISCOVER_FAILURE` |
 | `symbol/query` | `symbol` | sqlite | Query compiler-indexed declarations with symbolic hard filters, fielded lexical/name matching, bounded graph relationship evidence, and optional semantic discovery evidence | `query` | `workspaceRoot`<br>`modes`<br>`filters`<br>`anchor`<br>`graph`<br>`semantic`<br>`limit`<br>`includeEvidence`<br>`includeNextRequests` | `KastSymbolQueryResponse` | `SYMBOL_QUERY_SUCCESS`<br>`SYMBOL_QUERY_FAILURE` |
@@ -163,6 +167,39 @@ Response type: `RuntimeLifecycleResponse`.
 No request parameters.
 
 Response type: `BackendCapabilities`.
+
+</details>
+
+<details markdown="1">
+<summary><code>mutation/submit</code> - Submit an idempotent semantic mutation and return its stable operation identity</summary>
+
+| Field | Type | Required | Nullable | Values |
+| --- | --- | --- | --- | --- |
+| `type` | `string` | yes | no | `RENAME`<br>`ADD_FILE`<br>`ADD_DECLARATION`<br>`ADD_IMPLEMENTATION`<br>`ADD_STATEMENT`<br>`REPLACE_DECLARATION` |
+
+Response type: `KastMutationSubmissionReceipt`.
+
+</details>
+
+<details markdown="1">
+<summary><code>mutation/status</code> - Retrieve retained semantic mutation state by operation identity or idempotency key</summary>
+
+| Field | Type | Required | Nullable | Values |
+| --- | --- | --- | --- | --- |
+| `type` | `string` | yes | no | `BY_OPERATION_ID`<br>`BY_IDEMPOTENCY_KEY` |
+
+Response type: `KastMutationOperationSnapshot`.
+
+</details>
+
+<details markdown="1">
+<summary><code>mutation/cancel</code> - Request cooperative cancellation and retrieve the latest semantic mutation state</summary>
+
+| Field | Type | Required | Nullable | Values |
+| --- | --- | --- | --- | --- |
+| `type` | `string` | yes | no | `BY_OPERATION_ID`<br>`BY_IDEMPOTENCY_KEY` |
+
+Response type: `KastMutationOperationSnapshot`.
 
 </details>
 

--- a/cli-rs/resources/kast-skill/SKILL.md
+++ b/cli-rs/resources/kast-skill/SKILL.md
@@ -20,7 +20,7 @@ the first iteration surface.
 2. Resolve identity with `kast agent symbol --query <name> --workspace-root "$PWD"`. Add `--kind`, `--file-hint`, `--containing-type`, `--references`, or `--callers incoming|outgoing` only when needed.
 3. Check changed files with `kast agent diagnostics --file-path <path> --workspace-root "$PWD"`.
 4. Query source-index impact with `kast agent impact --symbol <fq-name> --workspace-root "$PWD"`.
-5. Mutate only through typed plans. First run `kast agent rename`, `add-file`, `add-declaration`, `add-implementation`, `add-statement`, or `replace-declaration` without `--apply`; then add `--apply` after reviewing the plan and content file.
+5. Mutate only through typed plans. First run `kast agent rename`, `add-file`, `add-declaration`, `add-implementation`, `add-statement`, or `replace-declaration` without `--apply`; then add `--apply --idempotency-key <stable-key>` after reviewing the plan and content file.
 6. Use `--output json` for JSON-only parsed scripts; otherwise `kast agent` defaults to compact TOON.
 
 Completion criterion: every Kotlin semantic claim, edit target, relationship set,
@@ -38,7 +38,11 @@ work is explicitly outside Kotlin semantics.
 
 Use `--inside-file` or `--inside-scope` for scope selectors, and use `--at`,
 `--after-symbol`, or `--before-symbol` for declaration and implementation
-placement. Add `--apply` only after the plan is correct.
+placement. Add `--apply --idempotency-key <stable-key>` only after the plan is correct.
+
+## Mutation Recovery
+
+After a yield or disconnect, run `kast agent operation status --idempotency-key <stable-key> --workspace-root "$PWD"`; retrying the original request with the same key is also idempotent. Use `kast agent operation cancel` with the same selector to request cooperative cancellation. A filesystem fallback is safe only when retrieved terminal state proves edit application never started. Missing state after daemon restart is ambiguous; inspect the workspace instead of applying a fallback or using a new key.
 
 ## Health
 

--- a/cli-rs/resources/kast-skill/references/commands.json
+++ b/cli-rs/resources/kast-skill/references/commands.json
@@ -9,6 +9,11 @@
       "runtime/restart",
       "capabilities"
     ],
+    "mutation": [
+      "mutation/submit",
+      "mutation/status",
+      "mutation/cancel"
+    ],
     "symbol": [
       "symbol/scaffold",
       "symbol/discover",
@@ -97,6 +102,271 @@
         "fields": {}
       },
       "responseType": "BackendCapabilities"
+    },
+    "mutation/submit": {
+      "method": "mutation/submit",
+      "category": "mutation",
+      "summary": "Submit an idempotent semantic mutation and return its stable operation identity",
+      "dataSource": "backend",
+      "request": {
+        "fields": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "RENAME",
+              "ADD_FILE",
+              "ADD_DECLARATION",
+              "ADD_IMPLEMENTATION",
+              "ADD_STATEMENT",
+              "REPLACE_DECLARATION"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "responseType": "KastMutationSubmissionReceipt",
+      "variants": {
+        "RENAME": {
+          "fields": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "idempotencyKey",
+            "request"
+          ],
+          "sample": {
+            "type": "RENAME",
+            "idempotencyKey": "rename-order-service-process",
+            "request": {
+              "type": "RENAME_BY_SYMBOL_REQUEST",
+              "symbol": "com.example.OrderService.process",
+              "newName": "processSafely"
+            }
+          }
+        },
+        "ADD_FILE": {
+          "fields": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "idempotencyKey",
+            "request"
+          ],
+          "sample": {
+            "type": "ADD_FILE",
+            "idempotencyKey": "add-example-file",
+            "request": {
+              "filePath": "/workspace/src/main/kotlin/com/example/Added.kt",
+              "contentFile": "/tmp/Added.kt"
+            }
+          }
+        },
+        "ADD_DECLARATION": {
+          "fields": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "idempotencyKey",
+            "request"
+          ],
+          "sample": {
+            "type": "ADD_DECLARATION",
+            "idempotencyKey": "add-example-declaration",
+            "request": {
+              "placement": {
+                "scope": {
+                  "type": "FILE_SCOPE",
+                  "insideFile": "/workspace/src/main/kotlin/com/example/Example.kt"
+                },
+                "anchor": {
+                  "type": "AT_ANCHOR",
+                  "anchor": "file-bottom"
+                }
+              },
+              "contentFile": "/tmp/declaration.kt"
+            }
+          }
+        },
+        "ADD_IMPLEMENTATION": {
+          "fields": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "idempotencyKey",
+            "request"
+          ],
+          "sample": {
+            "type": "ADD_IMPLEMENTATION",
+            "idempotencyKey": "add-example-implementation",
+            "request": {
+              "placement": {
+                "scope": {
+                  "type": "NAMED_SCOPE",
+                  "insideScope": "com.example.Widget"
+                },
+                "anchor": {
+                  "type": "AT_ANCHOR",
+                  "anchor": "body-end"
+                }
+              },
+              "contentFile": "/tmp/implementation.kt"
+            }
+          }
+        },
+        "ADD_STATEMENT": {
+          "fields": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "idempotencyKey",
+            "request"
+          ],
+          "sample": {
+            "type": "ADD_STATEMENT",
+            "idempotencyKey": "add-example-statement",
+            "request": {
+              "insideScope": "com.example.Widget.render",
+              "anchor": "body-end",
+              "contentFile": "/tmp/statement.kt"
+            }
+          }
+        },
+        "REPLACE_DECLARATION": {
+          "fields": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "idempotencyKey",
+            "request"
+          ],
+          "sample": {
+            "type": "REPLACE_DECLARATION",
+            "idempotencyKey": "replace-example-declaration",
+            "request": {
+              "symbol": "com.example.Widget.render",
+              "contentFile": "/tmp/replacement.kt"
+            }
+          }
+        }
+      }
+    },
+    "mutation/status": {
+      "method": "mutation/status",
+      "category": "mutation",
+      "summary": "Retrieve retained semantic mutation state by operation identity or idempotency key",
+      "dataSource": "backend",
+      "request": {
+        "fields": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "BY_OPERATION_ID",
+              "BY_IDEMPOTENCY_KEY"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "responseType": "KastMutationOperationSnapshot",
+      "variants": {
+        "BY_OPERATION_ID": {
+          "fields": {
+            "operationId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "operationId"
+          ]
+        },
+        "BY_IDEMPOTENCY_KEY": {
+          "fields": {
+            "idempotencyKey": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "idempotencyKey"
+          ]
+        }
+      }
+    },
+    "mutation/cancel": {
+      "method": "mutation/cancel",
+      "category": "mutation",
+      "summary": "Request cooperative cancellation and retrieve the latest semantic mutation state",
+      "dataSource": "backend",
+      "request": {
+        "fields": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "BY_OPERATION_ID",
+              "BY_IDEMPOTENCY_KEY"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "responseType": "KastMutationOperationSnapshot",
+      "variants": {
+        "BY_OPERATION_ID": {
+          "fields": {
+            "operationId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "operationId"
+          ]
+        },
+        "BY_IDEMPOTENCY_KEY": {
+          "fields": {
+            "idempotencyKey": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "idempotencyKey"
+          ]
+        }
+      }
     },
     "symbol/scaffold": {
       "method": "symbol/scaffold",

--- a/cli-rs/resources/kast-skill/references/commands.yaml
+++ b/cli-rs/resources/kast-skill/references/commands.yaml
@@ -2,6 +2,10 @@ $schema: ./commands.schema.json
 categories:
   database:
   - database/metrics
+  mutation:
+  - mutation/submit
+  - mutation/status
+  - mutation/cancel
   raw:
   - raw/resolve
   - raw/references
@@ -107,6 +111,186 @@ commands:
       fields: {}
     responseType: HealthResponse
     summary: Basic health check
+  mutation/cancel:
+    category: mutation
+    dataSource: backend
+    method: mutation/cancel
+    request:
+      fields:
+        type:
+          enum:
+          - BY_OPERATION_ID
+          - BY_IDEMPOTENCY_KEY
+          type: string
+      required:
+      - type
+    responseType: KastMutationOperationSnapshot
+    summary: Request cooperative cancellation and retrieve the latest semantic mutation state
+    variants:
+      BY_IDEMPOTENCY_KEY:
+        fields:
+          idempotencyKey:
+            type: string
+        required:
+        - idempotencyKey
+      BY_OPERATION_ID:
+        fields:
+          operationId:
+            type: string
+        required:
+        - operationId
+  mutation/status:
+    category: mutation
+    dataSource: backend
+    method: mutation/status
+    request:
+      fields:
+        type:
+          enum:
+          - BY_OPERATION_ID
+          - BY_IDEMPOTENCY_KEY
+          type: string
+      required:
+      - type
+    responseType: KastMutationOperationSnapshot
+    summary: Retrieve retained semantic mutation state by operation identity or idempotency key
+    variants:
+      BY_IDEMPOTENCY_KEY:
+        fields:
+          idempotencyKey:
+            type: string
+        required:
+        - idempotencyKey
+      BY_OPERATION_ID:
+        fields:
+          operationId:
+            type: string
+        required:
+        - operationId
+  mutation/submit:
+    category: mutation
+    dataSource: backend
+    method: mutation/submit
+    request:
+      fields:
+        type:
+          enum:
+          - RENAME
+          - ADD_FILE
+          - ADD_DECLARATION
+          - ADD_IMPLEMENTATION
+          - ADD_STATEMENT
+          - REPLACE_DECLARATION
+          type: string
+      required:
+      - type
+    responseType: KastMutationSubmissionReceipt
+    summary: Submit an idempotent semantic mutation and return its stable operation identity
+    variants:
+      ADD_DECLARATION:
+        fields:
+          idempotencyKey:
+            type: string
+          request:
+            type: object
+        required:
+        - idempotencyKey
+        - request
+        sample:
+          idempotencyKey: add-example-declaration
+          request:
+            contentFile: /tmp/declaration.kt
+            placement:
+              anchor:
+                anchor: file-bottom
+                type: AT_ANCHOR
+              scope:
+                insideFile: /workspace/src/main/kotlin/com/example/Example.kt
+                type: FILE_SCOPE
+          type: ADD_DECLARATION
+      ADD_FILE:
+        fields:
+          idempotencyKey:
+            type: string
+          request:
+            type: object
+        required:
+        - idempotencyKey
+        - request
+        sample:
+          idempotencyKey: add-example-file
+          request:
+            contentFile: /tmp/Added.kt
+            filePath: /workspace/src/main/kotlin/com/example/Added.kt
+          type: ADD_FILE
+      ADD_IMPLEMENTATION:
+        fields:
+          idempotencyKey:
+            type: string
+          request:
+            type: object
+        required:
+        - idempotencyKey
+        - request
+        sample:
+          idempotencyKey: add-example-implementation
+          request:
+            contentFile: /tmp/implementation.kt
+            placement:
+              anchor:
+                anchor: body-end
+                type: AT_ANCHOR
+              scope:
+                insideScope: com.example.Widget
+                type: NAMED_SCOPE
+          type: ADD_IMPLEMENTATION
+      ADD_STATEMENT:
+        fields:
+          idempotencyKey:
+            type: string
+          request:
+            type: object
+        required:
+        - idempotencyKey
+        - request
+        sample:
+          idempotencyKey: add-example-statement
+          request:
+            anchor: body-end
+            contentFile: /tmp/statement.kt
+            insideScope: com.example.Widget.render
+          type: ADD_STATEMENT
+      RENAME:
+        fields:
+          idempotencyKey:
+            type: string
+          request:
+            type: object
+        required:
+        - idempotencyKey
+        - request
+        sample:
+          idempotencyKey: rename-order-service-process
+          request:
+            newName: processSafely
+            symbol: com.example.OrderService.process
+            type: RENAME_BY_SYMBOL_REQUEST
+          type: RENAME
+      REPLACE_DECLARATION:
+        fields:
+          idempotencyKey:
+            type: string
+          request:
+            type: object
+        required:
+        - idempotencyKey
+        - request
+        sample:
+          idempotencyKey: replace-example-declaration
+          request:
+            contentFile: /tmp/replacement.kt
+            symbol: com.example.Widget.render
+          type: REPLACE_DECLARATION
   raw/apply-edits:
     category: raw
     dataSource: backend

--- a/cli-rs/resources/kast-skill/references/quickstart.md
+++ b/cli-rs/resources/kast-skill/references/quickstart.md
@@ -33,11 +33,23 @@ kast agent symbol --query process --workspace-root "$PWD" --callers incoming
 kast agent diagnostics --workspace-root "$PWD" --file-path "$PWD/src/main/kotlin/App.kt"
 kast agent impact --workspace-root "$PWD" --symbol com.example.EventBean
 kast agent rename --workspace-root "$PWD" --symbol com.example.EventBean --new-name DomainEvent
-kast agent rename --workspace-root "$PWD" --symbol com.example.EventBean --new-name DomainEvent --apply
+kast agent rename --workspace-root "$PWD" --symbol com.example.EventBean --new-name DomainEvent --apply --idempotency-key rename-event-bean
 ```
 
 `--symbol` means a compiler-resolved fully-qualified identity. Use
 `agent symbol --query <name>` for lookup before mutation.
+
+If the apply command disconnects, retrieve its retained state with the same
+key. Cancellation is a request; poll status until the operation is terminal.
+
+```console
+kast agent operation status --workspace-root "$PWD" --idempotency-key rename-event-bean
+kast agent operation cancel --workspace-root "$PWD" --idempotency-key rename-event-bean
+```
+
+Use a direct filesystem fallback only when retrieved terminal state proves
+`editApplicationState` is `NOT_STARTED`. Missing state after daemon restart is
+ambiguous and requires workspace inspection.
 
 ## Boundaries
 

--- a/cli-rs/resources/kast-skill/references/requests/mutation/cancel/BY_IDEMPOTENCY_KEY/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/cancel/BY_IDEMPOTENCY_KEY/maximal.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/cancel",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "type": "BY_IDEMPOTENCY_KEY"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/cancel/BY_IDEMPOTENCY_KEY/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/cancel/BY_IDEMPOTENCY_KEY/minimal.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/cancel",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "type": "BY_IDEMPOTENCY_KEY"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/cancel/BY_OPERATION_ID/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/cancel/BY_OPERATION_ID/maximal.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/cancel",
+  "params": {
+    "operationId": "example-operationId",
+    "type": "BY_OPERATION_ID"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/cancel/BY_OPERATION_ID/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/cancel/BY_OPERATION_ID/minimal.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/cancel",
+  "params": {
+    "operationId": "example-operationId",
+    "type": "BY_OPERATION_ID"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/cancel/request.schema.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/cancel/request.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "oneOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "jsonrpc": {
+      "enum": [
+        "2.0"
+      ],
+      "type": "string"
+    },
+    "method": {
+      "enum": [
+        "mutation/cancel"
+      ],
+      "type": "string"
+    },
+    "params": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "type": {
+              "const": "BY_IDEMPOTENCY_KEY",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "idempotencyKey"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "operationId": {
+              "type": "string"
+            },
+            "type": {
+              "const": "BY_OPERATION_ID",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "operationId"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "required": [
+    "jsonrpc",
+    "method",
+    "params",
+    "id"
+  ],
+  "title": "Kast mutation/cancel JSON-RPC request",
+  "type": "object"
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/status/BY_IDEMPOTENCY_KEY/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/status/BY_IDEMPOTENCY_KEY/maximal.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/status",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "type": "BY_IDEMPOTENCY_KEY"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/status/BY_IDEMPOTENCY_KEY/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/status/BY_IDEMPOTENCY_KEY/minimal.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/status",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "type": "BY_IDEMPOTENCY_KEY"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/status/BY_OPERATION_ID/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/status/BY_OPERATION_ID/maximal.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/status",
+  "params": {
+    "operationId": "example-operationId",
+    "type": "BY_OPERATION_ID"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/status/BY_OPERATION_ID/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/status/BY_OPERATION_ID/minimal.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/status",
+  "params": {
+    "operationId": "example-operationId",
+    "type": "BY_OPERATION_ID"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/status/request.schema.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/status/request.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "oneOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "jsonrpc": {
+      "enum": [
+        "2.0"
+      ],
+      "type": "string"
+    },
+    "method": {
+      "enum": [
+        "mutation/status"
+      ],
+      "type": "string"
+    },
+    "params": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "type": {
+              "const": "BY_IDEMPOTENCY_KEY",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "idempotencyKey"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "operationId": {
+              "type": "string"
+            },
+            "type": {
+              "const": "BY_OPERATION_ID",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "operationId"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "required": [
+    "jsonrpc",
+    "method",
+    "params",
+    "id"
+  ],
+  "title": "Kast mutation/status JSON-RPC request",
+  "type": "object"
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_DECLARATION/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_DECLARATION/maximal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "ADD_DECLARATION"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_DECLARATION/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_DECLARATION/minimal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "ADD_DECLARATION"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_FILE/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_FILE/maximal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "ADD_FILE"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_FILE/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_FILE/minimal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "ADD_FILE"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_IMPLEMENTATION/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_IMPLEMENTATION/maximal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "ADD_IMPLEMENTATION"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_IMPLEMENTATION/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_IMPLEMENTATION/minimal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "ADD_IMPLEMENTATION"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_STATEMENT/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_STATEMENT/maximal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "ADD_STATEMENT"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_STATEMENT/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/ADD_STATEMENT/minimal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "ADD_STATEMENT"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/RENAME/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/RENAME/maximal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "RENAME"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/RENAME/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/RENAME/minimal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "RENAME"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/REPLACE_DECLARATION/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/REPLACE_DECLARATION/maximal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "REPLACE_DECLARATION"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/REPLACE_DECLARATION/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/REPLACE_DECLARATION/minimal.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "mutation/submit",
+  "params": {
+    "idempotencyKey": "example-idempotencyKey",
+    "request": {
+      "example": true
+    },
+    "type": "REPLACE_DECLARATION"
+  }
+}

--- a/cli-rs/resources/kast-skill/references/requests/mutation/submit/request.schema.json
+++ b/cli-rs/resources/kast-skill/references/requests/mutation/submit/request.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "oneOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "jsonrpc": {
+      "enum": [
+        "2.0"
+      ],
+      "type": "string"
+    },
+    "method": {
+      "enum": [
+        "mutation/submit"
+      ],
+      "type": "string"
+    },
+    "params": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": {
+              "const": "ADD_DECLARATION",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "idempotencyKey",
+            "request"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": {
+              "const": "ADD_FILE",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "idempotencyKey",
+            "request"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": {
+              "const": "ADD_IMPLEMENTATION",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "idempotencyKey",
+            "request"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": {
+              "const": "ADD_STATEMENT",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "idempotencyKey",
+            "request"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": {
+              "const": "RENAME",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "idempotencyKey",
+            "request"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "idempotencyKey": {
+              "type": "string"
+            },
+            "request": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": {
+              "const": "REPLACE_DECLARATION",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "idempotencyKey",
+            "request"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "required": [
+    "jsonrpc",
+    "method",
+    "params",
+    "id"
+  ],
+  "title": "Kast mutation/submit JSON-RPC request",
+  "type": "object"
+}

--- a/cli-rs/src/agent.rs
+++ b/cli-rs/src/agent.rs
@@ -3,7 +3,8 @@
 use crate::SCHEMA_VERSION;
 use crate::cli::OutputFormat;
 use crate::cli::{
-    AgentAddFileArgs, AgentCommand, AgentDiagnosticsArgs, AgentImpactArgs, AgentRenameArgs,
+    AgentAddFileArgs, AgentCommand, AgentDiagnosticsArgs, AgentImpactArgs, AgentMutationApplyArgs,
+    AgentOperationArgs, AgentOperationCommand, AgentOperationSelectorArgs, AgentRenameArgs,
     AgentReplaceDeclarationArgs, AgentRuntimeArgs, AgentScopedMutationArgs,
     AgentStatementMutationArgs, AgentSymbolArgs, AgentVerifyArgs,
 };

--- a/cli-rs/src/agent/dispatch.rs
+++ b/cli-rs/src/agent/dispatch.rs
@@ -64,17 +64,20 @@ fn execute(command: AgentCommand) -> AgentEnvelope {
         AgentCommand::AddDeclaration(args) => execute_agent_scoped_mutation(
             "agent/add-declaration",
             "symbol/add-declaration",
+            "ADD_DECLARATION",
             "add-declaration",
             args,
         ),
         AgentCommand::AddImplementation(args) => execute_agent_scoped_mutation(
             "agent/add-implementation",
             "symbol/add-implementation",
+            "ADD_IMPLEMENTATION",
             "add-implementation",
             args,
         ),
         AgentCommand::AddStatement(args) => execute_agent_add_statement(args),
         AgentCommand::ReplaceDeclaration(args) => execute_agent_replace_declaration(args),
+        AgentCommand::Operation(args) => execute_agent_operation(args),
     }
 }
 
@@ -214,8 +217,8 @@ fn execute_agent_rename(args: AgentRenameArgs) -> AgentEnvelope {
         "fileHint": args.file_hint,
         "containingType": args.containing_type,
     }));
-    let request = json_rpc_request("symbol/rename", params);
-    if !args.apply {
+    let request = json_rpc_request("symbol/rename", params.clone());
+    if !args.mutation.apply {
         let result = json!({
             "type": "KAST_AGENT_RENAME_PLAN",
             "ok": true,
@@ -229,8 +232,20 @@ fn execute_agent_rename(args: AgentRenameArgs) -> AgentEnvelope {
         });
         return result_envelope("agent/rename".to_string(), result);
     }
+    let idempotency_key = match applied_idempotency_key("agent/rename", args.mutation) {
+        Ok(key) => key,
+        Err(envelope) => return envelope,
+    };
+    let request = json_rpc_request(
+        "mutation/submit",
+        json!({
+            "type": "RENAME",
+            "idempotencyKey": idempotency_key,
+            "request": params,
+        }),
+    );
     execute_request(AgentRequest {
-        method: "symbol/rename".to_string(),
+        method: "mutation/submit".to_string(),
         request,
         runtime: args.runtime,
         full_response: true,
@@ -245,9 +260,10 @@ fn execute_agent_add_file(args: AgentAddFileArgs) -> AgentEnvelope {
     execute_agent_mutation(
         "agent/add-file",
         "symbol/add-file",
+        "ADD_FILE",
         "add-file",
         params,
-        args.apply,
+        args.mutation,
         args.runtime,
     )
 }
@@ -255,6 +271,7 @@ fn execute_agent_add_file(args: AgentAddFileArgs) -> AgentEnvelope {
 fn execute_agent_scoped_mutation(
     agent_method: &'static str,
     request_method: &'static str,
+    mutation_kind: &'static str,
     command_name: &'static str,
     args: AgentScopedMutationArgs,
 ) -> AgentEnvelope {
@@ -275,9 +292,10 @@ fn execute_agent_scoped_mutation(
     execute_agent_mutation(
         agent_method,
         request_method,
+        mutation_kind,
         command_name,
         params,
-        args.apply,
+        args.mutation,
         args.runtime,
     )
 }
@@ -291,9 +309,10 @@ fn execute_agent_add_statement(args: AgentStatementMutationArgs) -> AgentEnvelop
     execute_agent_mutation(
         "agent/add-statement",
         "symbol/add-statement",
+        "ADD_STATEMENT",
         "add-statement",
         params,
-        args.apply,
+        args.mutation,
         args.runtime,
     )
 }
@@ -309,9 +328,10 @@ fn execute_agent_replace_declaration(args: AgentReplaceDeclarationArgs) -> Agent
     execute_agent_mutation(
         "agent/replace-declaration",
         "symbol/replace-declaration",
+        "REPLACE_DECLARATION",
         "replace-declaration",
         params,
-        args.apply,
+        args.mutation,
         args.runtime,
     )
 }
@@ -319,19 +339,93 @@ fn execute_agent_replace_declaration(args: AgentReplaceDeclarationArgs) -> Agent
 fn execute_agent_mutation(
     agent_method: &'static str,
     request_method: &'static str,
+    mutation_kind: &'static str,
     command_name: &'static str,
     params: Value,
-    apply: bool,
+    mutation: AgentMutationApplyArgs,
     runtime: AgentRuntimeArgs,
 ) -> AgentEnvelope {
-    let request = json_rpc_request(request_method, params);
-    if !apply {
+    let request = json_rpc_request(request_method, params.clone());
+    if !mutation.apply {
         return mutation_plan_envelope(agent_method, command_name, request);
     }
+    let idempotency_key = match applied_idempotency_key(agent_method, mutation) {
+        Ok(key) => key,
+        Err(envelope) => return envelope,
+    };
+    let request = json_rpc_request(
+        "mutation/submit",
+        json!({
+            "type": mutation_kind,
+            "idempotencyKey": idempotency_key,
+            "request": params,
+        }),
+    );
     execute_request(AgentRequest {
-        method: request_method.to_string(),
+        method: "mutation/submit".to_string(),
         request,
         runtime,
+        full_response: true,
+    })
+}
+
+fn applied_idempotency_key(
+    agent_method: &'static str,
+    mutation: AgentMutationApplyArgs,
+) -> std::result::Result<String, AgentEnvelope> {
+    let Some(key) = mutation.idempotency_key else {
+        return Err(error_envelope(
+            agent_method.to_string(),
+            None,
+            agent_error(
+                "AGENT_USAGE",
+                "--idempotency-key is required whenever --apply is used",
+            ),
+        ));
+    };
+    if key.is_empty() || key.len() > 128 || key.trim() != key {
+        return Err(error_envelope(
+            agent_method.to_string(),
+            None,
+            agent_error(
+                "AGENT_USAGE",
+                "--idempotency-key must contain 1 to 128 characters without surrounding whitespace",
+            ),
+        ));
+    }
+    Ok(key)
+}
+
+fn execute_agent_operation(args: AgentOperationArgs) -> AgentEnvelope {
+    match args.command {
+        AgentOperationCommand::Status(selector) => {
+            execute_agent_operation_request("mutation/status", selector)
+        }
+        AgentOperationCommand::Cancel(selector) => {
+            execute_agent_operation_request("mutation/cancel", selector)
+        }
+    }
+}
+
+fn execute_agent_operation_request(
+    method: &'static str,
+    args: AgentOperationSelectorArgs,
+) -> AgentEnvelope {
+    let selector = match (args.operation_id, args.idempotency_key) {
+        (Some(operation_id), None) => json!({
+            "type": "BY_OPERATION_ID",
+            "operationId": operation_id,
+        }),
+        (None, Some(idempotency_key)) => json!({
+            "type": "BY_IDEMPOTENCY_KEY",
+            "idempotencyKey": idempotency_key,
+        }),
+        _ => unreachable!("clap requires exactly one operation selector"),
+    };
+    execute_request(AgentRequest {
+        method: method.to_string(),
+        request: json_rpc_request(method, selector),
+        runtime: args.runtime,
         full_response: true,
     })
 }

--- a/cli-rs/src/agent/dispatch.rs
+++ b/cli-rs/src/agent/dispatch.rs
@@ -232,9 +232,9 @@ fn execute_agent_rename(args: AgentRenameArgs) -> AgentEnvelope {
         });
         return result_envelope("agent/rename".to_string(), result);
     }
-    let idempotency_key = match applied_idempotency_key("agent/rename", args.mutation) {
+    let idempotency_key = match applied_idempotency_key(args.mutation) {
         Ok(key) => key,
-        Err(envelope) => return envelope,
+        Err(error) => return error_envelope("agent/rename".to_string(), None, error),
     };
     let request = json_rpc_request(
         "mutation/submit",
@@ -349,9 +349,9 @@ fn execute_agent_mutation(
     if !mutation.apply {
         return mutation_plan_envelope(agent_method, command_name, request);
     }
-    let idempotency_key = match applied_idempotency_key(agent_method, mutation) {
+    let idempotency_key = match applied_idempotency_key(mutation) {
         Ok(key) => key,
-        Err(envelope) => return envelope,
+        Err(error) => return error_envelope(agent_method.to_string(), None, error),
     };
     let request = json_rpc_request(
         "mutation/submit",
@@ -370,27 +370,18 @@ fn execute_agent_mutation(
 }
 
 fn applied_idempotency_key(
-    agent_method: &'static str,
     mutation: AgentMutationApplyArgs,
-) -> std::result::Result<String, AgentEnvelope> {
+) -> std::result::Result<String, AgentError> {
     let Some(key) = mutation.idempotency_key else {
-        return Err(error_envelope(
-            agent_method.to_string(),
-            None,
-            agent_error(
-                "AGENT_USAGE",
-                "--idempotency-key is required whenever --apply is used",
-            ),
+        return Err(agent_error(
+            "AGENT_USAGE",
+            "--idempotency-key is required whenever --apply is used",
         ));
     };
     if key.is_empty() || key.len() > 128 || key.trim() != key {
-        return Err(error_envelope(
-            agent_method.to_string(),
-            None,
-            agent_error(
-                "AGENT_USAGE",
-                "--idempotency-key must contain 1 to 128 characters without surrounding whitespace",
-            ),
+        return Err(agent_error(
+            "AGENT_USAGE",
+            "--idempotency-key must contain 1 to 128 characters without surrounding whitespace",
         ));
     }
     Ok(key)

--- a/cli-rs/src/cli/agent.rs
+++ b/cli-rs/src/cli/agent.rs
@@ -29,6 +29,8 @@ pub enum AgentCommand {
     AddStatement(AgentStatementMutationArgs),
     /// Replace a named declaration by symbol identity.
     ReplaceDeclaration(AgentReplaceDeclarationArgs),
+    /// Query or cancel an observable semantic mutation operation.
+    Operation(AgentOperationArgs),
     /// List catalog-backed tools for CLI-capable agent hosts.
     #[command(hide = true)]
     Tools(RemovedAgentCommandArgs),
@@ -131,6 +133,16 @@ pub struct AgentDiagnosticsArgs {
     pub skip_refresh: bool,
 }
 
+#[derive(Debug, Args, Clone, Default)]
+pub struct AgentMutationApplyArgs {
+    /// Apply the mutation. Without this flag, Kast only reports the planned request.
+    #[arg(long)]
+    pub apply: bool,
+    /// Stable caller-owned key used to retry and recover this applied mutation.
+    #[arg(long)]
+    pub idempotency_key: Option<String>,
+}
+
 #[derive(Debug, Args, Clone)]
 pub struct AgentRenameArgs {
     #[command(flatten)]
@@ -146,9 +158,8 @@ pub struct AgentRenameArgs {
     pub file_hint: Option<String>,
     #[arg(long)]
     pub containing_type: Option<String>,
-    /// Apply the rename. Without this flag, Kast only reports the planned request.
-    #[arg(long)]
-    pub apply: bool,
+    #[command(flatten)]
+    pub mutation: AgentMutationApplyArgs,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -161,9 +172,8 @@ pub struct AgentAddFileArgs {
     /// File containing the complete content to write.
     #[arg(long)]
     pub content_file: PathBuf,
-    /// Apply the file creation. Without this flag, Kast only reports the planned request.
-    #[arg(long)]
-    pub apply: bool,
+    #[command(flatten)]
+    pub mutation: AgentMutationApplyArgs,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -188,9 +198,8 @@ pub struct AgentScopedMutationArgs {
     /// File containing the declaration or implementation content.
     #[arg(long)]
     pub content_file: PathBuf,
-    /// Apply the mutation. Without this flag, Kast only reports the planned request.
-    #[arg(long)]
-    pub apply: bool,
+    #[command(flatten)]
+    pub mutation: AgentMutationApplyArgs,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -206,9 +215,8 @@ pub struct AgentStatementMutationArgs {
     /// File containing the statement content.
     #[arg(long)]
     pub content_file: PathBuf,
-    /// Apply the mutation. Without this flag, Kast only reports the planned request.
-    #[arg(long)]
-    pub apply: bool,
+    #[command(flatten)]
+    pub mutation: AgentMutationApplyArgs,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -227,9 +235,40 @@ pub struct AgentReplaceDeclarationArgs {
     pub file_hint: Option<String>,
     #[arg(long)]
     pub containing_type: Option<String>,
-    /// Apply the replacement. Without this flag, Kast only reports the planned request.
+    #[command(flatten)]
+    pub mutation: AgentMutationApplyArgs,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct AgentOperationArgs {
+    #[command(subcommand)]
+    pub command: AgentOperationCommand,
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum AgentOperationCommand {
+    /// Retrieve the latest retained operation state.
+    Status(AgentOperationSelectorArgs),
+    /// Request cooperative cancellation and return the latest retained state.
+    Cancel(AgentOperationSelectorArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+#[command(group(
+    clap::ArgGroup::new("selector")
+        .required(true)
+        .multiple(false)
+        .args(["operation_id", "idempotency_key"])
+))]
+pub struct AgentOperationSelectorArgs {
+    #[command(flatten)]
+    pub runtime: AgentRuntimeArgs,
+    /// Server-issued semantic mutation operation UUID.
     #[arg(long)]
-    pub apply: bool,
+    pub operation_id: Option<String>,
+    /// Caller-owned mutation idempotency key.
+    #[arg(long)]
+    pub idempotency_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]

--- a/cli-rs/tests/agent_operation_surface_smoke.rs
+++ b/cli-rs/tests/agent_operation_surface_smoke.rs
@@ -1,0 +1,349 @@
+mod support;
+
+use serde_json::{Value, json};
+use support::*;
+
+#[test]
+fn applied_mutation_requires_idempotency_key_before_runtime_discovery() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let content_file = temp.path().join("Added.kt");
+    let target = temp.path().join("Target.kt");
+    std::fs::write(&content_file, "class Added\n").expect("content");
+    let target = target.to_str().expect("target").to_string();
+    let content = content_file.to_str().expect("content").to_string();
+    let cases = [
+        vec![
+            "rename".to_string(),
+            "--symbol".to_string(),
+            "sample.Example".to_string(),
+            "--new-name".to_string(),
+            "Renamed".to_string(),
+        ],
+        vec![
+            "add-file".to_string(),
+            "--file-path".to_string(),
+            target.clone(),
+            "--content-file".to_string(),
+            content.clone(),
+        ],
+        vec![
+            "add-declaration".to_string(),
+            "--inside-file".to_string(),
+            target.clone(),
+            "--at".to_string(),
+            "file-bottom".to_string(),
+            "--content-file".to_string(),
+            content.clone(),
+        ],
+        vec![
+            "add-implementation".to_string(),
+            "--inside-scope".to_string(),
+            "sample.Example".to_string(),
+            "--at".to_string(),
+            "body-end".to_string(),
+            "--content-file".to_string(),
+            content.clone(),
+        ],
+        vec![
+            "add-statement".to_string(),
+            "--inside-scope".to_string(),
+            "sample.Example.run".to_string(),
+            "--at".to_string(),
+            "body-end".to_string(),
+            "--content-file".to_string(),
+            content.clone(),
+        ],
+        vec![
+            "replace-declaration".to_string(),
+            "--symbol".to_string(),
+            "sample.Example".to_string(),
+            "--content-file".to_string(),
+            content,
+        ],
+    ];
+
+    for args in cases {
+        let output = kast(&home, &config_home)
+            .args(["--output", "json", "agent"])
+            .args(args)
+            .arg("--apply")
+            .output()
+            .expect("applied mutation");
+
+        assert!(!output.status.success(), "missing key must fail");
+        let stdout: Value = serde_json::from_slice(&output.stdout).expect("structured usage error");
+        assert_eq!(stdout["error"]["code"], "AGENT_USAGE", "{stdout}");
+        assert!(
+            stdout["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("--idempotency-key")),
+            "{stdout}"
+        );
+    }
+}
+
+#[test]
+fn operation_selector_requires_exactly_one_identity() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+
+    for args in [
+        vec!["agent", "operation", "status"],
+        vec![
+            "agent",
+            "operation",
+            "cancel",
+            "--operation-id",
+            "00000000-0000-0000-0000-000000000001",
+            "--idempotency-key",
+            "issue-333",
+        ],
+    ] {
+        let output = kast(&home, &config_home)
+            .args(args)
+            .output()
+            .expect("operation selector parse");
+        assert!(!output.status.success(), "invalid selector must fail");
+        let diagnostic = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert!(
+            diagnostic.contains("required") || diagnostic.contains("cannot be used"),
+            "{diagnostic}"
+        );
+    }
+}
+
+#[test]
+fn applied_add_file_submits_typed_mutation_request() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let socket_path = temp.path().join("idea.sock");
+    let content_file = temp.path().join("Added.kt");
+    let target = workspace.join("src/Added.kt");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(&content_file, "class Added\n").expect("content");
+    let backend = spawn_operation_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        "mutation/submit",
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "add-file",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+            "--file-path",
+            target.to_str().expect("target"),
+            "--content-file",
+            content_file.to_str().expect("content"),
+            "--apply",
+            "--idempotency-key",
+            "issue-333-add-file",
+        ])
+        .output()
+        .expect("submit mutation");
+
+    assert!(
+        output.status.success(),
+        "submit should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let requests = backend.join().expect("backend");
+    let submit = requests
+        .iter()
+        .find(|request| request["method"] == "mutation/submit")
+        .expect("mutation submit request");
+    assert_eq!(submit["params"]["type"], "ADD_FILE", "{submit}");
+    assert_eq!(
+        submit["params"]["idempotencyKey"], "issue-333-add-file",
+        "{submit}"
+    );
+    assert_eq!(
+        submit["params"]["request"]["filePath"],
+        target.to_str().unwrap()
+    );
+    assert_eq!(
+        submit["params"]["request"]["contentFile"],
+        content_file.to_str().unwrap()
+    );
+}
+
+#[test]
+fn operation_status_and_cancel_preserve_typed_backend_snapshots() {
+    let cases = [
+        (
+            "status",
+            "mutation/status",
+            vec!["--operation-id", "00000000-0000-0000-0000-000000000001"],
+            "BY_OPERATION_ID",
+        ),
+        (
+            "cancel",
+            "mutation/cancel",
+            vec!["--idempotency-key", "issue-333-add-file"],
+            "BY_IDEMPOTENCY_KEY",
+        ),
+    ];
+
+    for (command, method, selector_args, selector_type) in cases {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let config_home = temp.path().join("config");
+        let workspace = temp.path().join("workspace");
+        let socket_path = temp.path().join("idea.sock");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        let backend =
+            spawn_operation_backend(&home, &config_home, &workspace, &socket_path, method);
+        let mut args = vec![
+            "--output",
+            "json",
+            "agent",
+            "operation",
+            command,
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ];
+        args.extend(selector_args);
+
+        let output = kast(&home, &config_home)
+            .args(args)
+            .output()
+            .expect("operation command");
+
+        assert!(
+            output.status.success(),
+            "{command} should succeed: stdout={}, stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let stdout: Value = serde_json::from_slice(&output.stdout).expect("operation output");
+        assert_eq!(
+            stdout["result"]["operationId"],
+            "00000000-0000-0000-0000-000000000001"
+        );
+        assert_eq!(stdout["result"]["state"]["type"], "QUEUED");
+        let requests = backend.join().expect("backend");
+        let terminal = requests
+            .iter()
+            .find(|request| request["method"] == method)
+            .expect("operation request");
+        assert_eq!(terminal["params"]["type"], selector_type, "{terminal}");
+    }
+}
+
+fn spawn_operation_backend(
+    home: &std::path::Path,
+    config_home: &std::path::Path,
+    workspace: &std::path::Path,
+    socket_path: &std::path::Path,
+    terminal_method: &'static str,
+) -> std::thread::JoinHandle<Vec<Value>> {
+    let descriptor_dir = default_descriptor_dir(home);
+    std::fs::create_dir_all(config_home).expect("config home");
+    std::fs::create_dir_all(&descriptor_dir).expect("descriptor dir");
+    write_macos_plugin_workspace_metadata(workspace);
+    std::fs::write(
+        config_home.join("config.toml"),
+        "[runtime]\ndefaultBackend = \"idea\"\n",
+    )
+    .expect("config");
+    std::fs::write(
+        descriptor_dir.join("daemons.json"),
+        format!(
+            r#"[{{
+  "workspaceRoot": "{}",
+  "backendName": "idea",
+  "backendVersion": "test",
+  "transport": "uds",
+  "socketPath": "{}",
+  "pid": {},
+  "schemaVersion": 3
+}}]"#,
+            workspace.display(),
+            socket_path.display(),
+            std::process::id(),
+        ),
+    )
+    .expect("descriptor");
+    let listener = UnixListener::bind(socket_path).expect("bind backend");
+    let workspace = workspace.to_path_buf();
+    std::thread::spawn(move || {
+        let mut requests = Vec::new();
+        while requests
+            .iter()
+            .all(|request: &Value| request["method"] != terminal_method)
+        {
+            let (mut stream, _) = listener.accept().expect("accept client");
+            let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+            let mut line = String::new();
+            reader.read_line(&mut line).expect("read request");
+            let request: Value = serde_json::from_str(&line).expect("request json");
+            let method = request["method"].as_str().expect("method");
+            let result = match method {
+                "runtime/status" => json!({
+                    "state": "READY",
+                    "healthy": true,
+                    "active": true,
+                    "indexing": false,
+                    "backendName": "idea",
+                    "backendVersion": "test",
+                    "workspaceRoot": workspace,
+                    "schemaVersion": 3
+                }),
+                "capabilities" => json!({
+                    "backendName": "idea",
+                    "backendVersion": "test",
+                    "workspaceRoot": workspace,
+                    "readCapabilities": [],
+                    "mutationCapabilities": [],
+                    "limits": {
+                        "requestTimeoutMillis": 60000,
+                        "maxResults": 1000,
+                        "maxConcurrentRequests": 4
+                    },
+                    "schemaVersion": 3
+                }),
+                "mutation/submit" => mutation_snapshot(true),
+                "mutation/status" | "mutation/cancel" => mutation_snapshot(false),
+                other => panic!("unexpected method {other}"),
+            };
+            requests.push(request.clone());
+            writeln!(
+                stream,
+                "{}",
+                json!({"jsonrpc": "2.0", "id": request["id"], "result": result})
+            )
+            .expect("write response");
+        }
+        requests
+    })
+}
+
+fn mutation_snapshot(receipt: bool) -> Value {
+    let operation = json!({
+        "operationId": "00000000-0000-0000-0000-000000000001",
+        "idempotencyKey": "issue-333-add-file",
+        "mutationKind": "ADD_FILE",
+        "state": {"type": "QUEUED", "trace": {"enteredStages": [], "editApplicationState": "NOT_STARTED"}, "cancellationRequested": false}
+    });
+    if receipt {
+        json!({"operation": operation, "deduplicated": false})
+    } else {
+        operation
+    }
+}

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -69,6 +69,15 @@ fn packaged_skill_stays_usage_first_and_public_agent_only() {
         skill.contains("`--output json` for JSON-only parsed scripts"),
         "{skill}"
     );
+    assert!(
+        skill.contains("--apply --idempotency-key <stable-key>"),
+        "{skill}"
+    );
+    assert!(
+        skill.contains("kast agent operation status --idempotency-key <stable-key>"),
+        "{skill}"
+    );
+    assert!(skill.contains("edit application never started"), "{skill}");
     assert!(skill.contains("read-only readiness"), "{skill}");
     assert!(
         skill.contains("Do not teach `kast agent tools`, `kast agent call`, `kast agent workflow`"),

--- a/docs/reference/agent-commands.md
+++ b/docs/reference/agent-commands.md
@@ -22,6 +22,8 @@ names.
 | Check a touched file | Diagnostics | Confirms the backend sees the same source state |
 | Rename safely | Identity-first rename planning | Surfaces target identity, conflicts, and write set before mutation |
 | Add or replace Kotlin | Plan-first mutations | Places content using a typed file, scope, or declaration target |
+| Recover an interrupted edit | Mutation operation status | Retrieves retained progress and terminal results after disconnects |
+| Stop an in-flight edit | Typed operation cancellation | Requests cooperative cancellation without inventing a rollback |
 | Serve editor integrations | LSP bridge | Lets editors reuse the same backend |
 
 ## Output For Humans And Automation
@@ -34,7 +36,13 @@ shapes.
 
 Agent edits are plan-first. Kast reports the selected target, planned write set,
 diagnostics, and conflicts before any write. The agent applies the operation
-only after the plan matches the requested change.
+only after the plan matches the requested change. Every applied mutation
+requires `--idempotency-key <stable-key>` and returns one stable operation ID.
+Repeating the same key and request retrieves the same operation; binding the key
+to another request fails before mutation.
+
+Operation state is retained for the lifetime of the backend daemon. Retention
+does not survive a daemon restart.
 
 Use [mutation selectors](mutation-selectors.md) for the selector model and
 [plan safe edits](../use/plan-safe-edits.md) for the developer-facing story.
@@ -52,6 +60,8 @@ Use [mutation selectors](mutation-selectors.md) for the selector model and
     - `kast agent add-implementation`
     - `kast agent add-statement`
     - `kast agent replace-declaration`
+    - `kast agent operation status`
+    - `kast agent operation cancel`
     - `kast agent lsp`
 
 ??? info "Example agent execution"
@@ -67,5 +77,14 @@ Use [mutation selectors](mutation-selectors.md) for the selector model and
     kast agent rename \
       --symbol com.example.OrderService \
       --new-name Orders \
+      --workspace-root "$PWD"
+    kast agent rename \
+      --symbol com.example.OrderService \
+      --new-name Orders \
+      --apply \
+      --idempotency-key rename-order-service \
+      --workspace-root "$PWD"
+    kast agent operation status \
+      --idempotency-key rename-order-service \
       --workspace-root "$PWD"
     ```

--- a/docs/reference/mutation-selectors.md
+++ b/docs/reference/mutation-selectors.md
@@ -19,10 +19,26 @@ scope target, then apply only after the plan matches the requested change.
 | Scope selector | A named declaration or executable body that receives content |
 | Placement anchor | A supported location inside the selected file or scope |
 | Content file | The Kotlin content the agent asks Kast to insert or replace |
+| Operation ID | The stable backend-issued identity of one applied mutation |
+| Idempotency key | The stable caller-issued identity used to submit and recover one mutation |
 
 Local-variable rename is not part of the current public dialect. Agents should
 use named declaration identities until Kast has a typed non-offset selector for
 locals.
+
+## Operation Selectors
+
+`kast agent operation status` and `kast agent operation cancel` accept exactly
+one operation selector:
+
+| Selector | Flag | Source |
+| --- | --- | --- |
+| Operation ID | `--operation-id <uuid>` | Returned by mutation submission |
+| Idempotency key | `--idempotency-key <stable-key>` | Chosen by the submitting caller |
+
+Status and cancellation requests are idempotent. A cancellation response can
+show `cancellationRequested` while the operation remains active; `CANCELLED` is
+terminal only after execution has cooperatively stopped.
 
 ## Plan Review
 

--- a/docs/use/automate-with-agents.md
+++ b/docs/use/automate-with-agents.md
@@ -52,5 +52,47 @@ An agent should resolve identity and check backend state before it asks Kast to
 plan an edit. It should apply an edit only after reviewing the planned target,
 diagnostics, conflicts, and write set.
 
+For each applied plan, choose a stable idempotency key and retain it with the
+task state:
+
+```console
+kast agent add-file \
+  --file-path "$PWD/src/main/kotlin/com/example/Added.kt" \
+  --content-file /tmp/Added.kt \
+  --apply \
+  --idempotency-key add-example-file \
+  --workspace-root "$PWD"
+```
+
+## Recover An Interrupted Mutation
+
+If the submitting process yields or disconnects, query with the same key. Do
+not submit a new key for the same intended edit.
+
+```console
+kast agent operation status \
+  --idempotency-key add-example-file \
+  --workspace-root "$PWD"
+```
+
+If the operation should stop, request cancellation and poll status until the
+state is terminal:
+
+```console
+kast agent operation cancel \
+  --idempotency-key add-example-file \
+  --workspace-root "$PWD"
+kast agent operation status \
+  --idempotency-key add-example-file \
+  --workspace-root "$PWD"
+```
+
+Use a direct filesystem fallback only when a successfully retrieved terminal
+state reports `editApplicationState: NOT_STARTED`. `STARTED` and `COMPLETED`
+both mean the filesystem may already have changed. If the backend daemon
+restarted and no retained state can be retrieved, the outcome is ambiguous;
+inspect and reconcile the workspace instead of applying a fallback or retrying
+under a new key.
+
 Use [agent commands](../reference/agent-commands.md) for the high-level command
 surface and [plan safe edits](plan-safe-edits.md) for mutation behavior.


### PR DESCRIPTION
## Summary

- model semantic mutation submissions as typed, observable operations with durable in-daemon receipts, progress, terminal outcomes, cancellation, and idempotency lookup
- expose typed CLI controls for operation status, wait, and cancel while preserving lightweight usage errors
- bind mutation workers to the analysis-server lifetime and make filesystem fallback safe only when a terminal operation proves edits never started
- integrate mutation outcomes with fail-closed per-file semantic completeness so applied writes with incomplete or invalid evidence remain observable typed failures
- document recovery, ambiguity after daemon restart, and the public lifecycle contract in ADR 0015 and generated/public guidance

## Safety properties

- operation state is published atomically before workers start
- server shutdown rejects new submissions, cancels and joins retained workers, and keeps descriptor authority until workers stop
- applied-but-invalid rename/scope responses cannot become successful operations
- queued, running, completed, cancelled-after-write, and failed-after-write operations never advertise filesystem fallback safety

## Verification

- `./gradlew test`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- generated contract check (`138` files)
- RPC summary, Copilot plugin, LSP config/pivot, routing eval, docs content/navigation, and Zensical gates
- `git diff --check`

Kast semantic verification in the isolated worktree correctly reported `MACOS_PLUGIN_WORKSPACE_REQUIRED`; the macOS plugin-owned setup was not mutated. Gradle compilation and tests provide the Kotlin proof.

Closes #333
