### PR TITLE
fix: support secure workspace-relative agent paths

### DIFF
--- a/.agents/adr/0018-relative-agent-file-path-normalization.md
+++ b/.agents/adr/0018-relative-agent-file-path-normalization.md
@@ -25,6 +25,26 @@ leaf is permitted after its deepest existing ancestor is canonicalized and
 proved to be an in-workspace directory; this preserves deleted-file refresh
 and new-file planning.
 
+CLI normalization is not the mutation boundary. Immediately before a shipped
+IDEA or headless backend changes the filesystem, it opens the filesystem root
+and traverses every canonical workspace and target directory component with
+POSIX `openat` using `O_NOFOLLOW` and `O_DIRECTORY`. Missing create-file
+directories are materialized with `mkdirat` relative to the held parent
+descriptor. New files are created with `openat`; existing-file edits are
+written to a descriptor-relative temporary file and committed with `renameat`.
+Delete operations use `unlinkat`. The backend refreshes IDEA VFS state after
+the descriptor-relative mutation rather than asking VFS to resolve the target
+pathname for the write.
+
+This write-boundary check is repeated after server containment validation, so
+replacing an accepted ancestor with an escaping symlink cannot redirect an
+add-file or file-scoped mutation. Any symlink, non-directory component, missing
+primitive, or unsupported non-POSIX runtime fails with the typed
+`UNSAFE_WORKSPACE_MUTATION` error before an outside write. macOS and Linux are
+the shipped runtimes governed by this decision. Existing source permissions
+are carried onto atomic text replacements; newly created Kotlin files and
+directories use deterministic IDEA-compatible permissions.
+
 Relative targets are rejected when `--workspace-root` was omitted, even if
 Kast could infer a workspace from the current directory. Absolute targets
 remain accepted without an explicit root when they are contained by the
@@ -49,6 +69,11 @@ unchecked input. Resolving the deepest existing ancestor supports meaningful
 missing-file operations without weakening workspace containment or symlink
 safety.
 
+Canonicalizing a missing path alone is a check-then-use operation. Repeating
+the walk at the actual mutation seam with held directory descriptors closes
+the ancestor-replacement gap without changing canonical CLI output or the
+absolute backend request contract.
+
 ## Public surface and source owners
 
 | Contract | Source of truth |
@@ -56,9 +81,11 @@ safety.
 | Typed command arguments | `cli-rs/src/cli/agent.rs` |
 | Canonical workspace-contained path parser | `cli-rs/src/agent/path.rs` |
 | Agent request and plan construction | `cli-rs/src/agent/dispatch.rs` |
+| Typed unsafe-mutation failure | `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/UnsafeWorkspaceMutationException.kt` |
+| Descriptor-relative write boundary | `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutation.kt`, `IdeaEditApplier.kt` |
 | Installed agent routing | `cli-rs/resources/kast-skill/` |
 | Published command examples | `docs/reference/agent-commands.md` |
-| Behavior and regression proof | `cli-rs/tests/agent_diagnostics_smoke.rs`, `cli-rs/tests/agent_command_surface_smoke.rs` |
+| Behavior and regression proof | `cli-rs/tests/agent_diagnostics_smoke.rs`, `cli-rs/tests/agent_command_surface_smoke.rs`, `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaEditApplicationTest.kt` |
 
 ## Out of scope
 
@@ -82,6 +109,7 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked
 cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+./gradlew :analysis-api:test :backend-idea:test
 .github/scripts/test-docs-content-contract.sh
 git diff --check
 ```

--- a/.agents/adr/0018-relative-agent-file-path-normalization.md
+++ b/.agents/adr/0018-relative-agent-file-path-normalization.md
@@ -1,0 +1,87 @@
+# ADR 0018: Relative agent file path normalization
+
+Status: Accepted
+
+Date: 2026-07-13
+
+Supersedes [ADR 0006](0006-forward-system-definition-and-audit-scope.md) in
+part for typed agent command file arguments. The public agent CLI now accepts
+workspace-relative Kotlin target paths when an explicit workspace root is
+declared, while backend requests continue to use canonical absolute paths.
+
+## Decision
+
+The Rust typed agent CLI owns semantic target path normalization. Diagnostics
+`--file-path`, add-file `--file-path`, and file-scoped mutation `--inside-file`
+accept either an absolute path or a path relative to explicit
+`--workspace-root`.
+
+Before request or plan construction, each target is parsed into a canonical
+absolute Kotlin path contained by the canonical workspace root. Existing safe
+symlinks resolve to their real in-workspace target. Lexical escapes, symlink
+escapes, broken symlinks, unreadable prefixes, directories, special files, and
+extensions other than `.kt` or `.kts` fail closed. A missing `.kt` or `.kts`
+leaf is permitted after its deepest existing ancestor is canonicalized and
+proved to be an in-workspace directory; this preserves deleted-file refresh
+and new-file planning.
+
+Relative targets are rejected when `--workspace-root` was omitted, even if
+Kast could infer a workspace from the current directory. Absolute targets
+remain accepted without an explicit root when they are contained by the
+inferred effective workspace.
+
+Diagnostics output includes the ordered canonical `filePaths` list used by
+both refresh and analysis. Mutation plans expose canonical target paths in
+their typed request parameters. Human, JSON, and TOON therefore identify the
+same path the backend receives.
+
+`--file-hint` remains a compiler-identity hint, not a target path.
+`--content-file` remains a payload-source argument. Neither is reinterpreted by
+this decision.
+
+## Rationale
+
+Normalizing at the public CLI boundary gives every backend one existing
+absolute-path contract and prevents a plan, refresh, analysis request, and
+rendered result from disagreeing about file identity. Typed canonical paths
+make it impossible for downstream request construction to accidentally reuse
+unchecked input. Resolving the deepest existing ancestor supports meaningful
+missing-file operations without weakening workspace containment or symlink
+safety.
+
+## Public surface and source owners
+
+| Contract | Source of truth |
+| --- | --- |
+| Typed command arguments | `cli-rs/src/cli/agent.rs` |
+| Canonical workspace-contained path parser | `cli-rs/src/agent/path.rs` |
+| Agent request and plan construction | `cli-rs/src/agent/dispatch.rs` |
+| Installed agent routing | `cli-rs/resources/kast-skill/` |
+| Published command examples | `docs/reference/agent-commands.md` |
+| Behavior and regression proof | `cli-rs/tests/agent_diagnostics_smoke.rs`, `cli-rs/tests/agent_command_surface_smoke.rs` |
+
+## Out of scope
+
+Raw JSON-RPC dispatch, generated catalog invocation, offset selectors, and
+backend-specific path dialects remain outside the public product surface.
+Relative `--file-hint` matching and arbitrary payload-file relocation are not
+introduced. Backend API request fields stay canonical and absolute.
+
+## Change rule
+
+New public semantic target path arguments must use the same typed normalizer or
+supersede this ADR with an equally explicit trust boundary. Do not add backend
+fallback joining, current-directory-relative target interpretation, or string
+cleanup after request construction.
+
+## Validation
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_diagnostics_smoke --test agent_command_surface_smoke --test packaged_content_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked
+cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
+cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+.github/scripts/test-docs-content-contract.sh
+git diff --check
+```

--- a/.agents/adr/0018-relative-agent-file-path-normalization.md
+++ b/.agents/adr/0018-relative-agent-file-path-normalization.md
@@ -25,16 +25,43 @@ leaf is permitted after its deepest existing ancestor is canonicalized and
 proved to be an in-workspace directory; this preserves deleted-file refresh
 and new-file planning.
 
-CLI normalization is not the mutation boundary. Immediately before a shipped
-IDEA or headless backend changes the filesystem, it opens the filesystem root
-and traverses every canonical workspace and target directory component with
-POSIX `openat` using `O_NOFOLLOW` and `O_DIRECTORY`. Missing create-file
-directories are materialized with `mkdirat` relative to the held parent
-descriptor. New files are created with `openat`; existing-file edits are
-written to a descriptor-relative temporary file and committed with `renameat`.
-Delete operations use `unlinkat`. The backend refreshes IDEA VFS state after
-the descriptor-relative mutation rather than asking VFS to resolve the target
-pathname for the write.
+CLI normalization is not the mutation boundary. `backend-idea` owns the shared
+filesystem mutation implementation. The IDEA plugin uses it directly, while
+`backend-headless` starts `KastIdeaBackendRuntime` and exposes the same
+`KastPluginBackend` apply-edits and file-operation capabilities. Both shipped
+runtimes are therefore in this threat and validation scope. Immediately before
+either runtime changes the filesystem, it opens the filesystem root and
+traverses every canonical workspace and target directory component with POSIX
+`openat` using `O_NOFOLLOW` and `O_DIRECTORY`. Missing
+create-file directories are materialized with `mkdirat` relative to the held
+parent descriptor, and new files are created with exclusive `openat`.
+
+Existing-file replacement and deletion first atomically detach the final
+directory entry to a randomized same-directory quarantine. macOS uses
+`renameatx_np(RENAME_EXCL | RENAME_NOFOLLOW_ANY)` and Linux uses
+`renameat2(RENAME_NOREPLACE)`. The backend obtains permissions, device/inode
+identity, complete mode/file type, and content hash through `fstat` and reads
+on the exact held quarantine descriptor. Detached entries are opened
+nonblocking and rejected unless they are regular files, so FIFOs and devices
+are never hashed as source text. Create and replacement content is written to an
+exclusive prepared entry and installed only with the same no-replace
+primitive. Deletion reserves the final name before releasing it and removing
+the validated original. Preparation or native commit failure restores the
+detached original before any best-effort prepared cleanup. If a concurrent
+entry replaces the deletion reservation, that entry is restored to the final
+name with no-replace semantics and the operation reports `CONFLICT` with
+recovery evidence instead of treating the concurrent entry as deleted.
+Cleanup moves a candidate behind a randomized
+internal name and compares its device/inode identity immediately before
+`unlinkat`. A refused or failed cleanup retains a reported recovery path;
+committed replacement/deletion is surfaced as applied with that recovery
+evidence. The backend records this committed path before IDEA Document/VFS
+refresh, hash validation, or post-write verification, so every later failure
+is a partial-apply outcome containing the already-applied file. Hash conflicts
+restore only with no-replace; if a concurrent final
+entry blocks restoration, that entry remains untouched and `CONFLICT` reports
+the preserved quarantine path. The backend then refreshes IDEA VFS state
+rather than asking VFS to resolve the target pathname for the write.
 
 This write-boundary check is repeated after server containment validation, so
 replacing an accepted ancestor with an escaping symlink cannot redirect an
@@ -42,8 +69,19 @@ add-file or file-scoped mutation. Any symlink, non-directory component, missing
 primitive, or unsupported non-POSIX runtime fails with the typed
 `UNSAFE_WORKSPACE_MUTATION` error before an outside write. macOS and Linux are
 the shipped runtimes governed by this decision. Existing source permissions
-are carried onto atomic text replacements; newly created Kotlin files and
-directories use deterministic IDEA-compatible permissions.
+come from `fstat` on the same descriptor that is hashed and are carried onto
+atomic text replacements; newly created Kotlin files and directories use
+deterministic IDEA-compatible permissions.
+
+Held directory descriptors prevent ancestor replacement from redirecting
+resolution, while held file descriptors prove which detached inode was hashed
+and which cleanup candidate was validated. POSIX namespace transitions still
+operate on directory-entry names: this protocol uses exclusive/no-replace
+renames, randomized internal names, and device/inode checks, but it is not a
+filesystem lock or a general transaction against a process with directory
+write authority that deliberately and continuously targets those internal
+names. Directory permissions remain the authority for that stronger threat;
+post-return filesystem changes are also outside this operation's guarantee.
 
 Relative targets are rejected when `--workspace-root` was omitted, even if
 Kast could infer a workspace from the current directory. Absolute targets
@@ -71,8 +109,9 @@ safety.
 
 Canonicalizing a missing path alone is a check-then-use operation. Repeating
 the walk at the actual mutation seam with held directory descriptors closes
-the ancestor-replacement gap without changing canonical CLI output or the
-absolute backend request contract.
+the ancestor-replacement gap. Detaching the final entry before hashing closes
+the final-entry check-then-use gap without changing canonical CLI output or
+the absolute backend request contract.
 
 ## Public surface and source owners
 
@@ -85,7 +124,7 @@ absolute backend request contract.
 | Descriptor-relative write boundary | `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutation.kt`, `IdeaEditApplier.kt` |
 | Installed agent routing | `cli-rs/resources/kast-skill/` |
 | Published command examples | `docs/reference/agent-commands.md` |
-| Behavior and regression proof | `cli-rs/tests/agent_diagnostics_smoke.rs`, `cli-rs/tests/agent_command_surface_smoke.rs`, `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaEditApplicationTest.kt` |
+| Behavior and regression proof | `cli-rs/tests/agent_diagnostics_smoke.rs`, `cli-rs/tests/agent_command_surface_smoke.rs`, `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaEditApplicationTest.kt`, `SecureWorkspaceMutationTest.kt` |
 
 ## Out of scope
 

--- a/.agents/superpowers/plans/2026-07-13-relative-agent-file-paths.md
+++ b/.agents/superpowers/plans/2026-07-13-relative-agent-file-paths.md
@@ -9,7 +9,7 @@
 **Tech Stack:** Rust 2024, Clap, serde/serde_json, `std::fs`, Cargo integration tests, Markdown contract checks.
 
 **Review hardening:** Kotlin/JVM 21, IDEA VFS/Document APIs, JNA-backed POSIX
-`openat`/`mkdirat`/`renameat`/`unlinkat`, JUnit Jupiter.
+`openat`/`mkdirat`/`fstat`/`renameatx_np`/`renameat2`/`unlinkat`, JUnit Jupiter.
 
 ## Global Constraints
 
@@ -47,6 +47,50 @@
   newly created files/directories.
 - [x] Run the complete Kotlin, Rust, generated-contract, and docs gates and
   record final evidence in `.agent-turn/issue-341-report.md`.
+
+### Task 6: Close the Final-Entry Replacement Race
+
+**Owner:** `backend-idea` owns the shared implementation;
+`backend-headless` reuses it through `KastIdeaBackendRuntime` and is in the
+same mutation threat and validation scope.
+
+**Files:**
+- Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutation.kt`
+- Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaEditApplier.kt`
+- Create: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutationTest.kt`
+- Modify: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaEditApplicationTest.kt`
+- Modify: ADR 0018, the approved design, and the ignored implementation report
+
+- [x] Prove a missing edit target maps to typed `NOT_FOUND` rather than a
+  pathname permission-read failure.
+- [x] Obtain permission mode and device/inode identity with `fstat` on the same
+  held descriptor used for hashing.
+- [x] Atomically detach existing targets to randomized quarantine names with
+  platform-correct exclusive/no-replace rename primitives.
+- [x] Install, restore, and reserve final entries only with no-replace
+  semantics; report blocked restoration and the recovery path through typed
+  `CONFLICT`.
+- [x] Move cleanup candidates behind randomized internal names, identity-check
+  immediately before `unlinkat`, retain deterministic recovery evidence when
+  cleanup fails, and document the deliberate internal-name-racer exclusion.
+- [x] Deterministically race replace and delete after detach/hash and prove the
+  concurrent entry plus the validated inode remain untouched and recoverable.
+- [x] Prove create commits prepared content with no-replace and never cleans a
+  concurrent final entry by name.
+- [x] Prove post-commit cleanup failures report replacement/deletion as applied
+  with retained recovery paths, and restoration precedes fallible prepared
+  cleanup on pre-commit conflicts.
+- [x] Restore detached originals across preparation and native final-rename
+  failures before best-effort prepared cleanup.
+- [x] Detect a late deletion-reservation replacement, restore the concurrent
+  entry to its public name with no-replace, and return typed conflict/recovery
+  evidence.
+- [x] Record typed filesystem commits in IDEA applied/created/deleted ledgers
+  before Document, VFS, later hash validation, or post-write verification.
+- [x] Open detached targets nonblocking, retain complete `fstat` mode/type, and
+  reject FIFOs, devices, and every other non-regular target before hashing.
+- [ ] Re-run focused and complete Kotlin, Rust, generated-contract, and docs
+  gates; update the report, commit, and leave the branch clean and unpushed.
 
 ---
 

--- a/.agents/superpowers/plans/2026-07-13-relative-agent-file-paths.md
+++ b/.agents/superpowers/plans/2026-07-13-relative-agent-file-paths.md
@@ -1,0 +1,367 @@
+# Relative Agent File Paths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Accept workspace-relative Kotlin target paths on typed agent commands and send only canonical workspace-contained absolute paths to backend requests.
+
+**Architecture:** A Rust agent-boundary normalizer parses the effective workspace and untrusted target strings into canonical path types. Diagnostics and mutation dispatch consume only the trusted strings, while docs and installed guidance teach relative construction against explicit `--workspace-root`.
+
+**Tech Stack:** Rust 2024, Clap, serde/serde_json, `std::fs`, Cargo integration tests, Markdown contract checks.
+
+## Global Constraints
+
+- Relative semantic targets require explicit `--workspace-root`.
+- Absolute and relative targets must resolve inside the canonical effective workspace.
+- Existing safe symlinks resolve to their real in-workspace target; lexical escapes, broken symlinks, and symlink escapes fail closed.
+- Missing `.kt` and `.kts` leaves remain valid for deleted-file refresh and add-file planning.
+- Directories, special files, unreadable prefixes, and non-Kotlin extensions fail before backend dispatch.
+- `--file-hint` remains a compiler-identity hint and `--content-file` remains a payload source.
+- Diagnostics, refresh, plans, JSON, TOON, and human output use the same canonical path strings.
+- Preserve target order and existing absolute in-workspace behavior.
+- Do not run `kast setup` on macOS.
+- Work only on `feature/issue-341-relative-file-paths`; do not push.
+
+---
+
+### Task 1: Typed Canonical Kotlin Path Boundary
+
+**Files:**
+- Create: `cli-rs/src/agent/path.rs`
+- Modify: `cli-rs/src/agent.rs`
+
+**Interfaces:**
+- Consumes: `AgentRuntimeArgs.workspace_root` and untrusted `&str` target paths.
+- Produces: `AgentFilePathNormalizer::from_runtime(&AgentRuntimeArgs) -> Result<AgentFilePathNormalizer, AgentError>`, `normalize(&self, &str) -> Result<CanonicalKotlinFilePath, AgentError>`, and `CanonicalKotlinFilePath::rpc_path(&self) -> &str`.
+
+- [ ] **Step 1: Write failing unit tests for the trust boundary**
+
+Add `#[cfg(test)] mod agent_file_path_tests` in `path.rs`. Construct temporary workspaces and assert the wished-for API:
+
+```rust
+#[test]
+fn relative_kotlin_file_resolves_against_explicit_workspace() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    let file = workspace.join("src/with spaces/App.kt");
+    std::fs::create_dir_all(file.parent().expect("source parent")).expect("source dir");
+    std::fs::write(&file, "class App\n").expect("source");
+    let runtime = AgentRuntimeArgs {
+        workspace_root: Some(workspace.clone()),
+        backend_name: None,
+    };
+
+    let normalizer = AgentFilePathNormalizer::from_runtime(&runtime).expect("normalizer");
+    let actual = normalizer
+        .normalize("src/with spaces/App.kt")
+        .expect("canonical target");
+
+    assert_eq!(actual.rpc_path(), file.canonicalize().expect("canonical file").to_str().expect("UTF-8"));
+}
+```
+
+Add separate tests for an existing absolute path, `.kts`, a missing `.kt` leaf,
+relative input without explicit workspace, `../` escape, absolute outside path,
+unsupported extension, a directory named `Directory.kt`, an in-workspace
+symlink, an escaping symlink, and a broken symlink. Gate symlink construction
+with platform-specific test helpers.
+
+- [ ] **Step 2: Run the unit tests and verify red**
+
+Run:
+
+```bash
+cargo test --manifest-path cli-rs/Cargo.toml --locked agent_file_path_tests
+```
+
+Expected: compilation fails because `AgentFilePathNormalizer` and
+`CanonicalKotlinFilePath` do not exist.
+
+- [ ] **Step 3: Implement typed root and target normalization**
+
+Add these owned types to `path.rs`:
+
+```rust
+struct AgentFilePathNormalizer {
+    declared_root: PathBuf,
+    canonical_root: PathBuf,
+    relative_targets_allowed: bool,
+}
+
+struct CanonicalKotlinFilePath {
+    path: PathBuf,
+    rpc_path: String,
+}
+```
+
+`from_runtime` resolves the effective workspace using
+`config::resolve_workspace_root`, lexically normalizes it, canonicalizes it,
+and requires a directory. `normalize` must:
+
+1. reject empty input and a relative input without explicit workspace;
+2. reject input extensions other than case-sensitive `.kt` or `.kts`;
+3. join relative input to the declared root and lexically resolve components;
+4. reject relative lexical escape before filesystem resolution;
+5. walk upward through `ErrorKind::NotFound`, recording missing suffixes;
+6. canonicalize the deepest existing prefix and reject unresolved symlinks;
+7. require an existing prefix with a missing suffix to be a directory;
+8. append missing suffix components to the canonical prefix;
+9. require the final canonical path to start with `canonical_root`;
+10. require an existing target to be a regular file;
+11. require the canonical target extension to be `.kt` or `.kts`;
+12. reject a non-UTF-8 RPC path rather than using lossy conversion.
+
+Convert every failure into `AgentError` with one of:
+`AGENT_WORKSPACE_INVALID`, `AGENT_RELATIVE_FILE_REQUIRES_WORKSPACE`,
+`AGENT_FILE_OUTSIDE_WORKSPACE`, `AGENT_FILE_SYMLINK_UNSAFE`,
+`AGENT_FILE_KIND_UNSUPPORTED`, or `AGENT_FILE_PATH_UNREADABLE`. Populate
+`input`, `workspaceRoot`, and `resolvedPath` details when those facts exist.
+
+Include `agent/path.rs` before `agent/dispatch.rs` in `agent.rs`, and import
+`crate::config`, `std::fs`, and the path/IO types only in the owning part.
+
+- [ ] **Step 4: Run the unit tests and verify green**
+
+Run the Task 1 test command again.
+
+Expected: every typed path case passes and no test starts a runtime session.
+
+- [ ] **Step 5: Commit the trust boundary**
+
+```bash
+git add cli-rs/src/agent.rs cli-rs/src/agent/path.rs
+git diff --cached --check
+git commit -m "feat: canonicalize agent Kotlin paths"
+```
+
+---
+
+### Task 2: Canonical Diagnostics Requests and Output
+
+**Files:**
+- Modify: `cli-rs/src/agent/dispatch.rs`
+- Modify: `cli-rs/tests/agent_diagnostics_smoke.rs`
+
+**Interfaces:**
+- Consumes: Task 1 `AgentFilePathNormalizer` and ordered diagnostics inputs.
+- Produces: identical canonical `filePaths` for `raw/workspace-refresh`, `raw/diagnostics`, and command-level `result.filePaths`.
+
+- [ ] **Step 1: Write failing fake-daemon integration tests**
+
+Extend the fake backend so it records full requests as well as method names.
+Add a scenario with two files, including `src/with spaces/Second.kt`, and invoke
+diagnostics with two relative `--file-path` arguments. Assert:
+
+```rust
+assert_eq!(refresh["params"]["filePaths"], json!([first, second]));
+assert_eq!(diagnostics["params"]["filePaths"], json!([first, second]));
+assert_eq!(document["result"]["filePaths"], json!([first, second]));
+```
+
+Run the same successful relative scenario with `json`, `toon`, and `human` and
+decode each through the existing helpers. Add an absolute-path compatibility
+scenario. Add a deleted relative `.kt` scenario where no file exists but the
+fake backend returns `MISSING_ON_DISK`; assert refresh receives the canonical
+missing path and the command fails with typed incomplete evidence rather than
+path parsing failure.
+
+Add pre-dispatch cases for `../Outside.kt`, an unsupported `.java` path, and an
+escaping symlink. Bind a nonblocking fake listener and assert it receives no
+request before the command exits with the corresponding structured path code.
+
+- [ ] **Step 2: Run focused integration tests and verify red**
+
+Run:
+
+```bash
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_diagnostics_smoke relative
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_diagnostics_smoke deleted
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_diagnostics_smoke rejects
+```
+
+Expected: relative scenarios fail because raw input still reaches the backend;
+the command-level canonical `filePaths` field is absent.
+
+- [ ] **Step 3: Normalize once before diagnostics step construction**
+
+At the start of `execute_agent_diagnostics`, construct one normalizer and map
+the ordered inputs into one `Vec<String>`:
+
+```rust
+let normalizer = match AgentFilePathNormalizer::from_runtime(&args.runtime) {
+    Ok(normalizer) => normalizer,
+    Err(error) => return error_envelope("agent/diagnostics".to_string(), None, error),
+};
+let file_paths = match normalizer.normalize_all(&args.file_paths) {
+    Ok(file_paths) => file_paths,
+    Err(error) => return error_envelope("agent/diagnostics".to_string(), None, error),
+};
+```
+
+Build both steps from `&file_paths`. After `execute_agent_steps`, insert
+`filePaths: file_paths` into the result object even when semantic analysis is
+incomplete, so every output shape reports what was attempted. Do not start a
+runtime session until every input has normalized successfully.
+
+- [ ] **Step 4: Run the diagnostics integration suite**
+
+```bash
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_diagnostics_smoke
+```
+
+Expected: all legacy completeness scenarios and new path scenarios pass.
+
+- [ ] **Step 5: Commit diagnostics behavior**
+
+```bash
+git add cli-rs/src/agent/dispatch.rs cli-rs/tests/agent_diagnostics_smoke.rs
+git diff --cached --check
+git commit -m "feat: accept relative diagnostic paths"
+```
+
+---
+
+### Task 3: Canonical File-Target Mutation Plans
+
+**Files:**
+- Modify: `cli-rs/src/agent/dispatch.rs`
+- Modify: `cli-rs/src/cli/agent.rs`
+- Modify: `cli-rs/tests/agent_command_surface_smoke.rs`
+
+**Interfaces:**
+- Consumes: Task 1 normalizer for add-file `file_path` and optional scoped-mutation `inside_file`.
+- Produces: canonical `params.filePath` and `params.placement.scope.insideFile` in read-only plans and applied requests.
+
+- [ ] **Step 1: Write failing plan tests**
+
+Create a temporary workspace, an external snippet payload, and relative target
+`src/generated/New File.kt`. Run add-file, add-declaration, and
+add-implementation without `--apply`, each with explicit `--workspace-root`.
+Assert the plan requests contain `workspace.join(target)` as canonical strings.
+Assert the external absolute `contentFile` remains unchanged. Add a separate
+test proving a relative target without `--workspace-root` returns
+`AGENT_RELATIVE_FILE_REQUIRES_WORKSPACE`.
+
+- [ ] **Step 2: Run the plan tests and verify red**
+
+```bash
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_command_surface_smoke relative_file
+```
+
+Expected: plan request fields still contain the relative input.
+
+- [ ] **Step 3: Normalize mutation targets before constructing plans**
+
+In `execute_agent_add_file`, normalize `args.file_path` and pass only its RPC
+string into `params.filePath`. In `execute_agent_scoped_mutation`, normalize
+`inside_file` when present before calling `scoped_placement_params`; leave
+named scopes unchanged. Convert any path error into the command's structured
+agent envelope before `execute_agent_mutation`.
+
+Update Clap help from “Absolute path” to “Absolute or workspace-root-relative
+path” for semantic target flags. Do not change content-file help or behavior.
+
+- [ ] **Step 4: Run command-surface and CLI core tests**
+
+```bash
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_command_surface_smoke --test cli_core_smoke
+```
+
+Expected: all plan and public-surface tests pass.
+
+- [ ] **Step 5: Commit mutation plan behavior**
+
+```bash
+git add cli-rs/src/agent/dispatch.rs cli-rs/src/cli/agent.rs cli-rs/tests/agent_command_surface_smoke.rs
+git diff --cached --check
+git commit -m "feat: canonicalize mutation file targets"
+```
+
+---
+
+### Task 4: Installed Guidance, Docs, and Full Proof
+
+**Files:**
+- Modify: `cli-rs/resources/kast-skill/SKILL.md`
+- Modify: `cli-rs/resources/kast-skill/references/quickstart.md`
+- Modify: `cli-rs/resources/kast-skill/references/runbook.md`
+- Modify: `cli-rs/resources/kast-skill/references/workflows.md`
+- Modify: `docs/reference/agent-commands.md`
+- Modify: `cli-rs/tests/packaged_content_smoke.rs`
+- Create: `.agent-turn/issue-341-report.md` (ignored evidence)
+
+**Interfaces:**
+- Consumes: Task 2 and Task 3 public behavior.
+- Produces: installed and published examples using `src/main/kotlin/App.kt` with explicit `--workspace-root "$PWD"`, plus final verification evidence.
+
+- [ ] **Step 1: Write failing packaged-guidance assertions**
+
+In `packaged_content_smoke.rs`, assert the installed skill and references
+contain:
+
+```text
+kast agent diagnostics --file-path src/main/kotlin/App.kt --workspace-root "$PWD"
+kast agent add-file --file-path src/main/kotlin/NewType.kt
+kast agent add-declaration --inside-file src/main/kotlin/App.kt
+```
+
+Also assert the semantic examples no longer require
+`$PWD/src/main/kotlin/App.kt` or `<absolute.kt>`.
+
+- [ ] **Step 2: Run packaged-content tests and verify red**
+
+```bash
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
+```
+
+Expected: relative guidance assertions fail against the current absolute-only examples.
+
+- [ ] **Step 3: Update authored guidance and published reference**
+
+Replace diagnostic semantic targets with workspace-relative paths whenever the
+same command already supplies `--workspace-root "$PWD"`. Change mutation target
+placeholders from `<absolute.kt>` to `<workspace-relative.kt>` and add one real
+relative add-file/declaration example. Keep payload `--content-file` examples
+unchanged. Update `docs/reference/agent-commands.md` with the same rule and
+state that output reports canonical absolute paths.
+
+- [ ] **Step 4: Run focused resource and contract checks**
+
+```bash
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+.github/scripts/test-docs-content-contract.sh
+```
+
+Expected: tests and checks exit zero with no stale generated output.
+
+- [ ] **Step 5: Run full verification**
+
+```bash
+cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
+cargo test --manifest-path cli-rs/Cargo.toml --locked
+cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
+.github/scripts/test-docs-content-contract.sh
+.github/scripts/test-docs-navigation-contract.sh
+git diff --check
+git status --short --branch
+```
+
+Expected: all commands exit zero and only the ignored evidence report is
+untracked. Remove generated `.kotlin/` if a Gradle/docs tool created it; do not
+remove unrelated files.
+
+- [ ] **Step 6: Record and commit the final slice**
+
+Write `.agent-turn/issue-341-report.md` with the isolated Kast failure,
+red-green evidence, commits, commands, counts, and remaining concerns. Then:
+
+```bash
+git add cli-rs/resources/kast-skill/SKILL.md \
+  cli-rs/resources/kast-skill/references/quickstart.md \
+  cli-rs/resources/kast-skill/references/runbook.md \
+  cli-rs/resources/kast-skill/references/workflows.md \
+  docs/reference/agent-commands.md \
+  cli-rs/tests/packaged_content_smoke.rs
+git diff --cached --check
+git commit -m "docs: teach relative agent file paths"
+```

--- a/.agents/superpowers/plans/2026-07-13-relative-agent-file-paths.md
+++ b/.agents/superpowers/plans/2026-07-13-relative-agent-file-paths.md
@@ -8,6 +8,9 @@
 
 **Tech Stack:** Rust 2024, Clap, serde/serde_json, `std::fs`, Cargo integration tests, Markdown contract checks.
 
+**Review hardening:** Kotlin/JVM 21, IDEA VFS/Document APIs, JNA-backed POSIX
+`openat`/`mkdirat`/`renameat`/`unlinkat`, JUnit Jupiter.
+
 ## Global Constraints
 
 - Relative semantic targets require explicit `--workspace-root`.
@@ -20,6 +23,30 @@
 - Preserve target order and existing absolute in-workspace behavior.
 - Do not run `kast setup` on macOS.
 - Work only on `feature/issue-341-relative-file-paths`; do not push.
+
+---
+
+### Task 5: Close the Write-Boundary Ancestor-Replacement Race
+
+**Files:**
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/UnsafeWorkspaceMutationException.kt`
+- Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutation.kt`
+- Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaEditApplier.kt`
+- Modify: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaEditApplicationTest.kt`
+- Modify: ADR 0018 and the approved design
+
+- [x] Reproduce the check-then-use gap by replacing a validated add-file
+  ancestor with an escaping symlink immediately before the write.
+- [x] Reproduce the same gap for an existing-file scoped mutation.
+- [x] Add a typed `UNSAFE_WORKSPACE_MUTATION` protocol failure.
+- [x] Traverse from the filesystem root with held directory descriptors and
+  no-follow semantics, then commit create/replace/delete relative to the held
+  parent descriptor.
+- [x] Refresh IDEA VFS/Documents without returning to pathname-based writes.
+- [x] Preserve existing source permissions and deterministic permissions for
+  newly created files/directories.
+- [x] Run the complete Kotlin, Rust, generated-contract, and docs gates and
+  record final evidence in `.agent-turn/issue-341-report.md`.
 
 ---
 

--- a/.agents/superpowers/specs/2026-07-13-relative-agent-file-paths-design.md
+++ b/.agents/superpowers/specs/2026-07-13-relative-agent-file-paths-design.md
@@ -1,0 +1,156 @@
+# Relative Agent File Paths Design
+
+Date: 2026-07-13
+
+Issue: [#341](https://github.com/amichne/kast/issues/341)
+
+Status: Approved for autonomous implementation
+
+## Objective
+
+Let typed agent commands accept repository-relative Kotlin target paths when
+the caller declares an explicit workspace root. Convert every accepted target
+to one canonical, workspace-contained absolute path before constructing any
+backend request or mutation plan.
+
+The defining regression is `kast agent diagnostics --workspace-root "$PWD"
+--file-path cli/src/main/kotlin/...`, which currently spends a semantic-check
+cycle only to have the backend reject the relative path as non-absolute.
+
+## Requirements
+
+1. Diagnostics `--file-path`, add-file `--file-path`, and mutation
+   `--inside-file` accept absolute paths or paths relative to an explicit
+   `--workspace-root`.
+2. Every semantic target becomes one canonical absolute path before JSON-RPC
+   request or mutation-plan construction.
+3. Canonical targets must remain contained by the canonical workspace root.
+4. Lexical escapes, symlink escapes, broken symlinks, unreadable path prefixes,
+   directories, special files, and extensions other than `.kt` or `.kts` fail
+   closed with a structured agent error before backend dispatch.
+5. Existing files and safe in-workspace symlinks resolve to their real paths.
+   A missing Kotlin leaf remains valid so diagnostics can refresh a deleted
+   file and add-file can plan a new target.
+6. Diagnostics output explicitly reports the canonical paths used for both
+   refresh and analysis. Mutation plans report canonical paths in their typed
+   request parameters.
+7. Multiple targets retain caller order, paths containing spaces remain one
+   argument, and existing absolute in-workspace paths remain compatible.
+8. Installed agent guidance prefers concise workspace-relative examples where
+   an explicit workspace root already establishes the base.
+
+## Considered Approaches
+
+### Normalize in every backend
+
+Each backend could join relative paths to its workspace. This duplicates
+security-sensitive behavior across IDEA and headless hosts, lets mutation plans
+display a different path than the path eventually used, and leaves CLI output
+unable to state the canonical target before dispatch.
+
+### Perform lexical normalization in the CLI
+
+The CLI could remove `.` and `..` segments without filesystem resolution. This
+is fast but does not detect symlink escapes or distinguish a missing Kotlin
+target from a directory or special file.
+
+### Parse once into typed canonical paths
+
+The selected approach adds a Rust agent-boundary parser that produces typed
+canonical workspace roots and Kotlin target paths. It resolves the deepest
+existing ancestor, checks the resolved target against the canonical workspace,
+and only then converts the trusted path to the RPC string used by every step.
+This centralizes the invariant, supports deleted targets, and makes request and
+output identity agree.
+
+## Path Contract
+
+The parser receives the declared `AgentRuntimeArgs` and one semantic target.
+It first resolves and canonicalizes the effective workspace root. Relative
+targets require `AgentRuntimeArgs.workspace_root` to be present; an inferred
+current workspace is insufficient because the caller has not declared the
+base. Absolute targets continue to work with either an explicit or inferred
+workspace, but their resolved path must be contained by that workspace.
+
+The parser lexically removes `.` and resolves `..` before touching the
+filesystem. A relative target that leaves the declared root is rejected. It
+then walks upward to the deepest existing path component and canonicalizes
+that prefix:
+
+- if the complete target exists, it must resolve to a regular `.kt` or `.kts`
+  file inside the canonical workspace;
+- if the leaf is missing, the deepest existing prefix must resolve to a
+  directory inside the workspace, and the normalized missing suffix is
+  appended to that canonical prefix;
+- if an existing or broken symlink cannot be resolved safely, or resolves
+  outside the workspace, the target is rejected;
+- if metadata cannot be read, the command fails instead of guessing.
+
+Safe symlinks that resolve within the workspace are accepted and the real
+target is reported. Missing `.kt` and `.kts` leaves are accepted because a
+deleted-file refresh and a new-file mutation are both meaningful typed
+operations. Missing paths with unsupported extensions are rejected before
+backend dispatch.
+
+## Command Surface
+
+The path parser applies to semantic target arguments:
+
+| Command | Target argument | Canonical request field |
+| --- | --- | --- |
+| `kast agent diagnostics` | repeatable `--file-path` | `filePaths[]` for refresh and diagnostics |
+| `kast agent add-file` | `--file-path` | `filePath` |
+| `kast agent add-declaration` | `--inside-file` | `placement.scope.insideFile` |
+| `kast agent add-implementation` | `--inside-file` | `placement.scope.insideFile` |
+
+`--file-hint` remains a compiler-identity refinement rather than a target path;
+canonicalizing it would destroy its current basename and partial-match
+semantics. `--content-file` remains a payload-source argument and is not a
+semantic workspace target. Scope-identity mutations and symbol identities do
+not change.
+
+Diagnostics adds command-level `filePaths` to `KAST_AGENT_COMMAND`. The list is
+the same canonical list used to build both backend steps, so JSON, TOON, and
+human rendering do not depend on a backend echo to identify the analyzed
+files. Existing semantic completeness evidence continues to validate backend
+file statuses against the canonical request paths.
+
+## Error Contract
+
+Path failures use structured agent envelopes and exit status one. Stable error
+codes distinguish missing explicit context, invalid workspace roots, lexical
+workspace escapes, unsafe symlink resolution, unsupported Kotlin target kinds,
+and unreadable filesystem state. Error details include the original input and
+the canonical workspace root when available. No backend session starts after a
+path-validation error.
+
+## Testing
+
+Unit tests at the Rust path boundary cover relative and absolute files, lexical
+escapes, safe and escaping symlinks, broken symlinks, deleted files, spaces,
+unsupported extensions, directories, and special filesystem errors that can be
+constructed portably.
+
+Fake-daemon integration tests prove that:
+
+- multiple relative diagnostics targets become ordered canonical request
+  paths in both refresh and diagnostics calls;
+- JSON, TOON, and human output expose the canonical paths;
+- a deleted relative `.kt` path still reaches workspace refresh and then fails
+  or succeeds according to typed backend completeness evidence;
+- invalid targets fail before any backend request;
+- existing absolute paths keep their prior request identity;
+- add-file and file-scoped mutation plans contain canonical target paths.
+
+Packaged-content tests pin the concise relative guidance. Final validation runs
+the locked Rust suite, formatting, Clippy with warnings denied, release
+contract checks, docs contracts, and diff hygiene.
+
+## Non-Goals
+
+- changing `--file-hint` resolution or exact symbol lookup;
+- constraining mutation `--content-file` payloads to the workspace;
+- changing backend absolute-path request contracts;
+- making diagnostics treat a deleted file as semantically analyzed;
+- resolving runtime/worktree readiness or backend attachment;
+- restoring raw or arbitrary JSON-RPC command surfaces.

--- a/.agents/superpowers/specs/2026-07-13-relative-agent-file-paths-design.md
+++ b/.agents/superpowers/specs/2026-07-13-relative-agent-file-paths-design.md
@@ -66,13 +66,39 @@ output identity agree.
 ### Revalidate pathname containment at the backend write seam
 
 Canonical CLI paths still cross a process boundary before the backend mutates
-the filesystem. An accepted ancestor can therefore be replaced by an escaping
-symlink after CLI parsing or server validation. The selected implementation
-repeats traversal at the final IDEA/headless mutation seam with POSIX directory
-descriptors: every path component is opened without following symlinks, and
-create, replace, and delete commit relative to the held parent descriptor.
-This is a separate write-boundary guarantee; it does not change request or
-rendered path identity.
+the filesystem. An accepted ancestor or final entry can therefore be replaced
+after CLI parsing or server validation. The selected implementation repeats
+traversal in the shared `backend-idea` mutation implementation with POSIX
+directory descriptors. The IDEA plugin uses that implementation directly;
+`backend-headless` exposes the same mutation capabilities through
+`KastIdeaBackendRuntime` and `KastPluginBackend`, so both hosts are in scope.
+Every path component is opened without following symlinks. Existing
+replace/delete
+targets are atomically detached to a randomized quarantine with macOS
+`renameatx_np(RENAME_EXCL)` or Linux `renameat2(RENAME_NOREPLACE)`, then hashed
+and inspected with `fstat` through the same held descriptor. The open is
+nonblocking and only a regular-file mode may proceed to hashing; FIFOs and
+devices fail closed. Prepared commits, restoration, and recovery never
+overwrite a concurrent final entry. Preparation/native commit failure restores
+the original before prepared cleanup. A late replacement of a deletion
+reservation is restored to the final name with no-replace and reported as a
+typed conflict rather than displaced as cleanup. Cleanup
+moves candidates behind randomized internal names and device/inode-checks them
+immediately before unlinking. Cleanup refusal retains a recovery path, and a
+replacement or deletion that already committed is reported as applied with
+that evidence. IDEA records the typed commit before any later Document/VFS
+work, hash validation, or post-write verification, so later failures retain
+the committed path in partial-apply evidence. This is a separate
+write-boundary guarantee; it does not change
+request or rendered path identity.
+
+The descriptor proves detached file identity; the held parent descriptor and
+no-replace operations govern namespace transitions. Because POSIX rename and
+unlink remain name-based, this protocol is not a directory lock or a general
+transaction against a process with write permission that deliberately races
+Kast's randomized internal names. Such authority is governed by directory
+permissions. Changes made after the operation returns are also outside the
+guarantee.
 
 ## Path Contract
 
@@ -157,8 +183,19 @@ IDEA backend tests deterministically replace a validated ancestor with an
 escaping symlink immediately before add-file creation and file-scoped text
 replacement. Both operations must return `UNSAFE_WORKSPACE_MUTATION` without
 touching either the outside target or the displaced in-workspace directory.
-The same suite proves normal creates, missing parent creation, VFS document
-synchronization, deletes, and existing source permissions remain intact.
+Separate post-detach tests create a concurrent final entry after the original
+inode has been hashed and `fstat`-inspected. Replacement and deletion must
+leave the concurrent entry untouched and either restore the validated inode or
+report its quarantine recovery path through typed `CONFLICT`. The same suite
+proves create never cleans a concurrent final entry by name, missing edit
+targets map to `NOT_FOUND`, original permissions come from the hashed inode,
+rollback restoration precedes fallible prepared cleanup, and committed
+cleanup failures retain deterministic recovery evidence without being
+reported as unapplied. Additional seams prove preparation/native-rename
+rollback, late deletion-reservation replacement, nonblocking FIFO rejection,
+and applied ledgers surviving post-commit create/delete/text and later hash
+failures. Normal create, VFS document synchronization, and delete behavior
+remain intact.
 
 Packaged-content tests pin the concise relative guidance. Final validation runs
 the locked Rust suite, formatting, Clippy with warnings denied, release

--- a/.agents/superpowers/specs/2026-07-13-relative-agent-file-paths-design.md
+++ b/.agents/superpowers/specs/2026-07-13-relative-agent-file-paths-design.md
@@ -63,6 +63,17 @@ and only then converts the trusted path to the RPC string used by every step.
 This centralizes the invariant, supports deleted targets, and makes request and
 output identity agree.
 
+### Revalidate pathname containment at the backend write seam
+
+Canonical CLI paths still cross a process boundary before the backend mutates
+the filesystem. An accepted ancestor can therefore be replaced by an escaping
+symlink after CLI parsing or server validation. The selected implementation
+repeats traversal at the final IDEA/headless mutation seam with POSIX directory
+descriptors: every path component is opened without following symlinks, and
+create, replace, and delete commit relative to the held parent descriptor.
+This is a separate write-boundary guarantee; it does not change request or
+rendered path identity.
+
 ## Path Contract
 
 The parser receives the declared `AgentRuntimeArgs` and one semantic target.
@@ -141,6 +152,13 @@ Fake-daemon integration tests prove that:
 - invalid targets fail before any backend request;
 - existing absolute paths keep their prior request identity;
 - add-file and file-scoped mutation plans contain canonical target paths.
+
+IDEA backend tests deterministically replace a validated ancestor with an
+escaping symlink immediately before add-file creation and file-scoped text
+replacement. Both operations must return `UNSAFE_WORKSPACE_MUTATION` without
+touching either the outside target or the displaced in-workspace directory.
+The same suite proves normal creates, missing parent creation, VFS document
+synchronization, deletes, and existing source permissions remain intact.
 
 Packaged-content tests pin the concise relative guidance. Final validation runs
 the locked Rust suite, formatting, Clippy with warnings denied, release

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/UnsafeWorkspaceMutationException.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/UnsafeWorkspaceMutationException.kt
@@ -1,0 +1,14 @@
+package io.github.amichne.kast.api.protocol
+
+/**
+ * A workspace mutation could not preserve its filesystem containment guarantee.
+ */
+class UnsafeWorkspaceMutationException(
+    message: String,
+    details: Map<String, String>,
+) : AnalysisException(
+    statusCode = 409,
+    errorCode = "UNSAFE_WORKSPACE_MUTATION",
+    message = message,
+    details = details,
+)

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaEditApplier.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaEditApplier.kt
@@ -25,7 +25,6 @@ import io.github.amichne.kast.api.validation.FileHashing
 import io.github.amichne.kast.api.validation.ValidatedFileEdits
 import io.github.amichne.kast.api.validation.ValidatedFileOperation
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 import java.nio.file.Path
 
 /**
@@ -42,6 +41,10 @@ internal class IdeaEditApplier(
     private val secureWorkspaceMutation: SecureWorkspaceMutation =
         SecureWorkspaceMutation(workspaceIdentity.canonicalWorkspaceRootPath),
     private val beforeSecureMutation: (Path, IdeaWorkspaceMutation) -> Unit = { _, _ -> },
+    private val afterFilesystemCommit: (Path, IdeaWorkspaceMutation) -> Unit = { _, _ -> },
+    private val runFileOperationWriteAction: suspend (() -> Unit) -> Unit = { operation ->
+        writeAction { operation() }
+    },
 ) {
     /**
      * Applies text edits and file operations through IDEA APIs.
@@ -105,45 +108,56 @@ internal class IdeaEditApplier(
 
         // Check hashes against current IDEA state
         validatedEdits.forEach { plan ->
-            val virtualFile = vfsManager.findFileByUrl("file://${plan.filePath}")
-                ?: throw NotFoundException(
-                    message = "The requested file does not exist",
-                    details = mapOf("filePath" to plan.filePath),
-                )
+            try {
+                val virtualFile = vfsManager.findFileByUrl("file://${plan.filePath}")
+                    ?: throw NotFoundException(
+                        message = "The requested file does not exist",
+                        details = mapOf("filePath" to plan.filePath),
+                    )
 
-            val currentContent = readAction {
-                val document = fileDocumentManager.getCachedDocument(virtualFile)
-                if (document != null) {
-                    document.text
-                } else {
-                    String(virtualFile.contentsToByteArray(), StandardCharsets.UTF_8)
+                val currentContent = readAction {
+                    val document = fileDocumentManager.getCachedDocument(virtualFile)
+                    if (document != null) {
+                        document.text
+                    } else {
+                        String(virtualFile.contentsToByteArray(), StandardCharsets.UTF_8)
+                    }
                 }
-            }
 
-            val currentHash = FileHashing.sha256(currentContent)
-            if (currentHash != plan.expectedHash) {
-                KastStructuredTrace.event(
-                    eventName = "idea.apply_edits.hash_conflict",
-                    project = project,
-                    workspaceRoot = normalizedWorkspaceRoot,
-                    fields = KastStructuredTraceFields(
-                        invocationId = invocationId,
-                        agentRole = "idea-edit-applier",
-                        targetFilePath = plan.filePath,
-                    ),
-                    outcome = "failed",
-                    detail = mapOf(
-                        "expectedHash" to plan.expectedHash,
-                        "actualHash" to currentHash,
-                    ),
-                )
-                throw ConflictException(
-                    message = "The file changed after the edit plan was created",
-                    details = mapOf(
-                        "filePath" to plan.filePath,
-                        "expectedHash" to plan.expectedHash,
-                        "actualHash" to currentHash,
-                    ),
+                val currentHash = FileHashing.sha256(currentContent)
+                if (currentHash != plan.expectedHash) {
+                    KastStructuredTrace.event(
+                        eventName = "idea.apply_edits.hash_conflict",
+                        project = project,
+                        workspaceRoot = normalizedWorkspaceRoot,
+                        fields = KastStructuredTraceFields(
+                            invocationId = invocationId,
+                            agentRole = "idea-edit-applier",
+                            targetFilePath = plan.filePath,
+                        ),
+                        outcome = "failed",
+                        detail = mapOf(
+                            "expectedHash" to plan.expectedHash,
+                            "actualHash" to currentHash,
+                        ),
+                    )
+                    throw ConflictException(
+                        message = "The file changed after the edit plan was created",
+                        details = mapOf(
+                            "filePath" to plan.filePath,
+                            "expectedHash" to plan.expectedHash,
+                            "actualHash" to currentHash,
+                        ),
+                    )
+                }
+            } catch (exception: Exception) {
+                if (affectedFiles.isEmpty()) throw exception
+                throw partialApplyFailure(
+                    failedFile = plan.filePath,
+                    appliedFiles = affectedFiles,
+                    createdFiles = createdFiles,
+                    deletedFiles = deletedFiles,
+                    exception = exception,
                 )
             }
         }
@@ -153,6 +167,7 @@ internal class IdeaEditApplier(
         val editAffectedFiles = mutableListOf<String>()
 
         validatedEdits.forEach { plan ->
+            var committedMutation: SecureWorkspaceMutationResult? = null
             try {
                 applyTextEdits(
                     plan,
@@ -161,11 +176,29 @@ internal class IdeaEditApplier(
                     psiDocumentManager,
                     invocationId,
                     normalizedWorkspaceRoot,
+                    onFilesystemCommitted = { mutationResult ->
+                        committedMutation = mutationResult
+                        editAffectedFiles += plan.filePath
+                        appliedEdits += plan.edits.sortedBy { it.startOffset }
+                        afterFilesystemCommit(
+                            Path.of(plan.filePath).toAbsolutePath().normalize(),
+                            IdeaWorkspaceMutation.TEXT_EDIT,
+                        )
+                    },
                 )
-                editAffectedFiles += plan.filePath
-                appliedEdits += plan.edits.sortedBy { it.startOffset }
+                checkNotNull(committedMutation).requireNoRecovery(
+                    committedFile = plan.filePath,
+                    appliedFiles = affectedFiles + editAffectedFiles,
+                    createdFiles = createdFiles,
+                    deletedFiles = deletedFiles,
+                )
             } catch (exception: Exception) {
-                if (exception is UnsafeWorkspaceMutationException && affectedFiles.isEmpty() && editAffectedFiles.isEmpty()) {
+                if (exception is PartialApplyException) throw exception
+                if (
+                    exception.isTypedSecureMutationFailure() &&
+                    affectedFiles.isEmpty() &&
+                    editAffectedFiles.isEmpty()
+                ) {
                     throw exception
                 }
                 KastStructuredTrace.event(
@@ -184,14 +217,13 @@ internal class IdeaEditApplier(
                     ),
                 )
                 throw PartialApplyException(
-                    details = mapOf(
-                        "failedFile" to plan.filePath,
-                        "appliedFiles" to (affectedFiles + editAffectedFiles).joinToString(","),
-                        "createdFiles" to createdFiles.joinToString(","),
-                        "deletedFiles" to deletedFiles.joinToString(","),
-                        "reason" to (exception.message ?: exception::class.java.simpleName),
-                        "exceptionClass" to (exception::class.qualifiedName ?: "Unknown"),
-                        "stackTrace" to exception.stackTraceToString().take(500),
+                    details = partialApplyDetails(
+                        failedFile = plan.filePath,
+                        appliedFiles = affectedFiles + editAffectedFiles,
+                        createdFiles = createdFiles,
+                        deletedFiles = deletedFiles,
+                        exception = exception,
+                        committedMutation = committedMutation,
                     ),
                 )
             }
@@ -231,6 +263,7 @@ internal class IdeaEditApplier(
         val deletedFiles = mutableListOf<String>()
 
         operations.forEach { operation ->
+            var committedMutation: SecureWorkspaceMutationResult? = null
             try {
                 when (operation) {
                     is ValidatedFileOperation.CreateFile -> {
@@ -244,11 +277,21 @@ internal class IdeaEditApplier(
                                 targetFilePath = operation.filePath,
                             ),
                         )
-                        writeAction {
+                        runFileOperationWriteAction {
                             val filePath = Path.of(operation.filePath).toAbsolutePath().normalize()
                             beforeSecureMutation(filePath, IdeaWorkspaceMutation.CREATE_FILE)
-                            secureWorkspaceMutation.createFile(filePath, operation.content)
+                            val mutationResult = secureWorkspaceMutation.createFile(filePath, operation.content)
+                            committedMutation = mutationResult
+                            createdFiles += operation.filePath
+                            affectedFiles += operation.filePath
+                            afterFilesystemCommit(filePath, IdeaWorkspaceMutation.CREATE_FILE)
                         }
+                        val mutationResult = checkNotNull(committedMutation)
+                        secureWorkspaceMutation.verifyCommittedFile(
+                            target = Path.of(operation.filePath).toAbsolutePath().normalize(),
+                            expectedContent = operation.content,
+                            mutation = IdeaWorkspaceMutation.CREATE_FILE,
+                        )
                         LocalFileSystem.getInstance().refreshAndFindFileByNioFile(Path.of(operation.filePath))
                             ?: throw ValidationException(
                                 message = "Kast IDEA could not refresh the securely created file",
@@ -262,7 +305,12 @@ internal class IdeaEditApplier(
                             invocationId = invocationId,
                             workspaceRoot = workspaceRoot,
                         )
-                        createdFiles += operation.filePath
+                        mutationResult.requireNoRecovery(
+                            committedFile = operation.filePath,
+                            appliedFiles = affectedFiles,
+                            createdFiles = createdFiles,
+                            deletedFiles = deletedFiles,
+                        )
                         KastStructuredTrace.event(
                             eventName = "idea.apply_edits.file_create_completed",
                             project = project,
@@ -287,11 +335,19 @@ internal class IdeaEditApplier(
                                 targetFilePath = operation.filePath,
                             ),
                         )
-                        writeAction {
+                        runFileOperationWriteAction {
                             val filePath = Path.of(operation.filePath).toAbsolutePath().normalize()
                             beforeSecureMutation(filePath, IdeaWorkspaceMutation.DELETE_FILE)
-                            secureWorkspaceMutation.deleteFile(filePath, operation.expectedHash)
+                            val mutationResult = secureWorkspaceMutation.deleteFile(filePath, operation.expectedHash)
+                            committedMutation = mutationResult
+                            deletedFiles += operation.filePath
+                            affectedFiles += operation.filePath
+                            afterFilesystemCommit(filePath, IdeaWorkspaceMutation.DELETE_FILE)
                         }
+                        val mutationResult = checkNotNull(committedMutation)
+                        secureWorkspaceMutation.verifyCommittedDeletion(
+                            Path.of(operation.filePath).toAbsolutePath().normalize(),
+                        )
                         LocalFileSystem.getInstance().refreshAndFindFileByNioFile(Path.of(operation.filePath))
                         verifyPostWrite(
                             filePath = operation.filePath,
@@ -301,7 +357,12 @@ internal class IdeaEditApplier(
                             invocationId = invocationId,
                             workspaceRoot = workspaceRoot,
                         )
-                        deletedFiles += operation.filePath
+                        mutationResult.requireNoRecovery(
+                            committedFile = operation.filePath,
+                            appliedFiles = affectedFiles,
+                            createdFiles = createdFiles,
+                            deletedFiles = deletedFiles,
+                        )
                         KastStructuredTrace.event(
                             eventName = "idea.apply_edits.file_delete_completed",
                             project = project,
@@ -315,9 +376,9 @@ internal class IdeaEditApplier(
                         )
                     }
                 }
-                affectedFiles += operation.filePath
             } catch (exception: Exception) {
-                if (exception is UnsafeWorkspaceMutationException && affectedFiles.isEmpty()) {
+                if (exception is PartialApplyException) throw exception
+                if (exception.isTypedSecureMutationFailure() && affectedFiles.isEmpty()) {
                     throw exception
                 }
                 KastStructuredTrace.event(
@@ -336,12 +397,13 @@ internal class IdeaEditApplier(
                     ),
                 )
                 throw PartialApplyException(
-                    details = mapOf(
-                        "failedFile" to operation.filePath,
-                        "appliedFiles" to affectedFiles.joinToString(","),
-                        "createdFiles" to createdFiles.joinToString(","),
-                        "deletedFiles" to deletedFiles.joinToString(","),
-                        "reason" to (exception.message ?: exception::class.java.simpleName),
+                    details = partialApplyDetails(
+                        failedFile = operation.filePath,
+                        appliedFiles = affectedFiles,
+                        createdFiles = createdFiles,
+                        deletedFiles = deletedFiles,
+                        exception = exception,
+                        committedMutation = committedMutation,
                     ),
                 )
             }
@@ -367,6 +429,70 @@ internal class IdeaEditApplier(
             requireWorkspaceTarget(workspaceIdentity, plan.filePath, IdeaWorkspaceMutation.TEXT_EDIT, invocationId)
         }
     }
+
+    private fun Exception.isTypedSecureMutationFailure(): Boolean =
+        this is UnsafeWorkspaceMutationException || this is ConflictException || this is NotFoundException
+
+    private fun SecureWorkspaceMutationResult.requireNoRecovery(
+        committedFile: String,
+        appliedFiles: List<String>,
+        createdFiles: List<String>,
+        deletedFiles: List<String>,
+    ) {
+        if (this !is SecureWorkspaceMutationResult.CommittedWithRecovery) return
+        throw PartialApplyException(
+            message = "The workspace mutation committed but retained recovery evidence",
+            details = mapOf(
+                "failedFile" to committedFile,
+                "appliedFiles" to appliedFiles.joinToString(","),
+                "createdFiles" to createdFiles.joinToString(","),
+                "deletedFiles" to deletedFiles.joinToString(","),
+                "recoveryFilePaths" to recoveryFilePaths.joinToString(","),
+                "reason" to "Committed filesystem mutation retained recovery entries",
+            ),
+        )
+    }
+
+    private fun partialApplyFailure(
+        failedFile: String,
+        appliedFiles: List<String>,
+        createdFiles: List<String>,
+        deletedFiles: List<String>,
+        exception: Exception,
+        committedMutation: SecureWorkspaceMutationResult? = null,
+    ): PartialApplyException = PartialApplyException(
+        details = partialApplyDetails(
+            failedFile = failedFile,
+            appliedFiles = appliedFiles,
+            createdFiles = createdFiles,
+            deletedFiles = deletedFiles,
+            exception = exception,
+            committedMutation = committedMutation,
+        ),
+    )
+
+    private fun partialApplyDetails(
+        failedFile: String,
+        appliedFiles: List<String>,
+        createdFiles: List<String>,
+        deletedFiles: List<String>,
+        exception: Exception,
+        committedMutation: SecureWorkspaceMutationResult? = null,
+    ): Map<String, String> = mapOf(
+        "failedFile" to failedFile,
+        "appliedFiles" to appliedFiles.joinToString(","),
+        "createdFiles" to createdFiles.joinToString(","),
+        "deletedFiles" to deletedFiles.joinToString(","),
+        "reason" to (exception.message ?: exception::class.java.simpleName),
+        "exceptionClass" to (exception::class.qualifiedName ?: "Unknown"),
+    ) + committedMutation.recoveryDetails()
+
+    private fun SecureWorkspaceMutationResult?.recoveryDetails(): Map<String, String> =
+        if (this is SecureWorkspaceMutationResult.CommittedWithRecovery) {
+            mapOf("recoveryFilePaths" to recoveryFilePaths.joinToString(","))
+        } else {
+            emptyMap()
+        }
 
     private suspend fun <T> withVcsFileOperationConfirmationsSuppressed(
         fileOperations: List<ValidatedFileOperation>,
@@ -444,6 +570,7 @@ internal class IdeaEditApplier(
         psiDocumentManager: PsiDocumentManager,
         invocationId: String,
         workspaceRoot: Path,
+        onFilesystemCommitted: (SecureWorkspaceMutationResult) -> Unit,
     ) {
         KastStructuredTrace.event(
             eventName = "idea.apply_edits.text_edit_started",
@@ -484,7 +611,13 @@ internal class IdeaEditApplier(
         WriteCommandAction.runWriteCommandAction(project) {
             val filePath = Path.of(plan.filePath).toAbsolutePath().normalize()
             beforeSecureMutation(filePath, IdeaWorkspaceMutation.TEXT_EDIT)
-            secureWorkspaceMutation.replaceFile(filePath, diskHash, updatedContent)
+            val mutationResult = secureWorkspaceMutation.replaceFile(filePath, diskHash, updatedContent)
+            onFilesystemCommitted(mutationResult)
+            secureWorkspaceMutation.verifyCommittedFile(
+                target = filePath,
+                expectedContent = updatedContent,
+                mutation = IdeaWorkspaceMutation.TEXT_EDIT,
+            )
             plan.edits.forEach { edit ->
                 document.replaceString(edit.startOffset, edit.endOffset, edit.newText)
             }
@@ -523,8 +656,7 @@ internal class IdeaEditApplier(
     ) {
         val path = Path.of(filePath).toAbsolutePath().normalize()
         val workspaceFile = workspaceIdentity.workspaceIdentity.contains(path)
-        val diskExists = Files.exists(path)
-        if (!workspaceFile || diskExists != expectedExists) {
+        if (!workspaceFile) {
             throw ValidationException(
                 message = "Kast IDEA post-write verification failed",
                 details = mapOf(
@@ -532,24 +664,10 @@ internal class IdeaEditApplier(
                     "mutation" to mutation.wireName,
                     "workspaceContained" to workspaceFile.toString(),
                     "expectedExists" to expectedExists.toString(),
-                    "diskExists" to diskExists.toString(),
                 ) + workspaceIdentity.stringTraceDetails(),
             )
         }
-        if (expectedExists && expectedContent != null) {
-            val diskContent = Files.readString(path)
-            if (diskContent != expectedContent) {
-                throw ConflictException(
-                    message = "Kast IDEA post-write content verification failed",
-                    details = mapOf(
-                        "filePath" to filePath,
-                        "mutation" to mutation.wireName,
-                        "expectedHash" to FileHashing.sha256(expectedContent),
-                        "actualHash" to FileHashing.sha256(diskContent),
-                    ),
-                )
-            }
-        }
+        val diskExists = expectedExists
 
         val refreshedFile = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(path)
         val vfsExists = refreshedFile?.isValid == true

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaEditApplier.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaEditApplier.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.vcs.ProjectLevelVcsManager
 import com.intellij.openapi.vcs.VcsConfiguration
 import com.intellij.openapi.vcs.VcsShowConfirmationOption
 import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiManager
@@ -19,6 +18,7 @@ import io.github.amichne.kast.api.contract.TextEdit
 import io.github.amichne.kast.api.protocol.ConflictException
 import io.github.amichne.kast.api.protocol.NotFoundException
 import io.github.amichne.kast.api.protocol.PartialApplyException
+import io.github.amichne.kast.api.protocol.UnsafeWorkspaceMutationException
 import io.github.amichne.kast.api.protocol.ValidationException
 import io.github.amichne.kast.api.validation.EditPlanValidator
 import io.github.amichne.kast.api.validation.FileHashing
@@ -29,24 +29,28 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 /**
- * Applies edits using IDEA's VFS, Document, and WriteCommandAction APIs.
+ * Applies edits using descriptor-relative filesystem writes plus IDEA's
+ * Document and WriteCommandAction APIs.
  *
- * Preserves IDEA's undo/redo, PSI synchronization, and VFS notification semantics.
- * All mutations happen through proper IDEA APIs with write actions.
+ * Preserves IDEA's undo/redo, PSI synchronization, and VFS notification
+ * semantics while preventing pathname replacement from escaping the workspace.
  */
 internal class IdeaEditApplier(
     private val project: Project,
     private val workspaceRoot: Path,
     private val workspaceIdentity: IdeaWorkspaceIdentity = IdeaWorkspaceIdentity.fromProject(project, workspaceRoot),
+    private val secureWorkspaceMutation: SecureWorkspaceMutation =
+        SecureWorkspaceMutation(workspaceIdentity.canonicalWorkspaceRootPath),
+    private val beforeSecureMutation: (Path, IdeaWorkspaceMutation) -> Unit = { _, _ -> },
 ) {
     /**
      * Applies text edits and file operations through IDEA APIs.
      *
      * Workflow:
      * 1. Validate operations against current VFS state
-     * 2. Apply file operations (create/delete) through VFS
-     * 3. Apply text edits through Document API with WriteCommandAction
-     * 4. Commit and save documents
+     * 2. Apply file operations relative to held workspace directory descriptors
+     * 3. Apply text edits through the same secure boundary and an IDEA command
+     * 4. Refresh VFS state and commit documents
      *
      * @param query The edit query with edits, hashes, and file operations
      * @return Result with applied edits and affected files
@@ -161,6 +165,9 @@ internal class IdeaEditApplier(
                 editAffectedFiles += plan.filePath
                 appliedEdits += plan.edits.sortedBy { it.startOffset }
             } catch (exception: Exception) {
+                if (exception is UnsafeWorkspaceMutationException && affectedFiles.isEmpty() && editAffectedFiles.isEmpty()) {
+                    throw exception
+                }
                 KastStructuredTrace.event(
                     eventName = "idea.apply_edits.text_edit_failed",
                     project = project,
@@ -239,24 +246,14 @@ internal class IdeaEditApplier(
                         )
                         writeAction {
                             val filePath = Path.of(operation.filePath).toAbsolutePath().normalize()
-                            val parentPath = checkNotNull(filePath.parent) {
-                                "Create file target has no parent directory: ${operation.filePath}"
-                            }
-                            val fileName = checkNotNull(filePath.fileName) {
-                                "Create file target has no file name: ${operation.filePath}"
-                            }.toString()
-                            val parentFile = VfsUtil.createDirectories(parentPath.toString())
-
-                            if (parentFile.findChild(fileName) != null) {
-                                throw ConflictException(
-                                    message = "The requested file already exists",
-                                    details = mapOf("filePath" to operation.filePath),
-                                )
-                            }
-
-                            val newFile = parentFile.createChildData(this, fileName)
-                            newFile.setBinaryContent(operation.content.toByteArray(StandardCharsets.UTF_8))
+                            beforeSecureMutation(filePath, IdeaWorkspaceMutation.CREATE_FILE)
+                            secureWorkspaceMutation.createFile(filePath, operation.content)
                         }
+                        LocalFileSystem.getInstance().refreshAndFindFileByNioFile(Path.of(operation.filePath))
+                            ?: throw ValidationException(
+                                message = "Kast IDEA could not refresh the securely created file",
+                                details = mapOf("filePath" to operation.filePath),
+                            )
                         verifyPostWrite(
                             filePath = operation.filePath,
                             mutation = IdeaWorkspaceMutation.CREATE_FILE,
@@ -290,46 +287,12 @@ internal class IdeaEditApplier(
                                 targetFilePath = operation.filePath,
                             ),
                         )
-                        val virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(Path.of(operation.filePath))
-                            ?: throw NotFoundException(
-                                message = "The requested file does not exist",
-                                details = mapOf("filePath" to operation.filePath),
-                            )
-
-                        val currentContent = readAction {
-                            String(virtualFile.contentsToByteArray(), StandardCharsets.UTF_8)
-                        }
-                        val currentHash = FileHashing.sha256(currentContent)
-
-                        if (currentHash != operation.expectedHash) {
-                            KastStructuredTrace.event(
-                                eventName = "idea.apply_edits.file_delete_hash_conflict",
-                                project = project,
-                                workspaceRoot = workspaceRoot,
-                                fields = KastStructuredTraceFields(
-                                    invocationId = invocationId,
-                                    agentRole = "idea-edit-applier",
-                                    targetFilePath = operation.filePath,
-                                ),
-                                outcome = "failed",
-                                detail = mapOf(
-                                    "expectedHash" to operation.expectedHash,
-                                    "actualHash" to currentHash,
-                                ),
-                            )
-                            throw ConflictException(
-                                message = "The file changed after the delete plan was created",
-                                details = mapOf(
-                                    "filePath" to operation.filePath,
-                                    "expectedHash" to operation.expectedHash,
-                                    "actualHash" to currentHash,
-                                ),
-                            )
-                        }
-
                         writeAction {
-                            virtualFile.delete(this)
+                            val filePath = Path.of(operation.filePath).toAbsolutePath().normalize()
+                            beforeSecureMutation(filePath, IdeaWorkspaceMutation.DELETE_FILE)
+                            secureWorkspaceMutation.deleteFile(filePath, operation.expectedHash)
                         }
+                        LocalFileSystem.getInstance().refreshAndFindFileByNioFile(Path.of(operation.filePath))
                         verifyPostWrite(
                             filePath = operation.filePath,
                             mutation = IdeaWorkspaceMutation.DELETE_FILE,
@@ -354,6 +317,9 @@ internal class IdeaEditApplier(
                 }
                 affectedFiles += operation.filePath
             } catch (exception: Exception) {
+                if (exception is UnsafeWorkspaceMutationException && affectedFiles.isEmpty()) {
+                    throw exception
+                }
                 KastStructuredTrace.event(
                     eventName = "idea.apply_edits.file_operation_failed",
                     project = project,
@@ -502,17 +468,29 @@ internal class IdeaEditApplier(
             fileDocumentManager.getDocument(virtualFile)
         } ?: throw IllegalStateException("Cannot get Document for file: ${plan.filePath}")
 
-        // Apply edits in WriteCommandAction (required for Document modifications)
+        val diskHash = readAction {
+            FileHashing.sha256(String(virtualFile.contentsToByteArray(), StandardCharsets.UTF_8))
+        }
+        val updatedContent = readAction {
+            StringBuilder(document.text).apply {
+                plan.edits.forEach { edit ->
+                    replace(edit.startOffset, edit.endOffset, edit.newText)
+                }
+            }.toString()
+        }
+
+        // Keep the IDEA command boundary, but make the disk write relative to a
+        // held directory descriptor so a replaced ancestor cannot redirect it.
         WriteCommandAction.runWriteCommandAction(project) {
-            // Validated edits are already sorted descending by start offset, so offsets remain stable as replacements are applied.
+            val filePath = Path.of(plan.filePath).toAbsolutePath().normalize()
+            beforeSecureMutation(filePath, IdeaWorkspaceMutation.TEXT_EDIT)
+            secureWorkspaceMutation.replaceFile(filePath, diskHash, updatedContent)
             plan.edits.forEach { edit ->
                 document.replaceString(edit.startOffset, edit.endOffset, edit.newText)
             }
-
             psiDocumentManager.commitDocument(document)
-
-            // Save to VFS
-            fileDocumentManager.saveDocument(document)
+            virtualFile.refresh(false, false)
+            fileDocumentManager.reloadFromDisk(document)
         }
         verifyPostWrite(
             filePath = plan.filePath,

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutation.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutation.kt
@@ -274,7 +274,7 @@ internal class SecureWorkspaceMutation(
                         )
                     },
                 )
-                reservation.use {
+                val reservationRelease = reservation.use {
                     val commitOutcome = try {
                         beforeFinalCommit(normalizedTarget, IdeaWorkspaceMutation.DELETE_FILE)
                         renameNoReplace(
@@ -322,18 +322,18 @@ internal class SecureWorkspaceMutation(
                             platform = platform,
                         )
                     }
+
+                    afterDeleteReservationCommitted(normalizedTarget)
+
+                    releaseFinalReservation(
+                        parent = parent,
+                        fileName = fileName,
+                        reservation = reservation,
+                        target = normalizedTarget,
+                        api = api,
+                        platform = platform,
+                    )
                 }
-
-                afterDeleteReservationCommitted(normalizedTarget)
-
-                val reservationRelease = releaseFinalReservation(
-                    parent = parent,
-                    fileName = fileName,
-                    reservation = reservation,
-                    target = normalizedTarget,
-                    api = api,
-                    platform = platform,
-                )
                 val reservationCleanup = when (reservationRelease) {
                     is FinalReservationRelease.Released -> reservationRelease.cleanup
                     is FinalReservationRelease.Blocked -> {

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutation.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutation.kt
@@ -1,0 +1,453 @@
+package io.github.amichne.kast.idea
+
+import com.sun.jna.Library
+import com.sun.jna.Memory
+import com.sun.jna.Native
+import com.sun.jna.NativeLong
+import com.sun.jna.Platform
+import io.github.amichne.kast.api.protocol.ConflictException
+import io.github.amichne.kast.api.protocol.NotFoundException
+import io.github.amichne.kast.api.protocol.UnsafeWorkspaceMutationException
+import io.github.amichne.kast.api.validation.FileHashing
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.util.UUID
+
+/**
+ * Performs workspace mutations relative to held POSIX directory descriptors.
+ *
+ * The walk starts at the filesystem root and refuses symlinks for every
+ * component. Once a directory is open, later symlink replacement cannot
+ * redirect resolution away from that held directory identity.
+ */
+internal class SecureWorkspaceMutation(
+    workspaceRoot: Path,
+) {
+    private val normalizedWorkspaceRoot = workspaceRoot.toAbsolutePath().normalize()
+
+    fun createFile(target: Path, content: String) {
+        val normalizedTarget = requireWorkspaceTarget(target, IdeaWorkspaceMutation.CREATE_FILE)
+        withParentDescriptor(normalizedTarget, createParents = true) { parent, fileName, api, platform ->
+            val descriptor = api.openat(
+                parent.value,
+                fileName,
+                platform.createExclusiveFileFlags,
+                FILE_MODE,
+            )
+            if (descriptor < 0) {
+                val errno = Native.getLastError()
+                if (errno == platform.alreadyExistsErrno) {
+                    throw ConflictException(
+                        message = "The requested file already exists",
+                        details = mapOf("filePath" to normalizedTarget.toString()),
+                    )
+                }
+                throw nativeFailure("openat-create", normalizedTarget, fileName, errno)
+            }
+
+            NativeDescriptor(api, descriptor).use { file ->
+                try {
+                    requireSuccess(api.fchmod(file.value, CREATED_FILE_MODE), "fchmod-create", normalizedTarget, fileName)
+                    writeFully(api, file.value, content.toByteArray(StandardCharsets.UTF_8), normalizedTarget)
+                    requireSuccess(api.fsync(file.value), "fsync", normalizedTarget, fileName)
+                } catch (exception: Exception) {
+                    api.unlinkat(parent.value, fileName, 0)
+                    throw exception
+                }
+            }
+        }
+    }
+
+    fun replaceFile(target: Path, expectedDiskHash: String, content: String) {
+        val normalizedTarget = requireWorkspaceTarget(target, IdeaWorkspaceMutation.TEXT_EDIT)
+        val currentMode = targetMode(normalizedTarget)
+        withParentDescriptor(normalizedTarget, createParents = false) { parent, fileName, api, platform ->
+            val currentDescriptor = api.openat(parent.value, fileName, platform.readFileFlags, 0)
+            if (currentDescriptor < 0) {
+                val errno = Native.getLastError()
+                if (errno == platform.notFoundErrno) {
+                    throw NotFoundException(
+                        message = "The requested file does not exist",
+                        details = mapOf("filePath" to normalizedTarget.toString()),
+                    )
+                }
+                throw nativeFailure("openat-read", normalizedTarget, fileName, errno)
+            }
+            val currentContent = NativeDescriptor(api, currentDescriptor).use { file ->
+                readFully(api, file.value, normalizedTarget)
+            }
+            val actualDiskHash = FileHashing.sha256(currentContent)
+            if (actualDiskHash != expectedDiskHash) {
+                throw ConflictException(
+                    message = "The file changed at the secure write boundary",
+                    details = mapOf(
+                        "filePath" to normalizedTarget.toString(),
+                        "expectedHash" to expectedDiskHash,
+                        "actualHash" to actualDiskHash,
+                    ),
+                )
+            }
+
+            val temporaryName = ".kast-secure-${UUID.randomUUID()}.tmp"
+            val temporaryDescriptor = api.openat(
+                parent.value,
+                temporaryName,
+                platform.createExclusiveFileFlags,
+                FILE_MODE,
+            )
+            if (temporaryDescriptor < 0) {
+                throw nativeFailure(
+                    "openat-temporary",
+                    normalizedTarget,
+                    temporaryName,
+                    Native.getLastError(),
+                )
+            }
+
+            try {
+                NativeDescriptor(api, temporaryDescriptor).use { temporary ->
+                    requireSuccess(
+                        api.fchmod(temporary.value, currentMode),
+                        "fchmod-temporary",
+                        normalizedTarget,
+                        temporaryName,
+                    )
+                    writeFully(api, temporary.value, content.toByteArray(StandardCharsets.UTF_8), normalizedTarget)
+                    requireSuccess(api.fsync(temporary.value), "fsync-temporary", normalizedTarget, temporaryName)
+                }
+                requireSuccess(
+                    api.renameat(parent.value, temporaryName, parent.value, fileName),
+                    "renameat",
+                    normalizedTarget,
+                    fileName,
+                )
+            } finally {
+                api.unlinkat(parent.value, temporaryName, 0)
+            }
+        }
+    }
+
+    fun deleteFile(target: Path, expectedDiskHash: String) {
+        val normalizedTarget = requireWorkspaceTarget(target, IdeaWorkspaceMutation.DELETE_FILE)
+        withParentDescriptor(normalizedTarget, createParents = false) { parent, fileName, api, platform ->
+            val currentDescriptor = api.openat(parent.value, fileName, platform.readFileFlags, 0)
+            if (currentDescriptor < 0) {
+                val errno = Native.getLastError()
+                if (errno == platform.notFoundErrno) {
+                    throw NotFoundException(
+                        message = "The requested file does not exist",
+                        details = mapOf("filePath" to normalizedTarget.toString()),
+                    )
+                }
+                throw nativeFailure("openat-delete", normalizedTarget, fileName, errno)
+            }
+            val currentContent = NativeDescriptor(api, currentDescriptor).use { file ->
+                readFully(api, file.value, normalizedTarget)
+            }
+            val actualDiskHash = FileHashing.sha256(currentContent)
+            if (actualDiskHash != expectedDiskHash) {
+                throw ConflictException(
+                    message = "The file changed after the delete plan was created",
+                    details = mapOf(
+                        "filePath" to normalizedTarget.toString(),
+                        "expectedHash" to expectedDiskHash,
+                        "actualHash" to actualDiskHash,
+                    ),
+                )
+            }
+            requireSuccess(
+                api.unlinkat(parent.value, fileName, 0),
+                "unlinkat",
+                normalizedTarget,
+                fileName,
+            )
+        }
+    }
+
+    private fun <T> withParentDescriptor(
+        target: Path,
+        createParents: Boolean,
+        action: (NativeDescriptor, String, PosixFileApi, PosixPlatform) -> T,
+    ): T {
+        val platform = PosixPlatform.current()
+            ?: throw unsupportedPlatform(target)
+        val api = loadApi(target)
+        val filesystemRoot = checkNotNull(normalizedWorkspaceRoot.root) {
+            "Absolute workspace root must have a filesystem root"
+        }
+        val rootDescriptor = api.open(filesystemRoot.toString(), platform.directoryFlags, 0)
+        if (rootDescriptor < 0) {
+            throw nativeFailure("open-root", target, filesystemRoot.toString(), Native.getLastError())
+        }
+
+        return NativeDescriptor(api, rootDescriptor).use { root ->
+            var current = root
+            val opened = mutableListOf<NativeDescriptor>()
+            try {
+                val workspaceComponents = filesystemRoot.relativize(normalizedWorkspaceRoot).map(Path::toString)
+                workspaceComponents.forEach { component ->
+                    val next = openDirectory(api, platform, current, component, target, create = false)
+                    opened += next
+                    current = next
+                }
+
+                val relativeTarget = normalizedWorkspaceRoot.relativize(target)
+                val targetComponents = relativeTarget.map(Path::toString).toList()
+                targetComponents.dropLast(1).forEach { component ->
+                    val next = openDirectory(api, platform, current, component, target, createParents)
+                    opened += next
+                    current = next
+                }
+                action(current, targetComponents.last(), api, platform)
+            } finally {
+                opened.asReversed().forEach(NativeDescriptor::close)
+            }
+        }
+    }
+
+    private fun openDirectory(
+        api: PosixFileApi,
+        platform: PosixPlatform,
+        parent: NativeDescriptor,
+        component: String,
+        target: Path,
+        create: Boolean,
+    ): NativeDescriptor {
+        var descriptor = api.openat(parent.value, component, platform.directoryFlags, 0)
+        if (descriptor >= 0) {
+            return NativeDescriptor(api, descriptor)
+        }
+        var errno = Native.getLastError()
+        var createdDirectory = false
+        if (create && errno == platform.notFoundErrno) {
+            val mkdirResult = api.mkdirat(parent.value, component, DIRECTORY_MODE)
+            val mkdirErrno = Native.getLastError()
+            if (mkdirResult < 0 && mkdirErrno != platform.alreadyExistsErrno) {
+                throw nativeFailure("mkdirat", target, component, mkdirErrno)
+            }
+            createdDirectory = mkdirResult == 0
+            descriptor = api.openat(parent.value, component, platform.directoryFlags, 0)
+            errno = Native.getLastError()
+            if (descriptor >= 0 && createdDirectory && api.fchmod(descriptor, CREATED_DIRECTORY_MODE) < 0) {
+                val chmodErrno = Native.getLastError()
+                api.close(descriptor)
+                throw nativeFailure("fchmod-directory", target, component, chmodErrno)
+            }
+        }
+        if (descriptor < 0) {
+            throw nativeFailure("openat-directory", target, component, errno)
+        }
+        return NativeDescriptor(api, descriptor)
+    }
+
+    private fun requireWorkspaceTarget(target: Path, mutation: IdeaWorkspaceMutation): Path {
+        val normalizedTarget = target.toAbsolutePath().normalize()
+        if (normalizedTarget == normalizedWorkspaceRoot || !normalizedTarget.startsWith(normalizedWorkspaceRoot)) {
+            throw UnsafeWorkspaceMutationException(
+                message = "Secure mutation target is outside the active workspace",
+                details = failureDetails(normalizedTarget, mutation.wireName),
+            )
+        }
+        return normalizedTarget
+    }
+
+    private fun writeFully(api: PosixFileApi, descriptor: Int, bytes: ByteArray, target: Path) {
+        if (bytes.isEmpty()) return
+        val memory = Memory(bytes.size.toLong())
+        memory.write(0, bytes, 0, bytes.size)
+        var offset = 0L
+        while (offset < bytes.size) {
+            val written = api.write(descriptor, memory.share(offset), NativeLong(bytes.size - offset))
+            if (written.toLong() <= 0) {
+                throw nativeFailure("write", target, target.fileName.toString(), Native.getLastError())
+            }
+            offset += written.toLong()
+        }
+    }
+
+    private fun readFully(api: PosixFileApi, descriptor: Int, target: Path): String {
+        val output = ByteArrayOutputStream()
+        val buffer = Memory(BUFFER_SIZE.toLong())
+        while (true) {
+            val read = api.read(descriptor, buffer, NativeLong(BUFFER_SIZE.toLong())).toLong()
+            if (read == 0L) break
+            if (read < 0L) {
+                throw nativeFailure("read", target, target.fileName.toString(), Native.getLastError())
+            }
+            output.write(buffer.getByteArray(0, read.toInt()))
+        }
+        return output.toString(StandardCharsets.UTF_8)
+    }
+
+    private fun targetMode(target: Path): Int {
+        val permissions = try {
+            Files.getPosixFilePermissions(target, LinkOption.NOFOLLOW_LINKS)
+        } catch (exception: Exception) {
+            throw UnsafeWorkspaceMutationException(
+                message = "Secure workspace mutation could not preserve target permissions",
+                details = failureDetails(target, "read-target-permissions") + mapOf(
+                    "cause" to (exception.message ?: exception::class.java.simpleName),
+                ),
+            )
+        }
+        return permissions.fold(0) { mode, permission ->
+            mode or permission.modeBit
+        }
+    }
+
+    private val PosixFilePermission.modeBit: Int
+        get() = when (this) {
+            PosixFilePermission.OWNER_READ -> 256
+            PosixFilePermission.OWNER_WRITE -> 128
+            PosixFilePermission.OWNER_EXECUTE -> 64
+            PosixFilePermission.GROUP_READ -> 32
+            PosixFilePermission.GROUP_WRITE -> 16
+            PosixFilePermission.GROUP_EXECUTE -> 8
+            PosixFilePermission.OTHERS_READ -> 4
+            PosixFilePermission.OTHERS_WRITE -> 2
+            PosixFilePermission.OTHERS_EXECUTE -> 1
+        }
+
+    private fun requireSuccess(result: Int, operation: String, target: Path, component: String) {
+        if (result < 0) {
+            throw nativeFailure(operation, target, component, Native.getLastError())
+        }
+    }
+
+    private fun loadApi(target: Path): PosixFileApi = try {
+        api
+    } catch (exception: LinkageError) {
+        throw UnsafeWorkspaceMutationException(
+            message = "Secure workspace mutation primitives are unavailable",
+            details = failureDetails(target, "native-load") + mapOf(
+                "cause" to (exception.message ?: exception::class.java.simpleName),
+            ),
+        )
+    }
+
+    private fun unsupportedPlatform(target: Path): UnsafeWorkspaceMutationException =
+        UnsafeWorkspaceMutationException(
+            message = "Secure workspace mutations require a supported POSIX runtime",
+            details = failureDetails(target, "unsupported-platform") + mapOf(
+                "operatingSystem" to System.getProperty("os.name", "unknown"),
+            ),
+        )
+
+    private fun nativeFailure(
+        operation: String,
+        target: Path,
+        component: String,
+        errno: Int,
+    ): UnsafeWorkspaceMutationException = UnsafeWorkspaceMutationException(
+        message = "Secure workspace mutation refused an unsafe filesystem path",
+        details = failureDetails(target, operation) + mapOf(
+            "pathComponent" to component,
+            "errno" to errno.toString(),
+        ),
+    )
+
+    private fun failureDetails(target: Path, operation: String): Map<String, String> = mapOf(
+        "filePath" to target.toString(),
+        "workspaceRoot" to normalizedWorkspaceRoot.toString(),
+        "nativeOperation" to operation,
+    )
+
+    private class NativeDescriptor(
+        private val api: PosixFileApi,
+        val value: Int,
+    ) : AutoCloseable {
+        private var open = true
+
+        override fun close() {
+            if (open) {
+                open = false
+                api.close(value)
+            }
+        }
+    }
+
+    private interface PosixFileApi : Library {
+        fun open(path: String, flags: Int, mode: Int): Int
+
+        fun openat(directoryDescriptor: Int, path: String, flags: Int, mode: Int): Int
+
+        fun mkdirat(directoryDescriptor: Int, path: String, mode: Int): Int
+
+        fun unlinkat(directoryDescriptor: Int, path: String, flags: Int): Int
+
+        fun renameat(
+            oldDirectoryDescriptor: Int,
+            oldPath: String,
+            newDirectoryDescriptor: Int,
+            newPath: String,
+        ): Int
+
+        fun read(descriptor: Int, buffer: com.sun.jna.Pointer, count: NativeLong): NativeLong
+
+        fun write(descriptor: Int, buffer: com.sun.jna.Pointer, count: NativeLong): NativeLong
+
+        fun fsync(descriptor: Int): Int
+
+        fun fchmod(descriptor: Int, mode: Int): Int
+
+        fun close(descriptor: Int): Int
+    }
+
+    private data class PosixPlatform(
+        val directoryFlags: Int,
+        val readFileFlags: Int,
+        val createExclusiveFileFlags: Int,
+        val notFoundErrno: Int = 2,
+        val alreadyExistsErrno: Int = 17,
+    ) {
+        companion object {
+            fun current(): PosixPlatform? = when {
+                Platform.isMac() -> PosixPlatform(
+                    directoryFlags = MAC_OPEN_DIRECTORY or MAC_OPEN_NOFOLLOW or MAC_OPEN_CLOEXEC,
+                    readFileFlags = MAC_OPEN_NOFOLLOW or MAC_OPEN_CLOEXEC,
+                    createExclusiveFileFlags = MAC_OPEN_WRITE_ONLY or MAC_OPEN_CREATE or MAC_OPEN_EXCLUSIVE or
+                        MAC_OPEN_NOFOLLOW or MAC_OPEN_CLOEXEC,
+                )
+
+                Platform.isLinux() -> PosixPlatform(
+                    directoryFlags = LINUX_OPEN_DIRECTORY or LINUX_OPEN_NOFOLLOW or LINUX_OPEN_CLOEXEC,
+                    readFileFlags = LINUX_OPEN_NOFOLLOW or LINUX_OPEN_CLOEXEC,
+                    createExclusiveFileFlags = LINUX_OPEN_WRITE_ONLY or LINUX_OPEN_CREATE or LINUX_OPEN_EXCLUSIVE or
+                        LINUX_OPEN_NOFOLLOW or LINUX_OPEN_CLOEXEC,
+                )
+
+                else -> null
+            }
+        }
+    }
+
+    private companion object {
+        const val FILE_MODE = 438 // 0666; the process umask still applies.
+        const val DIRECTORY_MODE = 511 // 0777; the process umask still applies.
+        const val CREATED_FILE_MODE = 420 // 0644; deterministic IDEA-compatible source permissions.
+        const val CREATED_DIRECTORY_MODE = 493 // 0755; deterministic IDEA-compatible directory permissions.
+        const val BUFFER_SIZE = 8192
+
+        const val MAC_OPEN_WRITE_ONLY = 0x0001
+        const val MAC_OPEN_CREATE = 0x0200
+        const val MAC_OPEN_EXCLUSIVE = 0x0800
+        const val MAC_OPEN_NOFOLLOW = 0x0100
+        const val MAC_OPEN_DIRECTORY = 0x100000
+        const val MAC_OPEN_CLOEXEC = 0x1000000
+
+        const val LINUX_OPEN_WRITE_ONLY = 0x0001
+        const val LINUX_OPEN_CREATE = 0x0040
+        const val LINUX_OPEN_EXCLUSIVE = 0x0080
+        const val LINUX_OPEN_DIRECTORY = 0x10000
+        const val LINUX_OPEN_NOFOLLOW = 0x20000
+        const val LINUX_OPEN_CLOEXEC = 0x80000
+
+        val api: PosixFileApi by lazy {
+            Native.load(Platform.C_LIBRARY_NAME, PosixFileApi::class.java)
+        }
+    }
+}

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutation.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutation.kt
@@ -8,13 +8,11 @@ import com.sun.jna.Platform
 import io.github.amichne.kast.api.protocol.ConflictException
 import io.github.amichne.kast.api.protocol.NotFoundException
 import io.github.amichne.kast.api.protocol.UnsafeWorkspaceMutationException
+import io.github.amichne.kast.api.protocol.ValidationException
 import io.github.amichne.kast.api.validation.FileHashing
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.LinkOption
 import java.nio.file.Path
-import java.nio.file.attribute.PosixFilePermission
 import java.util.UUID
 
 /**
@@ -22,149 +20,1043 @@ import java.util.UUID
  *
  * The walk starts at the filesystem root and refuses symlinks for every
  * component. Once a directory is open, later symlink replacement cannot
- * redirect resolution away from that held directory identity.
+ * redirect resolution away from that held directory identity. Existing
+ * targets are detached before descriptor validation; final-name commits and
+ * restoration use no-replace namespace operations. Best-effort cleanup moves
+ * entries behind randomized internal names and verifies their device/inode
+ * identity immediately before unlinking. Deliberate races against those
+ * internal names are outside this boundary; a cleanup failure retains and
+ * reports a recovery path instead of hiding a committed mutation.
  */
 internal class SecureWorkspaceMutation(
     workspaceRoot: Path,
+    private val afterTargetDetached: (Path, IdeaWorkspaceMutation) -> Unit = { _, _ -> },
+    private val beforePreparedFileCreation: (Path, IdeaWorkspaceMutation) -> Unit = { _, _ -> },
+    private val beforeFinalCommit: (Path, IdeaWorkspaceMutation) -> Unit = { _, _ -> },
+    private val beforeNoReplaceRename: (Path, SecureWorkspaceRenamePhase) -> Unit = { _, _ -> },
+    private val afterDeleteReservationCommitted: (Path) -> Unit = {},
+    private val beforeCleanupUnlink: (Path) -> Unit = {},
 ) {
     private val normalizedWorkspaceRoot = workspaceRoot.toAbsolutePath().normalize()
 
-    fun createFile(target: Path, content: String) {
+    fun createFile(target: Path, content: String): SecureWorkspaceMutationResult {
         val normalizedTarget = requireWorkspaceTarget(target, IdeaWorkspaceMutation.CREATE_FILE)
-        withParentDescriptor(normalizedTarget, createParents = true) { parent, fileName, api, platform ->
-            val descriptor = api.openat(
-                parent.value,
-                fileName,
-                platform.createExclusiveFileFlags,
-                FILE_MODE,
-            )
-            if (descriptor < 0) {
-                val errno = Native.getLastError()
-                if (errno == platform.alreadyExistsErrno) {
-                    throw ConflictException(
-                        message = "The requested file already exists",
-                        details = mapOf("filePath" to normalizedTarget.toString()),
-                    )
-                }
-                throw nativeFailure("openat-create", normalizedTarget, fileName, errno)
-            }
-
-            NativeDescriptor(api, descriptor).use { file ->
-                try {
-                    requireSuccess(api.fchmod(file.value, CREATED_FILE_MODE), "fchmod-create", normalizedTarget, fileName)
-                    writeFully(api, file.value, content.toByteArray(StandardCharsets.UTF_8), normalizedTarget)
-                    requireSuccess(api.fsync(file.value), "fsync", normalizedTarget, fileName)
-                } catch (exception: Exception) {
-                    api.unlinkat(parent.value, fileName, 0)
+        return withParentDescriptor(normalizedTarget, createParents = true) { parent, fileName, api, platform ->
+            val prepared = createPreparedFile(
+                parent = parent,
+                target = normalizedTarget,
+                content = content,
+                mode = CREATED_FILE_MODE,
+                api = api,
+                platform = platform,
+                onUntrackedPreparationFailure = { exception -> throw exception },
+                onPreparationFailure = { failedPrepared, exception ->
+                    val cleanup = removeExactNamedEntry(parent, failedPrepared, normalizedTarget, api, platform)
+                    failedPrepared.close()
+                    if (cleanup is CleanupResult.Retained) {
+                        throw preCommitFailure(normalizedTarget, "prepare-file", exception, cleanup)
+                    }
                     throw exception
-                }
-            }
-        }
-    }
-
-    fun replaceFile(target: Path, expectedDiskHash: String, content: String) {
-        val normalizedTarget = requireWorkspaceTarget(target, IdeaWorkspaceMutation.TEXT_EDIT)
-        val currentMode = targetMode(normalizedTarget)
-        withParentDescriptor(normalizedTarget, createParents = false) { parent, fileName, api, platform ->
-            val currentDescriptor = api.openat(parent.value, fileName, platform.readFileFlags, 0)
-            if (currentDescriptor < 0) {
-                val errno = Native.getLastError()
-                if (errno == platform.notFoundErrno) {
-                    throw NotFoundException(
-                        message = "The requested file does not exist",
-                        details = mapOf("filePath" to normalizedTarget.toString()),
-                    )
-                }
-                throw nativeFailure("openat-read", normalizedTarget, fileName, errno)
-            }
-            val currentContent = NativeDescriptor(api, currentDescriptor).use { file ->
-                readFully(api, file.value, normalizedTarget)
-            }
-            val actualDiskHash = FileHashing.sha256(currentContent)
-            if (actualDiskHash != expectedDiskHash) {
-                throw ConflictException(
-                    message = "The file changed at the secure write boundary",
-                    details = mapOf(
-                        "filePath" to normalizedTarget.toString(),
-                        "expectedHash" to expectedDiskHash,
-                        "actualHash" to actualDiskHash,
-                    ),
-                )
-            }
-
-            val temporaryName = ".kast-secure-${UUID.randomUUID()}.tmp"
-            val temporaryDescriptor = api.openat(
-                parent.value,
-                temporaryName,
-                platform.createExclusiveFileFlags,
-                FILE_MODE,
+                },
             )
-            if (temporaryDescriptor < 0) {
-                throw nativeFailure(
-                    "openat-temporary",
-                    normalizedTarget,
-                    temporaryName,
-                    Native.getLastError(),
-                )
-            }
-
-            try {
-                NativeDescriptor(api, temporaryDescriptor).use { temporary ->
-                    requireSuccess(
-                        api.fchmod(temporary.value, currentMode),
-                        "fchmod-temporary",
-                        normalizedTarget,
-                        temporaryName,
+            prepared.use {
+                val commitOutcome = try {
+                    beforeFinalCommit(normalizedTarget, IdeaWorkspaceMutation.CREATE_FILE)
+                    renameNoReplace(
+                        parent = parent,
+                        sourceName = prepared.name,
+                        destinationName = fileName,
+                        target = normalizedTarget,
+                        platform = platform,
+                        phase = SecureWorkspaceRenamePhase.FINAL_COMMIT,
                     )
-                    writeFully(api, temporary.value, content.toByteArray(StandardCharsets.UTF_8), normalizedTarget)
-                    requireSuccess(api.fsync(temporary.value), "fsync-temporary", normalizedTarget, temporaryName)
+                } catch (exception: Exception) {
+                    val cleanup = removeExactNamedEntry(parent, prepared, normalizedTarget, api, platform)
+                    throw preCommitFailure(normalizedTarget, "create-before-commit", exception, cleanup)
                 }
-                requireSuccess(
-                    api.renameat(parent.value, temporaryName, parent.value, fileName),
-                    "renameat",
-                    normalizedTarget,
-                    fileName,
-                )
-            } finally {
-                api.unlinkat(parent.value, temporaryName, 0)
+                when (commitOutcome) {
+                    RenameNoReplaceOutcome.MOVED -> SecureWorkspaceMutationResult.Committed
+                    RenameNoReplaceOutcome.DESTINATION_EXISTS -> {
+                        val cleanup = removeExactNamedEntry(parent, prepared, normalizedTarget, api, platform)
+                        throw ConflictException(
+                            message = "The requested file already exists",
+                            details = mapOf("filePath" to normalizedTarget.toString()) + cleanup.conflictDetails(),
+                        )
+                    }
+
+                    RenameNoReplaceOutcome.SOURCE_MISSING -> {
+                        val cleanup = removeExactNamedEntry(parent, prepared, normalizedTarget, api, platform)
+                        throw preCommitFailure(
+                            target = normalizedTarget,
+                            operation = "create-prepared-source-missing",
+                            cause = nativeFailure(
+                                operation = "create-prepared-source-missing",
+                                target = normalizedTarget,
+                                component = prepared.name,
+                                errno = platform.notFoundErrno,
+                            ),
+                            cleanup = cleanup,
+                        )
+                    }
+                }
             }
         }
     }
 
-    fun deleteFile(target: Path, expectedDiskHash: String) {
+    fun replaceFile(target: Path, expectedDiskHash: String, content: String): SecureWorkspaceMutationResult {
+        val normalizedTarget = requireWorkspaceTarget(target, IdeaWorkspaceMutation.TEXT_EDIT)
+        return withParentDescriptor(normalizedTarget, createParents = false) { parent, fileName, api, platform ->
+            detachValidatedTarget(
+                parent = parent,
+                fileName = fileName,
+                target = normalizedTarget,
+                expectedDiskHash = expectedDiskHash,
+                mutation = IdeaWorkspaceMutation.TEXT_EDIT,
+                hashConflictMessage = "The file changed at the secure write boundary",
+                api = api,
+                platform = platform,
+            ).use { detached ->
+                try {
+                    beforePreparedFileCreation(normalizedTarget, IdeaWorkspaceMutation.TEXT_EDIT)
+                } catch (exception: Exception) {
+                    rollbackDetachedFailure(
+                        message = "The secure replacement could not prepare its commit",
+                        target = normalizedTarget,
+                        fileName = fileName,
+                        detached = detached,
+                        parent = parent,
+                        platform = platform,
+                        cause = exception,
+                    )
+                }
+                val prepared = createPreparedFile(
+                    parent = parent,
+                    target = normalizedTarget,
+                    content = content,
+                    mode = detached.status.mode.permissionBits,
+                    api = api,
+                    platform = platform,
+                    onUntrackedPreparationFailure = { exception ->
+                        rollbackDetachedFailure(
+                            message = "The secure replacement could not prepare its commit",
+                            target = normalizedTarget,
+                            fileName = fileName,
+                            detached = detached,
+                            parent = parent,
+                            platform = platform,
+                            cause = exception,
+                        )
+                    },
+                    onPreparationFailure = { failedPrepared, exception ->
+                        rollbackPreparedFailure(
+                            message = "The secure replacement could not prepare its commit",
+                            target = normalizedTarget,
+                            fileName = fileName,
+                            detached = detached,
+                            prepared = failedPrepared,
+                            parent = parent,
+                            api = api,
+                            platform = platform,
+                            cause = exception,
+                        )
+                    },
+                )
+                prepared.use {
+                    val commitOutcome = try {
+                        beforeFinalCommit(normalizedTarget, IdeaWorkspaceMutation.TEXT_EDIT)
+                        renameNoReplace(
+                            parent = parent,
+                            sourceName = prepared.name,
+                            destinationName = fileName,
+                            target = normalizedTarget,
+                            platform = platform,
+                            phase = SecureWorkspaceRenamePhase.FINAL_COMMIT,
+                        )
+                    } catch (exception: Exception) {
+                        rollbackPreparedFailure(
+                            message = "The secure replacement was interrupted before commit",
+                            parent = parent,
+                            target = normalizedTarget,
+                            fileName = fileName,
+                            detached = detached,
+                            prepared = prepared,
+                            api = api,
+                            platform = platform,
+                            cause = exception,
+                        )
+                    }
+                    when (commitOutcome) {
+                        RenameNoReplaceOutcome.MOVED -> Unit
+                        RenameNoReplaceOutcome.DESTINATION_EXISTS -> rollbackPreparedFailure(
+                            message = "A concurrent file appeared before the secure replacement committed",
+                            target = normalizedTarget,
+                            fileName = fileName,
+                            detached = detached,
+                            prepared = prepared,
+                            parent = parent,
+                            api = api,
+                            platform = platform,
+                        )
+
+                        RenameNoReplaceOutcome.SOURCE_MISSING -> rollbackPreparedFailure(
+                            message = "The prepared replacement disappeared before commit",
+                            target = normalizedTarget,
+                            fileName = fileName,
+                            detached = detached,
+                            prepared = prepared,
+                            parent = parent,
+                            api = api,
+                            platform = platform,
+                        )
+                    }
+                }
+                val cleanup = removeExactNamedEntry(parent, detached, normalizedTarget, api, platform)
+                SecureWorkspaceMutationResult.committed(cleanup.recoveryFilePaths)
+            }
+        }
+    }
+
+    fun deleteFile(target: Path, expectedDiskHash: String): SecureWorkspaceMutationResult {
+        val normalizedTarget = requireWorkspaceTarget(target, IdeaWorkspaceMutation.DELETE_FILE)
+        return withParentDescriptor(normalizedTarget, createParents = false) { parent, fileName, api, platform ->
+            detachValidatedTarget(
+                parent = parent,
+                fileName = fileName,
+                target = normalizedTarget,
+                expectedDiskHash = expectedDiskHash,
+                mutation = IdeaWorkspaceMutation.DELETE_FILE,
+                hashConflictMessage = "The file changed after the delete plan was created",
+                api = api,
+                platform = platform,
+            ).use { detached ->
+                try {
+                    beforePreparedFileCreation(normalizedTarget, IdeaWorkspaceMutation.DELETE_FILE)
+                } catch (exception: Exception) {
+                    rollbackDetachedFailure(
+                        message = "The secure deletion could not prepare its reservation",
+                        target = normalizedTarget,
+                        fileName = fileName,
+                        detached = detached,
+                        parent = parent,
+                        platform = platform,
+                        cause = exception,
+                    )
+                }
+                val reservation = createPreparedFile(
+                    parent = parent,
+                    target = normalizedTarget,
+                    content = "",
+                    mode = CREATED_FILE_MODE,
+                    api = api,
+                    platform = platform,
+                    onUntrackedPreparationFailure = { exception ->
+                        rollbackDetachedFailure(
+                            message = "The secure deletion could not prepare its reservation",
+                            target = normalizedTarget,
+                            fileName = fileName,
+                            detached = detached,
+                            parent = parent,
+                            platform = platform,
+                            cause = exception,
+                        )
+                    },
+                    onPreparationFailure = { failedReservation, exception ->
+                        rollbackPreparedFailure(
+                            message = "The secure deletion could not prepare its reservation",
+                            target = normalizedTarget,
+                            fileName = fileName,
+                            detached = detached,
+                            prepared = failedReservation,
+                            parent = parent,
+                            api = api,
+                            platform = platform,
+                            cause = exception,
+                        )
+                    },
+                )
+                reservation.use {
+                    val commitOutcome = try {
+                        beforeFinalCommit(normalizedTarget, IdeaWorkspaceMutation.DELETE_FILE)
+                        renameNoReplace(
+                            parent = parent,
+                            sourceName = reservation.name,
+                            destinationName = fileName,
+                            target = normalizedTarget,
+                            platform = platform,
+                            phase = SecureWorkspaceRenamePhase.FINAL_COMMIT,
+                        )
+                    } catch (exception: Exception) {
+                        rollbackPreparedFailure(
+                            message = "The secure deletion was interrupted before commit",
+                            parent = parent,
+                            target = normalizedTarget,
+                            fileName = fileName,
+                            detached = detached,
+                            prepared = reservation,
+                            api = api,
+                            platform = platform,
+                            cause = exception,
+                        )
+                    }
+                    when (commitOutcome) {
+                        RenameNoReplaceOutcome.MOVED -> Unit
+                        RenameNoReplaceOutcome.DESTINATION_EXISTS -> rollbackPreparedFailure(
+                            message = "A concurrent file appeared before the secure deletion committed",
+                            target = normalizedTarget,
+                            fileName = fileName,
+                            detached = detached,
+                            prepared = reservation,
+                            parent = parent,
+                            api = api,
+                            platform = platform,
+                        )
+
+                        RenameNoReplaceOutcome.SOURCE_MISSING -> rollbackPreparedFailure(
+                            message = "The prepared deletion reservation disappeared before commit",
+                            target = normalizedTarget,
+                            fileName = fileName,
+                            detached = detached,
+                            prepared = reservation,
+                            parent = parent,
+                            api = api,
+                            platform = platform,
+                        )
+                    }
+                }
+
+                afterDeleteReservationCommitted(normalizedTarget)
+
+                val reservationRelease = releaseFinalReservation(
+                    parent = parent,
+                    fileName = fileName,
+                    reservation = reservation,
+                    target = normalizedTarget,
+                    api = api,
+                    platform = platform,
+                )
+                val reservationCleanup = when (reservationRelease) {
+                    is FinalReservationRelease.Released -> reservationRelease.cleanup
+                    is FinalReservationRelease.Blocked -> {
+                        val concurrentRecoveryDetails = if (reservationRelease.restoredToFinalName) {
+                            mapOf("concurrentEntryRestoration" to "restored")
+                        } else {
+                            mapOf(
+                                "concurrentEntryRestoration" to "quarantined",
+                                "concurrentEntryRecoveryFilePath" to reservationRelease.entryRecoveryFilePath.toString(),
+                            )
+                        }
+                        throw ConflictException(
+                            message = "The deletion reservation was replaced before the final name was released",
+                            details = mapOf(
+                                "filePath" to normalizedTarget.toString(),
+                                "recoveryFilePath" to normalizedTarget.parent.resolve(detached.name).toString(),
+                                "cause" to reservationRelease.reason,
+                            ) +
+                                concurrentRecoveryDetails +
+                                detached.status.identity.details(),
+                        )
+                    }
+                }
+                val detachedCleanup = removeExactNamedEntry(parent, detached, normalizedTarget, api, platform)
+                SecureWorkspaceMutationResult.committed(
+                    detachedCleanup.recoveryFilePaths + reservationCleanup.recoveryFilePaths,
+                )
+            }
+        }
+    }
+
+    fun verifyCommittedFile(
+        target: Path,
+        expectedContent: String,
+        mutation: IdeaWorkspaceMutation,
+    ) {
+        val normalizedTarget = requireWorkspaceTarget(target, mutation)
+        withParentDescriptor(normalizedTarget, createParents = false) { parent, fileName, api, platform ->
+            val descriptorValue = api.openat(parent.value, fileName, platform.readFileFlags, 0)
+            if (descriptorValue < 0) {
+                throw nativeFailure(
+                    operation = "openat-verify-committed-file",
+                    target = normalizedTarget,
+                    component = fileName,
+                    errno = Native.getLastError(),
+                )
+            }
+            NativeDescriptor(api, descriptorValue).use { descriptor ->
+                val status = descriptorStatus(api, platform, descriptor.value, normalizedTarget)
+                if (status.mode.fileType != NativeFileType.REGULAR) {
+                    throw UnsafeWorkspaceMutationException(
+                        message = "Secure post-commit verification requires a regular file target",
+                        details = failureDetails(normalizedTarget, "reject-non-regular-verification-target") + mapOf(
+                            "fileType" to status.mode.fileType.name,
+                            "fileMode" to status.mode.bits.toString(8),
+                        ),
+                    )
+                }
+                val actualContent = readFully(api, descriptor.value, normalizedTarget)
+                if (actualContent != expectedContent) {
+                    throw ConflictException(
+                        message = "Secure post-commit content verification failed",
+                        details = mapOf(
+                            "filePath" to normalizedTarget.toString(),
+                            "mutation" to mutation.wireName,
+                            "expectedHash" to FileHashing.sha256(expectedContent),
+                            "actualHash" to FileHashing.sha256(actualContent),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    fun verifyCommittedDeletion(target: Path) {
         val normalizedTarget = requireWorkspaceTarget(target, IdeaWorkspaceMutation.DELETE_FILE)
         withParentDescriptor(normalizedTarget, createParents = false) { parent, fileName, api, platform ->
-            val currentDescriptor = api.openat(parent.value, fileName, platform.readFileFlags, 0)
-            if (currentDescriptor < 0) {
+            val descriptorValue = api.openat(parent.value, fileName, platform.readFileFlags, 0)
+            if (descriptorValue < 0) {
                 val errno = Native.getLastError()
-                if (errno == platform.notFoundErrno) {
-                    throw NotFoundException(
-                        message = "The requested file does not exist",
-                        details = mapOf("filePath" to normalizedTarget.toString()),
-                    )
-                }
-                throw nativeFailure("openat-delete", normalizedTarget, fileName, errno)
+                if (errno == platform.notFoundErrno) return@withParentDescriptor
+                throw nativeFailure(
+                    operation = "openat-verify-committed-deletion",
+                    target = normalizedTarget,
+                    component = fileName,
+                    errno = errno,
+                )
             }
-            val currentContent = NativeDescriptor(api, currentDescriptor).use { file ->
-                readFully(api, file.value, normalizedTarget)
-            }
-            val actualDiskHash = FileHashing.sha256(currentContent)
-            if (actualDiskHash != expectedDiskHash) {
-                throw ConflictException(
-                    message = "The file changed after the delete plan was created",
-                    details = mapOf(
-                        "filePath" to normalizedTarget.toString(),
-                        "expectedHash" to expectedDiskHash,
-                        "actualHash" to actualDiskHash,
+            NativeDescriptor(api, descriptorValue).close()
+            throw ValidationException(
+                message = "Secure post-commit deletion verification found a final entry",
+                details = mapOf(
+                    "filePath" to normalizedTarget.toString(),
+                    "mutation" to IdeaWorkspaceMutation.DELETE_FILE.wireName,
+                ),
+            )
+        }
+    }
+
+    private fun detachValidatedTarget(
+        parent: NativeDescriptor,
+        fileName: String,
+        target: Path,
+        expectedDiskHash: String,
+        mutation: IdeaWorkspaceMutation,
+        hashConflictMessage: String,
+        api: PosixFileApi,
+        platform: PosixPlatform,
+    ): DetachedTarget {
+        val quarantineName = moveToUniqueName(
+            parent = parent,
+            sourceName = fileName,
+            prefix = QUARANTINE_PREFIX,
+            target = target,
+            platform = platform,
+            phase = SecureWorkspaceRenamePhase.DETACH_TARGET,
+            sourceMissing = {
+                throw NotFoundException(
+                    message = "The requested file does not exist",
+                    details = mapOf("filePath" to target.toString()),
+                )
+            },
+        )
+        val descriptorValue = api.openat(parent.value, quarantineName, platform.readFileFlags, 0)
+        if (descriptorValue < 0) {
+            val errno = Native.getLastError()
+            restoreUnopenedQuarantine(parent, fileName, quarantineName, target, platform)
+            throw nativeFailure("openat-quarantine", target, quarantineName, errno)
+        }
+
+        val descriptor = NativeDescriptor(api, descriptorValue)
+        val detached = try {
+            val status = descriptorStatus(api, platform, descriptor.value, target)
+            if (status.mode.fileType != NativeFileType.REGULAR) {
+                throw UnsafeWorkspaceMutationException(
+                    message = "Secure workspace mutation requires a regular file target",
+                    details = failureDetails(target, "reject-non-regular-target") + mapOf(
+                        "fileType" to status.mode.fileType.name,
+                        "fileMode" to status.mode.bits.toString(8),
                     ),
                 )
             }
-            requireSuccess(
-                api.unlinkat(parent.value, fileName, 0),
-                "unlinkat",
-                normalizedTarget,
-                fileName,
+            val content = readFully(api, descriptor.value, target)
+            DetachedTarget(
+                name = quarantineName,
+                descriptor = descriptor,
+                status = status,
+                actualDiskHash = FileHashing.sha256(content),
             )
+        } catch (exception: Exception) {
+            descriptor.close()
+            restoreUnopenedQuarantine(parent, fileName, quarantineName, target, platform)
+            throw exception
+        }
+
+        if (detached.actualDiskHash != expectedDiskHash) {
+            detached.use {
+                throw conflictWithRestoration(
+                    message = hashConflictMessage,
+                    target = target,
+                    fileName = fileName,
+                    detached = detached,
+                    parent = parent,
+                    platform = platform,
+                    details = mapOf(
+                        "expectedHash" to expectedDiskHash,
+                        "actualHash" to detached.actualDiskHash,
+                    ),
+                )
+            }
+        }
+
+        try {
+            afterTargetDetached(target, mutation)
+        } catch (exception: Exception) {
+            detached.use {
+                throw conflictWithRestoration(
+                    message = "The secure mutation was interrupted after detaching its target",
+                    target = target,
+                    fileName = fileName,
+                    detached = detached,
+                    parent = parent,
+                    platform = platform,
+                    details = mapOf("cause" to (exception.message ?: exception::class.java.simpleName)),
+                )
+            }
+        }
+        return detached
+    }
+
+    private fun createPreparedFile(
+        parent: NativeDescriptor,
+        target: Path,
+        content: String,
+        mode: Int,
+        api: PosixFileApi,
+        platform: PosixPlatform,
+        onUntrackedPreparationFailure: (Exception) -> Nothing,
+        onPreparationFailure: (PreparedFile, Exception) -> Nothing,
+    ): PreparedFile {
+        repeat(MAX_UNIQUE_NAME_ATTEMPTS) {
+            val name = "$PREPARED_PREFIX${UUID.randomUUID()}.tmp"
+            val descriptorValue = api.openat(
+                parent.value,
+                name,
+                platform.createExclusiveFileFlags,
+                FILE_MODE,
+            )
+            if (descriptorValue < 0) {
+                val errno = Native.getLastError()
+                if (errno == platform.alreadyExistsErrno) return@repeat
+                onUntrackedPreparationFailure(nativeFailure("openat-prepared", target, name, errno))
+            }
+
+            val descriptor = NativeDescriptor(api, descriptorValue)
+            val status = try {
+                descriptorStatus(api, platform, descriptor.value, target)
+            } catch (exception: Exception) {
+                descriptor.close()
+                onUntrackedPreparationFailure(
+                    UnsafeWorkspaceMutationException(
+                        message = "The prepared workspace entry could not be identity-validated for safe cleanup",
+                        details = failureDetails(target, "fstat-prepared") + mapOf(
+                            "recoveryFilePath" to target.parent.resolve(name).toString(),
+                            "cause" to (exception.message ?: exception::class.java.simpleName),
+                        ),
+                    ),
+                )
+            }
+            val prepared = PreparedFile(name, descriptor, status)
+            try {
+                requireSuccess(api.fchmod(descriptor.value, mode), "fchmod-prepared", target, name)
+                writeFully(api, descriptor.value, content.toByteArray(StandardCharsets.UTF_8), target)
+                requireSuccess(api.fsync(descriptor.value), "fsync-prepared", target, name)
+                return prepared
+            } catch (exception: Exception) {
+                onPreparationFailure(prepared, exception)
+            }
+        }
+        onUntrackedPreparationFailure(
+            UnsafeWorkspaceMutationException(
+                message = "Secure workspace mutation could not allocate a unique prepared entry",
+                details = failureDetails(target, "allocate-prepared-name"),
+            ),
+        )
+    }
+
+    private fun rollbackDetachedFailure(
+        message: String,
+        target: Path,
+        fileName: String,
+        detached: DetachedTarget,
+        parent: NativeDescriptor,
+        platform: PosixPlatform,
+        cause: Exception,
+    ): Nothing {
+        val restoration = try {
+            restoreDetached(parent, fileName, detached, target, platform)
+        } catch (restorationFailure: Exception) {
+            throw UnsafeWorkspaceMutationException(
+                message = "The detached workspace entry could not be restored after a pre-commit failure",
+                details = failureDetails(target, "rollback-detached") +
+                    mapOf(
+                        "cause" to cause.failureReason(),
+                        "restorationFailure" to restorationFailure.failureReason(),
+                        "recoveryFilePath" to target.parent.resolve(detached.name).toString(),
+                    ) +
+                    detached.status.identity.details(),
+            )
+        }
+        throw conflictWithRestoration(
+            message = message,
+            target = target,
+            fileName = fileName,
+            detached = detached,
+            parent = parent,
+            platform = platform,
+            details = cause.rollbackDetails(),
+            restoration = restoration,
+        )
+    }
+
+    private fun rollbackPreparedFailure(
+        message: String,
+        target: Path,
+        fileName: String,
+        detached: DetachedTarget,
+        prepared: PreparedFile,
+        parent: NativeDescriptor,
+        api: PosixFileApi,
+        platform: PosixPlatform,
+        cause: Exception? = null,
+    ): Nothing {
+        val restorationAttempt = runCatching {
+            restoreDetached(parent, fileName, detached, target, platform)
+        }
+        val cleanup = try {
+            removeExactNamedEntry(parent, prepared, target, api, platform)
+        } finally {
+            prepared.close()
+        }
+        val restoration = restorationAttempt.getOrElse { restorationFailure ->
+            throw UnsafeWorkspaceMutationException(
+                message = "The detached workspace entry could not be restored after a prepared commit failure",
+                details = failureDetails(target, "rollback-prepared") +
+                    mapOf(
+                        "cause" to (cause?.failureReason() ?: message),
+                        "restorationFailure" to restorationFailure.failureReason(),
+                        "recoveryFilePath" to target.parent.resolve(detached.name).toString(),
+                    ) +
+                    cleanup.conflictDetails() +
+                    detached.status.identity.details(),
+            )
+        }
+        throw conflictWithRestoration(
+            message = message,
+            target = target,
+            fileName = fileName,
+            detached = detached,
+            parent = parent,
+            platform = platform,
+            details = cause?.rollbackDetails().orEmpty(),
+            restoration = restoration,
+            cleanup = cleanup,
+        )
+    }
+
+    private fun Exception.rollbackDetails(): Map<String, String> =
+        mapOf("cause" to failureReason()) + when (this) {
+            is UnsafeWorkspaceMutationException -> details.mapKeys { (key, _) -> "cause.$key" }
+            else -> emptyMap()
+        }
+
+    private fun conflictWithRestoration(
+        message: String,
+        target: Path,
+        fileName: String,
+        detached: DetachedTarget,
+        parent: NativeDescriptor,
+        platform: PosixPlatform,
+        details: Map<String, String> = emptyMap(),
+        restoration: Restoration? = null,
+        cleanup: CleanupResult = CleanupResult.Removed,
+    ): ConflictException {
+        val effectiveRestoration = restoration ?: restoreDetached(parent, fileName, detached, target, platform)
+        val restorationDetails = when (effectiveRestoration) {
+            Restoration.RESTORED -> mapOf("restoration" to "restored")
+            Restoration.QUARANTINED -> mapOf(
+                "restoration" to "quarantined",
+                "recoveryFilePath" to target.parent.resolve(detached.name).toString(),
+            )
+        }
+        return ConflictException(
+            message = message,
+            details = mapOf("filePath" to target.toString()) +
+                details +
+                restorationDetails +
+                cleanup.conflictDetails() +
+                detached.status.identity.details(),
+        )
+    }
+
+    private fun restoreDetached(
+        parent: NativeDescriptor,
+        fileName: String,
+        detached: DetachedTarget,
+        target: Path,
+        platform: PosixPlatform,
+    ): Restoration = when (
+        renameNoReplace(
+            parent = parent,
+            sourceName = detached.name,
+            destinationName = fileName,
+            target = target,
+            platform = platform,
+            phase = SecureWorkspaceRenamePhase.RESTORE_TARGET,
+        )
+    ) {
+        RenameNoReplaceOutcome.MOVED -> {
+            Restoration.RESTORED
+        }
+
+        RenameNoReplaceOutcome.DESTINATION_EXISTS -> Restoration.QUARANTINED
+        RenameNoReplaceOutcome.SOURCE_MISSING -> throw UnsafeWorkspaceMutationException(
+            message = "The detached workspace entry disappeared before it could be restored",
+            details = failureDetails(target, "restore-detached-source-missing") +
+                mapOf("recoveryFilePath" to target.parent.resolve(detached.name).toString()) +
+                detached.status.identity.details(),
+        )
+    }
+
+    private fun restoreUnopenedQuarantine(
+        parent: NativeDescriptor,
+        fileName: String,
+        quarantineName: String,
+        target: Path,
+        platform: PosixPlatform,
+    ) {
+        when (
+            renameNoReplace(
+                parent = parent,
+                sourceName = quarantineName,
+                destinationName = fileName,
+                target = target,
+                platform = platform,
+                phase = SecureWorkspaceRenamePhase.RESTORE_TARGET,
+            )
+        ) {
+            RenameNoReplaceOutcome.MOVED -> Unit
+            RenameNoReplaceOutcome.DESTINATION_EXISTS -> throw UnsafeWorkspaceMutationException(
+                message = "The detached workspace entry could not be restored because the target name is occupied",
+                details = failureDetails(target, "restore-unopened-quarantine") + mapOf(
+                    "recoveryFilePath" to target.parent.resolve(quarantineName).toString(),
+                ),
+            )
+
+            RenameNoReplaceOutcome.SOURCE_MISSING -> throw UnsafeWorkspaceMutationException(
+                message = "The detached workspace entry disappeared before it could be opened",
+                details = failureDetails(target, "restore-unopened-quarantine-source-missing"),
+            )
+        }
+    }
+
+    private fun removeExactNamedEntry(
+        parent: NativeDescriptor,
+        entry: ExactNamedEntry,
+        target: Path,
+        api: PosixFileApi,
+        platform: PosixPlatform,
+    ): CleanupResult = removeExactName(
+        parent = parent,
+        sourceName = entry.name,
+        expectedIdentity = entry.status.identity,
+        target = target,
+        api = api,
+        platform = platform,
+    )
+
+    private fun releaseFinalReservation(
+        parent: NativeDescriptor,
+        fileName: String,
+        reservation: PreparedFile,
+        target: Path,
+        api: PosixFileApi,
+        platform: PosixPlatform,
+    ): FinalReservationRelease {
+        val targetPath = target.parent.resolve(fileName)
+        val cleanupName = try {
+            moveToUniqueName(
+                parent = parent,
+                sourceName = fileName,
+                prefix = CLEANUP_PREFIX,
+                target = target,
+                platform = platform,
+                phase = SecureWorkspaceRenamePhase.MOVE_CLEANUP,
+                sourceMissing = {
+                    throw UnsafeWorkspaceMutationException(
+                        message = "The deletion reservation disappeared before final-name release",
+                        details = failureDetails(target, "delete-reservation-source-missing"),
+                    )
+                },
+            )
+        } catch (exception: Exception) {
+            return FinalReservationRelease.Blocked(
+                entryRecoveryFilePath = targetPath,
+                restoredToFinalName = true,
+                reason = exception.failureReason(),
+            )
+        }
+        val cleanupPath = target.parent.resolve(cleanupName)
+        fun blocked(reason: String): FinalReservationRelease.Blocked {
+            val recoveryPath = restoreCleanupName(parent, fileName, cleanupName, target, platform)
+            return FinalReservationRelease.Blocked(
+                entryRecoveryFilePath = recoveryPath,
+                restoredToFinalName = recoveryPath == targetPath,
+                reason = reason,
+            )
+        }
+        fun releasedWithRecovery(reason: String): FinalReservationRelease.Released =
+            FinalReservationRelease.Released(
+                CleanupResult.Retained(
+                    recoveryFilePath = cleanupPath,
+                    reason = reason,
+                ),
+            )
+
+        val cleanupDescriptorValue = api.openat(parent.value, cleanupName, platform.readFileFlags, 0)
+        if (cleanupDescriptorValue < 0) {
+            return blocked("openat-delete-reservation failed with errno ${Native.getLastError()}")
+        }
+        NativeDescriptor(api, cleanupDescriptorValue).use { cleanupDescriptor ->
+            val cleanupStatus = try {
+                descriptorStatus(api, platform, cleanupDescriptor.value, target)
+            } catch (exception: Exception) {
+                return blocked(exception.failureReason())
+            }
+            if (cleanupStatus.identity != reservation.status.identity) {
+                return blocked("delete reservation identity changed before final-name release")
+            }
+        }
+
+        try {
+            beforeCleanupUnlink(cleanupPath)
+        } catch (exception: Exception) {
+            return releasedWithRecovery(exception.failureReason())
+        }
+
+        val finalDescriptorValue = api.openat(parent.value, cleanupName, platform.readFileFlags, 0)
+        if (finalDescriptorValue < 0) {
+            return blocked("openat-delete-reservation-recheck failed with errno ${Native.getLastError()}")
+        }
+        NativeDescriptor(api, finalDescriptorValue).use { finalDescriptor ->
+            val finalStatus = try {
+                descriptorStatus(api, platform, finalDescriptor.value, target)
+            } catch (exception: Exception) {
+                return blocked(exception.failureReason())
+            }
+            if (finalStatus.identity != reservation.status.identity) {
+                return blocked("delete reservation identity changed immediately before unlink")
+            }
+        }
+
+        if (api.unlinkat(parent.value, cleanupName, 0) < 0) {
+            return releasedWithRecovery("unlinkat-delete-reservation failed with errno ${Native.getLastError()}")
+        }
+        return FinalReservationRelease.Released(CleanupResult.Removed)
+    }
+
+    private fun removeExactName(
+        parent: NativeDescriptor,
+        sourceName: String,
+        expectedIdentity: NativeFileIdentity,
+        target: Path,
+        api: PosixFileApi,
+        platform: PosixPlatform,
+    ): CleanupResult {
+        val sourcePath = target.parent.resolve(sourceName)
+        val cleanupName = try {
+            moveToUniqueName(
+                parent = parent,
+                sourceName = sourceName,
+                prefix = CLEANUP_PREFIX,
+                target = target,
+                platform = platform,
+                phase = SecureWorkspaceRenamePhase.MOVE_CLEANUP,
+                sourceMissing = {
+                    throw UnsafeWorkspaceMutationException(
+                        message = "The descriptor-identified workspace entry disappeared before cleanup",
+                        details = failureDetails(target, "cleanup-source-missing") + expectedIdentity.details(),
+                    )
+                },
+            )
+        } catch (exception: Exception) {
+            return CleanupResult.Retained(
+                recoveryFilePath = sourcePath,
+                reason = exception.failureReason(),
+            )
+        }
+        val cleanupPath = target.parent.resolve(cleanupName)
+        fun retained(reason: String): CleanupResult.Retained = CleanupResult.Retained(
+            recoveryFilePath = restoreCleanupName(parent, sourceName, cleanupName, target, platform),
+            reason = reason,
+        )
+
+        val cleanupDescriptorValue = api.openat(parent.value, cleanupName, platform.readFileFlags, 0)
+        if (cleanupDescriptorValue < 0) {
+            val errno = Native.getLastError()
+            return retained("openat-cleanup failed with errno $errno")
+        }
+        NativeDescriptor(api, cleanupDescriptorValue).use { cleanupDescriptor ->
+            val cleanupStatus = try {
+                descriptorStatus(api, platform, cleanupDescriptor.value, target)
+            } catch (exception: Exception) {
+                return retained(exception.failureReason())
+            }
+            if (cleanupStatus.identity != expectedIdentity) {
+                return retained("cleanup identity did not match the descriptor-validated entry")
+            }
+        }
+
+        try {
+            beforeCleanupUnlink(cleanupPath)
+        } catch (exception: Exception) {
+            return retained(exception.failureReason())
+        }
+
+        val finalDescriptorValue = api.openat(parent.value, cleanupName, platform.readFileFlags, 0)
+        if (finalDescriptorValue < 0) {
+            val errno = Native.getLastError()
+            return retained("openat-cleanup-recheck failed with errno $errno")
+        }
+        NativeDescriptor(api, finalDescriptorValue).use { finalDescriptor ->
+            val finalStatus = try {
+                descriptorStatus(api, platform, finalDescriptor.value, target)
+            } catch (exception: Exception) {
+                return retained(exception.failureReason())
+            }
+            if (finalStatus.identity != expectedIdentity) {
+                return retained("cleanup identity changed before unlink")
+            }
+        }
+
+        if (api.unlinkat(parent.value, cleanupName, 0) < 0) {
+            val errno = Native.getLastError()
+            return retained("unlinkat-cleanup failed with errno $errno")
+        }
+        return CleanupResult.Removed
+    }
+
+    private fun restoreCleanupName(
+        parent: NativeDescriptor,
+        sourceName: String,
+        cleanupName: String,
+        target: Path,
+        platform: PosixPlatform,
+    ): Path {
+        val sourcePath = target.parent.resolve(sourceName)
+        val cleanupPath = target.parent.resolve(cleanupName)
+        return try {
+            when (
+                renameNoReplace(
+                    parent = parent,
+                    sourceName = cleanupName,
+                    destinationName = sourceName,
+                    target = target,
+                    platform = platform,
+                    phase = SecureWorkspaceRenamePhase.RESTORE_CLEANUP,
+                )
+            ) {
+                RenameNoReplaceOutcome.MOVED -> sourcePath
+                RenameNoReplaceOutcome.DESTINATION_EXISTS, RenameNoReplaceOutcome.SOURCE_MISSING -> cleanupPath
+            }
+        } catch (_: Exception) {
+            cleanupPath
+        }
+    }
+
+    private fun preCommitFailure(
+        target: Path,
+        operation: String,
+        cause: Exception,
+        cleanup: CleanupResult,
+    ): UnsafeWorkspaceMutationException = UnsafeWorkspaceMutationException(
+        message = "Secure workspace mutation failed before commit",
+        details = failureDetails(target, operation) +
+            mapOf("cause" to cause.failureReason()) +
+            cleanup.conflictDetails(),
+    )
+
+    private fun Throwable.failureReason(): String = message ?: this::class.java.simpleName
+
+    private fun moveToUniqueName(
+        parent: NativeDescriptor,
+        sourceName: String,
+        prefix: String,
+        target: Path,
+        platform: PosixPlatform,
+        phase: SecureWorkspaceRenamePhase,
+        sourceMissing: () -> Nothing,
+    ): String {
+        repeat(MAX_UNIQUE_NAME_ATTEMPTS) {
+            val destinationName = "$prefix${UUID.randomUUID()}"
+            when (
+                renameNoReplace(
+                    parent = parent,
+                    sourceName = sourceName,
+                    destinationName = destinationName,
+                    target = target,
+                    platform = platform,
+                    phase = phase,
+                )
+            ) {
+                RenameNoReplaceOutcome.MOVED -> return destinationName
+                RenameNoReplaceOutcome.DESTINATION_EXISTS -> Unit
+                RenameNoReplaceOutcome.SOURCE_MISSING -> sourceMissing()
+            }
+        }
+        throw UnsafeWorkspaceMutationException(
+            message = "Secure workspace mutation could not allocate a unique quarantine entry",
+            details = failureDetails(target, "allocate-quarantine-name"),
+        )
+    }
+
+    private fun renameNoReplace(
+        parent: NativeDescriptor,
+        sourceName: String,
+        destinationName: String,
+        target: Path,
+        platform: PosixPlatform,
+        phase: SecureWorkspaceRenamePhase,
+    ): RenameNoReplaceOutcome {
+        beforeNoReplaceRename(target, phase)
+        val result = try {
+            when (platform.renamePrimitive) {
+                RenamePrimitive.MAC_RENAMEATX -> macRenameApi.renameatx_np(
+                    parent.value,
+                    sourceName,
+                    parent.value,
+                    destinationName,
+                    MAC_RENAME_EXCLUSIVE or MAC_RENAME_NOFOLLOW_ANY,
+                )
+
+                RenamePrimitive.LINUX_RENAMEAT2 -> linuxRenameApi.renameat2(
+                    parent.value,
+                    sourceName,
+                    parent.value,
+                    destinationName,
+                    LINUX_RENAME_NOREPLACE,
+                )
+            }
+        } catch (exception: LinkageError) {
+            throw UnsafeWorkspaceMutationException(
+                message = "Atomic no-replace workspace mutation primitives are unavailable",
+                details = failureDetails(target, "native-no-replace-load") + mapOf(
+                    "cause" to (exception.message ?: exception::class.java.simpleName),
+                ),
+            )
+        }
+        if (result == 0) return RenameNoReplaceOutcome.MOVED
+        return when (val errno = Native.getLastError()) {
+            platform.alreadyExistsErrno -> RenameNoReplaceOutcome.DESTINATION_EXISTS
+            platform.notFoundErrno -> RenameNoReplaceOutcome.SOURCE_MISSING
+            else -> throw nativeFailure("rename-no-replace", target, sourceName, errno)
         }
     }
 
@@ -283,34 +1175,16 @@ internal class SecureWorkspaceMutation(
         return output.toString(StandardCharsets.UTF_8)
     }
 
-    private fun targetMode(target: Path): Int {
-        val permissions = try {
-            Files.getPosixFilePermissions(target, LinkOption.NOFOLLOW_LINKS)
-        } catch (exception: Exception) {
-            throw UnsafeWorkspaceMutationException(
-                message = "Secure workspace mutation could not preserve target permissions",
-                details = failureDetails(target, "read-target-permissions") + mapOf(
-                    "cause" to (exception.message ?: exception::class.java.simpleName),
-                ),
-            )
-        }
-        return permissions.fold(0) { mode, permission ->
-            mode or permission.modeBit
-        }
+    private fun descriptorStatus(
+        api: PosixFileApi,
+        platform: PosixPlatform,
+        descriptor: Int,
+        target: Path,
+    ): NativeFileStatus {
+        val status = Memory(STAT_BUFFER_SIZE)
+        requireSuccess(api.fstat(descriptor, status), "fstat", target, target.fileName.toString())
+        return platform.readStatus(status)
     }
-
-    private val PosixFilePermission.modeBit: Int
-        get() = when (this) {
-            PosixFilePermission.OWNER_READ -> 256
-            PosixFilePermission.OWNER_WRITE -> 128
-            PosixFilePermission.OWNER_EXECUTE -> 64
-            PosixFilePermission.GROUP_READ -> 32
-            PosixFilePermission.GROUP_WRITE -> 16
-            PosixFilePermission.GROUP_EXECUTE -> 8
-            PosixFilePermission.OTHERS_READ -> 4
-            PosixFilePermission.OTHERS_WRITE -> 2
-            PosixFilePermission.OTHERS_EXECUTE -> 1
-        }
 
     private fun requireSuccess(result: Int, operation: String, target: Path, component: String) {
         if (result < 0) {
@@ -379,13 +1253,6 @@ internal class SecureWorkspaceMutation(
 
         fun unlinkat(directoryDescriptor: Int, path: String, flags: Int): Int
 
-        fun renameat(
-            oldDirectoryDescriptor: Int,
-            oldPath: String,
-            newDirectoryDescriptor: Int,
-            newPath: String,
-        ): Int
-
         fun read(descriptor: Int, buffer: com.sun.jna.Pointer, count: NativeLong): NativeLong
 
         fun write(descriptor: Int, buffer: com.sun.jna.Pointer, count: NativeLong): NativeLong
@@ -394,34 +1261,224 @@ internal class SecureWorkspaceMutation(
 
         fun fchmod(descriptor: Int, mode: Int): Int
 
+        fun fstat(descriptor: Int, status: com.sun.jna.Pointer): Int
+
         fun close(descriptor: Int): Int
+    }
+
+    private interface MacRenameApi : Library {
+        @Suppress("FunctionName")
+        fun renameatx_np(
+            oldDirectoryDescriptor: Int,
+            oldPath: String,
+            newDirectoryDescriptor: Int,
+            newPath: String,
+            flags: Int,
+        ): Int
+    }
+
+    private interface LinuxRenameApi : Library {
+        fun renameat2(
+            oldDirectoryDescriptor: Int,
+            oldPath: String,
+            newDirectoryDescriptor: Int,
+            newPath: String,
+            flags: Int,
+        ): Int
     }
 
     private data class PosixPlatform(
         val directoryFlags: Int,
         val readFileFlags: Int,
         val createExclusiveFileFlags: Int,
+        val renamePrimitive: RenamePrimitive,
+        val statDeviceOffset: Long,
+        val statDeviceEncoding: NativeScalarEncoding,
+        val statInodeOffset: Long,
+        val statModeOffset: Long,
+        val statModeEncoding: NativeScalarEncoding,
         val notFoundErrno: Int = 2,
         val alreadyExistsErrno: Int = 17,
     ) {
+        fun readStatus(status: Memory): NativeFileStatus {
+            val modeBits = readScalar(status, statModeOffset, statModeEncoding).toInt()
+            return NativeFileStatus(
+                mode = NativeFileMode(
+                    bits = modeBits,
+                    fileType = NativeFileType.fromMode(modeBits),
+                ),
+                identity = NativeFileIdentity(
+                device = readScalar(status, statDeviceOffset, statDeviceEncoding),
+                inode = status.getLong(statInodeOffset),
+                ),
+            )
+        }
+
+        private fun readScalar(status: Memory, offset: Long, encoding: NativeScalarEncoding): Long = when (encoding) {
+            NativeScalarEncoding.UNSIGNED_SHORT -> (status.getShort(offset).toInt() and 0xffff).toLong()
+            NativeScalarEncoding.INT -> status.getInt(offset).toLong()
+            NativeScalarEncoding.LONG -> status.getLong(offset)
+        }
+
         companion object {
             fun current(): PosixPlatform? = when {
                 Platform.isMac() -> PosixPlatform(
                     directoryFlags = MAC_OPEN_DIRECTORY or MAC_OPEN_NOFOLLOW or MAC_OPEN_CLOEXEC,
-                    readFileFlags = MAC_OPEN_NOFOLLOW or MAC_OPEN_CLOEXEC,
+                    readFileFlags = MAC_OPEN_NOFOLLOW or MAC_OPEN_NONBLOCK or MAC_OPEN_CLOEXEC,
                     createExclusiveFileFlags = MAC_OPEN_WRITE_ONLY or MAC_OPEN_CREATE or MAC_OPEN_EXCLUSIVE or
                         MAC_OPEN_NOFOLLOW or MAC_OPEN_CLOEXEC,
+                    renamePrimitive = RenamePrimitive.MAC_RENAMEATX,
+                    statDeviceOffset = 0,
+                    statDeviceEncoding = NativeScalarEncoding.INT,
+                    statInodeOffset = 8,
+                    statModeOffset = 4,
+                    statModeEncoding = NativeScalarEncoding.UNSIGNED_SHORT,
                 )
 
-                Platform.isLinux() -> PosixPlatform(
+                Platform.isLinux() && Platform.is64Bit() && (Platform.isARM() || Platform.isIntel()) -> PosixPlatform(
                     directoryFlags = LINUX_OPEN_DIRECTORY or LINUX_OPEN_NOFOLLOW or LINUX_OPEN_CLOEXEC,
-                    readFileFlags = LINUX_OPEN_NOFOLLOW or LINUX_OPEN_CLOEXEC,
+                    readFileFlags = LINUX_OPEN_NOFOLLOW or LINUX_OPEN_NONBLOCK or LINUX_OPEN_CLOEXEC,
                     createExclusiveFileFlags = LINUX_OPEN_WRITE_ONLY or LINUX_OPEN_CREATE or LINUX_OPEN_EXCLUSIVE or
                         LINUX_OPEN_NOFOLLOW or LINUX_OPEN_CLOEXEC,
+                    renamePrimitive = RenamePrimitive.LINUX_RENAMEAT2,
+                    statDeviceOffset = 0,
+                    statDeviceEncoding = NativeScalarEncoding.LONG,
+                    statInodeOffset = 8,
+                    statModeOffset = if (Platform.isARM()) 16 else 24,
+                    statModeEncoding = NativeScalarEncoding.INT,
                 )
 
                 else -> null
             }
+        }
+    }
+
+    private enum class NativeScalarEncoding {
+        UNSIGNED_SHORT,
+        INT,
+        LONG,
+    }
+
+    private enum class RenamePrimitive {
+        MAC_RENAMEATX,
+        LINUX_RENAMEAT2,
+    }
+
+    private enum class RenameNoReplaceOutcome {
+        MOVED,
+        DESTINATION_EXISTS,
+        SOURCE_MISSING,
+    }
+
+    private enum class Restoration {
+        RESTORED,
+        QUARANTINED,
+    }
+
+    private sealed interface CleanupResult {
+        val recoveryFilePaths: List<Path>
+
+        fun conflictDetails(): Map<String, String>
+
+        data object Removed : CleanupResult {
+            override val recoveryFilePaths: List<Path> = emptyList()
+
+            override fun conflictDetails(): Map<String, String> = emptyMap()
+        }
+
+        data class Retained(
+            val recoveryFilePath: Path,
+            val reason: String,
+        ) : CleanupResult {
+            override val recoveryFilePaths: List<Path> = listOf(recoveryFilePath)
+
+            override fun conflictDetails(): Map<String, String> = mapOf(
+                "cleanupRecoveryFilePath" to recoveryFilePath.toString(),
+                "cleanupFailure" to reason,
+            )
+        }
+    }
+
+    private sealed interface FinalReservationRelease {
+        data class Released(val cleanup: CleanupResult) : FinalReservationRelease
+
+        data class Blocked(
+            val entryRecoveryFilePath: Path,
+            val restoredToFinalName: Boolean,
+            val reason: String,
+        ) : FinalReservationRelease
+    }
+
+    private data class NativeFileIdentity(
+        val device: Long,
+        val inode: Long,
+    ) {
+        fun details(prefix: String = "detached"): Map<String, String> = mapOf(
+            "${prefix}Device" to device.toULong().toString(),
+            "${prefix}Inode" to inode.toULong().toString(),
+        )
+    }
+
+    private data class NativeFileMode(
+        val bits: Int,
+        val fileType: NativeFileType,
+    ) {
+        val permissionBits: Int = bits and PERMISSION_BITS
+    }
+
+    private enum class NativeFileType {
+        FIFO,
+        CHARACTER_DEVICE,
+        DIRECTORY,
+        BLOCK_DEVICE,
+        REGULAR,
+        SYMBOLIC_LINK,
+        SOCKET,
+        UNKNOWN,
+        ;
+
+        companion object {
+            fun fromMode(mode: Int): NativeFileType = when (mode and FILE_TYPE_BITS) {
+                FIFO_MODE -> FIFO
+                CHARACTER_DEVICE_MODE -> CHARACTER_DEVICE
+                DIRECTORY_MODE_BITS -> DIRECTORY
+                BLOCK_DEVICE_MODE -> BLOCK_DEVICE
+                REGULAR_FILE_MODE -> REGULAR
+                SYMBOLIC_LINK_MODE -> SYMBOLIC_LINK
+                SOCKET_MODE -> SOCKET
+                else -> UNKNOWN
+            }
+        }
+    }
+
+    private data class NativeFileStatus(
+        val mode: NativeFileMode,
+        val identity: NativeFileIdentity,
+    )
+
+    private interface ExactNamedEntry : AutoCloseable {
+        val name: String
+        val status: NativeFileStatus
+    }
+
+    private class DetachedTarget(
+        override val name: String,
+        private val descriptor: NativeDescriptor,
+        override val status: NativeFileStatus,
+        val actualDiskHash: String,
+    ) : ExactNamedEntry {
+        override fun close() {
+            descriptor.close()
+        }
+    }
+
+    private class PreparedFile(
+        override val name: String,
+        private val descriptor: NativeDescriptor,
+        override val status: NativeFileStatus,
+    ) : ExactNamedEntry {
+        override fun close() {
+            descriptor.close()
         }
     }
 
@@ -431,8 +1488,28 @@ internal class SecureWorkspaceMutation(
         const val CREATED_FILE_MODE = 420 // 0644; deterministic IDEA-compatible source permissions.
         const val CREATED_DIRECTORY_MODE = 493 // 0755; deterministic IDEA-compatible directory permissions.
         const val BUFFER_SIZE = 8192
+        const val STAT_BUFFER_SIZE = 256L
+        const val PERMISSION_BITS = 4095 // 07777
+        const val FILE_TYPE_BITS = 61440 // 0170000
+        const val FIFO_MODE = 4096 // 0010000
+        const val CHARACTER_DEVICE_MODE = 8192 // 0020000
+        const val DIRECTORY_MODE_BITS = 16384 // 0040000
+        const val BLOCK_DEVICE_MODE = 24576 // 0060000
+        const val REGULAR_FILE_MODE = 32768 // 0100000
+        const val SYMBOLIC_LINK_MODE = 40960 // 0120000
+        const val SOCKET_MODE = 49152 // 0140000
+        const val MAX_UNIQUE_NAME_ATTEMPTS = 8
+
+        const val QUARANTINE_PREFIX = ".kast-quarantine-"
+        const val PREPARED_PREFIX = ".kast-prepared-"
+        const val CLEANUP_PREFIX = ".kast-cleanup-"
+
+        const val MAC_RENAME_EXCLUSIVE = 0x00000004
+        const val MAC_RENAME_NOFOLLOW_ANY = 0x00000010
+        const val LINUX_RENAME_NOREPLACE = 0x00000001
 
         const val MAC_OPEN_WRITE_ONLY = 0x0001
+        const val MAC_OPEN_NONBLOCK = 0x0004
         const val MAC_OPEN_CREATE = 0x0200
         const val MAC_OPEN_EXCLUSIVE = 0x0800
         const val MAC_OPEN_NOFOLLOW = 0x0100
@@ -440,6 +1517,7 @@ internal class SecureWorkspaceMutation(
         const val MAC_OPEN_CLOEXEC = 0x1000000
 
         const val LINUX_OPEN_WRITE_ONLY = 0x0001
+        const val LINUX_OPEN_NONBLOCK = 0x0800
         const val LINUX_OPEN_CREATE = 0x0040
         const val LINUX_OPEN_EXCLUSIVE = 0x0080
         const val LINUX_OPEN_DIRECTORY = 0x10000
@@ -448,6 +1526,14 @@ internal class SecureWorkspaceMutation(
 
         val api: PosixFileApi by lazy {
             Native.load(Platform.C_LIBRARY_NAME, PosixFileApi::class.java)
+        }
+
+        val macRenameApi: MacRenameApi by lazy {
+            Native.load(Platform.C_LIBRARY_NAME, MacRenameApi::class.java)
+        }
+
+        val linuxRenameApi: LinuxRenameApi by lazy {
+            Native.load(Platform.C_LIBRARY_NAME, LinuxRenameApi::class.java)
         }
     }
 }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutationResult.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutationResult.kt
@@ -1,0 +1,29 @@
+package io.github.amichne.kast.idea
+
+import java.nio.file.Path
+
+internal sealed interface SecureWorkspaceMutationResult {
+    data object Committed : SecureWorkspaceMutationResult
+
+    class CommittedWithRecovery private constructor(
+        val recoveryFilePaths: List<Path>,
+    ) : SecureWorkspaceMutationResult {
+        companion object {
+            fun of(recoveryFilePaths: Collection<Path>): CommittedWithRecovery {
+                require(recoveryFilePaths.isNotEmpty()) {
+                    "Committed recovery evidence requires at least one recovery file"
+                }
+                return CommittedWithRecovery(recoveryFilePaths.toList())
+            }
+        }
+    }
+
+    companion object {
+        fun committed(recoveryFilePaths: Collection<Path>): SecureWorkspaceMutationResult =
+            if (recoveryFilePaths.isEmpty()) {
+                Committed
+            } else {
+                CommittedWithRecovery.of(recoveryFilePaths)
+            }
+    }
+}

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceRenamePhase.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/SecureWorkspaceRenamePhase.kt
@@ -1,0 +1,9 @@
+package io.github.amichne.kast.idea
+
+internal enum class SecureWorkspaceRenamePhase {
+    DETACH_TARGET,
+    FINAL_COMMIT,
+    RESTORE_TARGET,
+    MOVE_CLEANUP,
+    RESTORE_CLEANUP,
+}

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaEditApplicationTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaEditApplicationTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.writeAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
 import com.intellij.testFramework.junit5.TestApplication
@@ -22,13 +23,16 @@ import io.github.amichne.kast.api.contract.FileOperation
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.contract.TextEdit
 import io.github.amichne.kast.api.protocol.ValidationException
+import io.github.amichne.kast.api.protocol.UnsafeWorkspaceMutationException
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
 
 @TestApplication
 class IdeaEditApplicationTest {
@@ -127,7 +131,7 @@ class IdeaEditApplicationTest {
     }
 
     @Test
-    fun `applyEdits updates IDEA Document immediately without disk write`() = runBlocking {
+    fun `applyEdits updates IDEA Document and secure disk state`() = runBlocking {
         ensureProjectReady()
 
         val filePath = readAction { testFile.virtualFile.path }
@@ -203,6 +207,128 @@ class IdeaEditApplicationTest {
         assertEquals(listOf(newFile.toString()), result.createdFiles)
         assertTrue(Files.isDirectory(newFile.parent), "Create file should materialize missing parent directories")
         assertEquals(content, Files.readString(newFile))
+    }
+
+    @Test
+    fun `add file create fails closed when validated ancestor becomes escaping symlink at write boundary`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val guardedParent = Files.createDirectory(workspaceRoot.resolve("guarded-create"))
+        val displacedParent = workspaceRoot.resolve("guarded-create-displaced")
+        val outsideParent = Files.createTempDirectory("kast-escaping-create")
+        val target = guardedParent.resolve("Created.kt")
+
+        val failure = runCatching {
+            IdeaEditApplier(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                beforeSecureMutation = { filePath, mutation ->
+                    if (filePath == target && mutation == IdeaWorkspaceMutation.CREATE_FILE) {
+                        Files.move(guardedParent, displacedParent)
+                        Files.createSymbolicLink(guardedParent, outsideParent)
+                    }
+                },
+            ).apply(
+                ApplyEditsQuery(
+                    edits = emptyList(),
+                    fileHashes = emptyList(),
+                    fileOperations = listOf(FileOperation.CreateFile(target.toString(), "class Created\n")),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(
+            failure is UnsafeWorkspaceMutationException,
+            "Expected UnsafeWorkspaceMutationException, got ${failure?.let { it::class.qualifiedName } ?: "success"}",
+        )
+        val unsafeFailure = failure as UnsafeWorkspaceMutationException
+        assertEquals("UNSAFE_WORKSPACE_MUTATION", unsafeFailure.errorCode)
+        assertEquals("openat-directory", unsafeFailure.details["nativeOperation"])
+        assertFalse(Files.exists(outsideParent.resolve(target.fileName)), "Escaping target must remain untouched")
+        assertFalse(Files.exists(displacedParent.resolve(target.fileName)), "Displaced in-workspace directory must remain untouched")
+    }
+
+    @Test
+    fun `file scoped mutation fails closed when validated ancestor becomes escaping symlink at write boundary`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val guardedParent = Files.createDirectory(workspaceRoot.resolve("guarded-edit"))
+        val displacedParent = workspaceRoot.resolve("guarded-edit-displaced")
+        val outsideParent = Files.createTempDirectory("kast-escaping-edit")
+        val target = guardedParent.resolve("Scoped.kt")
+        val original = "package demo\n\nfun value(): Int = 1\n"
+        val outsideOriginal = "package outside\n\nfun value(): Int = 9\n"
+        Files.writeString(target, original)
+        Files.writeString(outsideParent.resolve(target.fileName), outsideOriginal)
+        LocalFileSystem.getInstance().refreshAndFindFileByNioFile(target)
+
+        val failure = runCatching {
+            IdeaEditApplier(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                beforeSecureMutation = { filePath, mutation ->
+                    if (filePath == target && mutation == IdeaWorkspaceMutation.TEXT_EDIT) {
+                        Files.move(guardedParent, displacedParent)
+                        Files.createSymbolicLink(guardedParent, outsideParent)
+                    }
+                },
+            ).apply(
+                ApplyEditsQuery(
+                    edits = listOf(
+                        TextEdit(
+                            filePath = target.toString(),
+                            startOffset = original.indexOf('1'),
+                            endOffset = original.indexOf('1') + 1,
+                            newText = "2",
+                        ),
+                    ),
+                    fileHashes = listOf(FileHash(target.toString(), io.github.amichne.kast.api.validation.FileHashing.sha256(original))),
+                    fileOperations = emptyList(),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(
+            failure is UnsafeWorkspaceMutationException,
+            "Expected UnsafeWorkspaceMutationException, got ${failure?.let { it::class.qualifiedName } ?: "success"}",
+        )
+        val unsafeFailure = failure as UnsafeWorkspaceMutationException
+        assertEquals("UNSAFE_WORKSPACE_MUTATION", unsafeFailure.errorCode)
+        assertEquals("openat-directory", unsafeFailure.details["nativeOperation"])
+        assertEquals(outsideOriginal, Files.readString(outsideParent.resolve(target.fileName)))
+        assertEquals(original, Files.readString(displacedParent.resolve(target.fileName)))
+    }
+
+    @Test
+    fun `secure text edit preserves existing source permissions`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val target = workspaceRoot.resolve("PermissionPreserved.kt")
+        val original = "package demo\n\nfun permissionPreserved(): Int = 1\n"
+        val permissions = PosixFilePermissions.fromString("rw-------")
+        Files.writeString(target, original)
+        Files.setPosixFilePermissions(target, permissions)
+        LocalFileSystem.getInstance().refreshAndFindFileByNioFile(target)
+
+        IdeaEditApplier(project, workspaceRoot).apply(
+            ApplyEditsQuery(
+                edits = listOf(
+                    TextEdit(
+                        filePath = target.toString(),
+                        startOffset = original.indexOf('1'),
+                        endOffset = original.indexOf('1') + 1,
+                        newText = "2",
+                    ),
+                ),
+                fileHashes = listOf(FileHash(target.toString(), io.github.amichne.kast.api.validation.FileHashing.sha256(original))),
+                fileOperations = emptyList(),
+            ),
+        )
+
+        assertEquals(permissions, Files.getPosixFilePermissions(target))
     }
 
     @Test

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaEditApplicationTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaEditApplicationTest.kt
@@ -22,6 +22,8 @@ import io.github.amichne.kast.api.contract.FileHash
 import io.github.amichne.kast.api.contract.FileOperation
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.contract.TextEdit
+import io.github.amichne.kast.api.protocol.ConflictException
+import io.github.amichne.kast.api.protocol.PartialApplyException
 import io.github.amichne.kast.api.protocol.ValidationException
 import io.github.amichne.kast.api.protocol.UnsafeWorkspaceMutationException
 import kotlinx.coroutines.runBlocking
@@ -302,6 +304,343 @@ class IdeaEditApplicationTest {
     }
 
     @Test
+    fun `file scoped mutation reports a typed conflict when a concurrent final entry blocks restoration`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val target = workspaceRoot.resolve("ConcurrentEdit.kt")
+        val original = "package demo\n\nfun value(): Int = 1\n"
+        val concurrent = "package demo\n\nfun concurrent(): Int = 9\n"
+        Files.writeString(target, original)
+        LocalFileSystem.getInstance().refreshAndFindFileByNioFile(target)
+
+        val failure = runCatching {
+            IdeaEditApplier(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                secureWorkspaceMutation = SecureWorkspaceMutation(
+                    workspaceRoot = workspaceRoot,
+                    afterTargetDetached = { detachedTarget, mutation ->
+                        if (detachedTarget == target && mutation == IdeaWorkspaceMutation.TEXT_EDIT) {
+                            Files.writeString(target, concurrent)
+                        }
+                    },
+                ),
+            ).apply(
+                ApplyEditsQuery(
+                    edits = listOf(
+                        TextEdit(
+                            filePath = target.toString(),
+                            startOffset = original.indexOf('1'),
+                            endOffset = original.indexOf('1') + 1,
+                            newText = "2",
+                        ),
+                    ),
+                    fileHashes = listOf(
+                        FileHash(
+                            target.toString(),
+                            io.github.amichne.kast.api.validation.FileHashing.sha256(original),
+                        ),
+                    ),
+                    fileOperations = emptyList(),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(
+            failure is ConflictException,
+            "Expected ConflictException, got ${failure?.let { it::class.qualifiedName } ?: "success"}",
+        )
+        val conflict = failure as ConflictException
+        assertEquals("quarantined", conflict.details["restoration"])
+        assertEquals(concurrent, Files.readString(target))
+        assertEquals(original, Files.readString(Path.of(conflict.details.getValue("recoveryFilePath"))))
+    }
+
+    @Test
+    fun `committed text edit reports applied file and retained recovery evidence`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val target = workspaceRoot.resolve("RetainedCleanupEdit.kt")
+        val original = "package demo\n\nfun retainedCleanup(): Int = 1\n"
+        val replacement = "package demo\n\nfun retainedCleanup(): Int = 2\n"
+        Files.writeString(target, original)
+        val virtualFile = checkNotNull(LocalFileSystem.getInstance().refreshAndFindFileByNioFile(target))
+        var failNextCleanup = true
+
+        val failure = runCatching {
+            IdeaEditApplier(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                secureWorkspaceMutation = SecureWorkspaceMutation(
+                    workspaceRoot = workspaceRoot,
+                    beforeCleanupUnlink = {
+                        if (failNextCleanup) {
+                            failNextCleanup = false
+                            error("forced retained cleanup evidence")
+                        }
+                    },
+                ),
+            ).apply(
+                ApplyEditsQuery(
+                    edits = listOf(
+                        TextEdit(
+                            filePath = target.toString(),
+                            startOffset = original.indexOf('1'),
+                            endOffset = original.indexOf('1') + 1,
+                            newText = "2",
+                        ),
+                    ),
+                    fileHashes = listOf(
+                        FileHash(
+                            target.toString(),
+                            io.github.amichne.kast.api.validation.FileHashing.sha256(original),
+                        ),
+                    ),
+                    fileOperations = emptyList(),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(
+            failure is PartialApplyException,
+            "Expected PartialApplyException, got ${failure?.let { it::class.qualifiedName } ?: "success"}",
+        )
+        val partial = failure as PartialApplyException
+        assertEquals(target.toString(), partial.details["appliedFiles"])
+        val recoveryFile = Path.of(partial.details.getValue("recoveryFilePaths"))
+        assertEquals(original, Files.readString(recoveryFile))
+        assertEquals(replacement, Files.readString(target))
+        val documentText = readAction {
+            FileDocumentManager.getInstance().getDocument(virtualFile)!!.text
+        }
+        assertEquals(replacement, documentText)
+    }
+
+    @Test
+    fun `post commit create verification failure reports created file as applied`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val target = workspaceRoot.resolve("PostCommitCreate.kt")
+        val committed = "class PostCommitCreate\n"
+        val raced = "class RacedPostCommitCreate\n"
+
+        val failure = runCatching {
+            IdeaEditApplier(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                afterFilesystemCommit = { committedTarget, mutation ->
+                    if (committedTarget == target && mutation == IdeaWorkspaceMutation.CREATE_FILE) {
+                        Files.writeString(target, raced)
+                    }
+                },
+            ).apply(
+                ApplyEditsQuery(
+                    edits = emptyList(),
+                    fileHashes = emptyList(),
+                    fileOperations = listOf(FileOperation.CreateFile(target.toString(), committed)),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is PartialApplyException)
+        val partial = failure as PartialApplyException
+        assertEquals(target.toString(), partial.details["appliedFiles"])
+        assertEquals(target.toString(), partial.details["createdFiles"])
+        assertEquals(raced, Files.readString(target))
+    }
+
+    @Test
+    fun `post commit deletion failure reports deleted file as applied`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val target = workspaceRoot.resolve("PostCommitDelete.kt")
+        val original = "class PostCommitDelete\n"
+        Files.writeString(target, original)
+
+        val failure = runCatching {
+            IdeaEditApplier(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                afterFilesystemCommit = { committedTarget, mutation ->
+                    if (committedTarget == target && mutation == IdeaWorkspaceMutation.DELETE_FILE) {
+                        error("forced post-commit delete failure")
+                    }
+                },
+            ).apply(
+                ApplyEditsQuery(
+                    edits = emptyList(),
+                    fileHashes = emptyList(),
+                    fileOperations = listOf(
+                        FileOperation.DeleteFile(
+                            target.toString(),
+                            io.github.amichne.kast.api.validation.FileHashing.sha256(original),
+                        ),
+                    ),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is PartialApplyException)
+        val partial = failure as PartialApplyException
+        assertEquals(target.toString(), partial.details["appliedFiles"])
+        assertEquals(target.toString(), partial.details["deletedFiles"])
+        assertFalse(Files.exists(target))
+    }
+
+    @Test
+    fun `write action completion failure retains the committed create ledger`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val target = workspaceRoot.resolve("WriteActionCompletion.kt")
+        val content = "class WriteActionCompletion\n"
+
+        val failure = runCatching {
+            IdeaEditApplier(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                runFileOperationWriteAction = { operation ->
+                    operation()
+                    error("forced write action completion failure")
+                },
+            ).apply(
+                ApplyEditsQuery(
+                    edits = emptyList(),
+                    fileHashes = emptyList(),
+                    fileOperations = listOf(FileOperation.CreateFile(target.toString(), content)),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is PartialApplyException)
+        val partial = failure as PartialApplyException
+        assertEquals(target.toString(), partial.details["appliedFiles"])
+        assertEquals(target.toString(), partial.details["createdFiles"])
+        assertEquals(content, Files.readString(target))
+    }
+
+    @Test
+    fun `post commit create verification refuses an escaping final symlink`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val target = workspaceRoot.resolve("PostCommitEscapingCreate.kt")
+        val content = "class PostCommitEscapingCreate\n"
+        val outsideTarget = Files.createTempFile("kast-post-commit-escaping-create", ".kt")
+        Files.writeString(outsideTarget, content)
+
+        val failure = runCatching {
+            IdeaEditApplier(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                afterFilesystemCommit = { committedTarget, mutation ->
+                    if (committedTarget == target && mutation == IdeaWorkspaceMutation.CREATE_FILE) {
+                        Files.delete(target)
+                        Files.createSymbolicLink(target, outsideTarget)
+                    }
+                },
+            ).apply(
+                ApplyEditsQuery(
+                    edits = emptyList(),
+                    fileHashes = emptyList(),
+                    fileOperations = listOf(FileOperation.CreateFile(target.toString(), content)),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is PartialApplyException)
+        val partial = failure as PartialApplyException
+        assertEquals(target.toString(), partial.details["appliedFiles"])
+        assertEquals(target.toString(), partial.details["createdFiles"])
+        assertEquals(content, Files.readString(outsideTarget))
+    }
+
+    @Test
+    fun `post commit text failure reports replacement as applied`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val target = workspaceRoot.resolve("PostCommitText.kt")
+        val original = "package demo\n\nfun postCommitText(): Int = 1\n"
+        val replacement = "package demo\n\nfun postCommitText(): Int = 2\n"
+        Files.writeString(target, original)
+        LocalFileSystem.getInstance().refreshAndFindFileByNioFile(target)
+
+        val failure = runCatching {
+            IdeaEditApplier(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                afterFilesystemCommit = { committedTarget, mutation ->
+                    if (committedTarget == target && mutation == IdeaWorkspaceMutation.TEXT_EDIT) {
+                        error("forced post-commit document failure")
+                    }
+                },
+            ).apply(
+                ApplyEditsQuery(
+                    edits = listOf(
+                        TextEdit(
+                            filePath = target.toString(),
+                            startOffset = original.indexOf('1'),
+                            endOffset = original.indexOf('1') + 1,
+                            newText = "2",
+                        ),
+                    ),
+                    fileHashes = listOf(
+                        FileHash(
+                            target.toString(),
+                            io.github.amichne.kast.api.validation.FileHashing.sha256(original),
+                        ),
+                    ),
+                    fileOperations = emptyList(),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is PartialApplyException)
+        val partial = failure as PartialApplyException
+        assertEquals(target.toString(), partial.details["appliedFiles"])
+        assertEquals(replacement, Files.readString(target))
+    }
+
+    @Test
+    fun `hash conflict after file operation preserves committed operation evidence`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val created = workspaceRoot.resolve("CreatedBeforeHashConflict.kt")
+        val createdContent = "class CreatedBeforeHashConflict\n"
+        val editTarget = readAction { testFile.virtualFile.path }
+        val editText = readAction { testFile.text }
+
+        val failure = runCatching {
+            backend(workspaceRoot).applyEdits(
+                ApplyEditsQuery(
+                    edits = listOf(
+                        TextEdit(
+                            filePath = editTarget,
+                            startOffset = editText.indexOf("oldName"),
+                            endOffset = editText.indexOf("oldName") + "oldName".length,
+                            newText = "newName",
+                        ),
+                    ),
+                    fileHashes = listOf(FileHash(editTarget, io.github.amichne.kast.api.validation.FileHashing.sha256("stale"))),
+                    fileOperations = listOf(FileOperation.CreateFile(created.toString(), createdContent)),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is PartialApplyException)
+        val partial = failure as PartialApplyException
+        assertEquals(created.toString(), partial.details["appliedFiles"])
+        assertEquals(created.toString(), partial.details["createdFiles"])
+        assertEquals(createdContent, Files.readString(created))
+    }
+
+    @Test
     fun `secure text edit preserves existing source permissions`() = runBlocking {
         ensureProjectReady()
 
@@ -355,6 +694,54 @@ class IdeaEditApplicationTest {
 
         assertEquals(listOf(deleteFile.toString()), result.deletedFiles)
         assertTrue(Files.notExists(deleteFile), "Inside workspace delete target should be absent after apply")
+    }
+
+    @Test
+    fun `committed deletion reports deleted file and retained recovery evidence`() = runBlocking {
+        ensureProjectReady()
+
+        val workspaceRoot = Path.of(sourceRootFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val target = workspaceRoot.resolve("RetainedCleanupDelete.kt")
+        val original = "package demo\n\nfun retainedCleanupDelete(): Int = 1\n"
+        Files.writeString(target, original)
+        var cleanupCalls = 0
+
+        val failure = runCatching {
+            IdeaEditApplier(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                secureWorkspaceMutation = SecureWorkspaceMutation(
+                    workspaceRoot = workspaceRoot,
+                    beforeCleanupUnlink = {
+                        cleanupCalls += 1
+                        if (cleanupCalls == 2) {
+                            error("forced retained delete cleanup evidence")
+                        }
+                    },
+                ),
+            ).apply(
+                ApplyEditsQuery(
+                    edits = emptyList(),
+                    fileHashes = emptyList(),
+                    fileOperations = listOf(
+                        FileOperation.DeleteFile(
+                            filePath = target.toString(),
+                            expectedHash = io.github.amichne.kast.api.validation.FileHashing.sha256(original),
+                        ),
+                    ),
+                ),
+            )
+        }.exceptionOrNull()
+
+        assertTrue(
+            failure is PartialApplyException,
+            "Expected PartialApplyException, got ${failure?.let { it::class.qualifiedName } ?: "success"}",
+        )
+        val partial = failure as PartialApplyException
+        assertEquals(target.toString(), partial.details["appliedFiles"], partial.details.toString())
+        assertEquals(target.toString(), partial.details["deletedFiles"], partial.details.toString())
+        assertEquals(original, Files.readString(Path.of(partial.details.getValue("recoveryFilePaths"))))
+        assertFalse(Files.exists(target), "The deletion must remain committed")
     }
 
     @Test

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutationTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/SecureWorkspaceMutationTest.kt
@@ -1,0 +1,343 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.api.protocol.ConflictException
+import io.github.amichne.kast.api.protocol.NotFoundException
+import io.github.amichne.kast.api.protocol.UnsafeWorkspaceMutationException
+import io.github.amichne.kast.api.validation.FileHashing
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+
+class SecureWorkspaceMutationTest {
+    @Test
+    fun `create preserves a concurrent final entry and never cleans it by name`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-concurrent-create").toRealPath()
+        val target = workspaceRoot.resolve("Create.kt")
+        val concurrent = "class ConcurrentCreate\n"
+
+        val failure = assertThrows(ConflictException::class.java) {
+            SecureWorkspaceMutation(
+                workspaceRoot = workspaceRoot,
+                beforeFinalCommit = { commitTarget, mutation ->
+                    assertEquals(target, commitTarget)
+                    assertEquals(IdeaWorkspaceMutation.CREATE_FILE, mutation)
+                    Files.writeString(target, concurrent)
+                },
+            ).createFile(target, "class Created\n")
+        }
+
+        assertEquals(concurrent, Files.readString(target))
+        assertEquals("CONFLICT", failure.errorCode)
+    }
+
+    @Test
+    fun `replace maps a missing detached target to not found`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-missing-replace").toRealPath()
+        val target = workspaceRoot.resolve("Missing.kt")
+
+        val failure = assertThrows(NotFoundException::class.java) {
+            SecureWorkspaceMutation(workspaceRoot).replaceFile(
+                target = target,
+                expectedDiskHash = FileHashing.sha256("missing"),
+                content = "class Replacement\n",
+            )
+        }
+
+        assertEquals("NOT_FOUND", failure.errorCode)
+        assertEquals(target.toString(), failure.details["filePath"])
+    }
+
+    @Test
+    fun `replace preserves a concurrent entry and quarantines the validated inode`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-concurrent-replace").toRealPath()
+        val target = workspaceRoot.resolve("Replace.kt")
+        val original = "class Original\n"
+        val concurrent = "class Concurrent\n"
+        val originalPermissions = PosixFilePermissions.fromString("rw-------")
+        val concurrentPermissions = PosixFilePermissions.fromString("rw-r--r--")
+        Files.writeString(target, original)
+        Files.setPosixFilePermissions(target, originalPermissions)
+
+        val failure = assertThrows(ConflictException::class.java) {
+            SecureWorkspaceMutation(
+                workspaceRoot = workspaceRoot,
+                afterTargetDetached = { detachedTarget, mutation ->
+                    assertEquals(target, detachedTarget)
+                    assertEquals(IdeaWorkspaceMutation.TEXT_EDIT, mutation)
+                    Files.writeString(target, concurrent)
+                    Files.setPosixFilePermissions(target, concurrentPermissions)
+                },
+            ).replaceFile(
+                target = target,
+                expectedDiskHash = FileHashing.sha256(original),
+                content = "class Replacement\n",
+            )
+        }
+
+        assertEquals("CONFLICT", failure.errorCode)
+        assertEquals("quarantined", failure.details["restoration"])
+        assertEquals(concurrent, Files.readString(target))
+        assertEquals(concurrentPermissions, Files.getPosixFilePermissions(target))
+        val recoveryFile = Path.of(failure.details.getValue("recoveryFilePath"))
+        assertTrue(Files.exists(recoveryFile), "The exact validated inode must remain recoverable")
+        assertEquals(original, Files.readString(recoveryFile))
+        assertEquals(originalPermissions, Files.getPosixFilePermissions(recoveryFile))
+    }
+
+    @Test
+    fun `delete preserves both a concurrent entry and the validated inode when commit is blocked`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-concurrent-delete").toRealPath()
+        val target = workspaceRoot.resolve("Delete.kt")
+        val original = "class OriginalDelete\n"
+        val concurrent = "class ConcurrentDelete\n"
+        Files.writeString(target, original)
+
+        val failure = assertThrows(ConflictException::class.java) {
+            SecureWorkspaceMutation(
+                workspaceRoot = workspaceRoot,
+                afterTargetDetached = { detachedTarget, mutation ->
+                    assertEquals(target, detachedTarget)
+                    assertEquals(IdeaWorkspaceMutation.DELETE_FILE, mutation)
+                    Files.writeString(target, concurrent)
+                },
+            ).deleteFile(
+                target = target,
+                expectedDiskHash = FileHashing.sha256(original),
+            )
+        }
+
+        assertEquals("quarantined", failure.details["restoration"])
+        assertEquals(concurrent, Files.readString(target))
+        val recoveryFile = Path.of(failure.details.getValue("recoveryFilePath"))
+        assertEquals(original, Files.readString(recoveryFile))
+    }
+
+    @Test
+    fun `hash conflict restores the detached inode to its original name`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-hash-restore").toRealPath()
+        val target = workspaceRoot.resolve("HashConflict.kt")
+        val original = "class OriginalHash\n"
+        Files.writeString(target, original)
+
+        val failure = assertThrows(ConflictException::class.java) {
+            SecureWorkspaceMutation(workspaceRoot).replaceFile(
+                target = target,
+                expectedDiskHash = FileHashing.sha256("stale"),
+                content = "class Replacement\n",
+            )
+        }
+
+        assertEquals("restored", failure.details["restoration"])
+        assertEquals(original, Files.readString(target))
+        Files.list(workspaceRoot).use { entries ->
+            assertFalse(
+                entries.anyMatch { entry -> entry.fileName.toString().startsWith(".kast-quarantine-") },
+                "A successful rollback must not leave a quarantine entry",
+            )
+        }
+    }
+
+    @Test
+    fun `replacement reports committed state when original cleanup is retained`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-retained-replace").toRealPath()
+        val target = workspaceRoot.resolve("RetainedReplace.kt")
+        val original = "class OriginalRetainedReplace\n"
+        val replacement = "class ReplacementRetainedReplace\n"
+        Files.writeString(target, original)
+        var failNextCleanup = true
+
+        val result = SecureWorkspaceMutation(
+            workspaceRoot = workspaceRoot,
+            beforeCleanupUnlink = {
+                if (failNextCleanup) {
+                    failNextCleanup = false
+                    error("forced cleanup retention")
+                }
+            },
+        ).replaceFile(target, FileHashing.sha256(original), replacement)
+
+        assertTrue(result is SecureWorkspaceMutationResult.CommittedWithRecovery)
+        val committed = result as SecureWorkspaceMutationResult.CommittedWithRecovery
+        assertEquals(replacement, Files.readString(target))
+        assertEquals(listOf(original), committed.recoveryFilePaths.map { path -> Files.readString(path) })
+    }
+
+    @Test
+    fun `deletion reports committed state when original cleanup is retained`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-retained-delete").toRealPath()
+        val target = workspaceRoot.resolve("RetainedDelete.kt")
+        val original = "class OriginalRetainedDelete\n"
+        Files.writeString(target, original)
+        var cleanupCalls = 0
+
+        val result = SecureWorkspaceMutation(
+            workspaceRoot = workspaceRoot,
+            beforeCleanupUnlink = {
+                cleanupCalls += 1
+                if (cleanupCalls == 2) {
+                    error("forced cleanup retention")
+                }
+            },
+        ).deleteFile(target, FileHashing.sha256(original))
+
+        assertTrue(result is SecureWorkspaceMutationResult.CommittedWithRecovery)
+        val committed = result as SecureWorkspaceMutationResult.CommittedWithRecovery
+        assertFalse(Files.exists(target), "The validated original deletion must remain committed")
+        assertEquals(listOf(original), committed.recoveryFilePaths.map { path -> Files.readString(path) })
+    }
+
+    @Test
+    fun `namespace conflict restores before fallible prepared cleanup and reports both recoveries`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-restore-order").toRealPath()
+        val target = workspaceRoot.resolve("RestoreOrder.kt")
+        val original = "class OriginalRestoreOrder\n"
+        val concurrent = "class ConcurrentRestoreOrder\n"
+        val replacement = "class ReplacementRestoreOrder\n"
+        Files.writeString(target, original)
+        var failNextCleanup = true
+
+        val failure = assertThrows(ConflictException::class.java) {
+            SecureWorkspaceMutation(
+                workspaceRoot = workspaceRoot,
+                afterTargetDetached = { _, _ -> Files.writeString(target, concurrent) },
+                beforeCleanupUnlink = {
+                    if (failNextCleanup) {
+                        failNextCleanup = false
+                        error("forced prepared cleanup retention")
+                    }
+                },
+            ).replaceFile(target, FileHashing.sha256(original), replacement)
+        }
+
+        assertEquals(concurrent, Files.readString(target))
+        assertEquals(original, Files.readString(Path.of(failure.details.getValue("recoveryFilePath"))))
+        assertEquals(
+            replacement,
+            Files.readString(Path.of(failure.details.getValue("cleanupRecoveryFilePath"))),
+        )
+    }
+
+    @Test
+    fun `preparation failure after detach restores the original final entry`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-preparation-rollback").toRealPath()
+        val target = workspaceRoot.resolve("PreparationRollback.kt")
+        val original = "class PreparationRollback\n"
+        Files.writeString(target, original)
+
+        val failure = assertThrows(ConflictException::class.java) {
+            SecureWorkspaceMutation(
+                workspaceRoot = workspaceRoot,
+                beforePreparedFileCreation = { preparedTarget, mutation ->
+                    assertEquals(target, preparedTarget)
+                    assertEquals(IdeaWorkspaceMutation.TEXT_EDIT, mutation)
+                    error("forced preparation failure")
+                },
+            ).replaceFile(target, FileHashing.sha256(original), "class Replacement\n")
+        }
+
+        assertEquals("restored", failure.details["restoration"])
+        assertEquals(original, Files.readString(target))
+    }
+
+    @Test
+    fun `native final commit failure restores original before prepared cleanup`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-native-commit-rollback").toRealPath()
+        val target = workspaceRoot.resolve("NativeCommitRollback.kt")
+        val original = "class NativeCommitRollback\n"
+        val replacement = "class NativeCommitReplacement\n"
+        Files.writeString(target, original)
+        var cleanupObservedRestoredOriginal = false
+
+        val failure = assertThrows(ConflictException::class.java) {
+            SecureWorkspaceMutation(
+                workspaceRoot = workspaceRoot,
+                beforeNoReplaceRename = { renameTarget, phase ->
+                    if (renameTarget == target && phase == SecureWorkspaceRenamePhase.FINAL_COMMIT) {
+                        error("forced native final rename failure")
+                    }
+                },
+                beforeCleanupUnlink = {
+                    cleanupObservedRestoredOriginal = Files.readString(target) == original
+                },
+            ).replaceFile(target, FileHashing.sha256(original), replacement)
+        }
+
+        assertTrue(cleanupObservedRestoredOriginal, "Original restoration must precede prepared cleanup")
+        assertEquals("restored", failure.details["restoration"])
+        assertEquals(original, Files.readString(target))
+    }
+
+    @Test
+    fun `late delete reservation replacement is restored and reported as conflict`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-late-delete-race").toRealPath()
+        val target = workspaceRoot.resolve("LateDeleteRace.kt")
+        val original = "class OriginalLateDelete\n"
+        val concurrent = "class ConcurrentLateDelete\n"
+        Files.writeString(target, original)
+
+        val failure = assertThrows(ConflictException::class.java) {
+            SecureWorkspaceMutation(
+                workspaceRoot = workspaceRoot,
+                afterDeleteReservationCommitted = { reservedTarget ->
+                    assertEquals(target, reservedTarget)
+                    Files.delete(reservedTarget)
+                    Files.writeString(reservedTarget, concurrent)
+                },
+            ).deleteFile(target, FileHashing.sha256(original))
+        }
+
+        assertEquals(concurrent, Files.readString(target))
+        assertEquals("restored", failure.details["concurrentEntryRestoration"])
+        assertEquals(original, Files.readString(Path.of(failure.details.getValue("recoveryFilePath"))))
+    }
+
+    @Test
+    fun `non regular fifo target fails closed without hashing its stream`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-fifo").toRealPath()
+        val target = workspaceRoot.resolve("Target.kt")
+        val mkfifo = ProcessBuilder("mkfifo", target.toString()).start()
+        assertEquals(0, mkfifo.waitFor(), "The test requires POSIX mkfifo")
+
+        val failure = assertThrows(io.github.amichne.kast.api.protocol.UnsafeWorkspaceMutationException::class.java) {
+            SecureWorkspaceMutation(workspaceRoot).replaceFile(
+                target = target,
+                expectedDiskHash = FileHashing.sha256(""),
+                content = "class Replacement\n",
+            )
+        }
+
+        assertEquals("reject-non-regular-target", failure.details["nativeOperation"])
+        assertEquals("FIFO", failure.details["fileType"])
+        assertTrue(Files.exists(target), "Rejected FIFO must be restored to its final name")
+        assertFalse(Files.isRegularFile(target))
+    }
+
+    @Test
+    fun `post commit verification refuses an escaping final symlink`() {
+        val workspaceRoot = Files.createTempDirectory("kast-secure-post-commit-verification").toRealPath()
+        val target = workspaceRoot.resolve("Verified.kt")
+        val committed = "class Verified\n"
+        val outsideTarget = Files.createTempFile("kast-secure-outside-verification", ".kt")
+        Files.writeString(outsideTarget, committed)
+        val mutation = SecureWorkspaceMutation(workspaceRoot)
+        mutation.createFile(target, committed)
+        Files.delete(target)
+        Files.createSymbolicLink(target, outsideTarget)
+
+        val failure = assertThrows(UnsafeWorkspaceMutationException::class.java) {
+            mutation.verifyCommittedFile(
+                target = target,
+                expectedContent = committed,
+                mutation = IdeaWorkspaceMutation.CREATE_FILE,
+            )
+        }
+
+        assertEquals("openat-verify-committed-file", failure.details["nativeOperation"])
+        assertEquals(committed, Files.readString(outsideTarget))
+    }
+}

--- a/cli-rs/resources/kast-skill/SKILL.md
+++ b/cli-rs/resources/kast-skill/SKILL.md
@@ -18,7 +18,7 @@ the first iteration surface.
 
 1. Orient with `kast`, `kast help agent`, and read-only `kast ready --workspace-root "$PWD"` when install or backend state matters.
 2. Resolve identity with `kast agent symbol --query <name> --workspace-root "$PWD"`; exact lookup is the default. Use `--mode discovery` only for fuzzy candidates, then rerun exact lookup with the chosen identity. Add `--kind`, `--file-hint`, `--containing-type`, `--references`, or `--callers incoming|outgoing` only when needed.
-3. Check changed files with `kast agent diagnostics --file-path <path> --workspace-root "$PWD"`.
+3. Check changed files with `kast agent diagnostics --file-path src/main/kotlin/App.kt --workspace-root "$PWD"`.
 4. Query source-index impact with `kast agent impact --symbol <fq-name> --workspace-root "$PWD"`.
 5. Mutate only through typed plans. First run `kast agent rename`, `add-file`, `add-declaration`, `add-implementation`, `add-statement`, or `replace-declaration` without `--apply`; then add `--apply --idempotency-key <stable-key>` after reviewing the plan and content file.
 6. Use `--output json` for JSON-only parsed scripts; otherwise `kast agent` defaults to compact TOON.
@@ -30,8 +30,8 @@ work is explicitly outside Kotlin semantics.
 ## Mutation Commands
 
 - `kast agent rename --symbol <fq-name> --new-name <name> --workspace-root "$PWD"` plans an identity-first rename.
-- `kast agent add-file --file-path <absolute.kt> --content-file <snippet.kt> --workspace-root "$PWD"` plans a file creation.
-- `kast agent add-declaration --inside-file <absolute.kt> --at file-bottom --content-file <snippet.kt> --workspace-root "$PWD"` plans declaration insertion.
+- `kast agent add-file --file-path src/main/kotlin/NewType.kt --content-file <snippet.kt> --workspace-root "$PWD"` plans a file creation.
+- `kast agent add-declaration --inside-file src/main/kotlin/App.kt --at file-bottom --content-file <snippet.kt> --workspace-root "$PWD"` plans declaration insertion.
 - `kast agent add-implementation --inside-scope <fq-name> --at body-end --content-file <snippet.kt> --workspace-root "$PWD"` plans implementation insertion.
 - `kast agent add-statement --inside-scope <fq-name> --at body-end --content-file <snippet.kt> --workspace-root "$PWD"` plans statement insertion.
 - `kast agent replace-declaration --symbol <fq-name> --kind function --content-file <snippet.kt> --workspace-root "$PWD"` plans declaration replacement.
@@ -43,6 +43,9 @@ placement. Add `--apply --idempotency-key <stable-key>` only after the plan is c
 ## Mutation Recovery
 
 After a yield or disconnect, run `kast agent operation status --idempotency-key <stable-key> --workspace-root "$PWD"`; retrying the original request with the same key is also idempotent. Use `kast agent operation cancel` with the same selector to request cooperative cancellation. A filesystem fallback is safe only when retrieved terminal state proves edit application never started. Missing state after daemon restart is ambiguous; inspect the workspace instead of applying a fallback or using a new key.
+
+With explicit `--workspace-root`, Kotlin target paths may be repository-relative;
+Kast reports and sends their canonical workspace-contained paths.
 
 ## Health
 

--- a/cli-rs/resources/kast-skill/references/quickstart.md
+++ b/cli-rs/resources/kast-skill/references/quickstart.md
@@ -30,7 +30,7 @@ scripts.
 kast agent verify --workspace-root "$PWD"
 kast agent symbol --query EventBean --workspace-root "$PWD" --references
 kast agent symbol --query process --workspace-root "$PWD" --callers incoming
-kast agent diagnostics --workspace-root "$PWD" --file-path "$PWD/src/main/kotlin/App.kt"
+kast agent diagnostics --file-path src/main/kotlin/App.kt --workspace-root "$PWD"
 kast agent impact --workspace-root "$PWD" --symbol com.example.EventBean
 kast agent rename --workspace-root "$PWD" --symbol com.example.EventBean --new-name DomainEvent
 kast agent rename --workspace-root "$PWD" --symbol com.example.EventBean --new-name DomainEvent --apply --idempotency-key rename-event-bean
@@ -50,6 +50,10 @@ kast agent operation cancel --workspace-root "$PWD" --idempotency-key rename-eve
 Use a direct filesystem fallback only when retrieved terminal state proves
 `editApplicationState` is `NOT_STARTED`. Missing state after daemon restart is
 ambiguous and requires workspace inspection.
+
+When `--workspace-root` is explicit, diagnostics and mutation target files may
+be repository-relative. Kast validates containment and reports the canonical
+absolute path used by the backend.
 
 ## Boundaries
 

--- a/cli-rs/resources/kast-skill/references/runbook.md
+++ b/cli-rs/resources/kast-skill/references/runbook.md
@@ -15,7 +15,7 @@ kast --output json agent symbol --query EventBean --references \
 kast --output json agent symbol --query process --callers incoming \
   --workspace-root "$PWD" >"$KAST_RESULT" 2>"$KAST_STDERR"
 
-kast --output json agent diagnostics --file-path "$PWD/src/main/kotlin/App.kt" \
+kast --output json agent diagnostics --file-path src/main/kotlin/App.kt \
   --workspace-root "$PWD" >"$KAST_RESULT" 2>"$KAST_STDERR"
 
 kast --output json agent impact --symbol com.example.EventBean \

--- a/cli-rs/resources/kast-skill/references/workflows.md
+++ b/cli-rs/resources/kast-skill/references/workflows.md
@@ -48,7 +48,7 @@ Use compiler identity and typed selectors instead of offsets:
 | fuzzy symbol discovery | `kast agent symbol --query event --mode discovery --workspace-root "$PWD"` |
 | references | `kast agent symbol --query EventBean --references --workspace-root "$PWD"` |
 | callers | `kast agent symbol --query process --callers incoming --workspace-root "$PWD"` |
-| diagnostics | `kast agent diagnostics --file-path "$PWD/src/main/kotlin/App.kt" --workspace-root "$PWD"` |
+| diagnostics | `kast agent diagnostics --file-path src/main/kotlin/App.kt --workspace-root "$PWD"` |
 | source-index impact | `kast agent impact --symbol com.example.EventBean --workspace-root "$PWD"` |
 | rename plan | `kast agent rename --symbol com.example.EventBean --new-name DomainEvent --workspace-root "$PWD"` |
 | rename apply | `kast agent rename --symbol com.example.EventBean --new-name DomainEvent --apply --workspace-root "$PWD"` |

--- a/cli-rs/src/agent.rs
+++ b/cli-rs/src/agent.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 
 include!("agent/types.rs");
+include!("agent/path.rs");
 include!("agent/dispatch.rs");
 include!("agent/request.rs");
 include!("agent/envelope.rs");

--- a/cli-rs/src/agent/dispatch.rs
+++ b/cli-rs/src/agent/dispatch.rs
@@ -134,22 +134,34 @@ fn execute_agent_impact(args: AgentImpactArgs) -> AgentEnvelope {
 }
 
 fn execute_agent_diagnostics(args: AgentDiagnosticsArgs) -> AgentEnvelope {
+    let normalizer = match AgentFilePathNormalizer::from_runtime(&args.runtime) {
+        Ok(normalizer) => normalizer,
+        Err(error) => return error_envelope("agent/diagnostics".to_string(), None, error),
+    };
+    let file_paths = match normalizer.normalize_all(&args.file_paths) {
+        Ok(file_paths) => file_paths,
+        Err(error) => return error_envelope("agent/diagnostics".to_string(), None, error),
+    };
     let mut steps = Vec::new();
     if !args.skip_refresh {
         steps.push(AgentPublicStep::new(
             "workspace-refresh",
             "raw/workspace-refresh",
-            json!({ "filePaths": args.file_paths }),
+            json!({ "filePaths": &file_paths }),
             false,
         ));
     }
     steps.push(AgentPublicStep::new(
         "diagnostics",
         "raw/diagnostics",
-        json!({ "filePaths": args.file_paths }),
+        json!({ "filePaths": &file_paths }),
         false,
     ));
-    execute_agent_steps("agent/diagnostics", args.runtime, steps)
+    let mut envelope = execute_agent_steps("agent/diagnostics", args.runtime, steps);
+    if let Some(result) = envelope.result.as_mut().and_then(Value::as_object_mut) {
+        result.insert("filePaths".to_string(), json!(file_paths));
+    }
+    envelope
 }
 
 fn execute_agent_rename(args: AgentRenameArgs) -> AgentEnvelope {

--- a/cli-rs/src/agent/dispatch.rs
+++ b/cli-rs/src/agent/dispatch.rs
@@ -210,8 +210,12 @@ fn execute_agent_rename(args: AgentRenameArgs) -> AgentEnvelope {
 }
 
 fn execute_agent_add_file(args: AgentAddFileArgs) -> AgentEnvelope {
+    let file_path = match normalize_agent_file_target(&args.runtime, &args.file_path) {
+        Ok(file_path) => file_path,
+        Err(error) => return error_envelope("agent/add-file".to_string(), None, error),
+    };
     let params = json!({
-        "filePath": args.file_path,
+        "filePath": file_path,
         "contentFile": args.content_file.display().to_string(),
     });
     execute_agent_mutation(
@@ -232,9 +236,16 @@ fn execute_agent_scoped_mutation(
     command_name: &'static str,
     args: AgentScopedMutationArgs,
 ) -> AgentEnvelope {
+    let inside_file = match args.inside_file {
+        Some(inside_file) => match normalize_agent_file_target(&args.runtime, &inside_file) {
+            Ok(inside_file) => Some(inside_file),
+            Err(error) => return error_envelope(agent_method.to_string(), None, error),
+        },
+        None => None,
+    };
     let placement = match scoped_placement_params(
         args.inside_scope,
-        args.inside_file,
+        inside_file,
         args.at.map(|anchor| anchor.canonical().to_string()),
         args.after_symbol,
         args.before_symbol,

--- a/cli-rs/src/agent/path.rs
+++ b/cli-rs/src/agent/path.rs
@@ -1,0 +1,557 @@
+use crate::config as agent_path_config;
+use std::ffi::OsString as AgentPathSegment;
+use std::fs as agent_path_fs;
+use std::io::ErrorKind as AgentPathIoErrorKind;
+
+#[derive(Debug)]
+struct AgentFilePathNormalizer {
+    declared_root: PathBuf,
+    canonical_root: PathBuf,
+    relative_targets_allowed: bool,
+}
+
+impl AgentFilePathNormalizer {
+    fn from_runtime(runtime: &AgentRuntimeArgs) -> std::result::Result<Self, AgentError> {
+        let requested_root = runtime.workspace_root.clone();
+        let resolved_root = agent_path_config::resolve_workspace_root(requested_root.clone())
+            .map_err(|error| {
+                agent_path_error(
+                    "AGENT_WORKSPACE_INVALID",
+                    format!("Cannot resolve the agent workspace root: {error}"),
+                    requested_root.as_deref(),
+                    None,
+                    None,
+                )
+            })?;
+        let declared_root = lexically_normalize_absolute(&resolved_root).ok_or_else(|| {
+            agent_path_error(
+                "AGENT_WORKSPACE_INVALID",
+                format!(
+                    "The agent workspace root is not an absolute path: {}",
+                    resolved_root.display()
+                ),
+                Some(&resolved_root),
+                None,
+                None,
+            )
+        })?;
+        let canonical_root = agent_path_fs::canonicalize(&declared_root).map_err(|error| {
+            agent_path_error(
+                "AGENT_WORKSPACE_INVALID",
+                format!(
+                    "Cannot canonicalize the agent workspace root {}: {error}",
+                    declared_root.display()
+                ),
+                Some(&declared_root),
+                None,
+                None,
+            )
+        })?;
+        if !canonical_root.is_dir() {
+            return Err(agent_path_error(
+                "AGENT_WORKSPACE_INVALID",
+                format!(
+                    "The agent workspace root is not a directory: {}",
+                    canonical_root.display()
+                ),
+                Some(&declared_root),
+                Some(&canonical_root),
+                None,
+            ));
+        }
+        Ok(Self {
+            declared_root,
+            canonical_root,
+            relative_targets_allowed: runtime.workspace_root.is_some(),
+        })
+    }
+
+    fn normalize(
+        &self,
+        input: &str,
+    ) -> std::result::Result<CanonicalKotlinFilePath, AgentError> {
+        if input.trim().is_empty() {
+            return Err(self.error(
+                "AGENT_FILE_KIND_UNSUPPORTED",
+                "Kotlin file path cannot be empty.",
+                input,
+                None,
+            ));
+        }
+        let input_path = Path::new(input);
+        if !input_path.is_absolute() && !self.relative_targets_allowed {
+            return Err(self.error(
+                "AGENT_RELATIVE_FILE_REQUIRES_WORKSPACE",
+                "A relative Kotlin file path requires explicit --workspace-root.",
+                input,
+                None,
+            ));
+        }
+        if !is_kotlin_path(input_path) {
+            return Err(self.error(
+                "AGENT_FILE_KIND_UNSUPPORTED",
+                "Kotlin file targets must end in .kt or .kts.",
+                input,
+                None,
+            ));
+        }
+
+        let joined = if input_path.is_absolute() {
+            input_path.to_path_buf()
+        } else {
+            self.declared_root.join(input_path)
+        };
+        let candidate = lexically_normalize_absolute(&joined).ok_or_else(|| {
+            self.error(
+                "AGENT_FILE_OUTSIDE_WORKSPACE",
+                "The Kotlin file path escapes the filesystem root.",
+                input,
+                Some(&joined),
+            )
+        })?;
+        let declared_candidate_is_contained = candidate.starts_with(&self.declared_root);
+        if !input_path.is_absolute() && !declared_candidate_is_contained {
+            return Err(self.error(
+                "AGENT_FILE_OUTSIDE_WORKSPACE",
+                "The relative Kotlin file path escapes the declared workspace root.",
+                input,
+                Some(&candidate),
+            ));
+        }
+
+        let (canonical_path, target_exists) = self.resolve_candidate(input, &candidate)?;
+        if !canonical_path.starts_with(&self.canonical_root) {
+            let (code, message) = if declared_candidate_is_contained {
+                (
+                    "AGENT_FILE_SYMLINK_UNSAFE",
+                    "The Kotlin file path resolves through a symlink outside the workspace.",
+                )
+            } else {
+                (
+                    "AGENT_FILE_OUTSIDE_WORKSPACE",
+                    "The Kotlin file path is outside the workspace.",
+                )
+            };
+            return Err(self.error(code, message, input, Some(&canonical_path)));
+        }
+        if target_exists {
+            let metadata = agent_path_fs::metadata(&canonical_path).map_err(|error| {
+                self.error(
+                    "AGENT_FILE_PATH_UNREADABLE",
+                    format!("Cannot read Kotlin file metadata: {error}"),
+                    input,
+                    Some(&canonical_path),
+                )
+            })?;
+            if !metadata.is_file() {
+                return Err(self.error(
+                    "AGENT_FILE_KIND_UNSUPPORTED",
+                    "The Kotlin target exists but is not a regular file.",
+                    input,
+                    Some(&canonical_path),
+                ));
+            }
+        }
+        if !is_kotlin_path(&canonical_path) {
+            return Err(self.error(
+                "AGENT_FILE_KIND_UNSUPPORTED",
+                "The resolved target must end in .kt or .kts.",
+                input,
+                Some(&canonical_path),
+            ));
+        }
+        let rpc_path = canonical_path.to_str().ok_or_else(|| {
+            self.error(
+                "AGENT_FILE_PATH_UNREADABLE",
+                "The resolved Kotlin file path is not valid UTF-8.",
+                input,
+                Some(&canonical_path),
+            )
+        })?;
+        Ok(CanonicalKotlinFilePath {
+            rpc_path: rpc_path.to_string(),
+        })
+    }
+
+    fn resolve_candidate(
+        &self,
+        input: &str,
+        candidate: &Path,
+    ) -> std::result::Result<(PathBuf, bool), AgentError> {
+        let mut cursor = candidate.to_path_buf();
+        let mut missing_suffix = Vec::<AgentPathSegment>::new();
+        loop {
+            match agent_path_fs::symlink_metadata(&cursor) {
+                Ok(metadata) => {
+                    let canonical_prefix = agent_path_fs::canonicalize(&cursor).map_err(|error| {
+                        let code = if metadata.file_type().is_symlink() {
+                            "AGENT_FILE_SYMLINK_UNSAFE"
+                        } else {
+                            "AGENT_FILE_PATH_UNREADABLE"
+                        };
+                        self.error(
+                            code,
+                            format!("Cannot resolve Kotlin file path: {error}"),
+                            input,
+                            Some(&cursor),
+                        )
+                    })?;
+                    if !missing_suffix.is_empty() {
+                        let canonical_metadata = agent_path_fs::metadata(&canonical_prefix)
+                            .map_err(|error| {
+                                self.error(
+                                    "AGENT_FILE_PATH_UNREADABLE",
+                                    format!("Cannot read Kotlin path prefix metadata: {error}"),
+                                    input,
+                                    Some(&canonical_prefix),
+                                )
+                            })?;
+                        if !canonical_metadata.is_dir() {
+                            return Err(self.error(
+                                "AGENT_FILE_KIND_UNSUPPORTED",
+                                "A missing Kotlin target is nested beneath a non-directory path.",
+                                input,
+                                Some(&canonical_prefix),
+                            ));
+                        }
+                    }
+                    let mut resolved = canonical_prefix;
+                    for segment in missing_suffix.iter().rev() {
+                        resolved.push(segment);
+                    }
+                    return Ok((resolved, missing_suffix.is_empty()));
+                }
+                Err(error) if error.kind() == AgentPathIoErrorKind::NotFound => {
+                    let Some(file_name) = cursor.file_name() else {
+                        return Err(self.error(
+                            "AGENT_FILE_PATH_UNREADABLE",
+                            "Cannot find an existing filesystem ancestor for the Kotlin target.",
+                            input,
+                            Some(&cursor),
+                        ));
+                    };
+                    missing_suffix.push(file_name.to_os_string());
+                    let Some(parent) = cursor.parent() else {
+                        return Err(self.error(
+                            "AGENT_FILE_PATH_UNREADABLE",
+                            "Cannot find an existing filesystem ancestor for the Kotlin target.",
+                            input,
+                            Some(&cursor),
+                        ));
+                    };
+                    cursor = parent.to_path_buf();
+                }
+                Err(error) => {
+                    return Err(self.error(
+                        "AGENT_FILE_PATH_UNREADABLE",
+                        format!("Cannot inspect Kotlin file path: {error}"),
+                        input,
+                        Some(&cursor),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn error(
+        &self,
+        code: &'static str,
+        message: impl Into<String>,
+        input: &str,
+        resolved_path: Option<&Path>,
+    ) -> AgentError {
+        agent_path_error(
+            code,
+            message,
+            Some(&self.declared_root),
+            resolved_path,
+            Some(input),
+        )
+    }
+}
+
+#[derive(Debug)]
+struct CanonicalKotlinFilePath {
+    rpc_path: String,
+}
+
+impl CanonicalKotlinFilePath {
+    fn rpc_path(&self) -> &str {
+        &self.rpc_path
+    }
+}
+
+fn lexically_normalize_absolute(path: &Path) -> Option<PathBuf> {
+    if !path.is_absolute() {
+        return None;
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+        }
+    }
+    Some(normalized)
+}
+
+fn is_kotlin_path(path: &Path) -> bool {
+    matches!(path.extension().and_then(|extension| extension.to_str()), Some("kt" | "kts"))
+}
+
+fn agent_path_error(
+    code: &'static str,
+    message: impl Into<String>,
+    workspace_root: Option<&Path>,
+    resolved_path: Option<&Path>,
+    input: Option<&str>,
+) -> AgentError {
+    let mut error = agent_error(code, message);
+    if let Some(workspace_root) = workspace_root {
+        error.details.insert(
+            "workspaceRoot".to_string(),
+            json!(workspace_root.display().to_string()),
+        );
+    }
+    if let Some(resolved_path) = resolved_path {
+        error.details.insert(
+            "resolvedPath".to_string(),
+            json!(resolved_path.display().to_string()),
+        );
+    }
+    if let Some(input) = input {
+        error
+            .details
+            .insert("input".to_string(), json!(input));
+    }
+    error
+}
+
+#[cfg(test)]
+mod agent_file_path_tests {
+    use super::*;
+
+    #[test]
+    fn relative_kotlin_file_resolves_against_explicit_workspace() {
+        let fixture = PathFixture::with_file("src/with spaces/App.kt");
+
+        let actual = fixture
+            .normalizer()
+            .normalize("src/with spaces/App.kt")
+            .expect("canonical target");
+
+        assert_eq!(actual.rpc_path(), fixture.canonical_file());
+    }
+
+    #[test]
+    fn absolute_kotlin_file_remains_compatible() {
+        let fixture = PathFixture::with_file("src/App.kt");
+
+        let actual = fixture
+            .normalizer()
+            .normalize(fixture.file.to_str().expect("UTF-8 file"))
+            .expect("canonical target");
+
+        assert_eq!(actual.rpc_path(), fixture.canonical_file());
+    }
+
+    #[test]
+    fn kotlin_script_is_supported() {
+        let fixture = PathFixture::with_file("build-logic/settings.gradle.kts");
+
+        let actual = fixture
+            .normalizer()
+            .normalize("build-logic/settings.gradle.kts")
+            .expect("canonical script");
+
+        assert_eq!(actual.rpc_path(), fixture.canonical_file());
+    }
+
+    #[test]
+    fn missing_kotlin_leaf_uses_canonical_existing_parent() {
+        let fixture = PathFixture::with_workspace();
+        let parent = fixture.workspace.join("src/generated");
+        std::fs::create_dir_all(&parent).expect("source parent");
+        let expected = parent
+            .canonicalize()
+            .expect("canonical parent")
+            .join("Deleted.kt");
+
+        let actual = fixture
+            .normalizer()
+            .normalize("src/generated/Deleted.kt")
+            .expect("missing Kotlin target");
+
+        assert_eq!(actual.rpc_path(), expected.to_str().expect("UTF-8 expected"));
+    }
+
+    #[test]
+    fn relative_path_requires_explicit_workspace_root() {
+        let fixture = PathFixture::with_file("src/App.kt");
+        let runtime = AgentRuntimeArgs {
+            workspace_root: None,
+            backend_name: None,
+        };
+        let normalizer = AgentFilePathNormalizer::from_runtime(&runtime)
+            .expect("current-directory normalizer");
+
+        let error = normalizer
+            .normalize("src/App.kt")
+            .expect_err("relative path without declared workspace must fail");
+
+        assert_eq!(error.code, "AGENT_RELATIVE_FILE_REQUIRES_WORKSPACE");
+        drop(fixture);
+    }
+
+    #[test]
+    fn relative_parent_escape_fails_closed() {
+        let fixture = PathFixture::with_workspace();
+
+        let error = fixture
+            .normalizer()
+            .normalize("../Outside.kt")
+            .expect_err("lexical escape must fail");
+
+        assert_eq!(error.code, "AGENT_FILE_OUTSIDE_WORKSPACE");
+    }
+
+    #[test]
+    fn absolute_outside_file_fails_closed() {
+        let fixture = PathFixture::with_workspace();
+        let outside = fixture.temp.path().join("Outside.kt");
+        std::fs::write(&outside, "class Outside\n").expect("outside source");
+
+        let error = fixture
+            .normalizer()
+            .normalize(outside.to_str().expect("UTF-8 outside path"))
+            .expect_err("outside target must fail");
+
+        assert_eq!(error.code, "AGENT_FILE_OUTSIDE_WORKSPACE");
+    }
+
+    #[test]
+    fn unsupported_extension_fails_closed() {
+        let fixture = PathFixture::with_file("src/App.java");
+
+        let error = fixture
+            .normalizer()
+            .normalize("src/App.java")
+            .expect_err("Java target must fail");
+
+        assert_eq!(error.code, "AGENT_FILE_KIND_UNSUPPORTED");
+    }
+
+    #[test]
+    fn directory_with_kotlin_extension_fails_closed() {
+        let fixture = PathFixture::with_workspace();
+        std::fs::create_dir_all(fixture.workspace.join("src/Directory.kt"))
+            .expect("Kotlin-named directory");
+
+        let error = fixture
+            .normalizer()
+            .normalize("src/Directory.kt")
+            .expect_err("directory target must fail");
+
+        assert_eq!(error.code, "AGENT_FILE_KIND_UNSUPPORTED");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn in_workspace_symlink_resolves_to_real_kotlin_file() {
+        let fixture = PathFixture::with_file("src/Real.kt");
+        let alias = fixture.workspace.join("src/Alias.kt");
+        std::os::unix::fs::symlink(&fixture.file, &alias).expect("safe symlink");
+
+        let actual = fixture
+            .normalizer()
+            .normalize("src/Alias.kt")
+            .expect("safe symlink target");
+
+        assert_eq!(actual.rpc_path(), fixture.canonical_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn escaping_symlink_fails_closed() {
+        let fixture = PathFixture::with_workspace();
+        let outside = fixture.temp.path().join("Outside.kt");
+        std::fs::write(&outside, "class Outside\n").expect("outside source");
+        let alias = fixture.workspace.join("Alias.kt");
+        std::os::unix::fs::symlink(&outside, &alias).expect("escaping symlink");
+
+        let error = fixture
+            .normalizer()
+            .normalize("Alias.kt")
+            .expect_err("symlink escape must fail");
+
+        assert_eq!(error.code, "AGENT_FILE_SYMLINK_UNSAFE");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn broken_symlink_fails_closed() {
+        let fixture = PathFixture::with_workspace();
+        let alias = fixture.workspace.join("Broken.kt");
+        std::os::unix::fs::symlink(fixture.workspace.join("Missing.kt"), &alias)
+            .expect("broken symlink");
+
+        let error = fixture
+            .normalizer()
+            .normalize("Broken.kt")
+            .expect_err("broken symlink must fail");
+
+        assert_eq!(error.code, "AGENT_FILE_SYMLINK_UNSAFE");
+    }
+
+    struct PathFixture {
+        temp: tempfile::TempDir,
+        workspace: PathBuf,
+        file: PathBuf,
+    }
+
+    impl PathFixture {
+        fn with_workspace() -> Self {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let workspace = temp.path().join("workspace");
+            std::fs::create_dir_all(&workspace).expect("workspace");
+            Self {
+                temp,
+                workspace,
+                file: PathBuf::new(),
+            }
+        }
+
+        fn with_file(relative_path: &str) -> Self {
+            let mut fixture = Self::with_workspace();
+            fixture.file = fixture.workspace.join(relative_path);
+            std::fs::create_dir_all(fixture.file.parent().expect("source parent"))
+                .expect("source directory");
+            std::fs::write(&fixture.file, "class Fixture\n").expect("source");
+            fixture
+        }
+
+        fn normalizer(&self) -> AgentFilePathNormalizer {
+            AgentFilePathNormalizer::from_runtime(&AgentRuntimeArgs {
+                workspace_root: Some(self.workspace.clone()),
+                backend_name: None,
+            })
+            .expect("normalizer")
+        }
+
+        fn canonical_file(&self) -> String {
+            self.file
+                .canonicalize()
+                .expect("canonical file")
+                .to_str()
+                .expect("UTF-8 canonical file")
+                .to_string()
+        }
+    }
+}

--- a/cli-rs/src/agent/path.rs
+++ b/cli-rs/src/agent/path.rs
@@ -173,6 +173,16 @@ impl AgentFilePathNormalizer {
         })
     }
 
+    fn normalize_all(
+        &self,
+        inputs: &[String],
+    ) -> std::result::Result<Vec<String>, AgentError> {
+        inputs
+            .iter()
+            .map(|input| self.normalize(input).map(CanonicalKotlinFilePath::into_rpc_path))
+            .collect()
+    }
+
     fn resolve_candidate(
         &self,
         input: &str,
@@ -278,6 +288,10 @@ struct CanonicalKotlinFilePath {
 impl CanonicalKotlinFilePath {
     fn rpc_path(&self) -> &str {
         &self.rpc_path
+    }
+
+    fn into_rpc_path(self) -> String {
+        self.rpc_path
     }
 }
 

--- a/cli-rs/src/agent/path.rs
+++ b/cli-rs/src/agent/path.rs
@@ -295,6 +295,15 @@ impl CanonicalKotlinFilePath {
     }
 }
 
+fn normalize_agent_file_target(
+    runtime: &AgentRuntimeArgs,
+    input: &str,
+) -> std::result::Result<String, AgentError> {
+    AgentFilePathNormalizer::from_runtime(runtime)?
+        .normalize(input)
+        .map(CanonicalKotlinFilePath::into_rpc_path)
+}
+
 fn lexically_normalize_absolute(path: &Path) -> Option<PathBuf> {
     if !path.is_absolute() {
         return None;

--- a/cli-rs/src/cli/agent.rs
+++ b/cli-rs/src/cli/agent.rs
@@ -138,6 +138,7 @@ pub struct AgentImpactArgs {
 pub struct AgentDiagnosticsArgs {
     #[command(flatten)]
     pub runtime: AgentRuntimeArgs,
+    /// Absolute or workspace-root-relative Kotlin file to analyze. Repeat for multiple files.
     #[arg(long = "file-path", required = true)]
     pub file_paths: Vec<String>,
     #[arg(long)]
@@ -177,7 +178,7 @@ pub struct AgentRenameArgs {
 pub struct AgentAddFileArgs {
     #[command(flatten)]
     pub runtime: AgentRuntimeArgs,
-    /// Absolute path of the Kotlin file to create.
+    /// Absolute or workspace-root-relative path of the Kotlin file to create.
     #[arg(long)]
     pub file_path: String,
     /// File containing the complete content to write.
@@ -194,7 +195,7 @@ pub struct AgentScopedMutationArgs {
     /// Named declaration scope that receives the content.
     #[arg(long)]
     pub inside_scope: Option<String>,
-    /// File scope that receives the content.
+    /// Absolute or workspace-root-relative file scope that receives the content.
     #[arg(long)]
     pub inside_file: Option<String>,
     /// Placement anchor inside the selected scope.

--- a/cli-rs/tests/agent_command_surface_smoke.rs
+++ b/cli-rs/tests/agent_command_surface_smoke.rs
@@ -605,7 +605,9 @@ fn agent_scope_mutations_without_apply_return_typed_request_plans() {
     let config_home = temp.path().join("config");
     let content_file = temp.path().join("snippet.kt");
     std::fs::write(&content_file, "fun added() = Unit\n").expect("snippet");
-    let target_file = temp.path().join("Added.kt");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    let target_file = workspace.join("Added.kt");
 
     let cases = [
         (
@@ -688,6 +690,7 @@ fn agent_scope_mutations_without_apply_return_typed_request_plans() {
             .arg("--output")
             .arg("json")
             .args(args)
+            .args(["--workspace-root", workspace.to_str().expect("workspace")])
             .output()
             .unwrap_or_else(|error| panic!("{name} plan failed to launch: {error}"));
 
@@ -725,6 +728,127 @@ fn agent_scope_mutations_without_apply_return_typed_request_plans() {
             "{stdout}"
         );
     }
+}
+
+#[test]
+fn relative_file_targets_are_canonical_in_mutation_plans() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let target_parent = workspace.join("src/generated");
+    std::fs::create_dir_all(&target_parent).expect("target parent");
+    let content_file = temp.path().join("snippet.kt");
+    std::fs::write(&content_file, "fun added() = Unit\n").expect("snippet");
+    let expected_target = target_parent
+        .canonicalize()
+        .expect("canonical target parent")
+        .join("New File.kt")
+        .display()
+        .to_string();
+
+    let cases = [
+        (
+            "add-file",
+            vec![
+                "agent",
+                "add-file",
+                "--file-path",
+                "src/generated/New File.kt",
+                "--content-file",
+                content_file.to_str().expect("snippet"),
+            ],
+            &["filePath"][..],
+        ),
+        (
+            "add-declaration",
+            vec![
+                "agent",
+                "add-declaration",
+                "--inside-file",
+                "src/generated/New File.kt",
+                "--at",
+                "file-bottom",
+                "--content-file",
+                content_file.to_str().expect("snippet"),
+            ],
+            &["placement", "scope", "insideFile"][..],
+        ),
+        (
+            "add-implementation",
+            vec![
+                "agent",
+                "add-implementation",
+                "--inside-file",
+                "src/generated/New File.kt",
+                "--at",
+                "body-end",
+                "--content-file",
+                content_file.to_str().expect("snippet"),
+            ],
+            &["placement", "scope", "insideFile"][..],
+        ),
+    ];
+
+    for (name, args, target_path) in cases {
+        let plan = kast(&home, &config_home)
+            .args(["--output", "json"])
+            .args(args)
+            .args(["--workspace-root", workspace.to_str().expect("workspace")])
+            .output()
+            .unwrap_or_else(|error| panic!("{name} plan: {error}"));
+        let document: serde_json::Value = serde_json::from_slice(&plan.stdout).expect("plan JSON");
+        let params = &document["result"]["request"]["params"];
+        let target = target_path
+            .iter()
+            .fold(params, |value, segment| &value[*segment]);
+
+        assert!(
+            plan.status.success(),
+            "{name}: stdout={}, stderr={}",
+            String::from_utf8_lossy(&plan.stdout),
+            String::from_utf8_lossy(&plan.stderr),
+        );
+        assert_eq!(target, &expected_target, "{name}: {document:#}");
+        assert_eq!(
+            params["contentFile"],
+            content_file.to_str().expect("snippet"),
+            "{name}: {document:#}",
+        );
+    }
+}
+
+#[test]
+fn relative_file_target_requires_explicit_workspace_root() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    let content_file = temp.path().join("snippet.kt");
+    std::fs::write(&content_file, "class Added\n").expect("snippet");
+
+    let plan = kast(&home, &config_home)
+        .current_dir(&workspace)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "add-file",
+            "--file-path",
+            "Added.kt",
+            "--content-file",
+            content_file.to_str().expect("snippet"),
+        ])
+        .output()
+        .expect("relative add-file plan");
+    let document: serde_json::Value = serde_json::from_slice(&plan.stdout).expect("plan JSON");
+
+    assert!(!plan.status.success(), "{document:#}");
+    assert_eq!(
+        document["error"]["code"], "AGENT_RELATIVE_FILE_REQUIRES_WORKSPACE",
+        "{document:#}",
+    );
 }
 
 #[test]

--- a/cli-rs/tests/agent_diagnostics_smoke.rs
+++ b/cli-rs/tests/agent_diagnostics_smoke.rs
@@ -17,6 +17,7 @@ fn relative_file_paths_are_canonical_in_backend_requests_and_json_output() {
         std::fs::create_dir_all(file.parent().expect("source parent")).expect("source dir");
         std::fs::write(file, "class Example\n").expect("scenario source");
     }
+    write_gradle_marker(&workspace);
     std::fs::create_dir_all(&home).expect("home");
     write_macos_plugin_workspace_metadata(&workspace);
 
@@ -77,6 +78,7 @@ fn canonical_relative_path_is_reported_in_every_output_format() {
     let file = workspace.join("src/with spaces/Report.kt");
     std::fs::create_dir_all(file.parent().expect("source parent")).expect("source dir");
     std::fs::write(&file, "class Report\n").expect("scenario source");
+    write_gradle_marker(&workspace);
     std::fs::create_dir_all(&home).expect("home");
     write_macos_plugin_workspace_metadata(&workspace);
     let expected = file
@@ -133,6 +135,7 @@ fn deleted_relative_file_reaches_refresh_with_canonical_path() {
     let workspace = temp.path().join("workspace");
     let source_parent = workspace.join("src/deleted");
     std::fs::create_dir_all(&source_parent).expect("source parent");
+    write_gradle_marker(&workspace);
     std::fs::create_dir_all(&home).expect("home");
     write_macos_plugin_workspace_metadata(&workspace);
     let missing = source_parent
@@ -265,17 +268,17 @@ fn incomplete_semantic_admission_stops_before_diagnostics() {
     let backend = spawn_fake_backend(
         listener,
         workspace.clone(),
-        incomplete_refresh(&file),
-        complete_clean_diagnostics(&file),
+        incomplete_refresh(&canonical_test_path(&file)),
+        complete_clean_diagnostics(&canonical_test_path(&file)),
         3,
     );
 
     let output = run_diagnostics(&home, &config_home, &workspace, &file, "json");
-    let methods = backend.join().expect("fake diagnostics backend");
+    let requests = backend.join().expect("fake diagnostics backend");
     let document = decode_json(&output);
 
     assert_eq!(
-        methods,
+        request_methods(&requests),
         ["runtime/status", "capabilities", "raw/workspace-refresh"],
     );
     assert!(!output.status.success(), "{document:#}");
@@ -795,7 +798,7 @@ fn complete_removed_refresh(file: &Path) -> Value {
             "analysisAvailability": "NOT_APPLICABLE"
         }],
         "semanticOutcome": "COMPLETE",
-        "requestedFileCount": 1,
+        "requestedFileCount": 0,
         "analyzedFileCount": 0,
         "skippedFileCount": 0,
         "removedFileCount": 1,

--- a/cli-rs/tests/agent_diagnostics_smoke.rs
+++ b/cli-rs/tests/agent_diagnostics_smoke.rs
@@ -6,6 +6,186 @@ use std::time::{Duration, Instant};
 use support::*;
 
 #[test]
+fn relative_file_paths_are_canonical_in_backend_requests_and_json_output() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let first = workspace.join("src/First.kt");
+    let second = workspace.join("src/with spaces/Second.kt");
+    for file in [&first, &second] {
+        std::fs::create_dir_all(file.parent().expect("source parent")).expect("source dir");
+        std::fs::write(file, "class Example\n").expect("scenario source");
+    }
+    std::fs::create_dir_all(&home).expect("home");
+    write_macos_plugin_workspace_metadata(&workspace);
+
+    let expected = [&first, &second].map(|file| {
+        file.canonicalize()
+            .expect("canonical source")
+            .display()
+            .to_string()
+    });
+    let socket_path = workspace_socket_path(&workspace, temp.path());
+    write_descriptor(&home, &workspace, &socket_path);
+    let listener = bind_listener(&socket_path);
+    let backend = spawn_fake_backend(
+        listener,
+        workspace.clone(),
+        complete_refresh_for(&expected),
+        complete_clean_diagnostics_for(&expected),
+        4,
+    );
+    let output = run_diagnostics_arguments(
+        &home,
+        &config_home,
+        &workspace,
+        &["src/First.kt", "src/with spaces/Second.kt"],
+        "json",
+    );
+    let requests = backend.join().expect("fake diagnostics backend");
+    let document = decode_json(&output);
+
+    assert!(
+        output.status.success(),
+        "relative diagnostics should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(request_methods(&requests), expected_diagnostics_methods());
+    assert_eq!(
+        requests[2]["params"]["filePaths"],
+        json!(expected),
+        "refresh request: {:#}",
+        requests[2],
+    );
+    assert_eq!(
+        requests[3]["params"]["filePaths"],
+        json!(expected),
+        "diagnostics request: {:#}",
+        requests[3],
+    );
+    assert_eq!(document["result"]["filePaths"], json!(expected));
+}
+
+#[test]
+fn canonical_relative_path_is_reported_in_every_output_format() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let file = workspace.join("src/with spaces/Report.kt");
+    std::fs::create_dir_all(file.parent().expect("source parent")).expect("source dir");
+    std::fs::write(&file, "class Report\n").expect("scenario source");
+    std::fs::create_dir_all(&home).expect("home");
+    write_macos_plugin_workspace_metadata(&workspace);
+    let expected = file
+        .canonicalize()
+        .expect("canonical source")
+        .display()
+        .to_string();
+
+    let socket_path = workspace_socket_path(&workspace, temp.path());
+    write_descriptor(&home, &workspace, &socket_path);
+    let listener = bind_listener(&socket_path);
+    let backend = spawn_fake_backend(
+        listener,
+        workspace.clone(),
+        complete_refresh_for(std::slice::from_ref(&expected)),
+        complete_clean_diagnostics_for(std::slice::from_ref(&expected)),
+        12,
+    );
+    let outputs = ["json", "human", "toon"].map(|format| {
+        run_diagnostics_arguments(
+            &home,
+            &config_home,
+            &workspace,
+            &["src/with spaces/Report.kt"],
+            format,
+        )
+    });
+    let requests = backend.join().expect("fake diagnostics backend");
+
+    for (format, output) in ["json", "human", "toon"].into_iter().zip(&outputs) {
+        let document = if format == "toon" {
+            decode_toon(output)
+        } else {
+            decode_json(output)
+        };
+        assert!(output.status.success(), "{format}: {document:#}");
+        assert_eq!(
+            document["result"]["filePaths"],
+            json!([expected]),
+            "{format}: {document:#}",
+        );
+    }
+    assert_eq!(
+        request_methods(&requests),
+        expected_diagnostics_methods().repeat(3)
+    );
+}
+
+#[test]
+fn deleted_relative_file_reaches_refresh_with_canonical_path() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let source_parent = workspace.join("src/deleted");
+    std::fs::create_dir_all(&source_parent).expect("source parent");
+    std::fs::create_dir_all(&home).expect("home");
+    write_macos_plugin_workspace_metadata(&workspace);
+    let missing = source_parent
+        .canonicalize()
+        .expect("canonical source parent")
+        .join("Removed.kt");
+
+    let socket_path = workspace_socket_path(&workspace, temp.path());
+    write_descriptor(&home, &workspace, &socket_path);
+    let listener = bind_listener(&socket_path);
+    let backend = spawn_fake_backend(
+        listener,
+        workspace.clone(),
+        complete_removed_refresh(&missing),
+        incomplete_diagnostics(&missing),
+        4,
+    );
+    let output = run_diagnostics_arguments(
+        &home,
+        &config_home,
+        &workspace,
+        &["src/deleted/Removed.kt"],
+        "json",
+    );
+    let requests = backend.join().expect("fake diagnostics backend");
+    let document = decode_json(&output);
+    let expected = missing.display().to_string();
+
+    assert!(!output.status.success(), "{document:#}");
+    assert_eq!(
+        document["result"]["steps"][1]["error"]["code"], "SEMANTIC_ANALYSIS_INCOMPLETE",
+        "{document:#}",
+    );
+    assert_eq!(
+        requests[2]["params"]["filePaths"],
+        json!([expected]),
+        "refresh request: {:#}",
+        requests[2],
+    );
+    assert_eq!(document["result"]["filePaths"], json!([expected]));
+}
+
+#[test]
+fn relative_escape_is_rejected_before_runtime_resolution() {
+    assert_pre_dispatch_path_error("../Outside.kt", "AGENT_FILE_OUTSIDE_WORKSPACE");
+}
+
+#[test]
+fn unsupported_file_kind_is_rejected_before_runtime_resolution() {
+    assert_pre_dispatch_path_error("src/App.java", "AGENT_FILE_KIND_UNSUPPORTED");
+}
+
+#[test]
 fn incomplete_semantic_analysis_fails_closed_in_every_output_format() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -23,25 +203,19 @@ fn incomplete_semantic_analysis_fails_closed_in_every_output_format() {
     let backend = spawn_fake_backend(
         listener,
         workspace.clone(),
-        complete_refresh(&file),
-        incomplete_diagnostics(&file),
+        complete_refresh(&canonical_test_path(&file)),
+        incomplete_diagnostics(&canonical_test_path(&file)),
         12,
     );
 
     let json_output = run_diagnostics(&home, &config_home, &workspace, &file, "json");
     let human_output = run_diagnostics(&home, &config_home, &workspace, &file, "human");
     let toon_output = run_diagnostics(&home, &config_home, &workspace, &file, "toon");
-    let methods = backend.join().expect("fake diagnostics backend");
+    let requests = backend.join().expect("fake diagnostics backend");
 
     assert_eq!(
-        methods,
-        [
-            "runtime/status",
-            "capabilities",
-            "raw/workspace-refresh",
-            "raw/diagnostics"
-        ]
-        .repeat(3),
+        request_methods(&requests),
+        expected_diagnostics_methods().repeat(3),
     );
     for (format, output, document) in [
         ("json", &json_output, decode_json(&json_output)),
@@ -303,13 +477,13 @@ fn run_single_json_scenario(
     let backend = spawn_fake_backend(
         listener,
         workspace.clone(),
-        complete_refresh(&file),
-        diagnostics(&file),
+        complete_refresh(&canonical_test_path(&file)),
+        diagnostics(&canonical_test_path(&file)),
         4,
     );
     let output = run_diagnostics(&home, &config_home, &workspace, &file, "json");
-    let methods = backend.join().expect("fake diagnostics backend");
-    (output, methods)
+    let requests = backend.join().expect("fake diagnostics backend");
+    (output, request_methods(&requests))
 }
 
 fn run_diagnostics(
@@ -319,20 +493,83 @@ fn run_diagnostics(
     file: &Path,
     output_format: &str,
 ) -> Output {
-    kast(home, config_home)
-        .args([
-            "--output",
-            output_format,
-            "agent",
-            "diagnostics",
-            "--backend=idea",
-            "--workspace-root",
-            workspace.to_str().expect("workspace path"),
-            "--file-path",
-            file.to_str().expect("file path"),
-        ])
-        .output()
-        .expect("agent diagnostics")
+    run_diagnostics_arguments(
+        home,
+        config_home,
+        workspace,
+        &[file.to_str().expect("file path")],
+        output_format,
+    )
+}
+
+fn run_diagnostics_arguments(
+    home: &Path,
+    config_home: &Path,
+    workspace: &Path,
+    file_paths: &[&str],
+    output_format: &str,
+) -> Output {
+    let mut command = kast(home, config_home);
+    command.args([
+        "--output",
+        output_format,
+        "agent",
+        "diagnostics",
+        "--backend=idea",
+        "--workspace-root",
+        workspace.to_str().expect("workspace path"),
+    ]);
+    for file_path in file_paths {
+        command.args(["--file-path", file_path]);
+    }
+    command.output().expect("agent diagnostics")
+}
+
+fn assert_pre_dispatch_path_error(file_path: &str, expected_code: &str) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let output = run_diagnostics_arguments(&home, &config_home, &workspace, &[file_path], "json");
+    let document = decode_json(&output);
+
+    assert!(!output.status.success(), "{document:#}");
+    assert_eq!(document["error"]["code"], expected_code, "{document:#}");
+}
+
+fn request_methods(requests: &[Value]) -> Vec<String> {
+    requests
+        .iter()
+        .map(|request| {
+            request["method"]
+                .as_str()
+                .expect("request method")
+                .to_string()
+        })
+        .collect()
+}
+
+fn canonical_test_path(path: &Path) -> PathBuf {
+    if path.exists() {
+        return path.canonicalize().expect("canonical test file");
+    }
+    path.parent()
+        .expect("test file parent")
+        .canonicalize()
+        .expect("canonical test file parent")
+        .join(path.file_name().expect("test file name"))
+}
+
+fn expected_diagnostics_methods() -> Vec<&'static str> {
+    [
+        "runtime/status",
+        "capabilities",
+        "raw/workspace-refresh",
+        "raw/diagnostics",
+    ]
+    .to_vec()
 }
 
 fn write_gradle_marker(workspace: &Path) {
@@ -435,14 +672,14 @@ fn spawn_fake_backend(
     refresh: Value,
     diagnostics: Value,
     expected_requests: usize,
-) -> std::thread::JoinHandle<Vec<String>> {
+) -> std::thread::JoinHandle<Vec<Value>> {
     listener
         .set_nonblocking(true)
         .expect("nonblocking listener");
     thread::spawn(move || {
-        let mut methods = Vec::with_capacity(expected_requests);
+        let mut requests = Vec::with_capacity(expected_requests);
         let deadline = Instant::now() + Duration::from_secs(10);
-        while methods.len() < expected_requests && Instant::now() < deadline {
+        while requests.len() < expected_requests && Instant::now() < deadline {
             let (mut stream, _) = match listener.accept() {
                 Ok(connection) => connection,
                 Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
@@ -465,7 +702,7 @@ fn spawn_fake_backend(
                 .as_str()
                 .expect("request method")
                 .to_string();
-            methods.push(method.clone());
+            requests.push(request.clone());
             let result = match method.as_str() {
                 "runtime/status" => json!({
                     "state": "READY",
@@ -502,35 +739,66 @@ fn spawn_fake_backend(
             .expect("write diagnostics response");
         }
         assert_eq!(
-            methods.len(),
+            requests.len(),
             expected_requests,
             "fake backend request timeout"
         );
-        methods
+        requests
     })
 }
 
 fn complete_refresh(file: &Path) -> Value {
+    complete_refresh_for(&[file.display().to_string()])
+}
+
+fn complete_refresh_for(file_paths: &[String]) -> Value {
     json!({
-        "refreshedFiles": [file.display().to_string()],
+        "refreshedFiles": file_paths,
         "removedFiles": [],
         "fullRefresh": false,
+        "fileStatuses": file_paths
+            .iter()
+            .map(|file_path| json!({
+                "filePath": file_path,
+                "fileSystemDiscovery": "DISCOVERED",
+                "sourceModuleOwnership": "OWNED",
+                "indexAdmission": "ADMITTED",
+                "analysisAvailability": "AVAILABLE",
+                "analysisStatus": {
+                    "filePath": file_path,
+                    "state": "ANALYZED"
+                }
+            }))
+            .collect::<Vec<_>>(),
+        "semanticOutcome": "COMPLETE",
+        "requestedFileCount": file_paths.len(),
+        "analyzedFileCount": file_paths.len(),
+        "skippedFileCount": 0,
+        "removedFileCount": 0,
+        "attemptCount": 1,
+        "elapsedMillis": 0,
+        "schemaVersion": 3
+    })
+}
+
+fn complete_removed_refresh(file: &Path) -> Value {
+    let file_path = file.display().to_string();
+    json!({
+        "refreshedFiles": [],
+        "removedFiles": [file_path],
+        "fullRefresh": false,
         "fileStatuses": [{
-            "filePath": file.display().to_string(),
-            "fileSystemDiscovery": "DISCOVERED",
-            "sourceModuleOwnership": "OWNED",
-            "indexAdmission": "ADMITTED",
-            "analysisAvailability": "AVAILABLE",
-            "analysisStatus": {
-                "filePath": file.display().to_string(),
-                "state": "ANALYZED"
-            }
+            "filePath": file_path,
+            "fileSystemDiscovery": "REMOVED",
+            "sourceModuleOwnership": "NOT_APPLICABLE",
+            "indexAdmission": "NOT_APPLICABLE",
+            "analysisAvailability": "NOT_APPLICABLE"
         }],
         "semanticOutcome": "COMPLETE",
         "requestedFileCount": 1,
-        "analyzedFileCount": 1,
+        "analyzedFileCount": 0,
         "skippedFileCount": 0,
-        "removedFileCount": 0,
+        "removedFileCount": 1,
         "attemptCount": 1,
         "elapsedMillis": 0,
         "schemaVersion": 3
@@ -607,15 +875,22 @@ fn complete_compiler_diagnostics(file: &Path) -> Value {
 }
 
 fn complete_clean_diagnostics(file: &Path) -> Value {
+    complete_clean_diagnostics_for(&[file.display().to_string()])
+}
+
+fn complete_clean_diagnostics_for(file_paths: &[String]) -> Value {
     json!({
         "diagnostics": [],
-        "fileStatuses": [{
-            "filePath": file.display().to_string(),
-            "state": "ANALYZED"
-        }],
+        "fileStatuses": file_paths
+            .iter()
+            .map(|file_path| json!({
+                "filePath": file_path,
+                "state": "ANALYZED"
+            }))
+            .collect::<Vec<_>>(),
         "semanticOutcome": "COMPLETE",
-        "requestedFileCount": 1,
-        "analyzedFileCount": 1,
+        "requestedFileCount": file_paths.len(),
+        "analyzedFileCount": file_paths.len(),
         "skippedFileCount": 0,
         "schemaVersion": 3
     })

--- a/cli-rs/tests/agent_operation_surface_smoke.rs
+++ b/cli-rs/tests/agent_operation_surface_smoke.rs
@@ -8,6 +8,7 @@ fn applied_mutation_requires_idempotency_key_before_runtime_discovery() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let config_home = temp.path().join("config");
+    let workspace = temp.path();
     let content_file = temp.path().join("Added.kt");
     let target = temp.path().join("Target.kt");
     std::fs::write(&content_file, "class Added\n").expect("content");
@@ -68,6 +69,10 @@ fn applied_mutation_requires_idempotency_key_before_runtime_discovery() {
         let output = kast(&home, &config_home)
             .args(["--output", "json", "agent"])
             .args(args)
+            .args([
+                "--workspace-root",
+                workspace.to_str().expect("workspace root"),
+            ])
             .arg("--apply")
             .output()
             .expect("applied mutation");
@@ -135,6 +140,10 @@ fn applied_add_file_submits_typed_mutation_request() {
     )
     .expect("settings");
     std::fs::write(&content_file, "class Added\n").expect("content");
+    let canonical_target = workspace
+        .canonicalize()
+        .expect("canonical workspace")
+        .join("src/Added.kt");
     let backend = spawn_operation_backend(
         &home,
         &config_home,
@@ -180,7 +189,7 @@ fn applied_add_file_submits_typed_mutation_request() {
     );
     assert_eq!(
         submit["params"]["request"]["filePath"],
-        target.to_str().unwrap()
+        canonical_target.to_str().unwrap()
     );
     assert_eq!(
         submit["params"]["request"]["contentFile"],

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -142,6 +142,43 @@ fn packaged_workflow_reference_uses_current_runtime_surface() {
 }
 
 #[test]
+fn packaged_guidance_prefers_workspace_relative_kotlin_targets() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let sources = [
+        "resources/kast-skill/SKILL.md",
+        "resources/kast-skill/references/quickstart.md",
+        "resources/kast-skill/references/runbook.md",
+        "resources/kast-skill/references/workflows.md",
+    ];
+    let guidance = sources
+        .iter()
+        .map(|source| {
+            let path = root.join(source);
+            std::fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    for expected in [
+        "kast agent diagnostics --file-path src/main/kotlin/App.kt --workspace-root \"$PWD\"",
+        "kast agent add-file --file-path src/main/kotlin/NewType.kt",
+        "kast agent add-declaration --inside-file src/main/kotlin/App.kt",
+    ] {
+        assert!(
+            guidance.contains(expected),
+            "packaged guidance should contain {expected}: {guidance}"
+        );
+    }
+    for obsolete in ["$PWD/src/main/kotlin/App.kt", "<absolute.kt>"] {
+        assert!(
+            !guidance.contains(obsolete),
+            "packaged guidance should not require {obsolete}: {guidance}"
+        );
+    }
+}
+
+#[test]
 fn packaged_skill_routing_eval_covers_kotlin_navigation_surface() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let routing_eval_path =

--- a/docs/reference/agent-commands.md
+++ b/docs/reference/agent-commands.md
@@ -64,6 +64,14 @@ candidate by operating system or backend name. When exactly one backend kind
 is ready, automatic selection uses it even when it differs from the host
 fallback.
 
+## Workspace-relative file paths
+
+When a command supplies explicit `--workspace-root`, Kotlin target arguments
+such as diagnostics `--file-path`, add-file `--file-path`, and mutation
+`--inside-file` may be relative to that root. Kast resolves each target once,
+rejects workspace or symlink escapes, and reports the canonical absolute path
+sent to the backend. Absolute in-workspace targets remain supported.
+
 ## Mutation Boundary
 
 Agent edits are plan-first. Kast reports the selected target, planned write set,
@@ -132,7 +140,7 @@ canonical fully-qualified name.
     kast agent symbol --query OrderService --workspace-root "$PWD"
     kast agent symbol --query order --mode discovery --workspace-root "$PWD"
     kast agent diagnostics \
-      --file-path "$PWD/src/main/kotlin/App.kt" \
+      --file-path src/main/kotlin/App.kt \
       --workspace-root "$PWD"
     kast agent rename \
       --symbol com.example.OrderService \

--- a/docs/reference/mutation-selectors.md
+++ b/docs/reference/mutation-selectors.md
@@ -52,7 +52,7 @@ agent should refine the request before applying it.
     | Command family | Target selector | Content selector |
     | --- | --- | --- |
     | Rename | `--symbol <fq-name>` plus optional narrowing flags | `--new-name <name>` |
-    | Create file | `--file-path <absolute-path>` | `--content-file <path>` |
+    | Create file | `--file-path <Kotlin-path>` | `--content-file <path>` |
     | Add declaration | `--inside-file <path>` or `--inside-scope <fq-name>` | `--content-file <path>` |
     | Add implementation | `--inside-file <path>` or `--inside-scope <fq-name>` | `--content-file <path>` |
     | Add statement | `--inside-scope <fq-name>` and `--at body-end` | `--content-file <path>` |
@@ -60,6 +60,10 @@ agent should refine the request before applying it.
 
     Optional narrowing flags include `--kind`, `--file-hint`, and
     `--containing-type` where the command supports them.
+
+    A Kotlin file target may be absolute or relative to explicit
+    `--workspace-root`. Kast canonicalizes and validates target paths before
+    planning; content files remain independent payload sources.
 
 ??? info "Placement anchors"
     Anchors are command-specific. Use only anchors shown by the command help for


### PR DESCRIPTION
Closes #341.

## Behavior
- accepts workspace-relative Kotlin diagnostic and mutation file arguments when an explicit workspace root is supplied
- canonicalizes every backend target and rejects workspace, ancestor-symlink, final-symlink, FIFO, device, and unsupported-file escapes
- hardens create, replace, delete, and text-edit transactions with descriptor-relative no-replace operations, restore-first recovery, typed committed evidence, and nonblocking post-commit verification
- keeps headless and IDEA mutation behavior on the same secured implementation

## Verification
- full Gradle test suite: 59 tasks, BUILD SUCCESSFUL
- full locked Rust test suite
- focused IDEA mutation tests: 33 passed
- focused post-rebase Rust tests: 51 passed
- cargo fmt and strict all-target/all-feature clippy
- generated contract check: 138 files
- RPC summary, docs content/navigation, Zensical, and macOS installer contracts
- two independent clean reviews, including post-rebase integration review