### PR TITLE
docs: define first-class workspace file discovery

### DIFF
--- a/.agents/adr/0021-first-class-workspace-file-discovery.md
+++ b/.agents/adr/0021-first-class-workspace-file-discovery.md
@@ -194,8 +194,10 @@ are typed and conjunctive:
   the corresponding backend owner or build-qualified indexed Gradle project;
 - `--source-set` matches an exact model-proven Gradle source-set name;
 - `--kind source|script` distinguishes `.kt` from `.kts`;
-- `--package` matches an exact compiler/PSI-proven canonical Kotlin package
-  fully qualified name;
+- `--package` parses a closed selector: `root` or
+  `named:<canonical-kotlin-package-fq-name>`; `root` matches only
+  `PROVEN_ROOT`, while `named:` matches only the exact compiler/PSI-proven
+  `PROVEN_NAMED` canonical name;
 - `--dirty clean|dirty|unknown` filters the typed Git state class;
 - `--drift none|filesystem-only|index-only|missing-on-disk|not-applicable|unknown`
   filters cross-source drift;

--- a/.agents/adr/0021-first-class-workspace-file-discovery.md
+++ b/.agents/adr/0021-first-class-workspace-file-discovery.md
@@ -47,14 +47,17 @@ retains every candidate returned by all successfully exhausted backend pages
 and the Kotlin source-index snapshot, plus per-module completeness and
 limitation evidence. Issue #340 consumes the `.kts` candidates but writes
 Gradle declarations and relationships to its separate Gradle DSL index. If a
-backend page fails or returns an invalid token, only that module is partial and
-backend absence remains unprovable for paths that may belong to it. A stale
-workspace generation invalidates the whole backend attempt: Rust discards it,
+generic backend page transport fails or returns an invalid token, only that
+module is partial and backend absence remains unprovable for paths that may
+belong to it. A stale workspace generation invalidates the whole backend
+attempt: Rust discards it,
 restarts once from fresh metadata, and returns typed partial evidence if that
 single retry also becomes stale. The partial result carries
 `BACKEND_WORKSPACE_INVENTORY_STALE`, marks every module from the last metadata
 response incomplete, and retains no backend candidates from either stale
-attempt.
+attempt. A typed project-model-incomplete response is also workspace-wide:
+Rust discards every backend candidate from that attempt without consuming the
+stale retry and preserves the server's typed reason as a public limitation.
 
 ## Raw paging and project-model authority
 
@@ -90,9 +93,21 @@ project root. The IDEA 2025.3 adapter reads
 `BuildParticipant.getRootPath()` for included-build roots, then associates
 modules through `GradleModuleDataIndex.findGradleModuleData(Module)`,
 `GradleModuleData.isIncludedBuild()`, `getGradleProjectDir()`, and
-`ModuleData.getLinkedExternalProjectPath()`. A linked root that cannot be
-associated with a backend module fails the request as incomplete project-model
-evidence. Included builds retain their own linked roots and module owners.
+`ModuleData.getLinkedExternalProjectPath()`. The backend converts IDEA indexing,
+unavailable Gradle project-model data, and a linked root that cannot be
+associated with a backend module into
+`WorkspaceProjectModelIncompleteException`. Its stable
+`WORKSPACE_PROJECT_MODEL_INCOMPLETE` code uses status 503, is retryable, and
+carries one typed reason in `details.reason`: `RUNTIME_INDEXING`,
+`PROJECT_MODEL_UNAVAILABLE`, or `LINKED_ROOT_UNASSOCIATED`. Included builds
+retain their own linked roots and module owners.
+
+Rust maps those reasons to distinct `BACKEND_RUNTIME_INDEXING`,
+`BACKEND_PROJECT_MODEL_UNAVAILABLE`, and
+`BACKEND_LINKED_ROOT_UNASSOCIATED` limitations. Failure of the metadata request
+makes backend coverage unavailable. The same typed failure while paging makes
+the backend attempt workspace-wide partial and discards its earlier pages;
+generic transport or cursor failure remains local to the requested module.
 
 ## Public command contract
 
@@ -121,8 +136,9 @@ ownership set sorts by its typed module identity. The same evidence snapshot
 therefore produces deterministic JSON and TOON.
 
 The compact default emits a typed result with the exact workspace root,
-bounded file records, known-match and returned counts, truncation and
-inventory-completeness facts, typed limitations, and schema version. Each file
+bounded file records, ADR 0020's discriminated `EXACT` or `KNOWN_MINIMUM`
+cardinality, returned count, truncation, separate candidate-inventory and
+filter-evidence coverage, typed limitations, and schema version. Each file
 record includes:
 
 - absolute `filePath` and workspace-relative `relativePath`;
@@ -139,11 +155,23 @@ record includes:
   dirty, or unknown; and
 - verbose/explain evidence identifying which sources established the record.
 
+The candidate inventory is `COMPLETE` only when every candidate authority that
+could contribute a matching path is exhaustive. Filter evidence is `COMPLETE`
+only when every predicate used by the request is known for every candidate. A
+complete candidate inventory can therefore coexist with partial filter evidence:
+for example, unavailable Git status makes a `--dirty clean` query inexact even
+when all backend and source-index candidates are known. Cardinality is `EXACT`
+only when both relevant coverage dimensions are complete; otherwise it is
+`KNOWN_MINIMUM` and counts only matches actually proved. `returnedCount` equals
+the emitted file count. `truncated` is true when an exact total exceeds that
+count or cardinality is `KNOWN_MINIMUM`, because unseen matches remain possible.
+
 The default compact representation must remain within 120 lines and 1,500
 estimated tokens for a high-cardinality fixture. `--fields` selects typed file
-fields, `--count` reports known cardinalities without file payloads, and
-`--verbose` or `--explain` exposes source coverage and evidence without making
-raw transport envelopes the default.
+fields, `--count` reports the same typed overall cardinality plus discriminated
+cardinalities for grouped counts without file payloads, and `--verbose` or
+`--explain` exposes source coverage and evidence without making raw transport
+envelopes the default.
 
 `filePath` is the direct composition key for
 `kast agent diagnostics --file-path <path>` and
@@ -201,13 +229,14 @@ overlapping roots preserve every backend owner; duplicate paths are not
 malformed merely because their module names differ. If an indexed row cannot
 be associated with completely paged possible owners, absence remains unknown.
 
-Backend capability absence, page failure, repeated snapshot staleness,
-unavailable or incompatible source index, unavailable Git status, unavailable
-or invalid package metadata, and excluded out-of-root rows are distinct typed
-limitations. A usable backend-only or index-only snapshot may return partial
-evidence. Exact-root admission failure and malformed backend payloads fail
-closed. When neither backend nor index is usable, the command returns
-`WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` instead of a false empty success.
+Backend capability absence, metadata or page failure, runtime indexing,
+unavailable Gradle project-model data, unassociated linked roots, repeated
+snapshot staleness, unavailable or incompatible source index, unavailable Git
+status, unavailable or invalid package metadata, and excluded out-of-root rows
+are distinct typed limitations. A usable backend-only or index-only snapshot
+may return partial evidence. Exact-root admission failure and malformed backend
+payloads fail closed. When neither backend nor index is usable, the command
+returns `WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` instead of a false empty success.
 
 ## Capability callability invariant
 
@@ -228,9 +257,10 @@ agent workflow.
 ## Ownership
 
 - `analysis-api`, `analysis-server`, and `backend-idea` own typed deterministic
-  per-module workspace-file paging, source/content-root evidence, and
-  compiler/project-model `.kt`/`.kts` enumeration. Generated protocol and raw
-  RPC catalogs come from those source owners.
+  per-module workspace-file paging, source/content-root evidence,
+  compiler/project-model `.kt`/`.kts` enumeration, and typed project-model
+  incompleteness. Generated protocol artifacts come from those Kotlin source
+  owners.
 - `cli-rs/src/workspace_inventory.rs` and
   `cli-rs/src/workspace_inventory/` own the reusable uncapped inventory,
   exact-root Kotlin source-index reader, targeted filesystem evidence,
@@ -246,10 +276,15 @@ agent workflow.
   limitation, budget, exact-root, and composition regressions.
 - `docs/reference/agent-commands.md` and the packaged Kast skill teach the
   typed public command.
+- `cli-rs/resources/kast-skill/references/commands.json` is the hand-authored
+  internal raw-command catalog. Generated YAML, request schemas, and request
+  samples derive from it.
 
 The new inventory directory receives a scoped `AGENTS.md` when implementation
-begins because it creates a new source-ownership boundary. `analysis-api` and
-generated-contract ownership guidance is updated with the wire change.
+begins because it creates a new source-ownership boundary. `backend-idea`
+receives its nearest ownership guide for the project-model inventory and Gradle
+bridge. `analysis-api` and generated-contract ownership guidance is updated
+with the wire change.
 
 ## Validation
 

--- a/.agents/adr/0021-first-class-workspace-file-discovery.md
+++ b/.agents/adr/0021-first-class-workspace-file-discovery.md
@@ -35,7 +35,15 @@ request candidates.
 The backend is authoritative for current compiler/project-model ownership and
 may report one physical path as owned by multiple modules. The source index is
 authoritative only for Kotlin-source facts it actually stores: manifest
-membership, Gradle module path, source set, and package fully qualified name.
+membership, a build-qualified Gradle project identity when the producer proved
+one from the linked Gradle model, source set, and package fully qualified name.
+The legacy `file_metadata.module_path` value is an unqualified module label and
+is never parsed or exposed as a `GradleProjectPath`. The IDEA producer persists
+a set of separate association rows containing `(workspace-relative linked build
+root, absolute Gradle project path)` from `GradleModuleData`; an IDEA
+module-name fallback remains an unproven label and cannot enter those rows.
+Root and included builds may therefore both own `:app` without becoming the
+same indexed owner.
 `SourceIndexFilePolicy` remains `.kt`-only. A `.kts` record is therefore
 `NOT_APPLICABLE` to this Kotlin source index rather than `NOT_INDEXED`; issue
 #340 owns a separate Gradle DSL index. An index row alone does not prove current
@@ -46,19 +54,23 @@ The Rust CLI owns evidence composition. Its internal
 retains every candidate returned by all successfully exhausted backend pages
 and one generation-stamped Kotlin source-index snapshot, plus per-module and
 per-source completeness and limitation evidence. It publishes an exact
-composition only after a barrier proves the backend generation, source-index
-generation/progress/pending state, targeted filesystem evidence, and Git
-snapshot did not move during collection. The whole composition retries once
-when a lane moves; a second movement is typed partial evidence and can never
-produce `EXACT`. The independent bounds allow at most two composition attempts
-with at most two backend-generation attempts each. Issue #340 consumes the
-`.kts` candidates but writes
-Gradle declarations and relationships to its separate Gradle DSL index. If a
+composition only after a kind-relevant barrier proves the required backend
+generation, source-index generation/progress/pending state, targeted filesystem
+evidence, and requested filter/projection evidence did not move during
+collection. A source-only or mixed request requires the Kotlin source-index
+lane; a script-only request and issue #340 mark that lane irrelevant, do not
+read or validate it, and cannot lose exactness because unrelated `.kt` progress
+moves. The whole composition retries once when a relevant lane moves; a second
+movement is typed partial evidence and can never produce `EXACT` for the
+affected kind domain. The independent bounds allow at most two composition
+attempts with at most two backend-generation attempts each. Issue #340
+consumes the `.kts` candidates but writes Gradle declarations and relationships
+to its separate Gradle DSL index. If a
 generic backend page transport fails or returns an invalid token, only that
 module is partial and backend absence remains unprovable for paths that may
 belong to it. A stale workspace generation invalidates the whole backend
-attempt: Rust discards it,
-restarts once from fresh metadata, and returns typed partial evidence if that
+attempt: Rust discards it, restarts once from fresh metadata, and returns typed
+partial evidence if that
 single retry also becomes stale. The partial result carries
 `BACKEND_WORKSPACE_INVENTORY_STALE`, marks every module from the last metadata
 response incomplete, and retains no backend candidates from either stale
@@ -68,10 +80,13 @@ stale retry and preserves the server's typed reason as a public limitation.
 
 ## Raw paging and project-model authority
 
-An unpaged `raw/workspace-files` metadata request lists sorted module metadata
-and counts plus an opaque top-level `snapshotToken`. Rust echoes that token on
-every exact-module request with `includeFiles=true` and a positive
-server-bounded `maxFilesPerModule`. Snapshot and page handles use the shared
+An unpaged `raw/workspace-files` metadata request carries a typed
+source-only/script-only/mixed kind domain and lists sorted relevant module
+metadata and counts plus an opaque top-level `snapshotToken`. Rust echoes that
+kind domain and token on every exact-module request with `includeFiles=true`
+and a positive server-bounded `maxFilesPerModule`. The backend fingerprints and
+pages only the requested domain, so unrelated source movement cannot invalidate
+a script-only snapshot. Snapshot and page handles use the shared
 server-held opaque continuation mechanism established for ADR 0020 paging.
 Random canonical handles address typed state containing the generation, exact
 module, query identity, and next offset; neither clients nor Rust decode or
@@ -90,10 +105,21 @@ already-consumed, or query-mismatched handle fails as
 workspace-wide and discards the backend attempt; an invalid page handle is
 local to its module only while the snapshot lease still validates.
 
-The backend builds a canonical full-workspace inventory in one read action and
+The generic store owns every issued state and never returns an owning reference
+to callers. A typed disposer is invoked exactly once when an entry leaves the
+store through expiry, capacity eviction, replacement, query mismatch, explicit
+invalidation or completion, terminal single-use consumption, or server
+shutdown. Consuming and leased APIs run caller work under store-owned lifetime
+control and dispose in `finally` when ownership terminates, including callback
+failure. Shutdown drains every typed store; one disposer failure cannot skip
+the remaining entries. Stateless continuation families use a no-op disposer,
+while ADR 0020 reference/diagnostic state adapts its closeable IDEA traversal
+to this owner instead of keeping a parallel lifecycle.
+
+The backend builds a canonical requested-kind inventory in one read action and
 fingerprints its sorted module identities, source/content roots, dependencies,
-and candidate paths. Before serving any exact-module page or final barrier
-validation it recomputes the inventory and compares its generation with the
+kind domain, and candidate paths. Before serving any exact-module page or final
+barrier validation it recomputes the inventory and compares its generation with the
 leased snapshot state. Equal-cardinality path replacement, module
 addition/removal, or any other inventory change invalidates the lease and fails
 with `STALE_WORKSPACE_INVENTORY`. Only server-held state for a matching
@@ -138,8 +164,9 @@ The command accepts the standard exact-root `--workspace-root` and `--backend`
 flags and the result-view flags introduced by ADR 0020. Its discovery filters
 are typed and conjunctive:
 
-- `--module` matches any exact backend module name or indexed Gradle module
-  path in the record's ownership sets;
+- `--module` parses a closed selector: `backend:<exact-name>` or
+  `gradle:<workspace-relative-build-root>#<absolute-project-path>`, and matches
+  the corresponding backend owner or build-qualified indexed Gradle project;
 - `--source-set` matches an exact indexed source set;
 - `--kind source|script` distinguishes `.kt` from `.kts`;
 - `--package` matches an exact indexed package fully qualified name;
@@ -180,10 +207,21 @@ explicit new unpaged query.
 Five-hundred-record tests prove 200/200/100 continuation with no gaps or
 overlap.
 
+The composition digest canonically serializes the normalized requested-kind
+domain, each lane's relevance, and every relevant lane's discriminated
+`AVAILABLE(stamp)` or `UNAVAILABLE(reason)` state. It does not require all
+lanes to be available. A stable backend-only or index-only partial composition
+can therefore page its known matches without pretending to be exact; the token
+becomes stale when a bound lane changes stamp, availability, or unavailable
+reason. Irrelevant lanes are represented as `IRRELEVANT` and neither movement
+nor availability in such a lane invalidates a continuation.
+
 Registration and consumption travel through the internal typed
 `raw/workspace-files-continuation` method on the already admitted RPC session.
-That method stores or returns typed state but is not a public agent command or
-capability. It does not accept candidate enumeration authority.
+That method issues state or serializes consumed plain state inside the store's
+lifetime-controlled callback, but is not a public agent command or capability.
+It does not accept candidate enumeration authority or leak an owning state
+reference.
 
 The compact default emits a typed result with the exact workspace root,
 bounded file records, ADR 0020's discriminated `EXACT` or `KNOWN_MINIMUM`
@@ -192,7 +230,8 @@ candidate-inventory and filter-evidence coverage, typed limitations, and schema
 version. Each file record includes:
 
 - absolute `filePath` and workspace-relative `relativePath`;
-- sorted backend-module and indexed-Gradle-module ownership sets;
+- sorted backend-module and build-qualified indexed-Gradle-project ownership
+  sets;
 - source set when known;
 - `KOTLIN_SOURCE` or `KOTLIN_SCRIPT` kind;
 - `INDEXED`, `NOT_INDEXED`, `NOT_APPLICABLE`, or `UNKNOWN` Kotlin source-index
@@ -205,18 +244,26 @@ version. Each file record includes:
   dirty, or unknown; and
 - verbose/explain evidence identifying which sources established the record.
 
-The candidate inventory is `COMPLETE` only when every candidate authority that
-could contribute a matching path is exhaustive. Filter evidence is `COMPLETE`
-only when every predicate used by the request is known for every candidate. A
-complete candidate inventory can therefore coexist with partial filter evidence:
+The candidate inventory is `COMPLETE` only when every candidate authority
+relevant to the requested kind domain could contribute no additional matching
+path. Filter evidence is `COMPLETE` only when every requested predicate is
+known for every candidate in that domain. Source and script coverage are
+tracked separately and conjoined for the overall result whenever the selected
+kind domain is mixed; a script-only result and a script count group may be exact
+while `.kt` index
+progress is incomplete. A complete candidate inventory can therefore coexist
+with partial filter evidence:
 for example, unavailable Git status makes a `--dirty clean` query inexact even
-when all backend and source-index candidates are known. Cardinality is `EXACT`
-only when both relevant coverage dimensions are complete; otherwise it is
+when all kind-relevant backend and source-index candidates are known.
+Cardinality is `EXACT` only when both relevant coverage dimensions are complete;
+otherwise it is
 `KNOWN_MINIMUM` and counts only matches actually proved. `returnedCount` equals
 the emitted file count. `truncated` is true when an exact total exceeds that
 count or cardinality is `KNOWN_MINIMUM`, because unseen matches remain possible.
 `nextPageToken` is non-null only when another currently known matching record
-exists; partial evidence may therefore be truncated without offering a token.
+exists. Coherent partial evidence may continue through all currently known
+matches; unstable evidence, or a partial result with no further known match,
+remains truncated without a token.
 
 The default compact representation must remain within 120 lines and 1,500
 estimated tokens for a high-cardinality fixture. `--fields` selects typed file
@@ -234,15 +281,17 @@ not invent a second path dialect.
 
 The collector opens the configured exact-root source-index database read-only
 and reads one SQLite transaction joining `file_manifest`, `path_prefixes`,
-`file_metadata`, and `fq_names` together with `schema_version.generation`, all
-`module_index_progress`, and the count of unapplied `pending_updates`. It keeps
-only `.kt` candidates because that is the source index's declared policy.
+`file_metadata`, the dedicated `file_gradle_projects` association table, and
+`fq_names` together with `schema_version.generation`, all
+`module_index_progress`, and the count of unapplied `pending_updates`. It never
+promotes legacy `file_metadata.module_path` into Gradle identity. It keeps only
+`.kt` candidates because that is the source index's declared policy.
 Generation increments in the same write transaction as candidate, progress, or
 pending-state changes. Source-index coverage is complete only when the
 initialized progress set is nonempty, every row is `COMPLETE`, indexed counts
 equal totals, and no unapplied update remains. Existing candidates are checked
-individually; the
-implementation does not recurse from the workspace root. Git porcelain may
+individually; the implementation does not recurse from the workspace root. Git
+porcelain may
 annotate a candidate but never adds one absent from backend and index evidence.
 
 Every candidate is normalized against the admitted workspace root. Existing
@@ -257,17 +306,26 @@ race, or absence of any canonicalizable ancestor yields
 partial. Backend module source/content roots receive the same proof before they
 can establish ownership or completeness.
 
-After collecting backend, index, targeted filesystem, and Git evidence, the
-composition barrier validates the backend snapshot lease, re-reads the
-source-index generation/progress/pending stamp in a fresh transaction, repeats
-targeted filesystem facts, and repeats the normalized Git status fingerprint.
-Only identical before/after stamps form a coherent snapshot. One changed lane
-discards the whole attempt and retries once. A second change emits
-`CROSS_SOURCE_COMPOSITION_UNSTABLE`, marks candidate and affected filter
-coverage partial, suppresses public continuation, and forbids `EXACT`. Stable
+Before collection, the normalized query derives a closed source-only,
+script-only, or mixed kind domain and a relevance map for candidate, filter,
+and projection evidence. The composition stores each relevant lane as
+`AVAILABLE(typed stamp)` or `UNAVAILABLE(typed reason)` and marks non-required
+lanes `IRRELEVANT`. After collecting evidence, the barrier validates the
+backend snapshot lease or repeats its unavailable classification, re-reads a
+relevant source-index generation/progress/pending stamp or unavailable
+classification in a fresh transaction, repeats targeted filesystem facts, and
+repeats Git only when the selected filter/view/fields require it. Canonical
+before/after lane states, including availability tags and reasons, must match.
+One changed relevant lane discards the whole attempt and retries once. A second
+change emits `CROSS_SOURCE_COMPOSITION_UNSTABLE`, marks candidate and affected
+filter coverage partial, suppresses public continuation, and forbids `EXACT`.
+Stable
 but incomplete index progress or pending updates emits distinct
 `SOURCE_INDEX_PROGRESS_INCOMPLETE` or `SOURCE_INDEX_UPDATES_PENDING`
-limitations and likewise forbids exact candidate coverage.
+limitations and forbids exact source or mixed candidate coverage, but is
+irrelevant to script-only discovery and #340. Mixed/source/script fixtures
+prove that exactness and continuation invalidation follow only the selected
+kind partitions.
 
 The dirty-state adapter forces `status.relativePaths=false` so Git porcelain v2
 paths are repository-root-relative even when Git runs with
@@ -310,10 +368,11 @@ snapshot staleness, unavailable or incompatible source index, unavailable Git
 status, incomplete index progress, pending index updates, unstable cross-source
 composition, unprovable containment, unavailable or invalid package metadata,
 and excluded out-of-root rows are distinct typed limitations. A usable
-backend-only or index-only snapshot
-may return partial evidence. Exact-root admission failure and malformed backend
-payloads fail closed. When neither backend nor index is usable, the command
-returns `WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` instead of a false empty success.
+backend-only or index-only snapshot may return partial evidence. Exact-root
+admission failure and malformed backend payloads fail closed. When no candidate
+authority relevant to the selected kind
+domain is usable, the command returns `WORKSPACE_FILE_DISCOVERY_UNAVAILABLE`
+instead of a false empty success.
 
 ## Capability callability invariant
 
@@ -337,16 +396,19 @@ agent workflow.
   server-held opaque continuation leases, per-module workspace-file paging,
   public continuation state, source/content-root evidence,
   compiler/project-model `.kt`/`.kts` enumeration, and typed project-model
-  incompleteness. Generated protocol artifacts come from those Kotlin source
-  owners.
+  incompleteness. The shared store owns exact-once disposal, including #337
+  closeable IDEA traversal and server shutdown. Generated protocol artifacts
+  come from those Kotlin source owners.
 - `cli-rs/src/workspace_inventory.rs` and
   `cli-rs/src/workspace_inventory/` own the reusable uncapped inventory,
   generation/progress-aware exact-root Kotlin source-index reader, deepest-
   existing-ancestor containment, targeted filesystem evidence, dirty-state
-  annotation, cross-source composition barrier, and internal types.
-- `index-store` owns transactional maintenance of the existing source-index
-  generation, module progress, and pending-update state; this ADR adds no schema
-  column and does not widen `SourceIndexFilePolicy`.
+  annotation, kind-relevant discriminated cross-source composition barrier, and
+  internal types.
+- `index-store` owns transactional maintenance of the source-index generation,
+  module progress, pending-update state, and new `file_gradle_projects`
+  build-qualified ownership table. The IDEA producer supplies host-neutral
+  identity values; neither owner widens `SourceIndexFilePolicy`.
 - `cli-rs/src/agent/workspace_files.rs` owns public command execution and typed
   filter validation.
 - `cli-rs/src/agent/projection/workspace_files.rs` owns compact, selected,
@@ -385,6 +447,8 @@ cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
 ./gradlew :analysis-api:test :analysis-server:test :index-store:test :backend-idea:test --no-daemon
+./gradlew test --no-daemon
+./gradlew buildIdeaPlugin --no-daemon
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
 .github/scripts/test-kast-copilot-plugin.sh
 .github/scripts/test-lsp-pivot-gates.sh
@@ -398,8 +462,9 @@ git diff --check
 The implementation changes the Kotlin workspace-files query/result and shared
 continuation contracts, server validation, IDEA backend enumeration, source-
 index generation maintenance, fake backend, generated protocol, and raw
-catalogs. It does not change `SourceIndexFilePolicy` or the source-index schema.
-The index-store test that rejects `.kts` remains an explicit gate.
+catalogs. It adds and versions the `file_gradle_projects` source-index
+association table but does not change `SourceIndexFilePolicy`. The index-store
+test that rejects `.kts` remains an explicit gate.
 
 ## Change rule
 
@@ -408,7 +473,7 @@ additively. It must preserve exact-root containment, generation-bound
 exhaustive backend paging, the uncapped internal snapshot, set-valued module
 ownership, deterministic consumable public bounds, `.kt`-only source-index
 authority, deepest-existing-ancestor containment, coherent cross-source stamps,
-and the rule that incomplete backend or index evidence cannot prove
-`INDEX_ONLY` or `EXACT`. Any
+and the rule that incomplete relevant backend or index evidence cannot prove
+`INDEX_ONLY` or `EXACT` for its kind partition. Any
 change that uses filesystem or Git enumeration as candidate authority requires
 a superseding ADR.

--- a/.agents/adr/0021-first-class-workspace-file-discovery.md
+++ b/.agents/adr/0021-first-class-workspace-file-discovery.md
@@ -1,0 +1,203 @@
+# ADR 0021: First-class workspace file discovery
+
+Status: Accepted
+
+Date: 2026-07-13
+
+This ADR supersedes the typed-agent-command list and workspace-file portions
+of [ADR 0006](0006-forward-system-definition-and-audit-scope.md). It extends
+the exact-root admission contract in
+[ADR 0019](0019-exact-root-semantic-workspace-admission.md). The public agent
+surface now includes `kast agent workspace-files`; arbitrary raw RPC dispatch
+remains internal.
+
+## Decision
+
+Kast exposes `kast agent workspace-files` as the stable public path for
+discovering Kotlin source and Kotlin script files owned by the admitted
+semantic workspace. The command does not begin with a recursive filesystem
+walk or a Git file list. It composes evidence from the existing
+`raw/workspace-files` backend method and the exact-root SQLite source index,
+then annotates those candidates with targeted filesystem metadata and Git
+dirty state.
+
+The Rust CLI owns this composition. The existing Kotlin API, server, and
+backend `WorkspaceFilesQuery` and `WorkspaceFilesResult` wire contract does not
+change in this issue. The backend remains authoritative for compiler
+project-model ownership and module membership. The source index remains
+authoritative only for facts it actually stores: manifest membership, Gradle
+module path, source set, and package fully qualified name. An index row alone
+does not prove current semantic ownership.
+
+The internal `WorkspaceInventorySnapshot` is not subject to the public
+command's result limit or filters. It retains every Kotlin candidate returned
+by the available backend and source-index snapshots, plus source completeness
+and limitation evidence. Issue #340 may consume that internal inventory to
+classify Gradle Kotlin DSL scripts without reimplementing file discovery or
+mistaking index presence for project-model ownership. Source-layer limits are
+not hidden: if the existing backend reports a truncated module, the internal
+snapshot is partial even though the Rust collector itself is uncapped.
+
+## Public command contract
+
+The command accepts the standard exact-root `--workspace-root` and `--backend`
+flags and the result-view flags introduced by ADR 0020. Its discovery filters
+are typed and conjunctive:
+
+- `--module` matches an exact backend module name or exact indexed Gradle
+  module path;
+- `--source-set` matches an exact indexed source set;
+- `--kind source|script` distinguishes `.kt` from `.kts`;
+- `--package` matches an exact indexed package fully qualified name;
+- `--dirty clean|dirty|unknown` filters the typed Git state class;
+- `--drift none|filesystem-only|index-only|missing-on-disk|unknown` filters
+  cross-source drift;
+- `--path-prefix` accepts one normalized workspace-relative path prefix;
+- `--glob` accepts one bounded glob over normalized workspace-relative paths;
+  and
+- `--limit` defaults to 20 and accepts 1 through 200.
+
+Absolute path prefixes, parent traversal, empty semantic selectors, invalid
+package names, regex-prefixed globs, and out-of-range limits fail at the typed
+CLI boundary. Filters never widen the inventory and are applied before the
+public limit. Results sort by normalized workspace-relative path, then module
+identity, so the same evidence snapshot produces deterministic JSON and TOON.
+
+The compact default emits a typed result with the exact workspace root,
+bounded file records, known-match and returned counts, truncation and
+inventory-completeness facts, typed limitations, and schema version. Each file
+record includes:
+
+- absolute `filePath` and workspace-relative `relativePath`;
+- backend module name and indexed Gradle module path when known;
+- source set and package when known;
+- `KOTLIN_SOURCE` or `KOTLIN_SCRIPT` kind;
+- `INDEXED`, `NOT_INDEXED`, or `UNKNOWN` index state;
+- `NONE`, `FILESYSTEM_ONLY`, `INDEX_ONLY`, `MISSING_ON_DISK`, or `UNKNOWN`
+  drift;
+- detailed dirty state collapsed by the public dirty filter into clean,
+  dirty, or unknown; and
+- verbose/explain evidence identifying which sources established the record.
+
+The default compact representation must remain within 120 lines and 1,500
+estimated tokens for a high-cardinality fixture. `--fields` selects the typed
+file fields, `--count` reports known cardinalities without file payloads, and
+`--verbose` or `--explain` exposes source coverage and evidence without making
+raw transport envelopes the default.
+
+`filePath` is the direct composition key for
+`kast agent diagnostics --file-path <path>` and
+`kast agent symbol --query <name> --file-hint <path>`. The public command does
+not invent a second path dialect.
+
+## Evidence and drift rules
+
+The collector opens the configured exact-root source-index database read-only
+and reads a single SQLite snapshot joining `file_manifest`, `path_prefixes`,
+`file_metadata`, and `fq_names`. It keeps only `.kt` and `.kts` candidates.
+Existing files are checked individually; the implementation does not recurse
+from the workspace root. Git porcelain output may annotate a candidate but
+must never add a candidate that is absent from both backend and index
+evidence.
+
+Every candidate is normalized against the admitted workspace root. Existing
+paths whose canonical target leaves that root and index paths that are
+lexically outside it are omitted with a typed limitation. This prevents stale
+absolute index entries or another checkout's paths from becoming current-root
+workspace evidence.
+
+Drift is classified by this truth table:
+
+| Backend ownership | Index snapshot | Filesystem | Backend coverage | Result |
+| --- | --- | --- | --- | --- |
+| Present | Present | Present | Any | `NONE`, `INDEXED` |
+| Present | Absent | Present | Any | `FILESYSTEM_ONLY`, `NOT_INDEXED` |
+| Absent | Present | Any | Complete | `INDEX_ONLY`, `INDEXED` |
+| Absent | Present | Any | Truncated or unavailable | `UNKNOWN`, `INDEXED` |
+| Present or index-present | Any | Missing | Any | `MISSING_ON_DISK` with the independently proven index state |
+| Present | Index unavailable | Present | Any | `UNKNOWN`, `UNKNOWN` |
+
+`INDEX_ONLY` is therefore impossible when backend file enumeration is
+truncated or unavailable. A truncated module makes absence unprovable for that
+module. If the backend response cannot associate an indexed row with one
+complete module, absence remains unknown. This rule also prevents source-index
+rows from nested `.worktrees` or stale checkouts from posing as current
+project-model ownership.
+
+Backend capability absence, backend enumeration truncation, unavailable or
+incompatible source index, unavailable Git status, missing package metadata,
+and excluded out-of-root rows are distinct typed limitations. A usable
+backend-only or index-only snapshot may return partial evidence. Exact-root
+admission failure and malformed backend payloads fail closed. When neither
+backend nor index can supply candidates, the command returns
+`WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` instead of a false empty success.
+
+## Capability callability invariant
+
+Rust owns a typed public-capability route registry. Its first entry maps the
+backend `WORKSPACE_FILES` capability to
+`kast agent workspace-files`. Verification projects this capability as public
+only when the backend advertises it and the registered Clap command is
+callable. A contract test walks the same registry against the generated Clap
+command tree. A backend capability may remain visible as raw/internal evidence
+for diagnostics, but it cannot be presented as a public workspace-discovery
+route without a passing callable-command assertion.
+
+Issue #342 may extend this registry to every public capability. This issue
+establishes the invariant and covers `WORKSPACE_FILES`; it does not duplicate
+the entire RPC catalog in prose or promote `raw/workspace-files` to a public
+agent workflow.
+
+## Ownership
+
+- `cli-rs/src/workspace_inventory.rs` and
+  `cli-rs/src/workspace_inventory/` own the reusable uncapped inventory,
+  exact-root index reader, targeted filesystem evidence, dirty-state
+  annotation, composition, and internal types.
+- `cli-rs/src/agent/workspace_files.rs` owns public command execution and
+  typed filter validation.
+- `cli-rs/src/agent/projection/workspace_files.rs` owns compact, selected,
+  count, verbose, and explain projections after ADR 0020 lands.
+- `cli-rs/src/agent/public_capabilities.rs` owns the public capability route
+  registry and verification mapping.
+- `cli-rs/src/cli/agent.rs` owns the typed Clap command and arguments.
+- `cli-rs/tests/agent_workspace_files_smoke.rs` owns public discovery,
+  limitation, budget, and composition regressions.
+- `docs/reference/agent-commands.md` and the packaged Kast skill teach the
+  typed public command. Generated raw RPC catalog and protocol artifacts stay
+  unchanged because the existing Kotlin wire method is reused.
+
+The new inventory directory receives a scoped `AGENTS.md` when production
+implementation begins because it creates a new source-ownership boundary.
+
+## Validation
+
+Implementation must use red-green slices and run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projection_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test cli_core_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked
+cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
+cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+.github/scripts/test-docs-content-contract.sh
+.github/scripts/test-docs-navigation-contract.sh
+zensical build --clean
+git diff --check
+```
+
+The implementation does not require an `analysis-api`, `analysis-server`,
+backend, index schema, or generated protocol change. If implementation reveals
+that the existing raw contract cannot preserve the evidence rules above, stop
+and supersede this decision before changing Kotlin wire types.
+
+## Change rule
+
+Future work may add pagination, new file kinds, or Gradle Kotlin DSL subtype
+evidence additively. It must preserve exact-root containment, the uncapped
+internal snapshot, deterministic public bounds, and the rule that incomplete
+backend evidence cannot prove `INDEX_ONLY`. Any change that uses filesystem or
+Git enumeration as the candidate authority requires a superseding ADR.

--- a/.agents/adr/0021-first-class-workspace-file-discovery.md
+++ b/.agents/adr/0021-first-class-workspace-file-discovery.md
@@ -16,27 +16,61 @@ remains internal.
 Kast exposes `kast agent workspace-files` as the stable public path for
 discovering Kotlin source and Kotlin script files owned by the admitted
 semantic workspace. The command does not begin with a recursive filesystem
-walk or a Git file list. It composes evidence from the existing
-`raw/workspace-files` backend method and the exact-root SQLite source index,
-then annotates those candidates with targeted filesystem metadata and Git
-dirty state.
+walk or a Git file list. It composes compiler/project-model candidates from a
+paged `raw/workspace-files` backend method with Kotlin-source candidates from
+the exact-root SQLite source index, then annotates those candidates with
+targeted filesystem metadata and Git dirty state.
 
-The Rust CLI owns this composition. The existing Kotlin API, server, and
-backend `WorkspaceFilesQuery` and `WorkspaceFilesResult` wire contract does not
-change in this issue. The backend remains authoritative for compiler
-project-model ownership and module membership. The source index remains
-authoritative only for facts it actually stores: manifest membership, Gradle
-module path, source set, and package fully qualified name. An index row alone
-does not prove current semantic ownership.
+The Kotlin API, server, and backend `WorkspaceFilesQuery` and
+`WorkspaceFilesResult` contract gains a canonical offset page token,
+per-module `nextPageToken`, and explicit module content roots alongside source
+roots. Rust first reads the sorted module inventory, then exhausts every module
+page before classifying backend absence. The backend gathers Kotlin sources and
+scripts from IntelliJ's compiler/project model, including Gradle-linked root
+`build.gradle.kts` and `settings.gradle.kts`, convention-plugin scripts, and
+ordinary project scripts. It does not recursively scan the filesystem for
+request candidates.
 
-The internal `WorkspaceInventorySnapshot` is not subject to the public
-command's result limit or filters. It retains every Kotlin candidate returned
-by the available backend and source-index snapshots, plus source completeness
-and limitation evidence. Issue #340 may consume that internal inventory to
-classify Gradle Kotlin DSL scripts without reimplementing file discovery or
-mistaking index presence for project-model ownership. Source-layer limits are
-not hidden: if the existing backend reports a truncated module, the internal
-snapshot is partial even though the Rust collector itself is uncapped.
+The backend is authoritative for current compiler/project-model ownership and
+may report one physical path as owned by multiple modules. The source index is
+authoritative only for Kotlin-source facts it actually stores: manifest
+membership, Gradle module path, source set, and package fully qualified name.
+`SourceIndexFilePolicy` remains `.kt`-only. A `.kts` record is therefore
+`NOT_APPLICABLE` to this Kotlin source index rather than `NOT_INDEXED`; issue
+#340 owns a separate Gradle DSL index. An index row alone does not prove current
+semantic ownership.
+
+The Rust CLI owns evidence composition. Its internal
+`WorkspaceInventorySnapshot` is not subject to public filters or limits. It
+retains every candidate returned by all successfully exhausted backend pages
+and the Kotlin source-index snapshot, plus per-module completeness and
+limitation evidence. Issue #340 consumes the `.kts` candidates but writes
+Gradle declarations and relationships to its separate Gradle DSL index. If a
+backend page fails or returns an invalid token, only that module is partial and
+backend absence remains unprovable for paths that may belong to it.
+
+## Raw paging and project-model authority
+
+An unpaged `raw/workspace-files` request lists sorted module metadata and
+counts. Rust then requests each module by its exact backend name with
+`includeFiles=true`, a positive server-bounded `maxFilesPerModule`, and an
+optional canonical page token. The token encodes a positive next offset and is
+valid only with one exact module. The backend sorts and deduplicates a module's
+complete candidate set before slicing, returns `fileCount`,
+`returnedFileCount`, and `nextPageToken`, and rejects malformed or out-of-range
+tokens. Rust rejects repeated or non-advancing tokens, inconsistent totals,
+changed module identity, and overlapping pages before it marks the module
+complete.
+
+The backend candidate provider uses IntelliJ project scope, module content and
+source roots, and linked Gradle project roots. Known Gradle project roots make
+root build and settings scripts project-model candidates without a recursive
+walk. Project-scope Kotlin scripts supply convention-plugin and ordinary
+scripts. Each candidate carries every owning backend module; root-level
+project scripts use every root Gradle module associated with their linked
+project root. A linked root that cannot be associated with a backend module
+fails the request as incomplete project-model evidence. Included builds retain
+their own linked roots and module owners.
 
 ## Public command contract
 
@@ -44,14 +78,14 @@ The command accepts the standard exact-root `--workspace-root` and `--backend`
 flags and the result-view flags introduced by ADR 0020. Its discovery filters
 are typed and conjunctive:
 
-- `--module` matches an exact backend module name or exact indexed Gradle
-  module path;
+- `--module` matches any exact backend module name or indexed Gradle module
+  path in the record's ownership sets;
 - `--source-set` matches an exact indexed source set;
 - `--kind source|script` distinguishes `.kt` from `.kts`;
 - `--package` matches an exact indexed package fully qualified name;
 - `--dirty clean|dirty|unknown` filters the typed Git state class;
-- `--drift none|filesystem-only|index-only|missing-on-disk|unknown` filters
-  cross-source drift;
+- `--drift none|filesystem-only|index-only|missing-on-disk|not-applicable|unknown`
+  filters cross-source drift;
 - `--path-prefix` accepts one normalized workspace-relative path prefix;
 - `--glob` accepts one bounded glob over normalized workspace-relative paths;
   and
@@ -60,8 +94,9 @@ are typed and conjunctive:
 Absolute path prefixes, parent traversal, empty semantic selectors, invalid
 package names, regex-prefixed globs, and out-of-range limits fail at the typed
 CLI boundary. Filters never widen the inventory and are applied before the
-public limit. Results sort by normalized workspace-relative path, then module
-identity, so the same evidence snapshot produces deterministic JSON and TOON.
+public limit. Results sort by normalized workspace-relative path; every
+ownership set sorts by its typed module identity. The same evidence snapshot
+therefore produces deterministic JSON and TOON.
 
 The compact default emits a typed result with the exact workspace root,
 bounded file records, known-match and returned counts, truncation and
@@ -69,19 +104,22 @@ inventory-completeness facts, typed limitations, and schema version. Each file
 record includes:
 
 - absolute `filePath` and workspace-relative `relativePath`;
-- backend module name and indexed Gradle module path when known;
-- source set and package when known;
+- sorted backend-module and indexed-Gradle-module ownership sets;
+- source set when known;
 - `KOTLIN_SOURCE` or `KOTLIN_SCRIPT` kind;
-- `INDEXED`, `NOT_INDEXED`, or `UNKNOWN` index state;
-- `NONE`, `FILESYSTEM_ONLY`, `INDEX_ONLY`, `MISSING_ON_DISK`, or `UNKNOWN`
-  drift;
+- `INDEXED`, `NOT_INDEXED`, `NOT_APPLICABLE`, or `UNKNOWN` Kotlin source-index
+  state;
+- `NONE`, `FILESYSTEM_ONLY`, `INDEX_ONLY`, `MISSING_ON_DISK`,
+  `NOT_APPLICABLE`, or `UNKNOWN` drift;
+- `NAMED`, `ROOT`, `UNAVAILABLE`, or `INVALID_REFERENCE` package evidence,
+  with a package name only for `NAMED`;
 - detailed dirty state collapsed by the public dirty filter into clean,
   dirty, or unknown; and
 - verbose/explain evidence identifying which sources established the record.
 
 The default compact representation must remain within 120 lines and 1,500
-estimated tokens for a high-cardinality fixture. `--fields` selects the typed
-file fields, `--count` reports known cardinalities without file payloads, and
+estimated tokens for a high-cardinality fixture. `--fields` selects typed file
+fields, `--count` reports known cardinalities without file payloads, and
 `--verbose` or `--explain` exposes source coverage and evidence without making
 raw transport envelopes the default.
 
@@ -90,58 +128,75 @@ raw transport envelopes the default.
 `kast agent symbol --query <name> --file-hint <path>`. The public command does
 not invent a second path dialect.
 
-## Evidence and drift rules
+## Candidate, path, package, and Git evidence
 
 The collector opens the configured exact-root source-index database read-only
-and reads a single SQLite snapshot joining `file_manifest`, `path_prefixes`,
-`file_metadata`, and `fq_names`. It keeps only `.kt` and `.kts` candidates.
-Existing files are checked individually; the implementation does not recurse
-from the workspace root. Git porcelain output may annotate a candidate but
-must never add a candidate that is absent from both backend and index
-evidence.
+and reads one SQLite snapshot joining `file_manifest`, `path_prefixes`,
+`file_metadata`, and `fq_names`. It keeps only `.kt` candidates because that is
+the source index's declared policy. Existing candidates are checked
+individually; the implementation does not recurse from the workspace root.
+Git porcelain may annotate a candidate but never adds one absent from backend
+and index evidence.
 
 Every candidate is normalized against the admitted workspace root. Existing
 paths whose canonical target leaves that root and index paths that are
-lexically outside it are omitted with a typed limitation. This prevents stale
-absolute index entries or another checkout's paths from becoming current-root
-workspace evidence.
+lexically outside it are omitted with a typed limitation. Backend module
+source/content roots receive the same canonical containment proof before they
+can establish ownership or completeness.
 
-Drift is classified by this truth table:
+The dirty-state adapter forces `status.relativePaths=false` so Git porcelain v2
+paths are repository-root-relative even when Git runs with
+`-C <workspace-root>`. It resolves and canonicalizes the Git top level, proves
+the admitted workspace is contained by it, restricts status to that workspace,
+strips the exact workspace prefix from current and original rename paths, and
+only then matches normalized inventory keys. A rename with one endpoint
+outside the workspace annotates only its contained endpoint. Failure to prove
+this mapping produces `DIRTY_STATE_UNAVAILABLE`; unmatched nested-workspace
+paths never become false `CLEAN` evidence.
 
-| Backend ownership | Index snapshot | Filesystem | Backend coverage | Result |
-| --- | --- | --- | --- | --- |
-| Present | Present | Present | Any | `NONE`, `INDEXED` |
-| Present | Absent | Present | Any | `FILESYSTEM_ONLY`, `NOT_INDEXED` |
-| Absent | Present | Any | Complete | `INDEX_ONLY`, `INDEXED` |
-| Absent | Present | Any | Truncated or unavailable | `UNKNOWN`, `INDEXED` |
-| Present or index-present | Any | Missing | Any | `MISSING_ON_DISK` with the independently proven index state |
-| Present | Index unavailable | Present | Any | `UNKNOWN`, `UNKNOWN` |
+The index query selects a metadata-row marker, `package_fq_id`, and the joined
+package name separately. No metadata row is `UNAVAILABLE`; a present row with
+null `package_fq_id` proves `ROOT`; a non-null id with one joined name is
+`NAMED`; and a non-null id without a joined row is `INVALID_REFERENCE` plus
+`PACKAGE_METADATA_INVALID`. These states are never collapsed into one null.
 
-`INDEX_ONLY` is therefore impossible when backend file enumeration is
-truncated or unavailable. A truncated module makes absence unprovable for that
-module. If the backend response cannot associate an indexed row with one
-complete module, absence remains unknown. This rule also prevents source-index
-rows from nested `.worktrees` or stale checkouts from posing as current
-project-model ownership.
+## Drift and completeness rules
 
-Backend capability absence, backend enumeration truncation, unavailable or
-incompatible source index, unavailable Git status, missing package metadata,
-and excluded out-of-root rows are distinct typed limitations. A usable
+| Kind | Backend ownership | Kotlin source index | Filesystem | Relevant backend coverage | Result |
+| --- | --- | --- | --- | --- | --- |
+| `.kt` | Present | Present | Present | Any | `NONE`, `INDEXED` |
+| `.kt` | Present | Absent | Present | Any | `FILESYSTEM_ONLY`, `NOT_INDEXED` |
+| `.kt` | Absent | Present | Present | Complete for every possible owner | `INDEX_ONLY`, `INDEXED` |
+| `.kt` | Absent | Present | Present | Partial or unavailable for any possible owner | `UNKNOWN`, `INDEXED` |
+| `.kt` | Present or index-present | Any | Missing | Any | `MISSING_ON_DISK` with independently proven index state |
+| `.kt` | Present | Unavailable | Present | Any | `UNKNOWN`, `UNKNOWN` |
+| `.kts` | Present | Not queried | Present | Complete page evidence | `NOT_APPLICABLE`, `NOT_APPLICABLE` |
+| `.kts` | Present | Not queried | Missing | Any | `MISSING_ON_DISK`, `NOT_APPLICABLE` |
+
+`INDEX_ONLY` is impossible when any module that could own the path has
+incomplete paging. Physical-file ownership is a sorted set. Shared and
+overlapping roots preserve every backend owner; duplicate paths are not
+malformed merely because their module names differ. If an indexed row cannot
+be associated with completely paged possible owners, absence remains unknown.
+
+Backend capability absence, page failure, unavailable or incompatible source
+index, unavailable Git status, unavailable or invalid package metadata, and
+excluded out-of-root rows are distinct typed limitations. A usable
 backend-only or index-only snapshot may return partial evidence. Exact-root
 admission failure and malformed backend payloads fail closed. When neither
-backend nor index can supply candidates, the command returns
+backend nor index is usable, the command returns
 `WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` instead of a false empty success.
 
 ## Capability callability invariant
 
 Rust owns a typed public-capability route registry. Its first entry maps the
-backend `WORKSPACE_FILES` capability to
-`kast agent workspace-files`. Verification projects this capability as public
-only when the backend advertises it and the registered Clap command is
-callable. A contract test walks the same registry against the generated Clap
-command tree. A backend capability may remain visible as raw/internal evidence
-for diagnostics, but it cannot be presented as a public workspace-discovery
-route without a passing callable-command assertion.
+backend `WORKSPACE_FILES` capability to `kast agent workspace-files`.
+Verification projects this capability as public only when the backend
+advertises it and the registered Clap command is callable. A contract test
+walks the same registry against the generated Clap command tree. A backend
+capability may remain visible as raw/internal evidence for diagnostics, but it
+cannot be presented as a public workspace-discovery route without a passing
+callable-command assertion.
 
 Issue #342 may extend this registry to every public capability. This issue
 establishes the invariant and covers `WORKSPACE_FILES`; it does not duplicate
@@ -150,25 +205,29 @@ agent workflow.
 
 ## Ownership
 
+- `analysis-api`, `analysis-server`, and `backend-idea` own typed deterministic
+  per-module workspace-file paging, source/content-root evidence, and
+  compiler/project-model `.kt`/`.kts` enumeration. Generated protocol and raw
+  RPC catalogs come from those source owners.
 - `cli-rs/src/workspace_inventory.rs` and
   `cli-rs/src/workspace_inventory/` own the reusable uncapped inventory,
-  exact-root index reader, targeted filesystem evidence, dirty-state
-  annotation, composition, and internal types.
-- `cli-rs/src/agent/workspace_files.rs` owns public command execution and
-  typed filter validation.
+  exact-root Kotlin source-index reader, targeted filesystem evidence,
+  dirty-state annotation, composition, and internal types.
+- `cli-rs/src/agent/workspace_files.rs` owns public command execution and typed
+  filter validation.
 - `cli-rs/src/agent/projection/workspace_files.rs` owns compact, selected,
   count, verbose, and explain projections after ADR 0020 lands.
 - `cli-rs/src/agent/public_capabilities.rs` owns the public capability route
   registry and verification mapping.
 - `cli-rs/src/cli/agent.rs` owns the typed Clap command and arguments.
 - `cli-rs/tests/agent_workspace_files_smoke.rs` owns public discovery,
-  limitation, budget, and composition regressions.
+  limitation, budget, exact-root, and composition regressions.
 - `docs/reference/agent-commands.md` and the packaged Kast skill teach the
-  typed public command. Generated raw RPC catalog and protocol artifacts stay
-  unchanged because the existing Kotlin wire method is reused.
+  typed public command.
 
-The new inventory directory receives a scoped `AGENTS.md` when production
-implementation begins because it creates a new source-ownership boundary.
+The new inventory directory receives a scoped `AGENTS.md` when implementation
+begins because it creates a new source-ownership boundary. `analysis-api` and
+generated-contract ownership guidance is updated with the wire change.
 
 ## Validation
 
@@ -179,25 +238,29 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_fil
 cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projection_smoke
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test cli_core_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test semantic_workspace_admission_smoke
 cargo test --manifest-path cli-rs/Cargo.toml --locked
 cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+./gradlew :analysis-api:test :analysis-server:test :index-store:test :backend-idea:test --no-daemon
 .github/scripts/test-docs-content-contract.sh
 .github/scripts/test-docs-navigation-contract.sh
 zensical build --clean
 git diff --check
 ```
 
-The implementation does not require an `analysis-api`, `analysis-server`,
-backend, index schema, or generated protocol change. If implementation reveals
-that the existing raw contract cannot preserve the evidence rules above, stop
-and supersede this decision before changing Kotlin wire types.
+The implementation changes the Kotlin workspace-files query/result contract,
+server validation, IDEA backend enumeration, fake backend, generated protocol,
+and raw catalogs. It does not change `SourceIndexFilePolicy` or the source-index
+schema. The index-store test that rejects `.kts` remains an explicit gate.
 
 ## Change rule
 
-Future work may add pagination, new file kinds, or Gradle Kotlin DSL subtype
-evidence additively. It must preserve exact-root containment, the uncapped
-internal snapshot, deterministic public bounds, and the rule that incomplete
-backend evidence cannot prove `INDEX_ONLY`. Any change that uses filesystem or
-Git enumeration as the candidate authority requires a superseding ADR.
+Future work may add file kinds or Gradle Kotlin DSL subtype evidence
+additively. It must preserve exact-root containment, exhaustive typed backend
+paging, the uncapped internal snapshot, set-valued module ownership,
+deterministic public bounds, `.kt`-only source-index authority, and the rule
+that incomplete backend evidence cannot prove `INDEX_ONLY`. Any change that
+uses filesystem or Git enumeration as candidate authority requires a
+superseding ADR.

--- a/.agents/adr/0021-first-class-workspace-file-discovery.md
+++ b/.agents/adr/0021-first-class-workspace-file-discovery.md
@@ -130,10 +130,16 @@ has exited and its state has reached that terminal disposal path. One disposer
 failure cannot skip remaining entries.
 Stateless continuation families use a no-op disposer. `KastPluginBackend` owns
 the backend stores, `ObservedAnalysisBackend` forwards an explicit closeable
-backend contract, and `RunningAnalysisServer.close()` is the single lifecycle
-owner that drains the dispatcher and backend stores after request admission
-stops. `RunningKastIdeaBackend` closes only that server owner and never closes
-the backend a second time.
+backend contract, and `RunningAnalysisServer.close()` is the single backend and
+continuation lifecycle owner that drains the dispatcher and backend stores after
+request admission stops. `RunningKastIdeaBackend` remains the outer
+runtime-resource orchestrator:
+it cancels project indexing, closes `RunningAnalysisServer` as the sole
+backend/continuation owner, and only then closes the separately owned
+`SqliteSourceIndexStore` shared by backend lookup and indexing. It removes the
+redundant `backendResources::close` step rather than dropping source-index-store
+ownership. A failure in one phase does not skip the later phases, and repeated
+runtime close does not repeat any ownership action.
 
 The backend builds a canonical requested-kind inventory in one read action and
 fingerprints its sorted module identities, source/content roots, dependencies,
@@ -369,9 +375,14 @@ outside the workspace annotates only its contained endpoint. Failure to prove
 this mapping produces `DIRTY_STATE_UNAVAILABLE`; unmatched nested-workspace
 paths never become false `CLEAN` evidence.
 
-The index query selects a metadata-row marker, required `package_state`, typed
-`package_unproven_reason`, `package_fq_id`, the joined package name, and
-structured source-set association rows separately. `PROVEN_ROOT` requires a
+`backend-shared` owns the IntelliJ/Kotlin PSI read. `PsiSourceIndexScanner`
+converts `KtFile.packageFqName` or equivalent structured compiler evidence to
+host-neutral `IndexedPackageEvidence` inside that module and passes only that
+typed value in `FileIndexUpdate` to `index-store`; no IntelliJ or Kotlin PSI
+type crosses that boundary. The index query selects a metadata-row marker,
+required `package_state`, typed `package_unproven_reason`, `package_fq_id`, the
+joined package name, and structured source-set association rows separately.
+`PROVEN_ROOT` requires a
 null id/reason; `PROVEN_NAMED` requires one valid joined canonical name and null
 reason; `UNPROVEN` carries no package id and one typed reason; and any
 constraint violation or dangling id is `INVALID_REFERENCE` plus
@@ -438,9 +449,14 @@ agent workflow.
   compiler/project-model `.kt`/`.kts` enumeration, and typed project-model
   incompleteness. The shared store owns atomic `Complete`/`Reissue` transfer
   and exact-once disposal, including #337 closeable IDEA traversal.
-  `ObservedAnalysisBackend` and the running server lifecycle expose one backend
-  close owner so shutdown cannot leak or double-close those stores. Generated
-  protocol artifacts come from those Kotlin source owners.
+  `ObservedAnalysisBackend` and `RunningAnalysisServer` expose one backend and
+  continuation close owner. The IDEA runtime then closes its separately owned
+  source-index store after that server owner; it does not close the backend a
+  second time. Generated protocol artifacts come from those Kotlin source
+  owners.
+- `backend-shared` owns Kotlin PSI package extraction and converts it to
+  host-neutral `IndexedPackageEvidence` before calling `index-store`. IntelliJ
+  and Kotlin PSI types stay on the `backend-shared` side of that boundary.
 - `cli-rs/src/workspace_inventory.rs` and
   `cli-rs/src/workspace_inventory/` own the reusable uncapped inventory,
   generation/progress-aware exact-root Kotlin source-index reader, deepest-
@@ -453,8 +469,9 @@ agent workflow.
 - `index-store` owns transactional maintenance of the source-index generation,
   module progress, pending-update state, `package_state`, and new
   `file_gradle_projects` and `file_gradle_source_sets` association tables. The
-  IDEA producer supplies host-neutral structured identity values; neither
-  owner widens `SourceIndexFilePolicy` or promotes legacy guesses into proof.
+  IDEA and shared PSI producers supply host-neutral structured identity values;
+  no IntelliJ or Kotlin PSI type enters this module. Neither owner widens
+  `SourceIndexFilePolicy` or promotes legacy guesses into proof.
 - `cli-rs/src/agent/workspace_files.rs` owns public command execution and typed
   filter validation.
 - `cli-rs/src/agent/projection/workspace_files.rs` owns compact, selected,
@@ -475,10 +492,11 @@ agent workflow.
 The new inventory directory receives a scoped `AGENTS.md` when implementation
 begins because it creates a new source-ownership boundary. `backend-idea`
 receives its nearest ownership guide for the project-model inventory and Gradle
-bridge. `analysis-api` and generated-contract ownership guidance is updated
-with the wire change. `analysis-server`, `build-logic`, and `index-store`
-guidance records the single close owner, release-state generation chain, and
-version-8 provenance structures respectively.
+bridge. `backend-shared/AGENTS.md` records PSI ownership and the host-neutral
+`index-store` boundary. `analysis-api` and generated-contract ownership guidance
+is updated with the wire change. `analysis-server`, `build-logic`, and
+`index-store` guidance record the single backend close owner, release-state
+generation chain, and version-8 provenance structures respectively.
 
 ## Validation
 
@@ -495,7 +513,7 @@ cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
 ./gradlew -p build-logic test --tests WriteSourceIndexSchemaVersionTaskTest
-./gradlew :analysis-api:test :analysis-server:test :index-store:test :backend-idea:test --no-daemon
+./gradlew :analysis-api:test :analysis-server:test :backend-shared:test :index-store:test :backend-idea:test --no-daemon
 python3 packaging/homebrew/scripts/test-formulas.py
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test source_index_schema_version_smoke
 ./gradlew test --no-daemon

--- a/.agents/adr/0021-first-class-workspace-file-discovery.md
+++ b/.agents/adr/0021-first-class-workspace-file-discovery.md
@@ -22,11 +22,12 @@ the exact-root SQLite source index, then annotates those candidates with
 targeted filesystem metadata and Git dirty state.
 
 The Kotlin API, server, and backend `WorkspaceFilesQuery` and
-`WorkspaceFilesResult` contract gains a canonical offset page token,
-per-module `nextPageToken`, and explicit module content roots alongside source
-roots. Rust first reads the sorted module inventory, then exhausts every module
-page before classifying backend absence. The backend gathers Kotlin sources and
-scripts from IntelliJ's compiler/project model, including Gradle-linked root
+`WorkspaceFilesResult` contract gains an opaque workspace snapshot token,
+opaque per-module page cursors, and explicit module content roots alongside
+source roots. Rust first reads the sorted module inventory and its snapshot
+token, then exhausts every module page against that exact generation before
+classifying backend absence. The backend gathers Kotlin sources and scripts
+from IntelliJ's compiler/project model, including Gradle-linked root
 `build.gradle.kts` and `settings.gradle.kts`, convention-plugin scripts, and
 ordinary project scripts. It does not recursively scan the filesystem for
 request candidates.
@@ -47,20 +48,35 @@ and the Kotlin source-index snapshot, plus per-module completeness and
 limitation evidence. Issue #340 consumes the `.kts` candidates but writes
 Gradle declarations and relationships to its separate Gradle DSL index. If a
 backend page fails or returns an invalid token, only that module is partial and
-backend absence remains unprovable for paths that may belong to it.
+backend absence remains unprovable for paths that may belong to it. A stale
+workspace generation invalidates the whole backend attempt: Rust discards it,
+restarts once from fresh metadata, and returns typed partial evidence if that
+single retry also becomes stale. The partial result carries
+`BACKEND_WORKSPACE_INVENTORY_STALE`, marks every module from the last metadata
+response incomplete, and retains no backend candidates from either stale
+attempt.
 
 ## Raw paging and project-model authority
 
-An unpaged `raw/workspace-files` request lists sorted module metadata and
-counts. Rust then requests each module by its exact backend name with
-`includeFiles=true`, a positive server-bounded `maxFilesPerModule`, and an
-optional canonical page token. The token encodes a positive next offset and is
-valid only with one exact module. The backend sorts and deduplicates a module's
-complete candidate set before slicing, returns `fileCount`,
-`returnedFileCount`, and `nextPageToken`, and rejects malformed or out-of-range
-tokens. Rust rejects repeated or non-advancing tokens, inconsistent totals,
-changed module identity, and overlapping pages before it marks the module
-complete.
+An unpaged `raw/workspace-files` metadata request lists sorted module metadata
+and counts plus an opaque top-level `snapshotToken`. Rust echoes that token on
+every exact-module request with `includeFiles=true` and a positive
+server-bounded `maxFilesPerModule`. Each opaque `nextPageToken` is server-owned
+and binds the workspace generation, exact module identity, and positive next
+offset. Clients never decode or construct either token.
+
+The backend builds a canonical full-workspace inventory in one read action and
+fingerprints its sorted module identities, source/content roots, dependencies,
+and candidate paths. Before serving any exact-module page it recomputes that
+inventory and compares its generation with the echoed snapshot and decoded
+cursor. Equal-cardinality path replacement, module addition/removal, or any
+other inventory change fails with `STALE_WORKSPACE_INVENTORY`; a malformed,
+out-of-range, or cross-module cursor fails as
+`INVALID_WORKSPACE_FILE_CURSOR`. Only a matching generation may be sliced.
+The backend returns stable `fileCount`, `returnedFileCount`, and
+`nextPageToken` values. Rust additionally rejects repeated or non-advancing
+cursors, inconsistent totals, changed module identity, and overlapping pages
+before it marks the module complete.
 
 The backend candidate provider uses IntelliJ project scope, module content and
 source roots, and linked Gradle project roots. Known Gradle project roots make
@@ -68,9 +84,15 @@ root build and settings scripts project-model candidates without a recursive
 walk. Project-scope Kotlin scripts supply convention-plugin and ordinary
 scripts. Each candidate carries every owning backend module; root-level
 project scripts use every root Gradle module associated with their linked
-project root. A linked root that cannot be associated with a backend module
-fails the request as incomplete project-model evidence. Included builds retain
-their own linked roots and module owners.
+project root. The IDEA 2025.3 adapter reads
+`GradleProjectSettings.getCompositeBuild()`,
+`GradleProjectSettings.CompositeBuild.getCompositeParticipants()`, and
+`BuildParticipant.getRootPath()` for included-build roots, then associates
+modules through `GradleModuleDataIndex.findGradleModuleData(Module)`,
+`GradleModuleData.isIncludedBuild()`, `getGradleProjectDir()`, and
+`ModuleData.getLinkedExternalProjectPath()`. A linked root that cannot be
+associated with a backend module fails the request as incomplete project-model
+evidence. Included builds retain their own linked roots and module owners.
 
 ## Public command contract
 
@@ -179,12 +201,12 @@ overlapping roots preserve every backend owner; duplicate paths are not
 malformed merely because their module names differ. If an indexed row cannot
 be associated with completely paged possible owners, absence remains unknown.
 
-Backend capability absence, page failure, unavailable or incompatible source
-index, unavailable Git status, unavailable or invalid package metadata, and
-excluded out-of-root rows are distinct typed limitations. A usable
-backend-only or index-only snapshot may return partial evidence. Exact-root
-admission failure and malformed backend payloads fail closed. When neither
-backend nor index is usable, the command returns
+Backend capability absence, page failure, repeated snapshot staleness,
+unavailable or incompatible source index, unavailable Git status, unavailable
+or invalid package metadata, and excluded out-of-root rows are distinct typed
+limitations. A usable backend-only or index-only snapshot may return partial
+evidence. Exact-root admission failure and malformed backend payloads fail
+closed. When neither backend nor index is usable, the command returns
 `WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` instead of a false empty success.
 
 ## Capability callability invariant
@@ -258,9 +280,9 @@ schema. The index-store test that rejects `.kts` remains an explicit gate.
 ## Change rule
 
 Future work may add file kinds or Gradle Kotlin DSL subtype evidence
-additively. It must preserve exact-root containment, exhaustive typed backend
-paging, the uncapped internal snapshot, set-valued module ownership,
-deterministic public bounds, `.kt`-only source-index authority, and the rule
-that incomplete backend evidence cannot prove `INDEX_ONLY`. Any change that
-uses filesystem or Git enumeration as candidate authority requires a
-superseding ADR.
+additively. It must preserve exact-root containment, generation-bound
+exhaustive backend paging, the uncapped internal snapshot, set-valued module
+ownership, deterministic public bounds, `.kt`-only source-index authority, and
+the rule that incomplete backend evidence cannot prove `INDEX_ONLY`. Any
+change that uses filesystem or Git enumeration as candidate authority requires
+a superseding ADR.

--- a/.agents/adr/0021-first-class-workspace-file-discovery.md
+++ b/.agents/adr/0021-first-class-workspace-file-discovery.md
@@ -34,16 +34,22 @@ request candidates.
 
 The backend is authoritative for current compiler/project-model ownership and
 may report one physical path as owned by multiple modules. The source index is
-authoritative only for Kotlin-source facts it actually stores: manifest
-membership, a build-qualified Gradle project identity when the producer proved
-one from the linked Gradle model, source set, and package fully qualified name.
+authoritative only for Kotlin-source facts carried by typed producer evidence:
+manifest membership, build-qualified Gradle project and source-set identities
+proved by the linked Gradle model, and package identity proved by Kotlin PSI or
+compiler structure. The existing path-derived `source_set` and text-parser
+package guesses are legacy unproven labels, not workspace discovery facts.
 The legacy `file_metadata.module_path` value is an unqualified module label and
 is never parsed or exposed as a `GradleProjectPath`. The IDEA producer persists
 a set of separate association rows containing `(workspace-relative linked build
 root, absolute Gradle project path)` from `GradleModuleData`; an IDEA
 module-name fallback remains an unproven label and cannot enter those rows.
 Root and included builds may therefore both own `:app` without becoming the
-same indexed owner.
+same indexed owner. A custom `integrationTest` source root is a source-set fact
+only when the Gradle project model associates it; directory names do not prove
+it. Package evidence is a discriminated `PROVEN_ROOT`, `PROVEN_NAMED`,
+`UNPROVEN`, `UNAVAILABLE`, or `INVALID_REFERENCE` state. A nullable parser
+result can only produce `UNPROVEN`, never `PROVEN_ROOT`.
 `SourceIndexFilePolicy` remains `.kt`-only. A `.kts` record is therefore
 `NOT_APPLICABLE` to this Kotlin source index rather than `NOT_INDEXED`; issue
 #340 owns a separate Gradle DSL index. An index row alone does not prove current
@@ -106,15 +112,28 @@ workspace-wide and discards the backend attempt; an invalid page handle is
 local to its module only while the snapshot lease still validates.
 
 The generic store owns every issued state and never returns an owning reference
-to callers. A typed disposer is invoked exactly once when an entry leaves the
-store through expiry, capacity eviction, replacement, query mismatch, explicit
-invalidation or completion, terminal single-use consumption, or server
-shutdown. Consuming and leased APIs run caller work under store-owned lifetime
-control and dispose in `finally` when ownership terminates, including callback
-failure. Shutdown drains every typed store; one disposer failure cannot skip
-the remaining entries. Stateless continuation families use a no-op disposer,
-while ADR 0020 reference/diagnostic state adapts its closeable IDEA traversal
-to this owner instead of keeping a parallel lifecycle.
+to callers. Single-use consumption atomically claims the old handle and asks a
+borrowed-state callback for one typed `Complete(output)` or
+`Reissue(output, nextQuery)` transition. `Complete` ends ownership and disposes
+once. `Reissue` atomically moves the same owned state behind a fresh random
+handle, invalidates the old handle, returns the fresh handle with the output,
+and does not dispose. The callback cannot return `State`, so a #337 lazy IDEA
+traversal has exactly one owner while remaining open across pages.
+
+A typed disposer is invoked exactly once when ownership ends through expiry,
+capacity eviction, replacement, query mismatch, explicit invalidation,
+`Complete`, callback failure, or shutdown. Claimed entries remain store-owned:
+shutdown closes admissions and marks an in-flight claim for disposal after its
+callback, while a racing `Reissue` becomes terminal instead of republishing
+into a closed store. Store close does not return until every in-flight callback
+has exited and its state has reached that terminal disposal path. One disposer
+failure cannot skip remaining entries.
+Stateless continuation families use a no-op disposer. `KastPluginBackend` owns
+the backend stores, `ObservedAnalysisBackend` forwards an explicit closeable
+backend contract, and `RunningAnalysisServer.close()` is the single lifecycle
+owner that drains the dispatcher and backend stores after request admission
+stops. `RunningKastIdeaBackend` closes only that server owner and never closes
+the backend a second time.
 
 The backend builds a canonical requested-kind inventory in one read action and
 fingerprints its sorted module identities, source/content roots, dependencies,
@@ -167,9 +186,10 @@ are typed and conjunctive:
 - `--module` parses a closed selector: `backend:<exact-name>` or
   `gradle:<workspace-relative-build-root>#<absolute-project-path>`, and matches
   the corresponding backend owner or build-qualified indexed Gradle project;
-- `--source-set` matches an exact indexed source set;
+- `--source-set` matches an exact model-proven Gradle source-set name;
 - `--kind source|script` distinguishes `.kt` from `.kts`;
-- `--package` matches an exact indexed package fully qualified name;
+- `--package` matches an exact compiler/PSI-proven canonical Kotlin package
+  fully qualified name;
 - `--dirty clean|dirty|unknown` filters the typed Git state class;
 - `--drift none|filesystem-only|index-only|missing-on-disk|not-applicable|unknown`
   filters cross-source drift;
@@ -232,14 +252,16 @@ version. Each file record includes:
 - absolute `filePath` and workspace-relative `relativePath`;
 - sorted backend-module and build-qualified indexed-Gradle-project ownership
   sets;
-- source set when known;
+- discriminated proven/unproven source-set evidence, with build-qualified
+  Gradle source-set identities only for model-proven owners;
 - `KOTLIN_SOURCE` or `KOTLIN_SCRIPT` kind;
 - `INDEXED`, `NOT_INDEXED`, `NOT_APPLICABLE`, or `UNKNOWN` Kotlin source-index
   state;
 - `NONE`, `FILESYSTEM_ONLY`, `INDEX_ONLY`, `MISSING_ON_DISK`,
   `NOT_APPLICABLE`, or `UNKNOWN` drift;
-- `NAMED`, `ROOT`, `UNAVAILABLE`, or `INVALID_REFERENCE` package evidence,
-  with a package name only for `NAMED`;
+- `PROVEN_NAMED`, `PROVEN_ROOT`, `UNPROVEN`, `UNAVAILABLE`, or
+  `INVALID_REFERENCE` package evidence, with a canonical Kotlin package name
+  only for `PROVEN_NAMED`;
 - detailed dirty state collapsed by the public dirty filter into clean,
   dirty, or unknown; and
 - verbose/explain evidence identifying which sources established the record.
@@ -279,10 +301,20 @@ not invent a second path dialect.
 
 ## Candidate, path, package, and Git evidence
 
+`packaging/homebrew/release-state.json` is the single checked-in source-index
+schema authority. This change advances `source_index_schema_version` from 7 to
+8. The existing build-logic generator emits the Kotlin constant and
+`cli-rs/build.rs` emits the Rust constant from that file; neither language owns
+a second literal. Alignment tests compare both generated values with release
+state. `SqliteSourceIndexStore` rejects or resets a version-7 database before
+workspace reads, so an old database cannot silently lack the new association
+tables or provenance structures.
+
 The collector opens the configured exact-root source-index database read-only
 and reads one SQLite transaction joining `file_manifest`, `path_prefixes`,
-`file_metadata`, the dedicated `file_gradle_projects` association table, and
-`fq_names` together with `schema_version.generation`, all
+`file_metadata`, the dedicated `file_gradle_projects` and
+`file_gradle_source_sets` association tables, and `fq_names` together with
+`schema_version.generation`, all
 `module_index_progress`, and the count of unapplied `pending_updates`. It never
 promotes legacy `file_metadata.module_path` into Gradle identity. It keeps only
 `.kt` candidates because that is the source index's declared policy.
@@ -337,11 +369,19 @@ outside the workspace annotates only its contained endpoint. Failure to prove
 this mapping produces `DIRTY_STATE_UNAVAILABLE`; unmatched nested-workspace
 paths never become false `CLEAN` evidence.
 
-The index query selects a metadata-row marker, `package_fq_id`, and the joined
-package name separately. No metadata row is `UNAVAILABLE`; a present row with
-null `package_fq_id` proves `ROOT`; a non-null id with one joined name is
-`NAMED`; and a non-null id without a joined row is `INVALID_REFERENCE` plus
-`PACKAGE_METADATA_INVALID`. These states are never collapsed into one null.
+The index query selects a metadata-row marker, required `package_state`, typed
+`package_unproven_reason`, `package_fq_id`, the joined package name, and
+structured source-set association rows separately. `PROVEN_ROOT` requires a
+null id/reason; `PROVEN_NAMED` requires one valid joined canonical name and null
+reason; `UNPROVEN` carries no package id and one typed reason; and any
+constraint violation or dangling id is `INVALID_REFERENCE` plus
+`PACKAGE_METADATA_INVALID`. Kotlin PSI/compiler parsing canonicalizes escaped,
+backticked, and general Unicode package names before persistence. A missing or
+failed parser result is `UNPROVEN`, not root. Legacy `file_metadata.source_set`
+may be exposed only as an unproven label; `--source-set` matches only
+model-proven `file_gradle_source_sets` identities. Indexed metadata without a
+structured source-set owner remains `UNPROVEN`; absent metadata/index evidence
+is `UNAVAILABLE`. These states are never collapsed into one null or string.
 
 ## Drift and completeness rules
 
@@ -396,19 +436,25 @@ agent workflow.
   server-held opaque continuation leases, per-module workspace-file paging,
   public continuation state, source/content-root evidence,
   compiler/project-model `.kt`/`.kts` enumeration, and typed project-model
-  incompleteness. The shared store owns exact-once disposal, including #337
-  closeable IDEA traversal and server shutdown. Generated protocol artifacts
-  come from those Kotlin source owners.
+  incompleteness. The shared store owns atomic `Complete`/`Reissue` transfer
+  and exact-once disposal, including #337 closeable IDEA traversal.
+  `ObservedAnalysisBackend` and the running server lifecycle expose one backend
+  close owner so shutdown cannot leak or double-close those stores. Generated
+  protocol artifacts come from those Kotlin source owners.
 - `cli-rs/src/workspace_inventory.rs` and
   `cli-rs/src/workspace_inventory/` own the reusable uncapped inventory,
   generation/progress-aware exact-root Kotlin source-index reader, deepest-
   existing-ancestor containment, targeted filesystem evidence, dirty-state
   annotation, kind-relevant discriminated cross-source composition barrier, and
   internal types.
+- `packaging/homebrew/release-state.json` owns source-index schema version 8.
+  `build-logic` and `cli-rs/build.rs` generate aligned Kotlin and Rust constants
+  from it and test that alignment.
 - `index-store` owns transactional maintenance of the source-index generation,
-  module progress, pending-update state, and new `file_gradle_projects`
-  build-qualified ownership table. The IDEA producer supplies host-neutral
-  identity values; neither owner widens `SourceIndexFilePolicy`.
+  module progress, pending-update state, `package_state`, and new
+  `file_gradle_projects` and `file_gradle_source_sets` association tables. The
+  IDEA producer supplies host-neutral structured identity values; neither
+  owner widens `SourceIndexFilePolicy` or promotes legacy guesses into proof.
 - `cli-rs/src/agent/workspace_files.rs` owns public command execution and typed
   filter validation.
 - `cli-rs/src/agent/projection/workspace_files.rs` owns compact, selected,
@@ -430,7 +476,9 @@ The new inventory directory receives a scoped `AGENTS.md` when implementation
 begins because it creates a new source-ownership boundary. `backend-idea`
 receives its nearest ownership guide for the project-model inventory and Gradle
 bridge. `analysis-api` and generated-contract ownership guidance is updated
-with the wire change.
+with the wire change. `analysis-server`, `build-logic`, and `index-store`
+guidance records the single close owner, release-state generation chain, and
+version-8 provenance structures respectively.
 
 ## Validation
 
@@ -446,7 +494,10 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked
 cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+./gradlew -p build-logic test --tests WriteSourceIndexSchemaVersionTaskTest
 ./gradlew :analysis-api:test :analysis-server:test :index-store:test :backend-idea:test --no-daemon
+python3 packaging/homebrew/scripts/test-formulas.py
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test source_index_schema_version_smoke
 ./gradlew test --no-daemon
 ./gradlew buildIdeaPlugin --no-daemon
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
@@ -462,9 +513,10 @@ git diff --check
 The implementation changes the Kotlin workspace-files query/result and shared
 continuation contracts, server validation, IDEA backend enumeration, source-
 index generation maintenance, fake backend, generated protocol, and raw
-catalogs. It adds and versions the `file_gradle_projects` source-index
-association table but does not change `SourceIndexFilePolicy`. The index-store
-test that rejects `.kts` remains an explicit gate.
+catalogs. It advances the release-state-owned source-index schema from 7 to 8,
+adds build-qualified project/source-set association tables and explicit package
+provenance, but does not change `SourceIndexFilePolicy`. The index-store test
+that rejects `.kts` remains an explicit gate.
 
 ## Change rule
 

--- a/.agents/adr/0021-first-class-workspace-file-discovery.md
+++ b/.agents/adr/0021-first-class-workspace-file-discovery.md
@@ -44,8 +44,15 @@ semantic ownership.
 The Rust CLI owns evidence composition. Its internal
 `WorkspaceInventorySnapshot` is not subject to public filters or limits. It
 retains every candidate returned by all successfully exhausted backend pages
-and the Kotlin source-index snapshot, plus per-module completeness and
-limitation evidence. Issue #340 consumes the `.kts` candidates but writes
+and one generation-stamped Kotlin source-index snapshot, plus per-module and
+per-source completeness and limitation evidence. It publishes an exact
+composition only after a barrier proves the backend generation, source-index
+generation/progress/pending state, targeted filesystem evidence, and Git
+snapshot did not move during collection. The whole composition retries once
+when a lane moves; a second movement is typed partial evidence and can never
+produce `EXACT`. The independent bounds allow at most two composition attempts
+with at most two backend-generation attempts each. Issue #340 consumes the
+`.kts` candidates but writes
 Gradle declarations and relationships to its separate Gradle DSL index. If a
 generic backend page transport fails or returns an invalid token, only that
 module is partial and backend absence remains unprovable for paths that may
@@ -64,22 +71,37 @@ stale retry and preserves the server's typed reason as a public limitation.
 An unpaged `raw/workspace-files` metadata request lists sorted module metadata
 and counts plus an opaque top-level `snapshotToken`. Rust echoes that token on
 every exact-module request with `includeFiles=true` and a positive
-server-bounded `maxFilesPerModule`. Each opaque `nextPageToken` is server-owned
-and binds the workspace generation, exact module identity, and positive next
-offset. Clients never decode or construct either token.
+server-bounded `maxFilesPerModule`. Snapshot and page handles use the shared
+server-held opaque continuation mechanism established for ADR 0020 paging.
+Random canonical handles address typed state containing the generation, exact
+module, query identity, and next offset; neither clients nor Rust decode or
+construct that state.
+
+Each typed store instance uses the same generic mechanism but a distinct token
+and state namespace. It has positive typed TTL and capacity limits supplied by
+`ServerLimits`, removes expired entries before issue or lookup, and evicts the
+oldest expiring entry when capacity is reached. Page handles are single-use;
+snapshot leases remain reusable until completion, invalidation, eviction, or
+expiry. Canonical-token parsing, unguessable handle lookup, and exact query
+identity provide integrity. A malformed, forged, unknown, expired, evicted,
+already-consumed, or query-mismatched handle fails as
+`INVALID_WORKSPACE_FILE_CURSOR` with only typed `SNAPSHOT_HANDLE` or
+`PAGE_HANDLE` failure scope, never stored state. An invalid snapshot lease is
+workspace-wide and discards the backend attempt; an invalid page handle is
+local to its module only while the snapshot lease still validates.
 
 The backend builds a canonical full-workspace inventory in one read action and
 fingerprints its sorted module identities, source/content roots, dependencies,
-and candidate paths. Before serving any exact-module page it recomputes that
-inventory and compares its generation with the echoed snapshot and decoded
-cursor. Equal-cardinality path replacement, module addition/removal, or any
-other inventory change fails with `STALE_WORKSPACE_INVENTORY`; a malformed,
-out-of-range, or cross-module cursor fails as
-`INVALID_WORKSPACE_FILE_CURSOR`. Only a matching generation may be sliced.
-The backend returns stable `fileCount`, `returnedFileCount`, and
-`nextPageToken` values. Rust additionally rejects repeated or non-advancing
-cursors, inconsistent totals, changed module identity, and overlapping pages
-before it marks the module complete.
+and candidate paths. Before serving any exact-module page or final barrier
+validation it recomputes the inventory and compares its generation with the
+leased snapshot state. Equal-cardinality path replacement, module
+addition/removal, or any other inventory change invalidates the lease and fails
+with `STALE_WORKSPACE_INVENTORY`. Only server-held state for a matching
+generation may be sliced. The backend returns stable `fileCount`,
+`returnedFileCount`, and `nextPageToken` values. Rust treats handles as opaque
+and validates only that handles do not repeat, physical paths do not overlap,
+and cumulative returned evidence never exceeds and finally equals the declared
+module count before it marks the module complete.
 
 The backend candidate provider uses IntelliJ project scope, module content and
 source roots, and linked Gradle project roots. Known Gradle project roots make
@@ -106,8 +128,9 @@ Rust maps those reasons to distinct `BACKEND_RUNTIME_INDEXING`,
 `BACKEND_PROJECT_MODEL_UNAVAILABLE`, and
 `BACKEND_LINKED_ROOT_UNASSOCIATED` limitations. Failure of the metadata request
 makes backend coverage unavailable. The same typed failure while paging makes
-the backend attempt workspace-wide partial and discards its earlier pages;
-generic transport or cursor failure remains local to the requested module.
+the backend attempt workspace-wide partial and discards its earlier pages.
+Generic transport or invalid page-handle failure remains local to the requested
+module; invalid snapshot-lease or final-validation failure is workspace-wide.
 
 ## Public command contract
 
@@ -125,21 +148,48 @@ are typed and conjunctive:
   filters cross-source drift;
 - `--path-prefix` accepts one normalized workspace-relative path prefix;
 - `--glob` accepts one bounded glob over normalized workspace-relative paths;
-  and
-- `--limit` defaults to 20 and accepts 1 through 200.
+- `--limit` defaults to 20 and accepts 1 through 200; and
+- `--page-token` consumes one opaque continuation returned by the preceding
+  invocation of the identical normalized query.
 
 Absolute path prefixes, parent traversal, empty semantic selectors, invalid
 package names, regex-prefixed globs, and out-of-range limits fail at the typed
-CLI boundary. Filters never widen the inventory and are applied before the
+CLI boundary. `--page-token` conflicts with `--count` and requires every other
+result-affecting argument to reproduce the original normalized query. Filters
+never widen the inventory and are applied before the
 public limit. Results sort by normalized workspace-relative path; every
 ownership set sorts by its typed module identity. The same evidence snapshot
 therefore produces deterministic JSON and TOON.
 
+Public paging is distinct from raw per-module paging. When more known matches
+remain after the public limit, Rust registers a
+`WorkspaceFilesPublicContinuationState` through the mechanism's dedicated
+public workspace-file store and
+returns its opaque handle as `nextPageToken`. The state binds the exact root,
+backend, normalized filters, selected view/fields, limit, composition-stamp
+digest, last emitted relative path, and cumulative returned evidence. A later
+invocation consumes that single-use handle, must present the same normalized
+query, recollects a coherent snapshot, and must reproduce the bound composition
+stamp before seeking strictly after the last path. Filter/view/limit mismatch,
+malformed, forged, or unknown handles return
+`INVALID_WORKSPACE_FILES_PAGE_TOKEN`; movement in any bound source returns
+`STALE_WORKSPACE_FILES_PAGE`. Neither failure silently restarts at page one.
+The invalid-token failure is non-retryable status 400 and exposes no stored
+state. The stale-token failure is retryable conflict status 409 and requires an
+explicit new unpaged query.
+Five-hundred-record tests prove 200/200/100 continuation with no gaps or
+overlap.
+
+Registration and consumption travel through the internal typed
+`raw/workspace-files-continuation` method on the already admitted RPC session.
+That method stores or returns typed state but is not a public agent command or
+capability. It does not accept candidate enumeration authority.
+
 The compact default emits a typed result with the exact workspace root,
 bounded file records, ADR 0020's discriminated `EXACT` or `KNOWN_MINIMUM`
-cardinality, returned count, truncation, separate candidate-inventory and
-filter-evidence coverage, typed limitations, and schema version. Each file
-record includes:
+cardinality, returned count, truncation, optional next-page token, separate
+candidate-inventory and filter-evidence coverage, typed limitations, and schema
+version. Each file record includes:
 
 - absolute `filePath` and workspace-relative `relativePath`;
 - sorted backend-module and indexed-Gradle-module ownership sets;
@@ -165,6 +215,8 @@ only when both relevant coverage dimensions are complete; otherwise it is
 `KNOWN_MINIMUM` and counts only matches actually proved. `returnedCount` equals
 the emitted file count. `truncated` is true when an exact total exceeds that
 count or cardinality is `KNOWN_MINIMUM`, because unseen matches remain possible.
+`nextPageToken` is non-null only when another currently known matching record
+exists; partial evidence may therefore be truncated without offering a token.
 
 The default compact representation must remain within 120 lines and 1,500
 estimated tokens for a high-cardinality fixture. `--fields` selects typed file
@@ -181,18 +233,41 @@ not invent a second path dialect.
 ## Candidate, path, package, and Git evidence
 
 The collector opens the configured exact-root source-index database read-only
-and reads one SQLite snapshot joining `file_manifest`, `path_prefixes`,
-`file_metadata`, and `fq_names`. It keeps only `.kt` candidates because that is
-the source index's declared policy. Existing candidates are checked
-individually; the implementation does not recurse from the workspace root.
-Git porcelain may annotate a candidate but never adds one absent from backend
-and index evidence.
+and reads one SQLite transaction joining `file_manifest`, `path_prefixes`,
+`file_metadata`, and `fq_names` together with `schema_version.generation`, all
+`module_index_progress`, and the count of unapplied `pending_updates`. It keeps
+only `.kt` candidates because that is the source index's declared policy.
+Generation increments in the same write transaction as candidate, progress, or
+pending-state changes. Source-index coverage is complete only when the
+initialized progress set is nonempty, every row is `COMPLETE`, indexed counts
+equal totals, and no unapplied update remains. Existing candidates are checked
+individually; the
+implementation does not recurse from the workspace root. Git porcelain may
+annotate a candidate but never adds one absent from backend and index evidence.
 
 Every candidate is normalized against the admitted workspace root. Existing
 paths whose canonical target leaves that root and index paths that are
-lexically outside it are omitted with a typed limitation. Backend module
-source/content roots receive the same canonical containment proof before they
+lexically outside it are omitted with a typed limitation. For a missing leaf,
+the collector walks upward to the deepest existing ancestor, canonicalizes that
+ancestor against the canonical admitted root, and appends only normalized
+nonexistent components after containment succeeds. A missing path beneath an
+escaping symlink is therefore rejected. A permission error, dangling symlink,
+race, or absence of any canonicalizable ancestor yields
+`PATH_CONTAINMENT_UNPROVABLE`, excludes the path, and makes candidate coverage
+partial. Backend module source/content roots receive the same proof before they
 can establish ownership or completeness.
+
+After collecting backend, index, targeted filesystem, and Git evidence, the
+composition barrier validates the backend snapshot lease, re-reads the
+source-index generation/progress/pending stamp in a fresh transaction, repeats
+targeted filesystem facts, and repeats the normalized Git status fingerprint.
+Only identical before/after stamps form a coherent snapshot. One changed lane
+discards the whole attempt and retries once. A second change emits
+`CROSS_SOURCE_COMPOSITION_UNSTABLE`, marks candidate and affected filter
+coverage partial, suppresses public continuation, and forbids `EXACT`. Stable
+but incomplete index progress or pending updates emits distinct
+`SOURCE_INDEX_PROGRESS_INCOMPLETE` or `SOURCE_INDEX_UPDATES_PENDING`
+limitations and likewise forbids exact candidate coverage.
 
 The dirty-state adapter forces `status.relativePaths=false` so Git porcelain v2
 paths are repository-root-relative even when Git runs with
@@ -232,8 +307,10 @@ be associated with completely paged possible owners, absence remains unknown.
 Backend capability absence, metadata or page failure, runtime indexing,
 unavailable Gradle project-model data, unassociated linked roots, repeated
 snapshot staleness, unavailable or incompatible source index, unavailable Git
-status, unavailable or invalid package metadata, and excluded out-of-root rows
-are distinct typed limitations. A usable backend-only or index-only snapshot
+status, incomplete index progress, pending index updates, unstable cross-source
+composition, unprovable containment, unavailable or invalid package metadata,
+and excluded out-of-root rows are distinct typed limitations. A usable
+backend-only or index-only snapshot
 may return partial evidence. Exact-root admission failure and malformed backend
 payloads fail closed. When neither backend nor index is usable, the command
 returns `WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` instead of a false empty success.
@@ -257,14 +334,19 @@ agent workflow.
 ## Ownership
 
 - `analysis-api`, `analysis-server`, and `backend-idea` own typed deterministic
-  per-module workspace-file paging, source/content-root evidence,
+  server-held opaque continuation leases, per-module workspace-file paging,
+  public continuation state, source/content-root evidence,
   compiler/project-model `.kt`/`.kts` enumeration, and typed project-model
   incompleteness. Generated protocol artifacts come from those Kotlin source
   owners.
 - `cli-rs/src/workspace_inventory.rs` and
   `cli-rs/src/workspace_inventory/` own the reusable uncapped inventory,
-  exact-root Kotlin source-index reader, targeted filesystem evidence,
-  dirty-state annotation, composition, and internal types.
+  generation/progress-aware exact-root Kotlin source-index reader, deepest-
+  existing-ancestor containment, targeted filesystem evidence, dirty-state
+  annotation, cross-source composition barrier, and internal types.
+- `index-store` owns transactional maintenance of the existing source-index
+  generation, module progress, and pending-update state; this ADR adds no schema
+  column and does not widen `SourceIndexFilePolicy`.
 - `cli-rs/src/agent/workspace_files.rs` owns public command execution and typed
   filter validation.
 - `cli-rs/src/agent/projection/workspace_files.rs` owns compact, selected,
@@ -276,6 +358,8 @@ agent workflow.
   limitation, budget, exact-root, and composition regressions.
 - `docs/reference/agent-commands.md` and the packaged Kast skill teach the
   typed public command.
+- `cli-rs/AGENTS.md` and `cli-rs/resources/kast-skill/AGENTS.md` own the nearest
+  Rust/public-resource boundaries and mandatory package, LSP, and routing gates.
 - `cli-rs/resources/kast-skill/references/commands.json` is the hand-authored
   internal raw-command catalog. Generated YAML, request schemas, and request
   samples derive from it.
@@ -301,23 +385,30 @@ cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
 ./gradlew :analysis-api:test :analysis-server:test :index-store:test :backend-idea:test --no-daemon
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
+.github/scripts/test-kast-copilot-plugin.sh
+.github/scripts/test-lsp-pivot-gates.sh
+.github/scripts/test-kast-routing-evals.sh
 .github/scripts/test-docs-content-contract.sh
 .github/scripts/test-docs-navigation-contract.sh
 zensical build --clean
 git diff --check
 ```
 
-The implementation changes the Kotlin workspace-files query/result contract,
-server validation, IDEA backend enumeration, fake backend, generated protocol,
-and raw catalogs. It does not change `SourceIndexFilePolicy` or the source-index
-schema. The index-store test that rejects `.kts` remains an explicit gate.
+The implementation changes the Kotlin workspace-files query/result and shared
+continuation contracts, server validation, IDEA backend enumeration, source-
+index generation maintenance, fake backend, generated protocol, and raw
+catalogs. It does not change `SourceIndexFilePolicy` or the source-index schema.
+The index-store test that rejects `.kts` remains an explicit gate.
 
 ## Change rule
 
 Future work may add file kinds or Gradle Kotlin DSL subtype evidence
 additively. It must preserve exact-root containment, generation-bound
 exhaustive backend paging, the uncapped internal snapshot, set-valued module
-ownership, deterministic public bounds, `.kt`-only source-index authority, and
-the rule that incomplete backend evidence cannot prove `INDEX_ONLY`. Any
+ownership, deterministic consumable public bounds, `.kt`-only source-index
+authority, deepest-existing-ancestor containment, coherent cross-source stamps,
+and the rule that incomplete backend or index evidence cannot prove
+`INDEX_ONLY` or `EXACT`. Any
 change that uses filesystem or Git enumeration as candidate authority requires
 a superseding ADR.

--- a/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
+++ b/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
@@ -43,6 +43,10 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
   malformed/forged/unknown/expired failures. Rust never decodes handle state.
   Use distinct token/state namespaces and typed instances of the same generic
   mechanism; never mix continuation families in one untyped map.
+- Give the generic store exact-once disposal ownership. Expiry, eviction,
+  replacement, query mismatch, explicit completion/invalidation, terminal
+  consume, and server shutdown must all remove through the same disposer path;
+  #337 closeable IDEA traversal state is adapted to that owner.
 - Rust page validation is limited to non-repeated handles, non-overlapping
   physical paths, and cumulative returned evidence; generation/module/offset
   integrity belongs to the server-held state.
@@ -53,6 +57,9 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
   once. A second stale response is typed partial evidence with no backend
   candidates from either stale attempt.
 - Model physical-file backend and indexed module ownership as sorted sets.
+- Never parse `file_metadata.module_path` as `GradleProjectPath`. Persist and
+  read a separate build-qualified project-model tuple from the IDEA producer;
+  keep an IDEA module-name fallback only as a legacy unproven label.
 - Keep the internal inventory uncapped by public filters and `--limit`.
 - Default `--limit` to 20, reject values outside 1 through 200, and keep compact
   output below 120 lines and 1,500 estimated tokens.
@@ -62,11 +69,17 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Read source-index generation, module progress, and pending updates with the
   candidate rows. Increment generation transactionally on relevant writes and
   require complete progress plus zero pending updates before exact coverage.
+- Derive source-only, script-only, or mixed relevance before collection. The
+  raw backend generation and composition barrier cover only the selected kind
+  domain; `.kt` index state is irrelevant to script-only discovery and #340.
+  Keep per-kind candidate/filter coverage so mixed grouped counts remain honest.
 - Prove missing paths by canonicalizing their deepest existing ancestor.
   Exclude and type any containment that cannot be proved.
-- Revalidate backend, source-index, targeted filesystem, and Git stamps after
-  composition. Retry the entire attempt once when a lane moves; a second change
-  or stable incomplete lane forbids `EXACT`. Enforce a ceiling of two
+- Revalidate only kind/query-relevant backend, source-index, targeted
+  filesystem, and Git lane states after composition. Retry the entire attempt
+  once when a relevant lane moves; a second change
+  or stable incomplete relevant lane forbids `EXACT` for its kind partition.
+  Enforce a ceiling of two
   composition attempts with at most two backend-generation attempts each.
 - Change Kotlin wire/backend/generated contracts when required by paging;
   regenerate them from their source owners.
@@ -81,6 +94,8 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
   primary agent reviews every delegated result and runs final verification.
 - Preserve unrelated worktree changes and commit each red-green slice
   independently with a conventional commit.
+- Final acceptance must run both `./gradlew test` and
+  `./gradlew buildIdeaPlugin` after focused module gates.
 
 ---
 
@@ -91,6 +106,7 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Modify: `analysis-api/AGENTS.md`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/query/WorkspaceFilesQuery.kt`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceFilesResult.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/query/WorkspaceFileKindDomain.kt`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/ServerLimits.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceModule.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/WorkspaceFileSnapshotToken.kt`
@@ -99,6 +115,7 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationTtl.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationCapacity.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationClock.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationStateDisposer.kt`
 - Create: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/continuation/ServerHeldContinuationStoreTest.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedWorkspaceFilesQuery.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/WorkspaceInventoryStaleException.kt`
@@ -120,6 +137,7 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 **Interfaces:**
 
 - Produces: `WorkspaceFileSnapshotToken`, `WorkspaceFilePageToken`,
+  `WorkspaceFileKindDomain`,
   `ParsedWorkspaceFilesQuery.snapshotToken`,
   `ParsedWorkspaceFilesQuery.pageToken`, `WorkspaceFilesResult.snapshotToken`,
   `WorkspaceModule.returnedFileCount`, `WorkspaceModule.nextPageToken`, and
@@ -129,18 +147,20 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
   `WorkspaceProjectModelIncompleteReason` details.
 - Produces: reusable `ServerHeldContinuationStore<Token, Query, State>` with
   typed positive TTL/capacity, injected clock, deterministic eviction,
-  reusable leases, and single-use consumption.
+  reusable leases, single-use consumption, and exact-once state disposal.
 - Invariant: snapshot and page tokens are canonical random UUID handles, not
   encoded state. An input snapshot token is legal with `includeFiles=true` and
   one exact module, or with `includeFiles=false` and no module for final barrier
-  validation. A page token additionally requires the paging form.
+  validation. A page token additionally requires the paging form. Every page
+  and validation request reproduces the metadata request's exact kind domain.
 
 - [ ] **Step 1: Write failing query and server tests**
 
 Add parsing cases for canonical opaque snapshot/page handles and rejection of
 blank/noncanonical UUIDs, page token without snapshot token, either token with
 an illegal module/include-files combination, and a page size above server
-`maxResults`. Accept only the explicit snapshot-validation form with
+`maxResults`. Cover source-only, script-only, and mixed parsing plus kind-domain
+mismatch on a snapshot or page handle. Accept only the explicit snapshot-validation form with
 `includeFiles=false`, no module, and a snapshot token. Add fake-backend tests
 for two pages over five sorted files:
 
@@ -183,6 +203,16 @@ and migrate `FakeAnalysisBackend` reference/diagnostic continuation maps to this
 store before adding fake workspace-file state; do not maintain three ad hoc map
 policies.
 
+Use a close-counting fake state and prove exactly one disposal for expiry,
+eviction, same-handle replacement, query mismatch, explicit invalidation or
+successful completion, terminal consume, callback failure, and server
+shutdown. Trigger a second removal path after each case and assert the count
+stays one. A throwing disposer must not prevent shutdown from draining and
+disposing later entries. Adapt #337's closeable IDEA traversal to the same
+test surface so its resource lifetime is not merely theoretical. Race terminal
+consume against shutdown and expiry cleanup against replacement; atomic
+ownership transfer/removal must still close each fake state once.
+
 Assert invalid raw errors expose only typed `details.scope` of
 `SNAPSHOT_HANDLE` or `PAGE_HANDLE`. Snapshot failure discards the workspace-wide
 backend attempt; page failure remains module-local only if the snapshot lease
@@ -219,10 +249,16 @@ value class WorkspaceFileSnapshotToken private constructor(val value: String) {
 
 `WorkspaceFilePageToken` has the same canonical wire boundary but remains a
 distinct type. Add `snapshotToken: String?` and `pageToken: String?` to
-`WorkspaceFilesQuery`, parse each once, and reject illegal field combinations.
+`WorkspaceFilesQuery`, add the closed kind domain, parse each once, and reject
+illegal field combinations.
 The shared continuation store owns random issue, TTL cleanup, capacity
-eviction, query comparison, reusable lookup, and single-use consumption. Do
-not encode or decode offsets, generations, modules, or queries in a token. Keep
+eviction, query comparison, reusable lookup, single-use consumption, and
+exact-once disposal. Its lease/consume APIs accept callbacks rather than
+returning owning state; every terminating path removes through one
+idempotence-guarded disposer and `close()` drains the store at server shutdown.
+Make the dispatcher/server lifecycle the single owner that closes every typed
+store instance exactly once.
+Do not encode or decode offsets, generations, modules, or queries in a token. Keep
 the server's positive page-size and
 maximum checks. Add matching `AnalysisException` subtypes: stale inventory is
 HTTP/JSON-RPC status 409, code `STALE_WORKSPACE_INVENTORY`, and retryable;
@@ -267,8 +303,8 @@ cross-module, and non-overlap tests pass.
 
 - [ ] **Step 6: Update source ownership and commit**
 
-Record query/result/generated ownership and paging gates in
-`analysis-api/AGENTS.md`.
+Record query/result/generated ownership, exact-once continuation disposal, and
+paging/shutdown gates in `analysis-api/AGENTS.md`.
 
 ```console
 git add analysis-api analysis-server
@@ -289,22 +325,38 @@ git commit -m "feat: page raw workspace file results"
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceInventoryGeneration.kt`
 - Create: `backend-idea/src/main/java/io/github/amichne/kast/idea/IdeaGradleWorkspaceFileBridge.java`
 - Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt`
+- Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaProjectIndexer.kt`
 - Create: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventoryTest.kt`
 - Modify: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt`
+- Modify: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaProjectIndexerModuleNameTest.kt`
+- Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/BuildQualifiedGradleProjectIdentity.kt`
+- Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/GradleProjectPath.kt`
+- Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/WorkspaceRelativeGradleBuildRoot.kt`
+- Modify: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/FileIndexUpdate.kt`
+- Modify: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/SourceFileIndexParser.kt`
+- Modify: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.kt`
+- Modify: `index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SqliteSourceIndexStoreTest.kt`
+- Modify: `index-store/AGENTS.md`
+- Modify: `backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiSourceIndexScanner.kt`
 - Verify unchanged: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/SourceIndexFilePolicy.kt`
 - Verify unchanged: `index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SourceIndexFilePolicyTest.kt`
 
 **Interfaces:**
 
 - Produces:
-  `IdeaWorkspaceFileInventory.snapshot(): IdeaWorkspaceFileInventorySnapshot`.
+  `IdeaWorkspaceFileInventory.snapshot(WorkspaceFileKindDomain): IdeaWorkspaceFileInventorySnapshot`.
 - The inventory snapshot has one `IdeaWorkspaceInventoryGeneration` over every
-  module. Each module snapshot has sorted contained source/content roots,
-  sorted dependency names, and a complete sorted set of project-model `.kt`
-  and `.kts` paths.
+  module and the requested kind domain. Each module snapshot has sorted
+  contained source/content roots, sorted dependency names, and a complete
+  sorted set of project-model paths for that domain.
 - `IdeaWorkspaceFileSnapshotLease` and `IdeaWorkspaceFileContinuation` are
   typed server-held states addressed only by opaque UUID handles. They contain
   generation, exact module/query identity, next offset, and cumulative evidence.
+- Produces: host-neutral `BuildQualifiedGradleProjectIdentity` containing a
+  workspace-relative linked build root and absolute Gradle project path. The
+  source index persists a set of those owners in the dedicated
+  `file_gradle_projects` association table, distinct from legacy
+  `file_metadata.module_path`.
 
 - [ ] **Step 1: Write failing project-model inventory tests**
 
@@ -328,6 +380,11 @@ the last page, and a handle issued for one module returns
 capacity eviction, single-use, forged/unknown, and query mismatch through the
 real backend adapter.
 
+Exercise source-only, script-only, and mixed raw snapshots. Mutating only a
+`.kt` path must not stale a script-only lease, while mutating `.kts` must;
+source-only has the inverse rule and mixed reacts to either kind. Passing a
+lease or page handle with a different kind domain is an invalid cursor.
+
 Add three failure fixtures: IDEA dumb/index-not-ready state, unavailable linked
 Gradle project-model data, and a linked root with no root-module association.
 Assert the backend returns `WORKSPACE_PROJECT_MODEL_INCOMPLETE` with respective
@@ -336,15 +393,28 @@ typed reasons `RUNTIME_INDEXING`, `PROJECT_MODEL_UNAVAILABLE`, and
 Rust can distinguish whole-inventory failure from a generic page transport
 failure.
 
+Add a composite-build producer fixture in which both the admitted root build
+and an included build contain `:app`. Assert the IDEA adapter emits two
+different `BuildQualifiedGradleProjectIdentity` values, the source-index round
+trip preserves both build roots/project paths, and workspace identity never
+comes from `indexedModuleNameForFilePath` or an IDEA module-name fallback. Add
+missing/ambiguous Gradle-data cases that preserve only the legacy unproven label
+and leave the build-qualified owner set empty. Add malformed association rows
+whose build root or project path fails typed parsing. Prove multiple owners per
+file, schema migration/reset, and generation change when an association is
+added, replaced, or removed.
+
 After rebasing onto #337, migrate `KastPluginBackend` reference and diagnostic
 continuations to the shared store before adding workspace-file leases. Preserve
 their query/source/generation behavior and add TTL/capacity/single-use
-regressions; one mechanism owns all three continuation families.
+regressions. Adapt the closeable IDEA traversal to the store's typed disposer
+and assert exact-once close on mismatch, terminal consume, expiry/eviction, and
+plugin/server shutdown; one mechanism owns all three continuation families.
 
 - [ ] **Step 2: Run the focused red backend test**
 
 ```console
-./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --no-daemon
+./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --tests '*IdeaProjectIndexerModuleNameTest*' :index-store:test --tests '*SqliteSourceIndexStoreTest*' --no-daemon
 ```
 
 Expected: compilation fails because the inventory does not exist.
@@ -375,6 +445,22 @@ module data to `PROJECT_MODEL_UNAVAILABLE`; do not allow either to become an
 empty complete inventory. Canonical containment is mandatory before ownership
 is recorded.
 
+Reuse that bridge in `IdeaProjectIndexer`: resolve each `.kt` file's IDEA module
+through `GradleModuleDataIndex`, associate it with one direct/composite linked
+build root, and take `GradleModuleData.getGradlePathOrNull()` as the project
+path. Construct the host-neutral identity only after both typed components are
+proved. Collect every containing module's distinct model-proven identity. Add
+the dedicated non-null `file_gradle_projects(prefix_id, filename, build_root,
+project_path)` association table, advance the checked-in source-index schema
+version, add `FileIndexUpdate.gradleProjects` as a
+`Set<BuildQualifiedGradleProjectIdentity>`, and persist the owner set
+transactionally. Adding, replacing, or removing an association increments
+`schema_version.generation` in that same write transaction.
+`PsiSourceIndexScanner` accepts host-neutral module evidence;
+no IntelliJ type crosses into `backend-shared` or `index-store`. Keep
+`module_path` for existing symbol/metrics behavior,
+but workspace discovery must never select or parse it as Gradle identity.
+
 - [ ] **Step 4: Page sorted inventory with server-held state**
 
 Replace cap-before-sort logic with generation validation followed by slicing:
@@ -396,10 +482,11 @@ val nextToken = nextOffset
     ?.let { pageStore.issue(state.advanceTo(it)) }
 ```
 
-Build and fingerprint the canonical full inventory in one IDEA read action.
-The fingerprint includes sorted module identities, source/content roots,
-dependency names, and file paths, so equal-cardinality replacement and module
-add/remove cannot reuse a generation. Metadata requests store the typed snapshot
+Build and fingerprint the canonical requested-kind inventory in one IDEA read
+action. The fingerprint includes the kind domain, sorted module identities,
+source/content roots, dependency names, and relevant file paths, so
+equal-cardinality replacement and module add/remove cannot reuse a generation,
+while excluded-kind movement is irrelevant. Metadata requests store the typed snapshot
 lease and return only its opaque handle. Exact-module and final validation
 requests recompute and match the leased generation before slicing or success;
 unknown state, out-of-range stored offsets, or query/cross-module mismatch
@@ -412,10 +499,11 @@ Run:
 
 ```console
 ./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --tests '*KastPluginBackendContractTest*workspace files*' --no-daemon
-./gradlew :index-store:test --tests '*SourceIndexFilePolicyTest*' --no-daemon
+./gradlew :index-store:test --tests '*SourceIndexFilePolicyTest*' --tests '*SqliteSourceIndexStoreTest*' --no-daemon
 ```
 
 Expected: project scripts, shared ownership, included-build associations,
+build-qualified root/included project identities, legacy fallback isolation,
 generation changes, stale responses, and cross-module rejection pass; the
 typed indexing/project-model failures retain their reason; the index-store test
 still proves `.kts` rejection.
@@ -423,7 +511,7 @@ still proves `.kts` rejection.
 - [ ] **Step 6: Commit backend authority**
 
 ```console
-git add backend-idea
+git add backend-idea backend-shared index-store
 git diff --cached --check
 git commit -m "feat: enumerate project model Kotlin scripts"
 ```
@@ -431,8 +519,10 @@ git commit -m "feat: enumerate project model Kotlin scripts"
 `backend-idea/AGENTS.md` records that the inventory and Java Gradle bridge own
 model-proven `.kt`/`.kts` candidates, server-held generation-bound paging,
 TTL/capacity/integrity behavior, typed
-project-model incompleteness, and the focused backend tests above. This is the
-nearest guide for the new source boundary.
+project-model incompleteness, build-qualified index-producer identity, and the
+focused backend tests above. `index-store/AGENTS.md` records the dedicated
+identity association table and prohibits promoting the legacy module label. These are
+the nearest guides for the new source boundaries.
 
 Do not stage either source-index policy file; both are verification-only.
 
@@ -451,8 +541,8 @@ Do not stage either source-index policy file; both are verification-only.
 **Interfaces:**
 
 - Produces: `AgentCommand::WorkspaceFiles`, typed filters,
-  `AgentWorkspaceFilesField`, distinct `WorkspaceFilesPublicPageToken`, and a
-  temporary typed unavailable result.
+  `AgentWorkspaceFilesField`, closed `WorkspaceModuleSelector`, distinct
+  `WorkspaceFilesPublicPageToken`, and a temporary typed unavailable result.
 - Consumes: ADR 0020 `AgentResultView` and existing `AgentRuntimeArgs`.
 
 - [ ] **Step 1: Write failing command/help/argument tests**
@@ -462,6 +552,9 @@ all documented flags parse and reject limit `0`/`201`, absolute or parent path
 prefixes, `regex:` globs, blank selectors, and incompatible result views.
 Include `--drift not-applicable` and canonical `--page-token`; reject blank or
 noncanonical handles and page-token/count combinations that cannot emit files.
+Accept `backend:<exact-name>`, `gradle:.#:app`, and
+`gradle:included/tools#:app`; reject unprefixed/empty selectors, absolute or
+escaping build roots, and non-absolute Gradle project paths.
 
 - [ ] **Step 2: Run the red command tests**
 
@@ -477,7 +570,11 @@ Expected: Clap does not recognize `workspace-files`.
 Add `AgentWorkspaceFilesArgs` with `AgentRuntimeArgs`, the family-specific
 ADR 0020 view args, optional module/source-set/kind/package/dirty/drift/path
 prefix/glob filters, `WorkspaceFileLimit`, and `WorkspaceFilesPublicPageToken`.
-Use private-field newtypes and `FromStr` validation. Keep the public token type
+Parse module as `WorkspaceModuleSelector::Backend(BackendModuleName)` or a
+`Gradle` variant carrying private validated build-root and project-path selector
+newtypes; Task 4 maps that variant to the inventory identity. Derive the raw/composition
+source-only, script-only, or mixed domain from the kind filter, with no filter
+meaning mixed. Use private-field newtypes and `FromStr` validation. Keep the public token type
 distinct from raw snapshot/module-page tokens. The drift enum is:
 
 ```rust
@@ -529,6 +626,7 @@ git commit -m "feat: add typed workspace file command boundary"
   `WorkspaceIndexSnapshot`, `SourceIndexSnapshotStamp`,
   `SourceIndexGeneration`, `SourceIndexModuleProgress`,
   `SourceIndexPendingCount`, `WorkspacePackageEvidence`,
+  `BuildQualifiedGradleProjectIdentity`,
   `WorkspaceIndexRead`, `WorkspaceInventoryLimitationCode`,
   `WorkspaceMatchCoverage`, and `read_workspace_index(&WorkspaceRoot)`.
 - The index reader has no public limit and returns `.kt` rows only.
@@ -550,6 +648,12 @@ four package cases:
 
 Assert 500 valid `.kt` candidates, zero `.kts`, exact package variants, typed
 excluded/invalid counts, and no escaping missing path.
+
+Seed a root-build `:app`, an included-build `:app`, a legacy-only
+`module_path=idea.app.main`, and malformed association rows. Assert the first
+two decode as distinct build-qualified owners of the same file, the legacy
+value is never read as Gradle identity, and malformed build-root/project-path
+values are typed incompatible evidence rather than partial owners.
 
 Seed generation, `module_index_progress`, and unapplied `pending_updates`.
 Assert the snapshot carries their typed state; only a nonempty initialized
@@ -574,7 +678,7 @@ Use sorted sets for owners and source sets:
 pub(crate) struct WorkspaceInventoryFile {
     path: WorkspaceFilePath,
     backend_modules: BTreeSet<BackendModuleName>,
-    indexed_gradle_modules: BTreeSet<GradleModulePath>,
+    indexed_gradle_projects: BTreeSet<BuildQualifiedGradleProjectIdentity>,
     source_sets: BTreeSet<WorkspaceSourceSet>,
     kind: WorkspaceFileKind,
     package: WorkspacePackageEvidence,
@@ -602,21 +706,25 @@ when a requested predicate is unknown.
 - [ ] **Step 4: Implement the read-only query exactly from the design**
 
 Within one SQLite read transaction, select `metadata_present`, `package_fq_id`,
-and joined `fq_name` separately, plus `schema_version.generation`, all module
-progress rows, and the unapplied pending-update count. Use
+joined `fq_name`, and all joined `file_gradle_projects` rows separately,
+plus `schema_version.generation`, all module progress rows, and the unapplied
+pending-update count. Never select or parse `module_path` as Gradle ownership. Use
 `SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_URI`, configure query-only access, verify
 schema/tables, decode existing path prefixes, reject non-`.kt`, and map the four
 package states without collapsing nulls. For missing paths, canonicalize the
 deepest existing ancestor; lexical containment alone is insufficient.
 
 In `SqliteSourceIndexStore`, increment the existing generation in the same
-write transaction as any candidate-table, progress, or pending applied-state
-mutation. Do not add a schema column or admit `.kts`.
+write transaction as any candidate-table, build-qualified association,
+progress, or pending applied-state mutation. Task 2 already adds and versions
+the dedicated association table; do not add another ownership column or admit
+`.kts`.
 
 - [ ] **Step 5: Add the scoped ownership guide and verify**
 
 Update `index-store/AGENTS.md` to make transactional generation maintenance and
-truthful progress/pending state storage-owned gates. State in the new Rust guide
+truthful progress/pending state storage-owned gates, and to forbid interpreting
+legacy `module_path` as project-model Gradle identity. State in the new Rust guide
 that it owns uncapped exact-root composition, generation/progress/pending-aware
 `.kt` index reads, deepest-existing-ancestor containment, set-valued owners,
 backend page coverage, and Git annotation. Prohibit `.kts` source-index reads
@@ -654,6 +762,10 @@ git commit -m "feat: add uncapped Kotlin source inventory"
 - Backend collection uses one admitted `RawRpcSession`, a top-level opaque
   snapshot token, exact-module opaque cursors, bounded restart, and typed
   `BackendWorkspaceCoverage`/`BackendModuleCoverage`.
+- Produces: `WorkspaceRequestedKindDomain`, `WorkspaceLaneEvidence<Stamp>`,
+  `WorkspaceLaneStamp<Stamp>`, `WorkspaceLanePurpose`, and per-kind
+  `WorkspaceKindMatchCoverage`. Composition digests canonicalize those exact
+  discriminated states.
 
 - [ ] **Step 1: Write failing page-exhaustion and multi-owner tests**
 
@@ -725,6 +837,19 @@ cross-source drift/absence to `UNKNOWN`. Stable incomplete progress or pending
 updates does not spin and emits its specific partial limitation. Assert call
 counts never exceed two composition attempts times two backend attempts.
 
+Represent every relevant before/after observation as
+`WorkspaceLaneStamp::Available(stamp)` or `Unavailable(reason)` and cover
+available-to-unavailable, unavailable-to-available, and unavailable-reason
+changes. A stable unavailable lane is coherent partial evidence and may page
+known results; its canonical tag/reason participates in the continuation
+digest. Add source-only, script-only, and mixed queries. Prove script-only and
+#340 neither open nor validate the Kotlin source index and remain exact while
+`.kt` generation/progress/pending changes; prove source-only and mixed queries
+retry or become partial for the same mutation. In mixed count output, assert an
+exact script group can coexist with a known-minimum source group and overall
+count. Git movement is relevant only when dirty filtering/grouping/projection
+requests it.
+
 - [ ] **Step 5: Add the root-A/root-B exact-root regression**
 
 In both smoke files, configure root A with only root B's ready descriptor and
@@ -752,8 +877,9 @@ collector is absent.
 
 - [ ] **Step 7: Implement strict backend paging**
 
-Fetch module metadata and its opaque snapshot token, sort exact module names,
-and echo the snapshot while requesting opaque cursors until each module
+Derive the typed source-only/script-only/mixed kind domain before any lane read.
+Fetch matching module metadata and its opaque snapshot token, sort exact module
+names, and echo both kind domain and snapshot while requesting opaque cursors until each module
 returns no next token. Never parse or construct a token in Rust. Validate
 only non-repeated handles, non-overlapping physical paths, and cumulative
 returned evidence that never exceeds and finally equals the declared module
@@ -792,6 +918,10 @@ every possible owner complete. Unknown or overlapping partial ownership emits
 `PROJECT_MODEL_OWNERSHIP_UNKNOWN`. `.kts` never queries the source index and
 uses `NotApplicable` states.
 
+Read `.kt` rows only for source-only or mixed domains. Decode indexed Gradle
+ownership exclusively from the complete build-root/project-path pair; retain it
+as `BuildQualifiedGradleProjectIdentity` and never parse legacy `module_path`.
+
 For every missing candidate, walk to the deepest existing ancestor and
 canonicalize it against the admitted canonical root before appending normalized
 missing components. Exclude escaping or unprovable paths with
@@ -807,12 +937,16 @@ paths from repository root through the exact workspace prefix. Parse records
 
 - [ ] **Step 10: Implement the coherent composition barrier**
 
-Record the backend snapshot lease, source-index generation/progress/pending
-stamp, targeted filesystem fingerprint, and Git fingerprint. After composition,
-validate the backend lease and re-read every other lane. Publish a coherent
-snapshot only when stamps match. Retry the entire composition once after a
+Record the kind domain and each lane as relevant-with-purpose or irrelevant;
+each relevant lane contains an exact `Available(stamp)` or
+`Unavailable(reason)`. After composition, re-observe only relevant lanes and
+compare canonical discriminated states, including availability transitions and
+reason changes. Publish a coherent snapshot when all relevant states match,
+including stable unavailability. Retry the entire composition once after a
 change. A second change returns typed partial evidence, never mixed exact
-evidence. Stable incomplete index state is partial without retry.
+evidence. Stable incomplete index state is partial without retry only for a
+selected source partition. Canonically digest kind domain, relevance/purpose,
+and lane states for public continuation.
 
 - [ ] **Step 11: Run focused tests green and commit**
 
@@ -861,7 +995,8 @@ git commit -m "feat: compose exhaustive workspace file evidence"
 
 - [ ] **Step 1: Write failing output, filter, limitation, and budget tests**
 
-Assert compact records contain sorted owner sets, source sets, kind, structured
+Assert compact records contain sorted backend owners and structured
+build-qualified Gradle project owners, source sets, kind, structured
 package evidence, source-index state, drift, dirty state, and paths. Cover each
 filter and conjunction; partial pages, unavailable index/Git, invalid package
 reference, and both candidate sources unavailable. Seed 500 records and assert
@@ -880,11 +1015,19 @@ query rather than automatic restart.
 With `--limit 200`, consume returned public tokens and assert page sizes
 200/200/100, strictly increasing relative paths, no overlap or gaps, stable
 cardinality, per-page `returnedCount`, and no terminal token. Assert a changed
-backend/index/filesystem/Git composition stamp returns
+relevant bound backend/index/filesystem/Git composition lane returns
 `STALE_WORKSPACE_FILES_PAGE`; malformed, forged, unknown, expired, evicted, or
 already-consumed state returns `INVALID_WORKSPACE_FILES_PAGE_TOKEN`; and any
 filter, view, field selection, backend, root, or limit mismatch fails rather
 than reinterpreting the cursor.
+
+Run the same continuation fixture with stable backend-only and index-only
+partial evidence. Assert tokens are issued for further known matches, retain
+`KNOWN_MINIMUM`, and bind canonical `Unavailable(reason)` lane state without
+requiring a nonexistent stamp. Availability or unavailable-reason changes are
+stale. For script-only paging, mutate `.kt` generation/progress/pending between
+pages and assert the token remains valid because the index lane is irrelevant;
+the same mutations stale source-only and mixed tokens.
 
 Assert `EXACT.totalCount` only when candidate inventory and every selected
 predicate are complete. Cover these counterexamples explicitly:
@@ -897,6 +1040,10 @@ predicate are complete. Cover these counterexamples explicitly:
   `KNOWN_MINIMUM`; and
 - a complete inventory without a predicate that depends on unavailable Git is
   still `EXACT`.
+
+Also prove incomplete `.kt` progress leaves `--kind script` exact, makes
+`--kind source` known-minimum, and gives a mixed count an exact script group
+beside a known-minimum source group and overall result.
 
 In every view, assert `returnedCount == files.len()`. `truncated` is true when
 an exact total exceeds returned count or cardinality is `KNOWN_MINIMUM`.
@@ -930,8 +1077,10 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projec
 - [ ] **Step 4: Execute admitted collection and apply typed filters**
 
 Call `semantic_workspace_route`, copy the admitted root/backend into runtime
-args, open one raw session, collect the uncapped snapshot, then filter. Match
-module against any owner, sort by relative path and sorted owner sets, and only
+args, derive the normalized kind domain and lane relevance, open one raw
+session, collect the uncapped snapshot, then filter. Match the closed
+`backend:<name>` or `gradle:<build-root>#<project-path>` selector against its
+corresponding owner type, sort by relative path and sorted owner sets, and only
 then take `limit`. Compute candidate-inventory and selected-filter evidence
 coverage before projection. Do not infer exact match cardinality merely from a
 fully consumed known-candidate vector.
@@ -939,8 +1088,10 @@ fully consumed known-candidate vector.
 For a resumed request, consume the opaque public handle through the internal
 server continuation service, require the identical normalized query identity,
 recollect through the composition barrier, and compare the full composition-
-stamp digest. Seek strictly after the stored relative path and verify cumulative
-returned evidence. Never fall back to page one after invalid or stale state.
+stamp digest, including kind domain, lane relevance/purpose, and exact
+available/unavailable state. Seek strictly after the stored relative path and
+verify cumulative returned evidence. Never fall back to page one after invalid
+or stale state.
 
 - [ ] **Step 5: Add compact, fields, count, verbose, and explain projections**
 
@@ -957,7 +1108,8 @@ Register continuation state through the shared server-held store only after a
 coherent composition and only when more known matches remain. Store exact root,
 backend, normalized query/view/limit, composition-stamp digest, last path, and
 cumulative returned count; do not store or trust a serialized candidate page.
-Suppress continuation for an unstable composition.
+Coherent partial compositions with stable unavailable lane states may continue
+known matches; suppress continuation only for an unstable composition.
 
 - [ ] **Step 6: Implement the route registry and verification intersection**
 
@@ -1033,9 +1185,11 @@ Keep an unowned on-disk `.kt` file and assert it is absent.
 
 Add the command to `cli-rs/src/agent/AGENTS.md`. Teach source/script filters,
 public continuation, partial limitations, backend and cross-source bounded
-retries, owner sets, and direct path composition. State explicitly that `.kts`
-is not in the Kotlin source index and Gradle semantic declarations arrive with
-#340.
+retries, per-kind lane relevance, discriminated available/unavailable
+composition stamps, build-qualified Gradle owner sets, and direct path
+composition. State explicitly that `.kts` is not in the Kotlin source index,
+unrelated `.kt` progress cannot make script-only discovery partial, and Gradle
+semantic declarations arrive with #340.
 
 Update `cli-rs/AGENTS.md` to list `workspace-files` in the public typed command
 surface and assign `workspace_inventory` coherence/continuation ownership.
@@ -1046,11 +1200,13 @@ changes.
 
 - [ ] **Step 4: Update reference and how-to docs**
 
-Document every flag, limit, page token, result view, owner set, package state,
+Document every flag, limit, page token, result view, typed backend/build-
+qualified Gradle owner set, package state,
 drift/index truth table, limitations, exact-root behavior, server-held raw
-paging, coherent cross-source composition, and typed invalid/stale public
-continuation. Replace generic-search-first guidance with `workspace-files`,
-then diagnostics or exact symbol lookup.
+paging, exact-once store disposal, kind-relevant coherent cross-source
+composition, stable partial continuation, and typed invalid/stale public
+continuation. Replace generic-search-first guidance with `workspace-files`, then
+diagnostics or exact symbol lookup.
 
 - [ ] **Step 5: Validate guidance and commit**
 
@@ -1092,11 +1248,22 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test semantic_workspace_
 ```
 
 Expected: generation/fingerprint, stale, cursor-binding, paging/project-model
-TTL/capacity/integrity, final backend validation, source-index generation/
-progress/pending, and composition-barrier tests pass; `.kts` remains rejected
-by `SourceIndexFilePolicyTest`.
+TTL/capacity/integrity and exact-once disposal, final backend validation,
+build-qualified root/included project identity, source-index generation/
+progress/pending, and kind-relevant composition-barrier tests pass; `.kts`
+remains rejected by `SourceIndexFilePolicyTest`.
 
-- [ ] **Step 3: Run full Rust quality gates**
+- [ ] **Step 3: Run full Gradle and IDEA packaging gates**
+
+```console
+./gradlew test --no-daemon
+./gradlew buildIdeaPlugin --no-daemon
+```
+
+Expected: the complete JVM suite and packaged IDEA plugin pass after the
+cross-module continuation lifecycle, schema, and producer changes.
+
+- [ ] **Step 4: Run full Rust quality gates**
 
 ```console
 cargo test --manifest-path cli-rs/Cargo.toml --locked
@@ -1104,7 +1271,7 @@ cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
 ```
 
-- [ ] **Step 4: Prove generated contracts and docs are current**
+- [ ] **Step 5: Prove generated contracts and docs are current**
 
 ```console
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
@@ -1118,7 +1285,7 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_sm
 zensical build --clean
 ```
 
-- [ ] **Step 5: Review scope and whitespace**
+- [ ] **Step 6: Review scope and whitespace**
 
 ```console
 git status --short --branch
@@ -1127,10 +1294,11 @@ git diff --check origin/main...HEAD
 git diff --name-only origin/main...HEAD
 ```
 
-Expected: issue source/tests/guidance/ADR/spec/plan and required generated
-contracts only; no source-index schema or `SourceIndexFilePolicy` change.
+Expected: issue source/tests/guidance/ADR/spec/plan, the dedicated
+build-qualified source-index schema migration, and required generated contracts
+only; no `.kts` admission or unrelated source-index schema change.
 
-- [ ] **Step 6: Request independent review**
+- [ ] **Step 7: Request independent review**
 
 Ask a fresh reviewer to check generation-bound paging determinism,
 equal-cardinality/module-set stale detection, single bounded restart,
@@ -1139,11 +1307,14 @@ cross-module cursor rejection, included-build project-model script authority,
 mapping, exact-root rejected-no-request proof, package-state SQL, false
 `INDEX_ONLY`, project-model error/reason mapping, metadata failure, zero-module
 global partiality, candidate versus filter coverage, `EXACT` versus
-`KNOWN_MINIMUM`, server-held TTL/capacity/integrity, deepest-ancestor missing-
-path containment, index generation/progress/pending state, cross-source barrier
-mutation, public 200/200/100 continuation, invalid/stale/query-mismatched public
-tokens, hand-authored catalog ownership, Kotlin type isolation, scoped ownership
-guidance, package/LSP/routing gates, capability callability, #340 reuse,
+`KNOWN_MINIMUM`, server-held TTL/capacity/integrity and exact-once disposal,
+deepest-ancestor missing-path containment, build-qualified root/included Gradle
+identity without IDEA fallback promotion, index generation/progress/pending
+state, kind-relevant cross-source barrier mutation, available/unavailable lane
+digests, backend/index-only partial continuation, public 200/200/100
+continuation, invalid/stale/query-mismatched public tokens, hand-authored catalog
+ownership, Kotlin type isolation, scoped ownership guidance, package/LSP/routing
+gates, capability callability, #340 reuse, full `test`/`buildIdeaPlugin` gates,
 budgets, and every issue acceptance criterion. Repair each blocking finding
 with a focused red-green commit and rerun the affected gate plus full Rust and
 Kotlin suites.

--- a/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
+++ b/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
@@ -71,8 +71,10 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
   keep an IDEA module-name fallback only as a legacy unproven label.
 - Never treat path-derived `file_metadata.source_set` or nullable text-parser
   package output as proof. Persist model-proven build-qualified Gradle source
-  sets and Kotlin PSI/compiler package provenance as discriminated types. A
-  missing parser result is `UNPROVEN`, never root.
+  sets and Kotlin PSI/compiler package provenance as discriminated types.
+  `backend-shared` owns the PSI read and converts it to host-neutral
+  `IndexedPackageEvidence` before the `index-store` boundary. A missing parser
+  result is `UNPROVEN`, never root.
 - Advance `packaging/homebrew/release-state.json` from source-index schema 7 to
   8 in Task 2. It remains the only checked-in schema source; generated Kotlin
   and Rust constants and their tests must agree before a version-8 DB is read.
@@ -172,7 +174,9 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
   reusable leases, atomic single-use `Complete`/`Reissue` transitions, and
   exact-once state disposal.
 - Produces: `CloseableAnalysisBackend`, an explicit server-owned lifecycle
-  contract. `RunningAnalysisServer` is the sole close owner after start.
+  contract. `RunningAnalysisServer` is the sole backend and continuation close
+  owner after start; outer runtimes retain separately owned non-backend
+  resources.
 - Invariant: snapshot and page tokens are canonical random UUID handles, not
   encoded state. An input snapshot token is legal with `includeFiles=true` and
   one exact module, or with `includeFiles=false` and no module for final barrier
@@ -242,8 +246,9 @@ terminal and every fake closes once.
 
 Add socket/stdio lifecycle tests around a close-counting
 `CloseableAnalysisBackend`. Prove transport admission stops before backend
-close, dispatcher stores drain, backend close runs once on repeated server and
-runtime close, and a backend close failure does not skip descriptor cleanup.
+close, dispatcher stores drain, backend close runs once on repeated server
+close, and a backend close failure does not skip descriptor cleanup. The outer
+IDEA runtime/resource-order tests belong to Task 2.
 
 Assert invalid raw errors expose only typed `details.scope` of
 `SNAPSHOT_HANDLE` or `PAGE_HANDLE`. Snapshot failure discards the workspace-wide
@@ -372,6 +377,7 @@ git commit -m "feat: page raw workspace file results"
 - Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaProjectIndexer.kt`
 - Create: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventoryTest.kt`
 - Modify: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt`
+- Modify: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastIdeaBackendRuntimeTest.kt`
 - Modify: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaProjectIndexerModuleNameTest.kt`
 - Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/BuildQualifiedGradleProjectIdentity.kt`
 - Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/GradleProjectPath.kt`
@@ -385,6 +391,7 @@ git commit -m "feat: page raw workspace file results"
 - Modify: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.kt`
 - Modify: `index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SqliteSourceIndexStoreTest.kt`
 - Modify: `index-store/AGENTS.md`
+- Modify: `backend-shared/AGENTS.md`
 - Modify: `backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiSourceIndexScanner.kt`
 - Create: `backend-shared/src/test/kotlin/io/github/amichne/kast/shared/analysis/PsiSourceIndexScannerTest.kt`
 - Modify: `build-logic/AGENTS.md`
@@ -414,8 +421,10 @@ git commit -m "feat: page raw workspace file results"
   `file_gradle_projects` association table, distinct from legacy
   `file_metadata.module_path`.
 - Produces: `BuildQualifiedGradleSourceSetIdentity` from model-owned Gradle
-  source roots and `IndexedPackageEvidence` from Kotlin PSI/compiler structure.
-  Legacy path/module labels remain explicit unproven evidence.
+  source roots. `backend-shared` converts Kotlin PSI/compiler structure to
+  host-neutral `IndexedPackageEvidence` before constructing `FileIndexUpdate`;
+  no IntelliJ/Kotlin PSI type crosses into `index-store`. Legacy path/module
+  labels remain explicit unproven evidence.
 - Produces: release-state source-index schema version 8, with Kotlin and Rust
   constants generated from that one file and tested for alignment.
 
@@ -471,7 +480,10 @@ produces `BuildQualifiedGradleSourceSetIdentity` while `/src/main/`, source-root
 basename, and IDEA module-name heuristics cannot. Add Kotlin PSI/compiler
 package fixtures for root, escaped keyword (`com.example.\`when\``), backticked
 non-identifier, and general Unicode names. A missing/failed semantic package
-producer must persist `UNPROVEN`, never `PROVEN_ROOT`. Prove legacy
+producer must persist `UNPROVEN`, never `PROVEN_ROOT`. In
+`PsiSourceIndexScannerTest`, prove the `KtFile` result is converted to
+`IndexedPackageEvidence` inside `backend-shared` and only the host-neutral
+`FileIndexUpdate` crosses into `index-store`. Prove legacy
 `file_metadata.source_set` is unproven and cannot satisfy `--source-set`.
 
 Set `packaging/homebrew/release-state.json.source_index_schema_version` to 8.
@@ -496,15 +508,22 @@ after each `Reissue`, the prior token is invalid, and `Complete` closes once.
 Wire `KastPluginBackend` as a `CloseableAnalysisBackend`, forward close through
 `ObservedAnalysisBackend`, pass it from `KastIdeaBackendRuntime` into
 `AnalysisServer`, and prove repeated `RunningKastIdeaBackend.close()` and server
-shutdown have one backend close owner. Cover reissue versus shutdown/eviction
-and callback failure while the IDEA state is claimed, plus expiry/replacement
-and server-close/callback races.
+shutdown have one backend close owner. In `KastIdeaBackendRuntimeTest`, record
+the outer close sequence and prove it cancels project indexing, closes
+`RunningAnalysisServer`, then closes the separately owned
+`SqliteSourceIndexStore`. Inject failures at each phase and prove later cleanup
+still runs; repeated close must not repeat any phase. Assert the server phase
+closes the plugin backend/continuations exactly once, the source-index store
+remains usable until that phase completes, and no separate
+`backendResources::close` action survives. Cover reissue versus
+shutdown/eviction and callback failure while the IDEA state is claimed, plus
+expiry/replacement and server-close/callback races.
 
 - [ ] **Step 2: Run the focused red backend test**
 
 ```console
 ./gradlew -p build-logic test --tests WriteSourceIndexSchemaVersionTaskTest
-./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --tests '*IdeaProjectIndexerModuleNameTest*' :index-store:test --tests '*SqliteSourceIndexStoreTest*' --no-daemon
+./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --tests '*IdeaProjectIndexerModuleNameTest*' --tests '*KastIdeaBackendRuntimeTest*' :backend-shared:test --tests '*PsiSourceIndexScannerTest*' :index-store:test --tests '*SqliteSourceIndexStoreTest*' --no-daemon
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test source_index_schema_version_smoke
 python3 packaging/homebrew/scripts/test-formulas.py
 ```
@@ -561,20 +580,27 @@ replacing, or removing any
 association/evidence increments `schema_version.generation` in that transaction.
 
 `PsiSourceIndexScanner` reads `KtFile.packageFqName` or equivalent structured
-Kotlin PSI/compiler evidence and passes canonical `ProvenRoot`, `ProvenNamed`,
-or `Unproven(reason)` to `FileIndexUpdate`. `SourceFileIndexParser` may parse
-declarations but cannot turn nullable package output into root. No IntelliJ
-type crosses into `backend-shared` or `index-store`. Keep `module_path` and
-`source_set` for existing symbol/metrics behavior only; workspace discovery
-must never select or parse either legacy label as proven Gradle identity.
+Kotlin PSI/compiler evidence inside `backend-shared`, converts it there to
+canonical `IndexedPackageEvidence.ProvenRoot`, `ProvenNamed`, or
+`Unproven(reason)`, and passes only that host-neutral value through
+`FileIndexUpdate` to `index-store`. `SourceFileIndexParser` may parse
+declarations but cannot turn nullable package output into root. IntelliJ and
+Kotlin PSI types are allowed inside `backend-shared`; none may cross from it
+into `index-store`. Keep `module_path` and `source_set` for existing
+symbol/metrics behavior only; workspace discovery must never select or parse
+either legacy label as proven Gradle identity.
 
 Make `KastPluginBackend` implement `CloseableAnalysisBackend` and drain its
 snapshot/page/reference/diagnostic stores exactly once. Make
 `ObservedAnalysisBackend` implement the same type and forward close to its
 delegate. `KastIdeaBackendRuntime` passes the observed owner to
-`AnalysisServer`; `RunningKastIdeaBackend.close()` cancels indexing and closes
-only the running server. Do not close the backend directly from both runtime
-and server.
+`AnalysisServer`; `RunningAnalysisServer` is the sole backend/continuation close
+owner. `RunningKastIdeaBackend.close()` cancels indexing, closes that server,
+and then closes the separately owned `SqliteSourceIndexStore` shared by lookup
+and indexing. Remove only the redundant `backendResources::close` phase. Keep
+the three outer phases ordered, idempotent, and failure-tolerant so an earlier
+failure cannot skip later cleanup; do not close the backend directly from both
+runtime and server.
 
 - [ ] **Step 4: Page sorted inventory with server-held state**
 
@@ -625,7 +651,8 @@ Run:
 
 ```console
 ./gradlew -p build-logic test --tests WriteSourceIndexSchemaVersionTaskTest
-./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --tests '*KastPluginBackendContractTest*workspace files*' --no-daemon
+./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --tests '*KastPluginBackendContractTest*workspace files*' --tests '*KastIdeaBackendRuntimeTest*' --no-daemon
+./gradlew :backend-shared:test --tests '*PsiSourceIndexScannerTest*' --no-daemon
 ./gradlew :index-store:test --tests '*SourceIndexFilePolicyTest*' --tests '*SqliteSourceIndexStoreTest*' --no-daemon
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test source_index_schema_version_smoke
 python3 packaging/homebrew/scripts/test-formulas.py
@@ -635,9 +662,9 @@ Expected: project scripts, shared ownership, included-build associations,
 build-qualified root/included project identities, custom `integrationTest`,
 structured package provenance, legacy fallback isolation, schema 8 alignment,
 v7 rejection/reset, generation changes, stale responses, atomic multi-page
-reissue/close, and cross-module rejection pass. Typed indexing/project-model
-failures retain their reason; the index-store test still proves `.kts`
-rejection.
+reissue/close, runtime close ordering/failure continuation, and cross-module
+rejection pass. Typed indexing/project-model failures retain their reason; the
+index-store test still proves `.kts` rejection.
 
 - [ ] **Step 6: Commit backend authority**
 
@@ -651,8 +678,10 @@ git commit -m "feat: enumerate project model Kotlin scripts"
 model-proven `.kt`/`.kts` candidates, server-held generation-bound paging,
 TTL/capacity/integrity behavior, typed
 project-model incompleteness, atomic reissue, single close ownership,
-build-qualified project/source-set production, structured package evidence, and
-the focused backend tests above. `index-store/AGENTS.md` records version-8
+build-qualified project/source-set production, runtime/source-index-store close
+choreography, and the focused backend tests above. `backend-shared/AGENTS.md`
+records PSI package-evidence ownership and the host-neutral `index-store`
+firewall. `index-store/AGENTS.md` records version-8
 association/provenance structures and prohibits promoting legacy labels.
 `build-logic/AGENTS.md` records that release state generates the Kotlin schema
 constant and names its alignment gate. These are the nearest guides for the new
@@ -1406,13 +1435,14 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test source_index_schema
 
 ```console
 ./gradlew -p build-logic test --tests WriteSourceIndexSchemaVersionTaskTest
-./gradlew :analysis-api:test :analysis-server:test :index-store:test :backend-idea:test --no-daemon
+./gradlew :analysis-api:test :analysis-server:test :backend-shared:test :index-store:test :backend-idea:test --no-daemon
 python3 packaging/homebrew/scripts/test-formulas.py
 ```
 
 Expected: generation/fingerprint, stale, cursor-binding, paging/project-model
-TTL/capacity/integrity, atomic reissue, one backend close owner, and exact-once
-disposal pass. Release state, generated Kotlin/Rust schema version 8, v7 reset,
+TTL/capacity/integrity, atomic reissue, one backend close owner, ordered
+runtime/source-index-store shutdown, and exact-once disposal pass. Release
+state, generated Kotlin/Rust schema version 8, v7 reset,
 build-qualified root/included project and custom source-set identities,
 structured package provenance, source-index generation/progress/pending, final
 backend validation, and kind-relevant composition-barrier tests pass; `.kts`
@@ -1475,6 +1505,8 @@ mapping, exact-root rejected-no-request proof, package-state SQL, false
 global partiality, candidate versus filter coverage, `EXACT` versus
 `KNOWN_MINIMUM`, server-held TTL/capacity/integrity, atomic multi-page
 `Complete`/`Reissue`, single backend close ownership, and exact-once disposal,
+runtime cancellation/server/source-index-store close ordering under repeated and
+failing close,
 deepest-ancestor missing-path containment, build-qualified root/included Gradle
 identity and custom source sets without path/IDEA fallback promotion,
 Kotlin-structured escaped/backticked/Unicode package provenance with no

--- a/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
+++ b/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
@@ -39,6 +39,9 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Treat snapshot and page tokens as opaque server-owned values. Bind cursors to
   generation, exact module, and offset; never construct or advance them in
   Rust.
+- Reuse ADR 0020's discriminated `EXACT | KNOWN_MINIMUM` cardinality. Keep
+  candidate-inventory and selected-filter evidence coverage separate; neither
+  a bare count nor a completeness boolean may imply exact filtered matches.
 - On `STALE_WORKSPACE_INVENTORY`, discard the whole backend attempt and restart
   once. A second stale response is typed partial evidence with no backend
   candidates from either stale attempt.
@@ -48,6 +51,11 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
   output below 120 lines and 1,500 estimated tokens.
 - Change Kotlin wire/backend/generated contracts when required by paging;
   regenerate them from their source owners.
+- Treat `commands.json` as the hand-authored internal catalog source; regenerate
+  only YAML, schemas, and samples from it.
+- Preserve Kotlin top-level type isolation for every materially edited
+  workspace-file contract; direct sealed response variants may remain with
+  their root.
 - Add or update scoped `AGENTS.md` whenever source ownership or validation gates
   change. Do not publish ADR/spec/plan files in Zensical navigation.
 - Execute tasks sequentially when they edit shared agent/projection files. The
@@ -70,7 +78,12 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedWorkspaceFilesQuery.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/WorkspaceInventoryStaleException.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/InvalidWorkspaceFileCursorException.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/WorkspaceProjectModelIncompleteException.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/WorkspaceProjectModelIncompleteReason.kt`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedModels.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastWorkspaceFilesRequest.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastWorkspaceFilesQuery.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastWorkspaceFilesResponse.kt`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt`
 - Modify: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/ParsedModelsTest.kt`
 - Modify: `analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt`
@@ -84,6 +97,9 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
   `ParsedWorkspaceFilesQuery.pageToken`, `WorkspaceFilesResult.snapshotToken`,
   `WorkspaceModule.returnedFileCount`, `WorkspaceModule.nextPageToken`, and
   explicit `WorkspaceModule.contentRoots`.
+- Produces: `WorkspaceProjectModelIncompleteException` with stable
+  `WORKSPACE_PROJECT_MODEL_INCOMPLETE` code and typed
+  `WorkspaceProjectModelIncompleteReason` details.
 - Invariant: snapshot and page tokens are opaque to clients. An input snapshot
   token is legal only with `includeFiles=true` and one exact module; a page
   token additionally requires that snapshot token.
@@ -126,6 +142,11 @@ Pass the first page cursor back with a different exact module and assert
 then add and remove a module after metadata; each subsequent page request must
 return `STALE_WORKSPACE_INVENTORY` rather than a mixed page.
 
+Make the fake backend throw each project-model-incomplete reason and assert the
+dispatcher preserves status 503, `retryable=true`, stable error code, and exact
+`details.reason`. These are typed error-envelope tests, not string matching on
+an internal exception message.
+
 - [ ] **Step 2: Run the focused red tests**
 
 ```console
@@ -158,7 +179,10 @@ token generation and decoding. Keep the server's positive page-size and
 maximum checks. Add matching `AnalysisException` subtypes: stale inventory is
 HTTP/JSON-RPC status 409, code `STALE_WORKSPACE_INVENTORY`, and retryable;
 invalid cursor is status 400, code `INVALID_WORKSPACE_FILE_CURSOR`, and not
-retryable. The existing dispatcher maps both through its typed error envelope.
+retryable. Add `WorkspaceProjectModelIncompleteException` with status 503,
+code `WORKSPACE_PROJECT_MODEL_INCOMPLETE`, `retryable=true`, and a typed reason
+serialized into `details.reason`. The existing dispatcher maps all three
+through its typed error envelope.
 
 - [ ] **Step 4: Isolate and extend the result type**
 
@@ -180,6 +204,13 @@ nonblank. Validate source/content roots are sorted and deduplicated. Update
 skill response types and the fake backend with the same generation/fingerprint,
 opaque-cursor, sort-before-slice, stale, and cross-module-error contract.
 
+Extract the materially edited `KastWorkspaceFilesRequest` and
+`KastWorkspaceFilesQuery` from `SkillContracts.kt` into matching files. Move
+`KastWorkspaceFilesResponse` and its direct success/failure variants together
+to `KastWorkspaceFilesResponse.kt`; direct sealed variants may remain with
+their owner. Add snapshot/page fields to the request/query and the echoed
+snapshot to the success response. Do not migrate unrelated legacy skill types.
+
 - [ ] **Step 5: Run Kotlin paging tests green**
 
 Run the Step 2 command. Expected: all paging, validation, stale-generation,
@@ -200,6 +231,7 @@ git commit -m "feat: page raw workspace file results"
 
 **Files:**
 
+- Create: `backend-idea/AGENTS.md`
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventory.kt`
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventorySnapshot.kt`
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileModuleSnapshot.kt`
@@ -242,6 +274,14 @@ contract cases proving the old snapshot token returns
 `STALE_WORKSPACE_INVENTORY` and a cursor issued for one module returns
 `INVALID_WORKSPACE_FILE_CURSOR` when used with another.
 
+Add three failure fixtures: IDEA dumb/index-not-ready state, unavailable linked
+Gradle project-model data, and a linked root with no root-module association.
+Assert the backend returns `WORKSPACE_PROJECT_MODEL_INCOMPLETE` with respective
+typed reasons `RUNTIME_INDEXING`, `PROJECT_MODEL_UNAVAILABLE`, and
+`LINKED_ROOT_UNASSOCIATED`. Cover failure on metadata and after a prior page so
+Rust can distinguish whole-inventory failure from a generic page transport
+failure.
+
 - [ ] **Step 2: Run the focused red backend test**
 
 ```console
@@ -269,9 +309,12 @@ and root-module associations. For each model-proven root, look up only
 Project-scope `.kts` files under a contained module root acquire all containing
 module owners. A contained linked-root script without a content-root owner
 acquires every root module associated with that linked root. If the bridge
-cannot associate the linked root with any backend root module, fail the request
-as incomplete project-model evidence. Canonical containment is mandatory before
-ownership is recorded.
+cannot associate the linked root with any backend root module, throw
+`WorkspaceProjectModelIncompleteException(LINKED_ROOT_UNASSOCIATED)`. Map IDEA
+dumb/index-not-ready state to `RUNTIME_INDEXING` and missing linked settings or
+module data to `PROJECT_MODEL_UNAVAILABLE`; do not allow either to become an
+empty complete inventory. Canonical containment is mandatory before ownership
+is recorded.
 
 - [ ] **Step 4: Page sorted inventory in the backend**
 
@@ -314,7 +357,8 @@ Run:
 
 Expected: project scripts, shared ownership, included-build associations,
 generation changes, stale responses, and cross-module rejection pass; the
-index-store test still proves `.kts` rejection.
+typed indexing/project-model failures retain their reason; the index-store test
+still proves `.kts` rejection.
 
 - [ ] **Step 6: Commit backend authority**
 
@@ -323,6 +367,11 @@ git add backend-idea
 git diff --cached --check
 git commit -m "feat: enumerate project model Kotlin scripts"
 ```
+
+`backend-idea/AGENTS.md` records that the inventory and Java Gradle bridge own
+model-proven `.kt`/`.kts` candidates, generation-bound paging, typed
+project-model incompleteness, and the focused backend tests above. This is the
+nearest guide for the new source boundary.
 
 Do not stage either source-index policy file; both are verification-only.
 
@@ -411,7 +460,8 @@ git commit -m "feat: add typed workspace file command boundary"
 
 - Produces: `WorkspaceRoot`, `WorkspaceFilePath`,
   `WorkspaceIndexSnapshot`, `WorkspacePackageEvidence`,
-  `WorkspaceIndexRead`, and `read_workspace_index(&WorkspaceRoot)`.
+  `WorkspaceIndexRead`, `WorkspaceInventoryLimitationCode`,
+  `WorkspaceMatchCoverage`, and `read_workspace_index(&WorkspaceRoot)`.
 - The index reader has no public limit and returns `.kt` rows only.
 
 - [ ] **Step 1: Write failing schema, path, and package-state tests**
@@ -456,6 +506,15 @@ pub(crate) struct WorkspaceInventoryFile {
 
 Include `NotApplicable` in source-index state and drift. Keep fields private
 with read-only accessors required by agent/#340 consumers.
+
+Define closed limitation variants for backend capability, metadata, page,
+stale generation, runtime indexing, unavailable project model, unassociated
+linked root, source-index unavailable/incompatible, Git unavailable, package
+metadata invalid, unknown project-model ownership, and out-of-root exclusion.
+Keep `WorkspaceMatchCoverage` as two typed dimensions:
+`candidate_inventory` and `filter_evidence`, each `Complete` or `Partial`.
+This prevents a complete candidate set from asserting exact filtered matches
+when a requested predicate is unknown.
 
 - [ ] **Step 4: Implement the read-only query exactly from the design**
 
@@ -524,6 +583,14 @@ partial, every module from the last metadata response is partial,
 `BACKEND_WORKSPACE_INVENTORY_STALE` is emitted, and no stale backend candidate
 is composed. Cross-module cursor use is invalid and never becomes a page.
 
+Script typed `WORKSPACE_PROJECT_MODEL_INCOMPLETE` failures for metadata and for
+a later page after earlier modules succeeded. Assert metadata failure produces
+backend-unavailable coverage, page failure discards the whole backend attempt,
+neither consumes the stale retry, and neither composes a backend candidate.
+Map `RUNTIME_INDEXING`, `PROJECT_MODEL_UNAVAILABLE`, and
+`LINKED_ROOT_UNASSOCIATED` to distinct Rust limitations. Keep a generic page
+transport failure local to only its requested module.
+
 - [ ] **Step 2: Write failing drift tests**
 
 Prove:
@@ -533,6 +600,11 @@ Prove:
 - complete-owner index-only `.kt` is `INDEX_ONLY`;
 - any partial overlapping owner makes it `UNKNOWN`; and
 - missing files are `MISSING_ON_DISK` with independent index state.
+
+Also prove workspace-wide stale or project-model partial coverage can never
+produce `INDEX_ONLY`, including when the last metadata response contains zero
+modules. Unknown current module membership is not a vacuously complete owner
+set.
 
 - [ ] **Step 3: Write nested Git mapping tests**
 
@@ -585,6 +657,14 @@ No candidates from either stale attempt survive. Other page failures record
 only that module as `BackendModuleCoverage::Partial`; they never silently
 truncate.
 
+Decode the stable API error code and typed reason before classifying a failed
+metadata/page response. Metadata project-model failure is
+`BackendWorkspaceCoverage::Unavailable`. Project-model failure on any page is
+workspace-wide `Partial` and discards earlier pages from that attempt. Preserve
+the exact runtime-indexing, project-model-unavailable, or unassociated-root
+limitation. Only generic transport/invalid-response failure remains local to
+one module, and only `STALE_WORKSPACE_INVENTORY` consumes the single restart.
+
 - [ ] **Step 7: Implement conservative composition**
 
 Candidate keys come only from backend pages and `.kt` index rows. For index-only
@@ -631,6 +711,8 @@ git commit -m "feat: compose exhaustive workspace file evidence"
 
 - Produces: `KAST_AGENT_WORKSPACE_FILES_RESULT` views and
   `AgentPublicCapabilityRoute` for `WORKSPACE_FILES`.
+- Reuses: ADR 0020 `AgentResultCardinality::Exact | KnownMinimum` with
+  `returnedCount`, `truncated`, and separate typed candidate/filter coverage.
 
 - [ ] **Step 1: Write failing output, filter, limitation, and budget tests**
 
@@ -639,6 +721,23 @@ package evidence, source-index state, drift, dirty state, and paths. Cover each
 filter and conjunction; partial pages, unavailable index/Git, invalid package
 reference, and both candidate sources unavailable. Seed 500 records and assert
 20 default records, at most 120 lines, and at most 1,500 estimated tokens.
+
+Assert `EXACT.totalCount` only when candidate inventory and every selected
+predicate are complete. Cover these counterexamples explicitly:
+
+- complete candidate inventory plus unavailable Git and `--dirty clean` is
+  `KNOWN_MINIMUM` with partial filter evidence;
+- unavailable package/source-set metadata with a corresponding filter is
+  `KNOWN_MINIMUM` even if backend paging is complete;
+- partial backend pages or unavailable source-index candidate authority are
+  `KNOWN_MINIMUM`; and
+- a complete inventory without a predicate that depends on unavailable Git is
+  still `EXACT`.
+
+In every view, assert `returnedCount == files.len()`. `truncated` is true when
+an exact total exceeds returned count or cardinality is `KNOWN_MINIMUM`.
+Count-only group values also use `Exact` or `KnownMinimum`; no bare count may
+imply exactness.
 
 - [ ] **Step 2: Write failing capability route tests**
 
@@ -669,14 +768,19 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projec
 Call `semantic_workspace_route`, copy the admitted root/backend into runtime
 args, open one raw session, collect the uncapped snapshot, then filter. Match
 module against any owner, sort by relative path and sorted owner sets, and only
-then take `limit`.
+then take `limit`. Compute candidate-inventory and selected-filter evidence
+coverage before projection. Do not infer exact match cardinality merely from a
+fully consumed known-candidate vector.
 
 - [ ] **Step 5: Add compact, fields, count, verbose, and explain projections**
 
 Compact and selected views never contain raw envelopes. Count groups known
-records by kind/index/drift/dirty. Verbose adds per-module page coverage;
-explain adds normalized query and classification evidence. Preserve typed
-backend/index failures in failed envelopes.
+records by kind/index/drift/dirty, with the same discriminated exactness as the
+overall result. Compact and selected pages serialize `cardinality`,
+`returnedCount`, `truncated`, and `coverage.candidateInventory` plus
+`coverage.filterEvidence`. Verbose adds per-module page coverage; explain adds
+normalized query and classification evidence. Preserve typed backend/index
+failures in failed envelopes.
 
 - [ ] **Step 6: Implement the route registry and verification intersection**
 
@@ -699,7 +803,7 @@ git commit -m "feat: expose bounded workspace file discovery"
 **Files:**
 
 - Regenerate: `cli-rs/protocol/`
-- Regenerate: `cli-rs/resources/kast-skill/references/commands.json`
+- Modify: `cli-rs/resources/kast-skill/references/commands.json`
 - Regenerate: `cli-rs/resources/kast-skill/references/commands.yaml`
 - Regenerate: `cli-rs/resources/kast-skill/references/requests/raw/workspace-files/`
 - Modify: `cli-rs/tests/rpc_catalog_smoke.rs`
@@ -717,12 +821,23 @@ git commit -m "feat: expose bounded workspace file discovery"
 
 - [ ] **Step 1: Regenerate Kotlin-owned protocol artifacts**
 
-Run the repository generators, then prove raw request schemas include opaque
-`snapshotToken`/`pageToken`, results include the top-level snapshot token, and
-module results include returned count/next token:
+Generate protocol/OpenAPI artifacts from the Kotlin contract first:
 
 ```console
 ./gradlew :analysis-server:generateDocPages --no-daemon
+```
+
+Then hand-edit `commands.json`, the source catalog, to add opaque
+`snapshotToken`/`pageToken` request fields and replace the stale capped-secondary
+description with the current internal generation-bound paging contract. The
+release generator consumes that JSON; it does not produce it. Refresh the
+catalog-derived block in `cli-rs/protocol/api-specification.md`, regenerate the
+derived YAML, schemas, and samples, then prove requests include both tokens,
+results include the top-level snapshot token, and module results include
+returned count/next token:
+
+```console
+python3 .github/scripts/render-rpc-contract-summary.py --write
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test rpc_catalog_smoke
 ```
@@ -798,6 +913,7 @@ cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-feat
 
 ```console
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+python3 .github/scripts/render-rpc-contract-summary.py --check
 .github/scripts/test-docs-content-contract.sh
 .github/scripts/test-docs-navigation-contract.sh
 zensical build --clean
@@ -822,6 +938,9 @@ equal-cardinality/module-set stale detection, single bounded restart,
 cross-module cursor rejection, included-build project-model script authority,
 `.kt`-only source-index preservation, multi-owner physical files, nested Git
 mapping, exact-root rejected-no-request proof, package-state SQL, false
-`INDEX_ONLY`, capability callability, #340 reuse, budgets, and every issue
-acceptance criterion. Repair each blocking finding with a focused red-green
-commit and rerun the affected gate plus full Rust and Kotlin suites.
+`INDEX_ONLY`, project-model error/reason mapping, metadata failure, zero-module
+global partiality, candidate versus filter coverage, `EXACT` versus
+`KNOWN_MINIMUM`, hand-authored catalog ownership, Kotlin type isolation,
+scoped ownership guidance, capability callability, #340 reuse, budgets, and
+every issue acceptance criterion. Repair each blocking finding with a focused
+red-green commit and rerun the affected gate plus full Rust and Kotlin suites.

--- a/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
+++ b/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
@@ -1,0 +1,929 @@
+# Workspace File Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `kast agent workspace-files` as a bounded, typed, exact-root
+discovery command backed by compiler project-model and source-index evidence,
+with an uncapped internal inventory reusable by issue #340.
+
+**Architecture:** A new Rust `workspace_inventory` unit reads all available
+backend and exact-root index candidates without applying the public limit,
+then classifies cross-source drift and annotations conservatively. The public
+agent layer validates filters, applies deterministic bounds, projects ADR
+0020 result views, and uses a typed route registry to make capability
+advertisement depend on a callable Clap path.
+
+**Tech Stack:** Rust 2024, Clap, serde/serde_json, rusqlite, glob, Git porcelain
+v2, existing JSON/TOON output, tempfile-based integration fixtures, Markdown,
+and Zensical.
+
+## Global Constraints
+
+- Rebase this branch onto the merged issue #337 result before writing
+  production code; use its projection/view types instead of recreating them.
+- Do not change Kotlin request/response models, backend implementations,
+  analysis-server dispatch, source-index schema, generated RPC catalogs, or
+  generated protocol artifacts.
+- Keep `raw/workspace-files` internal; the public path is exactly
+  `kast agent workspace-files`.
+- Admit and report the exact normalized workspace root under ADR 0019.
+- Never use recursive filesystem discovery or a Git file list as candidate
+  authority.
+- Never emit `INDEX_ONLY` unless backend evidence proves exhaustive absence
+  for the relevant module/path.
+- Keep the internal inventory uncapped by public filters and `--limit`; retain
+  upstream backend truncation as typed partial evidence.
+- Default `--limit` to 20, reject values outside 1 through 200, and keep the
+  default compact result below 120 lines and 1,500 estimated tokens.
+- Preserve unrelated worktree changes and commit each red-green slice
+  independently with a conventional commit.
+- Add a scoped `AGENTS.md` for the new production ownership boundary and do
+  not add ADR/spec/plan files to published Zensical navigation.
+
+---
+
+### Task 1: Establish the typed public CLI boundary
+
+**Files:**
+
+- Modify: `cli-rs/src/cli/agent.rs`
+- Modify: `cli-rs/src/agent.rs`
+- Modify: `cli-rs/src/agent/dispatch.rs`
+- Modify: `cli-rs/src/agent/projection/view.rs`
+- Create: `cli-rs/src/agent/workspace_files.rs`
+- Create: `cli-rs/tests/agent_workspace_files_smoke.rs`
+- Modify: `cli-rs/tests/cli_core_smoke.rs`
+
+**Interfaces:**
+
+- Consumes: ADR 0020 `AgentResultView`, typed `AgentRuntimeArgs`, and the
+  existing agent envelope/output path.
+- Produces: `AgentCommand::WorkspaceFiles(AgentWorkspaceFilesArgs)`, typed
+  filter arguments, `AgentWorkspaceFilesField`, and a temporary structured
+  unavailable result that later tasks replace with inventory execution.
+
+- [ ] **Step 1: Write the failing public-command and usage tests**
+
+Add `workspace-files` to the visible agent-help assertion and remove it from
+the retired-alias list in `cli_core_smoke.rs`. In
+`agent_workspace_files_smoke.rs`, assert the command parses all documented
+filters and rejects invalid limits, parent traversal, absolute path prefixes,
+regex globs, blank selectors, and incompatible result-view flags:
+
+```rust
+#[test]
+fn workspace_files_is_public_and_rejects_untyped_bounds() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+
+    let help = kast(&home, &config_home)
+        .args(["agent", "workspace-files", "--help"])
+        .output()
+        .expect("workspace-files help");
+    assert!(help.status.success(), "{}", String::from_utf8_lossy(&help.stderr));
+
+    for invalid in [
+        vec!["--limit", "0"],
+        vec!["--limit", "201"],
+        vec!["--path-prefix", "../other"],
+        vec!["--path-prefix", "/absolute"],
+        vec!["--glob", "regex:.*\\.kt"],
+        vec!["--fields", "path", "--count"],
+    ] {
+        let output = kast(&home, &config_home)
+            .args(["agent", "workspace-files"])
+            .args(invalid)
+            .output()
+            .expect("invalid workspace-files command");
+        assert_eq!(output.status.code(), Some(2));
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused tests and observe the red state**
+
+Run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test cli_core_smoke smoke_core_cli_commands
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke workspace_files_is_public_and_rejects_untyped_bounds
+```
+
+Expected: the first test reports that `workspace-files` is still absent or
+retired, and the second fails because Clap does not recognize the command.
+
+- [ ] **Step 3: Add typed argument and field definitions**
+
+Add the command variant and these typed boundaries in `cli/agent.rs`. Keep
+validation in `FromStr` constructors, not in dispatch branches:
+
+```rust
+#[derive(Debug, Args, Clone)]
+pub struct AgentWorkspaceFilesArgs {
+    #[command(flatten)]
+    pub runtime: AgentRuntimeArgs,
+    #[arg(long)]
+    pub module: Option<WorkspaceModuleFilter>,
+    #[arg(long = "source-set")]
+    pub source_set: Option<WorkspaceSourceSetFilter>,
+    #[arg(long, value_enum)]
+    pub kind: Option<WorkspaceFileKindFilter>,
+    #[arg(long)]
+    pub package: Option<WorkspacePackageFilter>,
+    #[arg(long, value_enum)]
+    pub dirty: Option<WorkspaceDirtyFilter>,
+    #[arg(long, value_enum)]
+    pub drift: Option<WorkspaceDriftFilter>,
+    #[arg(long = "path-prefix")]
+    pub path_prefix: Option<WorkspacePathPrefix>,
+    #[arg(long)]
+    pub glob: Option<WorkspaceGlobFilter>,
+    #[arg(long, default_value_t = WorkspaceFileLimit::default())]
+    pub limit: WorkspaceFileLimit,
+    #[command(flatten)]
+    pub view: AgentWorkspaceFilesViewArgs,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum AgentWorkspaceFilesField {
+    Path,
+    Module,
+    SourceSet,
+    Kind,
+    Package,
+    Index,
+    Drift,
+    Dirty,
+    Evidence,
+}
+
+#[derive(Debug, Args, Clone, Default)]
+#[command(group(
+    clap::ArgGroup::new("workspace_files_result_view")
+        .multiple(false)
+        .args(["verbose", "explain", "fields", "count"])
+))]
+pub struct AgentWorkspaceFilesViewArgs {
+    #[arg(long)]
+    pub verbose: bool,
+    #[arg(long)]
+    pub explain: bool,
+    #[arg(long, value_enum, value_delimiter = ',', num_args = 1..)]
+    pub fields: Vec<AgentWorkspaceFilesField>,
+    #[arg(long)]
+    pub count: bool,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum WorkspaceDirtyFilter {
+    Clean,
+    Dirty,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum WorkspaceDriftFilter {
+    None,
+    FilesystemOnly,
+    IndexOnly,
+    MissingOnDisk,
+    Unknown,
+}
+```
+
+Use newtypes with private fields for module, source set, package, path prefix,
+glob, and limit. `WorkspaceFileLimit::from_str` must accept only 1 through 200.
+`WorkspacePathPrefix::from_str` must normalize slashes and reject root,
+absolute, `.`-only, and parent components. `WorkspaceGlobFilter::from_str`
+must reject `regex:` and compile `glob::Pattern` once.
+
+- [ ] **Step 4: Wire the command to a typed temporary failure**
+
+Add `execute_agent_workspace_files` to `agent/workspace_files.rs`, include it
+from `agent.rs`, add the exhaustive dispatch branch, and add a
+`WorkspaceFiles` projection request variant in `projection/view.rs`. Until the
+inventory exists, return:
+
+```rust
+error_envelope(
+    "agent/workspace-files".to_string(),
+    None,
+    agent_error(
+        "WORKSPACE_FILE_DISCOVERY_UNAVAILABLE",
+        "Workspace inventory collection is not available.",
+    ),
+)
+```
+
+This step exists only to make Clap and exhaustive Rust matches compile; do not
+claim discovery works yet.
+
+- [ ] **Step 5: Run the focused tests and verify green parsing behavior**
+
+Run the two commands from Step 2. Expected: both pass, and the command's valid
+invocation reaches the typed temporary execution error rather than a Clap
+unknown-command error.
+
+- [ ] **Step 6: Commit the CLI boundary**
+
+```console
+git add cli-rs/src/cli/agent.rs cli-rs/src/agent.rs cli-rs/src/agent/dispatch.rs cli-rs/src/agent/projection/view.rs cli-rs/src/agent/workspace_files.rs cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/cli_core_smoke.rs
+git commit -m "feat: add typed workspace file command boundary"
+```
+
+### Task 2: Build the uncapped exact-root source-index inventory
+
+**Files:**
+
+- Modify: `cli-rs/src/main.rs`
+- Create: `cli-rs/src/workspace_inventory.rs`
+- Create: `cli-rs/src/workspace_inventory/AGENTS.md`
+- Create: `cli-rs/src/workspace_inventory/model.rs`
+- Create: `cli-rs/src/workspace_inventory/index.rs`
+- Create: `cli-rs/src/workspace_inventory/tests.rs`
+- Modify: `cli-rs/tests/support/mod.rs`
+- Create: `cli-rs/tests/support/workspace_files.rs`
+
+**Interfaces:**
+
+- Consumes: `config::workspace_database_path`,
+  `source_index_db::configure_read_connection`,
+  `SOURCE_INDEX_SCHEMA_VERSION`, and the current index path-prefix encoding.
+- Produces: `WorkspaceRoot`, `WorkspaceFilePath`,
+  `WorkspaceIndexSnapshot`, `IndexedWorkspaceFile`, `WorkspaceIndexRead`, and
+  `read_workspace_index(&WorkspaceRoot) -> Result<WorkspaceIndexRead>`.
+
+- [ ] **Step 1: Add failing index-reader and type-invariant tests**
+
+Seed an exact-root database with indexed `.kt`, `.kts`, non-Kotlin, missing
+metadata, `__kast_rel__/`, `__kast_abs__/`, outside-root, and 500 Kotlin rows.
+Assert:
+
+```rust
+#[test]
+fn index_snapshot_is_uncapped_typed_and_exact_root() {
+    let fixture = WorkspaceInventoryFixture::new();
+    fixture.seed_index_rows(500);
+    fixture.seed_outside_root_row();
+    fixture.seed_non_kotlin_row();
+
+    let root = WorkspaceRoot::new(fixture.workspace()).expect("workspace root");
+    let WorkspaceIndexRead::Available(snapshot) =
+        read_workspace_index(&root).expect("index read")
+    else {
+        panic!("expected available index snapshot");
+    };
+
+    assert_eq!(snapshot.files.len(), 500);
+    assert!(snapshot.files.iter().all(|file| file.path.is_within(&root)));
+    assert!(snapshot.files.iter().any(|file| {
+        file.kind == WorkspaceFileKind::KotlinScript
+            && file.module.gradle_path() == Some(":build-logic")
+            && file.source_set.as_ref().is_some_and(|value| value.as_str() == "main")
+    }));
+    assert_eq!(snapshot.excluded_out_of_root_count, 1);
+}
+```
+
+Add separate tests for invalid schema, missing database, malformed package
+metadata, and `WorkspaceFilePath` rejecting traversal and symlink escape.
+
+- [ ] **Step 2: Run the unit filter and observe missing inventory types**
+
+Run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
+```
+
+Expected: compilation fails because `workspace_inventory` and its domain types
+do not exist.
+
+- [ ] **Step 3: Define the inventory domain model**
+
+Create a facade-only `workspace_inventory.rs` with explicit includes, and put
+the types in `model.rs`:
+
+```rust
+#[derive(Debug, Clone)]
+pub(crate) struct WorkspaceIndexSnapshot {
+    pub(crate) files: Vec<IndexedWorkspaceFile>,
+    pub(crate) excluded_out_of_root_count: usize,
+}
+
+#[derive(Debug)]
+pub(crate) enum WorkspaceIndexRead {
+    Available(WorkspaceIndexSnapshot),
+    Unavailable {
+        limitation: WorkspaceInventoryLimitation,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum WorkspaceInventoryLimitationCode {
+    BackendWorkspaceFilesUnavailable,
+    BackendEnumerationTruncated,
+    SourceIndexUnavailable,
+    SourceIndexSchemaUnsupported,
+    DirtyStateUnavailable,
+    PackageMetadataUnavailable,
+    WorkspacePathExcluded,
+    ProjectModelOwnershipUnknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkspaceInventoryLimitation {
+    pub(crate) code: WorkspaceInventoryLimitationCode,
+    pub(crate) message: String,
+    pub(crate) affected_count: usize,
+    pub(crate) module_names: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum WorkspaceFileKind {
+    KotlinSource,
+    KotlinScript,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum WorkspaceFileIndexState {
+    Indexed,
+    NotIndexed,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum WorkspaceFileDrift {
+    None,
+    FilesystemOnly,
+    IndexOnly,
+    MissingOnDisk,
+    Unknown,
+}
+```
+
+Add validated newtypes for the exact root, relative/absolute path pair,
+backend module name, Gradle module path, source set, and package. Expose only
+constructors that prove their invariants. Keep all fields private unless a
+consumer requires a read-only accessor.
+
+- [ ] **Step 4: Implement the read-only all-row index query**
+
+Open the configured database with
+`SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_URI`, configure the connection, verify the
+schema version and required tables, and run the exact SQL from the design.
+Decode paths through one function:
+
+```rust
+fn indexed_path(
+    root: &WorkspaceRoot,
+    dir_path: String,
+    filename: String,
+) -> Result<WorkspaceFilePath> {
+    let candidate = match dir_path.strip_prefix("__kast_abs__/") {
+        Some(absolute) => PathBuf::from(absolute).join(filename),
+        None => {
+            let relative = dir_path
+                .strip_prefix("__kast_rel__/")
+                .unwrap_or(&dir_path);
+            relative
+                .split('/')
+                .filter(|segment| !segment.is_empty())
+                .fold(root.as_path().to_path_buf(), PathBuf::join)
+                .join(filename)
+        }
+    };
+    WorkspaceFilePath::new(root, candidate)
+}
+```
+
+Read every row before returning. Do not accept a `limit` parameter. Map a
+missing or incompatible database to typed `IndexWorkspaceCoverage::Unavailable`
+evidence instead of an empty available snapshot.
+
+- [ ] **Step 5: Add the scoped source-ownership guide**
+
+Create `workspace_inventory/AGENTS.md` stating that this unit owns reusable,
+uncapped, exact-root candidate composition; source limits must remain explicit;
+public filtering/projection belongs in `agent`; and recursive filesystem/Git
+candidate discovery is prohibited. List the focused Rust test command.
+
+- [ ] **Step 6: Run focused tests and verify the uncapped snapshot**
+
+Run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
+```
+
+Expected: the high-cardinality test observes all 500 Kotlin rows, non-Kotlin
+and outside-root rows are excluded with evidence, and schema/path invariant
+tests pass.
+
+- [ ] **Step 7: Commit the internal index boundary**
+
+```console
+git add cli-rs/src/main.rs cli-rs/src/workspace_inventory.rs cli-rs/src/workspace_inventory cli-rs/tests/support/mod.rs cli-rs/tests/support/workspace_files.rs
+git commit -m "feat: add uncapped workspace index inventory"
+```
+
+### Task 3: Compose backend, filesystem, index, and dirty evidence
+
+**Files:**
+
+- Create: `cli-rs/src/workspace_inventory/backend.rs`
+- Create: `cli-rs/src/workspace_inventory/dirty.rs`
+- Create: `cli-rs/src/workspace_inventory/collect.rs`
+- Modify: `cli-rs/src/workspace_inventory/model.rs`
+- Modify: `cli-rs/src/workspace_inventory/tests.rs`
+- Modify: `cli-rs/src/workspace_inventory.rs`
+- Modify: `cli-rs/tests/support/workspace_files.rs`
+
+**Interfaces:**
+
+- Consumes: decoded `raw/workspace-files` result, `WorkspaceIndexSnapshot`,
+  exact-root candidate paths, targeted `symlink_metadata`, and Git porcelain
+  v2 output.
+- Produces:
+  `collect_workspace_inventory(WorkspaceInventoryInputs) -> Result<WorkspaceInventorySnapshot>`
+  with no public filters or result cap.
+
+- [ ] **Step 1: Write the failing drift truth-table tests**
+
+Construct typed inputs directly and assert every ADR row. The critical
+regressions are:
+
+```rust
+#[test]
+fn incomplete_backend_never_proves_index_only() {
+    for coverage in [
+        BackendWorkspaceCoverage::Truncated {
+            module_names: vec![BackendModuleName::new("app").expect("module")],
+        },
+        BackendWorkspaceCoverage::Unavailable {
+            code: WorkspaceInventoryLimitationCode::BackendWorkspaceFilesUnavailable,
+        },
+    ] {
+        let file = classify_candidate(candidate_inputs(|inputs| {
+            inputs.backend_present = false;
+            inputs.index_present = true;
+            inputs.filesystem_present = true;
+            inputs.backend_coverage = coverage;
+        }));
+        assert_eq!(file.index_state, WorkspaceFileIndexState::Indexed);
+        assert_eq!(file.drift, WorkspaceFileDrift::Unknown);
+    }
+}
+```
+
+Also prove backend-only present files are `FILESYSTEM_ONLY`, complete-backend
+index-only rows are `INDEX_ONLY`, agreed present rows are `NONE`, and missing
+paths are `MISSING_ON_DISK`.
+
+- [ ] **Step 2: Write failing Git and candidate-authority tests**
+
+Create a real temporary Git worktree containing clean, modified, added,
+deleted, renamed, untracked, and conflicted candidate paths. Assert porcelain
+v2 maps them to distinct `WorkspaceFileDirtyState` variants. Add an unowned
+`.kt` file that exists on disk and appears in Git status but in neither
+backend nor index inputs; assert it is absent from the inventory.
+
+- [ ] **Step 3: Run focused tests and observe missing composition**
+
+Run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
+```
+
+Expected: the new composition and dirty tests fail because the collector does
+not exist.
+
+- [ ] **Step 4: Decode and validate backend coverage**
+
+Deserialize the existing raw result into strict Rust input types carrying
+module name, source roots, dependency names, files, `filesTruncated`, and
+`fileCount`. Reject blank module names, invalid absolute paths, duplicate paths
+with conflicting module identities, a returned count greater than
+`fileCount`, and `filesTruncated=false` when the response contradicts its own
+count.
+
+Represent coverage as `Complete`, `Truncated { module_names }`, or
+`Unavailable { code }`. Preserve module records in the snapshot for #340; do
+not flatten source roots or dependency names into strings without their module
+owner.
+
+- [ ] **Step 5: Implement candidate union and conservative classification**
+
+Build the candidate key set exclusively from backend and index paths. Use this
+classification function after targeted filesystem evidence is known:
+
+```rust
+fn classify_drift(input: &CandidateClassificationInput) -> WorkspaceFileDrift {
+    if input.filesystem_state == WorkspaceFilesystemState::Missing {
+        return WorkspaceFileDrift::MissingOnDisk;
+    }
+    match (input.backend_present, input.index_present) {
+        (true, true) => WorkspaceFileDrift::None,
+        (true, false) if input.index_available => WorkspaceFileDrift::FilesystemOnly,
+        (false, true) if input.backend_proves_absence => WorkspaceFileDrift::IndexOnly,
+        (true, false) | (false, true) | (false, false) => WorkspaceFileDrift::Unknown,
+    }
+}
+```
+
+Set `backend_proves_absence` only for complete coverage of the associated
+module. If module association is missing while any backend module is
+truncated, set it false. Record `PROJECT_MODEL_OWNERSHIP_UNKNOWN` for those
+rows.
+
+- [ ] **Step 6: Implement targeted filesystem and Git annotation**
+
+Call `symlink_metadata` only for candidate paths. Canonicalize existing paths
+and exclude canonical targets outside the exact root. Run:
+
+```console
+git -C <workspace-root> status --porcelain=v2 -z --untracked-files=all
+```
+
+Parse record types `1`, `2`, `u`, and `?`, including the extra original path
+for rename records. Annotate only existing candidate keys. A successful Git
+snapshot makes absent candidate records `CLEAN`; command failure makes all
+states `UNKNOWN` and adds `DIRTY_STATE_UNAVAILABLE`.
+
+- [ ] **Step 7: Verify the full internal collector**
+
+Run the focused unit filter again. Expected: all drift, dirty-state, exact-root
+containment, no-filesystem-discovery, and uncapped snapshot tests pass.
+
+- [ ] **Step 8: Commit evidence composition**
+
+```console
+git add cli-rs/src/workspace_inventory.rs cli-rs/src/workspace_inventory cli-rs/tests/support/workspace_files.rs
+git commit -m "feat: compose typed workspace file evidence"
+```
+
+### Task 4: Execute and project bounded public discovery
+
+**Files:**
+
+- Modify: `cli-rs/src/agent/workspace_files.rs`
+- Modify: `cli-rs/src/agent/dispatch.rs`
+- Modify: `cli-rs/src/agent.rs`
+- Modify: `cli-rs/src/agent/projection.rs`
+- Modify: `cli-rs/src/agent/projection/view.rs`
+- Create: `cli-rs/src/agent/projection/workspace_files.rs`
+- Modify: `cli-rs/tests/agent_workspace_files_smoke.rs`
+- Modify: `cli-rs/tests/agent_result_projection_smoke.rs`
+
+**Interfaces:**
+
+- Consumes: admitted exact-root runtime session,
+  `collect_workspace_inventory`, typed `AgentWorkspaceFilesArgs`, and ADR 0020
+  result-view machinery.
+- Produces: `KAST_AGENT_WORKSPACE_FILES_RESULT`, selection, count, verbose, and
+  explain projections with deterministic filters and limits.
+
+- [ ] **Step 1: Add failing end-to-end discovery and filter tests**
+
+Use `spawn_sequenced_idea_backend` with `runtime/status`, `capabilities`, and
+`raw/workspace-files`, plus the index fixture. Assert the default record
+contains path, both module identities, source set, kind, package, index state,
+drift, and dirty state. Add one test per filter and one conjunction test. Assert
+the raw request is:
+
+```json
+{
+  "method": "raw/workspace-files",
+  "params": {"includeFiles": true}
+}
+```
+
+and does not pass the public `--limit` as `maxFilesPerModule`.
+
+- [ ] **Step 2: Add failing limitation and output-budget tests**
+
+Cover a truncated backend module, missing index, missing Git, backend
+capability absence, malformed backend payload, and both candidate sources
+unavailable. Seed 500 records and assert the default output has at most 20
+file records, no more than 120 lines, and no more than 1,500 estimated tokens.
+
+- [ ] **Step 3: Run focused public tests and observe the temporary error**
+
+Run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projection_smoke workspace_files
+```
+
+Expected: tests reach `WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` from Task 1 or
+fail because the projection is absent.
+
+- [ ] **Step 4: Implement exact-root collection and typed degradation**
+
+In `execute_agent_workspace_files`:
+
+1. call `runtime::semantic_workspace_route` and preserve its exact rejection;
+2. open one admitted raw RPC session;
+3. request and strictly decode `raw/workspace-files`;
+4. read the uncapped index snapshot;
+5. collect targeted filesystem and dirty evidence;
+6. return a detailed typed inventory result to the projection layer.
+
+Treat malformed backend JSON as `WORKSPACE_FILES_BACKEND_INVALID`. Treat
+capability absence as partial only when the index supplies candidates. Treat
+index absence as partial when the backend supplies candidates. Return
+`WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` when neither source is usable.
+
+- [ ] **Step 5: Apply typed filters, deterministic order, then public limit**
+
+Convert CLI arguments into `WorkspaceInventoryFilter` once. Match module
+against exact backend name or exact Gradle path, package and source set exactly,
+path prefix at segment boundaries, and glob against normalized relative path.
+Sort by relative path, Gradle module path, and backend module name before
+calling `take(limit.get())`.
+
+Populate page evidence as:
+
+```rust
+WorkspaceFilesPage {
+    known_match_count: filtered.len(),
+    returned_count: files.len(),
+    truncated: filtered.len() > files.len(),
+    inventory_complete: snapshot.is_complete(),
+    limit: args.limit.get(),
+}
+```
+
+Do not label `known_match_count` a total when `inventory_complete` is false.
+
+- [ ] **Step 6: Add all ADR 0020 projections**
+
+Add `AgentProjectionRequest::WorkspaceFiles` and project:
+
+- compact: required file fields, page, limitations;
+- fields: selected file fields plus type/ok/page/schema;
+- count: known counts grouped by kind/index/drift/dirty with no file payloads;
+- verbose: complete typed inventory and evidence sources; and
+- explain: verbose evidence plus normalized filters and classification source.
+
+Never put raw request/response envelopes into compact, fields, or count
+results. Preserve detailed typed backend/index errors in failed envelopes.
+
+- [ ] **Step 7: Run public and projection tests and verify green output**
+
+Run the commands from Step 3. Expected: all filters, limitation cases, view
+shapes, deterministic ordering, and budget assertions pass.
+
+- [ ] **Step 8: Commit public discovery and projections**
+
+```console
+git add cli-rs/src/agent.rs cli-rs/src/agent/dispatch.rs cli-rs/src/agent/workspace_files.rs cli-rs/src/agent/projection.rs cli-rs/src/agent/projection cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/agent_result_projection_smoke.rs
+git commit -m "feat: expose bounded workspace file discovery"
+```
+
+### Task 5: Couple capability advertisement to the callable route
+
+**Files:**
+
+- Create: `cli-rs/src/agent/public_capabilities.rs`
+- Modify: `cli-rs/src/agent.rs`
+- Modify: `cli-rs/src/agent/projection/verify.rs`
+- Modify: `cli-rs/src/agent/projection/tests.rs`
+- Modify: `cli-rs/tests/agent_workspace_files_smoke.rs`
+- Modify: `cli-rs/tests/agent_result_projection_smoke.rs`
+
+**Interfaces:**
+
+- Consumes: backend `readCapabilities`, `Cli::command()`, and the public
+  workspace-files command.
+- Produces: `AgentPublicCapabilityRoute`,
+  `callable_public_capabilities`, and verification `publicRead` route evidence.
+
+- [ ] **Step 1: Add failing registry and verification tests**
+
+Assert the registry contains exactly this initial route:
+
+```rust
+AgentPublicCapabilityRoute {
+    capability: AgentPublicCapability::WorkspaceFiles,
+    command_segments: &["agent", "workspace-files"],
+    display_command: "kast agent workspace-files",
+}
+```
+
+Walk `Cli::command()` through every segment and fail if any segment is absent
+or hidden. In verification projection tests, assert `WORKSPACE_FILES` produces
+one `publicRead` entry only when present in backend capabilities; omit it when
+the backend does not advertise it.
+
+- [ ] **Step 2: Run the focused projection tests and observe the missing route**
+
+Run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projection_smoke verify
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke capability
+```
+
+Expected: failures show no public capability registry or `publicRead`
+projection.
+
+- [ ] **Step 3: Implement the typed route registry**
+
+Define `AgentPublicCapability` as an enum and make its canonical backend string
+a total match. `callable_public_capabilities` intersects parsed backend read
+capabilities with the static registry and returns typed route projections.
+Verification keeps raw capability counts for runtime diagnosis but uses the
+intersection for public command evidence.
+
+- [ ] **Step 4: Verify callability and absence behavior**
+
+Run the two focused commands from Step 2. Expected: the route test resolves
+the real Clap command, advertised backend capability emits the public route,
+and absent backend capability emits no workspace discovery claim.
+
+- [ ] **Step 5: Commit the capability invariant**
+
+```console
+git add cli-rs/src/agent.rs cli-rs/src/agent/public_capabilities.rs cli-rs/src/agent/projection/verify.rs cli-rs/src/agent/projection/tests.rs cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/agent_result_projection_smoke.rs
+git commit -m "feat: couple workspace capability to public command"
+```
+
+### Task 6: Prove composition and teach the public path
+
+**Files:**
+
+- Modify: `cli-rs/tests/agent_workspace_files_smoke.rs`
+- Modify: `cli-rs/tests/support/workspace_files.rs`
+- Modify: `cli-rs/src/agent/AGENTS.md`
+- Modify: `cli-rs/resources/kast-skill/SKILL.md`
+- Modify: `cli-rs/resources/kast-skill/references/quickstart.md`
+- Modify: `docs/reference/agent-commands.md`
+- Modify: `docs/use/inspect-kotlin.md`
+
+**Interfaces:**
+
+- Consumes: stable `filePath`, workspace-files filters and limitations, typed
+  diagnostics, and exact symbol `--file-hint`.
+- Produces: executable no-search and composition regressions plus public and
+  packaged guidance aligned to the real command.
+
+- [ ] **Step 1: Add failing direct-composition regression**
+
+Run workspace discovery against the scripted backend, extract one returned
+`filePath`, then invoke:
+
+```console
+kast agent diagnostics --file-path <returned-file-path> --workspace-root <repo>
+kast agent symbol --query app.App --file-hint <returned-file-path> --workspace-root <repo>
+```
+
+Assert both backend requests receive the exact returned path. Keep an unowned
+on-disk `.kt` file in the fixture and assert it is never returned, proving the
+flow does not begin with generic filesystem discovery.
+
+- [ ] **Step 2: Run the composition test before documentation edits**
+
+Run:
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke composition
+```
+
+Expected: pass after Task 4. If it fails, repair the typed path composition
+before documenting the command.
+
+- [ ] **Step 3: Update source-ownership and packaged guidance**
+
+Add `workspace-files` to the public agent command list in
+`cli-rs/src/agent/AGENTS.md`. Teach this route in the packaged skill and
+quickstart:
+
+```console
+kast agent workspace-files --kind source --module :app --workspace-root "$PWD"
+kast agent workspace-files --kind script --drift unknown --workspace-root "$PWD" --explain
+```
+
+State that results are compiler/index evidence, that limitations make partial
+coverage explicit, and that agents should pass `filePath` directly to
+diagnostics or symbol `--file-hint`.
+
+- [ ] **Step 4: Update public reference and how-to docs**
+
+Document every flag, default/max limit, default result fields, result views,
+drift truth, limitation codes, and exact-root behavior in
+`docs/reference/agent-commands.md`. In `docs/use/inspect-kotlin.md`, replace the
+generic-search starting point with workspace-files discovery, then exact
+symbol lookup and diagnostics. Do not imply that #340 Gradle task symbol
+support exists yet.
+
+- [ ] **Step 5: Validate docs and packaged routing**
+
+Run:
+
+```console
+.github/scripts/test-docs-content-contract.sh
+.github/scripts/test-docs-navigation-contract.sh
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke composition
+zensical build --clean
+```
+
+Expected: every command example parses or is covered by existing command
+contracts, docs/navigation contracts pass, the packaged skill names the typed
+path, and Zensical renders without broken links.
+
+- [ ] **Step 6: Commit guidance and composition proof**
+
+```console
+git add cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/support/workspace_files.rs cli-rs/src/agent/AGENTS.md cli-rs/resources/kast-skill/SKILL.md cli-rs/resources/kast-skill/references/quickstart.md docs/reference/agent-commands.md docs/use/inspect-kotlin.md
+git commit -m "docs: teach semantic workspace file discovery"
+```
+
+### Task 7: Run full gates and prepare issue handoff
+
+**Files:**
+
+- Review: all files changed by Tasks 1 through 6
+- Update only when a gate proves drift: authored Rust, tests, or docs already
+  listed in this plan
+
+**Interfaces:**
+
+- Consumes: the complete issue #338 implementation.
+- Produces: fresh full-suite evidence, a clean focused diff, and a branch ready
+  for independent review and PR publication.
+
+- [ ] **Step 1: Run the focused issue gates from ADR 0021**
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projection_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test cli_core_smoke
+```
+
+Expected: all focused tests pass with zero ignored failures.
+
+- [ ] **Step 2: Run the full Rust quality gates**
+
+```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked
+cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
+cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
+```
+
+Expected: the full locked suite passes, formatting reports no changes, and
+clippy emits no warnings.
+
+- [ ] **Step 3: Prove generated raw contracts did not drift**
+
+```console
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+git diff --exit-code -- cli-rs/protocol cli-rs/resources/kast-skill/references/commands.json cli-rs/resources/kast-skill/references/commands.yaml
+```
+
+Expected: the contract checker passes and generated raw protocol/catalog files
+remain unchanged.
+
+- [ ] **Step 4: Run final documentation gates**
+
+```console
+.github/scripts/test-docs-content-contract.sh
+.github/scripts/test-docs-navigation-contract.sh
+zensical build --clean
+```
+
+Expected: both contracts and rendering pass.
+
+- [ ] **Step 5: Review scope and whitespace**
+
+```console
+git status --short --branch
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+git diff --name-only origin/main...HEAD
+```
+
+Expected: only issue #338 source, tests, guidance, ADR/spec/plan, and docs are
+present; there are no Kotlin wire/schema or generated protocol/catalog changes;
+the worktree is clean after commits.
+
+- [ ] **Step 6: Request independent review**
+
+Ask a fresh reviewer to check type invariants, exact-root containment, no
+recursive/Git candidate authority, the false-`INDEX_ONLY` rule under partial
+backend coverage, capability callability, #340 reuse, output budgets, and all
+acceptance criteria. Repair every blocking finding with a focused red-green
+commit and rerun the affected gate plus the full Rust suite.

--- a/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
+++ b/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
@@ -6,46 +6,265 @@
 > checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Ship `kast agent workspace-files` as a bounded, typed, exact-root
-discovery command backed by compiler project-model and source-index evidence,
-with an uncapped internal inventory reusable by issue #340.
+discovery command backed by exhaustively paged compiler/project-model evidence
+and the `.kt`-only source index, with `.kts` candidates reusable by issue #340's
+separate Gradle DSL index.
 
-**Architecture:** A new Rust `workspace_inventory` unit reads all available
-backend and exact-root index candidates without applying the public limit,
-then classifies cross-source drift and annotations conservatively. The public
-agent layer validates filters, applies deterministic bounds, projects ADR
-0020 result views, and uses a typed route registry to make capability
-advertisement depend on a callable Clap path.
+**Architecture:** Kotlin adds canonical per-module workspace-file paging and an
+IDEA project-model inventory for `.kt` and `.kts`. Rust exhausts every module
+page, unions physical paths while retaining all module owners, joins `.kt`
+index evidence, maps Git porcelain from repository root to the admitted root,
+then applies public filters, projections, and bounds.
 
-**Tech Stack:** Rust 2024, Clap, serde/serde_json, rusqlite, glob, Git porcelain
-v2, existing JSON/TOON output, tempfile-based integration fixtures, Markdown,
-and Zensical.
+**Tech Stack:** Kotlin/JVM, kotlinx.serialization, IntelliJ Platform and Gradle
+project model, Rust 2024, Clap, serde/serde_json, rusqlite, glob, Git porcelain
+v2, tempfile integration fixtures, Markdown, and Zensical.
 
 ## Global Constraints
 
-- Rebase this branch onto the merged issue #337 result before writing
-  production code; use its projection/view types instead of recreating them.
-- Do not change Kotlin request/response models, backend implementations,
-  analysis-server dispatch, source-index schema, generated RPC catalogs, or
-  generated protocol artifacts.
+- Rebase onto merged issue #337 before production work and reuse its result
+  views instead of recreating them.
+- Preserve the `.kt`-only `SourceIndexFilePolicy`; #340 owns the separate
+  Gradle DSL index and consumes `.kts` candidates from backend inventory.
 - Keep `raw/workspace-files` internal; the public path is exactly
   `kast agent workspace-files`.
 - Admit and report the exact normalized workspace root under ADR 0019.
-- Never use recursive filesystem discovery or a Git file list as candidate
-  authority.
-- Never emit `INDEX_ONLY` unless backend evidence proves exhaustive absence
-  for the relevant module/path.
-- Keep the internal inventory uncapped by public filters and `--limit`; retain
-  upstream backend truncation as typed partial evidence.
-- Default `--limit` to 20, reject values outside 1 through 200, and keep the
-  default compact result below 120 lines and 1,500 estimated tokens.
+- Never use recursive filesystem discovery or Git as candidate authority.
+  Targeted root build/settings lookups are allowed only for roots proved by the
+  linked Gradle project model.
+- Exhaust every valid backend module page before claiming that module complete.
+  Incomplete possible owners can never prove `INDEX_ONLY`.
+- Model physical-file backend and indexed module ownership as sorted sets.
+- Keep the internal inventory uncapped by public filters and `--limit`.
+- Default `--limit` to 20, reject values outside 1 through 200, and keep compact
+  output below 120 lines and 1,500 estimated tokens.
+- Change Kotlin wire/backend/generated contracts when required by paging;
+  regenerate them from their source owners.
+- Add or update scoped `AGENTS.md` whenever source ownership or validation gates
+  change. Do not publish ADR/spec/plan files in Zensical navigation.
+- Execute tasks sequentially when they edit shared agent/projection files. The
+  primary agent reviews every delegated result and runs final verification.
 - Preserve unrelated worktree changes and commit each red-green slice
   independently with a conventional commit.
-- Add a scoped `AGENTS.md` for the new production ownership boundary and do
-  not add ADR/spec/plan files to published Zensical navigation.
 
 ---
 
-### Task 1: Establish the typed public CLI boundary
+### Task 1: Add typed deterministic raw workspace-file paging
+
+**Files:**
+
+- Modify: `analysis-api/AGENTS.md`
+- Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/query/WorkspaceFilesQuery.kt`
+- Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceFilesResult.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceModule.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/WorkspaceFilePageOffset.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedWorkspaceFilesQuery.kt`
+- Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedModels.kt`
+- Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt`
+- Modify: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/ParsedModelsTest.kt`
+- Modify: `analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt`
+- Modify: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/RpcAnalysisDispatcher.kt`
+- Modify: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt`
+
+**Interfaces:**
+
+- Produces: `WorkspaceFilePageOffset`,
+  `ParsedWorkspaceFilesQuery.pageOffset`, `WorkspaceModule.returnedFileCount`,
+  `WorkspaceModule.nextPageToken`, and explicit `WorkspaceModule.contentRoots`.
+- Invariant: a page token is canonical positive decimal text and is legal only
+  with `includeFiles=true` and one exact module.
+
+- [ ] **Step 1: Write failing query and server tests**
+
+Add parsing cases for token `"2"` and rejection of `"0"`, `"02"`, `"-1"`,
+non-numeric text, token without module, token with `includeFiles=false`, and a
+page size above server `maxResults`. Add fake-backend tests for two pages over
+five sorted files:
+
+```kotlin
+val first = backend.workspaceFiles(
+    WorkspaceFilesQuery(
+        moduleName = "main",
+        includeFiles = true,
+        maxFilesPerModule = 2,
+    ),
+)
+val second = backend.workspaceFiles(
+    WorkspaceFilesQuery(
+        moduleName = "main",
+        includeFiles = true,
+        maxFilesPerModule = 2,
+        pageToken = first.modules.single().nextPageToken,
+    ),
+)
+assertEquals(5, first.modules.single().fileCount)
+assertEquals("2", first.modules.single().nextPageToken)
+assertEquals("4", second.modules.single().nextPageToken)
+assertTrue(first.modules.single().files.intersect(second.modules.single().files.toSet()).isEmpty())
+```
+
+- [ ] **Step 2: Run the focused red tests**
+
+```console
+./gradlew :analysis-api:test --tests '*ParsedModelsTest*workspace*' :analysis-server:test --tests '*AnalysisDispatcherTest*workspace*' --no-daemon
+```
+
+Expected: compilation fails because paging fields/types do not exist.
+
+- [ ] **Step 3: Extract and implement the typed query boundary**
+
+Move `ParsedWorkspaceFilesQuery` out of `ParsedModels.kt` to satisfy top-level
+type isolation. Add:
+
+```kotlin
+@JvmInline
+value class WorkspaceFilePageOffset private constructor(val value: Int) {
+    companion object {
+        fun parse(raw: String): WorkspaceFilePageOffset {
+            val parsed = raw.toIntOrNull()
+            require(parsed != null && parsed > 0 && raw == parsed.toString()) {
+                "Workspace file page tokens must be canonical positive offsets"
+            }
+            return WorkspaceFilePageOffset(parsed)
+        }
+    }
+}
+```
+
+Add `pageToken: String?` to `WorkspaceFilesQuery`. Parse once into
+`WorkspaceFilePageOffset?`; reject token-without-module and
+token-without-files at the validation boundary. Keep the server's positive
+page-size and maximum checks.
+
+- [ ] **Step 4: Isolate and extend the result type**
+
+Move `WorkspaceModule` to its matching file and add:
+
+```kotlin
+val contentRoots: List<String> = emptyList()
+val returnedFileCount: Int = files.size
+val nextPageToken: String? = null
+```
+
+Validate in tests that returned count equals `files.size`, `fileCount` is never
+smaller, and next tokens advance by returned count without exceeding total.
+Validate source/content roots are sorted and deduplicated. Update skill response
+types and fake backend with the same sort-before-slice contract.
+
+- [ ] **Step 5: Run Kotlin paging tests green**
+
+Run the Step 2 command. Expected: all paging, validation, and non-overlap tests
+pass.
+
+- [ ] **Step 6: Update source ownership and commit**
+
+Record query/result/generated ownership and paging gates in
+`analysis-api/AGENTS.md`.
+
+```console
+git add analysis-api analysis-server
+git diff --cached --check
+git commit -m "feat: page raw workspace file results"
+```
+
+### Task 2: Enumerate project-model Kotlin sources and scripts
+
+**Files:**
+
+- Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventory.kt`
+- Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileModuleSnapshot.kt`
+- Create: `backend-idea/src/main/java/io/github/amichne/kast/idea/IdeaGradleWorkspaceFileBridge.java`
+- Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt`
+- Create: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventoryTest.kt`
+- Modify: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt`
+- Verify unchanged: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/SourceIndexFilePolicy.kt`
+- Verify unchanged: `index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SourceIndexFilePolicyTest.kt`
+
+**Interfaces:**
+
+- Produces:
+  `IdeaWorkspaceFileInventory.snapshots(): List<IdeaWorkspaceFileModuleSnapshot>`.
+- Each snapshot has one backend module, sorted contained source/content roots,
+  sorted dependency names, and a complete sorted set of project-model `.kt`
+  and `.kts` paths.
+
+- [ ] **Step 1: Write failing project-model inventory tests**
+
+Create one IDEA fixture containing:
+
+- root `settings.gradle.kts` and `build.gradle.kts`;
+- `build-logic/src/main/kotlin/convention.gradle.kts`;
+- `scripts/release.main.kts`;
+- an included build with its own settings/build scripts;
+- one `.kt` shared by two module content roots; and
+- an outside-root `.kts` exposed by a test project scope.
+
+Assert the first five categories are candidates, the shared file appears in
+both module snapshots, and the outside path is absent.
+
+- [ ] **Step 2: Run the focused red backend test**
+
+```console
+./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --no-daemon
+```
+
+Expected: compilation fails because the inventory does not exist.
+
+- [ ] **Step 3: Implement model-backed candidate collection**
+
+Use `FileTypeIndex` with project and module content scopes for compiler-visible
+Kotlin files. Use `ModuleRootManager` content/source roots to retain every
+owner. The Java bridge reads `GradleSettings.linkedProjectsSettings` and
+returns normalized external project roots and root-module associations. For
+each model-proven root, look up only `settings.gradle.kts` and
+`build.gradle.kts`; do not walk directories.
+
+Project-scope `.kts` files under a contained module root acquire all containing
+module owners. A contained linked-root script without a content-root owner
+acquires every root module associated with that linked root. If the bridge
+cannot associate the linked root with any backend root module, fail the request
+as incomplete project-model evidence. Canonical containment is mandatory before
+ownership is recorded.
+
+- [ ] **Step 4: Page sorted inventory in the backend**
+
+Replace cap-before-sort logic with:
+
+```kotlin
+val allFiles = snapshot.filePaths.sorted()
+val offset = query.pageOffset?.value ?: 0
+require(offset <= allFiles.size)
+val files = if (query.includeFiles) allFiles.drop(offset).take(fileLimit) else emptyList()
+val nextOffset = offset + files.size
+val nextToken = nextOffset.takeIf { query.includeFiles && it < allFiles.size }?.toString()
+```
+
+Exact module requests page one snapshot. Metadata requests return every sorted
+module. Populate stable counts/tokens on every page.
+
+- [ ] **Step 5: Prove scripts, multiple owners, and pages**
+
+Run:
+
+```console
+./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --tests '*KastPluginBackendContractTest*workspace files*' --no-daemon
+./gradlew :index-store:test --tests '*SourceIndexFilePolicyTest*' --no-daemon
+```
+
+Expected: project scripts and shared ownership pass; the index-store test still
+proves `.kts` rejection.
+
+- [ ] **Step 6: Commit backend authority**
+
+```console
+git add backend-idea
+git diff --cached --check
+git commit -m "feat: enumerate project model Kotlin scripts"
+```
+
+Do not stage either source-index policy file; both are verification-only.
+
+### Task 3: Establish the typed public CLI boundary
 
 **Files:**
 
@@ -59,183 +278,61 @@ and Zensical.
 
 **Interfaces:**
 
-- Consumes: ADR 0020 `AgentResultView`, typed `AgentRuntimeArgs`, and the
-  existing agent envelope/output path.
-- Produces: `AgentCommand::WorkspaceFiles(AgentWorkspaceFilesArgs)`, typed
-  filter arguments, `AgentWorkspaceFilesField`, and a temporary structured
-  unavailable result that later tasks replace with inventory execution.
+- Produces: `AgentCommand::WorkspaceFiles`, typed filters,
+  `AgentWorkspaceFilesField`, and a temporary typed unavailable result.
+- Consumes: ADR 0020 `AgentResultView` and existing `AgentRuntimeArgs`.
 
-- [ ] **Step 1: Write the failing public-command and usage tests**
+- [ ] **Step 1: Write failing command/help/argument tests**
 
-Add `workspace-files` to the visible agent-help assertion and remove it from
-the retired-alias list in `cli_core_smoke.rs`. In
-`agent_workspace_files_smoke.rs`, assert the command parses all documented
-filters and rejects invalid limits, parent traversal, absolute path prefixes,
-regex globs, blank selectors, and incompatible result-view flags:
+Move `workspace-files` from retired aliases to visible agent commands. Assert
+all documented flags parse and reject limit `0`/`201`, absolute or parent path
+prefixes, `regex:` globs, blank selectors, and incompatible result views.
+Include `--drift not-applicable`.
 
-```rust
-#[test]
-fn workspace_files_is_public_and_rejects_untyped_bounds() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let home = temp.path().join("home");
-    let config_home = temp.path().join("config");
-
-    let help = kast(&home, &config_home)
-        .args(["agent", "workspace-files", "--help"])
-        .output()
-        .expect("workspace-files help");
-    assert!(help.status.success(), "{}", String::from_utf8_lossy(&help.stderr));
-
-    for invalid in [
-        vec!["--limit", "0"],
-        vec!["--limit", "201"],
-        vec!["--path-prefix", "../other"],
-        vec!["--path-prefix", "/absolute"],
-        vec!["--glob", "regex:.*\\.kt"],
-        vec!["--fields", "path", "--count"],
-    ] {
-        let output = kast(&home, &config_home)
-            .args(["agent", "workspace-files"])
-            .args(invalid)
-            .output()
-            .expect("invalid workspace-files command");
-        assert_eq!(output.status.code(), Some(2));
-    }
-}
-```
-
-- [ ] **Step 2: Run the focused tests and observe the red state**
-
-Run:
+- [ ] **Step 2: Run the red command tests**
 
 ```console
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test cli_core_smoke smoke_core_cli_commands
-cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke workspace_files_is_public_and_rejects_untyped_bounds
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke workspace_files_is_public
 ```
 
-Expected: the first test reports that `workspace-files` is still absent or
-retired, and the second fails because Clap does not recognize the command.
+Expected: Clap does not recognize `workspace-files`.
 
-- [ ] **Step 3: Add typed argument and field definitions**
+- [ ] **Step 3: Add typed args and filters**
 
-Add the command variant and these typed boundaries in `cli/agent.rs`. Keep
-validation in `FromStr` constructors, not in dispatch branches:
+Add `AgentWorkspaceFilesArgs` with `AgentRuntimeArgs`, the family-specific
+ADR 0020 view args, optional module/source-set/kind/package/dirty/drift/path
+prefix/glob filters, and `WorkspaceFileLimit`. Use private-field newtypes and
+`FromStr` validation. The drift enum is:
 
 ```rust
-#[derive(Debug, Args, Clone)]
-pub struct AgentWorkspaceFilesArgs {
-    #[command(flatten)]
-    pub runtime: AgentRuntimeArgs,
-    #[arg(long)]
-    pub module: Option<WorkspaceModuleFilter>,
-    #[arg(long = "source-set")]
-    pub source_set: Option<WorkspaceSourceSetFilter>,
-    #[arg(long, value_enum)]
-    pub kind: Option<WorkspaceFileKindFilter>,
-    #[arg(long)]
-    pub package: Option<WorkspacePackageFilter>,
-    #[arg(long, value_enum)]
-    pub dirty: Option<WorkspaceDirtyFilter>,
-    #[arg(long, value_enum)]
-    pub drift: Option<WorkspaceDriftFilter>,
-    #[arg(long = "path-prefix")]
-    pub path_prefix: Option<WorkspacePathPrefix>,
-    #[arg(long)]
-    pub glob: Option<WorkspaceGlobFilter>,
-    #[arg(long, default_value_t = WorkspaceFileLimit::default())]
-    pub limit: WorkspaceFileLimit,
-    #[command(flatten)]
-    pub view: AgentWorkspaceFilesViewArgs,
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
-pub enum AgentWorkspaceFilesField {
-    Path,
-    Module,
-    SourceSet,
-    Kind,
-    Package,
-    Index,
-    Drift,
-    Dirty,
-    Evidence,
-}
-
-#[derive(Debug, Args, Clone, Default)]
-#[command(group(
-    clap::ArgGroup::new("workspace_files_result_view")
-        .multiple(false)
-        .args(["verbose", "explain", "fields", "count"])
-))]
-pub struct AgentWorkspaceFilesViewArgs {
-    #[arg(long)]
-    pub verbose: bool,
-    #[arg(long)]
-    pub explain: bool,
-    #[arg(long, value_enum, value_delimiter = ',', num_args = 1..)]
-    pub fields: Vec<AgentWorkspaceFilesField>,
-    #[arg(long)]
-    pub count: bool,
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
-pub enum WorkspaceDirtyFilter {
-    Clean,
-    Dirty,
-    Unknown,
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum WorkspaceDriftFilter {
     None,
     FilesystemOnly,
     IndexOnly,
     MissingOnDisk,
+    NotApplicable,
     Unknown,
 }
 ```
 
-Use newtypes with private fields for module, source set, package, path prefix,
-glob, and limit. `WorkspaceFileLimit::from_str` must accept only 1 through 200.
-`WorkspacePathPrefix::from_str` must normalize slashes and reject root,
-absolute, `.`-only, and parent components. `WorkspaceGlobFilter::from_str`
-must reject `regex:` and compile `glob::Pattern` once.
+- [ ] **Step 4: Wire a typed temporary failure**
 
-- [ ] **Step 4: Wire the command to a typed temporary failure**
+Add exhaustive dispatch and projection request branches, but return
+`WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` until inventory exists. Do not claim
+discovery works.
 
-Add `execute_agent_workspace_files` to `agent/workspace_files.rs`, include it
-from `agent.rs`, add the exhaustive dispatch branch, and add a
-`WorkspaceFiles` projection request variant in `projection/view.rs`. Until the
-inventory exists, return:
+- [ ] **Step 5: Run command parsing green and commit**
 
-```rust
-error_envelope(
-    "agent/workspace-files".to_string(),
-    None,
-    agent_error(
-        "WORKSPACE_FILE_DISCOVERY_UNAVAILABLE",
-        "Workspace inventory collection is not available.",
-    ),
-)
-```
-
-This step exists only to make Clap and exhaustive Rust matches compile; do not
-claim discovery works yet.
-
-- [ ] **Step 5: Run the focused tests and verify green parsing behavior**
-
-Run the two commands from Step 2. Expected: both pass, and the command's valid
-invocation reaches the typed temporary execution error rather than a Clap
-unknown-command error.
-
-- [ ] **Step 6: Commit the CLI boundary**
+Run Step 2, then:
 
 ```console
 git add cli-rs/src/cli/agent.rs cli-rs/src/agent.rs cli-rs/src/agent/dispatch.rs cli-rs/src/agent/projection/view.rs cli-rs/src/agent/workspace_files.rs cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/cli_core_smoke.rs
+git diff --cached --check
 git commit -m "feat: add typed workspace file command boundary"
 ```
 
-### Task 2: Build the uncapped exact-root source-index inventory
+### Task 4: Build the uncapped `.kt` source-index inventory
 
 **Files:**
 
@@ -250,193 +347,78 @@ git commit -m "feat: add typed workspace file command boundary"
 
 **Interfaces:**
 
-- Consumes: `config::workspace_database_path`,
-  `source_index_db::configure_read_connection`,
-  `SOURCE_INDEX_SCHEMA_VERSION`, and the current index path-prefix encoding.
 - Produces: `WorkspaceRoot`, `WorkspaceFilePath`,
-  `WorkspaceIndexSnapshot`, `IndexedWorkspaceFile`, `WorkspaceIndexRead`, and
-  `read_workspace_index(&WorkspaceRoot) -> Result<WorkspaceIndexRead>`.
+  `WorkspaceIndexSnapshot`, `WorkspacePackageEvidence`,
+  `WorkspaceIndexRead`, and `read_workspace_index(&WorkspaceRoot)`.
+- The index reader has no public limit and returns `.kt` rows only.
 
-- [ ] **Step 1: Add failing index-reader and type-invariant tests**
+- [ ] **Step 1: Write failing schema, path, and package-state tests**
 
-Seed an exact-root database with indexed `.kt`, `.kts`, non-Kotlin, missing
-metadata, `__kast_rel__/`, `__kast_abs__/`, outside-root, and 500 Kotlin rows.
-Assert:
+Seed 500 `.kt` rows plus non-Kotlin, `.kts`, relative-escape, absolute,
+outside-root, and symlink-escape rows. Add four package cases:
 
-```rust
-#[test]
-fn index_snapshot_is_uncapped_typed_and_exact_root() {
-    let fixture = WorkspaceInventoryFixture::new();
-    fixture.seed_index_rows(500);
-    fixture.seed_outside_root_row();
-    fixture.seed_non_kotlin_row();
+1. no `file_metadata` row;
+2. metadata with null `package_fq_id`;
+3. metadata with a joined package name; and
+4. metadata with dangling `package_fq_id`.
 
-    let root = WorkspaceRoot::new(fixture.workspace()).expect("workspace root");
-    let WorkspaceIndexRead::Available(snapshot) =
-        read_workspace_index(&root).expect("index read")
-    else {
-        panic!("expected available index snapshot");
-    };
+Assert 500 valid `.kt` candidates, zero `.kts`, exact package variants, and
+typed excluded/invalid counts.
 
-    assert_eq!(snapshot.files.len(), 500);
-    assert!(snapshot.files.iter().all(|file| file.path.is_within(&root)));
-    assert!(snapshot.files.iter().any(|file| {
-        file.kind == WorkspaceFileKind::KotlinScript
-            && file.module.gradle_path() == Some(":build-logic")
-            && file.source_set.as_ref().is_some_and(|value| value.as_str() == "main")
-    }));
-    assert_eq!(snapshot.excluded_out_of_root_count, 1);
-}
-```
-
-Add separate tests for invalid schema, missing database, malformed package
-metadata, and `WorkspaceFilePath` rejecting traversal and symlink escape.
-
-- [ ] **Step 2: Run the unit filter and observe missing inventory types**
-
-Run:
+- [ ] **Step 2: Run the red inventory tests**
 
 ```console
 cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
 ```
 
-Expected: compilation fails because `workspace_inventory` and its domain types
-do not exist.
+Expected: compilation fails because inventory types do not exist.
 
-- [ ] **Step 3: Define the inventory domain model**
+- [ ] **Step 3: Define the invariant-carrying model**
 
-Create a facade-only `workspace_inventory.rs` with explicit includes, and put
-the types in `model.rs`:
+Use sorted sets for owners and source sets:
 
 ```rust
-#[derive(Debug, Clone)]
-pub(crate) struct WorkspaceIndexSnapshot {
-    pub(crate) files: Vec<IndexedWorkspaceFile>,
-    pub(crate) excluded_out_of_root_count: usize,
-}
-
-#[derive(Debug)]
-pub(crate) enum WorkspaceIndexRead {
-    Available(WorkspaceIndexSnapshot),
-    Unavailable {
-        limitation: WorkspaceInventoryLimitation,
-    },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub(crate) enum WorkspaceInventoryLimitationCode {
-    BackendWorkspaceFilesUnavailable,
-    BackendEnumerationTruncated,
-    SourceIndexUnavailable,
-    SourceIndexSchemaUnsupported,
-    DirtyStateUnavailable,
-    PackageMetadataUnavailable,
-    WorkspacePathExcluded,
-    ProjectModelOwnershipUnknown,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct WorkspaceInventoryLimitation {
-    pub(crate) code: WorkspaceInventoryLimitationCode,
-    pub(crate) message: String,
-    pub(crate) affected_count: usize,
-    pub(crate) module_names: Vec<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub(crate) enum WorkspaceFileKind {
-    KotlinSource,
-    KotlinScript,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub(crate) enum WorkspaceFileIndexState {
-    Indexed,
-    NotIndexed,
-    Unknown,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub(crate) enum WorkspaceFileDrift {
-    None,
-    FilesystemOnly,
-    IndexOnly,
-    MissingOnDisk,
-    Unknown,
+pub(crate) struct WorkspaceInventoryFile {
+    path: WorkspaceFilePath,
+    backend_modules: BTreeSet<BackendModuleName>,
+    indexed_gradle_modules: BTreeSet<GradleModulePath>,
+    source_sets: BTreeSet<WorkspaceSourceSet>,
+    kind: WorkspaceFileKind,
+    package: WorkspacePackageEvidence,
+    index_state: WorkspaceFileIndexState,
+    drift: WorkspaceFileDrift,
+    dirty_state: WorkspaceFileDirtyState,
+    evidence: BTreeSet<WorkspaceEvidenceSource>,
 }
 ```
 
-Add validated newtypes for the exact root, relative/absolute path pair,
-backend module name, Gradle module path, source set, and package. Expose only
-constructors that prove their invariants. Keep all fields private unless a
-consumer requires a read-only accessor.
+Include `NotApplicable` in source-index state and drift. Keep fields private
+with read-only accessors required by agent/#340 consumers.
 
-- [ ] **Step 4: Implement the read-only all-row index query**
+- [ ] **Step 4: Implement the read-only query exactly from the design**
 
-Open the configured database with
-`SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_URI`, configure the connection, verify the
-schema version and required tables, and run the exact SQL from the design.
-Decode paths through one function:
+Select `metadata_present`, `package_fq_id`, and joined `fq_name` separately.
+Use `SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_URI`, configure query-only access,
+verify schema/tables, decode existing path prefixes, reject non-`.kt`, and map
+the four package states without collapsing nulls.
 
-```rust
-fn indexed_path(
-    root: &WorkspaceRoot,
-    dir_path: String,
-    filename: String,
-) -> Result<WorkspaceFilePath> {
-    let candidate = match dir_path.strip_prefix("__kast_abs__/") {
-        Some(absolute) => PathBuf::from(absolute).join(filename),
-        None => {
-            let relative = dir_path
-                .strip_prefix("__kast_rel__/")
-                .unwrap_or(&dir_path);
-            relative
-                .split('/')
-                .filter(|segment| !segment.is_empty())
-                .fold(root.as_path().to_path_buf(), PathBuf::join)
-                .join(filename)
-        }
-    };
-    WorkspaceFilePath::new(root, candidate)
-}
-```
+- [ ] **Step 5: Add the scoped ownership guide and verify**
 
-Read every row before returning. Do not accept a `limit` parameter. Map a
-missing or incompatible database to typed `IndexWorkspaceCoverage::Unavailable`
-evidence instead of an empty available snapshot.
+State that this unit owns uncapped exact-root composition, `.kt` index reads,
+set-valued owners, backend page coverage, and Git annotation. Prohibit `.kts`
+source-index reads and filesystem/Git candidate enumeration.
 
-- [ ] **Step 5: Add the scoped source-ownership guide**
+Run Step 2. Expected: all 500 rows and package/path invariants pass.
 
-Create `workspace_inventory/AGENTS.md` stating that this unit owns reusable,
-uncapped, exact-root candidate composition; source limits must remain explicit;
-public filtering/projection belongs in `agent`; and recursive filesystem/Git
-candidate discovery is prohibited. List the focused Rust test command.
-
-- [ ] **Step 6: Run focused tests and verify the uncapped snapshot**
-
-Run:
-
-```console
-cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
-```
-
-Expected: the high-cardinality test observes all 500 Kotlin rows, non-Kotlin
-and outside-root rows are excluded with evidence, and schema/path invariant
-tests pass.
-
-- [ ] **Step 7: Commit the internal index boundary**
+- [ ] **Step 6: Commit the index boundary**
 
 ```console
 git add cli-rs/src/main.rs cli-rs/src/workspace_inventory.rs cli-rs/src/workspace_inventory cli-rs/tests/support/mod.rs cli-rs/tests/support/workspace_files.rs
-git commit -m "feat: add uncapped workspace index inventory"
+git diff --cached --check
+git commit -m "feat: add uncapped Kotlin source inventory"
 ```
 
-### Task 3: Compose backend, filesystem, index, and dirty evidence
+### Task 5: Exhaust backend pages and compose ownership, drift, and Git evidence
 
 **Files:**
 
@@ -447,132 +429,104 @@ git commit -m "feat: add uncapped workspace index inventory"
 - Modify: `cli-rs/src/workspace_inventory/tests.rs`
 - Modify: `cli-rs/src/workspace_inventory.rs`
 - Modify: `cli-rs/tests/support/workspace_files.rs`
+- Modify: `cli-rs/tests/agent_workspace_files_smoke.rs`
+- Modify: `cli-rs/tests/semantic_workspace_admission_smoke.rs`
 
 **Interfaces:**
 
-- Consumes: decoded `raw/workspace-files` result, `WorkspaceIndexSnapshot`,
-  exact-root candidate paths, targeted `symlink_metadata`, and Git porcelain
-  v2 output.
 - Produces:
-  `collect_workspace_inventory(WorkspaceInventoryInputs) -> Result<WorkspaceInventorySnapshot>`
-  with no public filters or result cap.
+  `collect_workspace_inventory(WorkspaceInventoryInputs) -> Result<WorkspaceInventorySnapshot>`.
+- Backend collection uses one admitted `RawRpcSession`, exact-module paging,
+  and typed `BackendModuleCoverage`.
 
-- [ ] **Step 1: Write the failing drift truth-table tests**
+- [ ] **Step 1: Write failing page-exhaustion and multi-owner tests**
 
-Construct typed inputs directly and assert every ADR row. The critical
-regressions are:
+Script three pages for one module and two pages for a second. Repeat one
+physical path in both modules. Assert every page is requested in order, the
+physical record has both owners, pages do not overlap, and all modules are
+complete. Add failures for repeated/non-advancing tokens, changed totals,
+overlap, missing module, and a page failure after earlier successes; only the
+affected module becomes partial.
 
-```rust
-#[test]
-fn incomplete_backend_never_proves_index_only() {
-    for coverage in [
-        BackendWorkspaceCoverage::Truncated {
-            module_names: vec![BackendModuleName::new("app").expect("module")],
-        },
-        BackendWorkspaceCoverage::Unavailable {
-            code: WorkspaceInventoryLimitationCode::BackendWorkspaceFilesUnavailable,
-        },
-    ] {
-        let file = classify_candidate(candidate_inputs(|inputs| {
-            inputs.backend_present = false;
-            inputs.index_present = true;
-            inputs.filesystem_present = true;
-            inputs.backend_coverage = coverage;
-        }));
-        assert_eq!(file.index_state, WorkspaceFileIndexState::Indexed);
-        assert_eq!(file.drift, WorkspaceFileDrift::Unknown);
-    }
-}
+- [ ] **Step 2: Write failing drift tests**
+
+Prove:
+
+- `.kts` backend candidates are `NOT_APPLICABLE` to source index/drift;
+- backend-only `.kt` is `FILESYSTEM_ONLY`;
+- complete-owner index-only `.kt` is `INDEX_ONLY`;
+- any partial overlapping owner makes it `UNKNOWN`; and
+- missing files are `MISSING_ON_DISK` with independent index state.
+
+- [ ] **Step 3: Write nested Git mapping tests**
+
+Create a repository with an admitted Gradle workspace below the Git top level
+and set `status.relativePaths=true` in its config. Cover modified, added,
+deleted, untracked, conflicted, inside-to-inside rename, outside-to-inside
+rename, and inside-to-outside rename. Assert the adapter's explicit
+`status.relativePaths=false` override makes porcelain paths repository-root
+relative, the exact workspace prefix is stripped, and only contained endpoints
+annotate candidates. A successful mapped snapshot alone may assign `CLEAN`.
+
+- [ ] **Step 4: Add the root-A/root-B exact-root regression**
+
+In both smoke files, configure root A with only root B's ready descriptor and
+source-index database. Invoke:
+
+```console
+kast agent workspace-files --workspace-root <root-a> --backend idea
 ```
 
-Also prove backend-only present files are `FILESYSTEM_ONLY`, complete-backend
-index-only rows are `INDEX_ONLY`, agreed present rows are `NONE`, and missing
-paths are `MISSING_ON_DISK`.
+Assert the typed exact-root rejection, zero `raw/workspace-files` requests,
+and no read/open observation for root B's database. This is a rejected-no-request
+test, not merely an output-path assertion.
 
-- [ ] **Step 2: Write failing Git and candidate-authority tests**
-
-Create a real temporary Git worktree containing clean, modified, added,
-deleted, renamed, untracked, and conflicted candidate paths. Assert porcelain
-v2 maps them to distinct `WorkspaceFileDirtyState` variants. Add an unowned
-`.kt` file that exists on disk and appears in Git status but in neither
-backend nor index inputs; assert it is absent from the inventory.
-
-- [ ] **Step 3: Run focused tests and observe missing composition**
-
-Run:
+- [ ] **Step 5: Run the focused red tests**
 
 ```console
 cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test semantic_workspace_admission_smoke workspace_files
 ```
 
-Expected: the new composition and dirty tests fail because the collector does
-not exist.
+Expected: paging, composition, Git, and exact-root cases fail because the
+collector is absent.
 
-- [ ] **Step 4: Decode and validate backend coverage**
+- [ ] **Step 6: Implement strict backend paging**
 
-Deserialize the existing raw result into strict Rust input types carrying
-module name, source roots, dependency names, files, `filesTruncated`, and
-`fileCount`. Reject blank module names, invalid absolute paths, duplicate paths
-with conflicting module identities, a returned count greater than
-`fileCount`, and `filesTruncated=false` when the response contradicts its own
-count.
+Fetch module metadata, sort exact module names, and request pages until each
+returns no next token. Validate total/returned counts, canonical advancement,
+module identity, non-overlap, and containment before merging. Preserve
+duplicate physical paths as one record with a `BTreeSet` of owners. A failed
+page records `BackendModuleCoverage::Partial`; it never silently truncates.
 
-Represent coverage as `Complete`, `Truncated { module_names }`, or
-`Unavailable { code }`. Preserve module records in the snapshot for #340; do
-not flatten source roots or dependency names into strings without their module
-owner.
+- [ ] **Step 7: Implement conservative composition**
 
-- [ ] **Step 5: Implement candidate union and conservative classification**
+Candidate keys come only from backend pages and `.kt` index rows. For index-only
+`.kt`, associate all canonical containing module roots; `INDEX_ONLY` requires
+every possible owner complete. Unknown or overlapping partial ownership emits
+`PROJECT_MODEL_OWNERSHIP_UNKNOWN`. `.kts` never queries the source index and
+uses `NotApplicable` states.
 
-Build the candidate key set exclusively from backend and index paths. Use this
-classification function after targeted filesystem evidence is known:
+- [ ] **Step 8: Implement exact-root Git mapping**
 
-```rust
-fn classify_drift(input: &CandidateClassificationInput) -> WorkspaceFileDrift {
-    if input.filesystem_state == WorkspaceFilesystemState::Missing {
-        return WorkspaceFileDrift::MissingOnDisk;
-    }
-    match (input.backend_present, input.index_present) {
-        (true, true) => WorkspaceFileDrift::None,
-        (true, false) if input.index_available => WorkspaceFileDrift::FilesystemOnly,
-        (false, true) if input.backend_proves_absence => WorkspaceFileDrift::IndexOnly,
-        (true, false) | (false, true) | (false, false) => WorkspaceFileDrift::Unknown,
-    }
-}
-```
+Resolve Git top level, prove containment, run porcelain v2 with
+`-c status.relativePaths=false` and `-- .`, and map both current and original
+paths from repository root through the exact workspace prefix. Parse records
+`1`, `2`, `u`, and `?`. Invalid bytes or mapping failure produces
+`DirtyWorkspaceCoverage::Unavailable`.
 
-Set `backend_proves_absence` only for complete coverage of the associated
-module. If module association is missing while any backend module is
-truncated, set it false. Record `PROJECT_MODEL_OWNERSHIP_UNKNOWN` for those
-rows.
+- [ ] **Step 9: Run focused tests green and commit**
 
-- [ ] **Step 6: Implement targeted filesystem and Git annotation**
-
-Call `symlink_metadata` only for candidate paths. Canonicalize existing paths
-and exclude canonical targets outside the exact root. Run:
+Run Step 5, then:
 
 ```console
-git -C <workspace-root> status --porcelain=v2 -z --untracked-files=all
+git add cli-rs/src/workspace_inventory.rs cli-rs/src/workspace_inventory cli-rs/tests/support/workspace_files.rs cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/semantic_workspace_admission_smoke.rs
+git diff --cached --check
+git commit -m "feat: compose exhaustive workspace file evidence"
 ```
 
-Parse record types `1`, `2`, `u`, and `?`, including the extra original path
-for rename records. Annotate only existing candidate keys. A successful Git
-snapshot makes absent candidate records `CLEAN`; command failure makes all
-states `UNKNOWN` and adds `DIRTY_STATE_UNAVAILABLE`.
-
-- [ ] **Step 7: Verify the full internal collector**
-
-Run the focused unit filter again. Expected: all drift, dirty-state, exact-root
-containment, no-filesystem-discovery, and uncapped snapshot tests pass.
-
-- [ ] **Step 8: Commit evidence composition**
-
-```console
-git add cli-rs/src/workspace_inventory.rs cli-rs/src/workspace_inventory cli-rs/tests/support/workspace_files.rs
-git commit -m "feat: compose typed workspace file evidence"
-```
-
-### Task 4: Execute and project bounded public discovery
+### Task 6: Project bounded public discovery and callable capability evidence
 
 **Files:**
 
@@ -582,122 +536,7 @@ git commit -m "feat: compose typed workspace file evidence"
 - Modify: `cli-rs/src/agent/projection.rs`
 - Modify: `cli-rs/src/agent/projection/view.rs`
 - Create: `cli-rs/src/agent/projection/workspace_files.rs`
-- Modify: `cli-rs/tests/agent_workspace_files_smoke.rs`
-- Modify: `cli-rs/tests/agent_result_projection_smoke.rs`
-
-**Interfaces:**
-
-- Consumes: admitted exact-root runtime session,
-  `collect_workspace_inventory`, typed `AgentWorkspaceFilesArgs`, and ADR 0020
-  result-view machinery.
-- Produces: `KAST_AGENT_WORKSPACE_FILES_RESULT`, selection, count, verbose, and
-  explain projections with deterministic filters and limits.
-
-- [ ] **Step 1: Add failing end-to-end discovery and filter tests**
-
-Use `spawn_sequenced_idea_backend` with `runtime/status`, `capabilities`, and
-`raw/workspace-files`, plus the index fixture. Assert the default record
-contains path, both module identities, source set, kind, package, index state,
-drift, and dirty state. Add one test per filter and one conjunction test. Assert
-the raw request is:
-
-```json
-{
-  "method": "raw/workspace-files",
-  "params": {"includeFiles": true}
-}
-```
-
-and does not pass the public `--limit` as `maxFilesPerModule`.
-
-- [ ] **Step 2: Add failing limitation and output-budget tests**
-
-Cover a truncated backend module, missing index, missing Git, backend
-capability absence, malformed backend payload, and both candidate sources
-unavailable. Seed 500 records and assert the default output has at most 20
-file records, no more than 120 lines, and no more than 1,500 estimated tokens.
-
-- [ ] **Step 3: Run focused public tests and observe the temporary error**
-
-Run:
-
-```console
-cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke
-cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projection_smoke workspace_files
-```
-
-Expected: tests reach `WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` from Task 1 or
-fail because the projection is absent.
-
-- [ ] **Step 4: Implement exact-root collection and typed degradation**
-
-In `execute_agent_workspace_files`:
-
-1. call `runtime::semantic_workspace_route` and preserve its exact rejection;
-2. open one admitted raw RPC session;
-3. request and strictly decode `raw/workspace-files`;
-4. read the uncapped index snapshot;
-5. collect targeted filesystem and dirty evidence;
-6. return a detailed typed inventory result to the projection layer.
-
-Treat malformed backend JSON as `WORKSPACE_FILES_BACKEND_INVALID`. Treat
-capability absence as partial only when the index supplies candidates. Treat
-index absence as partial when the backend supplies candidates. Return
-`WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` when neither source is usable.
-
-- [ ] **Step 5: Apply typed filters, deterministic order, then public limit**
-
-Convert CLI arguments into `WorkspaceInventoryFilter` once. Match module
-against exact backend name or exact Gradle path, package and source set exactly,
-path prefix at segment boundaries, and glob against normalized relative path.
-Sort by relative path, Gradle module path, and backend module name before
-calling `take(limit.get())`.
-
-Populate page evidence as:
-
-```rust
-WorkspaceFilesPage {
-    known_match_count: filtered.len(),
-    returned_count: files.len(),
-    truncated: filtered.len() > files.len(),
-    inventory_complete: snapshot.is_complete(),
-    limit: args.limit.get(),
-}
-```
-
-Do not label `known_match_count` a total when `inventory_complete` is false.
-
-- [ ] **Step 6: Add all ADR 0020 projections**
-
-Add `AgentProjectionRequest::WorkspaceFiles` and project:
-
-- compact: required file fields, page, limitations;
-- fields: selected file fields plus type/ok/page/schema;
-- count: known counts grouped by kind/index/drift/dirty with no file payloads;
-- verbose: complete typed inventory and evidence sources; and
-- explain: verbose evidence plus normalized filters and classification source.
-
-Never put raw request/response envelopes into compact, fields, or count
-results. Preserve detailed typed backend/index errors in failed envelopes.
-
-- [ ] **Step 7: Run public and projection tests and verify green output**
-
-Run the commands from Step 3. Expected: all filters, limitation cases, view
-shapes, deterministic ordering, and budget assertions pass.
-
-- [ ] **Step 8: Commit public discovery and projections**
-
-```console
-git add cli-rs/src/agent.rs cli-rs/src/agent/dispatch.rs cli-rs/src/agent/workspace_files.rs cli-rs/src/agent/projection.rs cli-rs/src/agent/projection cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/agent_result_projection_smoke.rs
-git commit -m "feat: expose bounded workspace file discovery"
-```
-
-### Task 5: Couple capability advertisement to the callable route
-
-**Files:**
-
 - Create: `cli-rs/src/agent/public_capabilities.rs`
-- Modify: `cli-rs/src/agent.rs`
 - Modify: `cli-rs/src/agent/projection/verify.rs`
 - Modify: `cli-rs/src/agent/projection/tests.rs`
 - Modify: `cli-rs/tests/agent_workspace_files_smoke.rs`
@@ -705,14 +544,20 @@ git commit -m "feat: expose bounded workspace file discovery"
 
 **Interfaces:**
 
-- Consumes: backend `readCapabilities`, `Cli::command()`, and the public
-  workspace-files command.
-- Produces: `AgentPublicCapabilityRoute`,
-  `callable_public_capabilities`, and verification `publicRead` route evidence.
+- Produces: `KAST_AGENT_WORKSPACE_FILES_RESULT` views and
+  `AgentPublicCapabilityRoute` for `WORKSPACE_FILES`.
 
-- [ ] **Step 1: Add failing registry and verification tests**
+- [ ] **Step 1: Write failing output, filter, limitation, and budget tests**
 
-Assert the registry contains exactly this initial route:
+Assert compact records contain sorted owner sets, source sets, kind, structured
+package evidence, source-index state, drift, dirty state, and paths. Cover each
+filter and conjunction; partial pages, unavailable index/Git, invalid package
+reference, and both candidate sources unavailable. Seed 500 records and assert
+20 default records, at most 120 lines, and at most 1,500 estimated tokens.
+
+- [ ] **Step 2: Write failing capability route tests**
+
+Define the expected initial route:
 
 ```rust
 AgentPublicCapabilityRoute {
@@ -722,50 +567,58 @@ AgentPublicCapabilityRoute {
 }
 ```
 
-Walk `Cli::command()` through every segment and fail if any segment is absent
-or hidden. In verification projection tests, assert `WORKSPACE_FILES` produces
-one `publicRead` entry only when present in backend capabilities; omit it when
-the backend does not advertise it.
+Assert the registry path resolves through `Cli::command()`. Verification emits
+public-read evidence only when backend `WORKSPACE_FILES` and the route both
+exist.
 
-- [ ] **Step 2: Run the focused projection tests and observe the missing route**
-
-Run:
+- [ ] **Step 3: Run focused red tests**
 
 ```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projection_smoke workspace_files
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projection_smoke verify
-cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke capability
 ```
 
-Expected: failures show no public capability registry or `publicRead`
-projection.
+- [ ] **Step 4: Execute admitted collection and apply typed filters**
 
-- [ ] **Step 3: Implement the typed route registry**
+Call `semantic_workspace_route`, copy the admitted root/backend into runtime
+args, open one raw session, collect the uncapped snapshot, then filter. Match
+module against any owner, sort by relative path and sorted owner sets, and only
+then take `limit`.
 
-Define `AgentPublicCapability` as an enum and make its canonical backend string
-a total match. `callable_public_capabilities` intersects parsed backend read
-capabilities with the static registry and returns typed route projections.
-Verification keeps raw capability counts for runtime diagnosis but uses the
-intersection for public command evidence.
+- [ ] **Step 5: Add compact, fields, count, verbose, and explain projections**
 
-- [ ] **Step 4: Verify callability and absence behavior**
+Compact and selected views never contain raw envelopes. Count groups known
+records by kind/index/drift/dirty. Verbose adds per-module page coverage;
+explain adds normalized query and classification evidence. Preserve typed
+backend/index failures in failed envelopes.
 
-Run the two focused commands from Step 2. Expected: the route test resolves
-the real Clap command, advertised backend capability emits the public route,
-and absent backend capability emits no workspace discovery claim.
+- [ ] **Step 6: Implement the route registry and verification intersection**
 
-- [ ] **Step 5: Commit the capability invariant**
+Use one typed enum-to-backend-capability match. Keep raw capability counts for
+diagnosis, but expose public command evidence only through the registry
+intersection. #342 extends this owner rather than creating another list.
+
+- [ ] **Step 7: Run focused tests green and commit**
+
+Run Step 3, then:
 
 ```console
-git add cli-rs/src/agent.rs cli-rs/src/agent/public_capabilities.rs cli-rs/src/agent/projection/verify.rs cli-rs/src/agent/projection/tests.rs cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/agent_result_projection_smoke.rs
-git commit -m "feat: couple workspace capability to public command"
+git add cli-rs/src/agent.rs cli-rs/src/agent cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/agent_result_projection_smoke.rs
+git diff --cached --check
+git commit -m "feat: expose bounded workspace file discovery"
 ```
 
-### Task 6: Prove composition and teach the public path
+### Task 7: Regenerate contracts, prove composition, and teach the public path
 
 **Files:**
 
+- Regenerate: `cli-rs/protocol/`
+- Regenerate: `cli-rs/resources/kast-skill/references/commands.json`
+- Regenerate: `cli-rs/resources/kast-skill/references/commands.yaml`
+- Regenerate: `cli-rs/resources/kast-skill/references/requests/raw/workspace-files/`
+- Modify: `cli-rs/tests/rpc_catalog_smoke.rs`
 - Modify: `cli-rs/tests/agent_workspace_files_smoke.rs`
-- Modify: `cli-rs/tests/support/workspace_files.rs`
 - Modify: `cli-rs/src/agent/AGENTS.md`
 - Modify: `cli-rs/resources/kast-skill/SKILL.md`
 - Modify: `cli-rs/resources/kast-skill/references/quickstart.md`
@@ -774,109 +627,80 @@ git commit -m "feat: couple workspace capability to public command"
 
 **Interfaces:**
 
-- Consumes: stable `filePath`, workspace-files filters and limitations, typed
-  diagnostics, and exact symbol `--file-hint`.
-- Produces: executable no-search and composition regressions plus public and
-  packaged guidance aligned to the real command.
+- Produces generated paging contracts, public/package guidance, and direct
+  diagnostics/symbol composition proof.
 
-- [ ] **Step 1: Add failing direct-composition regression**
+- [ ] **Step 1: Regenerate Kotlin-owned protocol artifacts**
 
-Run workspace discovery against the scripted backend, extract one returned
-`filePath`, then invoke:
+Run the repository generators, then prove raw request schemas include
+`pageToken` and module results include returned count/next token:
 
 ```console
-kast agent diagnostics --file-path <returned-file-path> --workspace-root <repo>
-kast agent symbol --query app.App --file-hint <returned-file-path> --workspace-root <repo>
+./gradlew :analysis-server:generateDocPages --no-daemon
+cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test rpc_catalog_smoke
 ```
 
-Assert both backend requests receive the exact returned path. Keep an unowned
-on-disk `.kt` file in the fixture and assert it is never returned, proving the
-flow does not begin with generic filesystem discovery.
+- [ ] **Step 2: Add direct composition regression**
 
-- [ ] **Step 2: Run the composition test before documentation edits**
+Run workspace discovery, extract one `filePath`, then invoke diagnostics and
+symbol `--file-hint`. Assert both backend requests receive exactly that path.
+Keep an unowned on-disk `.kt` file and assert it is absent.
 
-Run:
+- [ ] **Step 3: Update ownership and packaged guidance**
 
-```console
-cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke composition
-```
+Add the command to `cli-rs/src/agent/AGENTS.md`. Teach source/script filters,
+partial limitations, owner sets, and direct path composition. State explicitly
+that `.kts` is not in the Kotlin source index and Gradle semantic declarations
+arrive with #340.
 
-Expected: pass after Task 4. If it fails, repair the typed path composition
-before documenting the command.
+- [ ] **Step 4: Update reference and how-to docs**
 
-- [ ] **Step 3: Update source-ownership and packaged guidance**
+Document every flag, limit, result view, owner set, package state, drift/index
+truth table, limitations, exact-root behavior, and paging-backed completeness.
+Replace generic-search-first guidance with `workspace-files`, then diagnostics
+or exact symbol lookup.
 
-Add `workspace-files` to the public agent command list in
-`cli-rs/src/agent/AGENTS.md`. Teach this route in the packaged skill and
-quickstart:
-
-```console
-kast agent workspace-files --kind source --module :app --workspace-root "$PWD"
-kast agent workspace-files --kind script --drift unknown --workspace-root "$PWD" --explain
-```
-
-State that results are compiler/index evidence, that limitations make partial
-coverage explicit, and that agents should pass `filePath` directly to
-diagnostics or symbol `--file-hint`.
-
-- [ ] **Step 4: Update public reference and how-to docs**
-
-Document every flag, default/max limit, default result fields, result views,
-drift truth, limitation codes, and exact-root behavior in
-`docs/reference/agent-commands.md`. In `docs/use/inspect-kotlin.md`, replace the
-generic-search starting point with workspace-files discovery, then exact
-symbol lookup and diagnostics. Do not imply that #340 Gradle task symbol
-support exists yet.
-
-- [ ] **Step 5: Validate docs and packaged routing**
-
-Run:
+- [ ] **Step 5: Validate guidance and commit**
 
 ```console
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke --test agent_workspace_files_smoke --test rpc_catalog_smoke
 .github/scripts/test-docs-content-contract.sh
 .github/scripts/test-docs-navigation-contract.sh
-cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
-cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke composition
 zensical build --clean
-```
-
-Expected: every command example parses or is covered by existing command
-contracts, docs/navigation contracts pass, the packaged skill names the typed
-path, and Zensical renders without broken links.
-
-- [ ] **Step 6: Commit guidance and composition proof**
-
-```console
-git add cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/support/workspace_files.rs cli-rs/src/agent/AGENTS.md cli-rs/resources/kast-skill/SKILL.md cli-rs/resources/kast-skill/references/quickstart.md docs/reference/agent-commands.md docs/use/inspect-kotlin.md
+git diff --check
+git add cli-rs/protocol cli-rs/resources cli-rs/tests/rpc_catalog_smoke.rs cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/src/agent/AGENTS.md docs
+git diff --cached --check
 git commit -m "docs: teach semantic workspace file discovery"
 ```
 
-### Task 7: Run full gates and prepare issue handoff
+### Task 8: Run full gates and prepare issue handoff
 
 **Files:**
 
-- Review: all files changed by Tasks 1 through 6
-- Update only when a gate proves drift: authored Rust, tests, or docs already
-  listed in this plan
+- Review: all issue #338 changes
+- Update only when a gate proves drift in files already owned by this plan
 
-**Interfaces:**
-
-- Consumes: the complete issue #338 implementation.
-- Produces: fresh full-suite evidence, a clean focused diff, and a branch ready
-  for independent review and PR publication.
-
-- [ ] **Step 1: Run the focused issue gates from ADR 0021**
+- [ ] **Step 1: Run focused Rust gates**
 
 ```console
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_files_smoke
 cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projection_smoke
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test cli_core_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test semantic_workspace_admission_smoke
 ```
 
-Expected: all focused tests pass with zero ignored failures.
+- [ ] **Step 2: Run Kotlin and source-index authority gates**
 
-- [ ] **Step 2: Run the full Rust quality gates**
+```console
+./gradlew :analysis-api:test :analysis-server:test :index-store:test :backend-idea:test --no-daemon
+```
+
+Expected: paging/project-model tests pass and `.kts` remains rejected by
+`SourceIndexFilePolicyTest`.
+
+- [ ] **Step 3: Run full Rust quality gates**
 
 ```console
 cargo test --manifest-path cli-rs/Cargo.toml --locked
@@ -884,28 +708,14 @@ cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
 ```
 
-Expected: the full locked suite passes, formatting reports no changes, and
-clippy emits no warnings.
-
-- [ ] **Step 3: Prove generated raw contracts did not drift**
+- [ ] **Step 4: Prove generated contracts and docs are current**
 
 ```console
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
-git diff --exit-code -- cli-rs/protocol cli-rs/resources/kast-skill/references/commands.json cli-rs/resources/kast-skill/references/commands.yaml
-```
-
-Expected: the contract checker passes and generated raw protocol/catalog files
-remain unchanged.
-
-- [ ] **Step 4: Run final documentation gates**
-
-```console
 .github/scripts/test-docs-content-contract.sh
 .github/scripts/test-docs-navigation-contract.sh
 zensical build --clean
 ```
-
-Expected: both contracts and rendering pass.
 
 - [ ] **Step 5: Review scope and whitespace**
 
@@ -916,14 +726,14 @@ git diff --check origin/main...HEAD
 git diff --name-only origin/main...HEAD
 ```
 
-Expected: only issue #338 source, tests, guidance, ADR/spec/plan, and docs are
-present; there are no Kotlin wire/schema or generated protocol/catalog changes;
-the worktree is clean after commits.
+Expected: issue source/tests/guidance/ADR/spec/plan and required generated
+contracts only; no source-index schema or `SourceIndexFilePolicy` change.
 
 - [ ] **Step 6: Request independent review**
 
-Ask a fresh reviewer to check type invariants, exact-root containment, no
-recursive/Git candidate authority, the false-`INDEX_ONLY` rule under partial
-backend coverage, capability callability, #340 reuse, output budgets, and all
-acceptance criteria. Repair every blocking finding with a focused red-green
-commit and rerun the affected gate plus the full Rust suite.
+Ask a fresh reviewer to check paging determinism, project-model script
+authority, `.kt`-only source-index preservation, multi-owner physical files,
+nested Git mapping, exact-root rejected-no-request proof, package-state SQL,
+false `INDEX_ONLY`, capability callability, #340 reuse, budgets, and every issue
+acceptance criterion. Repair each blocking finding with a focused red-green
+commit and rerun the affected gate plus full Rust and Kotlin suites.

--- a/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
+++ b/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
@@ -1,21 +1,22 @@
 # Workspace File Discovery Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use
-> superpowers:subagent-driven-development (recommended) or
-> superpowers:executing-plans to implement this plan task-by-task. Steps use
-> checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** Follow the root `AGENTS.md` Sub-Agent Delegation
+> contract. The primary agent may delegate concrete independent tasks, remains
+> responsible for integration and review, and runs final verification. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Ship `kast agent workspace-files` as a bounded, typed, exact-root
 discovery command backed by exhaustively paged compiler/project-model evidence
 and the `.kt`-only source index, with `.kts` candidates reusable by issue #340's
 separate Gradle DSL index.
 
-**Architecture:** Kotlin adds opaque generation-bound per-module workspace-file
-paging and an IDEA project-model inventory for `.kt` and `.kts`. Rust exhausts
-one coherent workspace generation, unions physical paths while retaining all
-module owners, joins `.kt` index evidence, maps Git porcelain from repository
-root to the admitted root, then applies public filters, projections, and
-bounds.
+**Architecture:** Kotlin adds shared server-held opaque continuation state,
+generation-bound per-module workspace-file paging, and an IDEA project-model
+inventory for `.kt` and `.kts`. Rust exhausts backend pages, reads
+generation/progress/pending-aware `.kt` index evidence, and accepts the
+composition only after backend, index, targeted filesystem, and Git stamps pass
+a bounded stability barrier. It then applies public filters, projections,
+bounds, and query-bound continuation.
 
 **Tech Stack:** Kotlin/JVM, kotlinx.serialization, IntelliJ Platform and Gradle
 project model, Rust 2024, Clap, serde/serde_json, rusqlite, glob, Git porcelain
@@ -36,9 +37,15 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Exhaust every valid backend module page from one workspace generation before
   claiming that module complete. Incomplete possible owners can never prove
   `INDEX_ONLY`.
-- Treat snapshot and page tokens as opaque server-owned values. Bind cursors to
-  generation, exact module, and offset; never construct or advance them in
-  Rust.
+- Reuse one typed server-held opaque continuation store for ADR 0020 and
+  workspace-file raw/public paging. Give it positive TTL/capacity limits,
+  deterministic eviction, single-use page handles, query binding, and typed
+  malformed/forged/unknown/expired failures. Rust never decodes handle state.
+  Use distinct token/state namespaces and typed instances of the same generic
+  mechanism; never mix continuation families in one untyped map.
+- Rust page validation is limited to non-repeated handles, non-overlapping
+  physical paths, and cumulative returned evidence; generation/module/offset
+  integrity belongs to the server-held state.
 - Reuse ADR 0020's discriminated `EXACT | KNOWN_MINIMUM` cardinality. Keep
   candidate-inventory and selected-filter evidence coverage separate; neither
   a bare count nor a completeness boolean may imply exact filtered matches.
@@ -49,6 +56,18 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Keep the internal inventory uncapped by public filters and `--limit`.
 - Default `--limit` to 20, reject values outside 1 through 200, and keep compact
   output below 120 lines and 1,500 estimated tokens.
+- Return a public `nextPageToken` when more known filtered results remain. Bind
+  it to the coherent composition stamp and every result-affecting query field;
+  never restart mismatched or stale continuation at page one.
+- Read source-index generation, module progress, and pending updates with the
+  candidate rows. Increment generation transactionally on relevant writes and
+  require complete progress plus zero pending updates before exact coverage.
+- Prove missing paths by canonicalizing their deepest existing ancestor.
+  Exclude and type any containment that cannot be proved.
+- Revalidate backend, source-index, targeted filesystem, and Git stamps after
+  composition. Retry the entire attempt once when a lane moves; a second change
+  or stable incomplete lane forbids `EXACT`. Enforce a ceiling of two
+  composition attempts with at most two backend-generation attempts each.
 - Change Kotlin wire/backend/generated contracts when required by paging;
   regenerate them from their source owners.
 - Treat `commands.json` as the hand-authored internal catalog source; regenerate
@@ -72,12 +91,19 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Modify: `analysis-api/AGENTS.md`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/query/WorkspaceFilesQuery.kt`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceFilesResult.kt`
+- Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/ServerLimits.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceModule.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/WorkspaceFileSnapshotToken.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/WorkspaceFilePageToken.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ServerHeldContinuationStore.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationTtl.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationCapacity.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationClock.kt`
+- Create: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/continuation/ServerHeldContinuationStoreTest.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedWorkspaceFilesQuery.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/WorkspaceInventoryStaleException.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/InvalidWorkspaceFileCursorException.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/InvalidWorkspaceFileCursorScope.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/WorkspaceProjectModelIncompleteException.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/WorkspaceProjectModelIncompleteReason.kt`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedModels.kt`
@@ -86,6 +112,7 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastWorkspaceFilesResponse.kt`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt`
 - Modify: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/ParsedModelsTest.kt`
+- Create: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/ServerLimitsTest.kt`
 - Modify: `analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt`
 - Modify: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/RpcAnalysisDispatcher.kt`
 - Modify: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt`
@@ -100,16 +127,22 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Produces: `WorkspaceProjectModelIncompleteException` with stable
   `WORKSPACE_PROJECT_MODEL_INCOMPLETE` code and typed
   `WorkspaceProjectModelIncompleteReason` details.
-- Invariant: snapshot and page tokens are opaque to clients. An input snapshot
-  token is legal only with `includeFiles=true` and one exact module; a page
-  token additionally requires that snapshot token.
+- Produces: reusable `ServerHeldContinuationStore<Token, Query, State>` with
+  typed positive TTL/capacity, injected clock, deterministic eviction,
+  reusable leases, and single-use consumption.
+- Invariant: snapshot and page tokens are canonical random UUID handles, not
+  encoded state. An input snapshot token is legal with `includeFiles=true` and
+  one exact module, or with `includeFiles=false` and no module for final barrier
+  validation. A page token additionally requires the paging form.
 
 - [ ] **Step 1: Write failing query and server tests**
 
-Add parsing cases for nonblank opaque snapshot/page tokens and rejection of
-blank tokens, page token without snapshot token, either token without a module,
-either token with `includeFiles=false`, and a page size above server
-`maxResults`. Add fake-backend tests for two pages over five sorted files:
+Add parsing cases for canonical opaque snapshot/page handles and rejection of
+blank/noncanonical UUIDs, page token without snapshot token, either token with
+an illegal module/include-files combination, and a page size above server
+`maxResults`. Accept only the explicit snapshot-validation form with
+`includeFiles=false`, no module, and a snapshot token. Add fake-backend tests
+for two pages over five sorted files:
 
 ```kotlin
 val metadata = backend.workspaceFiles(WorkspaceFilesQuery())
@@ -142,6 +175,19 @@ Pass the first page cursor back with a different exact module and assert
 then add and remove a module after metadata; each subsequent page request must
 return `STALE_WORKSPACE_INVENTORY` rather than a mixed page.
 
+Test the shared store with a fake clock and capacity two. Prove TTL expiry,
+oldest-expiry capacity eviction, single-use page consumption, reusable snapshot
+lease lookup, exact query mismatch, and malformed, forged, unknown, expired,
+evicted, or consumed handles all fail without returning state. Rebase onto #337
+and migrate `FakeAnalysisBackend` reference/diagnostic continuation maps to this
+store before adding fake workspace-file state; do not maintain three ad hoc map
+policies.
+
+Assert invalid raw errors expose only typed `details.scope` of
+`SNAPSHOT_HANDLE` or `PAGE_HANDLE`. Snapshot failure discards the workspace-wide
+backend attempt; page failure remains module-local only if the snapshot lease
+still validates.
+
 Make the fake backend throw each project-model-incomplete reason and assert the
 dispatcher preserves status 503, `retryable=true`, stable error code, and exact
 `details.reason`. These are typed error-envelope tests, not string matching on
@@ -159,23 +205,25 @@ not exist.
 - [ ] **Step 3: Extract and implement the typed query boundary**
 
 Move `ParsedWorkspaceFilesQuery` out of `ParsedModels.kt` to satisfy top-level
-type isolation. Add one nonblank opaque wire-token type per matching file:
+type isolation. Add one canonical UUID handle type per matching file:
 
 ```kotlin
 @JvmInline
 value class WorkspaceFileSnapshotToken private constructor(val value: String) {
     companion object {
         fun fromWire(raw: String): WorkspaceFileSnapshotToken =
-            WorkspaceFileSnapshotToken(raw.also { require(it.isNotBlank()) })
+            WorkspaceFileSnapshotToken(parseCanonicalUuid(raw))
     }
 }
 ```
 
-`WorkspaceFilePageToken` has the same nonblank wire boundary but remains a
+`WorkspaceFilePageToken` has the same canonical wire boundary but remains a
 distinct type. Add `snapshotToken: String?` and `pageToken: String?` to
 `WorkspaceFilesQuery`, parse each once, and reject illegal field combinations.
-Do not parse offsets or cursor payloads in `analysis-api`; backend providers own
-token generation and decoding. Keep the server's positive page-size and
+The shared continuation store owns random issue, TTL cleanup, capacity
+eviction, query comparison, reusable lookup, and single-use consumption. Do
+not encode or decode offsets, generations, modules, or queries in a token. Keep
+the server's positive page-size and
 maximum checks. Add matching `AnalysisException` subtypes: stale inventory is
 HTTP/JSON-RPC status 409, code `STALE_WORKSPACE_INVENTORY`, and retryable;
 invalid cursor is status 400, code `INVALID_WORKSPACE_FILE_CURSOR`, and not
@@ -202,7 +250,8 @@ Validate in tests that returned count equals `files.size`, `fileCount` is never
 smaller, every page echoes one snapshot token, and continuation tokens are
 nonblank. Validate source/content roots are sorted and deduplicated. Update
 skill response types and the fake backend with the same generation/fingerprint,
-opaque-cursor, sort-before-slice, stale, and cross-module-error contract.
+server-held cursor, sort-before-slice, stale, final validation, TTL/capacity,
+and cross-module-error contract.
 
 Extract the materially edited `KastWorkspaceFilesRequest` and
 `KastWorkspaceFilesQuery` from `SkillContracts.kt` into matching files. Move
@@ -235,7 +284,8 @@ git commit -m "feat: page raw workspace file results"
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventory.kt`
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventorySnapshot.kt`
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileModuleSnapshot.kt`
-- Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileCursor.kt`
+- Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileSnapshotLease.kt`
+- Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileContinuation.kt`
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceInventoryGeneration.kt`
 - Create: `backend-idea/src/main/java/io/github/amichne/kast/idea/IdeaGradleWorkspaceFileBridge.java`
 - Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt`
@@ -252,8 +302,9 @@ git commit -m "feat: page raw workspace file results"
   module. Each module snapshot has sorted contained source/content roots,
   sorted dependency names, and a complete sorted set of project-model `.kt`
   and `.kts` paths.
-- `IdeaWorkspaceFileCursor` is a server-owned opaque encoding of generation,
-  exact backend module name, and positive next offset.
+- `IdeaWorkspaceFileSnapshotLease` and `IdeaWorkspaceFileContinuation` are
+  typed server-held states addressed only by opaque UUID handles. They contain
+  generation, exact module/query identity, next offset, and cumulative evidence.
 
 - [ ] **Step 1: Write failing project-model inventory tests**
 
@@ -271,8 +322,11 @@ both module snapshots, and the outside path is absent. Capture a generation,
 then replace one path with another while preserving total cardinality, add a
 module, and remove a module. Each change must alter the generation. Add backend
 contract cases proving the old snapshot token returns
-`STALE_WORKSPACE_INVENTORY` and a cursor issued for one module returns
-`INVALID_WORKSPACE_FILE_CURSOR` when used with another.
+`STALE_WORKSPACE_INVENTORY`, the validation-only request catches mutation after
+the last page, and a handle issued for one module returns
+`INVALID_WORKSPACE_FILE_CURSOR` when used with another. Exercise fake-clock TTL,
+capacity eviction, single-use, forged/unknown, and query mismatch through the
+real backend adapter.
 
 Add three failure fixtures: IDEA dumb/index-not-ready state, unavailable linked
 Gradle project-model data, and a linked root with no root-module association.
@@ -281,6 +335,11 @@ typed reasons `RUNTIME_INDEXING`, `PROJECT_MODEL_UNAVAILABLE`, and
 `LINKED_ROOT_UNASSOCIATED`. Cover failure on metadata and after a prior page so
 Rust can distinguish whole-inventory failure from a generic page transport
 failure.
+
+After rebasing onto #337, migrate `KastPluginBackend` reference and diagnostic
+continuations to the shared store before adding workspace-file leases. Preserve
+their query/source/generation behavior and add TTL/capacity/single-use
+regressions; one mechanism owns all three continuation families.
 
 - [ ] **Step 2: Run the focused red backend test**
 
@@ -316,35 +375,36 @@ module data to `PROJECT_MODEL_UNAVAILABLE`; do not allow either to become an
 empty complete inventory. Canonical containment is mandatory before ownership
 is recorded.
 
-- [ ] **Step 4: Page sorted inventory in the backend**
+- [ ] **Step 4: Page sorted inventory with server-held state**
 
 Replace cap-before-sort logic with generation validation followed by slicing:
 
 ```kotlin
+val lease = snapshotStore.requireLease(query.snapshotToken, query.workspaceIdentity)
 val current = inventory.snapshot()
-val requestedGeneration = decodeSnapshotToken(query.snapshotToken)
-if (requestedGeneration != current.generation) {
-    throw WorkspaceInventoryStale
+lease.requireGeneration(current.generation)
+val continuation = query.pageToken?.let { token ->
+    pageStore.consume(token, WorkspacePageQuery.from(query))
 }
-val cursor = query.pageToken?.let(::decodePageCursor)
-cursor?.requireGenerationAndModule(current.generation, query.moduleName)
-val allFiles = current.module(query.moduleName).filePaths
-val offset = cursor?.nextOffset ?: 0
+val state = continuation ?: lease.firstPage(query.requireExactModule())
+val allFiles = current.module(state.moduleName).filePaths
+val offset = state.nextOffset
 val files = if (query.includeFiles) allFiles.drop(offset).take(fileLimit) else emptyList()
 val nextOffset = offset + files.size
 val nextToken = nextOffset
     .takeIf { query.includeFiles && it < allFiles.size }
-    ?.let { encodePageCursor(current.generation, query.moduleName, it) }
+    ?.let { pageStore.issue(state.advanceTo(it)) }
 ```
 
 Build and fingerprint the canonical full inventory in one IDEA read action.
 The fingerprint includes sorted module identities, source/content roots,
 dependency names, and file paths, so equal-cardinality replacement and module
-add/remove cannot reuse a generation. Metadata requests return every sorted
-module plus the opaque snapshot token. Exact-module requests must match that
-generation before slicing; malformed, out-of-range, or cross-module cursors
-return `INVALID_WORKSPACE_FILE_CURSOR`. Populate stable counts and opaque
-tokens on every page.
+add/remove cannot reuse a generation. Metadata requests store the typed snapshot
+lease and return only its opaque handle. Exact-module and final validation
+requests recompute and match the leased generation before slicing or success;
+unknown state, out-of-range stored offsets, or query/cross-module mismatch
+returns `INVALID_WORKSPACE_FILE_CURSOR`. Populate stable counts and opaque
+handles on every page. Rust never sees an offset or generation encoding.
 
 - [ ] **Step 5: Prove scripts, multiple owners, and pages**
 
@@ -369,7 +429,8 @@ git commit -m "feat: enumerate project model Kotlin scripts"
 ```
 
 `backend-idea/AGENTS.md` records that the inventory and Java Gradle bridge own
-model-proven `.kt`/`.kts` candidates, generation-bound paging, typed
+model-proven `.kt`/`.kts` candidates, server-held generation-bound paging,
+TTL/capacity/integrity behavior, typed
 project-model incompleteness, and the focused backend tests above. This is the
 nearest guide for the new source boundary.
 
@@ -390,7 +451,8 @@ Do not stage either source-index policy file; both are verification-only.
 **Interfaces:**
 
 - Produces: `AgentCommand::WorkspaceFiles`, typed filters,
-  `AgentWorkspaceFilesField`, and a temporary typed unavailable result.
+  `AgentWorkspaceFilesField`, distinct `WorkspaceFilesPublicPageToken`, and a
+  temporary typed unavailable result.
 - Consumes: ADR 0020 `AgentResultView` and existing `AgentRuntimeArgs`.
 
 - [ ] **Step 1: Write failing command/help/argument tests**
@@ -398,7 +460,8 @@ Do not stage either source-index policy file; both are verification-only.
 Move `workspace-files` from retired aliases to visible agent commands. Assert
 all documented flags parse and reject limit `0`/`201`, absolute or parent path
 prefixes, `regex:` globs, blank selectors, and incompatible result views.
-Include `--drift not-applicable`.
+Include `--drift not-applicable` and canonical `--page-token`; reject blank or
+noncanonical handles and page-token/count combinations that cannot emit files.
 
 - [ ] **Step 2: Run the red command tests**
 
@@ -413,8 +476,9 @@ Expected: Clap does not recognize `workspace-files`.
 
 Add `AgentWorkspaceFilesArgs` with `AgentRuntimeArgs`, the family-specific
 ADR 0020 view args, optional module/source-set/kind/package/dirty/drift/path
-prefix/glob filters, and `WorkspaceFileLimit`. Use private-field newtypes and
-`FromStr` validation. The drift enum is:
+prefix/glob filters, `WorkspaceFileLimit`, and `WorkspaceFilesPublicPageToken`.
+Use private-field newtypes and `FromStr` validation. Keep the public token type
+distinct from raw snapshot/module-page tokens. The drift enum is:
 
 ```rust
 pub enum WorkspaceDriftFilter {
@@ -453,13 +517,18 @@ git commit -m "feat: add typed workspace file command boundary"
 - Create: `cli-rs/src/workspace_inventory/model.rs`
 - Create: `cli-rs/src/workspace_inventory/index.rs`
 - Create: `cli-rs/src/workspace_inventory/tests.rs`
+- Modify: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.kt`
+- Modify: `index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SqliteSourceIndexStoreTest.kt`
+- Modify: `index-store/AGENTS.md`
 - Modify: `cli-rs/tests/support/mod.rs`
 - Create: `cli-rs/tests/support/workspace_files.rs`
 
 **Interfaces:**
 
 - Produces: `WorkspaceRoot`, `WorkspaceFilePath`,
-  `WorkspaceIndexSnapshot`, `WorkspacePackageEvidence`,
+  `WorkspaceIndexSnapshot`, `SourceIndexSnapshotStamp`,
+  `SourceIndexGeneration`, `SourceIndexModuleProgress`,
+  `SourceIndexPendingCount`, `WorkspacePackageEvidence`,
   `WorkspaceIndexRead`, `WorkspaceInventoryLimitationCode`,
   `WorkspaceMatchCoverage`, and `read_workspace_index(&WorkspaceRoot)`.
 - The index reader has no public limit and returns `.kt` rows only.
@@ -467,15 +536,27 @@ git commit -m "feat: add typed workspace file command boundary"
 - [ ] **Step 1: Write failing schema, path, and package-state tests**
 
 Seed 500 `.kt` rows plus non-Kotlin, `.kts`, relative-escape, absolute,
-outside-root, and symlink-escape rows. Add four package cases:
+outside-root, and symlink-escape rows. Cover a missing in-root leaf, a missing
+leaf below an in-root symlink to outside, a dangling symlink, permission or
+canonicalization failure, and an ancestor race. The first missing leaf is
+admitted through its deepest existing ancestor; every unprovable case is
+excluded with `PATH_CONTAINMENT_UNPROVABLE` and partial candidate coverage. Add
+four package cases:
 
 1. no `file_metadata` row;
 2. metadata with null `package_fq_id`;
 3. metadata with a joined package name; and
 4. metadata with dangling `package_fq_id`.
 
-Assert 500 valid `.kt` candidates, zero `.kts`, exact package variants, and
-typed excluded/invalid counts.
+Assert 500 valid `.kt` candidates, zero `.kts`, exact package variants, typed
+excluded/invalid counts, and no escaping missing path.
+
+Seed generation, `module_index_progress`, and unapplied `pending_updates`.
+Assert the snapshot carries their typed state; only a nonempty initialized
+progress set with every row `COMPLETE`, indexed count equal to total, and zero
+pending updates is exact.
+Add store tests proving candidate, progress, and pending-state write
+transactions increment generation atomically without changing the schema.
 
 - [ ] **Step 2: Run the red inventory tests**
 
@@ -509,8 +590,10 @@ with read-only accessors required by agent/#340 consumers.
 
 Define closed limitation variants for backend capability, metadata, page,
 stale generation, runtime indexing, unavailable project model, unassociated
-linked root, source-index unavailable/incompatible, Git unavailable, package
-metadata invalid, unknown project-model ownership, and out-of-root exclusion.
+linked root, source-index unavailable/incompatible/progress-incomplete/updates-
+pending, Git unavailable, unstable cross-source composition, unprovable path
+containment, package metadata invalid, unknown project-model ownership, and
+out-of-root exclusion.
 Keep `WorkspaceMatchCoverage` as two typed dimensions:
 `candidate_inventory` and `filter_evidence`, each `Complete` or `Partial`.
 This prevents a complete candidate set from asserting exact filtered matches
@@ -518,23 +601,33 @@ when a requested predicate is unknown.
 
 - [ ] **Step 4: Implement the read-only query exactly from the design**
 
-Select `metadata_present`, `package_fq_id`, and joined `fq_name` separately.
-Use `SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_URI`, configure query-only access,
-verify schema/tables, decode existing path prefixes, reject non-`.kt`, and map
-the four package states without collapsing nulls.
+Within one SQLite read transaction, select `metadata_present`, `package_fq_id`,
+and joined `fq_name` separately, plus `schema_version.generation`, all module
+progress rows, and the unapplied pending-update count. Use
+`SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_URI`, configure query-only access, verify
+schema/tables, decode existing path prefixes, reject non-`.kt`, and map the four
+package states without collapsing nulls. For missing paths, canonicalize the
+deepest existing ancestor; lexical containment alone is insufficient.
+
+In `SqliteSourceIndexStore`, increment the existing generation in the same
+write transaction as any candidate-table, progress, or pending applied-state
+mutation. Do not add a schema column or admit `.kts`.
 
 - [ ] **Step 5: Add the scoped ownership guide and verify**
 
-State that this unit owns uncapped exact-root composition, `.kt` index reads,
-set-valued owners, backend page coverage, and Git annotation. Prohibit `.kts`
-source-index reads and filesystem/Git candidate enumeration.
+Update `index-store/AGENTS.md` to make transactional generation maintenance and
+truthful progress/pending state storage-owned gates. State in the new Rust guide
+that it owns uncapped exact-root composition, generation/progress/pending-aware
+`.kt` index reads, deepest-existing-ancestor containment, set-valued owners,
+backend page coverage, and Git annotation. Prohibit `.kts` source-index reads
+and filesystem/Git candidate enumeration.
 
 Run Step 2. Expected: all 500 rows and package/path invariants pass.
 
 - [ ] **Step 6: Commit the index boundary**
 
 ```console
-git add cli-rs/src/main.rs cli-rs/src/workspace_inventory.rs cli-rs/src/workspace_inventory cli-rs/tests/support/mod.rs cli-rs/tests/support/workspace_files.rs
+git add index-store cli-rs/src/main.rs cli-rs/src/workspace_inventory.rs cli-rs/src/workspace_inventory cli-rs/tests/support/mod.rs cli-rs/tests/support/workspace_files.rs
 git diff --cached --check
 git commit -m "feat: add uncapped Kotlin source inventory"
 ```
@@ -546,6 +639,7 @@ git commit -m "feat: add uncapped Kotlin source inventory"
 - Create: `cli-rs/src/workspace_inventory/backend.rs`
 - Create: `cli-rs/src/workspace_inventory/dirty.rs`
 - Create: `cli-rs/src/workspace_inventory/collect.rs`
+- Create: `cli-rs/src/workspace_inventory/barrier.rs`
 - Modify: `cli-rs/src/workspace_inventory/model.rs`
 - Modify: `cli-rs/src/workspace_inventory/tests.rs`
 - Modify: `cli-rs/src/workspace_inventory.rs`
@@ -566,9 +660,11 @@ git commit -m "feat: add uncapped Kotlin source inventory"
 Script three pages for one module and two pages for a second. Repeat one
 physical path in both modules. Assert every page is requested in order, the
 physical record has both owners, pages do not overlap, and all modules are
-complete. Add failures for repeated/non-advancing tokens, changed totals,
-overlap, missing module, and a page failure after earlier successes; only the
-affected module becomes partial.
+complete. Add failures for repeated handles, overlap, cumulative returned
+evidence beyond or short of the declared total, and a page failure after
+earlier successes; only the affected module becomes partial. Rust must not
+decode or infer advancement, generation, module identity, or offset from token
+bytes.
 
 Add three generation regressions:
 
@@ -616,7 +712,20 @@ rename, and inside-to-outside rename. Assert the adapter's explicit
 relative, the exact workspace prefix is stripped, and only contained endpoints
 annotate candidates. A successful mapped snapshot alone may assign `CLEAN`.
 
-- [ ] **Step 4: Add the root-A/root-B exact-root regression**
+- [ ] **Step 4: Write the cross-source barrier mutation matrix**
+
+Inject lane observers around collection. Mutate, one case at a time, backend
+inventory generation after the last module page, source-index generation,
+module progress, pending updates, a candidate's filesystem existence/symlink
+resolution, and normalized Git status between before/after reads. Assert the
+whole attempt is discarded and retried once. A stable retry may be exact; a
+second movement emits `CROSS_SOURCE_COMPOSITION_UNSTABLE`, makes candidate and
+affected-filter coverage partial, suppresses public continuation, and forces
+cross-source drift/absence to `UNKNOWN`. Stable incomplete progress or pending
+updates does not spin and emits its specific partial limitation. Assert call
+counts never exceed two composition attempts times two backend attempts.
+
+- [ ] **Step 5: Add the root-A/root-B exact-root regression**
 
 In both smoke files, configure root A with only root B's ready descriptor and
 source-index database. Invoke:
@@ -629,7 +738,7 @@ Assert the typed exact-root rejection, zero `raw/workspace-files` requests,
 and no read/open observation for root B's database. This is a rejected-no-request
 test, not merely an output-path assertion.
 
-- [ ] **Step 5: Run the focused red tests**
+- [ ] **Step 6: Run the focused red tests**
 
 ```console
 cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
@@ -637,17 +746,20 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_fil
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test semantic_workspace_admission_smoke workspace_files
 ```
 
-Expected: generation-bound paging, bounded restart, composition, Git, and
-exact-root cases fail because the collector is absent.
+Expected: generation-bound paging, bounded backend/composition restarts,
+source-index state, containment, Git, and exact-root cases fail because the
+collector is absent.
 
-- [ ] **Step 6: Implement strict backend paging**
+- [ ] **Step 7: Implement strict backend paging**
 
 Fetch module metadata and its opaque snapshot token, sort exact module names,
 and echo the snapshot while requesting opaque cursors until each module
 returns no next token. Never parse or construct a token in Rust. Validate
-total/returned counts, cursor advancement, echoed snapshot, module identity,
-non-overlap, and containment before merging. Preserve duplicate physical paths
-as one record with a `BTreeSet` of owners.
+only non-repeated handles, non-overlapping physical paths, and cumulative
+returned evidence that never exceeds and finally equals the declared module
+count. Generation, query/module binding, offsets, expiry, and capacity integrity
+belong to server-held typed state. Preserve duplicate physical paths as one
+record with a `BTreeSet` of owners.
 
 On the first `STALE_WORKSPACE_INVENTORY`, discard the entire backend attempt
 and restart once from fresh metadata. If the retry is stale, discard it too,
@@ -663,9 +775,16 @@ metadata/page response. Metadata project-model failure is
 workspace-wide `Partial` and discards earlier pages from that attempt. Preserve
 the exact runtime-indexing, project-model-unavailable, or unassociated-root
 limitation. Only generic transport/invalid-response failure remains local to
-one module, and only `STALE_WORKSPACE_INVENTORY` consumes the single restart.
+one module. Invalid page state is local only after the snapshot independently
+validates; invalid snapshot state or final validation is workspace-wide and
+discards all backend pages. Only `STALE_WORKSPACE_INVENTORY` consumes the
+single backend restart.
 
-- [ ] **Step 7: Implement conservative composition**
+After the last page, use the validation-only raw request to prove the snapshot
+lease still names the current backend generation. This validation participates
+in the later whole-composition barrier.
+
+- [ ] **Step 8: Implement conservative composition and containment**
 
 Candidate keys come only from backend pages and `.kt` index rows. For index-only
 `.kt`, associate all canonical containing module roots; `INDEX_ONLY` requires
@@ -673,7 +792,12 @@ every possible owner complete. Unknown or overlapping partial ownership emits
 `PROJECT_MODEL_OWNERSHIP_UNKNOWN`. `.kts` never queries the source index and
 uses `NotApplicable` states.
 
-- [ ] **Step 8: Implement exact-root Git mapping**
+For every missing candidate, walk to the deepest existing ancestor and
+canonicalize it against the admitted canonical root before appending normalized
+missing components. Exclude escaping or unprovable paths with
+`PATH_CONTAINMENT_UNPROVABLE`; lexical containment alone is insufficient.
+
+- [ ] **Step 9: Implement exact-root Git mapping**
 
 Resolve Git top level, prove containment, run porcelain v2 with
 `-c status.relativePaths=false` and `-- .`, and map both current and original
@@ -681,9 +805,18 @@ paths from repository root through the exact workspace prefix. Parse records
 `1`, `2`, `u`, and `?`. Invalid bytes or mapping failure produces
 `DirtyWorkspaceCoverage::Unavailable`.
 
-- [ ] **Step 9: Run focused tests green and commit**
+- [ ] **Step 10: Implement the coherent composition barrier**
 
-Run Step 5, then:
+Record the backend snapshot lease, source-index generation/progress/pending
+stamp, targeted filesystem fingerprint, and Git fingerprint. After composition,
+validate the backend lease and re-read every other lane. Publish a coherent
+snapshot only when stamps match. Retry the entire composition once after a
+change. A second change returns typed partial evidence, never mixed exact
+evidence. Stable incomplete index state is partial without retry.
+
+- [ ] **Step 11: Run focused tests green and commit**
+
+Run Step 6, then:
 
 ```console
 git add cli-rs/src/workspace_inventory.rs cli-rs/src/workspace_inventory cli-rs/tests/support/workspace_files.rs cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/semantic_workspace_admission_smoke.rs
@@ -695,6 +828,14 @@ git commit -m "feat: compose exhaustive workspace file evidence"
 
 **Files:**
 
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/query/WorkspaceFilesContinuationQuery.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/query/WorkspaceFilesContinuationAction.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceFilesContinuationResult.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceFilesPublicContinuationState.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/WorkspaceFilesPublicPageToken.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/InvalidWorkspaceFilesPageTokenException.kt`
+- Modify: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/RpcAnalysisDispatcher.kt`
+- Modify: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt`
 - Modify: `cli-rs/src/agent/workspace_files.rs`
 - Modify: `cli-rs/src/agent/dispatch.rs`
 - Modify: `cli-rs/src/agent.rs`
@@ -711,6 +852,10 @@ git commit -m "feat: compose exhaustive workspace file evidence"
 
 - Produces: `KAST_AGENT_WORKSPACE_FILES_RESULT` views and
   `AgentPublicCapabilityRoute` for `WORKSPACE_FILES`.
+- Produces: internal issue/consume service for server-held
+  `WorkspaceFilesPublicContinuationState`, plus public
+  `WorkspaceFilesPublicPageToken`, `INVALID_WORKSPACE_FILES_PAGE_TOKEN`, and
+  `STALE_WORKSPACE_FILES_PAGE` failures.
 - Reuses: ADR 0020 `AgentResultCardinality::Exact | KnownMinimum` with
   `returnedCount`, `truncated`, and separate typed candidate/filter coverage.
 
@@ -721,6 +866,25 @@ package evidence, source-index state, drift, dirty state, and paths. Cover each
 filter and conjunction; partial pages, unavailable index/Git, invalid package
 reference, and both candidate sources unavailable. Seed 500 records and assert
 20 default records, at most 120 lines, and at most 1,500 estimated tokens.
+
+Add dispatcher contract tests for public continuation issue/consume. Prove the
+server returns only a random handle on issue, consumes it once with exact query
+identity, applies the shared TTL/capacity policy, and never serializes stored
+state into the token.
+
+Keep Kotlin and Rust public page-token types distinct from raw snapshot/page
+handles. `INVALID_WORKSPACE_FILES_PAGE_TOKEN` is non-retryable status 400;
+`STALE_WORKSPACE_FILES_PAGE` is retryable status 409 and requires a new unpaged
+query rather than automatic restart.
+
+With `--limit 200`, consume returned public tokens and assert page sizes
+200/200/100, strictly increasing relative paths, no overlap or gaps, stable
+cardinality, per-page `returnedCount`, and no terminal token. Assert a changed
+backend/index/filesystem/Git composition stamp returns
+`STALE_WORKSPACE_FILES_PAGE`; malformed, forged, unknown, expired, evicted, or
+already-consumed state returns `INVALID_WORKSPACE_FILES_PAGE_TOKEN`; and any
+filter, view, field selection, backend, root, or limit mismatch fails rather
+than reinterpreting the cursor.
 
 Assert `EXACT.totalCount` only when candidate inventory and every selected
 predicate are complete. Cover these counterexamples explicitly:
@@ -772,15 +936,28 @@ then take `limit`. Compute candidate-inventory and selected-filter evidence
 coverage before projection. Do not infer exact match cardinality merely from a
 fully consumed known-candidate vector.
 
+For a resumed request, consume the opaque public handle through the internal
+server continuation service, require the identical normalized query identity,
+recollect through the composition barrier, and compare the full composition-
+stamp digest. Seek strictly after the stored relative path and verify cumulative
+returned evidence. Never fall back to page one after invalid or stale state.
+
 - [ ] **Step 5: Add compact, fields, count, verbose, and explain projections**
 
 Compact and selected views never contain raw envelopes. Count groups known
 records by kind/index/drift/dirty, with the same discriminated exactness as the
 overall result. Compact and selected pages serialize `cardinality`,
 `returnedCount`, `truncated`, and `coverage.candidateInventory` plus
-`coverage.filterEvidence`. Verbose adds per-module page coverage; explain adds
+`coverage.filterEvidence`, plus `nextPageToken` only when another known match
+exists. Verbose adds per-module page coverage; explain adds
 normalized query and classification evidence. Preserve typed backend/index
 failures in failed envelopes.
+
+Register continuation state through the shared server-held store only after a
+coherent composition and only when more known matches remain. Store exact root,
+backend, normalized query/view/limit, composition-stamp digest, last path, and
+cumulative returned count; do not store or trust a serialized candidate page.
+Suppress continuation for an unstable composition.
 
 - [ ] **Step 6: Implement the route registry and verification intersection**
 
@@ -793,7 +970,7 @@ intersection. #342 extends this owner rather than creating another list.
 Run Step 3, then:
 
 ```console
-git add cli-rs/src/agent.rs cli-rs/src/agent cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/agent_result_projection_smoke.rs
+git add analysis-api analysis-server cli-rs/src/agent.rs cli-rs/src/agent cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/tests/agent_result_projection_smoke.rs
 git diff --cached --check
 git commit -m "feat: expose bounded workspace file discovery"
 ```
@@ -806,9 +983,12 @@ git commit -m "feat: expose bounded workspace file discovery"
 - Modify: `cli-rs/resources/kast-skill/references/commands.json`
 - Regenerate: `cli-rs/resources/kast-skill/references/commands.yaml`
 - Regenerate: `cli-rs/resources/kast-skill/references/requests/raw/workspace-files/`
+- Regenerate: `cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation/`
 - Modify: `cli-rs/tests/rpc_catalog_smoke.rs`
 - Modify: `cli-rs/tests/agent_workspace_files_smoke.rs`
+- Modify: `cli-rs/AGENTS.md`
 - Modify: `cli-rs/src/agent/AGENTS.md`
+- Modify: `cli-rs/resources/kast-skill/AGENTS.md`
 - Modify: `cli-rs/resources/kast-skill/SKILL.md`
 - Modify: `cli-rs/resources/kast-skill/references/quickstart.md`
 - Modify: `docs/reference/agent-commands.md`
@@ -828,9 +1008,10 @@ Generate protocol/OpenAPI artifacts from the Kotlin contract first:
 ```
 
 Then hand-edit `commands.json`, the source catalog, to add opaque
-`snapshotToken`/`pageToken` request fields and replace the stale capped-secondary
-description with the current internal generation-bound paging contract. The
-release generator consumes that JSON; it does not produce it. Refresh the
+`snapshotToken`/`pageToken` fields, the internal public-continuation issue/
+consume method, and replace the stale capped-secondary description with the
+current server-held generation-bound paging contract. The release generator
+consumes that JSON; it does not produce it. Refresh the
 catalog-derived block in `cli-rs/protocol/api-specification.md`, regenerate the
 derived YAML, schemas, and samples, then prove requests include both tokens,
 results include the top-level snapshot token, and module results include
@@ -851,26 +1032,38 @@ Keep an unowned on-disk `.kt` file and assert it is absent.
 - [ ] **Step 3: Update ownership and packaged guidance**
 
 Add the command to `cli-rs/src/agent/AGENTS.md`. Teach source/script filters,
-partial limitations, one bounded stale-snapshot retry, owner sets, and direct
-path composition. State explicitly that `.kts` is not in the Kotlin source
-index and Gradle semantic declarations arrive with #340.
+public continuation, partial limitations, backend and cross-source bounded
+retries, owner sets, and direct path composition. State explicitly that `.kts`
+is not in the Kotlin source index and Gradle semantic declarations arrive with
+#340.
+
+Update `cli-rs/AGENTS.md` to list `workspace-files` in the public typed command
+surface and assign `workspace_inventory` coherence/continuation ownership.
+Update `cli-rs/resources/kast-skill/AGENTS.md` to record the public routing and
+hand-authored catalog/generated-output boundary. Both guides make package,
+LSP, and routing gates below mandatory for workspace-files/catalog/guidance
+changes.
 
 - [ ] **Step 4: Update reference and how-to docs**
 
-Document every flag, limit, result view, owner set, package state, drift/index
-truth table, limitations, exact-root behavior, generation-bound paging, and the
-typed partial result after repeated staleness. Replace generic-search-first
-guidance with `workspace-files`, then diagnostics or exact symbol lookup.
+Document every flag, limit, page token, result view, owner set, package state,
+drift/index truth table, limitations, exact-root behavior, server-held raw
+paging, coherent cross-source composition, and typed invalid/stale public
+continuation. Replace generic-search-first guidance with `workspace-files`,
+then diagnostics or exact symbol lookup.
 
 - [ ] **Step 5: Validate guidance and commit**
 
 ```console
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke --test agent_workspace_files_smoke --test rpc_catalog_smoke
+.github/scripts/test-kast-copilot-plugin.sh
+.github/scripts/test-lsp-pivot-gates.sh
+.github/scripts/test-kast-routing-evals.sh
 .github/scripts/test-docs-content-contract.sh
 .github/scripts/test-docs-navigation-contract.sh
 zensical build --clean
 git diff --check
-git add cli-rs/protocol cli-rs/resources cli-rs/tests/rpc_catalog_smoke.rs cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/src/agent/AGENTS.md docs
+git add cli-rs/AGENTS.md cli-rs/protocol cli-rs/resources cli-rs/tests/rpc_catalog_smoke.rs cli-rs/tests/agent_workspace_files_smoke.rs cli-rs/src/agent/AGENTS.md docs
 git diff --cached --check
 git commit -m "docs: teach semantic workspace file discovery"
 ```
@@ -899,7 +1092,9 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test semantic_workspace_
 ```
 
 Expected: generation/fingerprint, stale, cursor-binding, paging/project-model
-tests pass and `.kts` remains rejected by `SourceIndexFilePolicyTest`.
+TTL/capacity/integrity, final backend validation, source-index generation/
+progress/pending, and composition-barrier tests pass; `.kts` remains rejected
+by `SourceIndexFilePolicyTest`.
 
 - [ ] **Step 3: Run full Rust quality gates**
 
@@ -914,6 +1109,10 @@ cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-feat
 ```console
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
 python3 .github/scripts/render-rpc-contract-summary.py --check
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
+.github/scripts/test-kast-copilot-plugin.sh
+.github/scripts/test-lsp-pivot-gates.sh
+.github/scripts/test-kast-routing-evals.sh
 .github/scripts/test-docs-content-contract.sh
 .github/scripts/test-docs-navigation-contract.sh
 zensical build --clean
@@ -940,7 +1139,11 @@ cross-module cursor rejection, included-build project-model script authority,
 mapping, exact-root rejected-no-request proof, package-state SQL, false
 `INDEX_ONLY`, project-model error/reason mapping, metadata failure, zero-module
 global partiality, candidate versus filter coverage, `EXACT` versus
-`KNOWN_MINIMUM`, hand-authored catalog ownership, Kotlin type isolation,
-scoped ownership guidance, capability callability, #340 reuse, budgets, and
-every issue acceptance criterion. Repair each blocking finding with a focused
-red-green commit and rerun the affected gate plus full Rust and Kotlin suites.
+`KNOWN_MINIMUM`, server-held TTL/capacity/integrity, deepest-ancestor missing-
+path containment, index generation/progress/pending state, cross-source barrier
+mutation, public 200/200/100 continuation, invalid/stale/query-mismatched public
+tokens, hand-authored catalog ownership, Kotlin type isolation, scoped ownership
+guidance, package/LSP/routing gates, capability callability, #340 reuse,
+budgets, and every issue acceptance criterion. Repair each blocking finding
+with a focused red-green commit and rerun the affected gate plus full Rust and
+Kotlin suites.

--- a/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
+++ b/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
@@ -717,8 +717,9 @@ Do not stage either source-index policy file; both are verification-only.
 **Interfaces:**
 
 - Produces: `AgentCommand::WorkspaceFiles`, typed filters,
-  `AgentWorkspaceFilesField`, closed `WorkspaceModuleSelector`, distinct
-  `WorkspaceFilesPublicPageToken`, and a temporary typed unavailable result.
+  `AgentWorkspaceFilesField`, closed `WorkspaceModuleSelector`, closed
+  `WorkspacePackageSelector`, distinct `WorkspaceFilesPublicPageToken`, and a
+  temporary typed unavailable result.
 - Consumes: ADR 0020 `AgentResultView` and existing `AgentRuntimeArgs`.
 
 - [ ] **Step 1: Write failing command/help/argument tests**
@@ -731,10 +732,11 @@ noncanonical handles and page-token/count combinations that cannot emit files.
 Accept `backend:<exact-name>`, `gradle:.#:app`, and
 `gradle:included/tools#:app`; reject unprefixed/empty selectors, absolute or
 escaping build roots, and non-absolute Gradle project paths.
-Accept canonical Kotlin package selectors for escaped/backticked and general
-Unicode identifiers, normalize them to semantic FQ names, and reject malformed
-package syntax. Accept a typed `integrationTest` source-set name without
-assuming any directory convention.
+Accept `root` and canonical `named:<fq-name>` package selectors. Cover
+escaped/backticked and general Unicode named identifiers, normalize named
+selectors to semantic FQ names, and reject unprefixed names, `named:` without a
+name, and malformed package syntax. Accept a typed `integrationTest` source-set
+name without assuming any directory convention.
 
 - [ ] **Step 2: Run the red command tests**
 
@@ -755,9 +757,11 @@ Parse module as `WorkspaceModuleSelector::Backend(BackendModuleName)` or a
 newtypes; Task 4 maps that variant to the inventory identity. Derive the raw/composition
 source-only, script-only, or mixed domain from the kind filter, with no filter
 meaning mixed. Use private-field newtypes and `FromStr` validation. Keep the public token type
-distinct from raw snapshot/module-page tokens. The drift enum is:
-Parse package filters through the same canonical Kotlin package-name boundary
-used by producer evidence. Parse source-set filters as names only, but allow
+distinct from raw snapshot/module-page tokens. Parse package filters as the
+closed `WorkspacePackageSelector::Root` or
+`WorkspacePackageSelector::Named(WorkspacePackageName)` union. Parse the named
+variant through the same canonical Kotlin package-name boundary used by
+producer evidence. Parse source-set filters as names only, but allow
 matches exclusively against model-proven build-qualified source-set evidence.
 Legacy labels never satisfy either filter. The drift enum is:
 
@@ -1281,7 +1285,9 @@ corresponding owner type, sort by relative path and sorted owner sets, and only
 then take `limit`. Compute candidate-inventory and selected-filter evidence
 coverage before projection. Do not infer exact match cardinality merely from a
 fully consumed known-candidate vector.
-Package and source-set filters match only `ProvenNamed`/`ProvenRoot` or
+`WorkspacePackageSelector::Root` matches only `ProvenRoot`, and
+`WorkspacePackageSelector::Named(expected)` matches only an equal
+`ProvenNamed(actual)`. Source-set filters match only
 `WorkspaceSourceSetEvidence::Proven`; legacy/unproven values remain visible to
 explain output but cannot become matches.
 

--- a/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
+++ b/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
@@ -10,11 +10,12 @@ discovery command backed by exhaustively paged compiler/project-model evidence
 and the `.kt`-only source index, with `.kts` candidates reusable by issue #340's
 separate Gradle DSL index.
 
-**Architecture:** Kotlin adds canonical per-module workspace-file paging and an
-IDEA project-model inventory for `.kt` and `.kts`. Rust exhausts every module
-page, unions physical paths while retaining all module owners, joins `.kt`
-index evidence, maps Git porcelain from repository root to the admitted root,
-then applies public filters, projections, and bounds.
+**Architecture:** Kotlin adds opaque generation-bound per-module workspace-file
+paging and an IDEA project-model inventory for `.kt` and `.kts`. Rust exhausts
+one coherent workspace generation, unions physical paths while retaining all
+module owners, joins `.kt` index evidence, maps Git porcelain from repository
+root to the admitted root, then applies public filters, projections, and
+bounds.
 
 **Tech Stack:** Kotlin/JVM, kotlinx.serialization, IntelliJ Platform and Gradle
 project model, Rust 2024, Clap, serde/serde_json, rusqlite, glob, Git porcelain
@@ -32,8 +33,15 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Never use recursive filesystem discovery or Git as candidate authority.
   Targeted root build/settings lookups are allowed only for roots proved by the
   linked Gradle project model.
-- Exhaust every valid backend module page before claiming that module complete.
-  Incomplete possible owners can never prove `INDEX_ONLY`.
+- Exhaust every valid backend module page from one workspace generation before
+  claiming that module complete. Incomplete possible owners can never prove
+  `INDEX_ONLY`.
+- Treat snapshot and page tokens as opaque server-owned values. Bind cursors to
+  generation, exact module, and offset; never construct or advance them in
+  Rust.
+- On `STALE_WORKSPACE_INVENTORY`, discard the whole backend attempt and restart
+  once. A second stale response is typed partial evidence with no backend
+  candidates from either stale attempt.
 - Model physical-file backend and indexed module ownership as sorted sets.
 - Keep the internal inventory uncapped by public filters and `--limit`.
 - Default `--limit` to 20, reject values outside 1 through 200, and keep compact
@@ -57,8 +65,11 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/query/WorkspaceFilesQuery.kt`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceFilesResult.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceModule.kt`
-- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/WorkspaceFilePageOffset.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/WorkspaceFileSnapshotToken.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/WorkspaceFilePageToken.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedWorkspaceFilesQuery.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/WorkspaceInventoryStaleException.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/InvalidWorkspaceFileCursorException.kt`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedModels.kt`
 - Modify: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt`
 - Modify: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/ParsedModelsTest.kt`
@@ -68,25 +79,30 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 
 **Interfaces:**
 
-- Produces: `WorkspaceFilePageOffset`,
-  `ParsedWorkspaceFilesQuery.pageOffset`, `WorkspaceModule.returnedFileCount`,
-  `WorkspaceModule.nextPageToken`, and explicit `WorkspaceModule.contentRoots`.
-- Invariant: a page token is canonical positive decimal text and is legal only
-  with `includeFiles=true` and one exact module.
+- Produces: `WorkspaceFileSnapshotToken`, `WorkspaceFilePageToken`,
+  `ParsedWorkspaceFilesQuery.snapshotToken`,
+  `ParsedWorkspaceFilesQuery.pageToken`, `WorkspaceFilesResult.snapshotToken`,
+  `WorkspaceModule.returnedFileCount`, `WorkspaceModule.nextPageToken`, and
+  explicit `WorkspaceModule.contentRoots`.
+- Invariant: snapshot and page tokens are opaque to clients. An input snapshot
+  token is legal only with `includeFiles=true` and one exact module; a page
+  token additionally requires that snapshot token.
 
 - [ ] **Step 1: Write failing query and server tests**
 
-Add parsing cases for token `"2"` and rejection of `"0"`, `"02"`, `"-1"`,
-non-numeric text, token without module, token with `includeFiles=false`, and a
-page size above server `maxResults`. Add fake-backend tests for two pages over
-five sorted files:
+Add parsing cases for nonblank opaque snapshot/page tokens and rejection of
+blank tokens, page token without snapshot token, either token without a module,
+either token with `includeFiles=false`, and a page size above server
+`maxResults`. Add fake-backend tests for two pages over five sorted files:
 
 ```kotlin
+val metadata = backend.workspaceFiles(WorkspaceFilesQuery())
 val first = backend.workspaceFiles(
     WorkspaceFilesQuery(
         moduleName = "main",
         includeFiles = true,
         maxFilesPerModule = 2,
+        snapshotToken = metadata.snapshotToken,
     ),
 )
 val second = backend.workspaceFiles(
@@ -94,14 +110,21 @@ val second = backend.workspaceFiles(
         moduleName = "main",
         includeFiles = true,
         maxFilesPerModule = 2,
+        snapshotToken = metadata.snapshotToken,
         pageToken = first.modules.single().nextPageToken,
     ),
 )
 assertEquals(5, first.modules.single().fileCount)
-assertEquals("2", first.modules.single().nextPageToken)
-assertEquals("4", second.modules.single().nextPageToken)
+assertEquals(metadata.snapshotToken, first.snapshotToken)
+assertNotNull(first.modules.single().nextPageToken)
+assertNotNull(second.modules.single().nextPageToken)
 assertTrue(first.modules.single().files.intersect(second.modules.single().files.toSet()).isEmpty())
 ```
+
+Pass the first page cursor back with a different exact module and assert
+`INVALID_WORKSPACE_FILE_CURSOR`. Mutate one path while preserving cardinality,
+then add and remove a module after metadata; each subsequent page request must
+return `STALE_WORKSPACE_INVENTORY` rather than a mixed page.
 
 - [ ] **Step 2: Run the focused red tests**
 
@@ -109,52 +132,58 @@ assertTrue(first.modules.single().files.intersect(second.modules.single().files.
 ./gradlew :analysis-api:test --tests '*ParsedModelsTest*workspace*' :analysis-server:test --tests '*AnalysisDispatcherTest*workspace*' --no-daemon
 ```
 
-Expected: compilation fails because paging fields/types do not exist.
+Expected: compilation fails because generation-bound paging fields/types do
+not exist.
 
 - [ ] **Step 3: Extract and implement the typed query boundary**
 
 Move `ParsedWorkspaceFilesQuery` out of `ParsedModels.kt` to satisfy top-level
-type isolation. Add:
+type isolation. Add one nonblank opaque wire-token type per matching file:
 
 ```kotlin
 @JvmInline
-value class WorkspaceFilePageOffset private constructor(val value: Int) {
+value class WorkspaceFileSnapshotToken private constructor(val value: String) {
     companion object {
-        fun parse(raw: String): WorkspaceFilePageOffset {
-            val parsed = raw.toIntOrNull()
-            require(parsed != null && parsed > 0 && raw == parsed.toString()) {
-                "Workspace file page tokens must be canonical positive offsets"
-            }
-            return WorkspaceFilePageOffset(parsed)
-        }
+        fun fromWire(raw: String): WorkspaceFileSnapshotToken =
+            WorkspaceFileSnapshotToken(raw.also { require(it.isNotBlank()) })
     }
 }
 ```
 
-Add `pageToken: String?` to `WorkspaceFilesQuery`. Parse once into
-`WorkspaceFilePageOffset?`; reject token-without-module and
-token-without-files at the validation boundary. Keep the server's positive
-page-size and maximum checks.
+`WorkspaceFilePageToken` has the same nonblank wire boundary but remains a
+distinct type. Add `snapshotToken: String?` and `pageToken: String?` to
+`WorkspaceFilesQuery`, parse each once, and reject illegal field combinations.
+Do not parse offsets or cursor payloads in `analysis-api`; backend providers own
+token generation and decoding. Keep the server's positive page-size and
+maximum checks. Add matching `AnalysisException` subtypes: stale inventory is
+HTTP/JSON-RPC status 409, code `STALE_WORKSPACE_INVENTORY`, and retryable;
+invalid cursor is status 400, code `INVALID_WORKSPACE_FILE_CURSOR`, and not
+retryable. The existing dispatcher maps both through its typed error envelope.
 
 - [ ] **Step 4: Isolate and extend the result type**
 
 Move `WorkspaceModule` to its matching file and add:
 
 ```kotlin
+// WorkspaceFilesResult
+val snapshotToken: String
+
+// WorkspaceModule
 val contentRoots: List<String> = emptyList()
 val returnedFileCount: Int = files.size
 val nextPageToken: String? = null
 ```
 
 Validate in tests that returned count equals `files.size`, `fileCount` is never
-smaller, and next tokens advance by returned count without exceeding total.
-Validate source/content roots are sorted and deduplicated. Update skill response
-types and fake backend with the same sort-before-slice contract.
+smaller, every page echoes one snapshot token, and continuation tokens are
+nonblank. Validate source/content roots are sorted and deduplicated. Update
+skill response types and the fake backend with the same generation/fingerprint,
+opaque-cursor, sort-before-slice, stale, and cross-module-error contract.
 
 - [ ] **Step 5: Run Kotlin paging tests green**
 
-Run the Step 2 command. Expected: all paging, validation, and non-overlap tests
-pass.
+Run the Step 2 command. Expected: all paging, validation, stale-generation,
+cross-module, and non-overlap tests pass.
 
 - [ ] **Step 6: Update source ownership and commit**
 
@@ -172,7 +201,10 @@ git commit -m "feat: page raw workspace file results"
 **Files:**
 
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventory.kt`
+- Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventorySnapshot.kt`
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileModuleSnapshot.kt`
+- Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileCursor.kt`
+- Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceInventoryGeneration.kt`
 - Create: `backend-idea/src/main/java/io/github/amichne/kast/idea/IdeaGradleWorkspaceFileBridge.java`
 - Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt`
 - Create: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventoryTest.kt`
@@ -183,10 +215,13 @@ git commit -m "feat: page raw workspace file results"
 **Interfaces:**
 
 - Produces:
-  `IdeaWorkspaceFileInventory.snapshots(): List<IdeaWorkspaceFileModuleSnapshot>`.
-- Each snapshot has one backend module, sorted contained source/content roots,
+  `IdeaWorkspaceFileInventory.snapshot(): IdeaWorkspaceFileInventorySnapshot`.
+- The inventory snapshot has one `IdeaWorkspaceInventoryGeneration` over every
+  module. Each module snapshot has sorted contained source/content roots,
   sorted dependency names, and a complete sorted set of project-model `.kt`
   and `.kts` paths.
+- `IdeaWorkspaceFileCursor` is a server-owned opaque encoding of generation,
+  exact backend module name, and positive next offset.
 
 - [ ] **Step 1: Write failing project-model inventory tests**
 
@@ -200,7 +235,12 @@ Create one IDEA fixture containing:
 - an outside-root `.kts` exposed by a test project scope.
 
 Assert the first five categories are candidates, the shared file appears in
-both module snapshots, and the outside path is absent.
+both module snapshots, and the outside path is absent. Capture a generation,
+then replace one path with another while preserving total cardinality, add a
+module, and remove a module. Each change must alter the generation. Add backend
+contract cases proving the old snapshot token returns
+`STALE_WORKSPACE_INVENTORY` and a cursor issued for one module returns
+`INVALID_WORKSPACE_FILE_CURSOR` when used with another.
 
 - [ ] **Step 2: Run the focused red backend test**
 
@@ -214,10 +254,17 @@ Expected: compilation fails because the inventory does not exist.
 
 Use `FileTypeIndex` with project and module content scopes for compiler-visible
 Kotlin files. Use `ModuleRootManager` content/source roots to retain every
-owner. The Java bridge reads `GradleSettings.linkedProjectsSettings` and
-returns normalized external project roots and root-module associations. For
-each model-proven root, look up only `settings.gradle.kts` and
-`build.gradle.kts`; do not walk directories.
+owner. The Java bridge reads `GradleSettings.getLinkedProjectsSettings()` for
+direct roots; reads
+`GradleProjectSettings.getCompositeBuild()`,
+`GradleProjectSettings.CompositeBuild.getCompositeParticipants()`, and
+`BuildParticipant.getRootPath()` for included-build roots; and associates
+modules with those roots through
+`GradleModuleDataIndex.findGradleModuleData(Module)`,
+`GradleModuleData.isIncludedBuild()`, `getGradleProjectDir()`, and
+`ModuleData.getLinkedExternalProjectPath()`. Return normalized external roots
+and root-module associations. For each model-proven root, look up only
+`settings.gradle.kts` and `build.gradle.kts`; do not walk directories.
 
 Project-scope `.kts` files under a contained module root acquire all containing
 module owners. A contained linked-root script without a content-root owner
@@ -228,19 +275,33 @@ ownership is recorded.
 
 - [ ] **Step 4: Page sorted inventory in the backend**
 
-Replace cap-before-sort logic with:
+Replace cap-before-sort logic with generation validation followed by slicing:
 
 ```kotlin
-val allFiles = snapshot.filePaths.sorted()
-val offset = query.pageOffset?.value ?: 0
-require(offset <= allFiles.size)
+val current = inventory.snapshot()
+val requestedGeneration = decodeSnapshotToken(query.snapshotToken)
+if (requestedGeneration != current.generation) {
+    throw WorkspaceInventoryStale
+}
+val cursor = query.pageToken?.let(::decodePageCursor)
+cursor?.requireGenerationAndModule(current.generation, query.moduleName)
+val allFiles = current.module(query.moduleName).filePaths
+val offset = cursor?.nextOffset ?: 0
 val files = if (query.includeFiles) allFiles.drop(offset).take(fileLimit) else emptyList()
 val nextOffset = offset + files.size
-val nextToken = nextOffset.takeIf { query.includeFiles && it < allFiles.size }?.toString()
+val nextToken = nextOffset
+    .takeIf { query.includeFiles && it < allFiles.size }
+    ?.let { encodePageCursor(current.generation, query.moduleName, it) }
 ```
 
-Exact module requests page one snapshot. Metadata requests return every sorted
-module. Populate stable counts/tokens on every page.
+Build and fingerprint the canonical full inventory in one IDEA read action.
+The fingerprint includes sorted module identities, source/content roots,
+dependency names, and file paths, so equal-cardinality replacement and module
+add/remove cannot reuse a generation. Metadata requests return every sorted
+module plus the opaque snapshot token. Exact-module requests must match that
+generation before slicing; malformed, out-of-range, or cross-module cursors
+return `INVALID_WORKSPACE_FILE_CURSOR`. Populate stable counts and opaque
+tokens on every page.
 
 - [ ] **Step 5: Prove scripts, multiple owners, and pages**
 
@@ -251,8 +312,9 @@ Run:
 ./gradlew :index-store:test --tests '*SourceIndexFilePolicyTest*' --no-daemon
 ```
 
-Expected: project scripts and shared ownership pass; the index-store test still
-proves `.kts` rejection.
+Expected: project scripts, shared ownership, included-build associations,
+generation changes, stale responses, and cross-module rejection pass; the
+index-store test still proves `.kts` rejection.
 
 - [ ] **Step 6: Commit backend authority**
 
@@ -436,8 +498,9 @@ git commit -m "feat: add uncapped Kotlin source inventory"
 
 - Produces:
   `collect_workspace_inventory(WorkspaceInventoryInputs) -> Result<WorkspaceInventorySnapshot>`.
-- Backend collection uses one admitted `RawRpcSession`, exact-module paging,
-  and typed `BackendModuleCoverage`.
+- Backend collection uses one admitted `RawRpcSession`, a top-level opaque
+  snapshot token, exact-module opaque cursors, bounded restart, and typed
+  `BackendWorkspaceCoverage`/`BackendModuleCoverage`.
 
 - [ ] **Step 1: Write failing page-exhaustion and multi-owner tests**
 
@@ -447,6 +510,19 @@ physical record has both owners, pages do not overlap, and all modules are
 complete. Add failures for repeated/non-advancing tokens, changed totals,
 overlap, missing module, and a page failure after earlier successes; only the
 affected module becomes partial.
+
+Add three generation regressions:
+
+- replace one path with another while preserving `fileCount` between pages;
+- add or remove a module after metadata; and
+- return a cursor bound to a different module.
+
+Assert the first two produce `STALE_WORKSPACE_INVENTORY`, discard every backend
+page from that attempt, and restart from fresh metadata exactly once. Assert a
+second stale response does not restart again: backend coverage is typed
+partial, every module from the last metadata response is partial,
+`BACKEND_WORKSPACE_INVENTORY_STALE` is emitted, and no stale backend candidate
+is composed. Cross-module cursor use is invalid and never becomes a page.
 
 - [ ] **Step 2: Write failing drift tests**
 
@@ -489,16 +565,25 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_workspace_fil
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test semantic_workspace_admission_smoke workspace_files
 ```
 
-Expected: paging, composition, Git, and exact-root cases fail because the
-collector is absent.
+Expected: generation-bound paging, bounded restart, composition, Git, and
+exact-root cases fail because the collector is absent.
 
 - [ ] **Step 6: Implement strict backend paging**
 
-Fetch module metadata, sort exact module names, and request pages until each
-returns no next token. Validate total/returned counts, canonical advancement,
-module identity, non-overlap, and containment before merging. Preserve
-duplicate physical paths as one record with a `BTreeSet` of owners. A failed
-page records `BackendModuleCoverage::Partial`; it never silently truncates.
+Fetch module metadata and its opaque snapshot token, sort exact module names,
+and echo the snapshot while requesting opaque cursors until each module
+returns no next token. Never parse or construct a token in Rust. Validate
+total/returned counts, cursor advancement, echoed snapshot, module identity,
+non-overlap, and containment before merging. Preserve duplicate physical paths
+as one record with a `BTreeSet` of owners.
+
+On the first `STALE_WORKSPACE_INVENTORY`, discard the entire backend attempt
+and restart once from fresh metadata. If the retry is stale, discard it too,
+return `BackendWorkspaceCoverage::Partial` with
+`BACKEND_WORKSPACE_INVENTORY_STALE`, and mark every last-known module partial.
+No candidates from either stale attempt survive. Other page failures record
+only that module as `BackendModuleCoverage::Partial`; they never silently
+truncate.
 
 - [ ] **Step 7: Implement conservative composition**
 
@@ -632,8 +717,9 @@ git commit -m "feat: expose bounded workspace file discovery"
 
 - [ ] **Step 1: Regenerate Kotlin-owned protocol artifacts**
 
-Run the repository generators, then prove raw request schemas include
-`pageToken` and module results include returned count/next token:
+Run the repository generators, then prove raw request schemas include opaque
+`snapshotToken`/`pageToken`, results include the top-level snapshot token, and
+module results include returned count/next token:
 
 ```console
 ./gradlew :analysis-server:generateDocPages --no-daemon
@@ -650,16 +736,16 @@ Keep an unowned on-disk `.kt` file and assert it is absent.
 - [ ] **Step 3: Update ownership and packaged guidance**
 
 Add the command to `cli-rs/src/agent/AGENTS.md`. Teach source/script filters,
-partial limitations, owner sets, and direct path composition. State explicitly
-that `.kts` is not in the Kotlin source index and Gradle semantic declarations
-arrive with #340.
+partial limitations, one bounded stale-snapshot retry, owner sets, and direct
+path composition. State explicitly that `.kts` is not in the Kotlin source
+index and Gradle semantic declarations arrive with #340.
 
 - [ ] **Step 4: Update reference and how-to docs**
 
 Document every flag, limit, result view, owner set, package state, drift/index
-truth table, limitations, exact-root behavior, and paging-backed completeness.
-Replace generic-search-first guidance with `workspace-files`, then diagnostics
-or exact symbol lookup.
+truth table, limitations, exact-root behavior, generation-bound paging, and the
+typed partial result after repeated staleness. Replace generic-search-first
+guidance with `workspace-files`, then diagnostics or exact symbol lookup.
 
 - [ ] **Step 5: Validate guidance and commit**
 
@@ -697,8 +783,8 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test semantic_workspace_
 ./gradlew :analysis-api:test :analysis-server:test :index-store:test :backend-idea:test --no-daemon
 ```
 
-Expected: paging/project-model tests pass and `.kts` remains rejected by
-`SourceIndexFilePolicyTest`.
+Expected: generation/fingerprint, stale, cursor-binding, paging/project-model
+tests pass and `.kts` remains rejected by `SourceIndexFilePolicyTest`.
 
 - [ ] **Step 3: Run full Rust quality gates**
 
@@ -731,9 +817,11 @@ contracts only; no source-index schema or `SourceIndexFilePolicy` change.
 
 - [ ] **Step 6: Request independent review**
 
-Ask a fresh reviewer to check paging determinism, project-model script
-authority, `.kt`-only source-index preservation, multi-owner physical files,
-nested Git mapping, exact-root rejected-no-request proof, package-state SQL,
-false `INDEX_ONLY`, capability callability, #340 reuse, budgets, and every issue
+Ask a fresh reviewer to check generation-bound paging determinism,
+equal-cardinality/module-set stale detection, single bounded restart,
+cross-module cursor rejection, included-build project-model script authority,
+`.kt`-only source-index preservation, multi-owner physical files, nested Git
+mapping, exact-root rejected-no-request proof, package-state SQL, false
+`INDEX_ONLY`, capability callability, #340 reuse, budgets, and every issue
 acceptance criterion. Repair each blocking finding with a focused red-green
 commit and rerun the affected gate plus full Rust and Kotlin suites.

--- a/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
+++ b/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
@@ -47,6 +47,15 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
   replacement, query mismatch, explicit completion/invalidation, terminal
   consume, and server shutdown must all remove through the same disposer path;
   #337 closeable IDEA traversal state is adapted to that owner.
+- Make single-use consumption an atomic typed ownership transition. A borrowed
+  callback returns `Complete(output)` or `Reissue(output, nextQuery)`; reissue
+  moves the same owned state behind a fresh handle without closing it, and the
+  callback can never return `State`. Shutdown makes racing reissue terminal.
+  Store close waits for every claimed callback to exit and dispose before it
+  returns.
+- Give the running server one explicit closeable-backend owner. Thread it from
+  `KastIdeaBackendRuntime` through `ObservedAnalysisBackend`; stop admissions,
+  close dispatcher state, and close backend stores exactly once on shutdown.
 - Rust page validation is limited to non-repeated handles, non-overlapping
   physical paths, and cumulative returned evidence; generation/module/offset
   integrity belongs to the server-held state.
@@ -60,6 +69,13 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Never parse `file_metadata.module_path` as `GradleProjectPath`. Persist and
   read a separate build-qualified project-model tuple from the IDEA producer;
   keep an IDEA module-name fallback only as a legacy unproven label.
+- Never treat path-derived `file_metadata.source_set` or nullable text-parser
+  package output as proof. Persist model-proven build-qualified Gradle source
+  sets and Kotlin PSI/compiler package provenance as discriminated types. A
+  missing parser result is `UNPROVEN`, never root.
+- Advance `packaging/homebrew/release-state.json` from source-index schema 7 to
+  8 in Task 2. It remains the only checked-in schema source; generated Kotlin
+  and Rust constants and their tests must agree before a version-8 DB is read.
 - Keep the internal inventory uncapped by public filters and `--limit`.
 - Default `--limit` to 20, reject values outside 1 through 200, and keep compact
   output below 120 lines and 1,500 estimated tokens.
@@ -116,7 +132,9 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationCapacity.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationClock.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationStateDisposer.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationTransition.kt`
 - Create: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/continuation/ServerHeldContinuationStoreTest.kt`
+- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/CloseableAnalysisBackend.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedWorkspaceFilesQuery.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/WorkspaceInventoryStaleException.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/InvalidWorkspaceFileCursorException.kt`
@@ -132,7 +150,11 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Create: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/ServerLimitsTest.kt`
 - Modify: `analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt`
 - Modify: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/RpcAnalysisDispatcher.kt`
+- Modify: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisServer.kt`
+- Modify: `analysis-server/src/main/kotlin/io/github/amichne/kast/server/RunningAnalysisServer.kt`
+- Modify: `analysis-server/AGENTS.md`
 - Modify: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt`
+- Modify: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt`
 
 **Interfaces:**
 
@@ -147,7 +169,10 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
   `WorkspaceProjectModelIncompleteReason` details.
 - Produces: reusable `ServerHeldContinuationStore<Token, Query, State>` with
   typed positive TTL/capacity, injected clock, deterministic eviction,
-  reusable leases, single-use consumption, and exact-once state disposal.
+  reusable leases, atomic single-use `Complete`/`Reissue` transitions, and
+  exact-once state disposal.
+- Produces: `CloseableAnalysisBackend`, an explicit server-owned lifecycle
+  contract. `RunningAnalysisServer` is the sole close owner after start.
 - Invariant: snapshot and page tokens are canonical random UUID handles, not
   encoded state. An input snapshot token is legal with `includeFiles=true` and
   one exact module, or with `includeFiles=false` and no module for final barrier
@@ -203,15 +228,22 @@ and migrate `FakeAnalysisBackend` reference/diagnostic continuation maps to this
 store before adding fake workspace-file state; do not maintain three ad hoc map
 policies.
 
-Use a close-counting fake state and prove exactly one disposal for expiry,
-eviction, same-handle replacement, query mismatch, explicit invalidation or
-successful completion, terminal consume, callback failure, and server
-shutdown. Trigger a second removal path after each case and assert the count
-stays one. A throwing disposer must not prevent shutdown from draining and
-disposing later entries. Adapt #337's closeable IDEA traversal to the same
-test surface so its resource lifetime is not merely theoretical. Race terminal
-consume against shutdown and expiry cleanup against replacement; atomic
-ownership transfer/removal must still close each fake state once.
+Use a close-counting fake state and consume at least three pages through
+`Reissue`, asserting the old token is invalid, each fresh token owns the same
+still-open state, and no close occurs before `Complete`. Then prove exactly one
+disposal for completion, callback failure, expiry, eviction, same-handle
+replacement, query mismatch, explicit invalidation, and server shutdown.
+Trigger a second removal path after each case and assert the count stays one.
+A throwing disposer must not prevent shutdown from draining later entries.
+Adapt #337's closeable IDEA traversal to the same test surface. Race
+`Complete` and `Reissue` against shutdown, expiry cleanup against replacement,
+and capacity eviction against reissue; a reissue that loses to shutdown is
+terminal and every fake closes once.
+
+Add socket/stdio lifecycle tests around a close-counting
+`CloseableAnalysisBackend`. Prove transport admission stops before backend
+close, dispatcher stores drain, backend close runs once on repeated server and
+runtime close, and a backend close failure does not skip descriptor cleanup.
 
 Assert invalid raw errors expose only typed `details.scope` of
 `SNAPSHOT_HANDLE` or `PAGE_HANDLE`. Snapshot failure discards the workspace-wide
@@ -252,12 +284,20 @@ distinct type. Add `snapshotToken: String?` and `pageToken: String?` to
 `WorkspaceFilesQuery`, add the closed kind domain, parse each once, and reject
 illegal field combinations.
 The shared continuation store owns random issue, TTL cleanup, capacity
-eviction, query comparison, reusable lookup, single-use consumption, and
-exact-once disposal. Its lease/consume APIs accept callbacks rather than
-returning owning state; every terminating path removes through one
-idempotence-guarded disposer and `close()` drains the store at server shutdown.
-Make the dispatcher/server lifecycle the single owner that closes every typed
-store instance exactly once.
+eviction, query comparison, reusable lookup, atomic single-use consumption,
+and exact-once disposal. Its callback receives borrowed state and returns only
+`ContinuationTransition.Complete(output)` or
+`ContinuationTransition.Reissue(output, nextQuery)`. Claim the old handle
+before callback execution. Complete/failure disposes; reissue atomically moves
+the same owned state behind a fresh handle and never returns `State`. Track
+in-flight claims so shutdown closes admissions and makes any racing reissue
+terminal after callback completion rather than closing a resource in use.
+`close()` waits for all claimed callbacks to finish and reach disposal.
+
+Introduce `CloseableAnalysisBackend` instead of a runtime cast. `AnalysisServer`
+accepts that type, and `RunningAnalysisServer.close()` owns ordered transport,
+dispatcher, backend, and descriptor cleanup exactly once. Fake/headless
+backends implement explicit no-resource close behavior.
 Do not encode or decode offsets, generations, modules, or queries in a token. Keep
 the server's positive page-size and
 maximum checks. Add matching `AnalysisException` subtypes: stale inventory is
@@ -299,12 +339,14 @@ snapshot to the success response. Do not migrate unrelated legacy skill types.
 - [ ] **Step 5: Run Kotlin paging tests green**
 
 Run the Step 2 command. Expected: all paging, validation, stale-generation,
-cross-module, and non-overlap tests pass.
+cross-module, non-overlap, atomic reissue, exact-close, and server close-owner
+tests pass.
 
 - [ ] **Step 6: Update source ownership and commit**
 
-Record query/result/generated ownership, exact-once continuation disposal, and
-paging/shutdown gates in `analysis-api/AGENTS.md`.
+Record query/result/generated ownership and atomic continuation transfer in
+`analysis-api/AGENTS.md`. Record ordered dispatcher/backend close ownership and
+shutdown gates in `analysis-server/AGENTS.md`.
 
 ```console
 git add analysis-api analysis-server
@@ -325,6 +367,8 @@ git commit -m "feat: page raw workspace file results"
 - Create: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceInventoryGeneration.kt`
 - Create: `backend-idea/src/main/java/io/github/amichne/kast/idea/IdeaGradleWorkspaceFileBridge.java`
 - Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt`
+- Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastIdeaBackendRuntime.kt`
+- Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/ObservedAnalysisBackend.kt`
 - Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaProjectIndexer.kt`
 - Create: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaWorkspaceFileInventoryTest.kt`
 - Modify: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt`
@@ -332,12 +376,24 @@ git commit -m "feat: page raw workspace file results"
 - Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/BuildQualifiedGradleProjectIdentity.kt`
 - Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/GradleProjectPath.kt`
 - Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/WorkspaceRelativeGradleBuildRoot.kt`
+- Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/BuildQualifiedGradleSourceSetIdentity.kt`
+- Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/GradleSourceSetName.kt`
+- Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/IndexedPackageEvidence.kt`
+- Create: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/IndexedPackageUnprovenReason.kt`
 - Modify: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/FileIndexUpdate.kt`
 - Modify: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/SourceFileIndexParser.kt`
 - Modify: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.kt`
 - Modify: `index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SqliteSourceIndexStoreTest.kt`
 - Modify: `index-store/AGENTS.md`
 - Modify: `backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiSourceIndexScanner.kt`
+- Create: `backend-shared/src/test/kotlin/io/github/amichne/kast/shared/analysis/PsiSourceIndexScannerTest.kt`
+- Modify: `build-logic/AGENTS.md`
+- Create: `build-logic/src/test/kotlin/WriteSourceIndexSchemaVersionTaskTest.kt`
+- Modify: `packaging/homebrew/release-state.json`
+- Verify unchanged: `packaging/homebrew/scripts/test-formulas.py`
+- Verify unchanged: `build-logic/src/main/kotlin/WriteSourceIndexSchemaVersionTask.kt`
+- Verify unchanged: `cli-rs/build.rs`
+- Create: `cli-rs/tests/source_index_schema_version_smoke.rs`
 - Verify unchanged: `index-store/src/main/kotlin/io/github/amichne/kast/indexstore/api/index/SourceIndexFilePolicy.kt`
 - Verify unchanged: `index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SourceIndexFilePolicyTest.kt`
 
@@ -357,6 +413,11 @@ git commit -m "feat: page raw workspace file results"
   source index persists a set of those owners in the dedicated
   `file_gradle_projects` association table, distinct from legacy
   `file_metadata.module_path`.
+- Produces: `BuildQualifiedGradleSourceSetIdentity` from model-owned Gradle
+  source roots and `IndexedPackageEvidence` from Kotlin PSI/compiler structure.
+  Legacy path/module labels remain explicit unproven evidence.
+- Produces: release-state source-index schema version 8, with Kotlin and Rust
+  constants generated from that one file and tested for alignment.
 
 - [ ] **Step 1: Write failing project-model inventory tests**
 
@@ -404,20 +465,52 @@ whose build root or project path fails typed parsing. Prove multiple owners per
 file, schema migration/reset, and generation change when an association is
 added, replaced, or removed.
 
+Add a Gradle fixture whose `integrationTest` source set owns a nonconventional
+root such as `quality/kotlin`; prove the structured Gradle source-set model
+produces `BuildQualifiedGradleSourceSetIdentity` while `/src/main/`, source-root
+basename, and IDEA module-name heuristics cannot. Add Kotlin PSI/compiler
+package fixtures for root, escaped keyword (`com.example.\`when\``), backticked
+non-identifier, and general Unicode names. A missing/failed semantic package
+producer must persist `UNPROVEN`, never `PROVEN_ROOT`. Prove legacy
+`file_metadata.source_set` is unproven and cannot satisfy `--source-set`.
+
+Set `packaging/homebrew/release-state.json.source_index_schema_version` to 8.
+Add a build-logic test that generates Kotlin
+`SOURCE_INDEX_SCHEMA_VERSION == 8` from that file and a Rust smoke test that
+compares its build-script-generated constant/environment with the same JSON and
+asserts the planned value is 8.
+Seed a structurally valid version-7 database without `file_gradle_projects` and
+prove `SqliteSourceIndexStore` rejects/resets it before any compatible read.
+Also prove a claimed version-8 database missing either association table or
+`package_state` fails closed rather than returning partial rows.
+
 After rebasing onto #337, migrate `KastPluginBackend` reference and diagnostic
 continuations to the shared store before adding workspace-file leases. Preserve
 their query/source/generation behavior and add TTL/capacity/single-use
 regressions. Adapt the closeable IDEA traversal to the store's typed disposer
-and assert exact-once close on mismatch, terminal consume, expiry/eviction, and
-plugin/server shutdown; one mechanism owns all three continuation families.
+and assert exact-once close on replacement, mismatch, `Complete`, callback
+failure, expiry, eviction, and repeated plugin/server shutdown; one mechanism
+owns all three continuation families.
+Use the real lazy traversal for at least three pages and assert it remains open
+after each `Reissue`, the prior token is invalid, and `Complete` closes once.
+Wire `KastPluginBackend` as a `CloseableAnalysisBackend`, forward close through
+`ObservedAnalysisBackend`, pass it from `KastIdeaBackendRuntime` into
+`AnalysisServer`, and prove repeated `RunningKastIdeaBackend.close()` and server
+shutdown have one backend close owner. Cover reissue versus shutdown/eviction
+and callback failure while the IDEA state is claimed, plus expiry/replacement
+and server-close/callback races.
 
 - [ ] **Step 2: Run the focused red backend test**
 
 ```console
+./gradlew -p build-logic test --tests WriteSourceIndexSchemaVersionTaskTest
 ./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --tests '*IdeaProjectIndexerModuleNameTest*' :index-store:test --tests '*SqliteSourceIndexStoreTest*' --no-daemon
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test source_index_schema_version_smoke
+python3 packaging/homebrew/scripts/test-formulas.py
 ```
 
-Expected: compilation fails because the inventory does not exist.
+Expected: the new inventory/provenance tests fail to compile, and schema
+alignment fails until release state advances to 8 and both generators agree.
 
 - [ ] **Step 3: Implement model-backed candidate collection**
 
@@ -446,20 +539,42 @@ empty complete inventory. Canonical containment is mandatory before ownership
 is recorded.
 
 Reuse that bridge in `IdeaProjectIndexer`: resolve each `.kt` file's IDEA module
-through `GradleModuleDataIndex`, associate it with one direct/composite linked
-build root, and take `GradleModuleData.getGradlePathOrNull()` as the project
-path. Construct the host-neutral identity only after both typed components are
-proved. Collect every containing module's distinct model-proven identity. Add
-the dedicated non-null `file_gradle_projects(prefix_id, filename, build_root,
-project_path)` association table, advance the checked-in source-index schema
-version, add `FileIndexUpdate.gradleProjects` as a
-`Set<BuildQualifiedGradleProjectIdentity>`, and persist the owner set
-transactionally. Adding, replacing, or removing an association increments
-`schema_version.generation` in that same write transaction.
-`PsiSourceIndexScanner` accepts host-neutral module evidence;
-no IntelliJ type crosses into `backend-shared` or `index-store`. Keep
-`module_path` for existing symbol/metrics behavior,
-but workspace discovery must never select or parse it as Gradle identity.
+through `GradleModuleDataIndex`, associate it with direct/composite linked build
+roots, and take `GradleModuleData.getGradlePathOrNull()` as the project path.
+Construct host-neutral project identity only after both typed components are
+proved. Resolve the file's owning Gradle source-set model nodes for its
+model-proven source roots and construct
+`BuildQualifiedGradleSourceSetIdentity(project, GradleSourceSetName)` only from
+those nodes. Delete `sourceSetForFile` as an authority; path fragments and
+source-root basenames may populate only a legacy unproven label.
+
+Add the dedicated non-null `file_gradle_projects(prefix_id, filename,
+build_root, project_path)` and `file_gradle_source_sets(prefix_id, filename,
+build_root, project_path, source_set_name)` association tables. Advance only
+`packaging/homebrew/release-state.json.source_index_schema_version` from 7 to
+8; keep `WriteSourceIndexSchemaVersionTask` and `cli-rs/build.rs` as the Kotlin
+and Rust generators rather than adding literals. Add
+`FileIndexUpdate.gradleProjects`, `gradleSourceSets`, and typed
+`packageEvidence`, then persist them transactionally with required
+`file_metadata.package_state`/`package_unproven_reason` constraints. Adding,
+replacing, or removing any
+association/evidence increments `schema_version.generation` in that transaction.
+
+`PsiSourceIndexScanner` reads `KtFile.packageFqName` or equivalent structured
+Kotlin PSI/compiler evidence and passes canonical `ProvenRoot`, `ProvenNamed`,
+or `Unproven(reason)` to `FileIndexUpdate`. `SourceFileIndexParser` may parse
+declarations but cannot turn nullable package output into root. No IntelliJ
+type crosses into `backend-shared` or `index-store`. Keep `module_path` and
+`source_set` for existing symbol/metrics behavior only; workspace discovery
+must never select or parse either legacy label as proven Gradle identity.
+
+Make `KastPluginBackend` implement `CloseableAnalysisBackend` and drain its
+snapshot/page/reference/diagnostic stores exactly once. Make
+`ObservedAnalysisBackend` implement the same type and forward close to its
+delegate. `KastIdeaBackendRuntime` passes the observed owner to
+`AnalysisServer`; `RunningKastIdeaBackend.close()` cancels indexing and closes
+only the running server. Do not close the backend directly from both runtime
+and server.
 
 - [ ] **Step 4: Page sorted inventory with server-held state**
 
@@ -469,18 +584,29 @@ Replace cap-before-sort logic with generation validation followed by slicing:
 val lease = snapshotStore.requireLease(query.snapshotToken, query.workspaceIdentity)
 val current = inventory.snapshot()
 lease.requireGeneration(current.generation)
-val continuation = query.pageToken?.let { token ->
-    pageStore.consume(token, WorkspacePageQuery.from(query))
-}
-val state = continuation ?: lease.firstPage(query.requireExactModule())
-val allFiles = current.module(state.moduleName).filePaths
-val offset = state.nextOffset
-val files = if (query.includeFiles) allFiles.drop(offset).take(fileLimit) else emptyList()
-val nextOffset = offset + files.size
-val nextToken = nextOffset
-    .takeIf { query.includeFiles && it < allFiles.size }
-    ?.let { pageStore.issue(state.advanceTo(it)) }
+val pageQuery = WorkspacePageQuery.from(query)
+val page = query.pageToken?.let { token ->
+    pageStore.consume(token, pageQuery) { state ->
+        val allFiles = current.module(state.moduleName).filePaths
+        val files = allFiles.drop(state.nextOffset).take(fileLimit)
+        val nextOffset = state.nextOffset + files.size
+        val output = state.output(files)
+        if (nextOffset < allFiles.size) {
+            state.advanceTo(nextOffset)
+            ContinuationTransition.Reissue(output, pageQuery)
+        } else {
+            ContinuationTransition.Complete(output)
+        }
+    }
+} ?: lease.withBorrowedState { state -> firstPage(current, state, pageQuery) }
 ```
+
+`consume` returns output plus a new opaque token only for `Reissue`; neither
+branch returns `State`. The initial-page helper issues one store-owned state
+when another page exists. #337 uses the same transition with its lazy traversal
+as the owned state. The callback has exclusive borrowed access and may advance
+that state's internal cursor before `Reissue`; reissue changes only the owning
+handle/query while keeping the traversal open.
 
 Build and fingerprint the canonical requested-kind inventory in one IDEA read
 action. The fingerprint includes the kind domain, sorted module identities,
@@ -498,20 +624,25 @@ handles on every page. Rust never sees an offset or generation encoding.
 Run:
 
 ```console
+./gradlew -p build-logic test --tests WriteSourceIndexSchemaVersionTaskTest
 ./gradlew :backend-idea:test --tests '*IdeaWorkspaceFileInventoryTest*' --tests '*KastPluginBackendContractTest*workspace files*' --no-daemon
 ./gradlew :index-store:test --tests '*SourceIndexFilePolicyTest*' --tests '*SqliteSourceIndexStoreTest*' --no-daemon
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test source_index_schema_version_smoke
+python3 packaging/homebrew/scripts/test-formulas.py
 ```
 
 Expected: project scripts, shared ownership, included-build associations,
-build-qualified root/included project identities, legacy fallback isolation,
-generation changes, stale responses, and cross-module rejection pass; the
-typed indexing/project-model failures retain their reason; the index-store test
-still proves `.kts` rejection.
+build-qualified root/included project identities, custom `integrationTest`,
+structured package provenance, legacy fallback isolation, schema 8 alignment,
+v7 rejection/reset, generation changes, stale responses, atomic multi-page
+reissue/close, and cross-module rejection pass. Typed indexing/project-model
+failures retain their reason; the index-store test still proves `.kts`
+rejection.
 
 - [ ] **Step 6: Commit backend authority**
 
 ```console
-git add backend-idea backend-shared index-store
+git add backend-idea backend-shared index-store build-logic/AGENTS.md build-logic/src/test/kotlin/WriteSourceIndexSchemaVersionTaskTest.kt packaging/homebrew/release-state.json cli-rs/tests/source_index_schema_version_smoke.rs
 git diff --cached --check
 git commit -m "feat: enumerate project model Kotlin scripts"
 ```
@@ -519,10 +650,13 @@ git commit -m "feat: enumerate project model Kotlin scripts"
 `backend-idea/AGENTS.md` records that the inventory and Java Gradle bridge own
 model-proven `.kt`/`.kts` candidates, server-held generation-bound paging,
 TTL/capacity/integrity behavior, typed
-project-model incompleteness, build-qualified index-producer identity, and the
-focused backend tests above. `index-store/AGENTS.md` records the dedicated
-identity association table and prohibits promoting the legacy module label. These are
-the nearest guides for the new source boundaries.
+project-model incompleteness, atomic reissue, single close ownership,
+build-qualified project/source-set production, structured package evidence, and
+the focused backend tests above. `index-store/AGENTS.md` records version-8
+association/provenance structures and prohibits promoting legacy labels.
+`build-logic/AGENTS.md` records that release state generates the Kotlin schema
+constant and names its alignment gate. These are the nearest guides for the new
+source boundaries.
 
 Do not stage either source-index policy file; both are verification-only.
 
@@ -555,6 +689,10 @@ noncanonical handles and page-token/count combinations that cannot emit files.
 Accept `backend:<exact-name>`, `gradle:.#:app`, and
 `gradle:included/tools#:app`; reject unprefixed/empty selectors, absolute or
 escaping build roots, and non-absolute Gradle project paths.
+Accept canonical Kotlin package selectors for escaped/backticked and general
+Unicode identifiers, normalize them to semantic FQ names, and reject malformed
+package syntax. Accept a typed `integrationTest` source-set name without
+assuming any directory convention.
 
 - [ ] **Step 2: Run the red command tests**
 
@@ -576,6 +714,10 @@ newtypes; Task 4 maps that variant to the inventory identity. Derive the raw/com
 source-only, script-only, or mixed domain from the kind filter, with no filter
 meaning mixed. Use private-field newtypes and `FromStr` validation. Keep the public token type
 distinct from raw snapshot/module-page tokens. The drift enum is:
+Parse package filters through the same canonical Kotlin package-name boundary
+used by producer evidence. Parse source-set filters as names only, but allow
+matches exclusively against model-proven build-qualified source-set evidence.
+Legacy labels never satisfy either filter. The drift enum is:
 
 ```rust
 pub enum WorkspaceDriftFilter {
@@ -626,7 +768,8 @@ git commit -m "feat: add typed workspace file command boundary"
   `WorkspaceIndexSnapshot`, `SourceIndexSnapshotStamp`,
   `SourceIndexGeneration`, `SourceIndexModuleProgress`,
   `SourceIndexPendingCount`, `WorkspacePackageEvidence`,
-  `BuildQualifiedGradleProjectIdentity`,
+  `WorkspaceSourceSetEvidence`, `BuildQualifiedGradleProjectIdentity`,
+  `BuildQualifiedGradleSourceSetIdentity`,
   `WorkspaceIndexRead`, `WorkspaceInventoryLimitationCode`,
   `WorkspaceMatchCoverage`, and `read_workspace_index(&WorkspaceRoot)`.
 - The index reader has no public limit and returns `.kt` rows only.
@@ -639,21 +782,24 @@ leaf below an in-root symlink to outside, a dangling symlink, permission or
 canonicalization failure, and an ancestor race. The first missing leaf is
 admitted through its deepest existing ancestor; every unprovable case is
 excluded with `PATH_CONTAINMENT_UNPROVABLE` and partial candidate coverage. Add
-four package cases:
+package/provenance cases:
 
 1. no `file_metadata` row;
-2. metadata with null `package_fq_id`;
-3. metadata with a joined package name; and
-4. metadata with dangling `package_fq_id`.
+2. `UNPROVEN` metadata with null `package_fq_id`;
+3. `PROVEN_ROOT` metadata with null `package_fq_id`;
+4. `PROVEN_NAMED` metadata joined to canonical escaped/backticked/Unicode names;
+5. a missing semantic parser result that stays `UNPROVEN`; and
+6. illegal state/id combinations or a dangling `package_fq_id`.
 
 Assert 500 valid `.kt` candidates, zero `.kts`, exact package variants, typed
 excluded/invalid counts, and no escaping missing path.
 
-Seed a root-build `:app`, an included-build `:app`, a legacy-only
-`module_path=idea.app.main`, and malformed association rows. Assert the first
-two decode as distinct build-qualified owners of the same file, the legacy
-value is never read as Gradle identity, and malformed build-root/project-path
-values are typed incompatible evidence rather than partial owners.
+Seed a root-build `:app`, an included-build `:app`, a model-proven
+`integrationTest`, legacy-only `module_path=idea.app.main` and `source_set=main`
+labels, and malformed association rows. Assert the projects decode as distinct
+owners, `integrationTest` is structured source-set evidence, neither legacy
+value is read as proof, and malformed components are typed incompatible
+evidence rather than partial owners.
 
 Seed generation, `module_index_progress`, and unapplied `pending_updates`.
 Assert the snapshot carries their typed state; only a nonempty initialized
@@ -672,14 +818,14 @@ Expected: compilation fails because inventory types do not exist.
 
 - [ ] **Step 3: Define the invariant-carrying model**
 
-Use sorted sets for owners and source sets:
+Use sorted sets inside discriminated ownership/evidence types:
 
 ```rust
 pub(crate) struct WorkspaceInventoryFile {
     path: WorkspaceFilePath,
     backend_modules: BTreeSet<BackendModuleName>,
     indexed_gradle_projects: BTreeSet<BuildQualifiedGradleProjectIdentity>,
-    source_sets: BTreeSet<WorkspaceSourceSet>,
+    source_sets: WorkspaceSourceSetEvidence,
     kind: WorkspaceFileKind,
     package: WorkspacePackageEvidence,
     index_state: WorkspaceFileIndexState,
@@ -691,6 +837,9 @@ pub(crate) struct WorkspaceInventoryFile {
 
 Include `NotApplicable` in source-index state and drift. Keep fields private
 with read-only accessors required by agent/#340 consumers.
+Define `WorkspaceSourceSetEvidence::Proven(set)`, `Unproven(legacy_labels)`,
+and `Unavailable`; define package as `ProvenRoot`, `ProvenNamed`, `Unproven`,
+`Unavailable`, or `InvalidReference`. Filters match only proven variants.
 
 Define closed limitation variants for backend capability, metadata, page,
 stale generation, runtime indexing, unavailable project model, unassociated
@@ -705,20 +854,23 @@ when a requested predicate is unknown.
 
 - [ ] **Step 4: Implement the read-only query exactly from the design**
 
-Within one SQLite read transaction, select `metadata_present`, `package_fq_id`,
-joined `fq_name`, and all joined `file_gradle_projects` rows separately,
+Within one SQLite read transaction, select `metadata_present`, required
+`package_state`, `package_unproven_reason`, `package_fq_id`, joined `fq_name`, all joined
+`file_gradle_projects` rows, and all joined `file_gradle_source_sets` rows,
 plus `schema_version.generation`, all module progress rows, and the unapplied
-pending-update count. Never select or parse `module_path` as Gradle ownership. Use
+pending-update count. Never select or parse `module_path` or legacy
+`source_set` as proven Gradle ownership. Use
 `SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_URI`, configure query-only access, verify
-schema/tables, decode existing path prefixes, reject non-`.kt`, and map the four
-package states without collapsing nulls. For missing paths, canonicalize the
+release-state-generated schema 8 and required structures, decode existing path
+prefixes, reject non-`.kt`, and map the package/source-set provenance states
+without collapsing nulls. For missing paths, canonicalize the
 deepest existing ancestor; lexical containment alone is insufficient.
 
 In `SqliteSourceIndexStore`, increment the existing generation in the same
-write transaction as any candidate-table, build-qualified association,
-progress, or pending applied-state mutation. Task 2 already adds and versions
-the dedicated association table; do not add another ownership column or admit
-`.kts`.
+write transaction as any candidate-table, build-qualified project/source-set
+association, package evidence, progress, or pending applied-state mutation.
+Task 2 already adds and versions the dedicated structures; do not add another
+ownership column or admit `.kts`.
 
 - [ ] **Step 5: Add the scoped ownership guide and verify**
 
@@ -728,7 +880,8 @@ legacy `module_path` as project-model Gradle identity. State in the new Rust gui
 that it owns uncapped exact-root composition, generation/progress/pending-aware
 `.kt` index reads, deepest-existing-ancestor containment, set-valued owners,
 backend page coverage, and Git annotation. Prohibit `.kts` source-index reads
-and filesystem/Git candidate enumeration.
+and filesystem/Git candidate enumeration. Also prohibit treating legacy
+`source_set` or nullable parser output as proven source-set/package evidence.
 
 Run Step 2. Expected: all 500 rows and package/path invariants pass.
 
@@ -995,11 +1148,13 @@ git commit -m "feat: compose exhaustive workspace file evidence"
 
 - [ ] **Step 1: Write failing output, filter, limitation, and budget tests**
 
-Assert compact records contain sorted backend owners and structured
-build-qualified Gradle project owners, source sets, kind, structured
-package evidence, source-index state, drift, dirty state, and paths. Cover each
-filter and conjunction; partial pages, unavailable index/Git, invalid package
-reference, and both candidate sources unavailable. Seed 500 records and assert
+Assert compact records contain sorted backend owners, structured
+build-qualified Gradle project owners, discriminated proven/unproven source-set
+evidence, kind, discriminated package provenance, source-index state, drift,
+dirty state, and paths. Cover each filter and conjunction; custom
+`integrationTest`, escaped/backticked/Unicode package names, nullable parser
+output that remains unproven, partial pages, unavailable index/Git, invalid
+package reference, and both candidate sources unavailable. Seed 500 records and assert
 20 default records, at most 120 lines, and at most 1,500 estimated tokens.
 
 Add dispatcher contract tests for public continuation issue/consume. Prove the
@@ -1034,7 +1189,7 @@ predicate are complete. Cover these counterexamples explicitly:
 
 - complete candidate inventory plus unavailable Git and `--dirty clean` is
   `KNOWN_MINIMUM` with partial filter evidence;
-- unavailable package/source-set metadata with a corresponding filter is
+- unavailable or unproven package/source-set evidence with a corresponding filter is
   `KNOWN_MINIMUM` even if backend paging is complete;
 - partial backend pages or unavailable source-index candidate authority are
   `KNOWN_MINIMUM`; and
@@ -1084,6 +1239,9 @@ corresponding owner type, sort by relative path and sorted owner sets, and only
 then take `limit`. Compute candidate-inventory and selected-filter evidence
 coverage before projection. Do not infer exact match cardinality merely from a
 fully consumed known-candidate vector.
+Package and source-set filters match only `ProvenNamed`/`ProvenRoot` or
+`WorkspaceSourceSetEvidence::Proven`; legacy/unproven values remain visible to
+explain output but cannot become matches.
 
 For a resumed request, consume the opaque public handle through the internal
 server continuation service, require the identical normalized query identity,
@@ -1187,7 +1345,9 @@ Add the command to `cli-rs/src/agent/AGENTS.md`. Teach source/script filters,
 public continuation, partial limitations, backend and cross-source bounded
 retries, per-kind lane relevance, discriminated available/unavailable
 composition stamps, build-qualified Gradle owner sets, and direct path
-composition. State explicitly that `.kts` is not in the Kotlin source index,
+composition. Teach discriminated proven/unproven package and source-set
+evidence, and that filters match only structured proof. State explicitly that
+`.kts` is not in the Kotlin source index,
 unrelated `.kt` progress cannot make script-only discovery partial, and Gradle
 semantic declarations arrive with #340.
 
@@ -1201,9 +1361,9 @@ changes.
 - [ ] **Step 4: Update reference and how-to docs**
 
 Document every flag, limit, page token, result view, typed backend/build-
-qualified Gradle owner set, package state,
+qualified Gradle owner and source-set evidence, package provenance state,
 drift/index truth table, limitations, exact-root behavior, server-held raw
-paging, exact-once store disposal, kind-relevant coherent cross-source
+paging, atomic continuation reissue and exact-once disposal, kind-relevant coherent cross-source
 composition, stable partial continuation, and typed invalid/stale public
 continuation. Replace generic-search-first guidance with `workspace-files`, then
 diagnostics or exact symbol lookup.
@@ -1239,18 +1399,23 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked workspace_inventory
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_result_projection_smoke
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test cli_core_smoke
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test semantic_workspace_admission_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test source_index_schema_version_smoke
 ```
 
 - [ ] **Step 2: Run Kotlin and source-index authority gates**
 
 ```console
+./gradlew -p build-logic test --tests WriteSourceIndexSchemaVersionTaskTest
 ./gradlew :analysis-api:test :analysis-server:test :index-store:test :backend-idea:test --no-daemon
+python3 packaging/homebrew/scripts/test-formulas.py
 ```
 
 Expected: generation/fingerprint, stale, cursor-binding, paging/project-model
-TTL/capacity/integrity and exact-once disposal, final backend validation,
-build-qualified root/included project identity, source-index generation/
-progress/pending, and kind-relevant composition-barrier tests pass; `.kts`
+TTL/capacity/integrity, atomic reissue, one backend close owner, and exact-once
+disposal pass. Release state, generated Kotlin/Rust schema version 8, v7 reset,
+build-qualified root/included project and custom source-set identities,
+structured package provenance, source-index generation/progress/pending, final
+backend validation, and kind-relevant composition-barrier tests pass; `.kts`
 remains rejected by `SourceIndexFilePolicyTest`.
 
 - [ ] **Step 3: Run full Gradle and IDEA packaging gates**
@@ -1295,8 +1460,9 @@ git diff --name-only origin/main...HEAD
 ```
 
 Expected: issue source/tests/guidance/ADR/spec/plan, the dedicated
-build-qualified source-index schema migration, and required generated contracts
-only; no `.kts` admission or unrelated source-index schema change.
+release-state-owned version-8 project/source-set and package-provenance schema
+migration, and required generated contracts only; no `.kts` admission or
+unrelated source-index schema change.
 
 - [ ] **Step 7: Request independent review**
 
@@ -1307,9 +1473,13 @@ cross-module cursor rejection, included-build project-model script authority,
 mapping, exact-root rejected-no-request proof, package-state SQL, false
 `INDEX_ONLY`, project-model error/reason mapping, metadata failure, zero-module
 global partiality, candidate versus filter coverage, `EXACT` versus
-`KNOWN_MINIMUM`, server-held TTL/capacity/integrity and exact-once disposal,
+`KNOWN_MINIMUM`, server-held TTL/capacity/integrity, atomic multi-page
+`Complete`/`Reissue`, single backend close ownership, and exact-once disposal,
 deepest-ancestor missing-path containment, build-qualified root/included Gradle
-identity without IDEA fallback promotion, index generation/progress/pending
+identity and custom source sets without path/IDEA fallback promotion,
+Kotlin-structured escaped/backticked/Unicode package provenance with no
+null-to-root collapse, release-state/Kotlin/Rust schema-8 alignment and v7
+rejection, index generation/progress/pending
 state, kind-relevant cross-source barrier mutation, available/unavailable lane
 digests, backend/index-only partial continuation, public 200/200/100
 continuation, invalid/stale/query-mismatched public tokens, hand-authored catalog

--- a/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
+++ b/.agents/superpowers/plans/2026-07-13-workspace-file-discovery.md
@@ -129,13 +129,20 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/WorkspaceModule.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/WorkspaceFileSnapshotToken.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/WorkspaceFilePageToken.kt`
-- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ServerHeldContinuationStore.kt`
+- Migrate and generalize:
+  `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/ServerHeldContinuationStore.kt`
+  -> `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ServerHeldContinuationStore.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationTtl.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationCapacity.kt`
-- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationClock.kt`
+- Migrate and generalize:
+  `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/ContinuationClock.kt`
+  -> `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationClock.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationStateDisposer.kt`
-- Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationTransition.kt`
-- Create: `analysis-api/src/test/kotlin/io/github/amichne/kast/api/continuation/ServerHeldContinuationStoreTest.kt`
+- Replace: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/ContinuationClaim.kt`
+  with `analysis-api/src/main/kotlin/io/github/amichne/kast/api/continuation/ContinuationTransition.kt`
+- Migrate and expand:
+  `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/ServerHeldContinuationStoreTest.kt`
+  -> `analysis-api/src/test/kotlin/io/github/amichne/kast/api/continuation/ServerHeldContinuationStoreTest.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/CloseableAnalysisBackend.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/validation/ParsedWorkspaceFilesQuery.kt`
 - Create: `analysis-api/src/main/kotlin/io/github/amichne/kast/api/protocol/WorkspaceInventoryStaleException.kt`
@@ -157,6 +164,8 @@ v2, tempfile integration fixtures, Markdown, and Zensical.
 - Modify: `analysis-server/AGENTS.md`
 - Modify: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt`
 - Modify: `analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt`
+- Modify: `backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt`
+- Modify: `backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt`
 
 **Interfaces:**
 
@@ -288,8 +297,12 @@ value class WorkspaceFileSnapshotToken private constructor(val value: String) {
 distinct type. Add `snapshotToken: String?` and `pageToken: String?` to
 `WorkspaceFilesQuery`, add the closed kind domain, parse each once, and reject
 illegal field combinations.
-The shared continuation store owns random issue, TTL cleanup, capacity
-eviction, query comparison, reusable lookup, atomic single-use consumption,
+Start from #337's IDEA-local store, clock, claim outcome, and tests. Move and
+generalize that implementation into `analysis-api`, migrate the reference and
+diagnostic callers to typed store instances, and remove the superseded
+`backend-idea` store/clock/claim files only after those callers compile against
+the shared owner. The shared continuation store owns random issue, TTL cleanup,
+capacity eviction, query comparison, reusable lookup, atomic single-use consumption,
 and exact-once disposal. Its callback receives borrowed state and returns only
 `ContinuationTransition.Complete(output)` or
 `ContinuationTransition.Reissue(output, nextQuery)`. Claim the old handle

--- a/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
+++ b/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
@@ -135,7 +135,11 @@ cursor exactly when more sorted paths remain.
 Both failures are typed `AnalysisException` subtypes carried by the existing
 JSON-RPC error envelope. `STALE_WORKSPACE_INVENTORY` uses conflict status 409
 and `retryable=true`; `INVALID_WORKSPACE_FILE_CURSOR` uses status 400 and is not
-retryable.
+retryable. A third subtype, `WorkspaceProjectModelIncompleteException`, uses
+status 503, stable code `WORKSPACE_PROJECT_MODEL_INCOMPLETE`, and
+`retryable=true`. Its typed `WorkspaceProjectModelIncompleteReason` is
+serialized in `details.reason` as `RUNTIME_INDEXING`,
+`PROJECT_MODEL_UNAVAILABLE`, or `LINKED_ROOT_UNASSOCIATED`.
 
 Rust still rejects repeated or non-advancing cursors, inconsistent counts,
 overlapping pages, or changed module identity. Equal-cardinality path
@@ -147,11 +151,27 @@ from the last metadata response partial, emits
 `BACKEND_WORKSPACE_INVENTORY_STALE`, and may compose index-only partial
 evidence. No page from a stale attempt contributes backend candidates.
 
+Project-model incompleteness does not consume the one stale-generation retry.
+If metadata fails with the typed code, backend coverage is unavailable. If a
+page fails with it after earlier pages succeeded, Rust discards the whole
+backend attempt and records workspace-wide partial coverage; no candidate from
+that attempt survives. The reason maps one-to-one to
+`BACKEND_RUNTIME_INDEXING`, `BACKEND_PROJECT_MODEL_UNAVAILABLE`, or
+`BACKEND_LINKED_ROOT_UNASSOCIATED`. Generic transport or invalid-response
+failures remain local to the requested module when coherent earlier pages are
+still valid.
+
 `includeFiles=false` returns sorted module metadata and the snapshot token.
 The compatibility form `includeFiles=true` without an input snapshot token
 returns each requested module's first page and a newly issued top-level token;
 any continuation must echo that token. The Rust collector always starts with
 metadata and uses exact-module requests bound to its token.
+
+The materially edited skill-facing workspace-file request, query, and response
+contracts move out of `SkillContracts.kt` into matching files. The sealed
+response root may retain its direct success and failure variants, while request
+and query each own one matching file. This follows the repository's production
+Kotlin type-isolation rule without migrating unrelated legacy contracts.
 
 ## Project-model `.kts` authority
 
@@ -180,9 +200,12 @@ Root project scripts use every root module associated with the linked Gradle
 project. Included builds retain their linked root and module owners. If a
 project-scope script has no content-root owner despite being contained by a
 linked Gradle root, the corresponding root-module association owns it. A
-linked root without any backend root-module association fails the request as
-incomplete project-model evidence. A path outside the canonical workspace or
-linked root is rejected before it reaches paging.
+linked root without any backend root-module association throws
+`WorkspaceProjectModelIncompleteException` with reason
+`LINKED_ROOT_UNASSOCIATED`. IDEA dumb/index-not-ready state maps to
+`RUNTIME_INDEXING`; unavailable linked Gradle settings or module data maps to
+`PROJECT_MODEL_UNAVAILABLE`. A path outside the canonical workspace or linked
+root is rejected before it reaches paging.
 
 The fake backend implements the same generation/fingerprint and opaque-cursor
 contract. Contract tests cover root build/settings scripts, a build-logic
@@ -284,6 +307,32 @@ pub(crate) enum BackendModuleCoverage {
         expected_count: usize,
     },
 }
+
+pub(crate) enum WorkspaceInventoryLimitationCode {
+    BackendCapabilityUnavailable,
+    BackendMetadataUnavailable,
+    BackendPageUnavailable,
+    BackendWorkspaceInventoryStale,
+    BackendRuntimeIndexing,
+    BackendProjectModelUnavailable,
+    BackendLinkedRootUnassociated,
+    SourceIndexUnavailable,
+    SourceIndexIncompatible,
+    DirtyStateUnavailable,
+    PackageMetadataInvalid,
+    ProjectModelOwnershipUnknown,
+    OutsideWorkspaceExcluded,
+}
+
+pub(crate) struct WorkspaceMatchCoverage {
+    candidate_inventory: WorkspaceCoverageState,
+    filter_evidence: WorkspaceCoverageState,
+}
+
+pub(crate) enum WorkspaceCoverageState {
+    Complete,
+    Partial,
+}
 ```
 
 One physical path produces one public record. Every backend owner and indexed
@@ -295,7 +344,11 @@ page remain invalid.
 including repeated `STALE_WORKSPACE_INVENTORY` after the single bounded retry.
 Every module in that final metadata response is partial and the stale attempt
 contributes no backend candidates. Per-module transport or cursor failures use
-`Available` with only the affected `BackendModuleCoverage` partial.
+`Available` with only the affected `BackendModuleCoverage` partial. A typed
+project-model failure during paging also uses workspace-wide `Partial`,
+discards all pages from that attempt, and carries its exact mapped limitation.
+A typed project-model failure before metadata uses `Unavailable` with the same
+reason.
 
 `WorkspaceFilePath` contains a proven workspace-relative path and canonical
 absolute counterpart. Its constructor rejects absolute relative input, parent
@@ -416,10 +469,13 @@ The compact result uses one physical-file record:
     }
   ],
   "page": {
-    "knownMatchCount": 1,
+    "cardinality": {"type": "EXACT", "totalCount": 1},
     "returnedCount": 1,
     "truncated": false,
-    "inventoryComplete": true,
+    "coverage": {
+      "candidateInventory": "COMPLETE",
+      "filterEvidence": "COMPLETE"
+    },
     "limit": 20
   },
   "limitations": [],
@@ -427,12 +483,24 @@ The compact result uses one physical-file record:
 }
 ```
 
-`knownMatchCount` never poses as a complete total when source coverage is
-partial. `--count` groups known counts by kind, index state, drift, and dirty
-class without file records. `--verbose` adds module/page/source coverage.
-`--explain` adds normalized filters and per-record classification evidence.
-The compact high-cardinality fixture remains under 120 lines and 1,500
-estimated tokens.
+The page reuses ADR 0020's `AgentResultCardinality`. `EXACT.totalCount` is legal
+only when candidate inventory is exhaustive and every predicate selected by the
+request is known for every candidate. Otherwise the page emits
+`KNOWN_MINIMUM.knownMinimumCount` for matches actually proved. Candidate and
+filter coverage remain separate because they answer different questions. For
+example, complete backend/index candidates plus unavailable Git status produce
+`candidateInventory=COMPLETE`, `filterEvidence=PARTIAL`, and `KNOWN_MINIMUM`
+for `--dirty clean`; without a dirty filter, that same Git limitation does not
+make match cardinality inexact.
+
+`returnedCount` equals the emitted file records. `truncated` is true when an
+exact total exceeds returned count or cardinality is `KNOWN_MINIMUM`, because
+unseen matches remain possible. `--count` groups known counts by kind, index
+state, drift, and dirty class without file records; each group uses the same
+discriminated cardinality rather than an unqualified integer. `--verbose` adds
+module/page/source coverage. `--explain` adds normalized filters and per-record
+classification evidence. The compact high-cardinality fixture remains under
+120 lines and 1,500 estimated tokens.
 
 ## Capability verification
 
@@ -442,6 +510,12 @@ capabilities with this registry. A Clap contract test resolves every registry
 path against `Cli::command()`, so removing or hiding the command breaks the
 same proof that authorizes public capability projection. Issue #342 extends
 the registry; #338 does not create a parallel catalog.
+
+The internal raw catalog has a separate, explicit source boundary:
+`cli-rs/resources/kast-skill/references/commands.json` is hand-authored and is
+updated with snapshot/page fields and current internal guidance. The release
+contract generator consumes that JSON to produce `commands.yaml`, request
+schemas, and request samples; it never generates the JSON source.
 
 ## Exact-root and testing strategy
 
@@ -465,12 +539,22 @@ The TDD sequence proves:
     `raw/workspace-files` request or root B index read;
 12. filters, output views, limitations, deterministic order, and budgets hold;
 13. returned `filePath` composes directly with diagnostics and symbol hinting;
-    and
-14. capability projection requires the real Clap route.
+14. `EXACT` versus `KNOWN_MINIMUM` follows both candidate and filter-evidence
+    coverage, including unavailable Git/package evidence;
+15. unassociated roots, runtime indexing, unavailable project models, and
+    metadata failures retain distinct typed limitations without stale backend
+    candidates; and
+16. capability projection requires the real Clap route.
 
 The exact-root regression lives in both
 `agent_workspace_files_smoke.rs` and `semantic_workspace_admission_smoke.rs`.
 Full gates cover Kotlin, generated contracts, Rust, docs, and rendering.
+
+`analysis-api/AGENTS.md` records the wire and generated-contract boundary.
+`backend-idea/AGENTS.md` records project-model inventory, Gradle bridge, typed
+incompleteness, and paging gates. The new Rust inventory directory owns its own
+scoped guide. These guides change with their new source boundaries rather than
+leaving ownership only in this design.
 
 ## Non-goals
 

--- a/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
+++ b/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
@@ -18,10 +18,13 @@ The backend advertises `WORKSPACE_FILES`, and the raw protocol implements
 The raw backend currently caps files per module without a page token. It also
 enumerates Kotlin files through module source scope, which does not guarantee
 root `build.gradle.kts`, `settings.gradle.kts`, convention-plugin scripts, or
-ordinary project scripts. The SQLite source index provides `.kt` manifest,
-module, source-set, and package facts, but `SourceIndexFilePolicy` deliberately
-rejects `.kts`. That policy remains correct: issue #340 owns a separate Gradle
-DSL index rather than mixing Gradle declarations into the Kotlin source index.
+ordinary project scripts. The SQLite source index provides `.kt` manifest and
+module labels, but its current path-derived source set and text-parsed package
+are heuristics. They cannot be authoritative: a custom Gradle
+`integrationTest` root need not follow the conventional directory shape, and
+Kotlin package syntax includes escaped, backticked, and general Unicode
+identifiers. `SourceIndexFilePolicy` deliberately rejects `.kts`; that policy
+remains correct because issue #340 owns a separate Gradle DSL index.
 
 Git and module ownership also need stronger boundaries. Porcelain paths are
 repository-root-relative, not admitted-workspace-relative. A physical source
@@ -150,16 +153,52 @@ local only after the snapshot lease independently validates.
 
 `ServerHeldContinuationStore<Token, Query, State>` owns entry lifetime through
 a typed `ContinuationStateDisposer<State>` and does not return owning state.
-Reusable lease access and single-use consumption take callbacks; when ownership
-terminates, disposal runs exactly once in `finally`, including callback failure.
-Expiry cleanup, deterministic capacity eviction, replacement, query mismatch,
-explicit invalidation/completion, terminal consumption, and server shutdown
-all remove through the same idempotence-guarded disposal path. Shutdown drains
-all entries even if one disposer fails. No-op state uses a no-op disposer; the
-#337 reference/diagnostic adapter supplies a disposer for its closeable IDEA
-traversal so the generic policy owns that resource too. Fake close-count tests
-exercise every exit path plus consume/shutdown and expiry/replacement races,
-proving that overlapping triggers never double-close.
+Reusable lease access takes a borrowed-state callback. Single-use consumption
+atomically claims and invalidates the old handle, then its borrowed-state
+callback returns one typed transition:
+
+```kotlin
+sealed interface ContinuationTransition<out Output, out Query> {
+    data class Complete<Output>(val output: Output) :
+        ContinuationTransition<Output, Nothing>
+
+    data class Reissue<Output, Query>(
+        val output: Output,
+        val nextQuery: Query,
+    ) : ContinuationTransition<Output, Query>
+}
+```
+
+`Complete` disposes the claimed state exactly once. `Reissue` atomically moves
+that same owned state behind a fresh random handle and returns the new handle
+with `output`; the old handle remains invalid and the callback never returns
+`State`. The callback has exclusive borrowed access and may advance the
+store-owned state's internal cursor before selecting `Reissue`. A #337 lazy
+IDEA traversal therefore stays open across page reissues without ever being
+caller-owned. Callback failure is terminal and disposes.
+
+The store tracks claimed entries as in-flight ownership. Shutdown first closes
+admission, drains issued entries, and marks in-flight claims to dispose when
+their callback returns. A racing `Reissue` against shutdown becomes terminal
+and cannot publish into the closed store. Close waits for all claimed callbacks
+to exit and their states to be disposed before it returns. Expiry cleanup,
+deterministic capacity eviction, replacement, query mismatch, explicit invalidation,
+`Complete`, callback failure, and shutdown share the idempotence-guarded
+disposal path. No-op state uses a no-op disposer. Tests keep a multi-page fake
+open through successive `Reissue` transitions, then exercise terminal, error,
+expiry, eviction, replacement, mismatch, and shutdown races with exact close
+counts.
+
+The server lifecycle also has an explicit typed owner. `KastPluginBackend`
+implements the closeable backend contract and drains its continuation stores.
+`ObservedAnalysisBackend` forwards both analysis calls and idempotent close.
+`KastIdeaBackendRuntime` passes that observed closeable backend to
+`AnalysisServer`; `RunningAnalysisServer.close()` stops request admission,
+closes dispatcher-owned public continuation state, and closes the backend once.
+`RunningKastIdeaBackend.close()` cancels indexing and delegates only to the
+running server, so no second backend owner exists. Headless and fake backends
+provide explicit no-resource close implementations instead of relying on a
+runtime cast.
 
 The backend gathers the complete requested-kind candidate set in one IDEA read
 action, maps paths and roots through exact-root containment, deduplicates, and
@@ -253,7 +292,7 @@ linked root without any backend root-module association throws
 root is rejected before it reaches paging.
 
 The same IDEA project-model adapter replaces the source-index producer's
-path-derived module guess. For every `.kt` file, it obtains
+path-derived module and source-set guesses. For every `.kt` file, it obtains
 `GradleModuleDataIndex.findGradleModuleData(module)`, associates the module with
 one model-proven direct or composite build root, and reads
 `GradleModuleData.getGradlePathOrNull()` as the absolute project path. The
@@ -267,7 +306,22 @@ module-name fallback may populate only that legacy field. Workspace discovery
 never parses it as Gradle identity. Fixtures place `:app` in both the root build
 and an included build and prove they persist, filter, and render as two distinct
 owners. Missing or ambiguous model identity produces no build-qualified owner,
-not a guessed one.
+not a guessed one. The adapter also resolves owning Gradle source-set model
+nodes for the file's model-proven source roots and emits a set of
+`BuildQualifiedGradleSourceSetIdentity` values. Each identity contains the
+build root, project path, and typed source-set name. Directory fragments such
+as `/src/main/`, root-folder basenames, and IDEA module-name suffixes may remain
+legacy labels but cannot construct a proven source-set identity. A fixture maps
+a nonconventional root to `integrationTest` and proves the model, not the path,
+owns that fact.
+
+`PsiSourceIndexScanner` accepts a `KtFile` semantic-evidence producer. It reads
+the Kotlin PSI/compiler package FQ name and passes a typed `ProvenRoot`,
+`ProvenNamed`, or `Unproven(reason)` value into host-neutral `FileIndexUpdate`.
+`SourceFileIndexParser` may continue parsing declarations, but its nullable or
+failed package extraction cannot construct root-package evidence. Tests cover
+escaped keyword, backticked non-identifier, and general Unicode package names
+through their canonical Kotlin semantic names.
 
 The fake backend implements the same generation/fingerprint and server-held
 cursor contract. Contract tests cover expiry, deterministic capacity eviction,
@@ -289,7 +343,12 @@ SELECT prefixes.dir_path,
        metadata.prefix_id IS NOT NULL AS metadata_present,
        gradle_projects.build_root,
        gradle_projects.project_path,
-       metadata.source_set,
+       gradle_source_sets.build_root,
+       gradle_source_sets.project_path,
+       gradle_source_sets.source_set_name,
+       metadata.source_set AS legacy_source_set,
+       metadata.package_state,
+       metadata.package_unproven_reason,
        metadata.package_fq_id,
        packages.fq_name
 FROM file_manifest AS manifest
@@ -301,33 +360,50 @@ LEFT JOIN file_metadata AS metadata
 LEFT JOIN file_gradle_projects AS gradle_projects
   ON gradle_projects.prefix_id = manifest.prefix_id
  AND gradle_projects.filename = manifest.filename
+LEFT JOIN file_gradle_source_sets AS gradle_source_sets
+  ON gradle_source_sets.prefix_id = manifest.prefix_id
+ AND gradle_source_sets.filename = manifest.filename
 LEFT JOIN fq_names AS packages
   ON packages.fq_id = metadata.package_fq_id
 ORDER BY prefixes.dir_path, manifest.filename,
-         gradle_projects.build_root, gradle_projects.project_path
+         gradle_projects.build_root, gradle_projects.project_path,
+         gradle_source_sets.build_root, gradle_source_sets.project_path,
+         gradle_source_sets.source_set_name
 ```
 
-The migration adds `file_gradle_projects(prefix_id, filename, build_root,
-project_path)` with all four columns non-null and a composite primary key, then
-increments the checked-in source-index schema version. The Rust reader groups
-the joined rows into a set and validates both identity components; it does not
-select `module_path` for workspace ownership. Store and producer tests prove
-multiple owners per file, root/included-build identity, identical project paths
-in different builds, malformed identity rejection, legacy IDEA fallback
-isolation, migration/reset behavior, and transactional generation change when
-an association is added, replaced, or removed.
+`packaging/homebrew/release-state.json` is the only checked-in source of the
+source-index schema version. This change advances it from 7 to 8. The existing
+`WriteSourceIndexSchemaVersionTask` generates the Kotlin constant, and
+`cli-rs/build.rs` generates the Rust constant, from that same file. Tests compare
+both generated values with release state and prove a version-7 database is
+rejected/reset before reads, so it cannot silently omit version-8 structures.
+
+Version 8 adds `file_gradle_projects(prefix_id, filename, build_root,
+project_path)` and `file_gradle_source_sets(prefix_id, filename, build_root,
+project_path, source_set_name)` with non-null identity columns and composite
+primary keys. It also adds required `file_metadata.package_state` and nullable
+`package_unproven_reason` with SQL constraints tying `PROVEN_ROOT` to a null id
+and reason, `PROVEN_NAMED` to a non-null id and null reason, and `UNPROVEN` to a
+null id and typed non-null reason. The Rust reader groups association
+rows into sets, validates every identity component, and never selects
+`module_path` or the legacy `source_set` as proof. Store and producer tests
+cover multiple owners, root/included-build identity, custom source sets,
+malformed identity rejection, legacy fallback isolation, v7 reset, and
+transactional generation changes.
 
 The same read transaction also selects `schema_version.generation`, every
 `module_index_progress` row, and the count of unapplied `pending_updates`. The
-reader verifies the checked-in schema version and required tables. It decodes
+reader verifies the release-state-generated schema version and required tables.
+It decodes
 `__kast_abs__/` and `__kast_rel__/` through the existing path rules, rejects
 non-`.kt` and out-of-root rows with typed evidence, and distinguishes package
 states:
 
 ```rust
 pub(crate) enum WorkspacePackageEvidence {
-    Named(WorkspacePackageName),
-    Root,
+    ProvenNamed(WorkspacePackageName),
+    ProvenRoot,
+    Unproven(WorkspacePackageUnprovenReason),
     Unavailable,
     InvalidReference { package_fq_id: i64 },
 }
@@ -340,6 +416,11 @@ pub(crate) struct BuildQualifiedGradleProjectIdentity {
     build_root: WorkspaceRelativeGradleBuildRoot,
     project_path: GradleProjectPath,
 }
+
+pub(crate) struct BuildQualifiedGradleSourceSetIdentity {
+    project: BuildQualifiedGradleProjectIdentity,
+    name: GradleSourceSetName,
+}
 ```
 
 `GradleProjectPath` accepts only Gradle absolute project-path syntax. The build
@@ -347,11 +428,29 @@ root is `.` for the admitted root build or a normalized contained relative path
 for an included build. Both components must be present before the identity can
 be constructed.
 
-No metadata row is `Unavailable`. A present row with null `package_fq_id` is
-`Root`. A non-null id with one valid joined name is `Named`. A non-null id
-without a joined row is `InvalidReference` and adds
-`PACKAGE_METADATA_INVALID`. This avoids using one null for four different
-facts.
+No metadata row is `Unavailable`. A row with `package_state=PROVEN_ROOT` and a
+null id/reason is `ProvenRoot`; `PROVEN_NAMED` plus one valid joined name and a
+null reason is `ProvenNamed`; and `UNPROVEN` plus a null id preserves its typed
+reason. Any illegal
+state/id combination or dangling id is `InvalidReference` and adds
+`PACKAGE_METADATA_INVALID`. A missing PSI/compiler package result becomes
+`Unproven`, never `ProvenRoot`. This avoids using one null for several facts.
+
+Source-set evidence is equally explicit:
+
+```rust
+pub(crate) enum WorkspaceSourceSetEvidence {
+    Proven(BTreeSet<BuildQualifiedGradleSourceSetIdentity>),
+    Unproven(BTreeSet<LegacySourceSetLabel>),
+    Unavailable,
+}
+```
+
+`--source-set` matches only `Proven` identities. An unproven legacy label is
+visible in explain evidence but cannot become a match; when the filter depends
+on it, filter coverage is partial. `Proven` is nonempty. An indexed metadata
+row without a model-proven source-set identity is `Unproven` even when it has
+no legacy label; absent metadata or an unavailable index is `Unavailable`.
 
 ```rust
 pub(crate) struct SourceIndexSnapshotStamp {
@@ -397,7 +496,7 @@ pub(crate) struct WorkspaceInventoryFile {
     pub(crate) path: WorkspaceFilePath,
     pub(crate) backend_modules: BTreeSet<BackendModuleName>,
     pub(crate) indexed_gradle_projects: BTreeSet<BuildQualifiedGradleProjectIdentity>,
-    pub(crate) source_sets: BTreeSet<WorkspaceSourceSet>,
+    pub(crate) source_sets: WorkspaceSourceSetEvidence,
     pub(crate) kind: WorkspaceFileKind,
     pub(crate) package: WorkspacePackageEvidence,
     pub(crate) index_state: WorkspaceFileIndexState,
@@ -667,9 +766,12 @@ kast agent workspace-files \
 All filters use AND semantics before the default limit of 20. Module parses a
 closed backend or build-qualified Gradle selector; `gradle:.#:app` identifies
 `:app` in the root build while `gradle:included/tools#:app` is distinct. Path
-prefix matches at a segment boundary;
-glob matches only normalized relative paths. Missing source-set/package
-evidence does not match those filters. `--page-token` conflicts with `--count`;
+prefix matches at a segment boundary; glob matches only normalized relative
+paths. Source-set and package filters match only structured `Proven` evidence;
+unavailable or legacy-unproven evidence does not match and makes filter
+coverage partial. Escaped, backticked, and Unicode package input is parsed to
+the same canonical Kotlin FQ-name type used by the producer. `--page-token`
+conflicts with `--count`;
 all other result-affecting arguments must reproduce the original normalized
 query exactly.
 
@@ -717,9 +819,14 @@ The compact result uses one physical-file record:
       "gradleProjects": [
         {"buildRoot": ".", "projectPath": ":app"}
       ],
-      "sourceSets": ["main"],
+      "sourceSets": {
+        "state": "PROVEN",
+        "values": [
+          {"buildRoot": ".", "projectPath": ":app", "name": "main"}
+        ]
+      },
       "kind": "KOTLIN_SOURCE",
-      "package": {"state": "NAMED", "name": "app"},
+      "package": {"state": "PROVEN_NAMED", "name": "app"},
       "indexState": "INDEXED",
       "drift": "NONE",
       "dirtyState": "MODIFIED"
@@ -791,8 +898,10 @@ The TDD sequence proves:
 
 1. Kotlin query parsing rejects illegal token combinations and blank tokens;
 2. the shared server-held store rejects malformed, forged, unknown, expired,
-   evicted, consumed, and query/cross-module-mismatched handles and disposes
-   owned state exactly once on every removal path and server shutdown;
+   evicted, consumed, and query/cross-module-mismatched handles; keeps one
+   closeable traversal open across multiple atomic `Reissue` pages; and closes
+   it exactly once on `Complete`, failure, expiry, eviction, replacement,
+   mismatch, or server shutdown, including races;
 3. equal-cardinality path replacement and module addition/removal return
    `STALE_WORKSPACE_INVENTORY`;
 4. Rust discards a stale attempt, restarts exactly once, and returns typed
@@ -800,8 +909,9 @@ The TDD sequence proves:
 5. fake and IDEA backends return stable non-overlapping pages and include root,
    settings, included-build, convention-plugin, and ordinary scripts;
 6. `.kts` remains rejected by `SourceIndexFilePolicy`;
-7. the index query distinguishes absent metadata, root package, named package,
-   and dangling package ids;
+7. structured Gradle and Kotlin PSI/compiler producers distinguish a custom
+   `integrationTest` source set, proven root/named packages, unproven parser
+   output, escaped/backticked/Unicode names, and dangling package ids;
 8. shared physical files retain multiple module owners;
 9. partial paging never produces `INDEX_ONLY`;
 10. nested Git roots and in/out rename endpoints map correctly;
@@ -823,11 +933,14 @@ The TDD sequence proves:
 19. public continuation returns 500 filtered records as 200/200/100 without
     overlap and rejects stale, forged/unknown, and filter-mismatched tokens;
 20. build-qualified producer/storage fixtures distinguish the root build's
-    `:app` from an included build's `:app` and never expose an IDEA fallback as
-    Gradle identity; and
+    `:app` from an included build's `:app`, preserve model-proven source sets,
+    and never expose an IDEA/path fallback as Gradle identity;
 21. mixed/source/script fixtures prove source-index progress is relevant only
     to a selected source partition, including continuation digests and grouped
-    cardinality.
+    cardinality; and
+22. release-state schema version 8 generates equal Kotlin and Rust constants,
+    version 7 is rejected/reset before reads, and required association/provenance
+    structures cannot be absent from a compatible database.
 
 The exact-root regression lives in both
 `agent_workspace_files_smoke.rs` and `semantic_workspace_admission_smoke.rs`.
@@ -836,12 +949,14 @@ acceptance also runs `./gradlew test` and `./gradlew buildIdeaPlugin` so the
 cross-module schema/producer contract and packaged IDEA plugin are proved as a
 whole.
 
-`analysis-api/AGENTS.md` records the wire, exact-once continuation disposal,
-and generated-contract boundary. `backend-idea/AGENTS.md` records project-model
-inventory, Gradle bridge, build-qualified source-index producer, typed
-incompleteness, and paging gates. `index-store/AGENTS.md` owns the association
-table, generation, and legacy-label prohibition. The new Rust inventory
-directory owns its own scoped guide. `cli-rs/AGENTS.md` and
+`analysis-api/AGENTS.md` records the atomic `Complete`/`Reissue` wire-neutral
+lifecycle contract. `analysis-server/AGENTS.md` records the single backend
+close owner. `backend-idea/AGENTS.md` records project-model inventory, Gradle
+bridge, structured project/source-set and Kotlin package producers, typed
+incompleteness, and paging gates. `build-logic/AGENTS.md` records generated
+Kotlin schema ownership from release state. `index-store/AGENTS.md` owns the
+version-8 tables, package provenance, generation, and legacy-label prohibition.
+The new Rust inventory directory owns its own scoped guide. `cli-rs/AGENTS.md` and
 `cli-rs/resources/kast-skill/AGENTS.md` record the public command, continuation,
 catalog/package ownership, and mandatory package, LSP, and routing gates. These
 guides change with their new source boundaries rather than leaving ownership
@@ -849,11 +964,11 @@ only in this design.
 
 ## Non-goals
 
-This issue changes the Kotlin source-index schema only to add the
-`file_gradle_projects` build-qualified ownership association table and advance
-its checked-in version; it does not admit `.kts` to `SourceIndexFilePolicy` or
-reinterpret legacy
-`module_path`. It does not recursively search the filesystem, use Git
+This issue advances the release-state-owned Kotlin source-index schema from 7
+to 8 only for build-qualified project/source-set associations and explicit
+package provenance; it does not admit `.kts` to `SourceIndexFilePolicy` or
+reinterpret legacy `module_path`/`source_set` guesses as proof. It does not
+recursively search the filesystem, use Git
 as candidate authority, classify Gradle task declarations, infer dynamic
 Gradle semantics, or expose arbitrary RPC dispatch. Issue #340 owns the Gradle
 DSL index and semantic subtype/declaration model; issue #342 owns registry

--- a/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
+++ b/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
@@ -1,0 +1,357 @@
+# Workspace File Discovery Design
+
+## Goal
+
+Expose `kast agent workspace-files` as a bounded public command that discovers
+Kotlin sources and scripts from semantic workspace evidence, reports index and
+filesystem drift honestly, and supplies a reusable uncapped inventory for the
+Gradle Kotlin DSL work in issue #340.
+
+## Current failure
+
+The backend advertises `WORKSPACE_FILES`, and the raw protocol implements
+`raw/workspace-files`, but the typed public `kast agent` command tree rejects
+`workspace-files`. Agents must either discover the hidden raw contract or fall
+back to `rg`, `find`, or Git paths. The existing raw result also lacks source
+set, package, index state, dirty state, and cross-source drift.
+
+The raw backend caps file paths per module. The source index contains
+`file_manifest`, `file_metadata`, `path_prefixes`, and `fq_names`, but index
+rows can be stale or belong to nested linked worktrees. Neither source is a
+complete public result by itself.
+
+## Considered approaches
+
+### Backend-only projection
+
+The smallest change would expose `raw/workspace-files` through a typed Clap
+command. This preserves project-model ownership but cannot satisfy package,
+source-set, indexed-state, dirty-state, or index-drift requirements. The
+per-module cap also becomes easy to misread as complete discovery.
+
+### Source-index-only query
+
+A direct SQLite command could provide module, source set, package, and manifest
+state without a daemon round trip. It would incorrectly treat every retained
+manifest row as current semantic ownership. The live index can contain nested
+worktree paths, and absence from a cache cannot establish current project-model
+state.
+
+### Typed hybrid inventory
+
+The chosen approach joins backend ownership and source-index facts by exact
+normalized path, then adds only targeted filesystem and Git annotations. It
+preserves each source's authority, exposes uncertainty as types, and creates a
+Rust inventory that #340 can reuse. It requires more composition code, but it
+is the only approach that meets the acceptance criteria without changing the
+Kotlin protocol.
+
+## Architecture
+
+The implementation has two boundaries:
+
+1. `workspace_inventory` collects all known candidates and source coverage.
+   It has no public result limit and applies no user filters.
+2. `agent workspace-files` validates typed filters, applies them to the
+   snapshot, sorts deterministically, enforces the public limit, and projects
+   the ADR 0020 result views.
+
+The command first performs ADR 0019 exact-root admission and opens one selected
+runtime session. It requests `raw/workspace-files` with `includeFiles=true`
+and no smaller CLI-owned per-module cap. In parallel with composition (not with
+shared mutation), it opens the configured source-index database read-only and
+reads all Kotlin manifest rows in one SQLite snapshot. The collector merges
+those sources after normalizing every path to the admitted root.
+
+The backend response already reports module name, source roots, dependency
+module names, file count, returned files, and `filesTruncated`. No Kotlin wire
+change is required. The index query is:
+
+```sql
+SELECT prefixes.dir_path,
+       manifest.filename,
+       metadata.module_path,
+       metadata.source_set,
+       packages.fq_name
+FROM file_manifest AS manifest
+JOIN path_prefixes AS prefixes
+  ON prefixes.prefix_id = manifest.prefix_id
+LEFT JOIN file_metadata AS metadata
+  ON metadata.prefix_id = manifest.prefix_id
+ AND metadata.filename = manifest.filename
+LEFT JOIN fq_names AS packages
+  ON packages.fq_id = metadata.package_fq_id
+ORDER BY prefixes.dir_path, manifest.filename
+```
+
+The reader verifies the checked-in source-index schema version and required
+tables before querying. It decodes the existing `__kast_abs__/` and
+`__kast_rel__/` prefixes through the same path rules as current Rust
+source-index readers. It discards non-`.kt`/`.kts` rows and out-of-root paths
+with typed limitation evidence.
+
+## Internal type model
+
+The collector exposes these responsibilities as types rather than boolean
+combinations:
+
+```rust
+pub(crate) struct WorkspaceInventorySnapshot {
+    pub(crate) workspace_root: WorkspaceRoot,
+    pub(crate) modules: Vec<WorkspaceInventoryModule>,
+    pub(crate) files: Vec<WorkspaceInventoryFile>,
+    pub(crate) backend_coverage: BackendWorkspaceCoverage,
+    pub(crate) index_coverage: IndexWorkspaceCoverage,
+    pub(crate) dirty_coverage: DirtyWorkspaceCoverage,
+    pub(crate) limitations: BTreeSet<WorkspaceInventoryLimitation>,
+}
+
+pub(crate) struct WorkspaceInventoryFile {
+    pub(crate) path: WorkspaceFilePath,
+    pub(crate) module: WorkspaceModuleEvidence,
+    pub(crate) source_set: Option<WorkspaceSourceSet>,
+    pub(crate) kind: WorkspaceFileKind,
+    pub(crate) package_name: Option<WorkspacePackageName>,
+    pub(crate) index_state: WorkspaceFileIndexState,
+    pub(crate) drift: WorkspaceFileDrift,
+    pub(crate) dirty_state: WorkspaceFileDirtyState,
+    pub(crate) evidence: BTreeSet<WorkspaceEvidenceSource>,
+}
+```
+
+`WorkspaceFilePath` contains a proven workspace-relative path and its absolute
+counterpart. Its constructor rejects absolute relative input, parent
+traversal, an empty filename, and paths outside the exact root. Existing paths
+are canonicalized to prevent a symlink target from escaping the root. Missing
+index-only paths remain lexical evidence and can be emitted only after lexical
+root containment succeeds.
+
+`WorkspaceModuleEvidence` preserves both optional backend module name and
+optional indexed Gradle module path. The public `--module` filter matches
+either exact value, while output retains both so an IDEA display name cannot
+silently replace Gradle identity. `WorkspaceSourceSet` and
+`WorkspacePackageName` are validated non-empty newtypes. Package validation
+accepts Kotlin identifier segments, including backticked segments, separated
+by dots.
+
+The file kind is intentionally coarse in #338:
+
+```rust
+pub(crate) enum WorkspaceFileKind {
+    KotlinSource,
+    KotlinScript,
+}
+```
+
+Issue #340 adds an independent Gradle script subtype such as project,
+settings, convention plugin, or ordinary Kotlin script. It consumes the
+uncapped inventory and project-model evidence; #338 does not guess those
+subtypes from a filename and claim Gradle semantics prematurely.
+
+Coverage is explicit:
+
+```rust
+pub(crate) enum BackendWorkspaceCoverage {
+    Complete,
+    Truncated { module_names: Vec<BackendModuleName> },
+    Unavailable { code: WorkspaceInventoryLimitationCode },
+}
+
+pub(crate) enum IndexWorkspaceCoverage {
+    Available,
+    Unavailable { code: WorkspaceInventoryLimitationCode },
+}
+
+pub(crate) enum DirtyWorkspaceCoverage {
+    Available,
+    Unavailable { code: WorkspaceInventoryLimitationCode },
+}
+```
+
+The source-index query is uncapped. `WorkspaceInventorySnapshot::files` keeps
+all candidates supplied by the available sources. Backend truncation remains
+visible in `backend_coverage`; "uncapped internal" never means pretending an
+upstream capped response was exhaustive.
+
+## Candidate and drift composition
+
+Backend paths and index paths are keyed by `WorkspaceRelativePath`. The
+collector does not add paths from filesystem or Git enumeration. It calls
+`symlink_metadata` only for an existing candidate, and the Git porcelain v2
+snapshot only annotates candidate paths.
+
+Index state is independent of drift:
+
+- `INDEXED` means the exact path is in the readable manifest snapshot.
+- `NOT_INDEXED` means a backend-owned path is absent from a readable manifest.
+- `UNKNOWN` means index evidence is unavailable.
+
+Drift follows the ADR 0021 truth table. A backend-owned path with no manifest
+row is `FILESYSTEM_ONLY` when it exists. A manifest path absent from backend is
+`INDEX_ONLY` only when backend coverage proves exhaustive absence. A missing
+candidate is `MISSING_ON_DISK`. Any unprovable absence is `UNKNOWN`.
+
+Backend completeness is evaluated per module before a global result is
+claimed. If any module is truncated and an index row cannot be associated with
+a distinct complete backend module, the row remains `UNKNOWN`. This
+conservative rule is more important than maximizing `INDEX_ONLY` counts.
+
+Detailed dirty states are `CLEAN`, `MODIFIED`, `ADDED`, `DELETED`, `RENAMED`,
+`UNTRACKED`, `CONFLICTED`, and `UNKNOWN`. The CLI filter collapses them into
+clean, dirty, or unknown; structured output preserves the detailed state. If
+the root is not a Git worktree or porcelain parsing fails, every candidate is
+`UNKNOWN` and the snapshot contains `DIRTY_STATE_UNAVAILABLE`.
+
+## Public arguments and filtering
+
+The new `AgentWorkspaceFilesArgs` contains `AgentRuntimeArgs`, ADR 0020's
+`AgentResultViewArgs`, and typed filters. The stable syntax is:
+
+```console
+kast agent workspace-files \
+  --workspace-root <repo> \
+  [--backend idea|headless] \
+  [--module <exact-module>] \
+  [--source-set <exact-source-set>] \
+  [--kind source|script] \
+  [--package <exact-package>] \
+  [--dirty clean|dirty|unknown] \
+  [--drift none|filesystem-only|index-only|missing-on-disk|unknown] \
+  [--path-prefix <workspace-relative-prefix>] \
+  [--glob <workspace-relative-glob>] \
+  [--limit <1..=200>] \
+  [--fields path,module,source-set,kind,package,index,drift,dirty,evidence | --count] \
+  [--verbose | --explain]
+```
+
+The default limit is 20. All filters use AND semantics and run before the
+limit. `--glob` matches only normalized relative paths and rejects the
+`regex:` prefix. `--path-prefix` matches a path exactly or at a segment
+boundary, never as a raw string prefix. Missing source-set/package evidence
+does not match a requested source-set/package filter.
+
+## Output and limitations
+
+The compact result shape is:
+
+```json
+{
+  "type": "KAST_AGENT_WORKSPACE_FILES_RESULT",
+  "ok": true,
+  "workspaceRoot": "/repo",
+  "files": [
+    {
+      "filePath": "/repo/app/src/main/kotlin/app/App.kt",
+      "relativePath": "app/src/main/kotlin/app/App.kt",
+      "module": {"backendName": "app.main", "gradlePath": ":app"},
+      "sourceSet": "main",
+      "kind": "KOTLIN_SOURCE",
+      "packageName": "app",
+      "indexState": "INDEXED",
+      "drift": "NONE",
+      "dirtyState": "MODIFIED"
+    }
+  ],
+  "page": {
+    "knownMatchCount": 1,
+    "returnedCount": 1,
+    "truncated": false,
+    "inventoryComplete": true,
+    "limit": 20
+  },
+  "limitations": [],
+  "schemaVersion": 3
+}
+```
+
+`knownMatchCount` never poses as a complete total when source coverage is
+partial. `inventoryComplete=false` and typed limitations carry that fact.
+`--count` returns known counts grouped by kind, index state, drift, and dirty
+class without file records. `--verbose` adds module/source coverage and
+evidence sources. `--explain` additionally echoes the normalized typed query
+and explains which source established each classification.
+
+Limitations have stable codes and structured affected-module/path counts:
+
+- `BACKEND_WORKSPACE_FILES_UNAVAILABLE`;
+- `BACKEND_ENUMERATION_TRUNCATED`;
+- `SOURCE_INDEX_UNAVAILABLE`;
+- `SOURCE_INDEX_SCHEMA_UNSUPPORTED`;
+- `DIRTY_STATE_UNAVAILABLE`;
+- `PACKAGE_METADATA_UNAVAILABLE`;
+- `WORKSPACE_PATH_EXCLUDED`; and
+- `PROJECT_MODEL_OWNERSHIP_UNKNOWN`.
+
+Malformed backend JSON is a fatal `WORKSPACE_FILES_BACKEND_INVALID` error.
+Exact-root admission failure remains the ADR 0019 error. Backend capability
+absence or source-index absence may degrade if the other candidate source is
+usable. If neither candidate source is usable, the command fails with
+`WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` rather than returning an empty list.
+
+## Capability verification
+
+`AgentPublicCapabilityRoute` is a typed registry entry with backend capability
+and public command path. Verification intersects raw backend capabilities with
+this registry and emits:
+
+```json
+{
+  "capability": "WORKSPACE_FILES",
+  "command": "kast agent workspace-files"
+}
+```
+
+only when both sides exist. A Clap contract test resolves each registry path
+against `Cli::command()`. Removing or renaming the command therefore breaks
+the same test that authorizes the public capability projection. Issue #342
+extends this small registry instead of introducing a second hand-maintained
+catalog.
+
+## #340 reuse boundary
+
+Issue #340 calls the internal collector before public filtering and limiting.
+It may inspect `KotlinScript` candidates, module/source-root facts, and source
+coverage to classify Gradle Kotlin DSL files. It must not treat
+`WorkspaceFileDrift::IndexOnly` or `Unknown` as compiler project-model
+ownership. Dynamic Gradle constructs retain typed degraded evidence instead
+of becoming not-found.
+
+The inventory API does not expose CLI output types to #340. Gradle script
+classification is an additive domain layer over `WorkspaceInventorySnapshot`,
+so #340 can evolve its own semantic types without destabilizing the public
+file projection.
+
+## Testing strategy
+
+The TDD sequence is:
+
+1. Add CLI/help regressions proving `workspace-files` is public and retired
+   raw aliases remain unavailable.
+2. Add source-index reader tests for package/module/source-set joins, `.kt`
+   and `.kts` kinds, exact-root containment, absolute prefix decoding, schema
+   failure, and an uncapped high-cardinality snapshot.
+3. Add composition tests for every drift truth-table row, especially
+   truncated/unavailable backend evidence never producing `INDEX_ONLY`.
+4. Add Git porcelain tests for clean, modified, added, deleted, renamed,
+   untracked, conflicted, and unavailable states.
+5. Add command tests for every filter, deterministic ordering, default and
+   maximum bounds, typed limitations, all ADR 0020 views, and a default output
+   below 120 lines/1,500 estimated tokens.
+6. Add a semantic ownership regression with an unowned `.kt` file on disk;
+   assert it is omitted because no recursive filesystem search supplies
+   candidates.
+7. Pipe a returned `filePath` into diagnostics and use it as a symbol
+   `--file-hint`, proving direct composition.
+8. Add capability tests proving `WORKSPACE_FILES` is projected only through a
+   registry entry whose Clap path exists.
+9. Run full Rust, contract, docs, and rendering gates. Kotlin modules are not
+   changed; the existing backend workspace-files tests remain the wire proof.
+
+## Non-goals
+
+This issue does not paginate or redesign `raw/workspace-files`, change the
+source-index schema, recursively search the filesystem, use Git as candidate
+authority, classify Gradle task declarations, infer dynamic Gradle semantics,
+or expose arbitrary RPC dispatch. It does not solve the full capability and
+installed-guidance lockstep requested by #342; it establishes the
+`WORKSPACE_FILES` registry invariant that #342 will generalize.

--- a/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
+++ b/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
@@ -764,7 +764,7 @@ kast agent workspace-files \
   [--module backend:<exact-name>|gradle:<build-root>#<project-path>] \
   [--source-set <exact-source-set>] \
   [--kind source|script] \
-  [--package <exact-package>] \
+  [--package root|named:<canonical-package-fq-name>] \
   [--dirty clean|dirty|unknown] \
   [--drift none|filesystem-only|index-only|missing-on-disk|not-applicable|unknown] \
   [--path-prefix <workspace-relative-prefix>] \
@@ -779,10 +779,13 @@ All filters use AND semantics before the default limit of 20. Module parses a
 closed backend or build-qualified Gradle selector; `gradle:.#:app` identifies
 `:app` in the root build while `gradle:included/tools#:app` is distinct. Path
 prefix matches at a segment boundary; glob matches only normalized relative
-paths. Source-set and package filters match only structured `Proven` evidence;
-unavailable or legacy-unproven evidence does not match and makes filter
-coverage partial. Escaped, backticked, and Unicode package input is parsed to
-the same canonical Kotlin FQ-name type used by the producer. `--page-token`
+paths. Package selection is a closed `WorkspacePackageSelector::Root` or
+`WorkspacePackageSelector::Named(WorkspacePackageName)` union. `root` matches
+only `ProvenRoot`; `named:` parses escaped, backticked, and Unicode input to the
+same canonical Kotlin FQ-name type used by the producer and matches only the
+equal `ProvenNamed` value. Source-set filters likewise match only structured
+`Proven` evidence. Unavailable or legacy-unproven evidence does not match and
+makes filter coverage partial. `--page-token`
 conflicts with `--count`;
 all other result-affecting arguments must reproduce the original normalized
 query exactly.

--- a/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
+++ b/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
@@ -43,13 +43,16 @@ intentional Kotlin-source versus Gradle-DSL boundary. Gradle task, plugin, and
 relationship facts need a separate schema and completeness model in #340.
 `SourceIndexFilePolicy` therefore stays `.kt`-only.
 
-### Page one generation of project-model candidates and compose the `.kt` index
+### Page stable source generations and compose behind one barrier
 
 This is the chosen approach. The Kotlin backend gains deterministic per-module
-paging, opaque generation-bound cursors, and a project-model inventory that
-includes `.kt` and `.kts`. Rust exhausts one coherent workspace generation,
-unions physical paths while preserving all module owners, and joins only `.kt`
-candidates to the existing Kotlin source index. Scripts remain
+paging, shared server-held opaque cursors, and a project-model inventory that
+includes `.kt` and `.kts`. Rust exhausts one backend generation, reads the
+source index with its generation/progress/pending state, unions physical paths
+while preserving all module owners, and joins only `.kt` candidates to the
+existing Kotlin source index. A bounded cross-source barrier accepts the
+composition only when backend, index, filesystem, and Git stamps remain stable.
+Scripts remain
 `NOT_APPLICABLE` to that index and become the authoritative input set for
 #340's separate Gradle DSL index.
 
@@ -60,17 +63,22 @@ The implementation has three boundaries:
 1. `raw/workspace-files` snapshots compiler/project-model `.kt` and `.kts`
    candidates, then pages that exact generation deterministically by backend
    module.
-2. `workspace_inventory` exhausts backend pages and reads all exact-root `.kt`
-   index rows without applying public filters or limits.
+2. `workspace_inventory` exhausts backend pages, reads all exact-root `.kt`
+   index rows plus generation/progress/pending state, and proves a stable
+   backend/index/filesystem/Git barrier without applying public filters or
+   limits.
 3. `agent workspace-files` validates filters, applies them to one typed
-   snapshot, sorts deterministically, enforces the public limit, and projects
-   ADR 0020 result views.
+   snapshot, sorts deterministically, enforces the public limit, projects ADR
+   0020 result views, and registers a query-bound continuation when known
+   matches remain.
 
 The command performs ADR 0019 admission first and passes the admitted exact
 root and selected backend to one raw RPC session. It fetches module metadata
 and an opaque snapshot token, then echoes that token while paging every module.
 Only after the backend snapshot is complete or has typed failures does it read
-the exact-root SQLite snapshot and compose records.
+the exact-root SQLite snapshot and compose records. It then revalidates every
+mutable lane; one change restarts the entire attempt once, while a second change
+returns typed partial evidence and never `EXACT`.
 
 ## Typed raw paging
 
@@ -109,28 +117,45 @@ data class WorkspaceModule(
 )
 ```
 
-`snapshotToken` and `pageToken` are opaque server-owned values. Clients may
-store and echo them but never decode, construct, or advance them. A page token
-is legal only when `includeFiles=true`, a nonblank `snapshotToken`, and one
-nonblank `moduleName` are present. The decoded cursor binds the snapshot
-generation, exact module identity, and positive next offset. The Kotlin parse
-boundary validates only nonblank wire tokens and their legal field
-combinations; the backend owns cursor decoding and semantic validation. The
-server continues to enforce a positive `maxFilesPerModule` no greater than
-`maxResults`.
+`snapshotToken` and `pageToken` are random canonical handles into typed
+instances of the shared server-held `OpaqueContinuationStore`; they contain no
+client-decoded offset or generation. The typed store entry binds workspace
+generation, exact module, query identity, next offset, issued/expiry time, and
+cumulative returned evidence. Clients may store and echo handles but never
+decode, construct, or advance state. A page token is legal only when
+`includeFiles=true`, a nonblank snapshot token, and one nonblank module are
+present. A snapshot token with `includeFiles=false` and no module is also legal
+as final barrier validation.
+The Kotlin parse boundary validates canonical token shape and legal field
+combinations; lookup owns semantic validation. The server continues to enforce
+a positive `maxFilesPerModule` no greater than `maxResults`.
+
+The generic store mechanism is extracted from ADR 0020 reference/diagnostic
+paging rather than adding another cursor encoding. Token/state namespaces
+remain distinct by type. `ContinuationTtl` and `ContinuationCapacity`
+are positive typed `ServerLimits`; tests inject a clock and small capacity.
+Expired entries are removed before issue or lookup, capacity evicts the oldest
+expiring entry deterministically, page handles are consumed once, and snapshot
+leases survive until completion, invalidation, eviction, or expiry. Canonical
+UUID parsing, unguessable lookup, and exact query comparison make malformed,
+forged, unknown, expired, evicted, consumed, or query-mismatched handles fail as
+`INVALID_WORKSPACE_FILE_CURSOR` with typed `details.scope` of
+`SNAPSHOT_HANDLE` or `PAGE_HANDLE`, without exposing stored state. Snapshot-
+handle failure invalidates the whole backend attempt. Page-handle failure stays
+local only after the snapshot lease independently validates.
 
 The backend gathers the complete workspace candidate set in one IDEA read
 action, maps paths and roots through exact-root containment, deduplicates, and
 sorts a canonical representation containing module identities,
 source/content roots, dependencies, and candidate paths. It fingerprints that
-representation as the workspace generation returned by the opaque
-`snapshotToken`. Before serving an exact-module page, it recomputes the full
-inventory and rejects a generation mismatch as
-`STALE_WORKSPACE_INVENTORY`. It rejects malformed, out-of-range, or
-cross-module cursors as `INVALID_WORKSPACE_FILE_CURSOR`. Only a matching
-generation may be sliced at the cursor's offset. The result echoes the same
-snapshot token, returns the same `fileCount` on every page, and emits a next
-cursor exactly when more sorted paths remain.
+representation as the workspace generation stored behind the opaque
+`snapshotToken`. Before serving an exact-module page or final validation
+request, it recomputes the full inventory and rejects a generation mismatch as
+`STALE_WORKSPACE_INVENTORY`. It rejects missing state, out-of-range stored
+offsets, or query/module mismatch as `INVALID_WORKSPACE_FILE_CURSOR`. Only a
+matching leased generation may be sliced. The result echoes the same snapshot
+token, returns the same `fileCount` on every page, and emits a next handle
+exactly when more sorted paths remain.
 
 Both failures are typed `AnalysisException` subtypes carried by the existing
 JSON-RPC error envelope. `STALE_WORKSPACE_INVENTORY` uses conflict status 409
@@ -141,11 +166,13 @@ status 503, stable code `WORKSPACE_PROJECT_MODEL_INCOMPLETE`, and
 serialized in `details.reason` as `RUNTIME_INDEXING`,
 `PROJECT_MODEL_UNAVAILABLE`, or `LINKED_ROOT_UNASSOCIATED`.
 
-Rust still rejects repeated or non-advancing cursors, inconsistent counts,
-overlapping pages, or changed module identity. Equal-cardinality path
-replacement and module addition/removal are caught by the generation before
-these structural checks. On the first typed stale response, Rust discards the
-entire backend attempt and restarts once from fresh metadata. A second stale
+Rust treats tokens as opaque. Its defensive checks are limited to repeated
+handles, overlapping physical paths, and cumulative returned evidence that
+never exceeds and finally equals the module's declared count. It does not infer
+cursor advancement, generation, or module identity from handle bytes.
+Equal-cardinality path replacement and module addition/removal are caught by
+the server-held generation. On the first typed stale response, Rust discards
+the entire backend attempt and restarts once from fresh metadata. A second stale
 response is not retried: Rust discards that backend attempt, marks every module
 from the last metadata response partial, emits
 `BACKEND_WORKSPACE_INVENTORY_STALE`, and may compose index-only partial
@@ -158,8 +185,9 @@ backend attempt and records workspace-wide partial coverage; no candidate from
 that attempt survives. The reason maps one-to-one to
 `BACKEND_RUNTIME_INDEXING`, `BACKEND_PROJECT_MODEL_UNAVAILABLE`, or
 `BACKEND_LINKED_ROOT_UNASSOCIATED`. Generic transport or invalid-response
-failures remain local to the requested module when coherent earlier pages are
-still valid.
+failures remain local to the requested module when coherent earlier pages and
+the snapshot lease are still valid. Invalid snapshot lease or final-validation
+failure is workspace-wide and discards all backend pages from the attempt.
 
 `includeFiles=false` returns sorted module metadata and the snapshot token.
 The compatibility form `includeFiles=true` without an input snapshot token
@@ -207,8 +235,10 @@ linked root without any backend root-module association throws
 `PROJECT_MODEL_UNAVAILABLE`. A path outside the canonical workspace or linked
 root is rejected before it reaches paging.
 
-The fake backend implements the same generation/fingerprint and opaque-cursor
-contract. Contract tests cover root build/settings scripts, a build-logic
+The fake backend implements the same generation/fingerprint and server-held
+cursor contract. Contract tests cover expiry, deterministic capacity eviction,
+single-use, forged/unknown/query-mismatched handles, root build/settings
+scripts, a build-logic
 convention plugin, an ordinary `.kts`, included builds, multiple owners, two
 non-overlapping pages, equal-cardinality path replacement, module addition and
 removal, cross-module cursors, and invalid tokens.
@@ -238,10 +268,12 @@ LEFT JOIN fq_names AS packages
 ORDER BY prefixes.dir_path, manifest.filename
 ```
 
-The reader verifies the checked-in schema version and required tables. It
-decodes `__kast_abs__/` and `__kast_rel__/` through the existing path rules,
-rejects non-`.kt` and out-of-root rows with typed evidence, and distinguishes
-package states:
+The same read transaction also selects `schema_version.generation`, every
+`module_index_progress` row, and the count of unapplied `pending_updates`. The
+reader verifies the checked-in schema version and required tables. It decodes
+`__kast_abs__/` and `__kast_rel__/` through the existing path rules, rejects
+non-`.kt` and out-of-root rows with typed evidence, and distinguishes package
+states:
 
 ```rust
 pub(crate) enum WorkspacePackageEvidence {
@@ -258,6 +290,29 @@ without a joined row is `InvalidReference` and adds
 `PACKAGE_METADATA_INVALID`. This avoids using one null for four different
 facts.
 
+```rust
+pub(crate) struct SourceIndexSnapshotStamp {
+    generation: SourceIndexGeneration,
+    progress: BTreeMap<SourceIndexModule, SourceIndexModuleProgress>,
+    unapplied_updates: SourceIndexPendingCount,
+}
+
+pub(crate) enum SourceIndexModuleProgress {
+    Complete { indexed: SourceIndexFileCount, total: SourceIndexFileCount },
+    Pending { indexed: SourceIndexFileCount, total: SourceIndexFileCount },
+    Indexing { indexed: SourceIndexFileCount, total: SourceIndexFileCount },
+    Failed,
+}
+```
+
+The existing generation column becomes an enforced change token: every write
+transaction that mutates candidate tables, progress, or pending applied state
+increments it before commit. Candidate authority is complete only when every
+row in the nonempty progress set initialized for the current index run is
+`Complete`, indexed equals total, and unapplied updates are zero. An empty
+progress set, `Pending`, `Indexing`, `Failed`, count mismatch, or pending updates
+is typed partial coverage even when the row set is readable.
+
 ## Internal inventory model
 
 The collector exposes source completeness and ownership as types:
@@ -270,6 +325,7 @@ pub(crate) struct WorkspaceInventorySnapshot {
     pub(crate) backend_coverage: BackendWorkspaceCoverage,
     pub(crate) index_coverage: IndexWorkspaceCoverage,
     pub(crate) dirty_coverage: DirtyWorkspaceCoverage,
+    pub(crate) composition: WorkspaceCompositionEvidence,
     pub(crate) limitations: BTreeSet<WorkspaceInventoryLimitation>,
 }
 
@@ -318,10 +374,27 @@ pub(crate) enum WorkspaceInventoryLimitationCode {
     BackendLinkedRootUnassociated,
     SourceIndexUnavailable,
     SourceIndexIncompatible,
+    SourceIndexProgressIncomplete,
+    SourceIndexUpdatesPending,
     DirtyStateUnavailable,
+    CrossSourceCompositionUnstable,
+    PathContainmentUnprovable,
     PackageMetadataInvalid,
     ProjectModelOwnershipUnknown,
     OutsideWorkspaceExcluded,
+}
+
+pub(crate) struct WorkspaceCompositionEvidence {
+    backend_generation: BackendWorkspaceGeneration,
+    source_index: SourceIndexSnapshotStamp,
+    filesystem_fingerprint: WorkspaceFilesystemFingerprint,
+    git_fingerprint: Option<WorkspaceGitFingerprint>,
+    state: WorkspaceCompositionState,
+}
+
+pub(crate) enum WorkspaceCompositionState {
+    Coherent,
+    Partial { changed: BTreeSet<WorkspaceEvidenceLane> },
 }
 
 pub(crate) struct WorkspaceMatchCoverage {
@@ -353,10 +426,37 @@ reason.
 `WorkspaceFilePath` contains a proven workspace-relative path and canonical
 absolute counterpart. Its constructor rejects absolute relative input, parent
 traversal, empty filenames, and paths outside the exact root. Existing paths
-are canonicalized to prevent symlink escape. Missing `.kt` index paths remain
-lexical evidence only after lexical containment succeeds. Backend source and
-content roots receive the same proof before they can associate an index row
-with a module.
+are canonicalized to prevent symlink escape. For a missing leaf, it walks to
+the deepest existing ancestor, canonicalizes that ancestor against the
+canonical root, and appends only normalized nonexistent components after the
+proof succeeds. A missing path beneath an escaping symlink is rejected. A
+dangling symlink, permission failure, race, or absent canonicalizable ancestor
+becomes `PATH_CONTAINMENT_UNPROVABLE`, excludes that candidate, and makes
+candidate coverage partial. Backend source and content roots receive the same
+proof before they can associate an index row with a module.
+
+## Cross-source composition barrier
+
+One composition attempt records the backend snapshot lease, reads source-index
+rows and `SourceIndexSnapshotStamp` in one SQLite transaction, captures
+canonical existence/containment facts for exactly the candidate paths, and
+captures normalized Git status. It then validates the backend lease, re-reads
+the index stamp in a fresh transaction, repeats targeted filesystem facts, and
+repeats the Git fingerprint. No directory walk is introduced.
+
+Identical before/after stamps produce `Coherent`. Any changed lane discards the
+whole attempt and retries once. If the second attempt also moves, the result
+carries `CROSS_SOURCE_COMPOSITION_UNSTABLE`, marks candidate and affected
+filter coverage partial, suppresses public continuation, and cannot emit
+`EXACT`; cross-source drift and absence classifications become `UNKNOWN`.
+Stable incomplete source-index progress or pending updates do not spin: they
+produce `SOURCE_INDEX_PROGRESS_INCOMPLETE` or
+`SOURCE_INDEX_UPDATES_PENDING`, retain proven rows, and keep candidate coverage
+partial. Mutation fixtures change backend generation, source-index generation,
+progress/pending state, filesystem existence/symlink resolution, and Git status
+between barrier reads to prove one retry and the terminal partial state. The
+separate budgets permit at most two composition attempts, each with at most two
+backend-generation attempts; call-count tests enforce the four-attempt ceiling.
 
 The coarse file kind remains:
 
@@ -438,6 +538,7 @@ kast agent workspace-files \
   [--path-prefix <workspace-relative-prefix>] \
   [--glob <workspace-relative-glob>] \
   [--limit <1..=200>] \
+  [--page-token <opaque>] \
   [--fields path,module,source-set,kind,package,index,drift,dirty,evidence | --count] \
   [--verbose | --explain]
 ```
@@ -445,7 +546,31 @@ kast agent workspace-files \
 All filters use AND semantics before the default limit of 20. Module matches
 any backend or indexed module owner. Path prefix matches at a segment boundary;
 glob matches only normalized relative paths. Missing source-set/package
-evidence does not match those filters.
+evidence does not match those filters. `--page-token` conflicts with `--count`;
+all other result-affecting arguments must reproduce the original normalized
+query exactly.
+
+The public page token is not a raw module cursor. After a coherent composition,
+Rust registers typed `WorkspaceFilesPublicContinuationState` in the shared
+mechanism's dedicated public workspace-file store whenever another known
+matching path exists. The state binds
+the exact root, backend, normalized filters, view/field selection, limit,
+composition-stamp digest, last emitted relative path, and cumulative returned
+evidence. A resumed invocation consumes the handle, requires the identical
+normalized query, recollects a coherent snapshot, compares its stamp digest,
+then seeks strictly after the bound path. Query mismatch, malformed, forged, or
+unknown state is `INVALID_WORKSPACE_FILES_PAGE_TOKEN`; source movement is
+`STALE_WORKSPACE_FILES_PAGE`. Both are typed failures rather than page-one
+fallback.
+
+`INVALID_WORKSPACE_FILES_PAGE_TOKEN` is non-retryable status 400 and preserves
+only the stable code plus failure class, never stored state.
+`STALE_WORKSPACE_FILES_PAGE` is retryable conflict status 409 and tells the
+caller to begin a new unpaged query explicitly.
+
+Issue and consume use internal `raw/workspace-files-continuation` over the
+already admitted session. It stores query/stamp/seek/cumulative state only and
+does not enumerate candidates or become a public capability.
 
 The compact result uses one physical-file record:
 
@@ -476,7 +601,8 @@ The compact result uses one physical-file record:
       "candidateInventory": "COMPLETE",
       "filterEvidence": "COMPLETE"
     },
-    "limit": 20
+    "limit": 20,
+    "nextPageToken": null
   },
   "limitations": [],
   "schemaVersion": 3
@@ -514,15 +640,17 @@ the registry; #338 does not create a parallel catalog.
 The internal raw catalog has a separate, explicit source boundary:
 `cli-rs/resources/kast-skill/references/commands.json` is hand-authored and is
 updated with snapshot/page fields and current internal guidance. The release
-contract generator consumes that JSON to produce `commands.yaml`, request
-schemas, and request samples; it never generates the JSON source.
+contract generator also records the internal continuation issue/consume method.
+It consumes that JSON to produce `commands.yaml`, request schemas, and request
+samples; it never generates the JSON source.
 
 ## Exact-root and testing strategy
 
 The TDD sequence proves:
 
 1. Kotlin query parsing rejects illegal token combinations and blank tokens;
-2. opaque cursors reject malformed and cross-module use;
+2. the shared server-held store rejects malformed, forged, unknown, expired,
+   evicted, consumed, and query/cross-module-mismatched handles;
 3. equal-cardinality path replacement and module addition/removal return
    `STALE_WORKSPACE_INVENTORY`;
 4. Rust discards a stale attempt, restarts exactly once, and returns typed
@@ -544,7 +672,14 @@ The TDD sequence proves:
 15. unassociated roots, runtime indexing, unavailable project models, and
     metadata failures retain distinct typed limitations without stale backend
     candidates; and
-16. capability projection requires the real Clap route.
+16. capability projection requires the real Clap route;
+17. deepest-existing-ancestor containment admits a missing in-root leaf but
+    excludes escaping/dangling symlink and unprovable cases with typed evidence;
+18. source-index generation, progress, and pending state plus backend,
+    filesystem, and Git mutations exercise the single composition retry and
+    prove unstable/incomplete evidence never emits `EXACT`; and
+19. public continuation returns 500 filtered records as 200/200/100 without
+    overlap and rejects stale, forged/unknown, and filter-mismatched tokens.
 
 The exact-root regression lives in both
 `agent_workspace_files_smoke.rs` and `semantic_workspace_admission_smoke.rs`.
@@ -553,8 +688,11 @@ Full gates cover Kotlin, generated contracts, Rust, docs, and rendering.
 `analysis-api/AGENTS.md` records the wire and generated-contract boundary.
 `backend-idea/AGENTS.md` records project-model inventory, Gradle bridge, typed
 incompleteness, and paging gates. The new Rust inventory directory owns its own
-scoped guide. These guides change with their new source boundaries rather than
-leaving ownership only in this design.
+scoped guide. `cli-rs/AGENTS.md` and
+`cli-rs/resources/kast-skill/AGENTS.md` record the public command, continuation,
+catalog/package ownership, and mandatory package, LSP, and routing gates. These
+guides change with their new source boundaries rather than leaving ownership
+only in this design.
 
 ## Non-goals
 

--- a/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
+++ b/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
@@ -3,75 +3,160 @@
 ## Goal
 
 Expose `kast agent workspace-files` as a bounded public command that discovers
-Kotlin sources and scripts from semantic workspace evidence, reports index and
-filesystem drift honestly, and supplies a reusable uncapped inventory for the
-Gradle Kotlin DSL work in issue #340.
+Kotlin sources and scripts from exact-root semantic evidence, reports Kotlin
+source-index and filesystem drift honestly, and supplies an exhaustive
+project-model script inventory for the separate Gradle DSL index in issue
+#340.
 
 ## Current failure
 
 The backend advertises `WORKSPACE_FILES`, and the raw protocol implements
 `raw/workspace-files`, but the typed public `kast agent` command tree rejects
-`workspace-files`. Agents must either discover the hidden raw contract or fall
-back to `rg`, `find`, or Git paths. The existing raw result also lacks source
-set, package, index state, dirty state, and cross-source drift.
+`workspace-files`. Agents must discover a hidden raw contract or fall back to
+`rg`, `find`, or Git paths.
 
-The raw backend caps file paths per module. The source index contains
-`file_manifest`, `file_metadata`, `path_prefixes`, and `fq_names`, but index
-rows can be stale or belong to nested linked worktrees. Neither source is a
-complete public result by itself.
+The raw backend currently caps files per module without a page token. It also
+enumerates Kotlin files through module source scope, which does not guarantee
+root `build.gradle.kts`, `settings.gradle.kts`, convention-plugin scripts, or
+ordinary project scripts. The SQLite source index provides `.kt` manifest,
+module, source-set, and package facts, but `SourceIndexFilePolicy` deliberately
+rejects `.kts`. That policy remains correct: issue #340 owns a separate Gradle
+DSL index rather than mixing Gradle declarations into the Kotlin source index.
+
+Git and module ownership also need stronger boundaries. Porcelain paths are
+repository-root-relative, not admitted-workspace-relative. A physical source
+may be owned by more than one backend module. Both facts must be represented
+before public filtering can be truthful.
 
 ## Considered approaches
 
-### Backend-only projection
+### Expose the existing capped raw response
 
-The smallest change would expose `raw/workspace-files` through a typed Clap
-command. This preserves project-model ownership but cannot satisfy package,
-source-set, indexed-state, dirty-state, or index-drift requirements. The
-per-module cap also becomes easy to misread as complete discovery.
+This preserves current project-model ownership but cannot prove complete
+absence, omits project scripts, and lacks index, package, dirty, and drift
+evidence. It would make `INDEX_ONLY` and #340 reuse unreliable.
 
-### Source-index-only query
+### Put `.kts` into the Kotlin source index
 
-A direct SQLite command could provide module, source set, package, and manifest
-state without a daemon round trip. It would incorrectly treat every retained
-manifest row as current semantic ownership. The live index can contain nested
-worktree paths, and absence from a cache cannot establish current project-model
-state.
+This would make the existing SQL inventory convenient, but it would erase the
+intentional Kotlin-source versus Gradle-DSL boundary. Gradle task, plugin, and
+relationship facts need a separate schema and completeness model in #340.
+`SourceIndexFilePolicy` therefore stays `.kt`-only.
 
-### Typed hybrid inventory
+### Page project-model candidates and compose the `.kt` index
 
-The chosen approach joins backend ownership and source-index facts by exact
-normalized path, then adds only targeted filesystem and Git annotations. It
-preserves each source's authority, exposes uncertainty as types, and creates a
-Rust inventory that #340 can reuse. It requires more composition code, but it
-is the only approach that meets the acceptance criteria without changing the
-Kotlin protocol.
+This is the chosen approach. The Kotlin backend gains deterministic per-module
+paging and a project-model inventory that includes `.kt` and `.kts`. Rust
+exhausts those pages, unions physical paths while preserving all module owners,
+and joins only `.kt` candidates to the existing Kotlin source index. Scripts
+remain `NOT_APPLICABLE` to that index and become the authoritative input set
+for #340's separate Gradle DSL index.
 
 ## Architecture
 
-The implementation has two boundaries:
+The implementation has three boundaries:
 
-1. `workspace_inventory` collects all known candidates and source coverage.
-   It has no public result limit and applies no user filters.
-2. `agent workspace-files` validates typed filters, applies them to the
+1. `raw/workspace-files` pages compiler/project-model `.kt` and `.kts`
+   candidates deterministically by backend module.
+2. `workspace_inventory` exhausts backend pages and reads all exact-root `.kt`
+   index rows without applying public filters or limits.
+3. `agent workspace-files` validates filters, applies them to one typed
    snapshot, sorts deterministically, enforces the public limit, and projects
-   the ADR 0020 result views.
+   ADR 0020 result views.
 
-The command first performs ADR 0019 exact-root admission and opens one selected
-runtime session. It requests `raw/workspace-files` with `includeFiles=true`
-and no smaller CLI-owned per-module cap. In parallel with composition (not with
-shared mutation), it opens the configured source-index database read-only and
-reads all Kotlin manifest rows in one SQLite snapshot. The collector merges
-those sources after normalizing every path to the admitted root.
+The command performs ADR 0019 admission first and passes the admitted exact
+root and selected backend to one raw RPC session. It fetches module metadata,
+then pages every module. Only after the backend snapshot is complete or has
+typed per-module failures does it read the exact-root SQLite snapshot and
+compose records.
 
-The backend response already reports module name, source roots, dependency
-module names, file count, returned files, and `filesTruncated`. No Kotlin wire
-change is required. The index query is:
+## Typed raw paging
+
+`WorkspaceFilesQuery` gains `pageToken`. `WorkspaceModule` gains
+`returnedFileCount` and `nextPageToken`. The wire contract is:
+
+```kotlin
+@Serializable
+data class WorkspaceFilesQuery(
+    val moduleName: String? = null,
+    val includeFiles: Boolean = false,
+    val maxFilesPerModule: Int? = null,
+    val pageToken: String? = null,
+)
+
+@Serializable
+data class WorkspaceModule(
+    val name: String,
+    val sourceRoots: List<String>,
+    val contentRoots: List<String> = emptyList(),
+    val dependencyModuleNames: List<String>,
+    val files: List<String> = emptyList(),
+    val filesTruncated: Boolean = false,
+    val fileCount: Int,
+    val returnedFileCount: Int = files.size,
+    val nextPageToken: String? = null,
+)
+```
+
+`pageToken` is legal only when `includeFiles=true` and one nonblank
+`moduleName` is present. It is the canonical decimal encoding of a positive
+next offset; the absent token means offset zero. `WorkspaceFilePageOffset`
+validates canonical form and positivity at the Kotlin parse boundary. The
+server continues to enforce a positive `maxFilesPerModule` no greater than
+`maxResults`.
+
+The backend gathers the complete candidate set for a requested module, maps
+every path through exact-root containment, deduplicates, sorts by normalized
+absolute path, and only then slices `[offset, offset + limit)`. It returns the
+same `fileCount` on every page and a next token exactly when more sorted paths
+remain. An offset beyond `fileCount`, a non-advancing token, inconsistent
+counts, an overlapping page, or a changed module identity invalidates that
+module snapshot in Rust. `includeFiles=false` returns sorted module metadata
+without pages. An unpaged `includeFiles=true` call remains compatible by
+returning each module's first page; Rust uses exact-module requests for all
+subsequent pages.
+
+## Project-model `.kts` authority
+
+`backend-idea` introduces `IdeaWorkspaceFileInventory`, with one
+`IdeaWorkspaceFileModuleSnapshot` per backend module. It obtains candidates
+from IntelliJ project scope, module content/source roots, and linked Gradle
+project roots rather than a filesystem walk:
+
+- module/project `FileTypeIndex` supplies compiler-visible `.kt` and `.kts`;
+- `ModuleRootManager` content and source roots establish every module owner;
+- `GradleSettings` linked project roots establish root build/settings scripts
+  and included-build roots;
+- targeted `build.gradle.kts` and `settings.gradle.kts` lookups under those
+  model-proven roots admit the root scripts without recursive discovery; and
+- project-scope `.kts` candidates cover convention plugins and ordinary
+  scripts, then acquire every containing module owner.
+
+Root project scripts use every root module associated with the linked Gradle
+project. Included builds retain their linked root and module owners. If a
+project-scope script has no content-root owner despite being contained by a
+linked Gradle root, the corresponding root-module association owns it. A
+linked root without any backend root-module association fails the request as
+incomplete project-model evidence. A path outside the canonical workspace or
+linked root is rejected before it reaches paging.
+
+The fake backend implements the same sort/slice/token contract. Contract tests
+cover root build/settings scripts, a build-logic convention plugin, an
+ordinary `.kts`, included builds, multiple owners, two non-overlapping pages,
+and invalid tokens. `SourceIndexFilePolicyTest` continues to prove all `.kts`
+paths are rejected by the Kotlin source index.
+
+## Source-index snapshot and package evidence
+
+The read-only SQLite query is uncapped and `.kt`-only:
 
 ```sql
 SELECT prefixes.dir_path,
        manifest.filename,
+       metadata.prefix_id IS NOT NULL AS metadata_present,
        metadata.module_path,
        metadata.source_set,
+       metadata.package_fq_id,
        packages.fq_name
 FROM file_manifest AS manifest
 JOIN path_prefixes AS prefixes
@@ -84,21 +169,34 @@ LEFT JOIN fq_names AS packages
 ORDER BY prefixes.dir_path, manifest.filename
 ```
 
-The reader verifies the checked-in source-index schema version and required
-tables before querying. It decodes the existing `__kast_abs__/` and
-`__kast_rel__/` prefixes through the same path rules as current Rust
-source-index readers. It discards non-`.kt`/`.kts` rows and out-of-root paths
-with typed limitation evidence.
+The reader verifies the checked-in schema version and required tables. It
+decodes `__kast_abs__/` and `__kast_rel__/` through the existing path rules,
+rejects non-`.kt` and out-of-root rows with typed evidence, and distinguishes
+package states:
 
-## Internal type model
+```rust
+pub(crate) enum WorkspacePackageEvidence {
+    Named(WorkspacePackageName),
+    Root,
+    Unavailable,
+    InvalidReference { package_fq_id: i64 },
+}
+```
 
-The collector exposes these responsibilities as types rather than boolean
-combinations:
+No metadata row is `Unavailable`. A present row with null `package_fq_id` is
+`Root`. A non-null id with one valid joined name is `Named`. A non-null id
+without a joined row is `InvalidReference` and adds
+`PACKAGE_METADATA_INVALID`. This avoids using one null for four different
+facts.
+
+## Internal inventory model
+
+The collector exposes source completeness and ownership as types:
 
 ```rust
 pub(crate) struct WorkspaceInventorySnapshot {
     pub(crate) workspace_root: WorkspaceRoot,
-    pub(crate) modules: Vec<WorkspaceInventoryModule>,
+    pub(crate) modules: BTreeMap<BackendModuleName, WorkspaceInventoryModule>,
     pub(crate) files: Vec<WorkspaceInventoryFile>,
     pub(crate) backend_coverage: BackendWorkspaceCoverage,
     pub(crate) index_coverage: IndexWorkspaceCoverage,
@@ -108,33 +206,50 @@ pub(crate) struct WorkspaceInventorySnapshot {
 
 pub(crate) struct WorkspaceInventoryFile {
     pub(crate) path: WorkspaceFilePath,
-    pub(crate) module: WorkspaceModuleEvidence,
-    pub(crate) source_set: Option<WorkspaceSourceSet>,
+    pub(crate) backend_modules: BTreeSet<BackendModuleName>,
+    pub(crate) indexed_gradle_modules: BTreeSet<GradleModulePath>,
+    pub(crate) source_sets: BTreeSet<WorkspaceSourceSet>,
     pub(crate) kind: WorkspaceFileKind,
-    pub(crate) package_name: Option<WorkspacePackageName>,
+    pub(crate) package: WorkspacePackageEvidence,
     pub(crate) index_state: WorkspaceFileIndexState,
     pub(crate) drift: WorkspaceFileDrift,
     pub(crate) dirty_state: WorkspaceFileDirtyState,
     pub(crate) evidence: BTreeSet<WorkspaceEvidenceSource>,
 }
+
+pub(crate) enum BackendWorkspaceCoverage {
+    Available {
+        modules: BTreeMap<BackendModuleName, BackendModuleCoverage>,
+    },
+    Unavailable {
+        code: WorkspaceInventoryLimitationCode,
+    },
+}
+
+pub(crate) enum BackendModuleCoverage {
+    Complete,
+    Partial {
+        code: WorkspaceInventoryLimitationCode,
+        returned_count: usize,
+        expected_count: usize,
+    },
+}
 ```
 
-`WorkspaceFilePath` contains a proven workspace-relative path and its absolute
-counterpart. Its constructor rejects absolute relative input, parent
-traversal, an empty filename, and paths outside the exact root. Existing paths
-are canonicalized to prevent a symlink target from escaping the root. Missing
-index-only paths remain lexical evidence and can be emitted only after lexical
-root containment succeeds.
+One physical path produces one public record. Every backend owner and indexed
+Gradle identity is retained in a sorted set. Duplicate backend paths with
+different module names are valid. Conflicting facts within the same module
+page remain invalid.
 
-`WorkspaceModuleEvidence` preserves both optional backend module name and
-optional indexed Gradle module path. The public `--module` filter matches
-either exact value, while output retains both so an IDEA display name cannot
-silently replace Gradle identity. `WorkspaceSourceSet` and
-`WorkspacePackageName` are validated non-empty newtypes. Package validation
-accepts Kotlin identifier segments, including backticked segments, separated
-by dots.
+`WorkspaceFilePath` contains a proven workspace-relative path and canonical
+absolute counterpart. Its constructor rejects absolute relative input, parent
+traversal, empty filenames, and paths outside the exact root. Existing paths
+are canonicalized to prevent symlink escape. Missing `.kt` index paths remain
+lexical evidence only after lexical containment succeeds. Backend source and
+content roots receive the same proof before they can associate an index row
+with a module.
 
-The file kind is intentionally coarse in #338:
+The coarse file kind remains:
 
 ```rust
 pub(crate) enum WorkspaceFileKind {
@@ -143,69 +258,63 @@ pub(crate) enum WorkspaceFileKind {
 }
 ```
 
-Issue #340 adds an independent Gradle script subtype such as project,
-settings, convention plugin, or ordinary Kotlin script. It consumes the
-uncapped inventory and project-model evidence; #338 does not guess those
-subtypes from a filename and claim Gradle semantics prematurely.
-
-Coverage is explicit:
-
-```rust
-pub(crate) enum BackendWorkspaceCoverage {
-    Complete,
-    Truncated { module_names: Vec<BackendModuleName> },
-    Unavailable { code: WorkspaceInventoryLimitationCode },
-}
-
-pub(crate) enum IndexWorkspaceCoverage {
-    Available,
-    Unavailable { code: WorkspaceInventoryLimitationCode },
-}
-
-pub(crate) enum DirtyWorkspaceCoverage {
-    Available,
-    Unavailable { code: WorkspaceInventoryLimitationCode },
-}
-```
-
-The source-index query is uncapped. `WorkspaceInventorySnapshot::files` keeps
-all candidates supplied by the available sources. Backend truncation remains
-visible in `backend_coverage`; "uncapped internal" never means pretending an
-upstream capped response was exhaustive.
+Issue #340 adds a separate Gradle DSL classification and index for project,
+settings, convention-plugin, and ordinary scripts. It consumes
+`KotlinScript` candidates and their backend ownership/coverage; it does not
+write `.kts` rows into the Kotlin source index.
 
 ## Candidate and drift composition
 
-Backend paths and index paths are keyed by `WorkspaceRelativePath`. The
-collector does not add paths from filesystem or Git enumeration. It calls
-`symlink_metadata` only for an existing candidate, and the Git porcelain v2
-snapshot only annotates candidate paths.
+Backend and index paths are keyed by `WorkspaceFilePath`. Filesystem and Git
+never add candidates. `.kt` index state and drift follow this table:
 
-Index state is independent of drift:
+- backend and index present: `INDEXED`, `NONE`;
+- backend present and readable index absent: `NOT_INDEXED`,
+  `FILESYSTEM_ONLY`;
+- index present and every possible backend owner complete: `INDEXED`,
+  `INDEX_ONLY`;
+- index present with any possible owner partial/unavailable: `INDEXED`,
+  `UNKNOWN`;
+- missing candidate: `MISSING_ON_DISK` with independent index state; and
+- index unavailable for a backend source: `UNKNOWN`, `UNKNOWN`.
 
-- `INDEXED` means the exact path is in the readable manifest snapshot.
-- `NOT_INDEXED` means a backend-owned path is absent from a readable manifest.
-- `UNKNOWN` means index evidence is unavailable.
+`.kts` is always `NOT_APPLICABLE` to the Kotlin source index. A present script
+has `NOT_APPLICABLE` drift; a missing script is `MISSING_ON_DISK`. #340 later
+adds independent Gradle-index state rather than changing these meanings.
 
-Drift follows the ADR 0021 truth table. A backend-owned path with no manifest
-row is `FILESYSTEM_ONLY` when it exists. A manifest path absent from backend is
-`INDEX_ONLY` only when backend coverage proves exhaustive absence. A missing
-candidate is `MISSING_ON_DISK`. Any unprovable absence is `UNKNOWN`.
+Potential ownership is conservative. Exact backend owners are used first.
+For an index-only `.kt`, canonical source/content-root containment may
+associate multiple modules. `INDEX_ONLY` requires every associated module to
+be complete. If association is empty or ambiguous while any module is partial,
+drift is `UNKNOWN` and the result carries
+`PROJECT_MODEL_OWNERSHIP_UNKNOWN`.
 
-Backend completeness is evaluated per module before a global result is
-claimed. If any module is truncated and an index row cannot be associated with
-a distinct complete backend module, the row remains `UNKNOWN`. This
-conservative rule is more important than maximizing `INDEX_ONLY` counts.
+## Exact-root Git dirty state
+
+The adapter runs:
+
+```console
+git -C <workspace-root> rev-parse --show-toplevel
+git -c status.relativePaths=false -C <workspace-root> status --porcelain=v2 -z --untracked-files=all -- .
+```
+
+It canonicalizes the Git top level and proves the admitted workspace root is
+contained. The explicit config override makes porcelain current and original
+rename paths repository-root-relative regardless of repository configuration.
+Those paths are normalized, restricted to the exact workspace prefix, and then
+relativized to the workspace. A rename annotates each contained candidate
+endpoint independently; crossing the workspace boundary never imports the
+outside endpoint. Invalid UTF-8, containment failure, or Git failure makes all
+candidate dirty states `UNKNOWN` with `DIRTY_STATE_UNAVAILABLE`. Only a
+successfully mapped snapshot makes an absent candidate `CLEAN`.
 
 Detailed dirty states are `CLEAN`, `MODIFIED`, `ADDED`, `DELETED`, `RENAMED`,
-`UNTRACKED`, `CONFLICTED`, and `UNKNOWN`. The CLI filter collapses them into
-clean, dirty, or unknown; structured output preserves the detailed state. If
-the root is not a Git worktree or porcelain parsing fails, every candidate is
-`UNKNOWN` and the snapshot contains `DIRTY_STATE_UNAVAILABLE`.
+`UNTRACKED`, `CONFLICTED`, and `UNKNOWN`. The public filter collapses them into
+clean, dirty, or unknown.
 
-## Public arguments and filtering
+## Public arguments and output
 
-The new `AgentWorkspaceFilesArgs` contains `AgentRuntimeArgs`, ADR 0020's
-`AgentResultViewArgs`, and typed filters. The stable syntax is:
+The stable syntax is:
 
 ```console
 kast agent workspace-files \
@@ -216,7 +325,7 @@ kast agent workspace-files \
   [--kind source|script] \
   [--package <exact-package>] \
   [--dirty clean|dirty|unknown] \
-  [--drift none|filesystem-only|index-only|missing-on-disk|unknown] \
+  [--drift none|filesystem-only|index-only|missing-on-disk|not-applicable|unknown] \
   [--path-prefix <workspace-relative-prefix>] \
   [--glob <workspace-relative-glob>] \
   [--limit <1..=200>] \
@@ -224,15 +333,12 @@ kast agent workspace-files \
   [--verbose | --explain]
 ```
 
-The default limit is 20. All filters use AND semantics and run before the
-limit. `--glob` matches only normalized relative paths and rejects the
-`regex:` prefix. `--path-prefix` matches a path exactly or at a segment
-boundary, never as a raw string prefix. Missing source-set/package evidence
-does not match a requested source-set/package filter.
+All filters use AND semantics before the default limit of 20. Module matches
+any backend or indexed module owner. Path prefix matches at a segment boundary;
+glob matches only normalized relative paths. Missing source-set/package
+evidence does not match those filters.
 
-## Output and limitations
-
-The compact result shape is:
+The compact result uses one physical-file record:
 
 ```json
 {
@@ -243,10 +349,11 @@ The compact result shape is:
     {
       "filePath": "/repo/app/src/main/kotlin/app/App.kt",
       "relativePath": "app/src/main/kotlin/app/App.kt",
-      "module": {"backendName": "app.main", "gradlePath": ":app"},
-      "sourceSet": "main",
+      "backendModules": ["app.main"],
+      "gradleModules": [":app"],
+      "sourceSets": ["main"],
       "kind": "KOTLIN_SOURCE",
-      "packageName": "app",
+      "package": {"state": "NAMED", "name": "app"},
       "indexState": "INDEXED",
       "drift": "NONE",
       "dirtyState": "MODIFIED"
@@ -265,93 +372,50 @@ The compact result shape is:
 ```
 
 `knownMatchCount` never poses as a complete total when source coverage is
-partial. `inventoryComplete=false` and typed limitations carry that fact.
-`--count` returns known counts grouped by kind, index state, drift, and dirty
-class without file records. `--verbose` adds module/source coverage and
-evidence sources. `--explain` additionally echoes the normalized typed query
-and explains which source established each classification.
-
-Limitations have stable codes and structured affected-module/path counts:
-
-- `BACKEND_WORKSPACE_FILES_UNAVAILABLE`;
-- `BACKEND_ENUMERATION_TRUNCATED`;
-- `SOURCE_INDEX_UNAVAILABLE`;
-- `SOURCE_INDEX_SCHEMA_UNSUPPORTED`;
-- `DIRTY_STATE_UNAVAILABLE`;
-- `PACKAGE_METADATA_UNAVAILABLE`;
-- `WORKSPACE_PATH_EXCLUDED`; and
-- `PROJECT_MODEL_OWNERSHIP_UNKNOWN`.
-
-Malformed backend JSON is a fatal `WORKSPACE_FILES_BACKEND_INVALID` error.
-Exact-root admission failure remains the ADR 0019 error. Backend capability
-absence or source-index absence may degrade if the other candidate source is
-usable. If neither candidate source is usable, the command fails with
-`WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` rather than returning an empty list.
+partial. `--count` groups known counts by kind, index state, drift, and dirty
+class without file records. `--verbose` adds module/page/source coverage.
+`--explain` adds normalized filters and per-record classification evidence.
+The compact high-cardinality fixture remains under 120 lines and 1,500
+estimated tokens.
 
 ## Capability verification
 
-`AgentPublicCapabilityRoute` is a typed registry entry with backend capability
-and public command path. Verification intersects raw backend capabilities with
-this registry and emits:
+`AgentPublicCapabilityRoute` maps backend `WORKSPACE_FILES` to
+`kast agent workspace-files`. Verification intersects backend read
+capabilities with this registry. A Clap contract test resolves every registry
+path against `Cli::command()`, so removing or hiding the command breaks the
+same proof that authorizes public capability projection. Issue #342 extends
+the registry; #338 does not create a parallel catalog.
 
-```json
-{
-  "capability": "WORKSPACE_FILES",
-  "command": "kast agent workspace-files"
-}
-```
+## Exact-root and testing strategy
 
-only when both sides exist. A Clap contract test resolves each registry path
-against `Cli::command()`. Removing or renaming the command therefore breaks
-the same test that authorizes the public capability projection. Issue #342
-extends this small registry instead of introducing a second hand-maintained
-catalog.
+The TDD sequence proves:
 
-## #340 reuse boundary
+1. Kotlin query parsing rejects invalid page tokens and token-without-module;
+2. fake and IDEA backends return stable non-overlapping pages and include root,
+   settings, included-build, convention-plugin, and ordinary scripts;
+3. `.kts` remains rejected by `SourceIndexFilePolicy`;
+4. the index query distinguishes absent metadata, root package, named package,
+   and dangling package ids;
+5. shared physical files retain multiple module owners;
+6. partial paging never produces `INDEX_ONLY`;
+7. nested Git roots and in/out rename endpoints map correctly;
+8. root A with only root B's descriptor is rejected before any
+   `raw/workspace-files` request or root B index read;
+9. filters, output views, limitations, deterministic order, and budgets hold;
+10. returned `filePath` composes directly with diagnostics and symbol hinting;
+    and
+11. capability projection requires the real Clap route.
 
-Issue #340 calls the internal collector before public filtering and limiting.
-It may inspect `KotlinScript` candidates, module/source-root facts, and source
-coverage to classify Gradle Kotlin DSL files. It must not treat
-`WorkspaceFileDrift::IndexOnly` or `Unknown` as compiler project-model
-ownership. Dynamic Gradle constructs retain typed degraded evidence instead
-of becoming not-found.
-
-The inventory API does not expose CLI output types to #340. Gradle script
-classification is an additive domain layer over `WorkspaceInventorySnapshot`,
-so #340 can evolve its own semantic types without destabilizing the public
-file projection.
-
-## Testing strategy
-
-The TDD sequence is:
-
-1. Add CLI/help regressions proving `workspace-files` is public and retired
-   raw aliases remain unavailable.
-2. Add source-index reader tests for package/module/source-set joins, `.kt`
-   and `.kts` kinds, exact-root containment, absolute prefix decoding, schema
-   failure, and an uncapped high-cardinality snapshot.
-3. Add composition tests for every drift truth-table row, especially
-   truncated/unavailable backend evidence never producing `INDEX_ONLY`.
-4. Add Git porcelain tests for clean, modified, added, deleted, renamed,
-   untracked, conflicted, and unavailable states.
-5. Add command tests for every filter, deterministic ordering, default and
-   maximum bounds, typed limitations, all ADR 0020 views, and a default output
-   below 120 lines/1,500 estimated tokens.
-6. Add a semantic ownership regression with an unowned `.kt` file on disk;
-   assert it is omitted because no recursive filesystem search supplies
-   candidates.
-7. Pipe a returned `filePath` into diagnostics and use it as a symbol
-   `--file-hint`, proving direct composition.
-8. Add capability tests proving `WORKSPACE_FILES` is projected only through a
-   registry entry whose Clap path exists.
-9. Run full Rust, contract, docs, and rendering gates. Kotlin modules are not
-   changed; the existing backend workspace-files tests remain the wire proof.
+The exact-root regression lives in both
+`agent_workspace_files_smoke.rs` and `semantic_workspace_admission_smoke.rs`.
+Full gates cover Kotlin, generated contracts, Rust, docs, and rendering.
 
 ## Non-goals
 
-This issue does not paginate or redesign `raw/workspace-files`, change the
-source-index schema, recursively search the filesystem, use Git as candidate
-authority, classify Gradle task declarations, infer dynamic Gradle semantics,
-or expose arbitrary RPC dispatch. It does not solve the full capability and
-installed-guidance lockstep requested by #342; it establishes the
-`WORKSPACE_FILES` registry invariant that #342 will generalize.
+This issue does not change the Kotlin source-index schema or admit `.kts` to
+`SourceIndexFilePolicy`. It does not recursively search the filesystem, use Git
+as candidate authority, classify Gradle task declarations, infer dynamic
+Gradle semantics, or expose arbitrary RPC dispatch. Issue #340 owns the Gradle
+DSL index and semantic subtype/declaration model; issue #342 owns registry
+generalization.

--- a/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
+++ b/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
@@ -47,12 +47,13 @@ relationship facts need a separate schema and completeness model in #340.
 
 This is the chosen approach. The Kotlin backend gains deterministic per-module
 paging, shared server-held opaque cursors, and a project-model inventory that
-includes `.kt` and `.kts`. Rust exhausts one backend generation, reads the
-source index with its generation/progress/pending state, unions physical paths
-while preserving all module owners, and joins only `.kt` candidates to the
-existing Kotlin source index. A bounded cross-source barrier accepts the
-composition only when backend, index, filesystem, and Git stamps remain stable.
-Scripts remain
+includes `.kt` and `.kts`. The raw query carries a typed source-only,
+script-only, or mixed domain. Rust exhausts one matching backend generation,
+reads the source index with its generation/progress/pending state only for a
+domain containing `.kt`, unions physical paths while preserving all module
+owners, and joins only `.kt` candidates to the existing Kotlin source index. A
+bounded cross-source barrier accepts the composition only when every relevant
+lane's discriminated available/unavailable state remains stable. Scripts remain
 `NOT_APPLICABLE` to that index and become the authoritative input set for
 #340's separate Gradle DSL index.
 
@@ -60,13 +61,13 @@ Scripts remain
 
 The implementation has three boundaries:
 
-1. `raw/workspace-files` snapshots compiler/project-model `.kt` and `.kts`
-   candidates, then pages that exact generation deterministically by backend
-   module.
+1. `raw/workspace-files` snapshots the compiler/project-model `.kt`, `.kts`, or
+   mixed kind domain requested by its typed selector, then pages that exact
+   generation deterministically by backend module.
 2. `workspace_inventory` exhausts backend pages, reads all exact-root `.kt`
-   index rows plus generation/progress/pending state, and proves a stable
-   backend/index/filesystem/Git barrier without applying public filters or
-   limits.
+   index rows plus generation/progress/pending state when source candidates are
+   relevant, and proves a stable query-relevant lane barrier without applying
+   public filters or limits.
 3. `agent workspace-files` validates filters, applies them to one typed
    snapshot, sorts deterministically, enforces the public limit, projects ADR
    0020 result views, and registers a query-bound continuation when known
@@ -76,9 +77,10 @@ The command performs ADR 0019 admission first and passes the admitted exact
 root and selected backend to one raw RPC session. It fetches module metadata
 and an opaque snapshot token, then echoes that token while paging every module.
 Only after the backend snapshot is complete or has typed failures does it read
-the exact-root SQLite snapshot and compose records. It then revalidates every
-mutable lane; one change restarts the entire attempt once, while a second change
-returns typed partial evidence and never `EXACT`.
+the exact-root SQLite snapshot when `.kt` candidates are relevant and compose
+records. It then revalidates every query-relevant mutable lane; one change
+restarts the entire attempt once, while a second change returns typed partial
+evidence and never `EXACT` for the affected kind partition.
 
 ## Typed raw paging
 
@@ -92,6 +94,7 @@ data class WorkspaceFilesQuery(
     val moduleName: String? = null,
     val includeFiles: Boolean = false,
     val maxFilesPerModule: Int? = null,
+    val kindDomain: WorkspaceFileKindDomain = WorkspaceFileKindDomain.MIXED,
     val snapshotToken: String? = null,
     val pageToken: String? = null,
 )
@@ -118,10 +121,11 @@ data class WorkspaceModule(
 ```
 
 `snapshotToken` and `pageToken` are random canonical handles into typed
-instances of the shared server-held `OpaqueContinuationStore`; they contain no
+instances of the shared `ServerHeldContinuationStore`; they contain no
 client-decoded offset or generation. The typed store entry binds workspace
 generation, exact module, query identity, next offset, issued/expiry time, and
-cumulative returned evidence. Clients may store and echo handles but never
+cumulative returned evidence, including the exact kind domain. Clients may
+store and echo handles but never
 decode, construct, or advance state. A page token is legal only when
 `includeFiles=true`, a nonblank snapshot token, and one nonblank module are
 present. A snapshot token with `includeFiles=false` and no module is also legal
@@ -144,12 +148,25 @@ forged, unknown, expired, evicted, consumed, or query-mismatched handles fail as
 handle failure invalidates the whole backend attempt. Page-handle failure stays
 local only after the snapshot lease independently validates.
 
-The backend gathers the complete workspace candidate set in one IDEA read
+`ServerHeldContinuationStore<Token, Query, State>` owns entry lifetime through
+a typed `ContinuationStateDisposer<State>` and does not return owning state.
+Reusable lease access and single-use consumption take callbacks; when ownership
+terminates, disposal runs exactly once in `finally`, including callback failure.
+Expiry cleanup, deterministic capacity eviction, replacement, query mismatch,
+explicit invalidation/completion, terminal consumption, and server shutdown
+all remove through the same idempotence-guarded disposal path. Shutdown drains
+all entries even if one disposer fails. No-op state uses a no-op disposer; the
+#337 reference/diagnostic adapter supplies a disposer for its closeable IDEA
+traversal so the generic policy owns that resource too. Fake close-count tests
+exercise every exit path plus consume/shutdown and expiry/replacement races,
+proving that overlapping triggers never double-close.
+
+The backend gathers the complete requested-kind candidate set in one IDEA read
 action, maps paths and roots through exact-root containment, deduplicates, and
 sorts a canonical representation containing module identities,
 source/content roots, dependencies, and candidate paths. It fingerprints that
-representation as the workspace generation stored behind the opaque
-`snapshotToken`. Before serving an exact-module page or final validation
+representation plus the kind domain as the workspace generation stored behind
+the opaque `snapshotToken`. Before serving an exact-module page or final validation
 request, it recomputes the full inventory and rejects a generation mismatch as
 `STALE_WORKSPACE_INVENTORY`. It rejects missing state, out-of-range stored
 offsets, or query/module mismatch as `INVALID_WORKSPACE_FILE_CURSOR`. Only a
@@ -235,6 +252,23 @@ linked root without any backend root-module association throws
 `PROJECT_MODEL_UNAVAILABLE`. A path outside the canonical workspace or linked
 root is rejected before it reaches paging.
 
+The same IDEA project-model adapter replaces the source-index producer's
+path-derived module guess. For every `.kt` file, it obtains
+`GradleModuleDataIndex.findGradleModuleData(module)`, associates the module with
+one model-proven direct or composite build root, and reads
+`GradleModuleData.getGradlePathOrNull()` as the absolute project path. The
+host-neutral `BuildQualifiedGradleProjectIdentity` crossing into `index-store`
+contains only a normalized workspace-relative build root and typed Gradle
+project path; no IntelliJ type crosses that dependency firewall. The producer
+collects every model-proven owner for a file, and the store persists the set in
+dedicated `file_gradle_projects` association rows. `module_path` remains a
+legacy unqualified label for existing symbol/metrics consumers, and an IDEA
+module-name fallback may populate only that legacy field. Workspace discovery
+never parses it as Gradle identity. Fixtures place `:app` in both the root build
+and an included build and prove they persist, filter, and render as two distinct
+owners. Missing or ambiguous model identity produces no build-qualified owner,
+not a guessed one.
+
 The fake backend implements the same generation/fingerprint and server-held
 cursor contract. Contract tests cover expiry, deterministic capacity eviction,
 single-use, forged/unknown/query-mismatched handles, root build/settings
@@ -253,7 +287,8 @@ The read-only SQLite query is uncapped and `.kt`-only:
 SELECT prefixes.dir_path,
        manifest.filename,
        metadata.prefix_id IS NOT NULL AS metadata_present,
-       metadata.module_path,
+       gradle_projects.build_root,
+       gradle_projects.project_path,
        metadata.source_set,
        metadata.package_fq_id,
        packages.fq_name
@@ -263,10 +298,24 @@ JOIN path_prefixes AS prefixes
 LEFT JOIN file_metadata AS metadata
   ON metadata.prefix_id = manifest.prefix_id
  AND metadata.filename = manifest.filename
+LEFT JOIN file_gradle_projects AS gradle_projects
+  ON gradle_projects.prefix_id = manifest.prefix_id
+ AND gradle_projects.filename = manifest.filename
 LEFT JOIN fq_names AS packages
   ON packages.fq_id = metadata.package_fq_id
-ORDER BY prefixes.dir_path, manifest.filename
+ORDER BY prefixes.dir_path, manifest.filename,
+         gradle_projects.build_root, gradle_projects.project_path
 ```
+
+The migration adds `file_gradle_projects(prefix_id, filename, build_root,
+project_path)` with all four columns non-null and a composite primary key, then
+increments the checked-in source-index schema version. The Rust reader groups
+the joined rows into a set and validates both identity components; it does not
+select `module_path` for workspace ownership. Store and producer tests prove
+multiple owners per file, root/included-build identity, identical project paths
+in different builds, malformed identity rejection, legacy IDEA fallback
+isolation, migration/reset behavior, and transactional generation change when
+an association is added, replaced, or removed.
 
 The same read transaction also selects `schema_version.generation`, every
 `module_index_progress` row, and the count of unapplied `pending_updates`. The
@@ -283,6 +332,20 @@ pub(crate) enum WorkspacePackageEvidence {
     InvalidReference { package_fq_id: i64 },
 }
 ```
+
+Indexed Gradle ownership is a structural tuple, never a renamed string:
+
+```rust
+pub(crate) struct BuildQualifiedGradleProjectIdentity {
+    build_root: WorkspaceRelativeGradleBuildRoot,
+    project_path: GradleProjectPath,
+}
+```
+
+`GradleProjectPath` accepts only Gradle absolute project-path syntax. The build
+root is `.` for the admitted root build or a normalized contained relative path
+for an included build. Both components must be present before the identity can
+be constructed.
 
 No metadata row is `Unavailable`. A present row with null `package_fq_id` is
 `Root`. A non-null id with one valid joined name is `Named`. A non-null id
@@ -311,7 +374,8 @@ increments it before commit. Candidate authority is complete only when every
 row in the nonempty progress set initialized for the current index run is
 `Complete`, indexed equals total, and unapplied updates are zero. An empty
 progress set, `Pending`, `Indexing`, `Failed`, count mismatch, or pending updates
-is typed partial coverage even when the row set is readable.
+is typed partial source coverage even when the row set is readable; it is not
+consulted for a script-only domain.
 
 ## Internal inventory model
 
@@ -332,7 +396,7 @@ pub(crate) struct WorkspaceInventorySnapshot {
 pub(crate) struct WorkspaceInventoryFile {
     pub(crate) path: WorkspaceFilePath,
     pub(crate) backend_modules: BTreeSet<BackendModuleName>,
-    pub(crate) indexed_gradle_modules: BTreeSet<GradleModulePath>,
+    pub(crate) indexed_gradle_projects: BTreeSet<BuildQualifiedGradleProjectIdentity>,
     pub(crate) source_sets: BTreeSet<WorkspaceSourceSet>,
     pub(crate) kind: WorkspaceFileKind,
     pub(crate) package: WorkspacePackageEvidence,
@@ -385,11 +449,37 @@ pub(crate) enum WorkspaceInventoryLimitationCode {
 }
 
 pub(crate) struct WorkspaceCompositionEvidence {
-    backend_generation: BackendWorkspaceGeneration,
-    source_index: SourceIndexSnapshotStamp,
-    filesystem_fingerprint: WorkspaceFilesystemFingerprint,
-    git_fingerprint: Option<WorkspaceGitFingerprint>,
+    kind_domain: WorkspaceRequestedKindDomain,
+    backend: WorkspaceLaneEvidence<BackendWorkspaceGeneration>,
+    source_index: WorkspaceLaneEvidence<SourceIndexSnapshotStamp>,
+    filesystem: WorkspaceLaneEvidence<WorkspaceFilesystemFingerprint>,
+    git: WorkspaceLaneEvidence<WorkspaceGitFingerprint>,
     state: WorkspaceCompositionState,
+}
+
+pub(crate) enum WorkspaceLaneEvidence<Stamp> {
+    Relevant {
+        purpose: BTreeSet<WorkspaceLanePurpose>,
+        stamp: WorkspaceLaneStamp<Stamp>,
+    },
+    Irrelevant,
+}
+
+pub(crate) enum WorkspaceLaneStamp<Stamp> {
+    Available(Stamp),
+    Unavailable(WorkspaceLaneUnavailableReason),
+}
+
+pub(crate) enum WorkspaceRequestedKindDomain {
+    KotlinSourceOnly,
+    KotlinScriptOnly,
+    SourceAndScript,
+}
+
+pub(crate) enum WorkspaceLanePurpose {
+    CandidateAuthority,
+    FilterEvidence,
+    ProjectionEvidence,
 }
 
 pub(crate) enum WorkspaceCompositionState {
@@ -398,6 +488,11 @@ pub(crate) enum WorkspaceCompositionState {
 }
 
 pub(crate) struct WorkspaceMatchCoverage {
+    source: WorkspaceKindMatchCoverage,
+    script: WorkspaceKindMatchCoverage,
+}
+
+pub(crate) struct WorkspaceKindMatchCoverage {
     candidate_inventory: WorkspaceCoverageState,
     filter_evidence: WorkspaceCoverageState,
 }
@@ -408,10 +503,17 @@ pub(crate) enum WorkspaceCoverageState {
 }
 ```
 
-One physical path produces one public record. Every backend owner and indexed
-Gradle identity is retained in a sorted set. Duplicate backend paths with
-different module names are valid. Conflicting facts within the same module
-page remain invalid.
+One physical path produces one public record. Every backend owner and
+build-qualified indexed Gradle identity is retained in a sorted set. Duplicate
+backend paths with different module names are valid. Conflicting facts within
+the same module page remain invalid.
+
+The composition digest uses canonical serialization of `kind_domain`, every
+lane's `Relevant` or `Irrelevant` tag, the purpose set, and the exact
+`Available(stamp)` or `Unavailable(reason)` value. This makes stable
+backend-only and index-only partial compositions representable and pageable.
+A continuation becomes stale if a relevant lane changes value, availability,
+or unavailable reason. An irrelevant lane is neither read nor compared.
 
 `BackendWorkspaceCoverage::Partial` represents a typed workspace-wide failure,
 including repeated `STALE_WORKSPACE_INVENTORY` after the single bounded retry.
@@ -437,26 +539,45 @@ proof before they can associate an index row with a module.
 
 ## Cross-source composition barrier
 
-One composition attempt records the backend snapshot lease, reads source-index
-rows and `SourceIndexSnapshotStamp` in one SQLite transaction, captures
-canonical existence/containment facts for exactly the candidate paths, and
-captures normalized Git status. It then validates the backend lease, re-reads
-the index stamp in a fresh transaction, repeats targeted filesystem facts, and
-repeats the Git fingerprint. No directory walk is introduced.
+The normalized query first derives `WorkspaceRequestedKindDomain` and lane
+purposes. Backend and targeted filesystem evidence are candidate-relevant for
+every domain. The Kotlin source index is candidate-relevant only for
+`KotlinSourceOnly` and `SourceAndScript`; it is `Irrelevant` for
+`KotlinScriptOnly` and #340. Git is filter/projection-relevant only when dirty
+selection, grouping, or projected fields require it. Package/source-set/index
+evidence is similarly relevant only to source records and selected predicates
+or fields. The raw backend request receives the same kind domain, so its
+generation and failure coverage cannot be polluted by the excluded file kind.
 
-Identical before/after stamps produce `Coherent`. Any changed lane discards the
-whole attempt and retries once. If the second attempt also moves, the result
+One composition attempt records each relevant lane as `Available(typed stamp)`
+or `Unavailable(typed reason)`, captures canonical existence/containment facts
+for exactly the candidate paths, and skips irrelevant reads. It then validates
+the backend lease or repeats backend unavailability, re-reads a relevant index
+stamp or unavailable classification in a fresh transaction, repeats targeted
+filesystem facts, and repeats Git only when relevant. No directory walk is
+introduced.
+
+Identical before/after canonical lane evidence produces `Coherent`, including
+stable unavailable lanes. Any changed relevant lane discards the whole attempt
+and retries once. If the second attempt also moves, the result
 carries `CROSS_SOURCE_COMPOSITION_UNSTABLE`, marks candidate and affected
 filter coverage partial, suppresses public continuation, and cannot emit
 `EXACT`; cross-source drift and absence classifications become `UNKNOWN`.
 Stable incomplete source-index progress or pending updates do not spin: they
 produce `SOURCE_INDEX_PROGRESS_INCOMPLETE` or
 `SOURCE_INDEX_UPDATES_PENDING`, retain proven rows, and keep candidate coverage
-partial. Mutation fixtures change backend generation, source-index generation,
-progress/pending state, filesystem existence/symlink resolution, and Git status
-between barrier reads to prove one retry and the terminal partial state. The
-separate budgets permit at most two composition attempts, each with at most two
-backend-generation attempts; call-count tests enforce the four-attempt ceiling.
+partial only for source and mixed domains. Script-only and #340 remain exact
+when their relevant lanes are complete. Mutation fixtures change backend
+generation, source-index generation, progress/pending state, filesystem
+existence/symlink resolution, and Git status between barrier reads to prove one
+retry and the terminal partial state. Availability-transition fixtures change
+available to unavailable, unavailable to available, and unavailable reasons.
+Mixed/source/script tests prove unrelated `.kt` progress neither retries nor
+invalidates script-only continuation, while mixed and source-only queries do.
+In mixed count output the script group can remain `Exact` while the source
+group and overall result are `KnownMinimum`. The separate budgets permit at
+most two composition attempts, each with at most two backend-generation
+attempts; call-count tests enforce the four-attempt ceiling.
 
 The coarse file kind remains:
 
@@ -529,7 +650,7 @@ The stable syntax is:
 kast agent workspace-files \
   --workspace-root <repo> \
   [--backend idea|headless] \
-  [--module <exact-module>] \
+  [--module backend:<exact-name>|gradle:<build-root>#<project-path>] \
   [--source-set <exact-source-set>] \
   [--kind source|script] \
   [--package <exact-package>] \
@@ -543,8 +664,10 @@ kast agent workspace-files \
   [--verbose | --explain]
 ```
 
-All filters use AND semantics before the default limit of 20. Module matches
-any backend or indexed module owner. Path prefix matches at a segment boundary;
+All filters use AND semantics before the default limit of 20. Module parses a
+closed backend or build-qualified Gradle selector; `gradle:.#:app` identifies
+`:app` in the root build while `gradle:included/tools#:app` is distinct. Path
+prefix matches at a segment boundary;
 glob matches only normalized relative paths. Missing source-set/package
 evidence does not match those filters. `--page-token` conflicts with `--count`;
 all other result-affecting arguments must reproduce the original normalized
@@ -562,6 +685,13 @@ then seeks strictly after the bound path. Query mismatch, malformed, forged, or
 unknown state is `INVALID_WORKSPACE_FILES_PAGE_TOKEN`; source movement is
 `STALE_WORKSPACE_FILES_PAGE`. Both are typed failures rather than page-one
 fallback.
+
+The digest includes the normalized kind domain, relevance/purpose of each lane,
+and each relevant lane's exact available stamp or unavailable reason. Stable
+backend-only and index-only partial compositions may therefore continue over
+known matches while preserving `KNOWN_MINIMUM`; a lane availability transition
+or reason change is stale. Script-only tokens contain an irrelevant index lane
+and survive unrelated `.kt` generation/progress/pending movement.
 
 `INVALID_WORKSPACE_FILES_PAGE_TOKEN` is non-retryable status 400 and preserves
 only the stable code plus failure class, never stored state.
@@ -584,7 +714,9 @@ The compact result uses one physical-file record:
       "filePath": "/repo/app/src/main/kotlin/app/App.kt",
       "relativePath": "app/src/main/kotlin/app/App.kt",
       "backendModules": ["app.main"],
-      "gradleModules": [":app"],
+      "gradleProjects": [
+        {"buildRoot": ".", "projectPath": ":app"}
+      ],
       "sourceSets": ["main"],
       "kind": "KOTLIN_SOURCE",
       "package": {"state": "NAMED", "name": "app"},
@@ -610,14 +742,23 @@ The compact result uses one physical-file record:
 ```
 
 The page reuses ADR 0020's `AgentResultCardinality`. `EXACT.totalCount` is legal
-only when candidate inventory is exhaustive and every predicate selected by the
-request is known for every candidate. Otherwise the page emits
+only when candidate inventory is exhaustive for the selected kind domain and
+every selected predicate is known for every candidate in that domain.
+Source/script coverage is computed separately and only the relevant partitions
+are conjoined. Otherwise the page emits
 `KNOWN_MINIMUM.knownMinimumCount` for matches actually proved. Candidate and
 filter coverage remain separate because they answer different questions. For
 example, complete backend/index candidates plus unavailable Git status produce
 `candidateInventory=COMPLETE`, `filterEvidence=PARTIAL`, and `KNOWN_MINIMUM`
 for `--dirty clean`; without a dirty filter, that same Git limitation does not
 make match cardinality inexact.
+
+For `--kind script`, unavailable or moving `.kt` index state is irrelevant and
+does not prevent exactness. A source-only request requires complete source-index
+authority; a mixed request requires both source and script partitions for an
+exact overall count. Count groups retain their partitioned cardinality, so a
+mixed result may report an exact script group beside a known-minimum source
+group and known-minimum overall cardinality.
 
 `returnedCount` equals the emitted file records. `truncated` is true when an
 exact total exceeds returned count or cardinality is `KNOWN_MINIMUM`, because
@@ -650,7 +791,8 @@ The TDD sequence proves:
 
 1. Kotlin query parsing rejects illegal token combinations and blank tokens;
 2. the shared server-held store rejects malformed, forged, unknown, expired,
-   evicted, consumed, and query/cross-module-mismatched handles;
+   evicted, consumed, and query/cross-module-mismatched handles and disposes
+   owned state exactly once on every removal path and server shutdown;
 3. equal-cardinality path replacement and module addition/removal return
    `STALE_WORKSPACE_INVENTORY`;
 4. Rust discards a stale attempt, restarts exactly once, and returns typed
@@ -677,18 +819,29 @@ The TDD sequence proves:
     excludes escaping/dangling symlink and unprovable cases with typed evidence;
 18. source-index generation, progress, and pending state plus backend,
     filesystem, and Git mutations exercise the single composition retry and
-    prove unstable/incomplete evidence never emits `EXACT`; and
+    prove unstable/incomplete relevant evidence never emits `EXACT`; and
 19. public continuation returns 500 filtered records as 200/200/100 without
-    overlap and rejects stale, forged/unknown, and filter-mismatched tokens.
+    overlap and rejects stale, forged/unknown, and filter-mismatched tokens;
+20. build-qualified producer/storage fixtures distinguish the root build's
+    `:app` from an included build's `:app` and never expose an IDEA fallback as
+    Gradle identity; and
+21. mixed/source/script fixtures prove source-index progress is relevant only
+    to a selected source partition, including continuation digests and grouped
+    cardinality.
 
 The exact-root regression lives in both
 `agent_workspace_files_smoke.rs` and `semantic_workspace_admission_smoke.rs`.
-Full gates cover Kotlin, generated contracts, Rust, docs, and rendering.
+Full gates cover Kotlin, generated contracts, Rust, docs, and rendering. Final
+acceptance also runs `./gradlew test` and `./gradlew buildIdeaPlugin` so the
+cross-module schema/producer contract and packaged IDEA plugin are proved as a
+whole.
 
-`analysis-api/AGENTS.md` records the wire and generated-contract boundary.
-`backend-idea/AGENTS.md` records project-model inventory, Gradle bridge, typed
-incompleteness, and paging gates. The new Rust inventory directory owns its own
-scoped guide. `cli-rs/AGENTS.md` and
+`analysis-api/AGENTS.md` records the wire, exact-once continuation disposal,
+and generated-contract boundary. `backend-idea/AGENTS.md` records project-model
+inventory, Gradle bridge, build-qualified source-index producer, typed
+incompleteness, and paging gates. `index-store/AGENTS.md` owns the association
+table, generation, and legacy-label prohibition. The new Rust inventory
+directory owns its own scoped guide. `cli-rs/AGENTS.md` and
 `cli-rs/resources/kast-skill/AGENTS.md` record the public command, continuation,
 catalog/package ownership, and mandatory package, LSP, and routing gates. These
 guides change with their new source boundaries rather than leaving ownership
@@ -696,8 +849,11 @@ only in this design.
 
 ## Non-goals
 
-This issue does not change the Kotlin source-index schema or admit `.kts` to
-`SourceIndexFilePolicy`. It does not recursively search the filesystem, use Git
+This issue changes the Kotlin source-index schema only to add the
+`file_gradle_projects` build-qualified ownership association table and advance
+its checked-in version; it does not admit `.kts` to `SourceIndexFilePolicy` or
+reinterpret legacy
+`module_path`. It does not recursively search the filesystem, use Git
 as candidate authority, classify Gradle task declarations, infer dynamic
 Gradle semantics, or expose arbitrary RPC dispatch. Issue #340 owns the Gradle
 DSL index and semantic subtype/declaration model; issue #342 owns registry

--- a/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
+++ b/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
@@ -43,21 +43,23 @@ intentional Kotlin-source versus Gradle-DSL boundary. Gradle task, plugin, and
 relationship facts need a separate schema and completeness model in #340.
 `SourceIndexFilePolicy` therefore stays `.kt`-only.
 
-### Page project-model candidates and compose the `.kt` index
+### Page one generation of project-model candidates and compose the `.kt` index
 
 This is the chosen approach. The Kotlin backend gains deterministic per-module
-paging and a project-model inventory that includes `.kt` and `.kts`. Rust
-exhausts those pages, unions physical paths while preserving all module owners,
-and joins only `.kt` candidates to the existing Kotlin source index. Scripts
-remain `NOT_APPLICABLE` to that index and become the authoritative input set
-for #340's separate Gradle DSL index.
+paging, opaque generation-bound cursors, and a project-model inventory that
+includes `.kt` and `.kts`. Rust exhausts one coherent workspace generation,
+unions physical paths while preserving all module owners, and joins only `.kt`
+candidates to the existing Kotlin source index. Scripts remain
+`NOT_APPLICABLE` to that index and become the authoritative input set for
+#340's separate Gradle DSL index.
 
 ## Architecture
 
 The implementation has three boundaries:
 
-1. `raw/workspace-files` pages compiler/project-model `.kt` and `.kts`
-   candidates deterministically by backend module.
+1. `raw/workspace-files` snapshots compiler/project-model `.kt` and `.kts`
+   candidates, then pages that exact generation deterministically by backend
+   module.
 2. `workspace_inventory` exhausts backend pages and reads all exact-root `.kt`
    index rows without applying public filters or limits.
 3. `agent workspace-files` validates filters, applies them to one typed
@@ -65,14 +67,15 @@ The implementation has three boundaries:
    ADR 0020 result views.
 
 The command performs ADR 0019 admission first and passes the admitted exact
-root and selected backend to one raw RPC session. It fetches module metadata,
-then pages every module. Only after the backend snapshot is complete or has
-typed per-module failures does it read the exact-root SQLite snapshot and
-compose records.
+root and selected backend to one raw RPC session. It fetches module metadata
+and an opaque snapshot token, then echoes that token while paging every module.
+Only after the backend snapshot is complete or has typed failures does it read
+the exact-root SQLite snapshot and compose records.
 
 ## Typed raw paging
 
-`WorkspaceFilesQuery` gains `pageToken`. `WorkspaceModule` gains
+`WorkspaceFilesQuery` gains `snapshotToken` and `pageToken`.
+`WorkspaceFilesResult` returns the snapshot token, and `WorkspaceModule` gains
 `returnedFileCount` and `nextPageToken`. The wire contract is:
 
 ```kotlin
@@ -81,7 +84,15 @@ data class WorkspaceFilesQuery(
     val moduleName: String? = null,
     val includeFiles: Boolean = false,
     val maxFilesPerModule: Int? = null,
+    val snapshotToken: String? = null,
     val pageToken: String? = null,
+)
+
+@Serializable
+data class WorkspaceFilesResult(
+    val modules: List<WorkspaceModule>,
+    val snapshotToken: String,
+    val schemaVersion: Int = SCHEMA_VERSION,
 )
 
 @Serializable
@@ -98,23 +109,49 @@ data class WorkspaceModule(
 )
 ```
 
-`pageToken` is legal only when `includeFiles=true` and one nonblank
-`moduleName` is present. It is the canonical decimal encoding of a positive
-next offset; the absent token means offset zero. `WorkspaceFilePageOffset`
-validates canonical form and positivity at the Kotlin parse boundary. The
+`snapshotToken` and `pageToken` are opaque server-owned values. Clients may
+store and echo them but never decode, construct, or advance them. A page token
+is legal only when `includeFiles=true`, a nonblank `snapshotToken`, and one
+nonblank `moduleName` are present. The decoded cursor binds the snapshot
+generation, exact module identity, and positive next offset. The Kotlin parse
+boundary validates only nonblank wire tokens and their legal field
+combinations; the backend owns cursor decoding and semantic validation. The
 server continues to enforce a positive `maxFilesPerModule` no greater than
 `maxResults`.
 
-The backend gathers the complete candidate set for a requested module, maps
-every path through exact-root containment, deduplicates, sorts by normalized
-absolute path, and only then slices `[offset, offset + limit)`. It returns the
-same `fileCount` on every page and a next token exactly when more sorted paths
-remain. An offset beyond `fileCount`, a non-advancing token, inconsistent
-counts, an overlapping page, or a changed module identity invalidates that
-module snapshot in Rust. `includeFiles=false` returns sorted module metadata
-without pages. An unpaged `includeFiles=true` call remains compatible by
-returning each module's first page; Rust uses exact-module requests for all
-subsequent pages.
+The backend gathers the complete workspace candidate set in one IDEA read
+action, maps paths and roots through exact-root containment, deduplicates, and
+sorts a canonical representation containing module identities,
+source/content roots, dependencies, and candidate paths. It fingerprints that
+representation as the workspace generation returned by the opaque
+`snapshotToken`. Before serving an exact-module page, it recomputes the full
+inventory and rejects a generation mismatch as
+`STALE_WORKSPACE_INVENTORY`. It rejects malformed, out-of-range, or
+cross-module cursors as `INVALID_WORKSPACE_FILE_CURSOR`. Only a matching
+generation may be sliced at the cursor's offset. The result echoes the same
+snapshot token, returns the same `fileCount` on every page, and emits a next
+cursor exactly when more sorted paths remain.
+
+Both failures are typed `AnalysisException` subtypes carried by the existing
+JSON-RPC error envelope. `STALE_WORKSPACE_INVENTORY` uses conflict status 409
+and `retryable=true`; `INVALID_WORKSPACE_FILE_CURSOR` uses status 400 and is not
+retryable.
+
+Rust still rejects repeated or non-advancing cursors, inconsistent counts,
+overlapping pages, or changed module identity. Equal-cardinality path
+replacement and module addition/removal are caught by the generation before
+these structural checks. On the first typed stale response, Rust discards the
+entire backend attempt and restarts once from fresh metadata. A second stale
+response is not retried: Rust discards that backend attempt, marks every module
+from the last metadata response partial, emits
+`BACKEND_WORKSPACE_INVENTORY_STALE`, and may compose index-only partial
+evidence. No page from a stale attempt contributes backend candidates.
+
+`includeFiles=false` returns sorted module metadata and the snapshot token.
+The compatibility form `includeFiles=true` without an input snapshot token
+returns each requested module's first page and a newly issued top-level token;
+any continuation must echo that token. The Rust collector always starts with
+metadata and uses exact-module requests bound to its token.
 
 ## Project-model `.kts` authority
 
@@ -125,8 +162,15 @@ project roots rather than a filesystem walk:
 
 - module/project `FileTypeIndex` supplies compiler-visible `.kt` and `.kts`;
 - `ModuleRootManager` content and source roots establish every module owner;
-- `GradleSettings` linked project roots establish root build/settings scripts
-  and included-build roots;
+- `GradleSettings.getLinkedProjectsSettings()` establishes directly linked
+  roots;
+- `GradleProjectSettings.getCompositeBuild()`,
+  `GradleProjectSettings.CompositeBuild.getCompositeParticipants()`, and
+  `BuildParticipant.getRootPath()` establish included-build roots;
+- `GradleModuleDataIndex.findGradleModuleData(Module)`,
+  `GradleModuleData.isIncludedBuild()`, `getGradleProjectDir()`, and
+  `ModuleData.getLinkedExternalProjectPath()` associate those roots with IDEA
+  modules;
 - targeted `build.gradle.kts` and `settings.gradle.kts` lookups under those
   model-proven roots admit the root scripts without recursive discovery; and
 - project-scope `.kts` candidates cover convention plugins and ordinary
@@ -140,11 +184,13 @@ linked root without any backend root-module association fails the request as
 incomplete project-model evidence. A path outside the canonical workspace or
 linked root is rejected before it reaches paging.
 
-The fake backend implements the same sort/slice/token contract. Contract tests
-cover root build/settings scripts, a build-logic convention plugin, an
-ordinary `.kts`, included builds, multiple owners, two non-overlapping pages,
-and invalid tokens. `SourceIndexFilePolicyTest` continues to prove all `.kts`
-paths are rejected by the Kotlin source index.
+The fake backend implements the same generation/fingerprint and opaque-cursor
+contract. Contract tests cover root build/settings scripts, a build-logic
+convention plugin, an ordinary `.kts`, included builds, multiple owners, two
+non-overlapping pages, equal-cardinality path replacement, module addition and
+removal, cross-module cursors, and invalid tokens.
+`SourceIndexFilePolicyTest` continues to prove all `.kts` paths are rejected by
+the Kotlin source index.
 
 ## Source-index snapshot and package evidence
 
@@ -221,6 +267,10 @@ pub(crate) enum BackendWorkspaceCoverage {
     Available {
         modules: BTreeMap<BackendModuleName, BackendModuleCoverage>,
     },
+    Partial {
+        code: WorkspaceInventoryLimitationCode,
+        modules: BTreeMap<BackendModuleName, BackendModuleCoverage>,
+    },
     Unavailable {
         code: WorkspaceInventoryLimitationCode,
     },
@@ -240,6 +290,12 @@ One physical path produces one public record. Every backend owner and indexed
 Gradle identity is retained in a sorted set. Duplicate backend paths with
 different module names are valid. Conflicting facts within the same module
 page remain invalid.
+
+`BackendWorkspaceCoverage::Partial` represents a typed workspace-wide failure,
+including repeated `STALE_WORKSPACE_INVENTORY` after the single bounded retry.
+Every module in that final metadata response is partial and the stale attempt
+contributes no backend candidates. Per-module transport or cursor failures use
+`Available` with only the affected `BackendModuleCoverage` partial.
 
 `WorkspaceFilePath` contains a proven workspace-relative path and canonical
 absolute counterpart. Its constructor rejects absolute relative input, parent
@@ -391,21 +447,26 @@ the registry; #338 does not create a parallel catalog.
 
 The TDD sequence proves:
 
-1. Kotlin query parsing rejects invalid page tokens and token-without-module;
-2. fake and IDEA backends return stable non-overlapping pages and include root,
+1. Kotlin query parsing rejects illegal token combinations and blank tokens;
+2. opaque cursors reject malformed and cross-module use;
+3. equal-cardinality path replacement and module addition/removal return
+   `STALE_WORKSPACE_INVENTORY`;
+4. Rust discards a stale attempt, restarts exactly once, and returns typed
+   partial evidence without stale backend candidates after a second mismatch;
+5. fake and IDEA backends return stable non-overlapping pages and include root,
    settings, included-build, convention-plugin, and ordinary scripts;
-3. `.kts` remains rejected by `SourceIndexFilePolicy`;
-4. the index query distinguishes absent metadata, root package, named package,
+6. `.kts` remains rejected by `SourceIndexFilePolicy`;
+7. the index query distinguishes absent metadata, root package, named package,
    and dangling package ids;
-5. shared physical files retain multiple module owners;
-6. partial paging never produces `INDEX_ONLY`;
-7. nested Git roots and in/out rename endpoints map correctly;
-8. root A with only root B's descriptor is rejected before any
-   `raw/workspace-files` request or root B index read;
-9. filters, output views, limitations, deterministic order, and budgets hold;
-10. returned `filePath` composes directly with diagnostics and symbol hinting;
+8. shared physical files retain multiple module owners;
+9. partial paging never produces `INDEX_ONLY`;
+10. nested Git roots and in/out rename endpoints map correctly;
+11. root A with only root B's descriptor is rejected before any
+    `raw/workspace-files` request or root B index read;
+12. filters, output views, limitations, deterministic order, and budgets hold;
+13. returned `filePath` composes directly with diagnostics and symbol hinting;
     and
-11. capability projection requires the real Clap route.
+14. capability projection requires the real Clap route.
 
 The exact-root regression lives in both
 `agent_workspace_files_smoke.rs` and `semantic_workspace_admission_smoke.rs`.

--- a/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
+++ b/.agents/superpowers/specs/2026-07-13-workspace-file-discovery-design.md
@@ -195,10 +195,17 @@ implements the closeable backend contract and drains its continuation stores.
 `KastIdeaBackendRuntime` passes that observed closeable backend to
 `AnalysisServer`; `RunningAnalysisServer.close()` stops request admission,
 closes dispatcher-owned public continuation state, and closes the backend once.
-`RunningKastIdeaBackend.close()` cancels indexing and delegates only to the
-running server, so no second backend owner exists. Headless and fake backends
-provide explicit no-resource close implementations instead of relying on a
-runtime cast.
+`RunningKastIdeaBackend.close()` is the outer resource choreography: cancel
+project indexing, close the running server as the sole backend/continuation
+owner, then close the separately owned `SqliteSourceIndexStore` shared by the
+reference lookup and indexer. It removes only the now-redundant
+`backendResources::close` action. Cleanup continues through later phases after
+an earlier failure, reports failure only after all phases are attempted, and is
+idempotent under repeated close. This ordering prevents indexing from racing
+shutdown, lets the server drain every lookup/continuation before the shared
+store closes, and never gives the runtime a second backend owner. Headless and
+fake backends provide explicit no-resource close implementations instead of
+relying on a runtime cast.
 
 The backend gathers the complete requested-kind candidate set in one IDEA read
 action, maps paths and roots through exact-root containment, deduplicates, and
@@ -298,7 +305,8 @@ one model-proven direct or composite build root, and reads
 `GradleModuleData.getGradlePathOrNull()` as the absolute project path. The
 host-neutral `BuildQualifiedGradleProjectIdentity` crossing into `index-store`
 contains only a normalized workspace-relative build root and typed Gradle
-project path; no IntelliJ type crosses that dependency firewall. The producer
+project path; no IntelliJ type crosses from `backend-idea` into `index-store`.
+The producer
 collects every model-proven owner for a file, and the store persists the set in
 dedicated `file_gradle_projects` association rows. `module_path` remains a
 legacy unqualified label for existing symbol/metrics consumers, and an IDEA
@@ -315,13 +323,17 @@ legacy labels but cannot construct a proven source-set identity. A fixture maps
 a nonconventional root to `integrationTest` and proves the model, not the path,
 owns that fact.
 
-`PsiSourceIndexScanner` accepts a `KtFile` semantic-evidence producer. It reads
-the Kotlin PSI/compiler package FQ name and passes a typed `ProvenRoot`,
-`ProvenNamed`, or `Unproven(reason)` value into host-neutral `FileIndexUpdate`.
-`SourceFileIndexParser` may continue parsing declarations, but its nullable or
-failed package extraction cannot construct root-package evidence. Tests cover
-escaped keyword, backticked non-identifier, and general Unicode package names
-through their canonical Kotlin semantic names.
+`backend-shared` intentionally owns IntelliJ and Kotlin PSI analysis.
+`PsiSourceIndexScanner` obtains a `KtFile`, reads its `packageFqName` or
+equivalent structured compiler evidence, and converts it inside
+`backend-shared` to host-neutral `IndexedPackageEvidence.ProvenRoot`,
+`ProvenNamed`, or `Unproven(reason)` before constructing `FileIndexUpdate`.
+No `PsiFile`, `KtFile`, IntelliJ `FqName`, or other IntelliJ/Kotlin PSI type
+crosses from `backend-shared` into `index-store`. `SourceFileIndexParser` may
+continue parsing declarations, but its nullable or failed package extraction
+cannot construct root-package evidence. Tests cover escaped keyword,
+backticked non-identifier, and general Unicode package names through their
+canonical Kotlin semantic names.
 
 The fake backend implements the same generation/fingerprint and server-held
 cursor contract. Contract tests cover expiry, deterministic capacity eviction,
@@ -937,10 +949,13 @@ The TDD sequence proves:
     and never expose an IDEA/path fallback as Gradle identity;
 21. mixed/source/script fixtures prove source-index progress is relevant only
     to a selected source partition, including continuation digests and grouped
-    cardinality; and
+    cardinality;
 22. release-state schema version 8 generates equal Kotlin and Rust constants,
     version 7 is rejected/reset before reads, and required association/provenance
-    structures cannot be absent from a compatible database.
+    structures cannot be absent from a compatible database; and
+23. runtime shutdown cancels indexing, closes the server-owned backend and
+    continuations, then closes the separately owned source-index store, without
+    duplicate backend close or failure-short-circuited cleanup.
 
 The exact-root regression lives in both
 `agent_workspace_files_smoke.rs` and `semantic_workspace_admission_smoke.rs`.
@@ -952,8 +967,11 @@ whole.
 `analysis-api/AGENTS.md` records the atomic `Complete`/`Reissue` wire-neutral
 lifecycle contract. `analysis-server/AGENTS.md` records the single backend
 close owner. `backend-idea/AGENTS.md` records project-model inventory, Gradle
-bridge, structured project/source-set and Kotlin package producers, typed
-incompleteness, and paging gates. `build-logic/AGENTS.md` records generated
+bridge, structured project/source-set production, typed incompleteness,
+runtime/source-index-store close choreography, and paging gates.
+`backend-shared/AGENTS.md` records that PSI is legal inside that module but must
+be converted to host-neutral package evidence before the `index-store` boundary.
+`build-logic/AGENTS.md` records generated
 Kotlin schema ownership from release state. `index-store/AGENTS.md` owns the
 version-8 tables, package provenance, generation, and legacy-label prohibition.
 The new Rust inventory directory owns its own scoped guide. `cli-rs/AGENTS.md` and

--- a/analysis-api/AGENTS.md
+++ b/analysis-api/AGENTS.md
@@ -28,6 +28,12 @@ Keep this unit small, stable, and reusable across every runtime host.
 - Keep edit application deterministic. Preserve conflict detection,
   non-overlapping range validation, and partial-apply reporting through any
   redesign.
+- Shared server-held continuation stores own issued state until removal. Keep
+  token/query namespaces typed, require an explicit state disposer, and dispose
+  exactly once on expiry, eviction, replacement, query mismatch, explicit
+  completion/invalidation, terminal consume, callback failure, and server
+  shutdown. Lease/consume APIs must not return owning closeable state; #337 IDEA
+  traversal resources use the same lifecycle owner.
 
 ## Verification
 
@@ -39,3 +45,5 @@ Validate the contract locally before you rely on downstream failures.
 - If you change shared config loading, descriptor discovery, or other
   startup-facing helpers, also run `./gradlew :backend-idea:test` when the
   IDEA Platform artifacts for the pinned IDE version are available.
+- For a continuation-lifecycle or cross-module workspace contract change, final
+  acceptance also requires `./gradlew test` and `./gradlew buildIdeaPlugin`.

--- a/analysis-api/AGENTS.md
+++ b/analysis-api/AGENTS.md
@@ -32,8 +32,16 @@ Keep this unit small, stable, and reusable across every runtime host.
   token/query namespaces typed, require an explicit state disposer, and dispose
   exactly once on expiry, eviction, replacement, query mismatch, explicit
   completion/invalidation, terminal consume, callback failure, and server
-  shutdown. Lease/consume APIs must not return owning closeable state; #337 IDEA
-  traversal resources use the same lifecycle owner.
+  shutdown. Lease/consume APIs must not return owning closeable state. A
+  single-use callback returns only typed `Complete(output)` or
+  `Reissue(output, nextQuery)`: complete disposes, while reissue atomically
+  moves the same owned state behind a fresh handle without closing it. Claimed
+  state remains store-owned through callback/shutdown races, and store close
+  waits for claimed callbacks to exit and dispose; #337 IDEA
+  traversal resources use this same lifecycle owner across pages.
+- Use the explicit `CloseableAnalysisBackend` contract for server-owned backend
+  lifetime. Do not discover closeability with a runtime cast or give runtime
+  and server two independent owners.
 
 ## Verification
 

--- a/analysis-server/AGENTS.md
+++ b/analysis-server/AGENTS.md
@@ -15,6 +15,11 @@ Keep this unit focused on transport concerns around the backend interface.
   descriptor directory; shutdown removes them.
 - Keep capability checks, truncation, and request-limit handling aligned with
   backend responses.
+- `RunningAnalysisServer` is the single close owner after start. Stop transport
+  admission, drain dispatcher-owned continuation state, close the explicit
+  `CloseableAnalysisBackend` once, and clean up descriptors even when one close
+  step fails. Repeated runtime/server close must be idempotent; never rely on a
+  cast to infer backend ownership.
 - PSI logic, workspace discovery, and CLI parsing stay in their runtime host
   and Rust CLI owners.
 
@@ -23,6 +28,8 @@ Keep this unit focused on transport concerns around the backend interface.
 Prove transport changes with server tests first, then broaden if needed.
 
 - Run `./gradlew :analysis-server:test`.
+- For continuation/backend lifetime changes, prove multi-page state remains
+  open through reissue and closes exactly once on terminal/error/shutdown races.
 - If you change descriptor or socket lifecycle, make sure the socket transport
   tests still pass, starting with
   `./gradlew :analysis-server:test --tests io.github.amichne.kast.server.AnalysisServerSocketTest`.

--- a/analysis-server/AGENTS.md
+++ b/analysis-server/AGENTS.md
@@ -15,11 +15,13 @@ Keep this unit focused on transport concerns around the backend interface.
   descriptor directory; shutdown removes them.
 - Keep capability checks, truncation, and request-limit handling aligned with
   backend responses.
-- `RunningAnalysisServer` is the single close owner after start. Stop transport
-  admission, drain dispatcher-owned continuation state, close the explicit
-  `CloseableAnalysisBackend` once, and clean up descriptors even when one close
-  step fails. Repeated runtime/server close must be idempotent; never rely on a
-  cast to infer backend ownership.
+- `RunningAnalysisServer` is the single backend and continuation close owner
+  after start. Stop transport admission, drain dispatcher-owned continuation
+  state, close the explicit `CloseableAnalysisBackend` once, and clean up
+  descriptors even when one close step fails. Repeated runtime/server close must
+  be idempotent; never rely on a cast to infer backend ownership. Runtime-owned
+  resources outside the backend contract, such as the IDEA source-index store,
+  remain with their runtime orchestrator and close only after this server owner.
 - PSI logic, workspace discovery, and CLI parsing stay in their runtime host
   and Rust CLI owners.
 

--- a/backend-shared/AGENTS.md
+++ b/backend-shared/AGENTS.md
@@ -1,0 +1,32 @@
+# Shared backend agent guide
+
+`backend-shared` owns IntelliJ Platform and Kotlin PSI analysis reused by the
+IDEA and headless backend hosts. PSI is an intentional implementation detail of
+this module; host-neutral contracts leave the module before persistence.
+
+## Ownership
+
+- Keep reusable PSI-backed analysis here rather than pretending the module is
+  independent of IntelliJ. Backend-host lifecycle, transport, and CLI concerns
+  remain with their owning modules.
+- `PsiSourceIndexScanner` owns semantic Kotlin package extraction. Read
+  `KtFile.packageFqName` or equivalent structured compiler evidence and convert
+  it inside this module to `IndexedPackageEvidence.ProvenRoot`, `ProvenNamed`,
+  or `Unproven(reason)`.
+- Pass only host-neutral `IndexedPackageEvidence` through `FileIndexUpdate` to
+  `index-store`. No `PsiFile`, `KtFile`, IntelliJ `FqName`, or other IntelliJ or
+  Kotlin PSI type may cross that dependency boundary.
+- `SourceFileIndexParser` may continue to provide declaration parsing, but a
+  nullable or failed text-parser package result cannot prove the root package.
+  Preserve that case as typed unproven evidence.
+- Keep escaped keywords, backticked non-identifiers, and Unicode package names
+  in their canonical Kotlin semantic form rather than reconstructing them from
+  source text.
+
+## Verification
+
+- Run `./gradlew :backend-shared:test` for local PSI-analysis changes.
+- For source-index package evidence, start with
+  `./gradlew :backend-shared:test --tests '*PsiSourceIndexScannerTest*'` and then
+  run `./gradlew :index-store:test --tests '*SqliteSourceIndexStoreTest*'`.
+- Final cross-host acceptance also requires `./gradlew :backend-idea:test`.

--- a/build-logic/AGENTS.md
+++ b/build-logic/AGENTS.md
@@ -20,6 +20,10 @@ Assume every edit in this unit can affect the whole repo.
 - Treat version bumps and plugin changes as cross-repo work. A small edit here
   can alter every module's compile, test, or packaging behavior.
 - Java 21 and shared version-catalog linkage are the build baseline.
+- `packaging/homebrew/release-state.json` is the checked-in source-index schema
+  authority. `WriteSourceIndexSchemaVersionTask` generates the Kotlin constant
+  from it; do not add a second Kotlin literal or let generated output drift from
+  the Rust build-script value.
 
 ## Verification
 
@@ -34,3 +38,6 @@ Validate both the immediate target and the wider build impact.
   with `./gradlew :backend-headless:syncRuntimeLibs :backend-headless:portableDistZip`
   for runtime-lib or portable distribution changes.
 - For significant build-logic edits, run `./gradlew build`.
+- For source-index schema generation, run
+  `./gradlew -p build-logic test --tests WriteSourceIndexSchemaVersionTaskTest`
+  and the Rust `source_index_schema_version_smoke` alignment test.

--- a/cli-rs/AGENTS.md
+++ b/cli-rs/AGENTS.md
@@ -65,6 +65,9 @@ and validation gates live in
 - Never match package/source-set filters against legacy strings. Only
   compiler/PSI-proven package states and model-proven build-qualified Gradle
   source sets match; unproven values remain explicit partial filter evidence.
+  The package selector is closed: `root` matches only proven-root evidence and
+  `named:<canonical-kotlin-package-fq-name>` matches only equal proven-named
+  evidence.
 - `packaging/homebrew/release-state.json` is the schema-version source consumed
   by `build.rs`. Keep its generated Rust value aligned with build-logic's Kotlin
   value and fail closed on an older/malformed source-index schema.

--- a/cli-rs/AGENTS.md
+++ b/cli-rs/AGENTS.md
@@ -11,13 +11,19 @@ resources.
 - `src/cli/root.rs` and `src/main.rs` define the root AXI CLI: compact context,
   setup, readiness, repair, status, and developer operations.
 - `src/cli/agent.rs` and `src/agent/` own typed compiler-backed agent commands:
-  `verify`, `symbol`, `diagnostics`, `impact`, `rename`, and `lsp`.
+  `verify`, `workspace-files`, `symbol`, `diagnostics`, `impact`, `rename`, and
+  `lsp`.
 - `src/runtime/` owns backend lifecycle inspection and mutation for IDEA and
   headless runtimes behind the same command dialect.
 - `src/install/` owns repository setup, managed guidance, machine install,
   repair, bundle activation, shell integration, and IDEA plugin installation.
 - `src/symbol_query/` and `src/metrics_database/` own operational source-index
   reads for the Rust CLI.
+- `src/workspace_inventory.rs` and `src/workspace_inventory/` own uncapped
+  exact-root `.kt` index reads, compiler/project-model candidate composition,
+  deepest-existing-ancestor path containment, source generation/progress/
+  pending evidence, the backend/index/filesystem/Git coherence barrier, and
+  typed limitations used by `agent workspace-files` and Gradle DSL consumers.
 - `src/install.rs`, `src/manifest.rs`, and `src/self_mgmt.rs` own install
   state, managed resource records, doctor checks, and repair behavior.
 - `resources/kast-skill/` owns the packaged `SKILL.md` and internal catalog
@@ -34,8 +40,16 @@ and validation gates live in
 
 - Keep command invariants in typed Rust structures. Clap, serde, and catalog
   schema validation own command parsing and structured data boundaries.
-- Agent-facing semantic workflows use typed `kast agent verify`, `symbol`,
-  `diagnostics`, `impact`, `rename`, and `lsp` commands.
+- Agent-facing semantic workflows use typed `kast agent verify`,
+  `workspace-files`, `symbol`, `diagnostics`, `impact`, `rename`, and `lsp`
+  commands.
+- Keep raw workspace paging handles and public workspace-file continuation
+  handles distinct and opaque. Public continuations bind every result-affecting
+  query field and the coherent multi-source composition stamp; invalid or stale
+  state must never restart at page one.
+- Do not assert `EXACT`, `INDEX_ONLY`, or clean filter evidence while a relevant
+  backend, source-index, filesystem, or Git lane is moving, incomplete, pending,
+  or unprovable. Retry the full composition only within its documented bound.
 - Captured or agent-run commands default to compact structured output. Public
   mutations are plan-first and gated: repair and rename require `--apply`;
   setup supports `--dry-run`; forceful replacement requires `--force`.
@@ -70,12 +84,15 @@ cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-feat
 cargo test --manifest-path cli-rs/Cargo.toml --locked
 ```
 
-For resource, package, or catalog changes, also run the relevant contracts:
+For any workspace-files, packaged guidance, resource, or catalog change, run
+all package, LSP, routing, generated-contract, and docs gates below:
 
 ```console
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
 .github/scripts/test-kast-copilot-plugin.sh
 .github/scripts/test-lsp-pivot-gates.sh
+.github/scripts/test-kast-routing-evals.sh
 .github/scripts/test-docs-content-contract.sh
 .github/scripts/test-docs-navigation-contract.sh
 zensical build --clean

--- a/cli-rs/AGENTS.md
+++ b/cli-rs/AGENTS.md
@@ -22,8 +22,9 @@ resources.
 - `src/workspace_inventory.rs` and `src/workspace_inventory/` own uncapped
   exact-root `.kt` index reads, compiler/project-model candidate composition,
   deepest-existing-ancestor path containment, source generation/progress/
-  pending evidence, the backend/index/filesystem/Git coherence barrier, and
-  typed limitations used by `agent workspace-files` and Gradle DSL consumers.
+  pending evidence, build-qualified indexed Gradle project identities, the
+  kind-relevant backend/index/filesystem/Git coherence barrier, and typed
+  limitations used by `agent workspace-files` and Gradle DSL consumers.
 - `src/install.rs`, `src/manifest.rs`, and `src/self_mgmt.rs` own install
   state, managed resource records, doctor checks, and repair behavior.
 - `resources/kast-skill/` owns the packaged `SKILL.md` and internal catalog
@@ -45,11 +46,21 @@ and validation gates live in
   commands.
 - Keep raw workspace paging handles and public workspace-file continuation
   handles distinct and opaque. Public continuations bind every result-affecting
-  query field and the coherent multi-source composition stamp; invalid or stale
-  state must never restart at page one.
+  query field and the coherent multi-source composition stamp, including each
+  relevant lane's exact available/unavailable state; invalid or stale state
+  must never restart at page one. Stable backend-only/index-only partial pages
+  may continue known matches without claiming exactness.
 - Do not assert `EXACT`, `INDEX_ONLY`, or clean filter evidence while a relevant
   backend, source-index, filesystem, or Git lane is moving, incomplete, pending,
   or unprovable. Retry the full composition only within its documented bound.
+- Compute lane relevance from the normalized source-only, script-only, or mixed
+  kind domain before collection. `.kt` index progress is irrelevant to
+  script-only discovery and #340; mixed results retain separate source/script
+  coverage before computing overall and grouped cardinality.
+- Never parse legacy `file_metadata.module_path` as Gradle project identity.
+  Indexed Gradle owners require validated rows from the dedicated
+  `file_gradle_projects` association table and render/filter as a
+  build-qualified identity.
 - Captured or agent-run commands default to compact structured output. Public
   mutations are plan-first and gated: repair and rename require `--apply`;
   setup supports `--dry-run`; forceful replacement requires `--force`.
@@ -96,4 +107,6 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_sm
 .github/scripts/test-docs-content-contract.sh
 .github/scripts/test-docs-navigation-contract.sh
 zensical build --clean
+./gradlew test --no-daemon
+./gradlew buildIdeaPlugin --no-daemon
 ```

--- a/cli-rs/AGENTS.md
+++ b/cli-rs/AGENTS.md
@@ -23,6 +23,7 @@ resources.
   exact-root `.kt` index reads, compiler/project-model candidate composition,
   deepest-existing-ancestor path containment, source generation/progress/
   pending evidence, build-qualified indexed Gradle project identities, the
+  structured Gradle source-set and Kotlin package provenance states, the
   kind-relevant backend/index/filesystem/Git coherence barrier, and typed
   limitations used by `agent workspace-files` and Gradle DSL consumers.
 - `src/install.rs`, `src/manifest.rs`, and `src/self_mgmt.rs` own install
@@ -61,6 +62,12 @@ and validation gates live in
   Indexed Gradle owners require validated rows from the dedicated
   `file_gradle_projects` association table and render/filter as a
   build-qualified identity.
+- Never match package/source-set filters against legacy strings. Only
+  compiler/PSI-proven package states and model-proven build-qualified Gradle
+  source sets match; unproven values remain explicit partial filter evidence.
+- `packaging/homebrew/release-state.json` is the schema-version source consumed
+  by `build.rs`. Keep its generated Rust value aligned with build-logic's Kotlin
+  value and fail closed on an older/malformed source-index schema.
 - Captured or agent-run commands default to compact structured output. Public
   mutations are plan-first and gated: repair and rename require `--apply`;
   setup supports `--dry-run`; forceful replacement requires `--force`.
@@ -101,6 +108,8 @@ all package, LSP, routing, generated-contract, and docs gates below:
 ```console
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test source_index_schema_version_smoke
+python3 packaging/homebrew/scripts/test-formulas.py
 .github/scripts/test-kast-copilot-plugin.sh
 .github/scripts/test-lsp-pivot-gates.sh
 .github/scripts/test-kast-routing-evals.sh

--- a/cli-rs/resources/kast-skill/AGENTS.md
+++ b/cli-rs/resources/kast-skill/AGENTS.md
@@ -36,13 +36,17 @@ AXI command dialect, and validation gates is
 - Skill guidance routes workspace discovery through public
   `kast agent workspace-files`, including typed source/script filters,
   generation/query-bound public continuation, kind-relevant partial coverage,
-  build-qualified Gradle ownership, and direct `filePath` composition with
+  build-qualified Gradle ownership, proven/unproven package and source-set
+  evidence, and direct `filePath` composition with
   diagnostics and exact symbol lookup. It must not teach
   `raw/workspace-files` as a public workflow.
 - Keep `.kts` source-index limitations and cross-source coherence limitations
   explicit. `.kt` index progress is irrelevant to a script-only request and
   #340, but relevant source/mixed partitions must remain partial. Never describe
   a partial or pending relevant candidate lane as exhaustive.
+- Teach package/source-set filters as proof-only: structured Kotlin
+  PSI/compiler package evidence and Gradle model source sets may match; legacy
+  or unavailable labels remain explicit partial evidence.
 - The packaged script is an internal verification helper. Keep it
   JSON-emitting, eager about input validation, and read-only by default.
 

--- a/cli-rs/resources/kast-skill/AGENTS.md
+++ b/cli-rs/resources/kast-skill/AGENTS.md
@@ -46,7 +46,9 @@ AXI command dialect, and validation gates is
   a partial or pending relevant candidate lane as exhaustive.
 - Teach package/source-set filters as proof-only: structured Kotlin
   PSI/compiler package evidence and Gradle model source sets may match; legacy
-  or unavailable labels remain explicit partial evidence.
+  or unavailable labels remain explicit partial evidence. Teach the closed
+  package selector as `root` for proven-root evidence or
+  `named:<canonical-kotlin-package-fq-name>` for exact proven-named evidence.
 - The packaged script is an internal verification helper. Keep it
   JSON-emitting, eager about input validation, and read-only by default.
 

--- a/cli-rs/resources/kast-skill/AGENTS.md
+++ b/cli-rs/resources/kast-skill/AGENTS.md
@@ -35,11 +35,14 @@ AXI command dialect, and validation gates is
   `kast agent` commands.
 - Skill guidance routes workspace discovery through public
   `kast agent workspace-files`, including typed source/script filters,
-  generation/query-bound public continuation, partial coverage, and direct
-  `filePath` composition with diagnostics and exact symbol lookup. It must not
-  teach `raw/workspace-files` as a public workflow.
+  generation/query-bound public continuation, kind-relevant partial coverage,
+  build-qualified Gradle ownership, and direct `filePath` composition with
+  diagnostics and exact symbol lookup. It must not teach
+  `raw/workspace-files` as a public workflow.
 - Keep `.kts` source-index limitations and cross-source coherence limitations
-  explicit. Never describe a partial or pending candidate lane as exhaustive.
+  explicit. `.kt` index progress is irrelevant to a script-only request and
+  #340, but relevant source/mixed partitions must remain partial. Never describe
+  a partial or pending relevant candidate lane as exhaustive.
 - The packaged script is an internal verification helper. Keep it
   JSON-emitting, eager about input validation, and read-only by default.
 
@@ -69,6 +72,8 @@ cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_sm
 .github/scripts/test-docs-content-contract.sh
 .github/scripts/test-docs-navigation-contract.sh
 zensical build --clean
+./gradlew test --no-daemon
+./gradlew buildIdeaPlugin --no-daemon
 ```
 
 The format-impact reports remain optional experiments. When running them, set

--- a/cli-rs/resources/kast-skill/AGENTS.md
+++ b/cli-rs/resources/kast-skill/AGENTS.md
@@ -33,6 +33,13 @@ AXI command dialect, and validation gates is
 - Keep recovery guidance resolve-first and compiler-backed.
 - Skill guidance routes agents to `kast ready`, `kast repair`, and typed
   `kast agent` commands.
+- Skill guidance routes workspace discovery through public
+  `kast agent workspace-files`, including typed source/script filters,
+  generation/query-bound public continuation, partial coverage, and direct
+  `filePath` composition with diagnostics and exact symbol lookup. It must not
+  teach `raw/workspace-files` as a public workflow.
+- Keep `.kts` source-index limitations and cross-source coherence limitations
+  explicit. Never describe a partial or pending candidate lane as exhaustive.
 - The packaged script is an internal verification helper. Keep it
   JSON-emitting, eager about input validation, and read-only by default.
 
@@ -44,22 +51,28 @@ Internal catalog changes can affect:
 - `cli-rs/src/lsp.rs` generated custom method list and dispatch metadata
 - `docs/commands/agent.md`, `docs/commands/lsp.md`, and package tests when
   internal method names or flow groups change
+- public workspace-file routing, paging examples, and installed skill content
+  when the typed command or continuation contract changes
 
 ## Verify
 
-Run the catalog and docs checks after internal catalog changes:
+For any workspace-files routing, packaged guidance, or internal catalog change,
+run all package, LSP, routing, and generated-contract checks below:
 
 ```console
 cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
 python3 .github/scripts/render-rpc-contract-summary.py --check
+cargo test --manifest-path cli-rs/Cargo.toml --locked --test packaged_content_smoke
+.github/scripts/test-kast-copilot-plugin.sh
 .github/scripts/test-kast-routing-evals.sh
-.github/scripts/run-kast-format-impact-report.sh
-.github/scripts/run-kast-routing-format-impact-report.sh
-.github/scripts/run-kast-skill-eval-format-comparison.sh
 .github/scripts/test-lsp-pivot-gates.sh
+.github/scripts/test-docs-content-contract.sh
+.github/scripts/test-docs-navigation-contract.sh
+zensical build --clean
 ```
 
-For skill-eval format experiments, set `KAST_SKILL_EVAL_AGENT_OUTPUT_SHAPE`
+The format-impact reports remain optional experiments. When running them, set
+`KAST_SKILL_EVAL_AGENT_OUTPUT_SHAPE`
 to `text`, `json`, or `toon` before running the comparison script. Suite-specific
 overrides are `KAST_FORMAT_IMPACT_AGENT_OUTPUT_SHAPE` and
 `KAST_ROUTING_FORMAT_IMPACT_AGENT_OUTPUT_SHAPE`; unset them to fall back to the

--- a/index-store/AGENTS.md
+++ b/index-store/AGENTS.md
@@ -18,6 +18,12 @@ Keep this unit focused on storage concerns and schema continuity.
   readable row set is not complete index evidence while the initialized
   progress set is empty/incomplete, indexed counts differ from totals, or
   updates remain pending.
+- Persist project-model Gradle ownership only as non-null association rows in
+  `file_gradle_projects`, produced from linked Gradle model evidence. The build
+  root is workspace-relative, and each file may retain multiple owners, so root
+  and included builds with the same project path remain distinct. Legacy
+  `file_metadata.module_path` is an unqualified symbol/metrics label; never
+  promote an IDEA fallback from it into Gradle identity.
 - Bootstrap `sqlite-jdbc` inside this module before `DriverManager` access.
   IDEA and other plugin classloaders require explicit driver registration.
 - Keep this unit runtime-agnostic. IDEA PSI logic, CLI process management, and
@@ -40,5 +46,11 @@ Prove storage changes here before relying on higher-level runtime tests.
   production continuation invalidation rather than only store-local behavior.
 - For generation/progress/pending changes, prove rollback atomicity and
   before/after generation behavior in `SqliteSourceIndexStoreTest`.
+- For build-qualified identity changes, prove schema migration/reset,
+  root-versus-included-build round trips, multiple owners per file, identical
+  project paths in different builds, malformed identity rejection, legacy
+  fallback isolation, and transactional generation change.
 - If you change schema bootstrap, connection setup, or hydration reads, exercise
   `SqliteSourceIndexStoreTest` and the affected headless/indexer tests.
+- Final acceptance for the cross-module workspace discovery contract also runs
+  `./gradlew test` and `./gradlew buildIdeaPlugin`.

--- a/index-store/AGENTS.md
+++ b/index-store/AGENTS.md
@@ -37,8 +37,11 @@ Keep this unit focused on storage concerns and schema continuity.
   Kotlin PSI/compiler evidence, including escaped/backticked/Unicode names.
 - Bootstrap `sqlite-jdbc` inside this module before `DriverManager` access.
   IDEA and other plugin classloaders require explicit driver registration.
-- Keep this unit runtime-agnostic. IDEA PSI logic, CLI process management, and
-  JSON-RPC transport code live in their runtime, CLI, and server owners.
+- Keep this unit runtime-agnostic. `backend-shared` may use IntelliJ/Kotlin PSI,
+  but it must convert package semantics to host-neutral
+  `IndexedPackageEvidence` before constructing `FileIndexUpdate`; no PSI type
+  crosses into this module. CLI process management and JSON-RPC transport code
+  live in their CLI and server owners.
 - Treat schema resets, additive migrations, and cache hydration changes as
   contract-sensitive. Operational source-index reads belong in the Rust CLI;
   Kotlin reads SQLite for headless hydration or targeted indexer/cache

--- a/index-store/AGENTS.md
+++ b/index-store/AGENTS.md
@@ -8,8 +8,10 @@ and headless/indexer hydration APIs shared across kast runtimes.
 Keep this unit focused on storage concerns and schema continuity.
 
 - Keep SQLite schema, migrations, interning codecs, and hydration helpers here.
-  `SOURCE_INDEX_SCHEMA_VERSION`, table layouts, and query columns must stay
-  aligned.
+  `packaging/homebrew/release-state.json` owns the checked-in schema version;
+  generated Kotlin/Rust `SOURCE_INDEX_SCHEMA_VERSION` values, table layouts,
+  and query columns must stay aligned. Version 8 is required for workspace-file
+  project/source-set and package-provenance reads; version 7 must reset/rebuild.
 - Treat `schema_version.generation` as the source-index change token. Increment
   it in the same write transaction as candidate-bearing tables, module index
   progress, or pending-update applied state so read-only consumers can prove a
@@ -24,6 +26,15 @@ Keep this unit focused on storage concerns and schema continuity.
   and included builds with the same project path remain distinct. Legacy
   `file_metadata.module_path` is an unqualified symbol/metrics label; never
   promote an IDEA fallback from it into Gradle identity.
+- Persist structured Gradle source-set evidence only in non-null
+  `file_gradle_source_sets` rows keyed by build root, project path, and source-set
+  name. Legacy `file_metadata.source_set` is an unproven label and cannot
+  satisfy workspace source-set filters.
+- Persist package provenance explicitly. `PROVEN_ROOT`, `PROVEN_NAMED`, and
+  `UNPROVEN` must agree with `package_fq_id` constraints; nullable or failed
+  parser output is `UNPROVEN` with a typed reason, never root. Proven states
+  cannot carry an unproven reason. Canonical package names come from
+  Kotlin PSI/compiler evidence, including escaped/backticked/Unicode names.
 - Bootstrap `sqlite-jdbc` inside this module before `DriverManager` access.
   IDEA and other plugin classloaders require explicit driver registration.
 - Keep this unit runtime-agnostic. IDEA PSI logic, CLI process management, and
@@ -50,6 +61,9 @@ Prove storage changes here before relying on higher-level runtime tests.
   root-versus-included-build round trips, multiple owners per file, identical
   project paths in different builds, malformed identity rejection, legacy
   fallback isolation, and transactional generation change.
+- For schema/provenance changes, prove release-state/Kotlin/Rust version
+  alignment, version-7 rejection/reset, required version-8 structures, a custom
+  `integrationTest` source root, and no null-to-root package collapse.
 - If you change schema bootstrap, connection setup, or hydration reads, exercise
   `SqliteSourceIndexStoreTest` and the affected headless/indexer tests.
 - Final acceptance for the cross-module workspace discovery contract also runs

--- a/index-store/AGENTS.md
+++ b/index-store/AGENTS.md
@@ -10,6 +10,14 @@ Keep this unit focused on storage concerns and schema continuity.
 - Keep SQLite schema, migrations, interning codecs, and hydration helpers here.
   `SOURCE_INDEX_SCHEMA_VERSION`, table layouts, and query columns must stay
   aligned.
+- Treat `schema_version.generation` as the source-index change token. Increment
+  it in the same write transaction as candidate-bearing tables, module index
+  progress, or pending-update applied state so read-only consumers can prove a
+  stable snapshot without changing the schema.
+- Keep `module_index_progress` and unapplied `pending_updates` truthful. A
+  readable row set is not complete index evidence while the initialized
+  progress set is empty/incomplete, indexed counts differ from totals, or
+  updates remain pending.
 - Bootstrap `sqlite-jdbc` inside this module before `DriverManager` access.
   IDEA and other plugin classloaders require explicit driver registration.
 - Keep this unit runtime-agnostic. IDEA PSI logic, CLI process management, and
@@ -30,5 +38,7 @@ Prove storage changes here before relying on higher-level runtime tests.
 - Run `./gradlew :index-store:test`.
 - For page/generation changes, also run `./gradlew :backend-idea:test` to prove
   production continuation invalidation rather than only store-local behavior.
+- For generation/progress/pending changes, prove rollback atomicity and
+  before/after generation behavior in `SqliteSourceIndexStoreTest`.
 - If you change schema bootstrap, connection setup, or hydration reads, exercise
   `SqliteSourceIndexStoreTest` and the affected headless/indexer tests.


### PR DESCRIPTION
## What

- define the first-class `kast agent workspace-files` contract and keep raw paging internal
- specify typed, server-held workspace snapshots and continuation ownership across backend and CLI layers
- preserve `.kt` source-index authority while reserving `.kts` project-model discovery for the later Gradle DSL lane
- align schema-version, package/source-set provenance, shutdown ordering, and installed-skill ownership guidance
- reconcile the implementation plan with #337's existing continuation store and paging resources

## Why

Issue #338 needs a stable cross-module contract before implementation changes the public command surface, source-index schema, and runtime ownership boundaries.

## Verification

- `.github/scripts/test-docs-content-contract.sh`
- `.github/scripts/test-docs-navigation-contract.sh`
- `zensical build --clean`
- `git diff --no-textconv --check main...HEAD`

## Scope

Contract-only prerequisite for #338. The issue remains open for implementation after this merges.
