### PR TITLE
feat: make symbol lookup exact and fail closed

### DIFF
--- a/.agents/adr/0016-fail-closed-exact-symbol-lookup.md
+++ b/.agents/adr/0016-fail-closed-exact-symbol-lookup.md
@@ -1,0 +1,103 @@
+# ADR 0016: Fail-closed exact symbol lookup
+
+Status: Accepted
+
+Date: 2026-07-13
+
+This ADR supersedes ADR 0006 only for the public symbol-lookup contract. ADR
+0006 remains authoritative for the rest of the product surface, system
+boundaries, setup, runtime, output, distribution, and audit posture.
+
+## Decision
+
+`kast agent symbol --query <name>` defaults to exact lookup. The command has a
+typed `--mode exact|discovery` selector; lexical or ranked fuzzy candidates are
+available only through `--mode discovery`.
+
+Exact lookup applies the query, optional kind, file hint, and containing type
+as hard constraints. Backticks are normalized only while comparing Kotlin
+identity. Successful responses retain the canonical identity returned by the
+compiler or source index.
+
+The exact result is a closed outcome:
+
+| Outcome | Meaning |
+| --- | --- |
+| `RESOLVED` | Exactly one declaration satisfies every exact constraint. |
+| `NOT_FOUND` | No declaration satisfies every exact constraint. |
+| `AMBIGUOUS` | Multiple declarations satisfy every exact constraint. |
+
+Every result reports one evidence source: compiler resolution, indexed exact
+identity, or fuzzy discovery. Exact `NOT_FOUND` and `AMBIGUOUS` outcomes never
+trigger lexical discovery. The CLI may use indexed exact identity only when a
+typed compiler or backend availability failure prevents compiler lookup and
+the source index can enforce every requested constraint. It must not reinterpret
+an operational compiler failure or an unsupported constraint as a match.
+
+Reference and caller requests run only after exact lookup has produced a
+resolved compiler identity. They use the canonical fully qualified name from
+that response rather than the original query text.
+
+## Rationale
+
+The previous public command ran indexed exact and lexical discovery before
+compiler resolution, while the name-based resolver ranked workspace candidates
+and chose the first one. An absent or newly unindexed name could therefore put
+an unrelated fuzzy declaration first. That behavior looked like identity
+resolution even though the request remained unresolved.
+
+Making mode and outcome explicit removes the unsafe implicit transition from
+lookup to discovery. Hard constraints and a closed outcome preserve what the
+system proved, while the source field lets agents distinguish compiler evidence
+from a source-index fallback or intentional fuzzy exploration.
+
+## Compatibility And Migration
+
+The internal `symbol/resolve` method keeps its existing `RESOLVE_SUCCESS` and
+`RESOLVE_FAILURE` variants. It adds expected `RESOLVE_NOT_FOUND` and
+`RESOLVE_AMBIGUOUS` variants. Internal consumers must exhaustively handle the
+two new variants; `RESOLVE_FAILURE` remains reserved for operational failure.
+
+The internal `symbol/query` method keeps its request and response envelope.
+Callers that want its historical lexical behavior must request lexical mode
+explicitly. The typed CLI supplies that request for `--mode discovery`.
+
+## Source Of Truth
+
+| Contract | Owner |
+| --- | --- |
+| Public mode and flags | `cli-rs/src/cli/agent.rs` |
+| Typed public outcome and orchestration | `cli-rs/src/agent/` |
+| Indexed exact and fuzzy query behavior | `cli-rs/src/symbol_query/` |
+| Compiler exact result contract | `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastResolveResponse.kt` |
+| Compiler exact selection | `analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt` |
+| Internal command catalog | `cli-rs/resources/kast-skill/references/commands.json` |
+| Public guidance | `cli-rs/resources/kast-skill/`, `docs/reference/agent-commands.md`, `docs/use/inspect-kotlin.md` |
+
+Generated protocol artifacts remain outputs of the contract generator. Edit
+the catalog and Kotlin contract owners, then regenerate them.
+
+## Validation
+
+Use focused exact-lookup tests before the broad contract gates:
+
+```console
+./gradlew :analysis-api:test :analysis-server:test
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_command_surface_smoke --test symbol_query_smoke
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+cargo test --manifest-path cli-rs/Cargo.toml --locked
+.github/scripts/test-docs-content-contract.sh
+zensical build --clean
+git diff --check
+```
+
+When the IntelliJ plugin has prepared the current workspace, also run Kast
+diagnostics for the changed Kotlin files. A temporary worktree without plugin
+metadata must report that limitation instead of running `kast setup` on macOS.
+
+## Change Rule
+
+Any future mode, evidence source, fallback rule, or exact outcome must
+supersede this ADR before public docs, packaged guidance, catalogs, or generated
+protocol assets change. Exact mode must continue to fail closed; discovery can
+never become an implicit fallback.

--- a/.agents/superpowers/plans/2026-07-13-exact-symbol-lookup.md
+++ b/.agents/superpowers/plans/2026-07-13-exact-symbol-lookup.md
@@ -1,0 +1,478 @@
+# Exact Symbol Lookup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the public symbol command return a unique exact identity or a typed not-found/ambiguous outcome, with fuzzy candidates available only through explicit discovery mode.
+
+**Architecture:** Harden the existing compiler `symbol/resolve` RPC into a hard-constrained exact boundary, then map its sealed outcomes into a typed Rust public result. The CLI falls back to indexed exact lookup only for an explicit availability-code allowlist; discovery is a separate lexical request and relation requests consume only canonical compiler identity.
+
+**Tech Stack:** Kotlin 2.2, kotlinx.serialization, JUnit Jupiter, Rust 2024, Clap, serde, SQLite source index, Gradle, Cargo, Zensical.
+
+## Global Constraints
+
+- Public default mode is `exact`; fuzzy discovery requires `--mode discovery`.
+- Exact `NOT_FOUND` and `AMBIGUOUS` never invoke lexical discovery or indexed fallback.
+- Backticks are normalized only for identity comparison; results retain canonical identity.
+- Kind, file hint, and containing type are hard constraints.
+- Indexed fallback remains exact and runs only for typed compiler/backend unavailability.
+- Relation steps run only after compiler `RESOLVE_SUCCESS`, using its canonical fully qualified name.
+- Production Kotlin keeps one non-private top-level named type per same-named file; direct sealed variants stay with their root.
+- Authored catalog sources generate protocol artifacts; generated files are never hand-edited.
+- This session executes inline because the task explicitly forbids subagents.
+
+---
+
+### Task 1: Compiler Exact Outcome Contract
+
+**Files:**
+
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastResolveResponse.kt`
+- Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt`
+- Create: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/skill/KastResolveResponseTest.kt`
+- Modify: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt`
+- Modify: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt`
+
+**Interfaces:**
+
+- Consumes: `KastResolveRequest`, `KastResolveQuery`, `Symbol`, and compiler workspace-symbol/resolve APIs.
+- Produces: `KastResolveResponse` with `RESOLVE_SUCCESS`, `RESOLVE_NOT_FOUND`, `RESOLVE_AMBIGUOUS`, and legacy `RESOLVE_FAILURE` variants. `KastResolveResponse.Source.COMPILER` serializes as `compiler`.
+
+- [ ] **Step 1: Add response migration tests before moving production types**
+
+Create `KastResolveResponseTest.kt` with serializer tests that decode existing success and failure payloads and the new expected variants:
+
+```kotlin
+class KastResolveResponseTest {
+    private val json = Json { ignoreUnknownKeys = false }
+
+    @Test
+    fun `existing success and failure discriminators remain compatible`() {
+        val success = json.decodeFromString<KastResolveResponse>(successJson)
+        val failure = json.decodeFromString<KastResolveResponse>(failureJson)
+
+        assertInstanceOf(KastResolveSuccessResponse::class.java, success)
+        assertInstanceOf(KastResolveFailureResponse::class.java, failure)
+    }
+
+    @Test
+    fun `expected exact outcomes decode distinctly`() {
+        val notFound = json.decodeFromString<KastResolveResponse>(notFoundJson)
+        val ambiguous = json.decodeFromString<KastResolveResponse>(ambiguousJson)
+
+        assertInstanceOf(KastResolveNotFoundResponse::class.java, notFound)
+        assertInstanceOf(KastResolveAmbiguousResponse::class.java, ambiguous)
+    }
+}
+```
+
+- [ ] **Step 2: Run the API test and verify RED**
+
+Run:
+
+```console
+./gradlew :analysis-api:test --tests io.github.amichne.kast.api.contract.skill.KastResolveResponseTest
+```
+
+Expected: compilation fails because the not-found and ambiguous response types do not exist.
+
+- [ ] **Step 3: Move the sealed response owner and add typed variants**
+
+Remove only the `KastResolveResponse` root and its existing direct variants from `SkillContracts.kt`. Create `KastResolveResponse.kt` with this shape:
+
+```kotlin
+@Serializable
+sealed interface KastResolveResponse {
+    @Serializable
+    enum class Source {
+        @SerialName("compiler")
+        COMPILER,
+    }
+}
+
+@Serializable
+@SerialName("RESOLVE_SUCCESS")
+data class KastResolveSuccessResponse(
+    val ok: Boolean = true,
+    val source: KastResolveResponse.Source = KastResolveResponse.Source.COMPILER,
+    val query: KastResolveQuery,
+    val symbol: Symbol,
+    val filePath: String,
+    val offset: Int,
+    val candidate: KastCandidate,
+    val context: KastResolveContext? = null,
+    val logFile: String,
+) : KastResolveResponse
+
+@Serializable
+@SerialName("RESOLVE_NOT_FOUND")
+data class KastResolveNotFoundResponse(
+    val ok: Boolean = true,
+    val source: KastResolveResponse.Source = KastResolveResponse.Source.COMPILER,
+    val query: KastResolveQuery,
+    val logFile: String,
+) : KastResolveResponse
+
+@Serializable
+@SerialName("RESOLVE_AMBIGUOUS")
+data class KastResolveAmbiguousResponse(
+    val ok: Boolean = true,
+    val source: KastResolveResponse.Source = KastResolveResponse.Source.COMPILER,
+    val query: KastResolveQuery,
+    val candidates: List<Symbol>,
+    val logFile: String,
+) : KastResolveResponse
+
+@Serializable
+@SerialName("RESOLVE_FAILURE")
+data class KastResolveFailureResponse(
+    val ok: Boolean = false,
+    val stage: String,
+    val message: String,
+    val query: KastResolveQuery,
+    val logFile: String,
+    val error: ApiErrorResponse? = null,
+    val errorText: String? = null,
+) : KastResolveResponse
+```
+
+- [ ] **Step 4: Run the API test and verify GREEN**
+
+Run the focused test from Step 2. Expected: pass.
+
+- [ ] **Step 5: Add server RED tests for exact selection**
+
+Extend `AnalysisDispatcherTest` with a private backend delegating to the sample backend while overriding `workspaceSymbolSearch` and `resolveSymbol`. Add separate tests proving:
+
+```kotlin
+@Test fun `symbol resolve returns not found instead of a fuzzy candidate`()
+@Test fun `symbol resolve returns ambiguous for overloaded exact members`()
+@Test fun `symbol resolve matches backticked simple and qualified names exactly`()
+@Test fun `symbol resolve applies kind file and containing type as hard constraints`()
+```
+
+The fuzzy fixture must include `sample.LegacyOrderService` for query `MissingOrderService`; the overload fixture must include two `sample.Parser.parse` symbols at different offsets; the backtick fixture must return canonical `sample.when`; and each hard-constraint mismatch must produce `KastResolveNotFoundResponse`.
+
+- [ ] **Step 6: Run the server tests and verify RED**
+
+Run:
+
+```console
+./gradlew :analysis-server:test --tests io.github.amichne.kast.server.AnalysisDispatcherTest
+```
+
+Expected: current resolver either chooses the fuzzy first candidate or returns success where ambiguity/not-found is required.
+
+- [ ] **Step 7: Implement exact compiler candidate selection**
+
+In `SkillRpcOrchestrator`, separate broad candidate collection from discovery ranking. Add pure helpers with these contracts:
+
+```kotlin
+private fun exactIdentityMatches(requested: String, candidateFqName: String): Boolean
+private fun normalizedKotlinIdentity(value: String): String
+private fun exactFileHintMatches(fileHint: String, candidateFile: String): Boolean
+private fun exactContainingTypeMatches(containingType: String, candidate: Symbol): Boolean
+private suspend fun exactNamedSymbolCandidates(
+    symbolName: String,
+    fileHint: String?,
+    kind: WrapperNamedSymbolKind?,
+    containingType: String?,
+): List<RankedNamedSymbolCandidate>
+```
+
+`resolve()` returns not-found for zero candidates, ambiguous for more than one, and resolves exactly one candidate. Discovery continues through `rankedNamedSymbolCandidates`; no lexical behavior is removed from `symbol/discover`.
+
+- [ ] **Step 8: Run focused Kotlin tests and verify GREEN**
+
+Run:
+
+```console
+./gradlew :analysis-api:test --tests io.github.amichne.kast.api.contract.skill.KastResolveResponseTest
+./gradlew :analysis-server:test --tests io.github.amichne.kast.server.AnalysisDispatcherTest
+```
+
+Expected: pass.
+
+- [ ] **Step 9: Commit the compiler contract slice**
+
+```console
+git add analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt \
+  analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastResolveResponse.kt \
+  analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/skill/KastResolveResponseTest.kt \
+  analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt \
+  analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+git commit -m "fix: make compiler symbol lookup exact"
+```
+
+### Task 2: Typed Public Exact And Discovery Modes
+
+**Files:**
+
+- Modify: `cli-rs/src/cli/agent.rs`
+- Modify: `cli-rs/src/agent.rs`
+- Create: `cli-rs/src/agent/symbol_lookup.rs`
+- Modify: `cli-rs/src/agent/dispatch.rs`
+- Modify: `cli-rs/src/agent/types.rs`
+- Modify: `cli-rs/tests/agent_command_surface_smoke.rs`
+- Modify: `cli-rs/tests/support/mod.rs`
+
+**Interfaces:**
+
+- Consumes: compiler `KastResolveResponse` JSON and indexed `SYMBOL_QUERY_SUCCESS` JSON.
+- Produces: `AgentSymbolMode::{Exact, Discovery}` and a structured `KAST_AGENT_SYMBOL_LOOKUP` result with a closed `outcome` and explicit `source`.
+
+- [ ] **Step 1: Add public CLI RED tests**
+
+Add deterministic fake-UDS backend support and tests asserting:
+
+```rust
+#[test] fn agent_symbol_defaults_to_exact_and_returns_compiler_identity()
+#[test] fn agent_symbol_not_found_does_not_request_indexed_or_lexical_fallback()
+#[test] fn agent_symbol_ambiguous_does_not_request_indexed_or_lexical_fallback()
+#[test] fn agent_symbol_discovery_requests_lexical_mode_explicitly()
+#[test] fn agent_symbol_relations_use_canonical_compiler_identity()
+#[test] fn agent_symbol_discovery_rejects_relation_flags_before_io()
+```
+
+The fake backend records methods and params. Not-found and ambiguous cases must record only `symbol/resolve`; the relation case must record `symbol/resolve` followed by relation requests whose `symbol` is the returned canonical `sample.when` rather than the backticked input.
+
+- [ ] **Step 2: Run the command-surface test and verify RED**
+
+Run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_command_surface_smoke
+```
+
+Expected: Clap rejects `--mode`, and the default command still sends indexed exact+lexical query before resolve.
+
+- [ ] **Step 3: Add typed CLI mode and outcome types**
+
+Add:
+
+```rust
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq, Default)]
+pub enum AgentSymbolMode {
+    #[default]
+    Exact,
+    Discovery,
+}
+```
+
+`AgentSymbolArgs.mode` uses `#[arg(long, value_enum, default_value_t)]`. In `agent/types.rs`, define serializable `AgentSymbolLookupResult`, `AgentSymbolLookupOutcome`, `AgentSymbolLookupSource`, `AgentSymbolRelation`, and `AgentCompilerFallback` types. Use serde tags so every state carries only valid fields.
+
+- [ ] **Step 4: Pin and test the exact availability allowlist**
+
+In `agent/symbol_lookup.rs`, define:
+
+```rust
+const INDEXED_EXACT_FALLBACK_CODES: [&str; 13] = [
+    "MACOS_PLUGIN_WORKSPACE_REQUIRED",
+    "NO_BACKEND_AVAILABLE",
+    "IDEA_NOT_RUNNING",
+    "IDEA_BACKEND_DISABLED",
+    "IDEA_PLUGIN_NOT_INSTALLED",
+    "IDEA_LAUNCH_FAILED",
+    "DAEMON_START_ERROR",
+    "DAEMON_UNREACHABLE",
+    "RUNTIME_TIMEOUT",
+    "RPC_RESPONSE_TIMEOUT",
+    "RPC_RESPONSE_MISSING",
+    "CAPABILITY_NOT_SUPPORTED",
+    "CAPABILITIES_UNAVAILABLE",
+];
+```
+
+Add a table test that iterates every constant and asserts fallback is allowed. Add negative cases for `IDEA_LAUNCH_CONFIG_INVALID`, `RPC_RESPONSE_INVALID`, `RESOLVE_FAILURE`, `VALIDATION_ERROR`, and `AGENT_REQUEST_INVALID`; each must remain fail-closed.
+
+- [ ] **Step 5: Implement compiler-first exact orchestration**
+
+Replace generic symbol steps with `execute_agent_symbol_exact` and `execute_agent_symbol_discovery`. Exact execution:
+
+```rust
+match compiler_result_type {
+    "RESOLVE_SUCCESS" => resolved_from_compiler(...),
+    "RESOLVE_NOT_FOUND" => not_found_from_compiler(...),
+    "RESOLVE_AMBIGUOUS" => ambiguous_from_compiler(...),
+    "RESOLVE_FAILURE" => preserve_compiler_failure(...),
+    other => invalid_compiler_contract(other),
+}
+```
+
+Only an allowlisted `AgentError.code` reaches `indexed_exact_fallback`. If `containing_type` is present, return the compiler availability error because the current source index cannot prove that constraint. Build file-hint and kind filters into the exact index request, use `modes=["exact"]`, and never include lexical mode. Discovery uses `modes=["lexical"]` and returns `source=fuzzy`.
+
+- [ ] **Step 6: Run Rust unit and public tests and verify GREEN**
+
+Run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked agent::
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_command_surface_smoke
+```
+
+Expected: pass, including all 13 allowlisted codes and all negative codes.
+
+### Task 3: Indexed Exact Identity And Backticks
+
+**Files:**
+
+- Modify: `cli-rs/src/symbol_query/ranking_and_filters.rs`
+- Modify: `cli-rs/tests/support/metrics.rs`
+- Modify: `cli-rs/tests/symbol_query_smoke.rs`
+
+**Interfaces:**
+
+- Consumes: raw query text and indexed declaration `fq_name`/derived simple name.
+- Produces: exact signals only when normalized Kotlin identity is equal; returned declarations remain unchanged.
+
+- [ ] **Step 1: Add source-index RED tests**
+
+Seed canonical indexed declarations `sample.when`, `alpha.Parser`, and `beta.Parser`, plus lexical-only `sample.MissingOrderServiceLegacy`. Add tests:
+
+```rust
+#[test] fn indexed_exact_lookup_normalizes_backticks_without_rewriting_identity()
+#[test] fn indexed_exact_lookup_returns_all_ambiguous_simple_name_matches()
+#[test] fn indexed_exact_lookup_never_returns_lexical_only_candidates()
+```
+
+- [ ] **Step 2: Run the symbol-query test and verify RED**
+
+Run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test symbol_query_smoke
+```
+
+Expected: the backticked exact query returns no results before normalization.
+
+- [ ] **Step 3: Implement comparison-only backtick normalization**
+
+Add a pure `normalized_kotlin_identity` helper and use it only inside
+`exact_matches`. Preserve case sensitivity and the original `fq_name` and
+`simple_name` fields in response records. Do not change lexical tokenization.
+
+- [ ] **Step 4: Run symbol-query and agent tests and verify GREEN**
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test symbol_query_smoke --test agent_command_surface_smoke
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit the Rust behavior slices**
+
+```console
+git add cli-rs/src/cli/agent.rs cli-rs/src/agent.rs cli-rs/src/agent \
+  cli-rs/src/symbol_query/ranking_and_filters.rs cli-rs/tests/agent_command_surface_smoke.rs \
+  cli-rs/tests/symbol_query_smoke.rs cli-rs/tests/support/mod.rs cli-rs/tests/support/metrics.rs
+git commit -m "feat: add fail-closed exact symbol mode"
+```
+
+### Task 4: Authored Guidance, Catalog, And Generated Contracts
+
+**Files:**
+
+- Modify: `cli-rs/resources/kast-skill/references/commands.json`
+- Modify: `cli-rs/resources/kast-skill/SKILL.md`
+- Modify: `cli-rs/resources/kast-skill/references/workflows.md`
+- Modify: `docs/reference/agent-commands.md`
+- Modify: `docs/use/inspect-kotlin.md`
+- Modify: `docs/learn/evidence-model.md`
+- Modify generated outputs reported by `kast developer release generate contract`
+- Modify: `cli-rs/tests/rpc_catalog_smoke.rs`
+- Modify: `cli-rs/tests/packaged_content_smoke.rs`
+
+**Interfaces:**
+
+- Consumes: accepted ADR 0016 and the implemented CLI/backend types.
+- Produces: catalog variants, migration guidance, packaged skill routing, public reference/how-to/explanation pages, and regenerated protocol artifacts.
+
+- [ ] **Step 1: Add catalog and packaged-guidance RED assertions**
+
+Assert that `symbol/resolve` lists all four response variants and that packaged guidance teaches exact default plus explicit `--mode discovery`. Keep raw catalog dispatch internal.
+
+- [ ] **Step 2: Run contract tests and verify RED**
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test rpc_catalog_smoke --test packaged_content_smoke
+```
+
+Expected: current catalog knows only success/failure and packaged guidance omits discovery mode.
+
+- [ ] **Step 3: Update authored sources**
+
+Update `commands.json` first. Preserve `RESOLVE_SUCCESS` and `RESOLVE_FAILURE` while adding `RESOLVE_NOT_FOUND` and `RESOLVE_AMBIGUOUS`. Document that existing internal consumers must match the new variants.
+
+Apply Diataxis boundaries:
+
+- `docs/reference/agent-commands.md`: factual mode, outcome, source, and flag reference.
+- `docs/use/inspect-kotlin.md`: how to use exact lookup and opt into discovery.
+- `docs/learn/evidence-model.md`: why source and typed ambiguity matter.
+- Packaged `SKILL.md` and workflows: concise routing examples only.
+
+- [ ] **Step 4: Regenerate owned protocol outputs**
+
+```console
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract
+```
+
+Review every generated path and keep only expected catalog-derived changes.
+
+- [ ] **Step 5: Verify generated and docs contracts**
+
+```console
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test rpc_catalog_smoke --test packaged_content_smoke
+.github/scripts/test-docs-content-contract.sh
+zensical build --clean
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit source and generated contract alignment**
+
+```console
+git add cli-rs/resources/kast-skill docs cli-rs/protocol cli-rs/tests/rpc_catalog_smoke.rs cli-rs/tests/packaged_content_smoke.rs
+git commit -m "docs: teach exact and discovery symbol modes"
+```
+
+### Task 5: Widening Verification, Review, And Durable Report
+
+**Files:**
+
+- Create ignored report: `.agent-turn/issue-334-report.md`
+- Create ignored Kotlin scorecard/evidence under `.agent-turn/kotlin-agentic-correctness/`
+
+**Interfaces:**
+
+- Consumes: the approved design, implementation diff, and validation logs.
+- Produces: clean commits, no untracked scoped source, a no-`Fail` Kotlin scorecard, and a durable worktree report.
+
+- [ ] **Step 1: Run Kotlin diagnostics or record the prepared-workspace limitation**
+
+Run `kast agent verify --workspace-root "$PWD"`. If plugin metadata remains absent, record `MACOS_PLUGIN_WORKSPACE_REQUIRED` and do not run `kast setup`. Use Gradle compile/test output as the authoritative Kotlin proof.
+
+- [ ] **Step 2: Run full formatting, lint, and test gates**
+
+```console
+cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
+cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
+cargo test --manifest-path cli-rs/Cargo.toml --locked
+./gradlew :analysis-api:test :analysis-server:test
+.github/scripts/test-docs-content-contract.sh
+zensical build --clean
+git diff --check
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 3: Review requirements and diff**
+
+Check every issue criterion against a test, inspect `git diff --stat`, review targeted diffs, confirm generated ownership, and verify no fuzzy request appears in exact execution. Confirm the availability test enumerates all 13 allowlisted codes and rejects the five negative codes.
+
+- [ ] **Step 4: Write Kotlin scorecard and durable report**
+
+Write the nine-dimension Kotlin scorecard with `Pass`, `Concern`, or `Fail`; no `Fail` may remain. Write `.agent-turn/issue-334-report.md` with status, commits, tests, evidence paths, and concerns, including the temporary-worktree Kast limitation.
+
+- [ ] **Step 5: Commit any final scoped corrections and report the branch state**
+
+Stage only tracked issue files. Run `git diff --cached --check`, commit with a conventional focused subject if needed, and leave the branch/worktree local without push or PR.

--- a/.agents/superpowers/specs/2026-07-13-exact-symbol-lookup-design.md
+++ b/.agents/superpowers/specs/2026-07-13-exact-symbol-lookup-design.md
@@ -1,0 +1,128 @@
+# Exact Symbol Lookup Design
+
+## Goal
+
+Make `kast agent symbol` return one exact symbol identity or a typed not-found
+or ambiguous outcome, while keeping fuzzy discovery available only through an
+explicit mode.
+
+## Current Failure
+
+The public command currently sends `symbol/query` with exact and lexical modes,
+then sends `symbol/resolve`. The resolver searches workspace symbols, scores
+the candidates, and resolves the first one. A name that is absent, stale, or
+not yet indexed can therefore surface unrelated lexical candidates before
+compiler identity is established.
+
+## Chosen Architecture
+
+The existing `symbol/resolve` RPC becomes the compiler-owned exact boundary.
+It searches broadly enough to collect candidates, then applies normalized
+simple-name or fully-qualified-name equality plus kind, file hint, and
+containing type as hard constraints. Backtick normalization exists only in the
+comparison function. The returned `Symbol` remains the backend's canonical
+identity.
+
+`KastResolveResponse` becomes a sealed four-variant contract:
+
+- `RESOLVE_SUCCESS` carries the unique compiler identity and
+  `source=compiler`.
+- `RESOLVE_NOT_FOUND` carries the exact query and `source=compiler`.
+- `RESOLVE_AMBIGUOUS` carries the bounded exact candidates and
+  `source=compiler`.
+- `RESOLVE_FAILURE` remains the operational error variant for existing
+  internal consumers.
+
+The response owner moves from the legacy aggregation file into
+`KastResolveResponse.kt`. The sealed variants stay with their root, satisfying
+the repository's Kotlin file-isolation rule without causing an unrelated
+package-wide migration.
+
+The Rust public boundary adds `AgentSymbolMode` with `exact` as the default and
+`discovery` as the only path to lexical candidates. Rust maps backend and index
+payloads into a typed public result whose outcome is `resolved`, `not-found`,
+`ambiguous`, or `discovery`, and whose evidence source is `compiler`,
+`indexed-exact`, or `fuzzy`.
+
+## Exact Data Flow
+
+1. Parse the CLI query and optional hard constraints into `AgentSymbolArgs`.
+2. Send `symbol/resolve` to the selected compiler backend.
+3. Return the compiler's resolved, not-found, or ambiguous outcome directly.
+4. If and only if the request fails with a typed backend-availability or
+   capability error, issue `symbol/query` with `modes=[exact]` and no lexical
+   mode.
+5. Map zero, one, or multiple hard-constrained index results to not-found,
+   resolved, or ambiguous with `source=indexed-exact`.
+6. If a requested constraint cannot be proven by the source index, preserve
+   the compiler availability error instead of weakening the request.
+7. Run references or callers only after compiler resolution, using the
+   canonical resolved fully qualified name.
+
+Compiler not-found and ambiguous outcomes terminate the flow. They never
+invoke the source index or fuzzy discovery.
+
+## Discovery Data Flow
+
+`--mode discovery` sends the existing indexed `symbol/query` request with
+`modes=[lexical]`. Its candidates are returned under a typed discovery outcome
+with `source=fuzzy`. Exact-looking lexical candidates do not change the source
+or outcome and cannot pose as resolved identity.
+
+References and callers are invalid in discovery mode because discovery does
+not establish one canonical compiler identity. The CLI returns a structured
+usage error before attempting relation requests.
+
+## Identity And Constraints
+
+The comparison boundary trims whitespace and removes one pair of Kotlin
+backticks from each qualified-name segment. It does not lowercase names,
+perform substring matching, or rewrite the result. A query without a package
+separator compares against the candidate's simple name; a qualified query
+compares against the complete qualified name.
+
+Kind, file hint, and containing type are filters, not ranking bonuses. Multiple
+overloads with the same fully qualified name remain ambiguous when the
+available constraints cannot distinguish their compiler locations.
+
+## Error Design
+
+Not-found and ambiguous are expected domain outcomes and therefore remain
+successful command execution with typed payloads. Missing runtime, unreachable
+daemon, unsupported compiler capability, and response timeout are operational
+availability errors. Only the defined availability set can authorize the
+indexed exact fallback. Invalid responses, compiler failures after dispatch,
+and unprovable index constraints remain errors.
+
+## Source And Generated Ownership
+
+The CLI definitions, agent orchestration, Kotlin response contract, server
+selection logic, command catalog, packaged skill, and public docs are authored
+sources. Protocol Markdown, schemas, and request samples generated from the
+catalog are regenerated through the release contract generator and are not
+hand-edited.
+
+## Testing
+
+The TDD slices are:
+
+1. Server tests for exact not-found, ambiguous overloads, backticked simple and
+   qualified names, and hard constraints. Each test fails against the current
+   first-ranked resolver before production changes.
+2. Rust public-command tests for default exact requests, explicit discovery,
+   typed outcome/source rendering, exact-only availability fallback, no
+   fallback after compiler not-found or ambiguous, and relation requests based
+   on canonical compiler identity.
+3. Source-index tests proving exact mode excludes lexical candidates and
+   normalizes backticked identity without changing returned names.
+4. Contract and migration tests proving internal consumers can still decode
+   `RESOLVE_SUCCESS` and `RESOLVE_FAILURE` while exhaustively recognizing the
+   two new expected variants.
+5. Generated contract, documentation, formatting, lint, module, and full-suite
+   gates.
+
+## Non-Goals
+
+This change does not add fuzzy fallback to exact mode, invent signature-level
+identity for overloads, redesign source-index storage, expose arbitrary RPC
+dispatch, or make generated protocol files an authored source of truth.

--- a/.github/scripts/render-rpc-contract-summary.py
+++ b/.github/scripts/render-rpc-contract-summary.py
@@ -191,11 +191,26 @@ def enum_values(field: dict[str, Any]) -> str:
     return "<br>".join(f"`{value}`" for value in values)
 
 
-def response_variants(spec: dict[str, Any]) -> str:
+def response_variant_names(spec: dict[str, Any]) -> list[str]:
+    declared = spec.get("responseVariants")
+    if declared is not None:
+        if not isinstance(declared, list) or not declared or not all(
+            isinstance(variant, str) and variant for variant in declared
+        ):
+            raise ValueError("responseVariants must be a non-empty list of non-empty strings")
+        return declared
+
     success = spec.get("successType")
     failure = spec.get("failureType")
     if success and failure:
-        return f"`{success}`<br>`{failure}`"
+        return [str(success), str(failure)]
+    return []
+
+
+def response_variants(spec: dict[str, Any]) -> str:
+    variants = response_variant_names(spec)
+    if variants:
+        return "<br>".join(f"`{variant}`" for variant in variants)
     return "single result"
 
 
@@ -358,10 +373,10 @@ def render_summary(catalog: dict[str, Any]) -> str:
                 f"Response type: `{spec.get('responseType', 'none')}`.",
             ]
         )
-        success = spec.get("successType")
-        failure = spec.get("failureType")
-        if success and failure:
-            lines.append(f"Result variants: `{success}`, `{failure}`.")
+        variants = response_variant_names(spec)
+        if variants:
+            formatted_variants = ", ".join(f"`{variant}`" for variant in variants)
+            lines.append(f"Result variants: {formatted_variants}.")
         notes = spec.get("notes") or []
         if notes:
             lines.extend(["", "Notes:", ""])

--- a/.github/scripts/test-docs-content-contract.sh
+++ b/.github/scripts/test-docs-content-contract.sh
@@ -98,6 +98,7 @@ operating_model_doc="${docs_root}/design/operating-model.md"
 journey_map="${repo_root}/.agents/docs/documentation-journeys.md"
 docs_adr="${repo_root}/.agents/adr/0011-journey-first-documentation-operating-model.md"
 protocol_dir="${repo_root}/cli-rs/protocol"
+api_specification="${protocol_dir}/api-specification.md"
 
 [[ ! -e "${repo_root}/docs/docs.json" ]] || die "docs/docs.json must not be used; zensical.toml owns published navigation"
 [[ ! -d "${docs_root}/adr" ]] || die "agent-focused ADRs must live under .agents/adr, not docs/adr"
@@ -126,6 +127,7 @@ require_absent_path "${docs_root}/cli-cheat-sheet.md" "Old CLI cheat sheet must 
 require_absent_path "${docs_root}/getting-started/backends.md" "Backend essay must not be published"
 [[ -f "${protocol_dir}/openapi.yaml" ]] || die "OpenAPI must remain generated outside the published docs tree"
 [[ -f "${protocol_dir}/api-reference.md" ]] || die "Generated protocol markdown must remain outside the published docs tree"
+require_contains "$api_specification" 'Result variants: `RESOLVE_SUCCESS`, `RESOLVE_NOT_FOUND`, `RESOLVE_AMBIGUOUS`, `RESOLVE_FAILURE`.' "Generated RPC summary must preserve every declared exact-resolve outcome"
 
 require_not_contains "$docs_root" "reference/api-reference" "Published docs must not link generated API reference"
 require_not_contains "$docs_root" "reference/api-specification" "Published docs must not link API specification"

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastResolveResponse.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastResolveResponse.kt
@@ -1,0 +1,62 @@
+package io.github.amichne.kast.api.contract.skill
+
+import io.github.amichne.kast.api.contract.Symbol
+import io.github.amichne.kast.api.protocol.ApiErrorResponse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface KastResolveResponse {
+    @Serializable
+    enum class Source {
+        @SerialName("compiler")
+        COMPILER,
+    }
+}
+
+@Serializable
+@SerialName("RESOLVE_SUCCESS")
+data class KastResolveSuccessResponse(
+    val ok: Boolean = true,
+    val source: KastResolveResponse.Source = KastResolveResponse.Source.COMPILER,
+    val query: KastResolveQuery,
+    val symbol: Symbol,
+    val filePath: String,
+    val offset: Int,
+    val candidate: KastCandidate,
+    val candidateCount: Int? = null,
+    val alternatives: List<String>? = null,
+    val context: KastResolveContext? = null,
+    val logFile: String,
+) : KastResolveResponse
+
+@Serializable
+@SerialName("RESOLVE_NOT_FOUND")
+data class KastResolveNotFoundResponse(
+    val ok: Boolean = true,
+    val source: KastResolveResponse.Source = KastResolveResponse.Source.COMPILER,
+    val query: KastResolveQuery,
+    val logFile: String,
+) : KastResolveResponse
+
+@Serializable
+@SerialName("RESOLVE_AMBIGUOUS")
+data class KastResolveAmbiguousResponse(
+    val ok: Boolean = true,
+    val source: KastResolveResponse.Source = KastResolveResponse.Source.COMPILER,
+    val query: KastResolveQuery,
+    val candidates: List<Symbol>,
+    val logFile: String,
+) : KastResolveResponse
+
+@Serializable
+@SerialName("RESOLVE_FAILURE")
+data class KastResolveFailureResponse(
+    val ok: Boolean = false,
+    val stage: String,
+    val message: String,
+    val query: KastResolveQuery,
+    val logFile: String,
+    val error: ApiErrorResponse? = null,
+    val errorText: String? = null,
+) : KastResolveResponse

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt
@@ -683,36 +683,6 @@ data class KastScaffoldTypeHierarchy(
 )
 
 @Serializable
-sealed interface KastResolveResponse
-
-@Serializable
-@SerialName("RESOLVE_SUCCESS")
-data class KastResolveSuccessResponse(
-    val ok: Boolean = true,
-    val query: KastResolveQuery,
-    val symbol: Symbol,
-    val filePath: String,
-    val offset: Int,
-    val candidate: KastCandidate,
-    val candidateCount: Int? = null,
-    val alternatives: List<String>? = null,
-    val context: KastResolveContext? = null,
-    val logFile: String,
-) : KastResolveResponse
-
-@Serializable
-@SerialName("RESOLVE_FAILURE")
-data class KastResolveFailureResponse(
-    val ok: Boolean = false,
-    val stage: String,
-    val message: String,
-    val query: KastResolveQuery,
-    val logFile: String,
-    val error: ApiErrorResponse? = null,
-    val errorText: String? = null,
-) : KastResolveResponse
-
-@Serializable
 sealed interface KastDiscoverResponse
 
 @Serializable

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/skill/KastResolveResponseTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/skill/KastResolveResponseTest.kt
@@ -1,0 +1,95 @@
+package io.github.amichne.kast.api.contract.skill
+
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+class KastResolveResponseTest {
+    private val json = Json
+
+    @Test
+    fun `existing success and failure discriminators remain compatible`() {
+        val success = json.decodeFromString<KastResolveResponse>(
+            """
+            {
+              "type":"RESOLVE_SUCCESS",
+              "ok":true,
+              "query":{"workspaceRoot":"/workspace","symbol":"sample.Parser"},
+              "symbol":$symbolJson,
+              "filePath":"/workspace/Parser.kt",
+              "offset":10,
+              "candidate":{"line":1,"column":1,"context":"class Parser"},
+              "candidateCount":1,
+              "alternatives":[],
+              "logFile":"/tmp/kast.log"
+            }
+            """.trimIndent(),
+        )
+        val failure = json.decodeFromString<KastResolveResponse>(
+            """
+            {
+              "type":"RESOLVE_FAILURE",
+              "ok":false,
+              "stage":"resolve",
+              "message":"backend failed",
+              "query":{"workspaceRoot":"/workspace","symbol":"sample.Parser"},
+              "logFile":"/tmp/kast.log"
+            }
+            """.trimIndent(),
+        )
+
+        assertInstanceOf(KastResolveSuccessResponse::class.java, success)
+        assertInstanceOf(KastResolveFailureResponse::class.java, failure)
+    }
+
+    @Test
+    fun `expected exact outcomes decode distinctly`() {
+        val notFound = json.decodeFromString<KastResolveResponse>(
+            """
+            {
+              "type":"RESOLVE_NOT_FOUND",
+              "ok":true,
+              "source":"compiler",
+              "query":{"workspaceRoot":"/workspace","symbol":"Missing"},
+              "logFile":"/tmp/kast.log"
+            }
+            """.trimIndent(),
+        )
+        val ambiguous = json.decodeFromString<KastResolveResponse>(
+            """
+            {
+              "type":"RESOLVE_AMBIGUOUS",
+              "ok":true,
+              "source":"compiler",
+              "query":{"workspaceRoot":"/workspace","symbol":"parse"},
+              "candidates":[$symbolJson,$symbolJson],
+              "logFile":"/tmp/kast.log"
+            }
+            """.trimIndent(),
+        )
+
+        val typedNotFound = assertInstanceOf(KastResolveNotFoundResponse::class.java, notFound)
+        val typedAmbiguous = assertInstanceOf(KastResolveAmbiguousResponse::class.java, ambiguous)
+        assertEquals(KastResolveResponse.Source.COMPILER, typedNotFound.source)
+        assertEquals(2, typedAmbiguous.candidates.size)
+    }
+
+    private companion object {
+        val symbolJson =
+            """
+            {
+              "fqName":"sample.Parser",
+              "kind":"CLASS",
+              "location":{
+                "filePath":"/workspace/Parser.kt",
+                "startOffset":10,
+                "endOffset":16,
+                "startLine":1,
+                "startColumn":1,
+                "preview":"class Parser"
+              }
+            }
+            """.trimIndent()
+    }
+}

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
@@ -61,7 +61,9 @@ import io.github.amichne.kast.api.contract.skill.KastRenameQuery
 import io.github.amichne.kast.api.contract.skill.KastRenameRequest
 import io.github.amichne.kast.api.contract.skill.KastRenameResponse
 import io.github.amichne.kast.api.contract.skill.KastRenameSuccessResponse
+import io.github.amichne.kast.api.contract.skill.KastResolveAmbiguousResponse
 import io.github.amichne.kast.api.contract.skill.KastResolveFailureResponse
+import io.github.amichne.kast.api.contract.skill.KastResolveNotFoundResponse
 import io.github.amichne.kast.api.contract.skill.KastResolveContext
 import io.github.amichne.kast.api.contract.skill.KastResolveParams
 import io.github.amichne.kast.api.contract.skill.KastResolveQuery
@@ -128,29 +130,33 @@ internal class SkillRpcOrchestrator(
             includeSurroundingMembers = request.includeSurroundingMembers,
         )
         validateResolveQuery(query)
-        val candidates = rankedNamedSymbolCandidates(
+        val candidates = exactNamedSymbolCandidates(
             symbolName = request.symbol,
             fileHint = request.fileHint,
             kind = request.kind,
             containingType = request.containingType,
-            line = null,
-            codeSnippet = null,
             includeDeclarationScope = false,
             searchLimit = minOf(config.maxResults, DEFAULT_DISCOVERY_SEARCH_LIMIT),
         )
-        val candidate = candidates.firstOrNull() ?: return KastResolveFailureResponse(
-            stage = "resolve",
-            message = "No symbol matching '${request.symbol}' found in workspace",
-            query = query,
-            logFile = placeholderLogFile(),
-        )
+        if (candidates.isEmpty()) {
+            return KastResolveNotFoundResponse(
+                query = query,
+                logFile = placeholderLogFile(),
+            )
+        }
+        if (candidates.size > 1) {
+            return KastResolveAmbiguousResponse(
+                query = query,
+                candidates = candidates.map(RankedNamedSymbolCandidate::symbol),
+                logFile = placeholderLogFile(),
+            )
+        }
+        val candidate = candidates.single()
         val resolved = resolveNamedSymbol(
             candidate = candidate,
             includeDeclarationScope = request.includeDeclarationScope,
             includeDocumentation = request.includeDocumentation,
-        ) ?: return KastResolveFailureResponse(
-            stage = "resolve",
-            message = "No symbol matching '${request.symbol}' found in workspace",
+        ) ?: return KastResolveNotFoundResponse(
             query = query,
             logFile = placeholderLogFile(),
         )
@@ -165,15 +171,8 @@ internal class SkillRpcOrchestrator(
                 column = resolved.symbol.location.startColumn,
                 context = resolved.symbol.location.preview,
             ),
-            candidateCount = candidates.size.takeIf { it > 1 },
-            alternatives = candidates
-                .asSequence()
-                .map { it.symbol.fqName }
-                .filter { it != candidate.symbol.fqName }
-                .distinct()
-                .take(3)
-                .toList()
-                .takeIf { it.isNotEmpty() },
+            candidateCount = 1,
+            alternatives = emptyList(),
             context = context,
             logFile = placeholderLogFile(),
         )
@@ -1100,8 +1099,91 @@ internal class SkillRpcOrchestrator(
             .toList()
     }
 
+    private suspend fun exactNamedSymbolCandidates(
+        symbolName: String,
+        fileHint: String?,
+        kind: WrapperNamedSymbolKind?,
+        containingType: String?,
+        includeDeclarationScope: Boolean,
+        searchLimit: Int,
+    ): List<RankedNamedSymbolCandidate> {
+        requireReadCapability(ReadCapability.WORKSPACE_SYMBOL_SEARCH)
+        return symbolSearchPatterns(symbolName)
+            .flatMap { pattern ->
+                backend.workspaceSymbolSearch(
+                    WorkspaceSymbolQuery(
+                        pattern = pattern,
+                        kind = kind?.toSymbolKind(),
+                        maxResults = searchLimit,
+                        includeDeclarationScope = includeDeclarationScope,
+                    ).parsed(),
+                ).withLimit(searchLimit) { workspaceSymbolPageToken(searchLimit) }.symbols
+            }
+            .distinctBy { symbol -> Triple(symbol.fqName, symbol.location.filePath, symbol.location.startOffset) }
+            .asSequence()
+            .filter { symbol -> exactIdentityMatches(symbolName, symbol.fqName) }
+            .filter { symbol -> kind == null || symbol.kind == kind.toSymbolKind() }
+            .filter { symbol -> fileHint == null || exactFileHintMatches(fileHint, symbol.location.filePath) }
+            .filter { symbol -> containingType == null || exactContainingTypeMatches(containingType, symbol) }
+            .sortedWith(
+                compareBy<Symbol> { it.location.filePath }
+                    .thenBy { it.location.startOffset }
+                    .thenBy { it.fqName },
+            )
+            .map { symbol ->
+                RankedNamedSymbolCandidate(
+                    symbol = symbol,
+                    score = 100,
+                    reasons = listOf("exact identity and constraints match"),
+                )
+            }
+            .toList()
+    }
+
+    private fun exactIdentityMatches(requested: String, candidateFqName: String): Boolean {
+        val normalizedRequested = normalizedKotlinIdentity(requested)
+        val normalizedCandidate = normalizedKotlinIdentity(candidateFqName)
+        return if (normalizedRequested.contains('.')) {
+            normalizedCandidate == normalizedRequested
+        } else {
+            normalizedCandidate.substringAfterLast('.') == normalizedRequested
+        }
+    }
+
+    private fun normalizedKotlinIdentity(value: String): String = value
+        .split('.')
+        .joinToString(".") { segment ->
+            segment.removeSurrounding("`")
+        }
+
+    private fun exactFileHintMatches(fileHint: String, candidateFile: String): Boolean {
+        val normalizedHint = Path.of(fileHint).normalize()
+        val normalizedCandidate = Path.of(candidateFile).normalize()
+        return if (normalizedHint.isAbsolute) {
+            normalizedCandidate == normalizedHint
+        } else {
+            normalizedCandidate.endsWith(normalizedHint)
+        }
+    }
+
+    private fun exactContainingTypeMatches(containingType: String, candidate: Symbol): Boolean {
+        val candidateContainer = candidate.containingDeclaration ?: return false
+        val normalizedRequested = normalizedKotlinIdentity(containingType)
+        val normalizedCandidate = normalizedKotlinIdentity(candidateContainer)
+        return if (normalizedRequested.contains('.')) {
+            normalizedCandidate == normalizedRequested
+        } else {
+            normalizedCandidate.substringAfterLast('.') == normalizedRequested
+        }
+    }
+
     private fun symbolSearchPatterns(symbolName: String): List<String> =
-        listOf(symbolName, symbolName.substringAfterLast('.'))
+        listOf(
+            symbolName,
+            symbolName.substringAfterLast('.'),
+            normalizedKotlinIdentity(symbolName),
+            normalizedKotlinIdentity(symbolName).substringAfterLast('.'),
+        )
             .map(String::trim)
             .filter(String::isNotEmpty)
             .distinct()

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
@@ -113,8 +113,15 @@ internal class SkillRpcOrchestrator(
 ) {
     private companion object {
         const val DEFAULT_DISCOVERY_SEARCH_LIMIT = 100
+        const val EXACT_CARDINALITY_LIMIT = 2
+        const val EXACT_CONSTRAINED_SEARCH_LIMIT = Int.MAX_VALUE
         const val MAX_SURROUNDING_LINES = 50
     }
+
+    private data class ExactNamedSymbolCandidate(
+        val ranked: RankedNamedSymbolCandidate,
+        val resolvedConstraintSymbol: Symbol?,
+    )
 
     suspend fun resolve(request: KastResolveRequest): KastResolveResponse {
         val workspaceRoot = workspaceRootFor(request.workspaceRoot)
@@ -136,7 +143,6 @@ internal class SkillRpcOrchestrator(
             kind = request.kind,
             containingType = request.containingType,
             includeDeclarationScope = false,
-            searchLimit = minOf(config.maxResults, DEFAULT_DISCOVERY_SEARCH_LIMIT),
         )
         if (candidates.isEmpty()) {
             return KastResolveNotFoundResponse(
@@ -147,13 +153,15 @@ internal class SkillRpcOrchestrator(
         if (candidates.size > 1) {
             return KastResolveAmbiguousResponse(
                 query = query,
-                candidates = candidates.map(RankedNamedSymbolCandidate::symbol),
+                candidates = candidates.map { candidate ->
+                    candidate.resolvedConstraintSymbol ?: candidate.ranked.symbol
+                },
                 logFile = placeholderLogFile(),
             )
         }
         val candidate = candidates.single()
         val resolved = resolveNamedSymbol(
-            candidate = candidate,
+            candidate = candidate.ranked,
             includeDeclarationScope = request.includeDeclarationScope,
             includeDocumentation = request.includeDocumentation,
         ) ?: return KastResolveNotFoundResponse(
@@ -1105,16 +1113,21 @@ internal class SkillRpcOrchestrator(
         kind: WrapperNamedSymbolKind?,
         containingType: String?,
         includeDeclarationScope: Boolean,
-        searchLimit: Int,
-    ): List<RankedNamedSymbolCandidate> {
+    ): List<ExactNamedSymbolCandidate> {
         requireReadCapability(ReadCapability.WORKSPACE_SYMBOL_SEARCH)
-        return symbolSearchPatterns(symbolName)
+        val searchLimit = if (fileHint == null && containingType == null) {
+            EXACT_CARDINALITY_LIMIT
+        } else {
+            EXACT_CONSTRAINED_SEARCH_LIMIT
+        }
+        val rankedCandidates = symbolSearchPatterns(symbolName)
             .flatMap { pattern ->
                 backend.workspaceSymbolSearch(
                     WorkspaceSymbolQuery(
-                        pattern = pattern,
+                        pattern = exactWorkspaceSymbolPattern(pattern),
                         kind = kind?.toSymbolKind(),
                         maxResults = searchLimit,
+                        regex = true,
                         includeDeclarationScope = includeDeclarationScope,
                     ).parsed(),
                 ).withLimit(searchLimit) { workspaceSymbolPageToken(searchLimit) }.symbols
@@ -1124,7 +1137,6 @@ internal class SkillRpcOrchestrator(
             .filter { symbol -> exactIdentityMatches(symbolName, symbol.fqName) }
             .filter { symbol -> kind == null || symbol.kind == kind.toSymbolKind() }
             .filter { symbol -> fileHint == null || exactFileHintMatches(fileHint, symbol.location.filePath) }
-            .filter { symbol -> containingType == null || exactContainingTypeMatches(containingType, symbol) }
             .sortedWith(
                 compareBy<Symbol> { it.location.filePath }
                     .thenBy { it.location.startOffset }
@@ -1138,6 +1150,26 @@ internal class SkillRpcOrchestrator(
                 )
             }
             .toList()
+        return if (containingType == null) {
+            rankedCandidates
+                .take(EXACT_CARDINALITY_LIMIT)
+                .map { candidate -> ExactNamedSymbolCandidate(candidate, resolvedConstraintSymbol = null) }
+        } else {
+            rankedCandidates
+                .mapNotNull { candidate ->
+                    val resolved = resolveNamedSymbol(
+                        candidate = candidate,
+                        includeDeclarationScope = false,
+                        includeDocumentation = false,
+                    ) ?: return@mapNotNull null
+                    if (exactContainingTypeMatches(containingType, resolved.symbol)) {
+                        ExactNamedSymbolCandidate(candidate, resolved.symbol)
+                    } else {
+                        null
+                    }
+                }
+                .take(EXACT_CARDINALITY_LIMIT)
+        }
     }
 
     private fun exactIdentityMatches(requested: String, candidateFqName: String): Boolean {
@@ -1155,6 +1187,9 @@ internal class SkillRpcOrchestrator(
         .joinToString(".") { segment ->
             segment.removeSurrounding("`")
         }
+
+    private fun exactWorkspaceSymbolPattern(value: String): String =
+        "^${Regex.escape(normalizedKotlinIdentity(value).substringAfterLast('.'))}$"
 
     private fun exactFileHintMatches(fileHint: String, candidateFile: String): Boolean {
         val normalizedHint = Path.of(fileHint).normalize()

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
@@ -270,6 +270,30 @@ class AnalysisDispatcherTest {
     }
 
     @Test
+    fun `symbol resolve cardinality is independent of server presentation limit`() {
+        val backend = ExactLookupBackend(
+            delegate = FakeAnalysisBackend.sample(tempDir),
+            symbols = listOf(
+                lookupSymbol("sample.Parser.parse", SymbolKind.FUNCTION, "Parser.kt", startOffset = 10),
+                lookupSymbol("sample.Parser.parse", SymbolKind.FUNCTION, "Parser.kt", startOffset = 40),
+            ),
+        )
+
+        val result = dispatchSuccessWithBackend<KastResolveResponse>(
+            backend = backend,
+            config = AnalysisServerConfig(maxResults = 1),
+            method = "symbol/resolve",
+            params = json.encodeToJsonElement(
+                KastResolveRequest.serializer(),
+                KastResolveRequest(workspaceRoot = tempDir.toString(), symbol = "parse"),
+            ),
+        )
+
+        val ambiguous = assertInstanceOf(KastResolveAmbiguousResponse::class.java, result)
+        assertEquals(2, ambiguous.candidates.size)
+    }
+
+    @Test
     fun `symbol resolve matches backticked simple and qualified names exactly`() {
         val backend = ExactLookupBackend(
             delegate = FakeAnalysisBackend.sample(tempDir),
@@ -337,6 +361,38 @@ class AnalysisDispatcherTest {
             )
             assertInstanceOf(KastResolveNotFoundResponse::class.java, result)
         }
+    }
+
+    @Test
+    fun `symbol resolve applies containing type using resolved compiler identity`() {
+        val workspaceSymbol = lookupSymbol(
+            fqName = "sample.Parser.parse",
+            kind = SymbolKind.FUNCTION,
+            fileName = "Parser.kt",
+            containingDeclaration = null,
+        )
+        val resolvedSymbol = workspaceSymbol.copy(containingDeclaration = "sample.Parser")
+        val backend = ExactLookupBackend(
+            delegate = FakeAnalysisBackend.sample(tempDir),
+            symbols = listOf(workspaceSymbol),
+            resolvedSymbols = listOf(resolvedSymbol),
+        )
+
+        val result = dispatchSuccessWithBackend<KastResolveResponse>(
+            backend = backend,
+            method = "symbol/resolve",
+            params = json.encodeToJsonElement(
+                KastResolveRequest.serializer(),
+                KastResolveRequest(
+                    workspaceRoot = tempDir.toString(),
+                    symbol = "parse",
+                    containingType = "sample.Parser",
+                ),
+            ),
+        )
+
+        val success = assertInstanceOf(KastResolveSuccessResponse::class.java, result)
+        assertEquals("sample.Parser", success.symbol.containingDeclaration)
     }
 
     @Test
@@ -1339,11 +1395,12 @@ class AnalysisDispatcherTest {
 
     private inline fun <reified T> dispatchSuccessWithBackend(
         backend: AnalysisBackend,
+        config: AnalysisServerConfig = AnalysisServerConfig(),
         method: String,
         params: JsonElement? = null,
     ): T {
         val raw = runBlocking {
-            RpcAnalysisDispatcher(backend = backend, config = AnalysisServerConfig()).dispatch(
+            RpcAnalysisDispatcher(backend = backend, config = config).dispatch(
                 JsonRpcRequest(id = JsonPrimitive(1), method = method, params = params),
             )
         }
@@ -1490,12 +1547,13 @@ private class CompilerDiagnosticsBeyondLimitBackend(
 private class ExactLookupBackend(
     private val delegate: AnalysisBackend,
     private val symbols: List<Symbol>,
+    private val resolvedSymbols: List<Symbol> = symbols,
 ) : AnalysisBackend by delegate {
     override suspend fun workspaceSymbolSearch(query: ParsedWorkspaceSymbolQuery): WorkspaceSymbolResult =
         WorkspaceSymbolResult(symbols = symbols)
 
     override suspend fun resolveSymbol(query: ParsedSymbolQuery): SymbolResult = SymbolResult(
-        symbol = symbols.single { symbol ->
+        symbol = resolvedSymbols.single { symbol ->
             symbol.location.filePath == query.position.filePath.value &&
                 symbol.location.startOffset == query.position.offset.value
         },

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
@@ -23,9 +23,9 @@ import io.github.amichne.kast.api.contract.FileOperation
 import io.github.amichne.kast.api.contract.query.FileOutlineQuery
 import io.github.amichne.kast.api.contract.result.FileOutlineResult
 import io.github.amichne.kast.api.contract.FilePosition
+import io.github.amichne.kast.api.contract.Location
 import io.github.amichne.kast.api.contract.NonBlankString
 import io.github.amichne.kast.api.contract.NormalizedPath
-import io.github.amichne.kast.api.contract.Location
 import io.github.amichne.kast.api.contract.query.ImportOptimizeQuery
 import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
 import io.github.amichne.kast.api.contract.query.ImplementationsQuery
@@ -48,6 +48,8 @@ import io.github.amichne.kast.api.contract.SemanticInsertionQuery
 import io.github.amichne.kast.api.contract.SemanticInsertionResult
 import io.github.amichne.kast.api.contract.SemanticInsertionTarget
 import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
+import io.github.amichne.kast.api.contract.Symbol
+import io.github.amichne.kast.api.contract.SymbolKind
 import io.github.amichne.kast.api.contract.query.SymbolQuery
 import io.github.amichne.kast.api.contract.result.SymbolResult
 import io.github.amichne.kast.api.contract.TextEdit
@@ -63,6 +65,8 @@ import io.github.amichne.kast.api.contract.skill.*
 import io.github.amichne.kast.api.contract.result.WorkspaceSymbolResult
 import io.github.amichne.kast.api.validation.ParsedApplyEditsQuery
 import io.github.amichne.kast.api.validation.ParsedDiagnosticsQuery
+import io.github.amichne.kast.api.validation.ParsedSymbolQuery
+import io.github.amichne.kast.api.validation.ParsedWorkspaceSymbolQuery
 import io.github.amichne.kast.testing.FakeAnalysisBackend
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -74,6 +78,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -220,6 +225,118 @@ class AnalysisDispatcherTest {
         assertEquals("sample.greet", success.symbol.fqName)
         assertEquals(file.toString(), success.filePath)
         assertEquals(true, success.ok)
+    }
+
+    @Test
+    fun `symbol resolve returns not found instead of a fuzzy candidate`() {
+        val backend = ExactLookupBackend(
+            delegate = FakeAnalysisBackend.sample(tempDir),
+            symbols = listOf(lookupSymbol("sample.LegacyOrderService", SymbolKind.CLASS, "LegacyOrderService.kt")),
+        )
+
+        val result = dispatchSuccessWithBackend<KastResolveResponse>(
+            backend = backend,
+            method = "symbol/resolve",
+            params = json.encodeToJsonElement(
+                KastResolveRequest.serializer(),
+                KastResolveRequest(workspaceRoot = tempDir.toString(), symbol = "MissingOrderService"),
+            ),
+        )
+
+        assertInstanceOf(KastResolveNotFoundResponse::class.java, result)
+    }
+
+    @Test
+    fun `symbol resolve returns ambiguous for overloaded exact members`() {
+        val backend = ExactLookupBackend(
+            delegate = FakeAnalysisBackend.sample(tempDir),
+            symbols = listOf(
+                lookupSymbol("sample.Parser.parse", SymbolKind.FUNCTION, "Parser.kt", startOffset = 10),
+                lookupSymbol("sample.Parser.parse", SymbolKind.FUNCTION, "Parser.kt", startOffset = 40),
+            ),
+        )
+
+        val result = dispatchSuccessWithBackend<KastResolveResponse>(
+            backend = backend,
+            method = "symbol/resolve",
+            params = json.encodeToJsonElement(
+                KastResolveRequest.serializer(),
+                KastResolveRequest(workspaceRoot = tempDir.toString(), symbol = "parse"),
+            ),
+        )
+
+        val ambiguous = assertInstanceOf(KastResolveAmbiguousResponse::class.java, result)
+        assertEquals(2, ambiguous.candidates.size)
+    }
+
+    @Test
+    fun `symbol resolve matches backticked simple and qualified names exactly`() {
+        val backend = ExactLookupBackend(
+            delegate = FakeAnalysisBackend.sample(tempDir),
+            symbols = listOf(lookupSymbol("sample.when", SymbolKind.FUNCTION, "Keywords.kt")),
+        )
+
+        val simple = dispatchSuccessWithBackend<KastResolveResponse>(
+            backend = backend,
+            method = "symbol/resolve",
+            params = json.encodeToJsonElement(
+                KastResolveRequest.serializer(),
+                KastResolveRequest(workspaceRoot = tempDir.toString(), symbol = "`when`"),
+            ),
+        )
+        val qualified = dispatchSuccessWithBackend<KastResolveResponse>(
+            backend = backend,
+            method = "symbol/resolve",
+            params = json.encodeToJsonElement(
+                KastResolveRequest.serializer(),
+                KastResolveRequest(workspaceRoot = tempDir.toString(), symbol = "sample.`when`"),
+            ),
+        )
+
+        assertEquals("sample.when", assertInstanceOf(KastResolveSuccessResponse::class.java, simple).symbol.fqName)
+        assertEquals("sample.when", assertInstanceOf(KastResolveSuccessResponse::class.java, qualified).symbol.fqName)
+    }
+
+    @Test
+    fun `symbol resolve applies kind file and containing type as hard constraints`() {
+        val fileName = "Parser.kt"
+        val backend = ExactLookupBackend(
+            delegate = FakeAnalysisBackend.sample(tempDir),
+            symbols = listOf(
+                lookupSymbol(
+                    fqName = "sample.Parser.parse",
+                    kind = SymbolKind.FUNCTION,
+                    fileName = fileName,
+                    containingDeclaration = "sample.Parser",
+                ),
+            ),
+        )
+        val mismatches = listOf(
+            KastResolveRequest(
+                workspaceRoot = tempDir.toString(),
+                symbol = "parse",
+                kind = WrapperNamedSymbolKind.CLASS,
+            ),
+            KastResolveRequest(
+                workspaceRoot = tempDir.toString(),
+                symbol = "parse",
+                fileHint = tempDir.resolve("Other.kt").toString(),
+            ),
+            KastResolveRequest(
+                workspaceRoot = tempDir.toString(),
+                symbol = "parse",
+                containingType = "sample.OtherParser",
+            ),
+        )
+
+        mismatches.forEach { request ->
+            val result = dispatchSuccessWithBackend<KastResolveResponse>(
+                backend = backend,
+                method = "symbol/resolve",
+                params = json.encodeToJsonElement(KastResolveRequest.serializer(), request),
+            )
+            assertInstanceOf(KastResolveNotFoundResponse::class.java, result)
+        }
     }
 
     @Test
@@ -1220,6 +1337,40 @@ class AnalysisDispatcherTest {
         )
     }
 
+    private inline fun <reified T> dispatchSuccessWithBackend(
+        backend: AnalysisBackend,
+        method: String,
+        params: JsonElement? = null,
+    ): T {
+        val raw = runBlocking {
+            RpcAnalysisDispatcher(backend = backend, config = AnalysisServerConfig()).dispatch(
+                JsonRpcRequest(id = JsonPrimitive(1), method = method, params = params),
+            )
+        }
+        val success = json.decodeFromString(JsonRpcSuccessResponse.serializer(), raw)
+        return json.decodeFromJsonElement(serializer<T>(), success.result)
+    }
+
+    private fun lookupSymbol(
+        fqName: String,
+        kind: SymbolKind,
+        fileName: String,
+        startOffset: Int = 10,
+        containingDeclaration: String? = null,
+    ): Symbol = Symbol(
+        fqName = fqName,
+        kind = kind,
+        location = Location(
+            filePath = tempDir.resolve(fileName).toString(),
+            startOffset = startOffset,
+            endOffset = startOffset + fqName.substringAfterLast('.').length,
+            startLine = startOffset,
+            startColumn = 1,
+            preview = fqName,
+        ),
+        containingDeclaration = containingDeclaration,
+    )
+
     private fun dispatchRaw(
         method: String,
         params: JsonElement? = null,
@@ -1334,4 +1485,19 @@ private class CompilerDiagnosticsBeyondLimitBackend(
             fileStatuses = listOf(FileAnalysisStatus.analyzed(filePath)),
         )
     }
+}
+
+private class ExactLookupBackend(
+    private val delegate: AnalysisBackend,
+    private val symbols: List<Symbol>,
+) : AnalysisBackend by delegate {
+    override suspend fun workspaceSymbolSearch(query: ParsedWorkspaceSymbolQuery): WorkspaceSymbolResult =
+        WorkspaceSymbolResult(symbols = symbols)
+
+    override suspend fun resolveSymbol(query: ParsedSymbolQuery): SymbolResult = SymbolResult(
+        symbol = symbols.single { symbol ->
+            symbol.location.filePath == query.position.filePath.value &&
+                symbol.location.startOffset == query.position.offset.value
+        },
+    )
 }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
@@ -75,6 +75,7 @@ import io.github.amichne.kast.shared.analysis.FileOutlineBuilder
 import io.github.amichne.kast.shared.analysis.ImportAnalysis
 import io.github.amichne.kast.shared.analysis.SemanticInsertionPointResolver
 import io.github.amichne.kast.shared.analysis.SymbolSearchMatcher
+import io.github.amichne.kast.shared.analysis.compilerContainingDeclarationName
 import io.github.amichne.kast.shared.analysis.declarationEdit
 import io.github.amichne.kast.shared.analysis.resolveTarget
 import io.github.amichne.kast.shared.analysis.resolvedFilePath
@@ -216,7 +217,7 @@ internal class KastPluginBackend(
                 SymbolResult(
                     analyze(file) {
                         target.toSymbolModel(
-                            containingDeclaration = null,
+                            containingDeclaration = compilerContainingDeclarationName(target),
                             supertypes = supertypeNames(target),
                             includeDeclarationScope = query.includeDeclarationScope,
                             includeDocumentation = query.includeDocumentation,

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt
@@ -58,6 +58,14 @@ class KastPluginBackendContractTest {
             fun useGreeting(): String = greet("idea")
         """
 
+        private const val memberSource = """
+            package demo
+
+            class Parser {
+                fun parse(input: String): String = input
+            }
+        """
+
         private const val hierarchySource = """
             package demo.hierarchy
 
@@ -89,6 +97,8 @@ class KastPluginBackendContractTest {
     private val sampleFileFixture: TestFixture<PsiFile> = mainSourceRootFixture.psiFileFixture("Sample.kt", sampleSource)
     private val sampleUsageFileFixture: TestFixture<PsiFile> =
         mainSourceRootFixture.psiFileFixture("SampleUsage.kt", sampleUsageSource)
+    private val memberFileFixture: TestFixture<PsiFile> =
+        mainSourceRootFixture.psiFileFixture("Parser.kt", memberSource)
     private val hierarchyFileFixture: TestFixture<PsiFile> = mainSourceRootFixture.psiFileFixture("Hierarchy.kt", hierarchySource)
     private val internalDeclarationFileFixture: TestFixture<PsiFile> =
         mainSourceRootFixture.psiFileFixture("InternalDeclaration.kt", internalDeclarationSource)
@@ -236,6 +246,26 @@ class KastPluginBackendContractTest {
         val declarationScope = result.symbol.declarationScope
         assertNotNull(declarationScope)
         assertTrue(declarationScope?.sourceText.orEmpty().contains("fun greet"))
+    }
+
+    @Test
+    fun `resolve symbol includes compiler enclosing declaration identity`() = runBlocking {
+        ensureProjectReady()
+
+        val memberFile = memberFileFixture.get()
+        val (filePath, offset) = readAction {
+            memberFile.virtualFile.path to memberFile.text.indexOf("parse")
+        }
+        val result = backend(Path.of(filePath).parent).resolveSymbol(
+            SymbolQuery(
+                position = FilePosition(
+                    filePath = filePath,
+                    offset = offset,
+                ),
+            ),
+        )
+
+        assertEquals("demo.Parser", result.symbol.containingDeclaration)
     }
 
     @Test

--- a/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiAnalysisUtils.kt
+++ b/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiAnalysisUtils.kt
@@ -22,6 +22,8 @@ import io.github.amichne.kast.api.contract.SymbolVisibility
 import io.github.amichne.kast.api.contract.TextEdit
 import io.github.amichne.kast.api.protocol.NotFoundException
 import org.jetbrains.kotlin.analysis.api.KaSession
+import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
@@ -87,6 +89,19 @@ fun PsiElement.toSymbolModel(
     visibility = visibility(),
     declarationScope = if (includeDeclarationScope) toDeclarationScope() else null,
 )
+
+fun KaSession.compilerContainingDeclarationName(target: PsiElement): String? = when (target) {
+    is KtDeclaration -> when (val symbol = target.symbol) {
+        is KaCallableSymbol -> symbol.callableId?.classId?.asSingleFqName()?.asString()
+        is KaClassSymbol -> symbol.classId?.outerClassId?.asSingleFqName()?.asString()
+        else -> null
+    }
+
+    is PsiMethod -> target.containingClass?.qualifiedName
+    is PsiField -> target.containingClass?.qualifiedName
+    is PsiClass -> target.containingClass?.qualifiedName
+    else -> null
+}
 
 /**
  * Builds a [DeclarationScope] from this element's full text range (not name range).

--- a/cli-rs/protocol/api-specification.md
+++ b/cli-rs/protocol/api-specification.md
@@ -92,7 +92,7 @@ uses a discriminated response envelope.
 | `symbol/scaffold` | `symbol` | backend | Gather structural generation context for a Kotlin file | `targetFile` | `workspaceRoot`<br>`targetSymbol`<br>`mode`<br>`kind` | `KastScaffoldResponse` | `SCAFFOLD_SUCCESS`<br>`SCAFFOLD_FAILURE` |
 | `symbol/discover` | `symbol` | backend | Rank candidate declarations for a simple symbol name | `symbol` | `workspaceRoot`<br>`fileHint`<br>`line`<br>`codeSnippet`<br>`kind`<br>`containingType`<br>`maxResults`<br>`includeDeclarationScope` | `KastDiscoverResponse` | `DISCOVER_SUCCESS`<br>`DISCOVER_FAILURE` |
 | `symbol/query` | `symbol` | sqlite | Query compiler-indexed declarations with symbolic hard filters, fielded lexical/name matching, bounded graph relationship evidence, and optional semantic discovery evidence | `query` | `workspaceRoot`<br>`modes`<br>`filters`<br>`anchor`<br>`graph`<br>`semantic`<br>`limit`<br>`includeEvidence`<br>`includeNextRequests` | `KastSymbolQueryResponse` | `SYMBOL_QUERY_SUCCESS`<br>`SYMBOL_QUERY_FAILURE` |
-| `symbol/resolve` | `symbol` | backend | Resolve a symbol by name to its declaration and optional context | `symbol` | `workspaceRoot`<br>`fileHint`<br>`kind`<br>`containingType`<br>`includeDeclarationScope`<br>`includeDocumentation`<br>`surroundingLines`<br>`includeSurroundingMembers` | `KastResolveResponse` | `RESOLVE_SUCCESS`<br>`RESOLVE_FAILURE` |
+| `symbol/resolve` | `symbol` | backend | Resolve an exact simple or fully-qualified symbol identity with hard constraints and typed expected outcomes | `symbol` | `workspaceRoot`<br>`fileHint`<br>`kind`<br>`containingType`<br>`includeDeclarationScope`<br>`includeDocumentation`<br>`surroundingLines`<br>`includeSurroundingMembers` | `KastResolveResponse` | `RESOLVE_SUCCESS`<br>`RESOLVE_NOT_FOUND`<br>`RESOLVE_AMBIGUOUS`<br>`RESOLVE_FAILURE` |
 | `symbol/references` | `symbol` | backend | Find every usage of a Kotlin symbol | `symbol` | `workspaceRoot`<br>`fileHint`<br>`kind`<br>`containingType`<br>`includeDeclaration` | `KastReferencesResponse` | `REFERENCES_SUCCESS`<br>`REFERENCES_FAILURE` |
 | `symbol/callers` | `symbol` | backend | Expand an incoming or outgoing call hierarchy | `symbol` | `workspaceRoot`<br>`fileHint`<br>`kind`<br>`containingType`<br>`direction`<br>`depth`<br>`maxTotalCalls`<br>`maxChildrenPerNode`<br>`timeoutMillis` | `KastCallersResponse` | `CALLERS_SUCCESS`<br>`CALLERS_FAILURE` |
 | `symbol/rename` | `symbol` | backend | Resolve or target a symbol and apply a rename | `type` | none | `KastRenameResponse` | `RENAME_SUCCESS`<br>`RENAME_FAILURE` |
@@ -276,7 +276,7 @@ Notes:
 </details>
 
 <details markdown="1">
-<summary><code>symbol/resolve</code> - Resolve a symbol by name to its declaration and optional context</summary>
+<summary><code>symbol/resolve</code> - Resolve an exact simple or fully-qualified symbol identity with hard constraints and typed expected outcomes</summary>
 
 | Field | Type | Required | Nullable | Values |
 | --- | --- | --- | --- | --- |
@@ -291,12 +291,14 @@ Notes:
 | `includeSurroundingMembers` | `boolean` | no | no |  |
 
 Response type: `KastResolveResponse`.
-Result variants: `RESOLVE_SUCCESS`, `RESOLVE_FAILURE`.
+Result variants: `RESOLVE_SUCCESS`, `RESOLVE_NOT_FOUND`, `RESOLVE_AMBIGUOUS`, `RESOLVE_FAILURE`.
 
 Notes:
 
-- The 'symbol' field takes simple names only (e.g. 'key'), never fully-qualified names.
-- Use 'containingType' for scoping and 'fileHint' for disambiguation.
+- The 'symbol' field accepts exact simple names or fully-qualified names; backticks are normalized only for comparison.
+- kind, containingType, and fileHint are hard constraints rather than ranking hints.
+- RESOLVE_NOT_FOUND and RESOLVE_AMBIGUOUS are expected typed outcomes and never select a fuzzy candidate.
+- Existing internal consumers must match RESOLVE_NOT_FOUND and RESOLVE_AMBIGUOUS in addition to RESOLVE_SUCCESS and RESOLVE_FAILURE.
 - Set includeDeclarationScope, includeDocumentation, surroundingLines, or includeSurroundingMembers only when the extra context is needed.
 
 </details>

--- a/cli-rs/resources/kast-skill/SKILL.md
+++ b/cli-rs/resources/kast-skill/SKILL.md
@@ -17,7 +17,7 @@ the first iteration surface.
 ## Loop
 
 1. Orient with `kast`, `kast help agent`, and read-only `kast ready --workspace-root "$PWD"` when install or backend state matters.
-2. Resolve identity with `kast agent symbol --query <name> --workspace-root "$PWD"`. Add `--kind`, `--file-hint`, `--containing-type`, `--references`, or `--callers incoming|outgoing` only when needed.
+2. Resolve identity with `kast agent symbol --query <name> --workspace-root "$PWD"`; exact lookup is the default. Use `--mode discovery` only for fuzzy candidates, then rerun exact lookup with the chosen identity. Add `--kind`, `--file-hint`, `--containing-type`, `--references`, or `--callers incoming|outgoing` only when needed.
 3. Check changed files with `kast agent diagnostics --file-path <path> --workspace-root "$PWD"`.
 4. Query source-index impact with `kast agent impact --symbol <fq-name> --workspace-root "$PWD"`.
 5. Mutate only through typed plans. First run `kast agent rename`, `add-file`, `add-declaration`, `add-implementation`, `add-statement`, or `replace-declaration` without `--apply`; then add `--apply --idempotency-key <stable-key>` after reviewing the plan and content file.

--- a/cli-rs/resources/kast-skill/references/commands.json
+++ b/cli-rs/resources/kast-skill/references/commands.json
@@ -759,7 +759,7 @@
     "symbol/resolve": {
       "method": "symbol/resolve",
       "category": "symbol",
-      "summary": "Resolve a symbol by name to its declaration and optional context",
+      "summary": "Resolve an exact simple or fully-qualified symbol identity with hard constraints and typed expected outcomes",
       "dataSource": "backend",
       "request": {
         "fields": {
@@ -818,14 +818,22 @@
       "responseType": "KastResolveResponse",
       "successType": "RESOLVE_SUCCESS",
       "failureType": "RESOLVE_FAILURE",
+      "responseVariants": [
+        "RESOLVE_SUCCESS",
+        "RESOLVE_NOT_FOUND",
+        "RESOLVE_AMBIGUOUS",
+        "RESOLVE_FAILURE"
+      ],
       "notes": [
-        "The 'symbol' field takes simple names only (e.g. 'key'), never fully-qualified names.",
-        "Use 'containingType' for scoping and 'fileHint' for disambiguation.",
+        "The 'symbol' field accepts exact simple names or fully-qualified names; backticks are normalized only for comparison.",
+        "kind, containingType, and fileHint are hard constraints rather than ranking hints.",
+        "RESOLVE_NOT_FOUND and RESOLVE_AMBIGUOUS are expected typed outcomes and never select a fuzzy candidate.",
+        "Existing internal consumers must match RESOLVE_NOT_FOUND and RESOLVE_AMBIGUOUS in addition to RESOLVE_SUCCESS and RESOLVE_FAILURE.",
         "Set includeDeclarationScope, includeDocumentation, surroundingLines, or includeSurroundingMembers only when the extra context is needed."
       ],
       "tool": {
         "name": "kast_resolve",
-        "description": "Resolve a Kotlin symbol to its declaration. Use when a name might be overloaded, inherited, or shadowed; disambiguate with kind, containingType, and fileHint before tracing references or callers."
+        "description": "Resolve one exact Kotlin symbol identity. A unique match returns RESOLVE_SUCCESS; zero or multiple exact matches return typed not-found or ambiguous outcomes without fuzzy selection."
       }
     },
     "symbol/references": {

--- a/cli-rs/resources/kast-skill/references/commands.schema.json
+++ b/cli-rs/resources/kast-skill/references/commands.schema.json
@@ -74,6 +74,15 @@
           "type": "string",
           "pattern": "^[A-Z][A-Z0-9_]*$"
         },
+        "responseVariants": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Z0-9_]*$"
+          }
+        },
         "variants": {
           "type": "object",
           "additionalProperties": {

--- a/cli-rs/resources/kast-skill/references/commands.yaml
+++ b/cli-rs/resources/kast-skill/references/commands.yaml
@@ -1477,8 +1477,10 @@ commands:
     failureType: RESOLVE_FAILURE
     method: symbol/resolve
     notes:
-    - The 'symbol' field takes simple names only (e.g. 'key'), never fully-qualified names.
-    - Use 'containingType' for scoping and 'fileHint' for disambiguation.
+    - The 'symbol' field accepts exact simple names or fully-qualified names; backticks are normalized only for comparison.
+    - kind, containingType, and fileHint are hard constraints rather than ranking hints.
+    - RESOLVE_NOT_FOUND and RESOLVE_AMBIGUOUS are expected typed outcomes and never select a fuzzy candidate.
+    - Existing internal consumers must match RESOLVE_NOT_FOUND and RESOLVE_AMBIGUOUS in addition to RESOLVE_SUCCESS and RESOLVE_FAILURE.
     - Set includeDeclarationScope, includeDocumentation, surroundingLines, or includeSurroundingMembers only when the extra context is needed.
     request:
       fields:
@@ -1522,10 +1524,15 @@ commands:
       required:
       - symbol
     responseType: KastResolveResponse
+    responseVariants:
+    - RESOLVE_SUCCESS
+    - RESOLVE_NOT_FOUND
+    - RESOLVE_AMBIGUOUS
+    - RESOLVE_FAILURE
     successType: RESOLVE_SUCCESS
-    summary: Resolve a symbol by name to its declaration and optional context
+    summary: Resolve an exact simple or fully-qualified symbol identity with hard constraints and typed expected outcomes
     tool:
-      description: Resolve a Kotlin symbol to its declaration. Use when a name might be overloaded, inherited, or shadowed; disambiguate with kind, containingType, and fileHint before tracing references or callers.
+      description: Resolve one exact Kotlin symbol identity. A unique match returns RESOLVE_SUCCESS; zero or multiple exact matches return typed not-found or ambiguous outcomes without fuzzy selection.
       name: kast_resolve
   symbol/scaffold:
     category: symbol

--- a/cli-rs/resources/kast-skill/references/workflows.md
+++ b/cli-rs/resources/kast-skill/references/workflows.md
@@ -45,6 +45,7 @@ Use compiler identity and typed selectors instead of offsets:
 | Need | Command |
 | --- | --- |
 | symbol lookup | `kast agent symbol --query EventBean --workspace-root "$PWD"` |
+| fuzzy symbol discovery | `kast agent symbol --query event --mode discovery --workspace-root "$PWD"` |
 | references | `kast agent symbol --query EventBean --references --workspace-root "$PWD"` |
 | callers | `kast agent symbol --query process --callers incoming --workspace-root "$PWD"` |
 | diagnostics | `kast agent diagnostics --file-path "$PWD/src/main/kotlin/App.kt" --workspace-root "$PWD"` |
@@ -55,6 +56,13 @@ Use compiler identity and typed selectors instead of offsets:
 Use `agent symbol --query <name>` for lookup. Reserve
 `--symbol <fq-name>` for compiler identity on commands that require a resolved
 target.
+
+Exact lookup returns `RESOLVED`, `NOT_FOUND`, or `AMBIGUOUS` without fuzzy
+selection. Its source is `compiler` when the backend proves identity or
+`indexed-exact` only when the compiler is unavailable and the source index can
+prove every requested constraint. Fuzzy candidates are source `fuzzy` and
+require explicit `--mode discovery`; choose a candidate and rerun exact lookup
+before requesting references or callers.
 
 ## Removed surfaces
 

--- a/cli-rs/src/agent.rs
+++ b/cli-rs/src/agent.rs
@@ -6,7 +6,7 @@ use crate::cli::{
     AgentAddFileArgs, AgentCommand, AgentDiagnosticsArgs, AgentImpactArgs, AgentMutationApplyArgs,
     AgentOperationArgs, AgentOperationCommand, AgentOperationSelectorArgs, AgentRenameArgs,
     AgentReplaceDeclarationArgs, AgentRuntimeArgs, AgentScopedMutationArgs,
-    AgentStatementMutationArgs, AgentSymbolArgs, AgentVerifyArgs,
+    AgentStatementMutationArgs, AgentSymbolArgs, AgentSymbolMode, AgentVerifyArgs,
 };
 use crate::error::{CliError, Result};
 use crate::{output, runtime, validate};
@@ -21,6 +21,7 @@ include!("agent/request.rs");
 include!("agent/envelope.rs");
 include!("agent/input.rs");
 include!("agent/response.rs");
+include!("agent/symbol_lookup.rs");
 
 #[cfg(test)]
 mod semantic_analysis_evidence_tests {

--- a/cli-rs/src/agent/dispatch.rs
+++ b/cli-rs/src/agent/dispatch.rs
@@ -109,66 +109,10 @@ fn execute_agent_verify(args: AgentVerifyArgs) -> AgentEnvelope {
 }
 
 fn execute_agent_symbol(args: AgentSymbolArgs) -> AgentEnvelope {
-    let mut steps = vec![
-        AgentPublicStep::new(
-            "symbol-query",
-            "symbol/query",
-            json!({
-                "query": args.query,
-                "modes": ["exact", "lexical"],
-                "filters": {},
-                "limit": args.limit,
-                "includeEvidence": true,
-                "includeNextRequests": true,
-            }),
-            false,
-        ),
-        AgentPublicStep::new(
-            "symbol-resolve",
-            "symbol/resolve",
-            drop_nulls(json!({
-                "symbol": args.query,
-                "kind": args.kind.map(|kind| kind.canonical()),
-                "fileHint": args.file_hint,
-                "containingType": args.containing_type,
-                "includeDeclarationScope": true,
-                "includeDocumentation": true,
-                "surroundingLines": 3,
-                "includeSurroundingMembers": true,
-            })),
-            false,
-        ),
-    ];
-    if args.references {
-        steps.push(AgentPublicStep::new(
-            "symbol-references",
-            "symbol/references",
-            drop_nulls(json!({
-                "symbol": args.query,
-                "kind": args.kind.map(|kind| kind.canonical()),
-                "fileHint": args.file_hint,
-                "containingType": args.containing_type,
-                "includeDeclaration": true,
-            })),
-            false,
-        ));
+    match args.mode {
+        AgentSymbolMode::Exact => execute_agent_symbol_exact(args),
+        AgentSymbolMode::Discovery => execute_agent_symbol_discovery(args),
     }
-    if let Some(direction) = args.callers {
-        steps.push(AgentPublicStep::new(
-            "symbol-callers",
-            "symbol/callers",
-            drop_nulls(json!({
-                "symbol": args.query,
-                "kind": args.kind.map(|kind| kind.canonical()),
-                "fileHint": args.file_hint,
-                "containingType": args.containing_type,
-                "direction": direction.canonical(),
-                "depth": args.caller_depth,
-            })),
-            false,
-        ));
-    }
-    execute_agent_steps("agent/symbol", args.runtime, steps)
 }
 
 fn execute_agent_impact(args: AgentImpactArgs) -> AgentEnvelope {

--- a/cli-rs/src/agent/symbol_lookup.rs
+++ b/cli-rs/src/agent/symbol_lookup.rs
@@ -13,6 +13,26 @@ const INDEXED_EXACT_FALLBACK_CODES: [&str; 13] = [
     "CAPABILITY_NOT_SUPPORTED",
     "CAPABILITIES_UNAVAILABLE",
 ];
+const INDEXED_EXACT_CARDINALITY_LIMIT: u32 = 2;
+const INDEXED_EXACT_LITERAL_FILE_SCAN_LIMIT: u32 = u32::MAX;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IndexedExactCandidateProof {
+    declaration: IndexedExactDeclarationProof,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IndexedExactDeclarationProof {
+    file: IndexedExactFileProof,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IndexedExactFileProof {
+    path: String,
+}
 
 fn execute_agent_symbol_exact(args: AgentSymbolArgs) -> AgentEnvelope {
     let compiler_params = drop_nulls(json!({
@@ -178,7 +198,11 @@ fn indexed_exact_or_compiler_error(
     compiler_request: Value,
     error: AgentError,
 ) -> AgentEnvelope {
-    if !compiler_availability_allows_indexed_exact(&error) || args.containing_type.is_some() {
+    if !compiler_availability_allows_indexed_exact(&error)
+        || args.containing_type.is_some()
+        || args.references
+        || args.callers.is_some()
+    {
         return error_envelope("agent/symbol".to_string(), Some(compiler_request), error);
     }
     let fallback = AgentCompilerFallback {
@@ -190,8 +214,8 @@ fn indexed_exact_or_compiler_error(
         json!({
             "query": args.query,
             "modes": ["exact"],
-            "filters": symbol_query_filters(args),
-            "limit": args.limit,
+            "filters": indexed_exact_query_filters(args),
+            "limit": indexed_exact_search_limit(args),
             "includeNextRequests": false,
         }),
     );
@@ -205,13 +229,12 @@ fn indexed_exact_or_compiler_error(
         Ok(result) => result,
         Err(envelope) => return *envelope,
     };
-    let candidates = result
-        .get("results")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|candidate| candidate.get("declaration").cloned())
-        .collect::<Vec<_>>();
+    let candidates = match indexed_exact_candidates(&result, args.file_hint.as_deref()) {
+        Ok(candidates) => candidates,
+        Err(error) => {
+            return error_envelope("agent/symbol".to_string(), Some(request), error);
+        }
+    };
     let outcome = match candidates.as_slice() {
         [] => AgentSymbolLookupOutcome::NotFound {
             source: AgentSymbolLookupSource::IndexedExact,
@@ -365,6 +388,89 @@ fn symbol_query_filters(args: &AgentSymbolArgs) -> Value {
     }))
 }
 
+fn indexed_exact_query_filters(args: &AgentSymbolArgs) -> Value {
+    drop_nulls(json!({
+        "kinds": args.kind.map(|kind| vec![kind.canonical().to_ascii_uppercase()]),
+    }))
+}
+
+fn indexed_exact_search_limit(args: &AgentSymbolArgs) -> u32 {
+    if args.file_hint.is_some() {
+        INDEXED_EXACT_LITERAL_FILE_SCAN_LIMIT
+    } else {
+        INDEXED_EXACT_CARDINALITY_LIMIT
+    }
+}
+
+fn indexed_exact_candidates(
+    result: &Value,
+    file_hint: Option<&str>,
+) -> std::result::Result<Vec<Value>, AgentError> {
+    let results = result
+        .get("results")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            agent_error(
+                "INVALID_SYMBOL_QUERY_RESPONSE",
+                "Indexed exact lookup returned no results array.",
+            )
+        })?;
+    results
+        .iter()
+        .map(|candidate| {
+            let proof = serde_json::from_value::<IndexedExactCandidateProof>(candidate.clone())
+                .map_err(|error| {
+                    agent_error(
+                        "INVALID_SYMBOL_QUERY_RESPONSE",
+                        format!("Indexed exact candidate lacked trustworthy file identity: {error}"),
+                    )
+                })?;
+            let declaration = candidate.get("declaration").cloned().ok_or_else(|| {
+                agent_error(
+                    "INVALID_SYMBOL_QUERY_RESPONSE",
+                    "Indexed exact candidate returned no declaration.",
+                )
+            })?;
+            Ok((proof, declaration))
+        })
+        .filter_map(|candidate| match candidate {
+            Ok((proof, declaration))
+                if file_hint.is_none_or(|hint| {
+                    literal_file_hint_matches(hint, &proof.declaration.file.path)
+                }) => Some(Ok(declaration)),
+            Ok(_) => None,
+            Err(error) => Some(Err(error)),
+        })
+        .collect()
+}
+
+fn literal_file_hint_matches(file_hint: &str, candidate_file: &str) -> bool {
+    let normalized_hint = lexically_normalized_path(std::path::Path::new(file_hint));
+    let normalized_candidate = lexically_normalized_path(std::path::Path::new(candidate_file));
+    if normalized_hint.is_absolute() {
+        normalized_candidate == normalized_hint
+    } else {
+        normalized_candidate.ends_with(normalized_hint)
+    }
+}
+
+fn lexically_normalized_path(path: &std::path::Path) -> std::path::PathBuf {
+    let mut normalized = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir
+                if normalized.file_name().is_some_and(|name| name != "..") =>
+            {
+                normalized.pop();
+            }
+            std::path::Component::ParentDir if normalized.has_root() => {}
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
 fn compiler_availability_allows_indexed_exact(error: &AgentError) -> bool {
     INDEXED_EXACT_FALLBACK_CODES.contains(&error.code.as_str())
 }
@@ -413,5 +519,25 @@ mod symbol_lookup_tests {
         ] {
             assert!(!compiler_availability_allows_indexed_exact(&agent_error(code, "not availability")));
         }
+    }
+
+    #[test]
+    fn indexed_exact_file_hints_are_literal_paths() {
+        assert!(literal_file_hint_matches(
+            "lib/Parser.kt",
+            "/workspace/lib/Parser.kt"
+        ));
+        assert!(literal_file_hint_matches(
+            "lib/../lib/Parser.kt",
+            "/workspace/lib/Parser.kt"
+        ));
+        assert!(!literal_file_hint_matches(
+            "lib/*Parser.kt",
+            "/workspace/lib/AlphaParser.kt"
+        ));
+        assert!(!literal_file_hint_matches(
+            "lib/[AB]Parser.kt",
+            "/workspace/lib/AParser.kt"
+        ));
     }
 }

--- a/cli-rs/src/agent/symbol_lookup.rs
+++ b/cli-rs/src/agent/symbol_lookup.rs
@@ -1,0 +1,417 @@
+const INDEXED_EXACT_FALLBACK_CODES: [&str; 13] = [
+    "MACOS_PLUGIN_WORKSPACE_REQUIRED",
+    "NO_BACKEND_AVAILABLE",
+    "IDEA_NOT_RUNNING",
+    "IDEA_BACKEND_DISABLED",
+    "IDEA_PLUGIN_NOT_INSTALLED",
+    "IDEA_LAUNCH_FAILED",
+    "DAEMON_START_ERROR",
+    "DAEMON_UNREACHABLE",
+    "RUNTIME_TIMEOUT",
+    "RPC_RESPONSE_TIMEOUT",
+    "RPC_RESPONSE_MISSING",
+    "CAPABILITY_NOT_SUPPORTED",
+    "CAPABILITIES_UNAVAILABLE",
+];
+
+fn execute_agent_symbol_exact(args: AgentSymbolArgs) -> AgentEnvelope {
+    let compiler_params = drop_nulls(json!({
+        "symbol": args.query,
+        "kind": args.kind.map(|kind| kind.canonical()),
+        "fileHint": args.file_hint,
+        "containingType": args.containing_type,
+        "includeDeclarationScope": true,
+        "includeDocumentation": true,
+        "surroundingLines": 3,
+        "includeSurroundingMembers": true,
+    }));
+    let compiler_request = json_rpc_request("symbol/resolve", compiler_params);
+    let session = match runtime::raw_rpc_session(
+        args.runtime.workspace_root.clone(),
+        args.runtime.backend_name,
+    ) {
+        Ok(session) => session,
+        Err(error) => {
+            return indexed_exact_or_compiler_error(
+                &args,
+                compiler_request,
+                AgentError::from_cli_error(error),
+            );
+        }
+    };
+    let compiler_envelope = execute_request_with_session(
+        AgentRequest {
+            method: "symbol/resolve".to_string(),
+            request: compiler_request.clone(),
+            runtime: args.runtime.clone(),
+            full_response: true,
+        },
+        Some(&session),
+    );
+    if !compiler_envelope.ok {
+        let error = compiler_envelope.error.unwrap_or_else(|| {
+            agent_error(
+                "INVALID_COMPILER_RESPONSE",
+                "Compiler symbol lookup failed without a typed error.",
+            )
+        });
+        return indexed_exact_or_compiler_error(&args, compiler_request, error);
+    }
+    let Some(result) = compiler_envelope.result else {
+        return error_envelope(
+            "agent/symbol".to_string(),
+            Some(compiler_request),
+            agent_error(
+                "INVALID_COMPILER_RESPONSE",
+                "Compiler symbol lookup returned no result.",
+            ),
+        );
+    };
+    let parsed = match serde_json::from_value::<AgentCompilerResolveResponse>(result.clone()) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return invalid_compiler_symbol_response(
+                compiler_request,
+                &format!("compiler response violated the exact lookup contract: {error}"),
+            );
+        }
+    };
+    match parsed {
+        AgentCompilerResolveResponse::Resolved { symbol } => {
+            let relations = match compiler_symbol_relations(&args, &symbol.fq_name, &session) {
+                Ok(relations) => relations,
+                Err(envelope) => return *envelope,
+            };
+            let symbol = serde_json::to_value(symbol).unwrap_or(Value::Null);
+            symbol_lookup_envelope(
+                args.mode,
+                compiler_request,
+                AgentSymbolLookupOutcome::Resolved {
+                    source: AgentSymbolLookupSource::Compiler,
+                    symbol,
+                    resolution: result,
+                    relations,
+                    compiler_fallback: None,
+                },
+            )
+        }
+        AgentCompilerResolveResponse::NotFound => symbol_lookup_envelope(
+            args.mode,
+            compiler_request,
+            AgentSymbolLookupOutcome::NotFound {
+                source: AgentSymbolLookupSource::Compiler,
+                query: args.query,
+                compiler_fallback: None,
+            },
+        ),
+        AgentCompilerResolveResponse::Ambiguous { candidates } if candidates.len() >= 2 => {
+            symbol_lookup_envelope(
+                args.mode,
+                compiler_request,
+                AgentSymbolLookupOutcome::Ambiguous {
+                    source: AgentSymbolLookupSource::Compiler,
+                    query: args.query,
+                    candidates,
+                    compiler_fallback: None,
+                },
+            )
+        }
+        AgentCompilerResolveResponse::Ambiguous { .. } => invalid_compiler_symbol_response(
+            compiler_request,
+            "RESOLVE_AMBIGUOUS must contain at least two candidates",
+        ),
+        AgentCompilerResolveResponse::OperationalFailure => invalid_compiler_symbol_response(
+            compiler_request,
+            "RESOLVE_FAILURE was marked successful",
+        ),
+    }
+}
+
+fn execute_agent_symbol_discovery(args: AgentSymbolArgs) -> AgentEnvelope {
+    if args.references || args.callers.is_some() {
+        return error_envelope(
+            "agent/symbol".to_string(),
+            None,
+            agent_error(
+                "AGENT_USAGE",
+                "--references and --callers require exact symbol mode",
+            ),
+        );
+    }
+    let request = json_rpc_request(
+        "symbol/query",
+        json!({
+            "query": args.query,
+            "modes": ["lexical"],
+            "filters": symbol_query_filters(&args),
+            "limit": args.limit,
+            "includeNextRequests": true,
+        }),
+    );
+    let envelope = execute_request(AgentRequest {
+        method: "symbol/query".to_string(),
+        request: request.clone(),
+        runtime: args.runtime,
+        full_response: true,
+    });
+    let result = match successful_symbol_query_result(envelope, request.clone()) {
+        Ok(result) => result,
+        Err(envelope) => return *envelope,
+    };
+    symbol_lookup_envelope(
+        args.mode,
+        request,
+        AgentSymbolLookupOutcome::Discovered {
+            source: AgentSymbolLookupSource::Fuzzy,
+            query: args.query,
+            candidates: result
+                .get("results")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default(),
+        },
+    )
+}
+
+fn indexed_exact_or_compiler_error(
+    args: &AgentSymbolArgs,
+    compiler_request: Value,
+    error: AgentError,
+) -> AgentEnvelope {
+    if !compiler_availability_allows_indexed_exact(&error) || args.containing_type.is_some() {
+        return error_envelope("agent/symbol".to_string(), Some(compiler_request), error);
+    }
+    let fallback = AgentCompilerFallback {
+        code: error.code,
+        message: error.message,
+    };
+    let request = json_rpc_request(
+        "symbol/query",
+        json!({
+            "query": args.query,
+            "modes": ["exact"],
+            "filters": symbol_query_filters(args),
+            "limit": args.limit,
+            "includeNextRequests": false,
+        }),
+    );
+    let envelope = execute_request(AgentRequest {
+        method: "symbol/query".to_string(),
+        request: request.clone(),
+        runtime: args.runtime.clone(),
+        full_response: true,
+    });
+    let result = match successful_symbol_query_result(envelope, request.clone()) {
+        Ok(result) => result,
+        Err(envelope) => return *envelope,
+    };
+    let candidates = result
+        .get("results")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|candidate| candidate.get("declaration").cloned())
+        .collect::<Vec<_>>();
+    let outcome = match candidates.as_slice() {
+        [] => AgentSymbolLookupOutcome::NotFound {
+            source: AgentSymbolLookupSource::IndexedExact,
+            query: args.query.clone(),
+            compiler_fallback: Some(fallback),
+        },
+        [symbol] => AgentSymbolLookupOutcome::Resolved {
+            source: AgentSymbolLookupSource::IndexedExact,
+            symbol: symbol.clone(),
+            resolution: result,
+            relations: Vec::new(),
+            compiler_fallback: Some(fallback),
+        },
+        _ => AgentSymbolLookupOutcome::Ambiguous {
+            source: AgentSymbolLookupSource::IndexedExact,
+            query: args.query.clone(),
+            candidates,
+            compiler_fallback: Some(fallback),
+        },
+    };
+    symbol_lookup_envelope(args.mode, request, outcome)
+}
+
+fn successful_symbol_query_result(
+    envelope: AgentEnvelope,
+    request: Value,
+) -> std::result::Result<Value, Box<AgentEnvelope>> {
+    if !envelope.ok {
+        return Err(Box::new(error_envelope(
+            "agent/symbol".to_string(),
+            Some(request),
+            envelope.error.unwrap_or_else(|| {
+                agent_error(
+                    "SYMBOL_QUERY_FAILED",
+                    "Symbol query failed without a typed error.",
+                )
+            }),
+        )));
+    }
+    let Some(result) = envelope.result else {
+        return Err(Box::new(error_envelope(
+            "agent/symbol".to_string(),
+            Some(request),
+            agent_error("SYMBOL_QUERY_FAILED", "Symbol query returned no result."),
+        )));
+    };
+    match result.get("type").and_then(Value::as_str) {
+        Some("SYMBOL_QUERY_SUCCESS") => Ok(result),
+        Some("SYMBOL_QUERY_FAILURE") => {
+            let code = result
+                .get("reason")
+                .and_then(Value::as_str)
+                .unwrap_or("SYMBOL_QUERY_FAILED");
+            let message = result
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("Symbol query failed.");
+            Err(Box::new(error_envelope(
+                "agent/symbol".to_string(),
+                Some(request),
+                agent_error(code, message),
+            )))
+        }
+        response_type => Err(Box::new(error_envelope(
+            "agent/symbol".to_string(),
+            Some(request),
+            agent_error(
+                "INVALID_SYMBOL_QUERY_RESPONSE",
+                format!("Unexpected symbol query response type: {response_type:?}"),
+            ),
+        ))),
+    }
+}
+
+fn compiler_symbol_relations(
+    args: &AgentSymbolArgs,
+    canonical_symbol: &str,
+    session: &runtime::RawRpcSession,
+) -> std::result::Result<Vec<AgentSymbolRelation>, Box<AgentEnvelope>> {
+    let mut requests = Vec::new();
+    if args.references {
+        requests.push((
+            "references",
+            "symbol/references",
+            drop_nulls(json!({
+                "symbol": canonical_symbol,
+                "kind": args.kind.map(|kind| kind.canonical()),
+                "fileHint": args.file_hint,
+                "containingType": args.containing_type,
+                "includeDeclaration": true,
+            })),
+        ));
+    }
+    if let Some(direction) = args.callers {
+        requests.push((
+            "callers",
+            "symbol/callers",
+            drop_nulls(json!({
+                "symbol": canonical_symbol,
+                "kind": args.kind.map(|kind| kind.canonical()),
+                "fileHint": args.file_hint,
+                "containingType": args.containing_type,
+                "direction": direction.canonical(),
+                "depth": args.caller_depth,
+            })),
+        ));
+    }
+    let mut relations = Vec::with_capacity(requests.len());
+    for (relation, method, params) in requests {
+        let request = json_rpc_request(method, params);
+        let envelope = execute_request_with_session(
+            AgentRequest {
+                method: method.to_string(),
+                request: request.clone(),
+                runtime: args.runtime.clone(),
+                full_response: true,
+            },
+            Some(session),
+        );
+        if !envelope.ok {
+            return Err(Box::new(error_envelope(
+                "agent/symbol".to_string(),
+                Some(request),
+                envelope.error.unwrap_or_else(|| {
+                    agent_error(
+                        "SYMBOL_RELATION_FAILED",
+                        format!("{relation} request failed without a typed error"),
+                    )
+                }),
+            )));
+        }
+        let Some(result) = envelope.result else {
+            return Err(Box::new(error_envelope(
+                "agent/symbol".to_string(),
+                Some(request),
+                agent_error(
+                    "SYMBOL_RELATION_FAILED",
+                    format!("{relation} request returned no result"),
+                ),
+            )));
+        };
+        relations.push(AgentSymbolRelation { relation, result });
+    }
+    Ok(relations)
+}
+
+fn symbol_query_filters(args: &AgentSymbolArgs) -> Value {
+    drop_nulls(json!({
+        "kinds": args.kind.map(|kind| vec![kind.canonical().to_ascii_uppercase()]),
+        "fileGlob": args.file_hint,
+    }))
+}
+
+fn compiler_availability_allows_indexed_exact(error: &AgentError) -> bool {
+    INDEXED_EXACT_FALLBACK_CODES.contains(&error.code.as_str())
+}
+
+fn invalid_compiler_symbol_response(request: Value, message: &str) -> AgentEnvelope {
+    error_envelope(
+        "agent/symbol".to_string(),
+        Some(request),
+        agent_error("INVALID_COMPILER_RESPONSE", message),
+    )
+}
+
+fn symbol_lookup_envelope(
+    mode: AgentSymbolMode,
+    request: Value,
+    outcome: AgentSymbolLookupOutcome,
+) -> AgentEnvelope {
+    result_envelope(
+        "agent/symbol".to_string(),
+        AgentSymbolLookupResult {
+            result_type: "KAST_AGENT_SYMBOL_LOOKUP",
+            ok: true,
+            mode,
+            request,
+            outcome,
+            schema_version: SCHEMA_VERSION,
+        },
+    )
+}
+
+#[cfg(test)]
+mod symbol_lookup_tests {
+    use super::*;
+
+    #[test]
+    fn exact_availability_allowlist_is_closed_and_exhaustive() {
+        for code in INDEXED_EXACT_FALLBACK_CODES {
+            assert!(compiler_availability_allows_indexed_exact(&agent_error(code, "unavailable")));
+        }
+        for code in [
+            "IDEA_LAUNCH_CONFIG_INVALID",
+            "RPC_RESPONSE_INVALID",
+            "RESOLVE_FAILURE",
+            "VALIDATION_ERROR",
+            "AGENT_REQUEST_INVALID",
+        ] {
+            assert!(!compiler_availability_allows_indexed_exact(&agent_error(code, "not availability")));
+        }
+    }
+}

--- a/cli-rs/src/agent/types.rs
+++ b/cli-rs/src/agent/types.rs
@@ -266,3 +266,93 @@ struct AgentRequest {
     runtime: AgentRuntimeArgs,
     full_response: bool,
 }
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentSymbolLookupResult {
+    #[serde(rename = "type")]
+    result_type: &'static str,
+    ok: bool,
+    mode: AgentSymbolMode,
+    request: Value,
+    outcome: AgentSymbolLookupOutcome,
+    schema_version: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(
+    tag = "type",
+    rename_all = "SCREAMING_SNAKE_CASE",
+    rename_all_fields = "camelCase"
+)]
+enum AgentSymbolLookupOutcome {
+    Resolved {
+        source: AgentSymbolLookupSource,
+        symbol: Value,
+        resolution: Value,
+        relations: Vec<AgentSymbolRelation>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        compiler_fallback: Option<AgentCompilerFallback>,
+    },
+    NotFound {
+        source: AgentSymbolLookupSource,
+        query: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        compiler_fallback: Option<AgentCompilerFallback>,
+    },
+    Ambiguous {
+        source: AgentSymbolLookupSource,
+        query: String,
+        candidates: Vec<Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        compiler_fallback: Option<AgentCompilerFallback>,
+    },
+    Discovered {
+        source: AgentSymbolLookupSource,
+        query: String,
+        candidates: Vec<Value>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum AgentSymbolLookupSource {
+    Compiler,
+    IndexedExact,
+    Fuzzy,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentSymbolRelation {
+    relation: &'static str,
+    result: Value,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentCompilerFallback {
+    code: String,
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum AgentCompilerResolveResponse {
+    #[serde(rename = "RESOLVE_SUCCESS")]
+    Resolved { symbol: AgentCompilerSymbolIdentity },
+    #[serde(rename = "RESOLVE_NOT_FOUND")]
+    NotFound,
+    #[serde(rename = "RESOLVE_AMBIGUOUS")]
+    Ambiguous { candidates: Vec<Value> },
+    #[serde(rename = "RESOLVE_FAILURE")]
+    OperationalFailure,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentCompilerSymbolIdentity {
+    fq_name: String,
+    #[serde(flatten)]
+    fields: BTreeMap<String, Value>,
+}

--- a/cli-rs/src/cli/agent.rs
+++ b/cli-rs/src/cli/agent.rs
@@ -94,6 +94,9 @@ pub struct AgentSymbolArgs {
     /// Symbol query text. Use this for lookup; mutating commands use --symbol <fq-name>.
     #[arg(long)]
     pub query: String,
+    /// Exact identity lookup by default; use discovery for fuzzy candidates.
+    #[arg(long, value_enum, default_value_t)]
+    pub mode: AgentSymbolMode,
     #[arg(long, value_enum)]
     pub kind: Option<AgentSymbolKind>,
     #[arg(long)]
@@ -108,6 +111,14 @@ pub struct AgentSymbolArgs {
     pub caller_depth: u32,
     #[arg(long, default_value_t = 10)]
     pub limit: u32,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq, Default, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentSymbolMode {
+    #[default]
+    Exact,
+    Discovery,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/cli-rs/src/demo/evidence.rs
+++ b/cli-rs/src/demo/evidence.rs
@@ -35,8 +35,18 @@ struct DemoDiagnosticsSummary {
 enum DemoResolveResponse {
     #[serde(rename = "RESOLVE_SUCCESS")]
     Success { symbol: DemoProtocolSymbol },
+    #[serde(rename = "RESOLVE_NOT_FOUND")]
+    NotFound,
+    #[serde(rename = "RESOLVE_AMBIGUOUS")]
+    Ambiguous { candidates: Vec<DemoResolveCandidate> },
     #[serde(rename = "RESOLVE_FAILURE")]
     Failure { message: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DemoResolveCandidate {
+    fq_name: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -194,6 +204,28 @@ fn compiler_story_evidence(
     )?;
     let symbol = match resolve {
         DemoResolveResponse::Success { symbol } => symbol,
+        DemoResolveResponse::NotFound => {
+            return Err(CliError::new(
+                "DEMO_RESOLVE_NOT_FOUND",
+                format!("No compiler symbol matched {}.", candidate.fq_name),
+            ));
+        }
+        DemoResolveResponse::Ambiguous { candidates } => {
+            let identities = candidates
+                .iter()
+                .map(|candidate| candidate.fq_name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(CliError::new(
+                "DEMO_RESOLVE_AMBIGUOUS",
+                format!(
+                    "Compiler symbol lookup for {} matched {} candidates: {}.",
+                    candidate.fq_name,
+                    candidates.len(),
+                    identities
+                ),
+            ));
+        }
         DemoResolveResponse::Failure { message } => {
             return Err(CliError::new("DEMO_RESOLVE_FAILED", message));
         }
@@ -203,7 +235,7 @@ fn compiler_story_evidence(
         &connection.socket_path,
         "symbol/references",
         serde_json::json!({
-            "symbol": simple_symbol_name(&candidate.fq_name),
+            "symbol": &symbol.fq_name,
             "fileHint": candidate.file,
             "includeDeclaration": true,
         }),

--- a/cli-rs/src/symbol_query/ranking_and_filters.rs
+++ b/cli-rs/src/symbol_query/ranking_and_filters.rs
@@ -91,15 +91,18 @@ fn exact_matches(
     anchor: &SymbolQueryAnchor,
 ) -> Vec<SignalMatch> {
     let trimmed = query.trim();
+    let normalized_query = normalized_kotlin_identity(trimmed);
+    let normalized_fq_name = normalized_kotlin_identity(&declaration.fq_name);
+    let normalized_simple_name = normalized_kotlin_identity(&declaration.simple_name);
     let mut matches = Vec::new();
-    if !trimmed.is_empty() && declaration.fq_name == trimmed {
+    if !trimmed.is_empty() && normalized_fq_name == normalized_query {
         matches.push(SignalMatch {
             field: "fq_names.fq_name",
             match_type: "EQUALS",
             evidence: Some(declaration.fq_name.clone()),
         });
     }
-    if !trimmed.is_empty() && declaration.simple_name == trimmed {
+    if !trimmed.is_empty() && normalized_simple_name == normalized_query {
         matches.push(SignalMatch {
             field: "fq_names.fq_name",
             match_type: "SIMPLE_NAME_EQUALS",
@@ -114,6 +117,19 @@ fn exact_matches(
         });
     }
     matches
+}
+
+fn normalized_kotlin_identity(value: &str) -> String {
+    value
+        .split('.')
+        .map(|segment| {
+            segment
+                .strip_prefix('`')
+                .and_then(|segment| segment.strip_suffix('`'))
+                .unwrap_or(segment)
+        })
+        .collect::<Vec<_>>()
+        .join(".")
 }
 
 fn anchor_matches(anchor: &SymbolQueryAnchor, declaration: &DeclarationRow) -> bool {

--- a/cli-rs/tests/agent_command_surface_smoke.rs
+++ b/cli-rs/tests/agent_command_surface_smoke.rs
@@ -281,6 +281,122 @@ fn agent_symbol_uses_indexed_exact_only_when_compiler_is_unavailable() {
 }
 
 #[test]
+fn agent_symbol_indexed_exact_cardinality_ignores_presentation_limit() {
+    for limit in ["0", "1"] {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let config_home = temp.path().join("config");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&home).expect("home");
+        seed_source_index(&workspace);
+        support::metrics::seed_exact_lookup_symbols(&workspace);
+
+        let output = kast(&home, &config_home)
+            .args([
+                "--output",
+                "json",
+                "agent",
+                "symbol",
+                "--query",
+                "Parser",
+                "--limit",
+                limit,
+                "--workspace-root",
+                workspace.to_str().expect("workspace"),
+            ])
+            .output()
+            .expect("indexed exact fallback");
+
+        assert!(
+            output.status.success(),
+            "limit={limit} stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout: Value = serde_json::from_slice(&output.stdout).expect("fallback json");
+        assert_eq!(stdout["result"]["outcome"]["type"], "AMBIGUOUS");
+        assert_eq!(
+            stdout["result"]["outcome"]["candidates"]
+                .as_array()
+                .expect("candidates")
+                .len(),
+            2
+        );
+    }
+}
+
+#[test]
+fn agent_symbol_indexed_file_hint_is_literal_and_suffix_equivalent() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    seed_source_index(&workspace);
+    support::metrics::seed_exact_lookup_symbols(&workspace);
+
+    for (file_hint, expected_outcome) in [
+        ("lib/AlphaParser.kt", "RESOLVED"),
+        ("lib/*Parser.kt", "NOT_FOUND"),
+    ] {
+        let output = kast(&home, &config_home)
+            .args([
+                "--output",
+                "json",
+                "agent",
+                "symbol",
+                "--query",
+                "Parser",
+                "--file-hint",
+                file_hint,
+                "--workspace-root",
+                workspace.to_str().expect("workspace"),
+            ])
+            .output()
+            .expect("indexed exact file hint");
+
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let stdout: Value = serde_json::from_slice(&output.stdout).expect("fallback json");
+        assert_eq!(stdout["result"]["outcome"]["type"], expected_outcome);
+    }
+}
+
+#[test]
+fn agent_symbol_relations_preserve_compiler_unavailability() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    seed_source_index(&workspace);
+    support::metrics::seed_exact_lookup_symbols(&workspace);
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "symbol",
+            "--query",
+            "`when`",
+            "--references",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("compiler unavailable relations");
+
+    assert!(!output.status.success());
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("failure json");
+    assert!(stdout["error"]["code"].as_str().is_some());
+    assert!(stdout["result"].is_null(), "{stdout}");
+}
+
+#[test]
 fn agent_symbol_containing_type_never_weakens_to_indexed_exact() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/cli-rs/tests/agent_command_surface_smoke.rs
+++ b/cli-rs/tests/agent_command_surface_smoke.rs
@@ -1,6 +1,342 @@
 mod support;
 
+use serde_json::{Value, json};
+use support::metrics::seed_source_index;
 use support::*;
+
+fn symbol_result(workspace: &Path, fq_name: &str) -> Value {
+    json!({
+        "type": "RESOLVE_SUCCESS",
+        "ok": true,
+        "source": "compiler",
+        "symbol": {
+            "fqName": fq_name,
+            "kind": "FUNCTION",
+            "location": {
+                "filePath": workspace.join("Keywords.kt").display().to_string(),
+                "startOffset": 10,
+                "endOffset": 16,
+                "startLine": 1,
+                "startColumn": 1,
+                "preview": "fun when()"
+            }
+        }
+    })
+}
+
+fn run_agent_symbol(
+    home: &Path,
+    config_home: &Path,
+    workspace: &Path,
+    extra_args: &[&str],
+) -> std::process::Output {
+    let mut command = kast(home, config_home);
+    command.args([
+        "--output",
+        "json",
+        "agent",
+        "symbol",
+        "--query",
+        "`when`",
+        "--workspace-root",
+        workspace.to_str().expect("workspace"),
+    ]);
+    command.args(extra_args).output().expect("agent symbol")
+}
+
+#[test]
+fn agent_symbol_defaults_to_exact_and_returns_compiler_identity() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let socket_path = temp.path().join("idea.sock");
+    let handle = spawn_scripted_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        vec![("symbol/resolve", symbol_result(&workspace, "sample.when"))],
+    );
+
+    let output = run_agent_symbol(&home, &config_home, &workspace, &[]);
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("symbol json");
+    assert_eq!(stdout["result"]["type"], "KAST_AGENT_SYMBOL_LOOKUP");
+    assert_eq!(stdout["result"]["mode"], "exact");
+    assert_eq!(stdout["result"]["outcome"]["type"], "RESOLVED");
+    assert_eq!(stdout["result"]["outcome"]["source"], "compiler");
+    assert_eq!(
+        stdout["result"]["outcome"]["symbol"]["fqName"],
+        "sample.when"
+    );
+    let requests = handle.join().expect("scripted backend");
+    assert_eq!(requests[2]["method"], "symbol/resolve");
+    assert_eq!(requests[2]["params"]["symbol"], "`when`");
+}
+
+#[test]
+fn agent_symbol_not_found_and_ambiguous_do_not_discover() {
+    for result in [
+        json!({"type":"RESOLVE_NOT_FOUND","ok":true,"source":"compiler"}),
+        json!({
+            "type":"RESOLVE_AMBIGUOUS",
+            "ok":true,
+            "source":"compiler",
+            "candidates":[{"fqName":"alpha.Parser.parse"},{"fqName":"beta.Parser.parse"}]
+        }),
+    ] {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let config_home = temp.path().join("config");
+        let workspace = temp.path().join("workspace");
+        let socket_path = temp.path().join("idea.sock");
+        let handle = spawn_scripted_idea_backend(
+            &home,
+            &config_home,
+            &workspace,
+            &socket_path,
+            vec![("symbol/resolve", result)],
+        );
+
+        let output = run_agent_symbol(&home, &config_home, &workspace, &[]);
+
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let stdout: Value = serde_json::from_slice(&output.stdout).expect("symbol json");
+        assert!(matches!(
+            stdout["result"]["outcome"]["type"].as_str(),
+            Some("NOT_FOUND" | "AMBIGUOUS")
+        ));
+        let requests = handle.join().expect("scripted backend");
+        assert_eq!(
+            requests.len(),
+            3,
+            "expected only runtime probes plus resolve"
+        );
+        assert_eq!(requests[2]["method"], "symbol/resolve");
+    }
+}
+
+#[test]
+fn agent_symbol_discovery_requests_lexical_mode_explicitly() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    seed_source_index(&workspace);
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "symbol",
+            "--query",
+            "Foo",
+            "--mode",
+            "discovery",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("discovery");
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("discovery json");
+    assert_eq!(stdout["result"]["mode"], "discovery");
+    assert_eq!(stdout["result"]["outcome"]["type"], "DISCOVERED");
+    assert_eq!(stdout["result"]["outcome"]["source"], "fuzzy");
+    assert_eq!(
+        stdout["result"]["request"]["params"]["modes"],
+        json!(["lexical"])
+    );
+}
+
+#[test]
+fn agent_symbol_relations_use_canonical_compiler_identity() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let socket_path = temp.path().join("idea.sock");
+    let handle = spawn_scripted_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        vec![
+            ("symbol/resolve", symbol_result(&workspace, "sample.when")),
+            (
+                "symbol/references",
+                json!({"type":"REFERENCES_SUCCESS","ok":true,"references":[]}),
+            ),
+            (
+                "symbol/callers",
+                json!({"type":"CALLERS_SUCCESS","ok":true,"calls":[]}),
+            ),
+        ],
+    );
+
+    let output = run_agent_symbol(
+        &home,
+        &config_home,
+        &workspace,
+        &["--references", "--callers", "incoming"],
+    );
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let requests = handle.join().expect("scripted backend");
+    assert_eq!(requests[3]["params"]["symbol"], "sample.when");
+    assert_eq!(requests[4]["params"]["symbol"], "sample.when");
+}
+
+#[test]
+fn agent_symbol_discovery_rejects_relation_flags_before_io() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let output = run_agent_symbol(
+        &home,
+        &config_home,
+        &workspace,
+        &["--mode", "discovery", "--references"],
+    );
+
+    assert!(!output.status.success());
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("usage json");
+    assert_eq!(stdout["error"]["code"], "AGENT_USAGE");
+}
+
+#[test]
+fn agent_symbol_uses_indexed_exact_only_when_compiler_is_unavailable() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    seed_source_index(&workspace);
+    support::metrics::seed_exact_lookup_symbols(&workspace);
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "symbol",
+            "--query",
+            "Parser",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("indexed exact fallback");
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("fallback json");
+    assert_eq!(stdout["result"]["outcome"]["type"], "AMBIGUOUS");
+    assert_eq!(stdout["result"]["outcome"]["source"], "indexed-exact");
+    assert_eq!(
+        stdout["result"]["request"]["params"]["modes"],
+        json!(["exact"])
+    );
+    assert_eq!(
+        stdout["result"]["outcome"]["candidates"]
+            .as_array()
+            .expect("candidates")
+            .len(),
+        2
+    );
+    assert!(
+        stdout["result"]["outcome"]["compilerFallback"]["code"]
+            .as_str()
+            .is_some_and(|code| !code.is_empty()),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn agent_symbol_containing_type_never_weakens_to_indexed_exact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    seed_source_index(&workspace);
+    support::metrics::seed_exact_lookup_symbols(&workspace);
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "symbol",
+            "--query",
+            "Parser",
+            "--containing-type",
+            "sample.Container",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("containing type fail closed");
+
+    assert!(!output.status.success());
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("failure json");
+    assert!(stdout["error"]["code"].as_str().is_some());
+    assert!(stdout["result"].is_null(), "{stdout}");
+}
+
+#[test]
+fn agent_symbol_operational_resolve_failure_never_falls_back() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let socket_path = temp.path().join("idea.sock");
+    let handle = spawn_scripted_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        vec![(
+            "symbol/resolve",
+            json!({"type":"RESOLVE_FAILURE","ok":false,"message":"compiler failed"}),
+        )],
+    );
+
+    let output = run_agent_symbol(&home, &config_home, &workspace, &[]);
+
+    assert!(!output.status.success());
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("failure json");
+    assert_eq!(stdout["error"]["code"], "RESOLVE_FAILURE");
+    assert_eq!(handle.join().expect("scripted backend").len(), 3);
+}
 
 fn assert_removed_agent_workflow(stdout: &serde_json::Value) {
     assert_eq!(stdout["ok"], false, "{stdout}");

--- a/cli-rs/tests/demo_smoke.rs
+++ b/cli-rs/tests/demo_smoke.rs
@@ -278,8 +278,12 @@ fn demo_reports_full_availability_from_an_existing_ready_backend() {
         String::from_utf8_lossy(&demo.stderr)
     );
     let response: Value = serde_json::from_slice(&demo.stdout).expect("demo json");
+    let requests = handle.join().expect("fake backend");
     assert_eq!(
-        handle.join().expect("fake backend"),
+        requests
+            .iter()
+            .map(|request| request["method"].as_str().expect("method"))
+            .collect::<Vec<_>>(),
         vec![
             "runtime/status",
             "capabilities",
@@ -405,7 +409,11 @@ fn backend_only_demo_fails_when_the_compiler_cannot_resolve_the_requested_symbol
         &workspace,
         &socket_path,
         3,
-        Some("No Kotlin symbol matched NoSuchSymbol"),
+        Some(serde_json::json!({
+            "type": "RESOLVE_FAILURE",
+            "ok": false,
+            "message": "No Kotlin symbol matched NoSuchSymbol"
+        })),
     );
 
     let demo = kast(&home, &config_home)
@@ -435,14 +443,124 @@ fn backend_only_demo_fails_when_the_compiler_cannot_resolve_the_requested_symbol
     );
 }
 
+#[test]
+fn backend_only_demo_handles_typed_not_found_and_ambiguous_resolve_outcomes() {
+    for (resolve_result, expected_code) in [
+        (
+            serde_json::json!({"type":"RESOLVE_NOT_FOUND","ok":true,"source":"compiler"}),
+            "DEMO_RESOLVE_NOT_FOUND",
+        ),
+        (
+            serde_json::json!({
+                "type":"RESOLVE_AMBIGUOUS",
+                "ok":true,
+                "source":"compiler",
+                "candidates":[{"fqName":"alpha.Foo"},{"fqName":"beta.Foo"}]
+            }),
+            "DEMO_RESOLVE_AMBIGUOUS",
+        ),
+    ] {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let config_home = temp.path().join("config");
+        let workspace = temp.path().join("workspace");
+        let socket_path = temp.path().join("idea.sock");
+        write_macos_plugin_workspace_metadata(&workspace);
+        let handle = spawn_ready_demo_backend(
+            &home,
+            &config_home,
+            &workspace,
+            &socket_path,
+            3,
+            Some(resolve_result),
+        );
+
+        let demo = kast(&home, &config_home)
+            .args([
+                "--output",
+                "json",
+                "demo",
+                "--workspace-root",
+                workspace.to_str().expect("workspace path"),
+                "--backend",
+                "idea",
+                "--symbol",
+                "Foo",
+            ])
+            .output()
+            .expect("typed resolve outcome demo");
+
+        assert!(!demo.status.success());
+        let response: Value = serde_json::from_slice(&demo.stdout).expect("demo error json");
+        assert_eq!(response["code"], expected_code);
+        assert_eq!(handle.join().expect("fake backend").len(), 3);
+    }
+}
+
+#[test]
+fn demo_relations_use_canonical_resolved_symbol_identity() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let socket_path = temp.path().join("idea.sock");
+    seed_source_index(&workspace);
+    let canonical_fq_name = "canonical.lib.Foo";
+    let handle = spawn_ready_demo_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        5,
+        Some(serde_json::json!({
+            "type": "RESOLVE_SUCCESS",
+            "ok": true,
+            "symbol": {
+                "fqName": canonical_fq_name,
+                "kind": "CLASS",
+                "location": {
+                    "filePath": workspace.join("lib/Foo.kt").display().to_string(),
+                    "startOffset": 13,
+                    "endOffset": 22,
+                    "startLine": 3,
+                    "startColumn": 1,
+                    "preview": "class Foo"
+                }
+            }
+        })),
+    );
+
+    let demo = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "demo",
+            "--workspace-root",
+            workspace.to_str().expect("workspace path"),
+            "--backend",
+            "idea",
+        ])
+        .output()
+        .expect("canonical relation demo");
+
+    assert!(
+        demo.status.success(),
+        "{}",
+        String::from_utf8_lossy(&demo.stdout)
+    );
+    let requests = handle.join().expect("fake backend");
+    assert_eq!(requests[3]["method"], "symbol/references");
+    assert_eq!(requests[3]["params"]["symbol"], canonical_fq_name);
+}
+
 fn spawn_ready_demo_backend(
     home: &std::path::Path,
     config_home: &std::path::Path,
     workspace: &std::path::Path,
     socket_path: &std::path::Path,
     expected_requests: usize,
-    resolve_error: Option<&str>,
-) -> std::thread::JoinHandle<Vec<String>> {
+    resolve_result: Option<Value>,
+) -> std::thread::JoinHandle<Vec<Value>> {
     let descriptor_dir = default_descriptor_dir(home);
     std::fs::create_dir_all(home).expect("home");
     std::fs::create_dir_all(workspace).expect("workspace");
@@ -475,11 +593,10 @@ fn spawn_ready_demo_backend(
     let listener = UnixListener::bind(socket_path).expect("bind fake backend");
     listener.set_nonblocking(true).expect("nonblocking backend");
     let server_workspace = workspace.to_path_buf();
-    let resolve_error = resolve_error.map(str::to_string);
     thread::spawn(move || {
-        let mut methods = Vec::new();
+        let mut requests = Vec::new();
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        while methods.len() < expected_requests && std::time::Instant::now() < deadline {
+        while requests.len() < expected_requests && std::time::Instant::now() < deadline {
             let (mut stream, _) = match listener.accept() {
                 Ok(connection) => connection,
                 Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
@@ -493,7 +610,7 @@ fn spawn_ready_demo_backend(
             reader.read_line(&mut request_line).expect("read request");
             let request: Value = serde_json::from_str(&request_line).expect("request json");
             let method = request["method"].as_str().expect("method").to_string();
-            methods.push(method.clone());
+            requests.push(request.clone());
             let result = match method.as_str() {
                 "runtime/status" => serde_json::json!({
                     "state": "READY",
@@ -519,8 +636,7 @@ fn spawn_ready_demo_backend(
                     },
                     "schemaVersion": 3
                 }),
-                "symbol/resolve" => resolve_error.as_ref().map_or_else(
-                    || serde_json::json!({
+                "symbol/resolve" => resolve_result.clone().unwrap_or_else(|| serde_json::json!({
                         "type": "RESOLVE_SUCCESS",
                         "ok": true,
                         "symbol": {
@@ -535,13 +651,7 @@ fn spawn_ready_demo_backend(
                                 "preview": "class Foo"
                             }
                         }
-                    }),
-                    |message| serde_json::json!({
-                        "type": "RESOLVE_FAILURE",
-                        "ok": false,
-                        "message": message
-                    }),
-                ),
+                    })),
                 "symbol/references" => serde_json::json!({
                     "type": "REFERENCES_SUCCESS",
                     "ok": true,
@@ -577,7 +687,7 @@ fn spawn_ready_demo_backend(
             )
             .expect("write response");
         }
-        methods
+        requests
     })
 }
 

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -56,6 +56,10 @@ fn packaged_skill_stays_usage_first_and_public_agent_only() {
         "{skill}"
     );
     assert!(
+        skill.contains("exact lookup is the default") && skill.contains("--mode discovery"),
+        "packaged guidance must separate exact lookup from fuzzy discovery: {skill}"
+    );
+    assert!(
         skill.contains(
             "`kast agent rename --symbol <fq-name> --new-name <name> --workspace-root \"$PWD\"`"
         ),
@@ -123,6 +127,12 @@ fn packaged_workflow_reference_uses_current_runtime_surface() {
 
     assert!(
         workflows.contains("`kast developer runtime status --workspace-root \"$PWD\"`"),
+        "{workflows}"
+    );
+    assert!(
+        workflows.contains("--mode discovery")
+            && workflows.contains("indexed-exact")
+            && workflows.contains("compiler"),
         "{workflows}"
     );
     assert!(

--- a/cli-rs/tests/rpc_catalog_smoke.rs
+++ b/cli-rs/tests/rpc_catalog_smoke.rs
@@ -10,6 +10,20 @@ fn catalog() -> Value {
     .expect("commands catalog")
 }
 
+#[test]
+fn symbol_resolve_catalog_declares_every_exact_outcome() {
+    let catalog = catalog();
+    assert_eq!(
+        catalog["commands"]["symbol/resolve"]["responseVariants"],
+        serde_json::json!([
+            "RESOLVE_SUCCESS",
+            "RESOLVE_NOT_FOUND",
+            "RESOLVE_AMBIGUOUS",
+            "RESOLVE_FAILURE"
+        ])
+    );
+}
+
 fn request_required(request: &Value) -> impl Iterator<Item = &str> {
     request
         .get("required")

--- a/cli-rs/tests/support/metrics.rs
+++ b/cli-rs/tests/support/metrics.rs
@@ -393,6 +393,48 @@ pub(crate) fn seed_source_index(workspace: &std::path::Path) {
     }
 }
 
+pub(crate) fn seed_exact_lookup_symbols(workspace: &std::path::Path) {
+    let db_path = workspace.join(".gradle/kast/cache/source-index.db");
+    let conn = Connection::open(db_path).expect("sqlite");
+    for (id, fq_name, filename, kind) in [
+        (20, "sample.when", "Keywords.kt", "FUNCTION"),
+        (21, "alpha.Parser", "AlphaParser.kt", "CLASS"),
+        (22, "beta.Parser", "BetaParser.kt", "CLASS"),
+        (
+            23,
+            "sample.MissingOrderServiceLegacy",
+            "MissingOrderServiceLegacy.kt",
+            "CLASS",
+        ),
+    ] {
+        std::fs::write(
+            workspace.join("lib").join(filename),
+            format!("// {fq_name}\n"),
+        )
+        .expect("exact lookup source");
+        conn.execute(
+            "INSERT INTO fq_names(fq_id, fq_name) VALUES (?, ?)",
+            params![id, fq_name],
+        )
+        .expect("exact lookup fq name");
+        conn.execute(
+            "INSERT INTO file_metadata(prefix_id, filename, module_path, source_set) VALUES (2, ?, ':lib', 'main')",
+            params![filename],
+        )
+        .expect("exact lookup file metadata");
+        conn.execute(
+            "INSERT INTO file_manifest(prefix_id, filename, last_modified_millis) VALUES (2, ?, 1)",
+            params![filename],
+        )
+        .expect("exact lookup file manifest");
+        conn.execute(
+            "INSERT INTO declarations(fq_id, kind, visibility, prefix_id, filename, declaration_offset, module_path, source_set) VALUES (?, ?, 'PUBLIC', 2, ?, 1, ':lib', 'main')",
+            params![id, kind, filename],
+        )
+        .expect("exact lookup declaration");
+    }
+}
+
 pub(crate) fn source_index_schema_version() -> i64 {
     env!("KAST_SOURCE_INDEX_SCHEMA_VERSION")
         .parse()

--- a/cli-rs/tests/support/mod.rs
+++ b/cli-rs/tests/support/mod.rs
@@ -148,6 +148,108 @@ pub(crate) fn write_macos_plugin_workspace_metadata(workspace: &Path) {
     }
 }
 
+pub(crate) fn spawn_scripted_idea_backend(
+    home: &Path,
+    config_home: &Path,
+    workspace: &Path,
+    socket_path: &Path,
+    scripted_results: Vec<(&'static str, serde_json::Value)>,
+) -> std::thread::JoinHandle<Vec<serde_json::Value>> {
+    let descriptor_dir = default_descriptor_dir(home);
+    std::fs::create_dir_all(home).expect("home");
+    std::fs::create_dir_all(workspace).expect("workspace");
+    std::fs::create_dir_all(config_home).expect("config home");
+    std::fs::create_dir_all(&descriptor_dir).expect("descriptor dir");
+    write_macos_plugin_workspace_metadata(workspace);
+    std::fs::write(
+        config_home.join("config.toml"),
+        "[runtime]\ndefaultBackend = \"idea\"\n",
+    )
+    .expect("config");
+    std::fs::write(
+        descriptor_dir.join("daemons.json"),
+        serde_json::to_vec_pretty(&serde_json::json!([{
+            "workspaceRoot": workspace.display().to_string(),
+            "backendName": "idea",
+            "backendVersion": "scripted-test",
+            "transport": "uds",
+            "socketPath": socket_path.display().to_string(),
+            "pid": std::process::id(),
+            "schemaVersion": 3
+        }]))
+        .expect("descriptor json"),
+    )
+    .expect("descriptor");
+
+    let listener = UnixListener::bind(socket_path).expect("bind scripted backend");
+    listener
+        .set_nonblocking(true)
+        .expect("nonblocking scripted backend");
+    let server_workspace = workspace.to_path_buf();
+    thread::spawn(move || {
+        let mut requests = Vec::new();
+        let mut scripted_results = scripted_results.into_iter();
+        let expected_requests = 2 + scripted_results.len();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while requests.len() < expected_requests && std::time::Instant::now() < deadline {
+            let (mut stream, _) = match listener.accept() {
+                Ok(connection) => connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(std::time::Duration::from_millis(10));
+                    continue;
+                }
+                Err(error) => panic!("accept scripted backend client: {error}"),
+            };
+            let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+            let mut request_line = String::new();
+            reader.read_line(&mut request_line).expect("read request");
+            let request: serde_json::Value =
+                serde_json::from_str(&request_line).expect("request json");
+            let method = request["method"].as_str().expect("method");
+            let result = match method {
+                "runtime/status" => serde_json::json!({
+                    "state": "READY",
+                    "healthy": true,
+                    "active": true,
+                    "indexing": false,
+                    "backendName": "idea",
+                    "backendVersion": "scripted-test",
+                    "workspaceRoot": server_workspace.display().to_string(),
+                    "schemaVersion": 3
+                }),
+                "capabilities" => serde_json::json!({
+                    "backendName": "idea",
+                    "backendVersion": "scripted-test",
+                    "workspaceRoot": server_workspace.display().to_string(),
+                    "readCapabilities": ["symbol/resolve", "symbol/references", "symbol/callers"],
+                    "mutationCapabilities": [],
+                    "limits": {
+                        "requestTimeoutMillis": 60000,
+                        "maxResults": 1000,
+                        "maxConcurrentRequests": 4
+                    },
+                    "schemaVersion": 3
+                }),
+                _ => {
+                    let (expected_method, result) = scripted_results
+                        .next()
+                        .unwrap_or_else(|| panic!("unexpected scripted method: {method}"));
+                    assert_eq!(method, expected_method, "scripted method order");
+                    result
+                }
+            };
+            requests.push(request);
+            writeln!(
+                stream,
+                "{}",
+                serde_json::json!({"jsonrpc":"2.0","id":1,"result":result})
+            )
+            .expect("write scripted response");
+        }
+        requests
+    })
+}
+
 #[cfg(target_os = "macos")]
 fn default_socket_path_for_test(workspace: &Path) -> PathBuf {
     use sha2::{Digest, Sha256};

--- a/cli-rs/tests/symbol_query_smoke.rs
+++ b/cli-rs/tests/symbol_query_smoke.rs
@@ -4,6 +4,73 @@ use serde_json::Value;
 use support::metrics::*;
 
 #[test]
+fn indexed_exact_lookup_normalizes_backticks_without_rewriting_identity() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    seed_source_index(&workspace);
+    seed_exact_lookup_symbols(&workspace);
+
+    for query in ["`when`", "sample.`when`"] {
+        let response = run_symbol_query(
+            &home,
+            &config_home,
+            &workspace,
+            60,
+            serde_json::json!({"query":query,"modes":["exact"],"limit":10}),
+        );
+        assert_eq!(result_fq_names(&response), vec!["sample.when".to_string()]);
+    }
+}
+
+#[test]
+fn indexed_exact_lookup_returns_all_ambiguous_simple_name_matches() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    seed_source_index(&workspace);
+    seed_exact_lookup_symbols(&workspace);
+
+    let response = run_symbol_query(
+        &home,
+        &config_home,
+        &workspace,
+        61,
+        serde_json::json!({"query":"Parser","modes":["exact"],"limit":10}),
+    );
+
+    assert_eq!(
+        result_fq_names(&response),
+        vec!["alpha.Parser".to_string(), "beta.Parser".to_string()]
+    );
+}
+
+#[test]
+fn indexed_exact_lookup_never_returns_lexical_only_candidates() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    seed_source_index(&workspace);
+    seed_exact_lookup_symbols(&workspace);
+
+    let response = run_symbol_query(
+        &home,
+        &config_home,
+        &workspace,
+        62,
+        serde_json::json!({"query":"MissingOrderService","modes":["exact"],"limit":10}),
+    );
+
+    assert_eq!(result_fq_names(&response), Vec::<String>::new());
+}
+
+#[test]
 fn symbol_query_reports_token_evidence_for_camel_case_declarations() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/docs/learn/evidence-model.md
+++ b/docs/learn/evidence-model.md
@@ -20,6 +20,17 @@ every matching string in the repository.
 The practical rule is: resolve broad names first, then act only after the
 selected identity matches the target declaration.
 
+Exact lookup distinguishes three expected states: one resolved declaration, no
+exact declaration, or multiple exact declarations. Keeping not-found and
+ambiguous explicit prevents a similarly spelled declaration from being treated
+as proof. Fuzzy candidates are useful for discovery, but they become actionable
+only after a separate exact lookup.
+
+Every public lookup names its evidence source. `compiler` is canonical backend
+identity, `indexed-exact` is equality proven by the source index while the
+compiler is unavailable, and `fuzzy` is discovery evidence. This makes the
+strength of the claim visible to the next agent step.
+
 ## Evidence Can Be Bounded
 
 Reference, caller, hierarchy, and impact evidence may be bounded by depth,

--- a/docs/reference/agent-commands.md
+++ b/docs/reference/agent-commands.md
@@ -47,6 +47,24 @@ does not survive a daemon restart.
 Use [mutation selectors](mutation-selectors.md) for the selector model and
 [plan safe edits](../use/plan-safe-edits.md) for the developer-facing story.
 
+## Symbol Lookup
+
+`kast agent symbol --query <name>` defaults to `--mode exact`. Exact mode accepts
+a simple or fully-qualified Kotlin name and applies `--kind`, `--file-hint`, and
+`--containing-type` as hard constraints. Backticks affect matching only; a
+resolved result reports the canonical identity returned by the compiler or
+source index.
+
+The lookup outcome is one of `RESOLVED`, `NOT_FOUND`, or `AMBIGUOUS`. Its
+`source` is `compiler` for compiler-backed identity or `indexed-exact` when the
+compiler is unavailable and the source index can prove the exact constraints.
+Not-found and ambiguous outcomes never trigger fuzzy search.
+
+`--mode discovery` is the explicit fuzzy surface. It reports `DISCOVERED` with
+`source: fuzzy`; `--references` and `--callers` are unavailable in that mode.
+Relation requests run only after compiler resolution and use the returned
+canonical fully-qualified name.
+
 ??? info "Command names for agent authors"
     The current typed agent commands are:
 
@@ -71,6 +89,7 @@ Use [mutation selectors](mutation-selectors.md) for the selector model and
     ```console
     kast agent verify --workspace-root "$PWD"
     kast agent symbol --query OrderService --workspace-root "$PWD"
+    kast agent symbol --query order --mode discovery --workspace-root "$PWD"
     kast agent diagnostics \
       --file-path "$PWD/src/main/kotlin/App.kt" \
       --workspace-root "$PWD"

--- a/docs/use/inspect-kotlin.md
+++ b/docs/use/inspect-kotlin.md
@@ -12,8 +12,23 @@ you after Kast is installed and the project is open.
 
 ## Resolve Identity First
 
-The agent starts broad, then narrows until the target declaration is clear.
-That avoids treating every matching string as the same Kotlin symbol.
+Start with exact lookup. A unique declaration resolves; zero or multiple exact
+matches return typed outcomes instead of silently choosing a similar name.
+
+```console
+kast agent symbol --query OrderService --workspace-root "$PWD"
+```
+
+If the name is unknown, opt into fuzzy discovery and inspect its candidates:
+
+```console
+kast agent symbol --query order --mode discovery --workspace-root "$PWD"
+```
+
+Then rerun exact lookup with the selected simple or fully-qualified identity.
+Use `--kind`, `--file-hint`, or `--containing-type` when the target requires a
+hard constraint. Request references or callers only from that exact lookup.
+This avoids treating every matching string as the same Kotlin symbol.
 
 ## Gather The Right Evidence
 
@@ -38,6 +53,7 @@ Continue with [plan safe edits](plan-safe-edits.md) for the mutation flow.
     ```console
     kast agent verify --workspace-root "$PWD"
     kast agent symbol --query OrderService --workspace-root "$PWD"
+    kast agent symbol --query order --mode discovery --workspace-root "$PWD"
     kast agent symbol --query OrderService --references --workspace-root "$PWD"
     kast agent diagnostics \
       --file-path "$PWD/src/main/kotlin/App.kt" \


### PR DESCRIPTION
## Summary

- make `kast agent symbol` default to fail-closed exact compiler lookup, with fuzzy discovery available only through explicit `--mode discovery`
- return four typed exact outcomes: resolved, not found, ambiguous, and operational failure
- apply kind, containing-type, and file constraints as hard filters; preserve compiler canonical identity and detect overload ambiguity independently of presentation limits
- permit indexed-exact fallback only for a closed compiler-unavailability allowlist, never for relation requests or weakened containing-type proof
- populate real containing declaration identity in the production IDEA adapter and migrate demo/relation consumers to canonical compiler identity
- update ADR 0016, installed guidance, command catalogs, generated protocol artifacts, and RPC summary rendering so all declared variants remain visible

## Integration

- rebased onto merged #333 (`920ba166`) while preserving #332 completeness fixtures and #333 operation modules
- fixed the RPC summary generator to render the catalog's complete `responseVariants` list; a docs contract now guards all four exact outcomes

## Verification

- `./gradlew :analysis-api:test :analysis-server:test :backend-idea:test`
- `./gradlew test`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- generated contract check (`138` artifacts)
- RPC summary, docs content/navigation, Zensical, Python compilation, and diff gates

Kast semantic verification in the isolated worktree correctly reported `MACOS_PLUGIN_WORKSPACE_REQUIRED`; no macOS plugin-owned setup was mutated.

Closes #334
