### PR TITLE
feat: expose public workspace file discovery

### DIFF
--- a/.agents/adr/0021-first-class-workspace-file-discovery.md
+++ b/.agents/adr/0021-first-class-workspace-file-discovery.md
@@ -252,12 +252,13 @@ It does not accept candidate enumeration authority or leak an owning state
 reference.
 
 The compact default emits a typed result with the exact workspace root,
-bounded file records, ADR 0020's discriminated `EXACT` or `KNOWN_MINIMUM`
+bounded file paths, ADR 0020's discriminated `EXACT` or `KNOWN_MINIMUM`
 cardinality, returned count, truncation, optional next-page token, separate
 candidate-inventory and filter-evidence coverage, typed limitations, and schema
-version. Each file record includes:
+version. Its `files` array groups only consecutive records with identical typed
+evidence after the records are globally sorted by normalized workspace-relative
+path. Each group carries:
 
-- absolute `filePath` and workspace-relative `relativePath`;
 - sorted backend-module and build-qualified indexed-Gradle-project ownership
   sets;
 - discriminated proven/unproven source-set evidence, with build-qualified
@@ -272,7 +273,14 @@ version. Each file record includes:
   only for `PROVEN_NAMED`;
 - detailed dirty state collapsed by the public dirty filter into clean,
   dirty, or unknown; and
-- verbose/explain evidence identifying which sources established the record.
+- a `paths` array whose rows retain both the absolute `filePath` and
+  workspace-relative `relativePath` for every file with that evidence.
+
+Grouping does not reorder paths or merge equal evidence across an intervening
+different record. Flattening `files[group].paths` therefore reproduces the
+globally path-sorted page exactly. `--fields`, `--verbose`, and `--explain`
+retain flat per-file records; verbose/explain also identify which evidence
+sources established each record.
 
 The candidate inventory is `COMPLETE` only when every candidate authority
 relevant to the requested kind domain could contribute no additional matching
@@ -288,8 +296,9 @@ when all kind-relevant backend and source-index candidates are known.
 Cardinality is `EXACT` only when both relevant coverage dimensions are complete;
 otherwise it is
 `KNOWN_MINIMUM` and counts only matches actually proved. `returnedCount` equals
-the emitted file count. `truncated` is true when an exact total exceeds that
-count or cardinality is `KNOWN_MINIMUM`, because unseen matches remain possible.
+the emitted path-row count, not the compact evidence-group count. `truncated`
+is true when an exact total exceeds that count or cardinality is
+`KNOWN_MINIMUM`, because unseen matches remain possible.
 `nextPageToken` is non-null only when another currently known matching record
 exists. Coherent partial evidence may continue through all currently known
 matches; unstable evidence, or a partial result with no further known match,
@@ -302,7 +311,8 @@ cardinalities for grouped counts without file payloads, and `--verbose` or
 `--explain` exposes source coverage and evidence without making raw transport
 envelopes the default.
 
-`filePath` is the direct composition key for
+The compact composition key is `files[group].paths[i].filePath`; `--fields path`
+returns the same key in a flat per-file record. `filePath` is the direct input for
 `kast agent diagnostics --file-path <path>` and
 `kast agent symbol --query <name> --file-hint <path>`. The public command does
 not invent a second path dialect.

--- a/cli-rs/src/agent.rs
+++ b/cli-rs/src/agent.rs
@@ -16,7 +16,21 @@ use crate::cli::{
     WorkspaceRelativeGlob, WorkspaceRelativePathPrefix, WorkspaceSourceSetName,
 };
 use crate::error::{CliError, Result};
+use crate::workspace_inventory::backend::{
+    BackendRpcFailure, BackendWorkspaceRpc, RawRpcWorkspaceBackend,
+};
+use crate::workspace_inventory::collect::{
+    SystemWorkspaceLaneReader, WorkspaceInventoryInputs, collect_workspace_inventory,
+};
+use crate::workspace_inventory::model::{
+    BackendModuleCoverage, BackendWorkspaceCoverage, WorkspaceCoverageDimension,
+    WorkspaceEvidenceSource, WorkspaceFileDirtyState, WorkspaceFileDrift, WorkspaceFileIndexState,
+    WorkspaceFileKind, WorkspaceInventoryFile, WorkspaceInventoryLimitationCode,
+    WorkspaceKindMatchCoverage, WorkspacePackageEvidence, WorkspaceRequestedKindDomain,
+    WorkspaceRoot, WorkspaceSourceSetEvidence,
+};
 use crate::{output, runtime, validate};
+use clap::CommandFactory;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -24,6 +38,7 @@ use std::path::{Component, Path, PathBuf};
 
 include!("agent/types.rs");
 include!("agent/path.rs");
+include!("agent/public_capabilities.rs");
 include!("agent/workspace_files.rs");
 include!("agent/dispatch.rs");
 include!("agent/request.rs");

--- a/cli-rs/src/agent/projection.rs
+++ b/cli-rs/src/agent/projection.rs
@@ -1,4 +1,5 @@
 include!("projection/view.rs");
+include!("projection/workspace_files.rs");
 include!("projection/diagnostics.rs");
 include!("projection/impact.rs");
 include!("projection/verify.rs");

--- a/cli-rs/src/agent/projection/verify.rs
+++ b/cli-rs/src/agent/projection/verify.rs
@@ -34,19 +34,24 @@ struct AgentCapabilitiesProjectionInput {
 struct AgentCapabilitiesProjection {
     read_count: usize,
     mutation_count: usize,
+    public_read_count: usize,
     read: Vec<String>,
     mutation: Vec<String>,
+    public_read: Vec<AgentPublicCapabilityProjection>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limits: Option<AgentServerLimitsProjection>,
 }
 
 impl From<AgentCapabilitiesProjectionInput> for AgentCapabilitiesProjection {
     fn from(value: AgentCapabilitiesProjectionInput) -> Self {
+        let public_read = public_read_capabilities(&value.read_capabilities);
         Self {
             read_count: value.read_capabilities.len(),
             mutation_count: value.mutation_capabilities.len(),
+            public_read_count: public_read.len(),
             read: value.read_capabilities,
             mutation: value.mutation_capabilities,
+            public_read,
             limits: value.limits,
         }
     }
@@ -107,6 +112,7 @@ struct AgentVerifyCountResult {
     failed_count: usize,
     read_capability_count: usize,
     mutation_capability_count: usize,
+    public_read_capability_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     semantic_workspace: Option<AgentSemanticWorkspaceProjection>,
     schema_version: u32,
@@ -230,6 +236,7 @@ fn project_verify_envelope(
                 failed_count,
                 read_capability_count: capabilities.read_count,
                 mutation_capability_count: capabilities.mutation_count,
+                public_read_capability_count: capabilities.public_read_count,
                 semantic_workspace,
                 schema_version: SCHEMA_VERSION,
             },

--- a/cli-rs/src/agent/projection/workspace_files.rs
+++ b/cli-rs/src/agent/projection/workspace_files.rs
@@ -1,5 +1,5 @@
 fn project_workspace_files_result(
-    result: WorkspaceFilesCompactResult,
+    result: WorkspaceFilesResult,
     view: &AgentWorkspaceFilesViewArgs,
     matching: &[&WorkspaceInventoryFile],
     cardinality: AgentResultCardinality,
@@ -30,13 +30,13 @@ fn project_workspace_files_result(
                 }
             }
         }
-    } else if view.verbose || view.explain {
-        if let Some(object) = value.as_object_mut() {
-            object.insert(
-                "view".to_string(),
-                Value::String(if view.explain { "EXPLAIN" } else { "VERBOSE" }.to_string()),
-            );
-        }
+    } else if (view.verbose || view.explain)
+        && let Some(object) = value.as_object_mut()
+    {
+        object.insert(
+            "view".to_string(),
+            Value::String(if view.explain { "EXPLAIN" } else { "VERBOSE" }.to_string()),
+        );
     }
     value
 }

--- a/cli-rs/src/agent/projection/workspace_files.rs
+++ b/cli-rs/src/agent/projection/workspace_files.rs
@@ -1,0 +1,185 @@
+fn project_workspace_files_result(
+    result: WorkspaceFilesCompactResult,
+    view: &AgentWorkspaceFilesViewArgs,
+    matching: &[&WorkspaceInventoryFile],
+    cardinality: AgentResultCardinality,
+    kind_coverage: WorkspaceKindMatchCoverage,
+    filter_coverage: WorkspaceCoverageDimension,
+) -> Value {
+    if view.count {
+        return workspace_files_count_result(
+            matching,
+            cardinality,
+            kind_coverage,
+            filter_coverage,
+        );
+    }
+    let mut value = serde_json::to_value(result).unwrap_or(Value::Null);
+    if !view.fields.is_empty() {
+        if let Some(object) = value.as_object_mut() {
+            object.insert(
+                "type".to_string(),
+                Value::String("KAST_AGENT_WORKSPACE_FILES_SELECTION".to_string()),
+            );
+            if let Some(files) = object.get_mut("files").and_then(Value::as_array_mut) {
+                for file in files {
+                    let Some(record) = file.as_object_mut() else {
+                        continue;
+                    };
+                    record.retain(|key, _| workspace_files_selected_key(key, &view.fields));
+                }
+            }
+        }
+    } else if view.verbose || view.explain {
+        if let Some(object) = value.as_object_mut() {
+            object.insert(
+                "view".to_string(),
+                Value::String(if view.explain { "EXPLAIN" } else { "VERBOSE" }.to_string()),
+            );
+        }
+    }
+    value
+}
+
+fn workspace_files_selected_key(key: &str, fields: &[AgentWorkspaceFilesField]) -> bool {
+    fields.iter().any(|field| match field {
+        AgentWorkspaceFilesField::Path => matches!(key, "filePath" | "relativePath"),
+        AgentWorkspaceFilesField::Module => {
+            matches!(key, "backendModules" | "indexedGradleProjects")
+        }
+        AgentWorkspaceFilesField::SourceSet => key == "sourceSets",
+        AgentWorkspaceFilesField::Kind => key == "kind",
+        AgentWorkspaceFilesField::Package => key == "package",
+        AgentWorkspaceFilesField::Index => key == "sourceIndex",
+        AgentWorkspaceFilesField::Drift => key == "drift",
+        AgentWorkspaceFilesField::Dirty => key == "dirty",
+        AgentWorkspaceFilesField::Evidence => key == "evidence",
+    })
+}
+
+fn workspace_files_count_result(
+    matching: &[&WorkspaceInventoryFile],
+    cardinality: AgentResultCardinality,
+    kind_coverage: WorkspaceKindMatchCoverage,
+    filter_coverage: WorkspaceCoverageDimension,
+) -> Value {
+    let groups = |values: Vec<(&'static str, WorkspaceFileKind)>| {
+        let mut counts = BTreeMap::<&'static str, (usize, bool)>::new();
+        for (value, kind) in values {
+            let exact = workspace_files_kind_group_is_exact(
+                kind,
+                kind_coverage,
+                filter_coverage,
+            );
+            counts
+                .entry(value)
+                .and_modify(|(count, group_exact)| {
+                    *count += 1;
+                    *group_exact &= exact;
+                })
+                .or_insert((1, exact));
+        }
+        values_to_group_cardinalities(counts)
+    };
+    let kind = groups(
+        matching
+            .iter()
+            .map(|file| {
+                let kind = file.kind();
+                let value = match kind {
+                    WorkspaceFileKind::Source => "KOTLIN_SOURCE",
+                    WorkspaceFileKind::Script => "KOTLIN_SCRIPT",
+                };
+                (value, kind)
+            })
+            .collect(),
+    );
+    let index = groups(
+        matching
+            .iter()
+            .map(|file| {
+                let value = match file.index_state() {
+                    WorkspaceFileIndexState::Indexed => "INDEXED",
+                    WorkspaceFileIndexState::MetadataUnavailable
+                    | WorkspaceFileIndexState::Incompatible(_) => "UNKNOWN",
+                    WorkspaceFileIndexState::NotApplicable => "NOT_APPLICABLE",
+                };
+                (value, file.kind())
+            })
+            .collect(),
+    );
+    let drift = groups(
+        matching
+            .iter()
+            .map(|file| {
+                let value = match file.drift() {
+                    WorkspaceFileDrift::InSync => "NONE",
+                    WorkspaceFileDrift::FilesystemOnly => "FILESYSTEM_ONLY",
+                    WorkspaceFileDrift::IndexOnly => "INDEX_ONLY",
+                    WorkspaceFileDrift::MissingOnDisk => "MISSING_ON_DISK",
+                    WorkspaceFileDrift::Unknown => "UNKNOWN",
+                    WorkspaceFileDrift::NotApplicable => "NOT_APPLICABLE",
+                };
+                (value, file.kind())
+            })
+            .collect(),
+    );
+    let dirty = groups(
+        matching
+            .iter()
+            .map(|file| {
+                let value = match file.dirty_state() {
+                    WorkspaceFileDirtyState::Clean => "CLEAN",
+                    WorkspaceFileDirtyState::Dirty => "DIRTY",
+                    WorkspaceFileDirtyState::Unknown => "UNKNOWN",
+                    WorkspaceFileDirtyState::NotApplicable => "NOT_APPLICABLE",
+                };
+                (value, file.kind())
+            })
+            .collect(),
+    );
+    json!({
+        "type": "KAST_AGENT_WORKSPACE_FILES_COUNT",
+        "ok": true,
+        "cardinality": cardinality,
+        "returnedCount": 0,
+        "truncated": !cardinality.is_exact() || cardinality.known_minimum() > 0,
+        "groupedCardinalities": {
+            "kind": kind,
+            "index": index,
+            "drift": drift,
+            "dirty": dirty,
+        },
+        "schemaVersion": SCHEMA_VERSION,
+    })
+}
+
+fn values_to_group_cardinalities(
+    counts: BTreeMap<&'static str, (usize, bool)>,
+) -> Vec<Value> {
+    counts
+        .into_iter()
+        .map(|(value, (count, exact))| {
+            let cardinality = if exact {
+                AgentResultCardinality::Exact { total_count: count }
+            } else {
+                AgentResultCardinality::KnownMinimum {
+                    known_minimum_count: count,
+                }
+            };
+            json!({"value": value, "cardinality": cardinality})
+        })
+        .collect()
+}
+
+fn workspace_files_kind_group_is_exact(
+    kind: WorkspaceFileKind,
+    kind_coverage: WorkspaceKindMatchCoverage,
+    filter_coverage: WorkspaceCoverageDimension,
+) -> bool {
+    filter_coverage == WorkspaceCoverageDimension::Complete
+        && match kind {
+            WorkspaceFileKind::Source => kind_coverage.source(),
+            WorkspaceFileKind::Script => kind_coverage.script(),
+        } == Some(WorkspaceCoverageDimension::Complete)
+}

--- a/cli-rs/src/agent/projection/workspace_files.rs
+++ b/cli-rs/src/agent/projection/workspace_files.rs
@@ -5,6 +5,7 @@ fn project_workspace_files_result(
     cardinality: AgentResultCardinality,
     kind_coverage: WorkspaceKindMatchCoverage,
     filter_coverage: WorkspaceCoverageDimension,
+    index_evidence_complete: bool,
 ) -> Value {
     if view.count {
         return workspace_files_count_result(
@@ -12,6 +13,7 @@ fn project_workspace_files_result(
             cardinality,
             kind_coverage,
             filter_coverage,
+            index_evidence_complete,
         );
     }
     let mut value = serde_json::to_value(result).unwrap_or(Value::Null);
@@ -62,6 +64,7 @@ fn workspace_files_count_result(
     cardinality: AgentResultCardinality,
     kind_coverage: WorkspaceKindMatchCoverage,
     filter_coverage: WorkspaceCoverageDimension,
+    index_evidence_complete: bool,
 ) -> Value {
     let groups = |values: Vec<(&'static str, WorkspaceFileKind)>| {
         let mut counts = BTreeMap::<&'static str, (usize, bool)>::new();
@@ -98,11 +101,11 @@ fn workspace_files_count_result(
         matching
             .iter()
             .map(|file| {
-                let value = match file.index_state() {
-                    WorkspaceFileIndexState::Indexed => "INDEXED",
-                    WorkspaceFileIndexState::MetadataUnavailable
-                    | WorkspaceFileIndexState::Incompatible(_) => "UNKNOWN",
-                    WorkspaceFileIndexState::NotApplicable => "NOT_APPLICABLE",
+                let value = match workspace_files_index_state(file, index_evidence_complete) {
+                    WorkspaceFilesIndexState::Indexed => "INDEXED",
+                    WorkspaceFilesIndexState::NotIndexed => "NOT_INDEXED",
+                    WorkspaceFilesIndexState::Unknown => "UNKNOWN",
+                    WorkspaceFilesIndexState::NotApplicable => "NOT_APPLICABLE",
                 };
                 (value, file.kind())
             })

--- a/cli-rs/src/agent/public_capabilities.rs
+++ b/cli-rs/src/agent/public_capabilities.rs
@@ -1,0 +1,99 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum AgentPublicCapability {
+    WorkspaceFiles,
+}
+
+impl AgentPublicCapability {
+    fn backend_capability(self) -> &'static str {
+        match self {
+            Self::WorkspaceFiles => "WORKSPACE_FILES",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AgentPublicCapabilityRoute {
+    capability: AgentPublicCapability,
+    command_segments: &'static [&'static str],
+    display_command: &'static str,
+}
+
+const AGENT_PUBLIC_CAPABILITY_ROUTES: &[AgentPublicCapabilityRoute] =
+    &[AgentPublicCapabilityRoute {
+        capability: AgentPublicCapability::WorkspaceFiles,
+        command_segments: &["agent", "workspace-files"],
+        display_command: "kast agent workspace-files",
+    }];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentPublicCapabilityProjection {
+    capability: AgentPublicCapability,
+    command: &'static str,
+}
+
+fn public_read_capabilities(raw_read_capabilities: &[String]) -> Vec<AgentPublicCapabilityProjection> {
+    AGENT_PUBLIC_CAPABILITY_ROUTES
+        .iter()
+        .filter(|route| {
+            raw_read_capabilities
+                .iter()
+                .any(|raw| raw == route.capability.backend_capability())
+                && public_capability_route_is_callable(route)
+        })
+        .map(|route| AgentPublicCapabilityProjection {
+            capability: route.capability,
+            command: route.display_command,
+        })
+        .collect()
+}
+
+fn public_capability_route_is_callable(route: &AgentPublicCapabilityRoute) -> bool {
+    let mut command = crate::cli::Cli::command();
+    for segment in route.command_segments {
+        let Some(next) = command
+            .get_subcommands()
+            .find(|subcommand| subcommand.get_name() == *segment)
+            .cloned()
+        else {
+            return false;
+        };
+        command = next;
+    }
+    true
+}
+
+#[cfg(test)]
+mod public_capability_route_tests {
+    use super::*;
+
+    #[test]
+    fn every_registered_public_capability_resolves_through_the_clap_command_tree() {
+        assert_eq!(
+            AGENT_PUBLIC_CAPABILITY_ROUTES,
+            &[AgentPublicCapabilityRoute {
+                capability: AgentPublicCapability::WorkspaceFiles,
+                command_segments: &["agent", "workspace-files"],
+                display_command: "kast agent workspace-files",
+            }]
+        );
+        assert!(
+            AGENT_PUBLIC_CAPABILITY_ROUTES
+                .iter()
+                .all(public_capability_route_is_callable)
+        );
+    }
+
+    #[test]
+    fn public_read_evidence_requires_both_backend_support_and_a_callable_route() {
+        assert!(public_read_capabilities(&[]).is_empty());
+        assert_eq!(
+            public_read_capabilities(&["WORKSPACE_FILES".to_string()]),
+            vec![AgentPublicCapabilityProjection {
+                capability: AgentPublicCapability::WorkspaceFiles,
+                command: "kast agent workspace-files",
+            }]
+        );
+    }
+}

--- a/cli-rs/src/agent/workspace_files.rs
+++ b/cli-rs/src/agent/workspace_files.rs
@@ -50,12 +50,12 @@ struct WorkspaceFilesNextAction {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct WorkspaceFilesCompactResult {
+struct WorkspaceFilesResult {
     #[serde(rename = "type")]
     result_type: &'static str,
     ok: bool,
     workspace_root: String,
-    files: Vec<WorkspaceFileCompactRecord>,
+    files: WorkspaceFilesResultFiles,
     cardinality: AgentResultCardinality,
     returned_count: usize,
     truncated: bool,
@@ -72,6 +72,13 @@ struct WorkspaceFilesCompactResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     composition_digest: Option<String>,
     schema_version: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum WorkspaceFilesResultFiles {
+    Compact(Vec<WorkspaceFileCompactGroup>),
+    Detailed(Vec<WorkspaceFileDetailedRecord>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -106,7 +113,7 @@ enum WorkspaceFilesContinuationResult {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct WorkspaceFileCompactRecord {
+struct WorkspaceFileDetailedRecord {
     file_path: String,
     relative_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -126,12 +133,40 @@ struct WorkspaceFileCompactRecord {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct WorkspaceFileCompactGroup {
+    #[serde(flatten)]
+    evidence: WorkspaceFileCompactEvidence,
+    paths: Vec<WorkspaceFileCompactPath>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFileCompactPath {
+    file_path: String,
+    relative_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFileCompactEvidence {
+    backend_modules: Vec<String>,
+    indexed_gradle_projects: Vec<WorkspaceFilesGradleProject>,
+    source_sets: WorkspaceFilesSourceSetEvidence,
+    kind: WorkspaceFilesKind,
+    package: WorkspaceFilesPackageEvidence,
+    source_index: WorkspaceFilesIndexState,
+    drift: WorkspaceFilesDrift,
+    dirty: WorkspaceFilesDirty,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct WorkspaceFilesGradleProject {
     build_root: String,
     project_path: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE", rename_all_fields = "camelCase")]
 enum WorkspaceFilesSourceSetEvidence {
     Proven { source_sets: Vec<WorkspaceFilesGradleSourceSet> },
@@ -139,7 +174,7 @@ enum WorkspaceFilesSourceSetEvidence {
     Unavailable,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WorkspaceFilesGradleSourceSet {
     build_root: String,
@@ -147,7 +182,7 @@ struct WorkspaceFilesGradleSourceSet {
     source_set_name: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE", rename_all_fields = "camelCase")]
 enum WorkspaceFilesPackageEvidence {
     ProvenRoot,
@@ -157,15 +192,15 @@ enum WorkspaceFilesPackageEvidence {
     InvalidReference,
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 enum WorkspaceFilesKind {
     KotlinSource,
     KotlinScript,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE", rename_all_fields = "camelCase")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 enum WorkspaceFilesIndexState {
     Indexed,
     NotIndexed,
@@ -173,7 +208,7 @@ enum WorkspaceFilesIndexState {
     NotApplicable,
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 enum WorkspaceFilesDrift {
     None,
@@ -184,7 +219,7 @@ enum WorkspaceFilesDrift {
     NotApplicable,
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 enum WorkspaceFilesDirty {
     Clean,
@@ -382,10 +417,14 @@ fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope
         },
         None => 0,
     };
-    let returned = matching
+    let returned_matches = matching
         .iter()
         .skip(start)
         .take(usize::from(args.limit.get()))
+        .copied()
+        .collect::<Vec<_>>();
+    let detailed_files = returned_matches
+        .iter()
         .map(|file| {
             project_workspace_file(
                 admission.workspace_root.as_path(),
@@ -395,13 +434,13 @@ fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope
             )
         })
         .collect::<Vec<_>>();
-    let returned_count = returned.len();
+    let returned_count = detailed_files.len();
     let has_more_known_matches = start.saturating_add(returned_count) < matching.len();
     let next_page_token = if !args.view.count
         && has_more_known_matches
         && snapshot.continuation_allowed()
     {
-        let Some(last_relative_path) = returned.last().map(|file| file.relative_path.clone()) else {
+        let Some(last_relative_path) = returned_matches.last().map(|file| file.path().to_string()) else {
             return invalid_projection_envelope(
                 "agent/workspace-files".to_string(),
                 "workspace-file continuation page omitted its final path",
@@ -422,11 +461,19 @@ fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope
     } else {
         None
     };
-    let result = WorkspaceFilesCompactResult {
+    let result = WorkspaceFilesResult {
         result_type: "KAST_AGENT_WORKSPACE_FILES_RESULT",
         ok: true,
         workspace_root: admission.workspace_root.display().to_string(),
-        files: returned,
+        files: if workspace_files_view_name(&args.view) == "compact" {
+            WorkspaceFilesResultFiles::Compact(project_workspace_file_groups(
+                admission.workspace_root.as_path(),
+                &returned_matches,
+                index_evidence_complete,
+            ))
+        } else {
+            WorkspaceFilesResultFiles::Detailed(detailed_files)
+        },
         cardinality,
         returned_count,
         truncated: !exact || has_more_known_matches,
@@ -870,7 +917,7 @@ fn project_workspace_file(
     file: &WorkspaceInventoryFile,
     index_evidence_complete: bool,
     view: &AgentWorkspaceFilesViewArgs,
-) -> WorkspaceFileCompactRecord {
+) -> WorkspaceFileDetailedRecord {
     let detailed = view.verbose || view.explain;
     let module_selected = detailed
         || view
@@ -887,40 +934,110 @@ fn project_workspace_file(
             .fields
             .iter()
             .any(|field| matches!(field, AgentWorkspaceFilesField::Evidence));
-    WorkspaceFileCompactRecord {
+    let evidence = project_workspace_file_evidence(file, index_evidence_complete);
+    WorkspaceFileDetailedRecord {
         file_path: root.join(file.path().as_path()).display().to_string(),
         relative_path: file.path().to_string(),
-        backend_modules: module_selected.then(|| {
-            file.backend_modules()
+        backend_modules: module_selected.then(|| evidence.backend_modules.clone()),
+        indexed_gradle_projects: module_selected
+            .then(|| evidence.indexed_gradle_projects.clone()),
+        source_sets: source_set_selected.then(|| evidence.source_sets.clone()),
+        kind: evidence.kind,
+        package: evidence.package,
+        source_index: evidence.source_index,
+        drift: evidence.drift,
+        dirty: evidence.dirty,
+        evidence: evidence_selected.then(|| {
+            file.evidence()
                 .iter()
-                .map(|module| module.as_str().to_string())
-                .collect()
-        }),
-        indexed_gradle_projects: module_selected.then(|| {
-            file.indexed_gradle_projects()
-                .iter()
-                .map(|project| WorkspaceFilesGradleProject {
-                    build_root: workspace_files_build_root(project.build_root().as_path()),
-                    project_path: project.project_path().as_str().to_string(),
+                .map(|source| match source {
+                    WorkspaceEvidenceSource::Manifest => WorkspaceFilesEvidenceSource::Manifest,
+                    WorkspaceEvidenceSource::PackageMetadata => {
+                        WorkspaceFilesEvidenceSource::PackageMetadata
+                    }
+                    WorkspaceEvidenceSource::GradleProjectModel => {
+                        WorkspaceFilesEvidenceSource::GradleProjectModel
+                    }
                 })
                 .collect()
         }),
-        source_sets: source_set_selected.then(|| match file.source_sets() {
-            WorkspaceSourceSetEvidence::Proven(source_sets) => WorkspaceFilesSourceSetEvidence::Proven {
-                source_sets: source_sets
-                    .iter()
-                    .map(|source_set| WorkspaceFilesGradleSourceSet {
-                        build_root: workspace_files_build_root(source_set.project().build_root().as_path()),
-                        project_path: source_set.project().project_path().as_str().to_string(),
-                        source_set_name: source_set.source_set_name().as_str().to_string(),
-                    })
-                    .collect(),
-            },
-            WorkspaceSourceSetEvidence::Unproven(labels) => WorkspaceFilesSourceSetEvidence::Unproven {
-                labels: labels.iter().map(|label| label.as_str().to_string()).collect(),
-            },
+    }
+}
+
+fn project_workspace_file_groups(
+    root: &Path,
+    files: &[&WorkspaceInventoryFile],
+    index_evidence_complete: bool,
+) -> Vec<WorkspaceFileCompactGroup> {
+    let mut groups: Vec<WorkspaceFileCompactGroup> = Vec::new();
+    for file in files {
+        let evidence = project_workspace_file_evidence(file, index_evidence_complete);
+        let path = WorkspaceFileCompactPath {
+            file_path: root.join(file.path().as_path()).display().to_string(),
+            relative_path: file.path().to_string(),
+        };
+        if let Some(group) = groups
+            .last_mut()
+            .filter(|group| group.evidence == evidence)
+        {
+            group.paths.push(path);
+        } else {
+            groups.push(WorkspaceFileCompactGroup {
+                evidence,
+                paths: vec![path],
+            });
+        }
+    }
+    groups
+}
+
+fn project_workspace_file_evidence(
+    file: &WorkspaceInventoryFile,
+    index_evidence_complete: bool,
+) -> WorkspaceFileCompactEvidence {
+    WorkspaceFileCompactEvidence {
+        backend_modules: file
+            .backend_modules()
+            .iter()
+            .map(|module| module.as_str().to_string())
+            .collect(),
+        indexed_gradle_projects: file
+            .indexed_gradle_projects()
+            .iter()
+            .map(|project| WorkspaceFilesGradleProject {
+                build_root: workspace_files_build_root(project.build_root().as_path()),
+                project_path: project.project_path().as_str().to_string(),
+            })
+            .collect(),
+        source_sets: match file.source_sets() {
+            WorkspaceSourceSetEvidence::Proven(source_sets) => {
+                WorkspaceFilesSourceSetEvidence::Proven {
+                    source_sets: source_sets
+                        .iter()
+                        .map(|source_set| WorkspaceFilesGradleSourceSet {
+                            build_root: workspace_files_build_root(
+                                source_set.project().build_root().as_path(),
+                            ),
+                            project_path: source_set
+                                .project()
+                                .project_path()
+                                .as_str()
+                                .to_string(),
+                            source_set_name: source_set.source_set_name().as_str().to_string(),
+                        })
+                        .collect(),
+                }
+            }
+            WorkspaceSourceSetEvidence::Unproven(labels) => {
+                WorkspaceFilesSourceSetEvidence::Unproven {
+                    labels: labels
+                        .iter()
+                        .map(|label| label.as_str().to_string())
+                        .collect(),
+                }
+            }
             WorkspaceSourceSetEvidence::Unavailable => WorkspaceFilesSourceSetEvidence::Unavailable,
-        }),
+        },
         kind: match file.kind() {
             WorkspaceFileKind::Source => WorkspaceFilesKind::KotlinSource,
             WorkspaceFileKind::Script => WorkspaceFilesKind::KotlinScript,
@@ -961,20 +1078,6 @@ fn project_workspace_file(
             WorkspaceFileDirtyState::Unknown => WorkspaceFilesDirty::Unknown,
             WorkspaceFileDirtyState::NotApplicable => WorkspaceFilesDirty::NotApplicable,
         },
-        evidence: evidence_selected.then(|| {
-            file.evidence()
-                .iter()
-                .map(|source| match source {
-                    WorkspaceEvidenceSource::Manifest => WorkspaceFilesEvidenceSource::Manifest,
-                    WorkspaceEvidenceSource::PackageMetadata => {
-                        WorkspaceFilesEvidenceSource::PackageMetadata
-                    }
-                    WorkspaceEvidenceSource::GradleProjectModel => {
-                        WorkspaceFilesEvidenceSource::GradleProjectModel
-                    }
-                })
-                .collect()
-        }),
     }
 }
 

--- a/cli-rs/src/agent/workspace_files.rs
+++ b/cli-rs/src/agent/workspace_files.rs
@@ -322,10 +322,12 @@ fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope
             return error_envelope("agent/workspace-files".to_string(), None, error);
         }
         Err(error) => {
+            let mut error = AgentError::from_cli_error(error);
+            workspace_files_query_details(&mut error, &admitted_query, page_handle.as_ref());
             return error_envelope(
                 "agent/workspace-files".to_string(),
                 None,
-                AgentError::from_cli_error(error),
+                error,
             );
         }
     };
@@ -334,10 +336,12 @@ fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope
     let root = match WorkspaceRoot::try_from(admission.workspace_root.as_path()) {
         Ok(root) => root,
         Err(error) => {
+            let mut error = agent_error("AGENT_WORKSPACE_INVALID", error.to_string());
+            workspace_files_query_details(&mut error, &admitted_query, page_handle.as_ref());
             return error_envelope(
                 "agent/workspace-files".to_string(),
                 None,
-                agent_error("AGENT_WORKSPACE_INVALID", error.to_string()),
+                error,
             );
         }
     };
@@ -347,10 +351,12 @@ fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope
     ) {
         Ok(session) => session,
         Err(error) => {
+            let mut error = AgentError::from_cli_error(error);
+            workspace_files_query_details(&mut error, &admitted_query, page_handle.as_ref());
             return error_envelope(
                 "agent/workspace-files".to_string(),
                 None,
-                AgentError::from_cli_error(error),
+                error,
             );
         }
     };

--- a/cli-rs/src/agent/workspace_files.rs
+++ b/cli-rs/src/agent/workspace_files.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct AdmittedWorkspaceFilesQueryIdentity {
     canonical_workspace_root: String,
@@ -11,7 +11,7 @@ struct AdmittedWorkspaceFilesQueryIdentity {
     limit: u8,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct AdmittedWorkspaceFileFilters {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -48,35 +48,972 @@ struct WorkspaceFilesNextAction {
     mutates_global_install_authority: bool,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFilesCompactResult {
+    #[serde(rename = "type")]
+    result_type: &'static str,
+    ok: bool,
+    workspace_root: String,
+    files: Vec<WorkspaceFileCompactRecord>,
+    cardinality: AgentResultCardinality,
+    returned_count: usize,
+    truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_page_token: Option<String>,
+    coverage: WorkspaceFilesCoverage,
+    limitations: Vec<WorkspaceFilesLimitation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backend_page_coverage: Option<WorkspaceFilesBackendPageCoverage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    classification_evidence: Option<Vec<WorkspaceFilesClassificationEvidence>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    normalized_query: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    composition_digest: Option<String>,
+    schema_version: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFilesContinuationIdentity {
+    workspace_root: String,
+    backend_name: String,
+    normalized_query: String,
+    projection: String,
+    limit: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFilesContinuationState {
+    identity: WorkspaceFilesContinuationIdentity,
+    composition_stamp_digest: String,
+    last_relative_path: String,
+    cumulative_returned_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "SCREAMING_SNAKE_CASE",
+    rename_all_fields = "camelCase"
+)]
+enum WorkspaceFilesContinuationResult {
+    Issued { page_token: String },
+    Consumed { state: WorkspaceFilesContinuationState },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFileCompactRecord {
+    file_path: String,
+    relative_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backend_modules: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    indexed_gradle_projects: Option<Vec<WorkspaceFilesGradleProject>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_sets: Option<WorkspaceFilesSourceSetEvidence>,
+    kind: WorkspaceFilesKind,
+    package: WorkspaceFilesPackageEvidence,
+    source_index: WorkspaceFilesIndexState,
+    drift: WorkspaceFilesDrift,
+    dirty: WorkspaceFilesDirty,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    evidence: Option<Vec<WorkspaceFilesEvidenceSource>>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFilesGradleProject {
+    build_root: String,
+    project_path: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE", rename_all_fields = "camelCase")]
+enum WorkspaceFilesSourceSetEvidence {
+    Proven { source_sets: Vec<WorkspaceFilesGradleSourceSet> },
+    Unproven { labels: Vec<String> },
+    Unavailable,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFilesGradleSourceSet {
+    build_root: String,
+    project_path: String,
+    source_set_name: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE", rename_all_fields = "camelCase")]
+enum WorkspaceFilesPackageEvidence {
+    ProvenRoot,
+    ProvenNamed { name: String },
+    Unproven,
+    Unavailable,
+    InvalidReference,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkspaceFilesKind {
+    KotlinSource,
+    KotlinScript,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE", rename_all_fields = "camelCase")]
+enum WorkspaceFilesIndexState {
+    Indexed,
+    NotIndexed,
+    Unknown,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkspaceFilesDrift {
+    None,
+    FilesystemOnly,
+    IndexOnly,
+    MissingOnDisk,
+    Unknown,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkspaceFilesDirty {
+    Clean,
+    Dirty,
+    Unknown,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkspaceFilesEvidenceSource {
+    Manifest,
+    PackageMetadata,
+    GradleProjectModel,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFilesCoverage {
+    candidate_inventory: WorkspaceFilesCoverageDimension,
+    filter_evidence: WorkspaceFilesCoverageDimension,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkspaceFilesCoverageDimension {
+    Complete,
+    Partial,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFilesLimitation {
+    code: &'static str,
+    count: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFilesBackendPageCoverage {
+    workspace: WorkspaceFilesBackendCoverage,
+    modules: Vec<WorkspaceFilesBackendModuleCoverage>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkspaceFilesBackendCoverage {
+    Complete,
+    Partial,
+    Unavailable,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFilesBackendModuleCoverage {
+    module_name: String,
+    declared_file_count: usize,
+    coverage: WorkspaceFilesModuleCoverage,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkspaceFilesModuleCoverage {
+    Complete,
+    Partial,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFilesClassificationEvidence {
+    relative_path: String,
+    kind: WorkspaceFilesKind,
+    sources: Vec<WorkspaceFilesEvidenceSource>,
+    package: &'static str,
+    source_sets: &'static str,
+}
+
 fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope {
-    let (admitted_query, page_handle) = match admit_workspace_files_query(&args) {
+    let (mut admitted_query, page_handle) = match admit_workspace_files_query(&args) {
         Ok(admitted) => admitted,
         Err(error) => {
             return error_envelope("agent/workspace-files".to_string(), None, error);
         }
     };
-    let next_action = workspace_files_next_action(&admitted_query);
+    let admission = match runtime::semantic_workspace_route(
+        args.runtime.workspace_root.clone(),
+        args.runtime.backend_name,
+    ) {
+        Ok(runtime::SemanticWorkspaceRoute::Admitted(admission)) => admission,
+        Ok(runtime::SemanticWorkspaceRoute::Rejected(rejection)) => {
+            let mut error = agent_error(rejection.code, rejection.message);
+            error
+                .details
+                .insert("semanticWorkspace".to_string(), json!(rejection.evidence));
+            workspace_files_query_details(&mut error, &admitted_query, page_handle.as_ref());
+            return error_envelope("agent/workspace-files".to_string(), None, error);
+        }
+        Err(error) => {
+            return error_envelope(
+                "agent/workspace-files".to_string(),
+                None,
+                AgentError::from_cli_error(error),
+            );
+        }
+    };
+    admitted_query.canonical_workspace_root = admission.workspace_root.display().to_string();
+    admitted_query.backend = Some(admission.backend_name.canonical());
+    let root = match WorkspaceRoot::try_from(admission.workspace_root.as_path()) {
+        Ok(root) => root,
+        Err(error) => {
+            return error_envelope(
+                "agent/workspace-files".to_string(),
+                None,
+                agent_error("AGENT_WORKSPACE_INVALID", error.to_string()),
+            );
+        }
+    };
+    let session = match runtime::raw_rpc_session(
+        Some(admission.workspace_root.clone()),
+        Some(admission.backend_name),
+    ) {
+        Ok(session) => session,
+        Err(error) => {
+            return error_envelope(
+                "agent/workspace-files".to_string(),
+                None,
+                AgentError::from_cli_error(error),
+            );
+        }
+    };
+    let mut backend = RawRpcWorkspaceBackend::new(&session, &root);
+    let continuation_identity = match workspace_files_continuation_identity(&admitted_query) {
+        Ok(identity) => identity,
+        Err(error) => {
+            return error_envelope("agent/workspace-files".to_string(), None, error);
+        }
+    };
+    let consumed_state = match page_handle {
+        Some(page_handle) => match consume_workspace_files_continuation(
+            &mut backend,
+            &continuation_identity,
+            &page_handle.token,
+        ) {
+            Ok(state) => Some(state),
+            Err(error) => {
+                return error_envelope("agent/workspace-files".to_string(), None, error);
+            }
+        },
+        None => None,
+    };
+    let mut lanes = SystemWorkspaceLaneReader;
+    let snapshot = match collect_workspace_inventory(WorkspaceInventoryInputs {
+        root,
+        kind_domain: workspace_files_kind_domain(args.kind_domain()),
+        dirty_evidence_relevant: workspace_files_dirty_evidence_relevant(&args),
+        backend: &mut backend,
+        lanes: &mut lanes,
+    }) {
+        Ok(snapshot) => snapshot,
+        Err(error) => match error {},
+    };
+    if workspace_files_candidate_authorities_unavailable(&snapshot, args.kind_domain()) {
+        return workspace_files_unavailable(admitted_query, None);
+    }
+    let coverage = snapshot.coverage();
+    let filter_coverage = workspace_files_filter_coverage(snapshot.files(), &args);
+    let exact = coverage.candidate_inventory() == WorkspaceCoverageDimension::Complete
+        && filter_coverage == WorkspaceCoverageDimension::Complete;
+    let matching = snapshot
+        .files()
+        .iter()
+        .filter(|file| workspace_file_matches(file, &args))
+        .collect::<Vec<_>>();
+    let cardinality = if exact {
+        AgentResultCardinality::Exact {
+            total_count: matching.len(),
+        }
+    } else {
+        AgentResultCardinality::KnownMinimum {
+            known_minimum_count: matching.len(),
+        }
+    };
+    let index_evidence_complete = workspace_files_index_evidence_complete(&snapshot);
+    let start = match consumed_state.as_ref() {
+        Some(state) => match workspace_files_resume_offset(
+            state,
+            &continuation_identity,
+            snapshot.composition_digest(),
+            &matching,
+        ) {
+            Ok(offset) => offset,
+            Err(error) => {
+                return error_envelope("agent/workspace-files".to_string(), None, error);
+            }
+        },
+        None => 0,
+    };
+    let returned = matching
+        .iter()
+        .skip(start)
+        .take(usize::from(args.limit.get()))
+        .map(|file| {
+            project_workspace_file(
+                admission.workspace_root.as_path(),
+                file,
+                index_evidence_complete,
+                &args.view,
+            )
+        })
+        .collect::<Vec<_>>();
+    let returned_count = returned.len();
+    let has_more_known_matches = start.saturating_add(returned_count) < matching.len();
+    let next_page_token = if !args.view.count
+        && has_more_known_matches
+        && snapshot.continuation_allowed()
+    {
+        let Some(last_relative_path) = returned.last().map(|file| file.relative_path.clone()) else {
+            return invalid_projection_envelope(
+                "agent/workspace-files".to_string(),
+                "workspace-file continuation page omitted its final path",
+            );
+        };
+        let state = WorkspaceFilesContinuationState {
+            identity: continuation_identity.clone(),
+            composition_stamp_digest: snapshot.composition_digest().to_string(),
+            last_relative_path,
+            cumulative_returned_count: start.saturating_add(returned_count),
+        };
+        match issue_workspace_files_continuation(&mut backend, &continuation_identity, &state) {
+            Ok(token) => Some(token),
+            Err(error) => {
+                return error_envelope("agent/workspace-files".to_string(), None, error);
+            }
+        }
+    } else {
+        None
+    };
+    let result = WorkspaceFilesCompactResult {
+        result_type: "KAST_AGENT_WORKSPACE_FILES_RESULT",
+        ok: true,
+        workspace_root: admission.workspace_root.display().to_string(),
+        files: returned,
+        cardinality,
+        returned_count,
+        truncated: !exact || has_more_known_matches,
+        next_page_token,
+        coverage: WorkspaceFilesCoverage {
+            candidate_inventory: workspace_files_coverage(coverage.candidate_inventory()),
+            filter_evidence: workspace_files_coverage(filter_coverage),
+        },
+        limitations: snapshot
+            .limitations()
+            .iter()
+            .map(|(code, count)| WorkspaceFilesLimitation {
+                code: workspace_files_limitation_code(*code),
+                count: *count,
+            })
+            .collect(),
+        backend_page_coverage: (args.view.verbose || args.view.explain)
+            .then(|| workspace_files_backend_page_coverage(&snapshot)),
+        classification_evidence: args.view.explain.then(|| {
+            matching
+                .iter()
+                .skip(start)
+                .take(returned_count)
+                .map(|file| workspace_files_classification_evidence(file))
+                .collect()
+        }),
+        normalized_query: args.view.explain.then(|| continuation_identity.normalized_query.clone()),
+        composition_digest: (args.view.verbose || args.view.explain)
+            .then(|| snapshot.composition_digest().to_string()),
+        schema_version: SCHEMA_VERSION,
+    };
+    result_envelope(
+        "agent/workspace-files".to_string(),
+        project_workspace_files_result(
+            result,
+            &args.view,
+            &matching,
+            cardinality,
+            snapshot.kind_coverage(),
+            filter_coverage,
+        ),
+    )
+}
+
+fn workspace_files_backend_page_coverage(
+    snapshot: &crate::workspace_inventory::model::WorkspaceInventorySnapshot,
+) -> WorkspaceFilesBackendPageCoverage {
+    WorkspaceFilesBackendPageCoverage {
+        workspace: match snapshot.backend_coverage() {
+            BackendWorkspaceCoverage::Complete => WorkspaceFilesBackendCoverage::Complete,
+            BackendWorkspaceCoverage::Partial => WorkspaceFilesBackendCoverage::Partial,
+            BackendWorkspaceCoverage::Unavailable => WorkspaceFilesBackendCoverage::Unavailable,
+        },
+        modules: snapshot
+            .backend_modules()
+            .values()
+            .map(|module| WorkspaceFilesBackendModuleCoverage {
+                module_name: module.name().as_str().to_string(),
+                declared_file_count: module.declared_file_count(),
+                coverage: match module.coverage() {
+                    BackendModuleCoverage::Complete => WorkspaceFilesModuleCoverage::Complete,
+                    BackendModuleCoverage::Partial => WorkspaceFilesModuleCoverage::Partial,
+                },
+            })
+            .collect(),
+    }
+}
+
+fn workspace_files_classification_evidence(
+    file: &WorkspaceInventoryFile,
+) -> WorkspaceFilesClassificationEvidence {
+    WorkspaceFilesClassificationEvidence {
+        relative_path: file.path().to_string(),
+        kind: match file.kind() {
+            WorkspaceFileKind::Source => WorkspaceFilesKind::KotlinSource,
+            WorkspaceFileKind::Script => WorkspaceFilesKind::KotlinScript,
+        },
+        sources: file
+            .evidence()
+            .iter()
+            .map(|source| match source {
+                WorkspaceEvidenceSource::Manifest => WorkspaceFilesEvidenceSource::Manifest,
+                WorkspaceEvidenceSource::PackageMetadata => {
+                    WorkspaceFilesEvidenceSource::PackageMetadata
+                }
+                WorkspaceEvidenceSource::GradleProjectModel => {
+                    WorkspaceFilesEvidenceSource::GradleProjectModel
+                }
+            })
+            .collect(),
+        package: match file.package() {
+            WorkspacePackageEvidence::ProvenRoot => "PROVEN_ROOT",
+            WorkspacePackageEvidence::ProvenNamed(_) => "PROVEN_NAMED",
+            WorkspacePackageEvidence::Unproven(_) => "UNPROVEN",
+            WorkspacePackageEvidence::Unavailable => "UNAVAILABLE",
+            WorkspacePackageEvidence::InvalidReference(_) => "INVALID_REFERENCE",
+        },
+        source_sets: match file.source_sets() {
+            WorkspaceSourceSetEvidence::Proven(_) => "PROVEN",
+            WorkspaceSourceSetEvidence::Unproven(_) => "UNPROVEN",
+            WorkspaceSourceSetEvidence::Unavailable => "UNAVAILABLE",
+        },
+    }
+}
+
+fn workspace_files_unavailable(
+    admitted_query: AdmittedWorkspaceFilesQueryIdentity,
+    page_handle: Option<WorkspaceFilesPageHandleIdentity>,
+) -> AgentEnvelope {
     let mut error = agent_error(
         "WORKSPACE_FILE_DISCOVERY_UNAVAILABLE",
         "Workspace file discovery is not available until the typed inventory is initialized.",
     );
-    error.details.insert(
-        "admittedQuery".to_string(),
-        serde_json::to_value(admitted_query)
-            .expect("the admitted workspace-file query identity is serializable"),
-    );
-    if let Some(page_handle) = page_handle {
-        error.details.insert(
-            "pageHandle".to_string(),
-            serde_json::to_value(page_handle)
-                .expect("the workspace-file page handle is serializable"),
-        );
-    }
-    error.details.insert(
-        "nextAction".to_string(),
-        serde_json::to_value(next_action).expect("the workspace-file next action is serializable"),
-    );
+    workspace_files_query_details(&mut error, &admitted_query, page_handle.as_ref());
     error_envelope("agent/workspace-files".to_string(), None, error)
+}
+
+fn workspace_files_query_details(
+    error: &mut AgentError,
+    admitted_query: &AdmittedWorkspaceFilesQueryIdentity,
+    page_handle: Option<&WorkspaceFilesPageHandleIdentity>,
+) {
+    if let Ok(value) = serde_json::to_value(admitted_query) {
+        error.details.insert("admittedQuery".to_string(), value);
+    }
+    if let Some(page_handle) = page_handle
+        && let Ok(value) = serde_json::to_value(page_handle)
+    {
+        error.details.insert("pageHandle".to_string(), value);
+    }
+    if let Ok(value) = serde_json::to_value(workspace_files_next_action(admitted_query)) {
+        error.details.insert("nextAction".to_string(), value);
+    }
+}
+
+fn workspace_files_kind_domain(domain: crate::cli::WorkspaceFileKindDomain) -> WorkspaceRequestedKindDomain {
+    match domain {
+        crate::cli::WorkspaceFileKindDomain::SourceOnly => WorkspaceRequestedKindDomain::SourceOnly,
+        crate::cli::WorkspaceFileKindDomain::ScriptOnly => WorkspaceRequestedKindDomain::ScriptOnly,
+        crate::cli::WorkspaceFileKindDomain::Mixed => WorkspaceRequestedKindDomain::Mixed,
+    }
+}
+
+fn workspace_files_dirty_evidence_relevant(args: &AgentWorkspaceFilesArgs) -> bool {
+    args.dirty.is_some()
+        || args.view.count
+        || args.view.verbose
+        || args.view.explain
+        || args.view.fields.is_empty()
+        || args
+            .view
+            .fields
+            .iter()
+            .any(|field| matches!(field, AgentWorkspaceFilesField::Dirty | AgentWorkspaceFilesField::Evidence))
+}
+
+fn workspace_file_matches(file: &WorkspaceInventoryFile, args: &AgentWorkspaceFilesArgs) -> bool {
+    let kind_matches = match args.kind {
+        None => true,
+        Some(WorkspaceFileKindFilter::Source) => file.kind() == WorkspaceFileKind::Source,
+        Some(WorkspaceFileKindFilter::Script) => file.kind() == WorkspaceFileKind::Script,
+    };
+    let module_matches = args.module.as_ref().is_none_or(|selector| match selector {
+        WorkspaceModuleSelector::Backend(expected) => file
+            .backend_modules()
+            .iter()
+            .any(|actual| actual.as_str() == expected.as_str()),
+        WorkspaceModuleSelector::Gradle {
+            build_root,
+            project_path,
+        } => file.indexed_gradle_projects().iter().any(|actual| {
+            workspace_files_build_root(actual.build_root().as_path()) == build_root.as_str()
+                && actual.project_path().as_str() == project_path.as_str()
+        }),
+    });
+    let source_set_matches = args.source_set.as_ref().is_none_or(|expected| {
+        matches!(file.source_sets(), WorkspaceSourceSetEvidence::Proven(source_sets) if source_sets
+            .iter()
+            .any(|actual| actual.source_set_name().as_str() == expected.as_str()))
+    });
+    let package_matches = args.package_selector.as_ref().is_none_or(|expected| {
+        match (expected, file.package()) {
+            (WorkspacePackageSelector::Root, WorkspacePackageEvidence::ProvenRoot) => true,
+            (
+                WorkspacePackageSelector::Named(expected),
+                WorkspacePackageEvidence::ProvenNamed(actual),
+            ) => actual.as_str() == expected.semantic_fq_name(),
+            _ => false,
+        }
+    });
+    let dirty_matches = args.dirty.is_none_or(|expected| {
+        matches!(
+            (expected, file.dirty_state()),
+            (WorkspaceDirtyFilter::Clean, WorkspaceFileDirtyState::Clean)
+                | (WorkspaceDirtyFilter::Dirty, WorkspaceFileDirtyState::Dirty)
+                | (WorkspaceDirtyFilter::Unknown, WorkspaceFileDirtyState::Unknown)
+        )
+    });
+    let drift_matches = args.drift.is_none_or(|expected| {
+        matches!(
+            (expected, file.drift()),
+            (WorkspaceDriftFilter::None, WorkspaceFileDrift::InSync)
+                | (WorkspaceDriftFilter::FilesystemOnly, WorkspaceFileDrift::FilesystemOnly)
+                | (WorkspaceDriftFilter::IndexOnly, WorkspaceFileDrift::IndexOnly)
+                | (WorkspaceDriftFilter::MissingOnDisk, WorkspaceFileDrift::MissingOnDisk)
+                | (WorkspaceDriftFilter::NotApplicable, WorkspaceFileDrift::NotApplicable)
+                | (WorkspaceDriftFilter::Unknown, WorkspaceFileDrift::Unknown)
+        )
+    });
+    let path_prefix_matches = args.path_prefix.as_ref().is_none_or(|prefix| {
+        file.path().as_path().starts_with(Path::new(prefix.as_str()))
+    });
+    let glob_matches = args.glob.as_ref().is_none_or(|glob| {
+        glob::Pattern::new(glob.as_str())
+            .is_ok_and(|pattern| pattern.matches_path(file.path().as_path()))
+    });
+    kind_matches
+        && module_matches
+        && source_set_matches
+        && package_matches
+        && dirty_matches
+        && drift_matches
+        && path_prefix_matches
+        && glob_matches
+}
+
+fn workspace_files_filter_coverage(
+    candidates: &[WorkspaceInventoryFile],
+    args: &AgentWorkspaceFilesArgs,
+) -> WorkspaceCoverageDimension {
+    let package_complete = args.package_selector.is_none()
+        || candidates.iter().all(|file| {
+            matches!(
+                file.package(),
+                WorkspacePackageEvidence::ProvenRoot | WorkspacePackageEvidence::ProvenNamed(_)
+            )
+        });
+    let source_set_complete = args.source_set.is_none()
+        || candidates
+            .iter()
+            .all(|file| matches!(file.source_sets(), WorkspaceSourceSetEvidence::Proven(_)));
+    let dirty_complete = args.dirty.is_none_or(|filter| {
+        filter == WorkspaceDirtyFilter::Unknown
+            || candidates
+                .iter()
+                .all(|file| file.dirty_state() != WorkspaceFileDirtyState::Unknown)
+    });
+    let drift_complete = args.drift.is_none_or(|filter| {
+        filter == WorkspaceDriftFilter::Unknown
+            || candidates
+                .iter()
+                .all(|file| file.drift() != WorkspaceFileDrift::Unknown)
+    });
+    if package_complete && source_set_complete && dirty_complete && drift_complete {
+        WorkspaceCoverageDimension::Complete
+    } else {
+        WorkspaceCoverageDimension::Partial
+    }
+}
+
+fn workspace_files_candidate_authorities_unavailable(
+    snapshot: &crate::workspace_inventory::model::WorkspaceInventorySnapshot,
+    domain: crate::cli::WorkspaceFileKindDomain,
+) -> bool {
+    if snapshot.backend_coverage()
+        != crate::workspace_inventory::model::BackendWorkspaceCoverage::Unavailable
+    {
+        return false;
+    }
+    let index_unavailable = snapshot
+        .limitations()
+        .keys()
+        .any(|code| {
+            matches!(
+                code,
+                WorkspaceInventoryLimitationCode::SourceIndexUnavailable
+                    | WorkspaceInventoryLimitationCode::SourceIndexIncompatible
+            )
+        });
+    matches!(domain, crate::cli::WorkspaceFileKindDomain::ScriptOnly) || index_unavailable
+}
+
+fn workspace_files_continuation_identity(
+    query: &AdmittedWorkspaceFilesQueryIdentity,
+) -> std::result::Result<WorkspaceFilesContinuationIdentity, AgentError> {
+    let backend_name = query.backend.ok_or_else(|| {
+        agent_error(
+            "AGENT_WORKSPACE_INVALID",
+            "Workspace-file continuation identity requires an admitted backend.",
+        )
+    })?;
+    let normalized_query = serde_json::to_string(&json!({
+        "filters": &query.filters,
+        "kindDomain": query.kind_domain,
+    }))
+    .map_err(|error| agent_error("AGENT_RESULT_INVALID", error.to_string()))?;
+    let projection = if query.view == "fields" {
+        format!("fields:{}", query.ordered_fields.join(","))
+    } else {
+        query.view.to_string()
+    };
+    Ok(WorkspaceFilesContinuationIdentity {
+        workspace_root: query.canonical_workspace_root.clone(),
+        backend_name: backend_name.to_string(),
+        normalized_query,
+        projection,
+        limit: query.limit,
+    })
+}
+
+fn consume_workspace_files_continuation(
+    backend: &mut dyn BackendWorkspaceRpc,
+    identity: &WorkspaceFilesContinuationIdentity,
+    token: &str,
+) -> std::result::Result<WorkspaceFilesContinuationState, AgentError> {
+    let result = backend
+        .request(json_rpc_request(
+            "raw/workspace-files-continuation",
+            json!({
+                "action": "CONSUME",
+                "identity": identity,
+                "pageToken": token,
+            }),
+        ))
+        .map_err(workspace_files_continuation_failure)?;
+    match serde_json::from_value::<WorkspaceFilesContinuationResult>(result) {
+        Ok(WorkspaceFilesContinuationResult::Consumed { state }) => Ok(state),
+        Ok(WorkspaceFilesContinuationResult::Issued { .. }) => Err(agent_error(
+            "AGENT_RESULT_INVALID",
+            "Workspace-file continuation consume returned an issue result.",
+        )),
+        Err(error) => Err(agent_error("AGENT_RESULT_INVALID", error.to_string())),
+    }
+}
+
+fn issue_workspace_files_continuation(
+    backend: &mut dyn BackendWorkspaceRpc,
+    identity: &WorkspaceFilesContinuationIdentity,
+    state: &WorkspaceFilesContinuationState,
+) -> std::result::Result<String, AgentError> {
+    let result = backend
+        .request(json_rpc_request(
+            "raw/workspace-files-continuation",
+            json!({
+                "action": "ISSUE",
+                "identity": identity,
+                "state": state,
+            }),
+        ))
+        .map_err(workspace_files_continuation_failure)?;
+    match serde_json::from_value::<WorkspaceFilesContinuationResult>(result) {
+        Ok(WorkspaceFilesContinuationResult::Issued { page_token }) => Ok(page_token),
+        Ok(WorkspaceFilesContinuationResult::Consumed { .. }) => Err(agent_error(
+            "AGENT_RESULT_INVALID",
+            "Workspace-file continuation issue returned a consume result.",
+        )),
+        Err(error) => Err(agent_error("AGENT_RESULT_INVALID", error.to_string())),
+    }
+}
+
+fn workspace_files_continuation_failure(failure: BackendRpcFailure) -> AgentError {
+    match failure {
+        BackendRpcFailure::Api { code, message, .. }
+            if code == "INVALID_WORKSPACE_FILES_PAGE_TOKEN" =>
+        {
+            let mut error = agent_error(&code, message);
+            error.details.insert("status".to_string(), json!(400));
+            error.details.insert("retryable".to_string(), json!(false));
+            error
+        }
+        failure => agent_error(
+            "WORKSPACE_FILES_CONTINUATION_UNAVAILABLE",
+            failure.to_string(),
+        ),
+    }
+}
+
+fn workspace_files_resume_offset(
+    state: &WorkspaceFilesContinuationState,
+    identity: &WorkspaceFilesContinuationIdentity,
+    composition_digest: &str,
+    matching: &[&WorkspaceInventoryFile],
+) -> std::result::Result<usize, AgentError> {
+    if &state.identity != identity {
+        return Err(invalid_workspace_files_page(
+            "Workspace-file continuation identity does not match this query.",
+        ));
+    }
+    if state.composition_stamp_digest != composition_digest {
+        return Err(stale_workspace_files_page());
+    }
+    let Some(last_index) = matching
+        .iter()
+        .position(|file| file.path().to_string() == state.last_relative_path)
+    else {
+        return Err(stale_workspace_files_page());
+    };
+    let offset = last_index.saturating_add(1);
+    if offset != state.cumulative_returned_count {
+        return Err(invalid_workspace_files_page(
+            "Workspace-file continuation cumulative count is inconsistent.",
+        ));
+    }
+    Ok(offset)
+}
+
+fn invalid_workspace_files_page(message: &str) -> AgentError {
+    let mut error = agent_error("INVALID_WORKSPACE_FILES_PAGE_TOKEN", message);
+    error.details.insert("status".to_string(), json!(400));
+    error.details.insert("retryable".to_string(), json!(false));
+    error
+}
+
+fn stale_workspace_files_page() -> AgentError {
+    let mut error = agent_error(
+        "STALE_WORKSPACE_FILES_PAGE",
+        "Workspace-file evidence changed; start a new unpaged query.",
+    );
+    error.details.insert("status".to_string(), json!(409));
+    error.details.insert("retryable".to_string(), json!(true));
+    error
+        .details
+        .insert("restartFromFirstPage".to_string(), json!(true));
+    error
+}
+
+fn workspace_files_index_evidence_complete(snapshot: &crate::workspace_inventory::model::WorkspaceInventorySnapshot) -> bool {
+    ![
+        WorkspaceInventoryLimitationCode::SourceIndexUnavailable,
+        WorkspaceInventoryLimitationCode::SourceIndexIncompatible,
+        WorkspaceInventoryLimitationCode::SourceIndexProgressIncomplete,
+        WorkspaceInventoryLimitationCode::SourceIndexUpdatesPending,
+        WorkspaceInventoryLimitationCode::CrossSourceCompositionUnstable,
+    ]
+    .into_iter()
+    .any(|code| snapshot.limitation_count(code) > 0)
+}
+
+fn project_workspace_file(
+    root: &Path,
+    file: &WorkspaceInventoryFile,
+    index_evidence_complete: bool,
+    view: &AgentWorkspaceFilesViewArgs,
+) -> WorkspaceFileCompactRecord {
+    let detailed = view.verbose || view.explain;
+    let module_selected = detailed
+        || view
+            .fields
+            .iter()
+            .any(|field| matches!(field, AgentWorkspaceFilesField::Module));
+    let source_set_selected = detailed
+        || view
+            .fields
+            .iter()
+            .any(|field| matches!(field, AgentWorkspaceFilesField::SourceSet));
+    let evidence_selected = detailed
+        || view
+            .fields
+            .iter()
+            .any(|field| matches!(field, AgentWorkspaceFilesField::Evidence));
+    WorkspaceFileCompactRecord {
+        file_path: root.join(file.path().as_path()).display().to_string(),
+        relative_path: file.path().to_string(),
+        backend_modules: module_selected.then(|| {
+            file.backend_modules()
+                .iter()
+                .map(|module| module.as_str().to_string())
+                .collect()
+        }),
+        indexed_gradle_projects: module_selected.then(|| {
+            file.indexed_gradle_projects()
+                .iter()
+                .map(|project| WorkspaceFilesGradleProject {
+                    build_root: workspace_files_build_root(project.build_root().as_path()),
+                    project_path: project.project_path().as_str().to_string(),
+                })
+                .collect()
+        }),
+        source_sets: source_set_selected.then(|| match file.source_sets() {
+            WorkspaceSourceSetEvidence::Proven(source_sets) => WorkspaceFilesSourceSetEvidence::Proven {
+                source_sets: source_sets
+                    .iter()
+                    .map(|source_set| WorkspaceFilesGradleSourceSet {
+                        build_root: workspace_files_build_root(source_set.project().build_root().as_path()),
+                        project_path: source_set.project().project_path().as_str().to_string(),
+                        source_set_name: source_set.source_set_name().as_str().to_string(),
+                    })
+                    .collect(),
+            },
+            WorkspaceSourceSetEvidence::Unproven(labels) => WorkspaceFilesSourceSetEvidence::Unproven {
+                labels: labels.iter().map(|label| label.as_str().to_string()).collect(),
+            },
+            WorkspaceSourceSetEvidence::Unavailable => WorkspaceFilesSourceSetEvidence::Unavailable,
+        }),
+        kind: match file.kind() {
+            WorkspaceFileKind::Source => WorkspaceFilesKind::KotlinSource,
+            WorkspaceFileKind::Script => WorkspaceFilesKind::KotlinScript,
+        },
+        package: match file.package() {
+            WorkspacePackageEvidence::ProvenRoot => WorkspaceFilesPackageEvidence::ProvenRoot,
+            WorkspacePackageEvidence::ProvenNamed(name) => {
+                WorkspaceFilesPackageEvidence::ProvenNamed {
+                    name: name.as_str().to_string(),
+                }
+            }
+            WorkspacePackageEvidence::Unproven(_) => WorkspaceFilesPackageEvidence::Unproven,
+            WorkspacePackageEvidence::Unavailable => WorkspaceFilesPackageEvidence::Unavailable,
+            WorkspacePackageEvidence::InvalidReference(_) => {
+                WorkspaceFilesPackageEvidence::InvalidReference
+            }
+        },
+        source_index: match file.index_state() {
+            WorkspaceFileIndexState::Indexed => WorkspaceFilesIndexState::Indexed,
+            WorkspaceFileIndexState::MetadataUnavailable if index_evidence_complete => {
+                WorkspaceFilesIndexState::NotIndexed
+            }
+            WorkspaceFileIndexState::MetadataUnavailable
+            | WorkspaceFileIndexState::Incompatible(_) => WorkspaceFilesIndexState::Unknown,
+            WorkspaceFileIndexState::NotApplicable => WorkspaceFilesIndexState::NotApplicable,
+        },
+        drift: match file.drift() {
+            WorkspaceFileDrift::InSync => WorkspaceFilesDrift::None,
+            WorkspaceFileDrift::FilesystemOnly => WorkspaceFilesDrift::FilesystemOnly,
+            WorkspaceFileDrift::IndexOnly => WorkspaceFilesDrift::IndexOnly,
+            WorkspaceFileDrift::MissingOnDisk => WorkspaceFilesDrift::MissingOnDisk,
+            WorkspaceFileDrift::Unknown => WorkspaceFilesDrift::Unknown,
+            WorkspaceFileDrift::NotApplicable => WorkspaceFilesDrift::NotApplicable,
+        },
+        dirty: match file.dirty_state() {
+            WorkspaceFileDirtyState::Clean => WorkspaceFilesDirty::Clean,
+            WorkspaceFileDirtyState::Dirty => WorkspaceFilesDirty::Dirty,
+            WorkspaceFileDirtyState::Unknown => WorkspaceFilesDirty::Unknown,
+            WorkspaceFileDirtyState::NotApplicable => WorkspaceFilesDirty::NotApplicable,
+        },
+        evidence: evidence_selected.then(|| {
+            file.evidence()
+                .iter()
+                .map(|source| match source {
+                    WorkspaceEvidenceSource::Manifest => WorkspaceFilesEvidenceSource::Manifest,
+                    WorkspaceEvidenceSource::PackageMetadata => {
+                        WorkspaceFilesEvidenceSource::PackageMetadata
+                    }
+                    WorkspaceEvidenceSource::GradleProjectModel => {
+                        WorkspaceFilesEvidenceSource::GradleProjectModel
+                    }
+                })
+                .collect()
+        }),
+    }
+}
+
+fn workspace_files_build_root(path: &Path) -> String {
+    if path.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        path.display().to_string()
+    }
+}
+
+fn workspace_files_coverage(dimension: WorkspaceCoverageDimension) -> WorkspaceFilesCoverageDimension {
+    match dimension {
+        WorkspaceCoverageDimension::Complete => WorkspaceFilesCoverageDimension::Complete,
+        WorkspaceCoverageDimension::Partial => WorkspaceFilesCoverageDimension::Partial,
+    }
+}
+
+fn workspace_files_limitation_code(code: WorkspaceInventoryLimitationCode) -> &'static str {
+    match code {
+        WorkspaceInventoryLimitationCode::BackendCapabilityUnavailable => "BACKEND_CAPABILITY_UNAVAILABLE",
+        WorkspaceInventoryLimitationCode::BackendMetadataUnavailable => "BACKEND_METADATA_UNAVAILABLE",
+        WorkspaceInventoryLimitationCode::BackendPageIncomplete => "BACKEND_PAGE_INCOMPLETE",
+        WorkspaceInventoryLimitationCode::BackendWorkspaceInventoryStale => "BACKEND_WORKSPACE_INVENTORY_STALE",
+        WorkspaceInventoryLimitationCode::RuntimeIndexing => "RUNTIME_INDEXING",
+        WorkspaceInventoryLimitationCode::ProjectModelUnavailable => "PROJECT_MODEL_UNAVAILABLE",
+        WorkspaceInventoryLimitationCode::LinkedRootUnassociated => "LINKED_ROOT_UNASSOCIATED",
+        WorkspaceInventoryLimitationCode::SourceIndexUnavailable => "SOURCE_INDEX_UNAVAILABLE",
+        WorkspaceInventoryLimitationCode::SourceIndexIncompatible => "SOURCE_INDEX_INCOMPATIBLE",
+        WorkspaceInventoryLimitationCode::SourceIndexProgressIncomplete => "SOURCE_INDEX_PROGRESS_INCOMPLETE",
+        WorkspaceInventoryLimitationCode::SourceIndexUpdatesPending => "SOURCE_INDEX_UPDATES_PENDING",
+        WorkspaceInventoryLimitationCode::GitUnavailable => "GIT_UNAVAILABLE",
+        WorkspaceInventoryLimitationCode::CrossSourceCompositionUnstable => "CROSS_SOURCE_COMPOSITION_UNSTABLE",
+        WorkspaceInventoryLimitationCode::PathContainmentUnprovable => "PATH_CONTAINMENT_UNPROVABLE",
+        WorkspaceInventoryLimitationCode::PackageMetadataInvalid => "PACKAGE_METADATA_INVALID",
+        WorkspaceInventoryLimitationCode::UnknownProjectModelOwnership => "UNKNOWN_PROJECT_MODEL_OWNERSHIP",
+        WorkspaceInventoryLimitationCode::ProjectModelOwnershipUnknown => "PROJECT_MODEL_OWNERSHIP_UNKNOWN",
+        WorkspaceInventoryLimitationCode::OutOfRootExcluded => "OUT_OF_ROOT_EXCLUDED",
+    }
 }
 
 fn workspace_files_next_action(

--- a/cli-rs/src/agent/workspace_files.rs
+++ b/cli-rs/src/agent/workspace_files.rs
@@ -409,8 +409,12 @@ fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope
     }
     let coverage = snapshot.coverage();
     let index_evidence_complete = workspace_files_index_evidence_complete(&snapshot);
-    let filter_coverage =
-        workspace_files_filter_coverage(snapshot.files(), &args, index_evidence_complete);
+    let filter_coverage = workspace_files_filter_coverage(
+        snapshot.files(),
+        snapshot.backend_coverage(),
+        &args,
+        index_evidence_complete,
+    );
     let exact = coverage.candidate_inventory() == WorkspaceCoverageDimension::Complete
         && filter_coverage == WorkspaceCoverageDimension::Complete;
     let matching = snapshot
@@ -722,11 +726,12 @@ fn workspace_file_matches(file: &WorkspaceInventoryFile, args: &AgentWorkspaceFi
 
 fn workspace_files_filter_coverage(
     candidates: &[WorkspaceInventoryFile],
+    backend_coverage: BackendWorkspaceCoverage,
     args: &AgentWorkspaceFilesArgs,
     index_evidence_complete: bool,
 ) -> WorkspaceCoverageDimension {
     let module_complete = args.module.as_ref().is_none_or(|selector| match selector {
-        WorkspaceModuleSelector::Backend(_) => true,
+        WorkspaceModuleSelector::Backend(_) => backend_coverage == BackendWorkspaceCoverage::Complete,
         WorkspaceModuleSelector::Gradle { .. } => candidates
             .iter()
             .all(|file| workspace_file_gradle_ownership_evidence_complete(file, index_evidence_complete)),

--- a/cli-rs/src/agent/workspace_files.rs
+++ b/cli-rs/src/agent/workspace_files.rs
@@ -1098,7 +1098,6 @@ fn workspace_files_coverage(dimension: WorkspaceCoverageDimension) -> WorkspaceF
 
 fn workspace_files_limitation_code(code: WorkspaceInventoryLimitationCode) -> &'static str {
     match code {
-        WorkspaceInventoryLimitationCode::BackendCapabilityUnavailable => "BACKEND_CAPABILITY_UNAVAILABLE",
         WorkspaceInventoryLimitationCode::BackendMetadataUnavailable => "BACKEND_METADATA_UNAVAILABLE",
         WorkspaceInventoryLimitationCode::BackendPageIncomplete => "BACKEND_PAGE_INCOMPLETE",
         WorkspaceInventoryLimitationCode::BackendWorkspaceInventoryStale => "BACKEND_WORKSPACE_INVENTORY_STALE",

--- a/cli-rs/src/agent/workspace_files.rs
+++ b/cli-rs/src/agent/workspace_files.rs
@@ -100,6 +100,10 @@ struct WorkspaceFilesContinuationState {
     cumulative_returned_count: usize,
 }
 
+struct ValidatedWorkspaceFilesContinuation<'a> {
+    state: &'a WorkspaceFilesContinuationState,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(
     tag = "type",
@@ -381,11 +385,26 @@ fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope
         Ok(snapshot) => snapshot,
         Err(error) => match error {},
     };
+    let resumed_continuation = match consumed_state.as_ref() {
+        Some(state) => match validate_workspace_files_resumed_snapshot(
+            state,
+            &continuation_identity,
+            &snapshot,
+        ) {
+            Ok(continuation) => Some(continuation),
+            Err(error) => {
+                return error_envelope("agent/workspace-files".to_string(), None, error);
+            }
+        },
+        None => None,
+    };
     if workspace_files_candidate_authorities_unavailable(&snapshot, args.kind_domain()) {
         return workspace_files_unavailable(admitted_query, None);
     }
     let coverage = snapshot.coverage();
-    let filter_coverage = workspace_files_filter_coverage(snapshot.files(), &args);
+    let index_evidence_complete = workspace_files_index_evidence_complete(&snapshot);
+    let filter_coverage =
+        workspace_files_filter_coverage(snapshot.files(), &args, index_evidence_complete);
     let exact = coverage.candidate_inventory() == WorkspaceCoverageDimension::Complete
         && filter_coverage == WorkspaceCoverageDimension::Complete;
     let matching = snapshot
@@ -402,14 +421,8 @@ fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope
             known_minimum_count: matching.len(),
         }
     };
-    let index_evidence_complete = workspace_files_index_evidence_complete(&snapshot);
-    let start = match consumed_state.as_ref() {
-        Some(state) => match workspace_files_resume_offset(
-            state,
-            &continuation_identity,
-            snapshot.composition_digest(),
-            &matching,
-        ) {
+    let start = match resumed_continuation.as_ref() {
+        Some(continuation) => match workspace_files_resume_offset(continuation, &matching) {
             Ok(offset) => offset,
             Err(error) => {
                 return error_envelope("agent/workspace-files".to_string(), None, error);
@@ -514,6 +527,7 @@ fn execute_agent_workspace_files(args: AgentWorkspaceFilesArgs) -> AgentEnvelope
             cardinality,
             snapshot.kind_coverage(),
             filter_coverage,
+            index_evidence_complete,
         ),
     )
 }
@@ -703,7 +717,14 @@ fn workspace_file_matches(file: &WorkspaceInventoryFile, args: &AgentWorkspaceFi
 fn workspace_files_filter_coverage(
     candidates: &[WorkspaceInventoryFile],
     args: &AgentWorkspaceFilesArgs,
+    index_evidence_complete: bool,
 ) -> WorkspaceCoverageDimension {
+    let module_complete = args.module.as_ref().is_none_or(|selector| match selector {
+        WorkspaceModuleSelector::Backend(_) => true,
+        WorkspaceModuleSelector::Gradle { .. } => candidates
+            .iter()
+            .all(|file| workspace_file_gradle_ownership_evidence_complete(file, index_evidence_complete)),
+    });
     let package_complete = args.package_selector.is_none()
         || candidates.iter().all(|file| {
             matches!(
@@ -727,10 +748,27 @@ fn workspace_files_filter_coverage(
                 .iter()
                 .all(|file| file.drift() != WorkspaceFileDrift::Unknown)
     });
-    if package_complete && source_set_complete && dirty_complete && drift_complete {
+    if module_complete
+        && package_complete
+        && source_set_complete
+        && dirty_complete
+        && drift_complete
+    {
         WorkspaceCoverageDimension::Complete
     } else {
         WorkspaceCoverageDimension::Partial
+    }
+}
+
+fn workspace_file_gradle_ownership_evidence_complete(
+    file: &WorkspaceInventoryFile,
+    index_evidence_complete: bool,
+) -> bool {
+    match file.index_state() {
+        WorkspaceFileIndexState::Indexed => !file.indexed_gradle_projects().is_empty(),
+        WorkspaceFileIndexState::MetadataUnavailable => index_evidence_complete,
+        WorkspaceFileIndexState::NotApplicable => true,
+        WorkspaceFileIndexState::Incompatible(_) => false,
     }
 }
 
@@ -825,7 +863,10 @@ fn issue_workspace_files_continuation(
         ))
         .map_err(workspace_files_continuation_failure)?;
     match serde_json::from_value::<WorkspaceFilesContinuationResult>(result) {
-        Ok(WorkspaceFilesContinuationResult::Issued { page_token }) => Ok(page_token),
+        Ok(WorkspaceFilesContinuationResult::Issued { page_token }) => page_token
+            .parse::<WorkspaceFilesPublicPageToken>()
+            .map(|token| token.canonical())
+            .map_err(|error| agent_error("AGENT_RESULT_INVALID", error)),
         Ok(WorkspaceFilesContinuationResult::Consumed { .. }) => Err(agent_error(
             "AGENT_RESULT_INVALID",
             "Workspace-file continuation issue returned a consume result.",
@@ -852,19 +893,10 @@ fn workspace_files_continuation_failure(failure: BackendRpcFailure) -> AgentErro
 }
 
 fn workspace_files_resume_offset(
-    state: &WorkspaceFilesContinuationState,
-    identity: &WorkspaceFilesContinuationIdentity,
-    composition_digest: &str,
+    continuation: &ValidatedWorkspaceFilesContinuation<'_>,
     matching: &[&WorkspaceInventoryFile],
 ) -> std::result::Result<usize, AgentError> {
-    if &state.identity != identity {
-        return Err(invalid_workspace_files_page(
-            "Workspace-file continuation identity does not match this query.",
-        ));
-    }
-    if state.composition_stamp_digest != composition_digest {
-        return Err(stale_workspace_files_page());
-    }
+    let state = continuation.state;
     let Some(last_index) = matching
         .iter()
         .position(|file| file.path().to_string() == state.last_relative_path)
@@ -878,6 +910,24 @@ fn workspace_files_resume_offset(
         ));
     }
     Ok(offset)
+}
+
+fn validate_workspace_files_resumed_snapshot<'a>(
+    state: &'a WorkspaceFilesContinuationState,
+    identity: &WorkspaceFilesContinuationIdentity,
+    snapshot: &crate::workspace_inventory::model::WorkspaceInventorySnapshot,
+) -> std::result::Result<ValidatedWorkspaceFilesContinuation<'a>, AgentError> {
+    if &state.identity != identity {
+        return Err(invalid_workspace_files_page(
+            "Workspace-file continuation identity does not match this query.",
+        ));
+    }
+    if state.composition_stamp_digest != snapshot.composition_digest()
+        || !snapshot.continuation_allowed()
+    {
+        return Err(stale_workspace_files_page());
+    }
+    Ok(ValidatedWorkspaceFilesContinuation { state })
 }
 
 fn invalid_workspace_files_page(message: &str) -> AgentError {
@@ -1055,15 +1105,7 @@ fn project_workspace_file_evidence(
                 WorkspaceFilesPackageEvidence::InvalidReference
             }
         },
-        source_index: match file.index_state() {
-            WorkspaceFileIndexState::Indexed => WorkspaceFilesIndexState::Indexed,
-            WorkspaceFileIndexState::MetadataUnavailable if index_evidence_complete => {
-                WorkspaceFilesIndexState::NotIndexed
-            }
-            WorkspaceFileIndexState::MetadataUnavailable
-            | WorkspaceFileIndexState::Incompatible(_) => WorkspaceFilesIndexState::Unknown,
-            WorkspaceFileIndexState::NotApplicable => WorkspaceFilesIndexState::NotApplicable,
-        },
+        source_index: workspace_files_index_state(file, index_evidence_complete),
         drift: match file.drift() {
             WorkspaceFileDrift::InSync => WorkspaceFilesDrift::None,
             WorkspaceFileDrift::FilesystemOnly => WorkspaceFilesDrift::FilesystemOnly,
@@ -1078,6 +1120,21 @@ fn project_workspace_file_evidence(
             WorkspaceFileDirtyState::Unknown => WorkspaceFilesDirty::Unknown,
             WorkspaceFileDirtyState::NotApplicable => WorkspaceFilesDirty::NotApplicable,
         },
+    }
+}
+
+fn workspace_files_index_state(
+    file: &WorkspaceInventoryFile,
+    index_evidence_complete: bool,
+) -> WorkspaceFilesIndexState {
+    match file.index_state() {
+        WorkspaceFileIndexState::Indexed => WorkspaceFilesIndexState::Indexed,
+        WorkspaceFileIndexState::MetadataUnavailable if index_evidence_complete => {
+            WorkspaceFilesIndexState::NotIndexed
+        }
+        WorkspaceFileIndexState::MetadataUnavailable
+        | WorkspaceFileIndexState::Incompatible(_) => WorkspaceFilesIndexState::Unknown,
+        WorkspaceFileIndexState::NotApplicable => WorkspaceFilesIndexState::NotApplicable,
     }
 }
 

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -24,7 +24,6 @@ mod source_index_schema;
 mod symbol_query;
 mod symbol_query_filters;
 mod validate;
-#[cfg(test)]
 mod workspace_inventory;
 
 use clap::{CommandFactory, Parser};

--- a/cli-rs/src/workspace_inventory/backend.rs
+++ b/cli-rs/src/workspace_inventory/backend.rs
@@ -35,6 +35,37 @@ pub(crate) trait BackendWorkspaceRpc {
     fn request(&mut self, request: Value) -> Result<Value, BackendRpcFailure>;
 }
 
+pub(crate) struct RawRpcWorkspaceBackend<'a> {
+    session: &'a crate::runtime::RawRpcSession,
+    workspace_root: PathBuf,
+}
+
+impl<'a> RawRpcWorkspaceBackend<'a> {
+    pub(crate) fn new(
+        session: &'a crate::runtime::RawRpcSession,
+        workspace_root: &WorkspaceRoot,
+    ) -> Self {
+        Self {
+            session,
+            workspace_root: workspace_root.as_path().to_path_buf(),
+        }
+    }
+}
+
+impl BackendWorkspaceRpc for RawRpcWorkspaceBackend<'_> {
+    fn request(&mut self, request: Value) -> Result<Value, BackendRpcFailure> {
+        let encoded = serde_json::to_string(&request)
+            .map_err(|error| BackendRpcFailure::InvalidResponse(error.to_string()))?;
+        let raw = crate::runtime::raw_request_passthrough_in_session(
+            encoded,
+            Some(self.workspace_root.clone()),
+            self.session,
+        )
+        .map_err(|error| BackendRpcFailure::Transport(error.to_string()))?;
+        decode_rpc_response(&raw)
+    }
+}
+
 fn decode_rpc_response(raw: &str) -> Result<Value, BackendRpcFailure> {
     let response: Value = serde_json::from_str(raw)
         .map_err(|error| BackendRpcFailure::InvalidResponse(error.to_string()))?;

--- a/cli-rs/src/workspace_inventory/collect.rs
+++ b/cli-rs/src/workspace_inventory/collect.rs
@@ -350,6 +350,7 @@ fn compose_snapshot(
     WorkspaceInventorySnapshot::new(
         files,
         backend.coverage(),
+        backend.modules().clone(),
         coverage,
         WorkspaceKindMatchCoverage::new(source_coverage, script_coverage),
         limitations,

--- a/cli-rs/src/workspace_inventory/collect.rs
+++ b/cli-rs/src/workspace_inventory/collect.rs
@@ -15,9 +15,10 @@ use super::model::{
     WorkspaceEvidenceSource, WorkspaceFileDirtyState, WorkspaceFileDrift, WorkspaceFileKind,
     WorkspaceFilePath, WorkspaceFilesystemPathState, WorkspaceFilesystemStamp, WorkspaceIndexRead,
     WorkspaceIndexSnapshot, WorkspaceInventoryFile, WorkspaceInventoryLimitationCode,
-    WorkspaceInventorySnapshot, WorkspaceKindMatchCoverage, WorkspaceLaneEvidence,
-    WorkspaceLanePurpose, WorkspaceLaneStamp, WorkspaceLaneUnavailableReason,
-    WorkspaceMatchCoverage, WorkspaceRequestedKindDomain, WorkspaceRoot,
+    WorkspaceInventorySnapshot, WorkspaceInventorySnapshotInputs, WorkspaceKindMatchCoverage,
+    WorkspaceLaneEvidence, WorkspaceLanePurpose, WorkspaceLaneStamp,
+    WorkspaceLaneUnavailableReason, WorkspaceMatchCoverage, WorkspaceRequestedKindDomain,
+    WorkspaceRoot,
 };
 
 pub(crate) trait WorkspaceInventoryLaneReader {
@@ -347,16 +348,16 @@ fn compose_snapshot(
         ),
         dirty_lane_evidence(dirty_read),
     );
-    WorkspaceInventorySnapshot::new(
+    WorkspaceInventorySnapshot::new(WorkspaceInventorySnapshotInputs {
         files,
-        backend.coverage(),
-        backend.modules().clone(),
+        backend_coverage: backend.coverage(),
+        backend_modules: backend.modules().clone(),
         coverage,
-        WorkspaceKindMatchCoverage::new(source_coverage, script_coverage),
+        kind_coverage: WorkspaceKindMatchCoverage::new(source_coverage, script_coverage),
         limitations,
-        true,
-        digest,
-    )
+        continuation_allowed: true,
+        composition_digest: digest,
+    })
 }
 
 fn file_index_and_drift(

--- a/cli-rs/src/workspace_inventory/model.rs
+++ b/cli-rs/src/workspace_inventory/model.rs
@@ -95,7 +95,10 @@ impl SourceIndexGeneration {
     pub(super) fn try_from_database(value: i64) -> Option<Self> {
         u64::try_from(value).ok().map(Self)
     }
+}
 
+#[cfg(test)]
+impl SourceIndexGeneration {
     pub(crate) fn value(self) -> u64 {
         self.0
     }
@@ -126,7 +129,10 @@ impl SourceIndexModuleName {
         (!value.is_empty() && value.trim() == value && !value.chars().any(char::is_control))
             .then_some(Self(value))
     }
+}
 
+#[cfg(test)]
+impl SourceIndexModuleName {
     pub(crate) fn as_str(&self) -> &str {
         &self.0
     }
@@ -175,10 +181,6 @@ impl SourceIndexModuleProgress {
         })
     }
 
-    pub(crate) fn module_name(&self) -> &SourceIndexModuleName {
-        &self.module_name
-    }
-
     pub(crate) fn status(&self) -> SourceIndexProgressStatus {
         self.status
     }
@@ -189,6 +191,13 @@ impl SourceIndexModuleProgress {
 
     pub(crate) fn total_file_count(&self) -> u64 {
         self.total_file_count
+    }
+}
+
+#[cfg(test)]
+impl SourceIndexModuleProgress {
+    pub(crate) fn module_name(&self) -> &SourceIndexModuleName {
+        &self.module_name
     }
 
     fn is_exact(&self) -> bool {
@@ -220,16 +229,19 @@ impl SourceIndexSnapshotStamp {
         }
     }
 
-    pub(crate) fn generation(&self) -> SourceIndexGeneration {
-        self.generation
-    }
-
     pub(crate) fn module_progress(&self) -> &BTreeSet<SourceIndexModuleProgress> {
         &self.module_progress
     }
 
     pub(crate) fn pending_count(&self) -> SourceIndexPendingCount {
         self.pending_count
+    }
+}
+
+#[cfg(test)]
+impl SourceIndexSnapshotStamp {
+    pub(crate) fn generation(&self) -> SourceIndexGeneration {
+        self.generation
     }
 
     pub(crate) fn is_exact(&self) -> bool {
@@ -532,7 +544,10 @@ impl DirtyWorkspaceStamp {
             dirty_paths,
         }
     }
+}
 
+#[cfg(test)]
+impl DirtyWorkspaceStamp {
     pub(crate) fn repository_root(&self) -> &Path {
         &self.repository_root
     }
@@ -608,15 +623,18 @@ impl WorkspaceFilesystemStamp {
         Self(states)
     }
 
-    pub(crate) fn states(&self) -> &BTreeMap<WorkspaceFilePath, WorkspaceFilesystemPathState> {
-        &self.0
-    }
-
     pub(crate) fn state_for(
         &self,
         path: &WorkspaceFilePath,
     ) -> Option<&WorkspaceFilesystemPathState> {
         self.0.get(path)
+    }
+}
+
+#[cfg(test)]
+impl WorkspaceFilesystemStamp {
+    pub(crate) fn states(&self) -> &BTreeMap<WorkspaceFilePath, WorkspaceFilesystemPathState> {
+        &self.0
     }
 }
 
@@ -740,16 +758,19 @@ impl BackendModuleInventory {
         &self.content_roots
     }
 
-    pub(crate) fn dependency_module_names(&self) -> &BTreeSet<BackendModuleName> {
-        &self.dependency_module_names
-    }
-
     pub(crate) fn declared_file_count(&self) -> usize {
         self.declared_file_count
     }
 
     pub(crate) fn coverage(&self) -> BackendModuleCoverage {
         self.coverage
+    }
+}
+
+#[cfg(test)]
+impl BackendModuleInventory {
+    pub(crate) fn dependency_module_names(&self) -> &BTreeSet<BackendModuleName> {
+        &self.dependency_module_names
     }
 }
 
@@ -1165,13 +1186,6 @@ pub(crate) struct WorkspaceMatchCoverage {
 }
 
 impl WorkspaceMatchCoverage {
-    pub(crate) fn complete() -> Self {
-        Self {
-            candidate_inventory: WorkspaceCoverageDimension::Complete,
-            filter_evidence: WorkspaceCoverageDimension::Complete,
-        }
-    }
-
     pub(super) fn from_dimensions(
         candidate_inventory: WorkspaceCoverageDimension,
         filter_evidence: WorkspaceCoverageDimension,
@@ -1184,6 +1198,16 @@ impl WorkspaceMatchCoverage {
 
     pub(crate) fn candidate_inventory(self) -> WorkspaceCoverageDimension {
         self.candidate_inventory
+    }
+}
+
+#[cfg(test)]
+impl WorkspaceMatchCoverage {
+    pub(crate) fn complete() -> Self {
+        Self {
+            candidate_inventory: WorkspaceCoverageDimension::Complete,
+            filter_evidence: WorkspaceCoverageDimension::Complete,
+        }
     }
 
     pub(crate) fn filter_evidence(self) -> WorkspaceCoverageDimension {
@@ -1227,12 +1251,15 @@ impl WorkspaceIndexSnapshot {
         &self.limitations
     }
 
-    pub(crate) fn limitation_count(&self, code: WorkspaceInventoryLimitationCode) -> usize {
-        self.limitations.get(&code).copied().unwrap_or_default()
-    }
-
     pub(crate) fn coverage(&self) -> WorkspaceMatchCoverage {
         self.coverage
+    }
+}
+
+#[cfg(test)]
+impl WorkspaceIndexSnapshot {
+    pub(crate) fn limitation_count(&self, code: WorkspaceInventoryLimitationCode) -> usize {
+        self.limitations.get(&code).copied().unwrap_or_default()
     }
 }
 

--- a/cli-rs/src/workspace_inventory/model.rs
+++ b/cli-rs/src/workspace_inventory/model.rs
@@ -1071,27 +1071,31 @@ pub(crate) struct WorkspaceInventorySnapshot {
     composition_digest: String,
 }
 
+pub(super) struct WorkspaceInventorySnapshotInputs {
+    pub(super) files: Vec<WorkspaceInventoryFile>,
+    pub(super) backend_coverage: BackendWorkspaceCoverage,
+    pub(super) backend_modules: BTreeMap<BackendModuleName, BackendModuleInventory>,
+    pub(super) coverage: WorkspaceMatchCoverage,
+    pub(super) kind_coverage: WorkspaceKindMatchCoverage,
+    pub(super) limitations: BTreeMap<WorkspaceInventoryLimitationCode, usize>,
+    pub(super) continuation_allowed: bool,
+    pub(super) composition_digest: String,
+}
+
 impl WorkspaceInventorySnapshot {
-    pub(super) fn new(
-        mut files: Vec<WorkspaceInventoryFile>,
-        backend_coverage: BackendWorkspaceCoverage,
-        backend_modules: BTreeMap<BackendModuleName, BackendModuleInventory>,
-        coverage: WorkspaceMatchCoverage,
-        kind_coverage: WorkspaceKindMatchCoverage,
-        limitations: BTreeMap<WorkspaceInventoryLimitationCode, usize>,
-        continuation_allowed: bool,
-        composition_digest: String,
-    ) -> Self {
-        files.sort_by(|left, right| left.path.cmp(&right.path));
+    pub(super) fn new(mut inputs: WorkspaceInventorySnapshotInputs) -> Self {
+        inputs
+            .files
+            .sort_by(|left, right| left.path.cmp(&right.path));
         Self {
-            files,
-            backend_coverage,
-            backend_modules,
-            coverage,
-            kind_coverage,
-            limitations,
-            continuation_allowed,
-            composition_digest,
+            files: inputs.files,
+            backend_coverage: inputs.backend_coverage,
+            backend_modules: inputs.backend_modules,
+            coverage: inputs.coverage,
+            kind_coverage: inputs.kind_coverage,
+            limitations: inputs.limitations,
+            continuation_allowed: inputs.continuation_allowed,
+            composition_digest: inputs.composition_digest,
         }
     }
 

--- a/cli-rs/src/workspace_inventory/model.rs
+++ b/cli-rs/src/workspace_inventory/model.rs
@@ -1063,6 +1063,7 @@ pub(crate) enum WorkspaceInventoryLimitationCode {
 pub(crate) struct WorkspaceInventorySnapshot {
     files: Vec<WorkspaceInventoryFile>,
     backend_coverage: BackendWorkspaceCoverage,
+    backend_modules: BTreeMap<BackendModuleName, BackendModuleInventory>,
     coverage: WorkspaceMatchCoverage,
     kind_coverage: WorkspaceKindMatchCoverage,
     limitations: BTreeMap<WorkspaceInventoryLimitationCode, usize>,
@@ -1074,6 +1075,7 @@ impl WorkspaceInventorySnapshot {
     pub(super) fn new(
         mut files: Vec<WorkspaceInventoryFile>,
         backend_coverage: BackendWorkspaceCoverage,
+        backend_modules: BTreeMap<BackendModuleName, BackendModuleInventory>,
         coverage: WorkspaceMatchCoverage,
         kind_coverage: WorkspaceKindMatchCoverage,
         limitations: BTreeMap<WorkspaceInventoryLimitationCode, usize>,
@@ -1084,6 +1086,7 @@ impl WorkspaceInventorySnapshot {
         Self {
             files,
             backend_coverage,
+            backend_modules,
             coverage,
             kind_coverage,
             limitations,
@@ -1098,6 +1101,10 @@ impl WorkspaceInventorySnapshot {
 
     pub(crate) fn backend_coverage(&self) -> BackendWorkspaceCoverage {
         self.backend_coverage
+    }
+
+    pub(crate) fn backend_modules(&self) -> &BTreeMap<BackendModuleName, BackendModuleInventory> {
+        &self.backend_modules
     }
 
     pub(crate) fn coverage(&self) -> WorkspaceMatchCoverage {

--- a/cli-rs/tests/agent_result_projection_smoke.rs
+++ b/cli-rs/tests/agent_result_projection_smoke.rs
@@ -1002,7 +1002,7 @@ fn verify_default_exposes_health_runtime_and_capability_evidence_without_steps()
         "backendName": "idea",
         "backendVersion": "scripted-test",
         "workspaceRoot": workspace.display().to_string(),
-        "readCapabilities": ["symbol/resolve", "symbol/references"],
+        "readCapabilities": ["WORKSPACE_FILES", "symbol/resolve", "symbol/references"],
         "mutationCapabilities": ["mutation/submit"],
         "limits": {
             "requestTimeoutMillis": 60000,
@@ -1049,8 +1049,16 @@ fn verify_default_exposes_health_runtime_and_capability_evidence_without_steps()
     assert_eq!(stdout["result"]["health"]["ok"], true);
     assert_eq!(stdout["result"]["runtime"]["state"], "READY");
     assert_eq!(stdout["result"]["runtime"]["backendName"], "idea");
-    assert_eq!(stdout["result"]["capabilities"]["readCount"], 2);
+    assert_eq!(stdout["result"]["capabilities"]["readCount"], 3);
     assert_eq!(stdout["result"]["capabilities"]["mutationCount"], 1);
+    assert_eq!(stdout["result"]["capabilities"]["publicReadCount"], 1);
+    assert_eq!(
+        stdout["result"]["capabilities"]["publicRead"],
+        json!([{
+            "capability": "WORKSPACE_FILES",
+            "command": "kast agent workspace-files"
+        }])
+    );
     assert!(stdout["result"].get("steps").is_none(), "{stdout}");
     assert_output_budget(&raw, VERIFY_LINE_BUDGET, VERIFY_TOKEN_BUDGET);
 }

--- a/cli-rs/tests/agent_workspace_files_smoke.rs
+++ b/cli-rs/tests/agent_workspace_files_smoke.rs
@@ -300,6 +300,177 @@ fn spawn_small_mixed_workspace_files_backend(
     )
 }
 
+fn spawn_structured_filter_workspace_files_backend(
+    home: &std::path::Path,
+    config_home: &std::path::Path,
+    workspace: &std::path::Path,
+    socket: &std::path::Path,
+) -> std::thread::JoinHandle<Vec<serde_json::Value>> {
+    let source_root = workspace.join("src/main/kotlin/sample");
+    let files = [
+        "Good.kt",
+        "WrongModule.kt",
+        "WrongSourceSet.kt",
+        "WrongPackage.kt",
+        "LegacyOnly.kt",
+    ]
+    .map(|name| source_root.join(name).display().to_string());
+    let module = |files: serde_json::Value, returned_file_count: usize| {
+        serde_json::json!({
+            "snapshotToken": "snapshot-structured-filters",
+            "modules": [{
+                "name": "fixture.main",
+                "sourceRoots": [source_root.display().to_string()],
+                "contentRoots": [workspace.display().to_string()],
+                "dependencyModuleNames": [],
+                "files": files,
+                "returnedFileCount": returned_file_count,
+                "filesTruncated": false,
+                "fileCount": 5,
+                "nextPageToken": null
+            }],
+            "schemaVersion": 3
+        })
+    };
+    let validation = serde_json::json!({
+        "snapshotToken": "snapshot-structured-filters",
+        "modules": [],
+        "schemaVersion": 3
+    });
+    spawn_scripted_idea_backend(
+        home,
+        config_home,
+        workspace,
+        socket,
+        vec![
+            ("raw/workspace-files", module(serde_json::json!([]), 0)),
+            ("raw/workspace-files", module(serde_json::json!(files), 5)),
+            ("raw/workspace-files", validation.clone()),
+            ("raw/workspace-files", validation),
+        ],
+    )
+}
+
+fn spawn_single_owned_workspace_files_backend(
+    home: &std::path::Path,
+    config_home: &std::path::Path,
+    workspace: &std::path::Path,
+    socket: &std::path::Path,
+    owned_file: &std::path::Path,
+) -> std::thread::JoinHandle<Vec<serde_json::Value>> {
+    let source_root = workspace.join("src/main/kotlin");
+    let module = |files: serde_json::Value, returned_file_count: usize| {
+        serde_json::json!({
+            "snapshotToken": "snapshot-composition",
+            "modules": [{
+                "name": "fixture.main",
+                "sourceRoots": [source_root.display().to_string()],
+                "contentRoots": [workspace.display().to_string()],
+                "dependencyModuleNames": [],
+                "files": files,
+                "returnedFileCount": returned_file_count,
+                "filesTruncated": false,
+                "fileCount": 1,
+                "nextPageToken": null
+            }],
+            "schemaVersion": 3
+        })
+    };
+    let validation = serde_json::json!({
+        "snapshotToken": "snapshot-composition",
+        "modules": [],
+        "schemaVersion": 3
+    });
+    spawn_scripted_idea_backend(
+        home,
+        config_home,
+        workspace,
+        socket,
+        vec![
+            ("raw/workspace-files", module(serde_json::json!([]), 0)),
+            (
+                "raw/workspace-files",
+                module(serde_json::json!([owned_file.display().to_string()]), 1),
+            ),
+            ("raw/workspace-files", validation.clone()),
+            ("raw/workspace-files", validation),
+        ],
+    )
+}
+
+fn seed_structured_filter_evidence(index: &workspace_files::WorkspaceIndexFixture) {
+    let connection = index.connection();
+    connection
+        .execute(
+            "INSERT INTO fq_names(fq_id, fq_name) VALUES (2, 'sample.target'), (3, 'sample.other')",
+            [],
+        )
+        .expect("filter package names");
+    for (filename, package_id, legacy_module, legacy_source_set, project, source_set) in [
+        (
+            "Good.kt",
+            Some(2),
+            None,
+            None,
+            Some(":app"),
+            Some("integrationTest"),
+        ),
+        (
+            "WrongModule.kt",
+            Some(2),
+            None,
+            None,
+            Some(":other"),
+            Some("integrationTest"),
+        ),
+        (
+            "WrongSourceSet.kt",
+            Some(2),
+            None,
+            None,
+            Some(":app"),
+            Some("main"),
+        ),
+        (
+            "WrongPackage.kt",
+            Some(3),
+            None,
+            None,
+            Some(":app"),
+            Some("integrationTest"),
+        ),
+        (
+            "LegacyOnly.kt",
+            None,
+            Some("gradle:.#:app"),
+            Some("integrationTest"),
+            None,
+            None,
+        ),
+    ] {
+        index.insert_manifest_file(1, "src/main/kotlin/sample", filename, true);
+        if let Some(package_id) = package_id {
+            connection
+                .execute(
+                    "INSERT INTO file_metadata(prefix_id, filename, package_fq_id, package_state, package_unproven_reason, module_path, source_set) VALUES (1, ?, ?, 'PROVEN_NAMED', NULL, ?, ?)",
+                    rusqlite::params![filename, package_id, legacy_module, legacy_source_set],
+                )
+                .expect("proven filter metadata");
+        } else {
+            connection
+                .execute(
+                    "INSERT INTO file_metadata(prefix_id, filename, package_fq_id, package_state, package_unproven_reason, module_path, source_set) VALUES (1, ?, NULL, 'UNPROVEN', 'LEGACY_TEXT_ONLY', ?, ?)",
+                    rusqlite::params![filename, legacy_module, legacy_source_set],
+                )
+                .expect("legacy-only filter metadata");
+        }
+        if let (Some(project), Some(source_set)) = (project, source_set) {
+            index.insert_project_evidence(1, filename, ".", project, source_set);
+        }
+    }
+    index.seed_progress("app", "COMPLETE", 5, 5);
+}
+
 fn grouped_cardinality<'a>(
     output: &'a serde_json::Value,
     group: &str,
@@ -413,7 +584,13 @@ fn exact_root_inventory_returns_a_bounded_compact_public_result() {
     );
     assert_eq!(stdout["result"]["returnedCount"], 1, "{stdout:#}");
     assert_eq!(
-        stdout["result"]["files"][0]["relativePath"], "src/main/kotlin/sample/Source0000.kt",
+        stdout["result"]["files"][0]["paths"][0]["filePath"],
+        source.display().to_string(),
+        "{stdout:#}"
+    );
+    assert_eq!(
+        stdout["result"]["files"][0]["paths"][0]["relativePath"],
+        "src/main/kotlin/sample/Source0000.kt",
         "{stdout:#}"
     );
     assert_eq!(
@@ -421,11 +598,8 @@ fn exact_root_inventory_returns_a_bounded_compact_public_result() {
         "{stdout:#}"
     );
     assert_eq!(
-        stdout["result"]["files"][0]["package"]["type"], "PROVEN_NAMED",
-        "{stdout:#}"
-    );
-    assert_eq!(
-        stdout["result"]["files"][0]["package"]["name"], "sample",
+        stdout["result"]["files"][0]["package"],
+        serde_json::json!({"type": "PROVEN_NAMED", "name": "sample"}),
         "{stdout:#}"
     );
     assert!(
@@ -505,6 +679,21 @@ fn public_continuations_return_five_hundred_files_as_200_200_100_without_gaps() 
     let second_requests = second_server
         .join()
         .expect("second workspace-files backend");
+    assert_eq!(
+        second_requests
+            .iter()
+            .map(|request| request["method"].as_str().expect("request method"))
+            .take(4)
+            .collect::<Vec<_>>(),
+        vec![
+            "runtime/status",
+            "capabilities",
+            "raw/workspace-files-continuation",
+            "raw/workspace-files",
+        ],
+        "public continuation must be consumed before any inventory collection"
+    );
+    assert_eq!(second_requests[2]["params"]["action"], "CONSUME");
     let second_state = workspace_files_issue_state(&second_requests);
 
     let third_server = spawn_paged_workspace_files_backend(
@@ -630,6 +819,41 @@ fn high_cardinality_default_compact_page_stays_within_agent_budget() {
     let stdout: serde_json::Value =
         toon_format::decode_default(&raw).expect("compact default TOON");
     assert_eq!(stdout["result"]["returnedCount"], 20);
+    assert_eq!(stdout["result"]["files"].as_array().map(Vec::len), Some(1));
+    let group = &stdout["result"]["files"][0];
+    assert_eq!(group["backendModules"], serde_json::json!(["fixture.main"]));
+    assert_eq!(
+        group["indexedGradleProjects"],
+        serde_json::json!([{"buildRoot": ".", "projectPath": ":app"}])
+    );
+    assert_eq!(
+        group["sourceSets"],
+        serde_json::json!({
+            "type": "PROVEN",
+            "sourceSets": [{
+                "buildRoot": ".",
+                "projectPath": ":app",
+                "sourceSetName": "main"
+            }]
+        })
+    );
+    assert_eq!(group["kind"], "KOTLIN_SOURCE");
+    assert_eq!(
+        group["package"],
+        serde_json::json!({"type": "PROVEN_NAMED", "name": "sample"})
+    );
+    assert_eq!(group["sourceIndex"], "INDEXED");
+    assert_eq!(group["drift"], "NONE");
+    assert_eq!(group["dirty"], "UNKNOWN");
+    assert_eq!(group["paths"].as_array().map(Vec::len), Some(20));
+    assert_eq!(
+        group["paths"][0],
+        serde_json::json!({
+            "filePath": workspace.join("src/main/kotlin/sample/Source0000.kt").display().to_string(),
+            "relativePath": "src/main/kotlin/sample/Source0000.kt"
+        }),
+        "compact projection must retain routing and coherence evidence: {stdout:#}"
+    );
     let lines = raw.lines().count();
     let tokens = tiktoken_rs::cl100k_base()
         .expect("cl100k tokenizer")
@@ -642,6 +866,592 @@ fn high_cardinality_default_compact_page_stays_within_agent_budget() {
     assert!(
         tokens <= 1_500,
         "compact page used {tokens} cl100k tokens; budget is 1500"
+    );
+}
+
+#[test]
+fn compact_groups_only_consecutive_globally_sorted_identical_evidence() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "group-boundaries", 500);
+    index
+        .connection()
+        .execute_batch(
+            r#"
+            DELETE FROM file_gradle_source_sets WHERE filename = 'Source0002.kt';
+            DELETE FROM file_gradle_projects WHERE filename = 'Source0002.kt';
+            INSERT INTO file_gradle_projects(prefix_id, filename, build_root, project_path)
+                VALUES (1, 'Source0002.kt', '.', ':other');
+            INSERT INTO file_gradle_source_sets(
+                prefix_id, filename, build_root, project_path, source_set_name
+            ) VALUES (1, 'Source0002.kt', '.', ':other', 'main');
+            "#,
+        )
+        .expect("distinct typed evidence");
+    let server = spawn_paged_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("group-boundaries.sock"),
+        None,
+        Some("550e8400-e29b-41d4-a716-446655440004"),
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--kind",
+            "source",
+        ])
+        .output()
+        .expect("compact workspace-files grouping");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    server.join().expect("grouping backend");
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("compact grouping JSON");
+    let groups = stdout["result"]["files"]
+        .as_array()
+        .expect("compact groups");
+    assert_eq!(groups.len(), 3, "{stdout:#}");
+    assert_eq!(
+        groups
+            .iter()
+            .map(|group| group["paths"].as_array().expect("group paths").len())
+            .collect::<Vec<_>>(),
+        vec![2, 1, 17]
+    );
+    let evidence = groups
+        .iter()
+        .map(|group| {
+            let mut evidence = group.as_object().expect("compact group").clone();
+            evidence.remove("paths");
+            evidence
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(evidence[0], evidence[2]);
+    assert_ne!(evidence[0], evidence[1]);
+    let relative_paths = groups
+        .iter()
+        .flat_map(|group| group["paths"].as_array().expect("group paths"))
+        .map(|path| path["relativePath"].as_str().expect("relativePath"))
+        .collect::<Vec<_>>();
+    assert_eq!(relative_paths.len(), 20);
+    assert!(relative_paths.windows(2).all(|pair| pair[0] < pair[1]));
+    assert_eq!(relative_paths[2], "src/main/kotlin/sample/Source0002.kt");
+}
+
+#[test]
+fn public_continuations_reject_query_mismatch_and_stale_evidence_without_restarting() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let _index = create_workspace_index(&home, &workspace, "continuation-failures", 500);
+
+    let seed_backend = spawn_paged_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("continuation-seed.sock"),
+        None,
+        Some("550e8400-e29b-41d4-a716-446655440010"),
+    );
+    let seed_output = run_workspace_files_page(&home, &config_home, &workspace, None);
+    assert!(
+        seed_output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&seed_output.stdout),
+        String::from_utf8_lossy(&seed_output.stderr),
+    );
+    let seed_requests = seed_backend.join().expect("continuation seed backend");
+    let seed_state = workspace_files_issue_state(&seed_requests);
+
+    for (name, mut consumed_state, expected_code) in [
+        (
+            "query-mismatch",
+            seed_state.clone(),
+            "INVALID_WORKSPACE_FILES_PAGE_TOKEN",
+        ),
+        (
+            "stale-evidence",
+            seed_state.clone(),
+            "STALE_WORKSPACE_FILES_PAGE",
+        ),
+    ] {
+        if name == "query-mismatch" {
+            consumed_state["identity"]["normalizedQuery"] =
+                serde_json::Value::String("{\"filters\":{\"kind\":\"script\"}}".to_string());
+        } else {
+            consumed_state["compositionStampDigest"] =
+                serde_json::Value::String("stale-composition".to_string());
+        }
+        let backend = spawn_paged_workspace_files_backend(
+            &home,
+            &config_home,
+            &workspace,
+            &temp.path().join(format!("{name}.sock")),
+            Some(consumed_state),
+            None,
+        );
+        let output = run_workspace_files_page(
+            &home,
+            &config_home,
+            &workspace,
+            Some("550e8400-e29b-41d4-a716-446655440010"),
+        );
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "case={name} stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let stdout: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("continuation failure JSON");
+        assert_eq!(
+            stdout["error"]["code"], expected_code,
+            "case={name} {stdout:#}"
+        );
+        assert!(stdout.get("result").is_none(), "case={name} {stdout:#}");
+        let requests = backend.join().expect("continuation failure backend");
+        assert_eq!(requests[2]["params"]["action"], "CONSUME");
+        assert_eq!(requests[3]["method"], "raw/workspace-files");
+        assert!(
+            requests.iter().all(|request| {
+                request["method"] != "raw/workspace-files-continuation"
+                    || request["params"]["action"] != "ISSUE"
+            }),
+            "invalid or stale continuation must never restart or issue a replacement: {requests:#?}"
+        );
+    }
+}
+
+#[test]
+fn stable_partial_inventory_can_continue_known_matches() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "stable-partial", 500);
+    index.seed_progress("app", "INDEXING", 499, 500);
+    let backend = spawn_paged_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("stable-partial.sock"),
+        None,
+        Some("550e8400-e29b-41d4-a716-446655440011"),
+    );
+
+    let output = run_workspace_files_page(&home, &config_home, &workspace, None);
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stable partial JSON");
+    assert_eq!(stdout["result"]["cardinality"]["type"], "KNOWN_MINIMUM");
+    assert_eq!(stdout["result"]["returnedCount"], 200);
+    assert_eq!(
+        stdout["result"]["nextPageToken"],
+        "550e8400-e29b-41d4-a716-446655440011"
+    );
+    assert!(
+        stdout["result"]["limitations"]
+            .as_array()
+            .expect("limitations")
+            .iter()
+            .any(|limitation| limitation["code"] == "SOURCE_INDEX_PROGRESS_INCOMPLETE"),
+        "{stdout:#}"
+    );
+    let requests = backend.join().expect("stable partial backend");
+    assert_eq!(
+        requests.last().expect("continuation issue")["params"]["action"],
+        "ISSUE"
+    );
+}
+
+#[test]
+fn complete_index_evidence_publishes_backend_only_source_as_not_indexed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "not-indexed", 0);
+    index.seed_progress("app", "COMPLETE", 0, 0);
+    let backend_only = workspace.join("src/main/kotlin/sample/BackendOnly.kt");
+    std::fs::create_dir_all(backend_only.parent().expect("source parent")).expect("source parent");
+    std::fs::write(&backend_only, "package sample\nclass BackendOnly\n")
+        .expect("backend-only source");
+    let backend = spawn_single_owned_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("not-indexed.sock"),
+        &backend_only,
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--kind",
+            "source",
+            "--fields",
+            "path,index,drift",
+        ])
+        .output()
+        .expect("not-indexed discovery");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    backend.join().expect("not-indexed backend");
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("not-indexed JSON");
+    assert_eq!(
+        stdout["result"]["files"],
+        serde_json::json!([{
+            "filePath": backend_only.display().to_string(),
+            "relativePath": "src/main/kotlin/sample/BackendOnly.kt",
+            "sourceIndex": "NOT_INDEXED",
+            "drift": "FILESYSTEM_ONLY"
+        }]),
+        "NOT_INDEXED requires complete source-index evidence: {stdout:#}"
+    );
+    assert_eq!(
+        stdout["result"]["cardinality"],
+        serde_json::json!({"type": "EXACT", "totalCount": 1})
+    );
+}
+
+#[test]
+fn structured_filters_are_conjunctive_and_never_match_legacy_labels() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "structured-filters", 0);
+    seed_structured_filter_evidence(&index);
+    let server = spawn_structured_filter_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("structured-filters.sock"),
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--module",
+            "gradle:.#:app",
+            "--source-set",
+            "integrationTest",
+            "--package",
+            "named:sample.target",
+            "--fields",
+            "path,module,source-set,package,index",
+        ])
+        .output()
+        .expect("structured filter query");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    server.join().expect("structured filter backend");
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("structured filter JSON");
+    assert_eq!(
+        stdout["result"]["files"],
+        serde_json::json!([{
+            "filePath": workspace.join("src/main/kotlin/sample/Good.kt").display().to_string(),
+            "relativePath": "src/main/kotlin/sample/Good.kt",
+            "backendModules": ["fixture.main"],
+            "indexedGradleProjects": [{"buildRoot": ".", "projectPath": ":app"}],
+            "sourceSets": {
+                "type": "PROVEN",
+                "sourceSets": [{
+                    "buildRoot": ".",
+                    "projectPath": ":app",
+                    "sourceSetName": "integrationTest"
+                }]
+            },
+            "package": {"type": "PROVEN_NAMED", "name": "sample.target"},
+            "sourceIndex": "INDEXED"
+        }]),
+        "each non-result fixture matches only a strict subset or legacy labels: {stdout:#}"
+    );
+    assert_eq!(
+        stdout["result"]["cardinality"],
+        serde_json::json!({"type": "KNOWN_MINIMUM", "knownMinimumCount": 1}),
+        "{stdout:#}"
+    );
+    assert_eq!(stdout["result"]["coverage"]["filterEvidence"], "PARTIAL");
+}
+
+#[test]
+fn discovered_file_path_composes_with_diagnostics_and_exact_symbol_lookup() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let _index = create_workspace_index(&home, &workspace, "direct-composition", 1);
+    let owned_file = workspace.join("src/main/kotlin/sample/Source0000.kt");
+    let unowned_file = workspace.join("src/main/kotlin/sample/Unowned.kt");
+    std::fs::write(&unowned_file, "package sample\nclass Unowned\n").expect("unowned source");
+
+    let discovery_backend = spawn_single_owned_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("composition-discovery.sock"),
+        &owned_file,
+    );
+    let discovery_output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--kind",
+            "source",
+            "--fields",
+            "path",
+        ])
+        .output()
+        .expect("workspace discovery");
+    assert!(
+        discovery_output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&discovery_output.stdout),
+        String::from_utf8_lossy(&discovery_output.stderr),
+    );
+    discovery_backend.join().expect("discovery backend");
+    let discovery: serde_json::Value =
+        serde_json::from_slice(&discovery_output.stdout).expect("discovery JSON");
+    assert_eq!(
+        discovery["result"]["files"].as_array().map(Vec::len),
+        Some(1),
+        "an existing but unowned .kt file must not enter semantic discovery: {discovery:#}"
+    );
+    let discovered_file_path = discovery["result"]["files"][0]["filePath"]
+        .as_str()
+        .expect("discovered filePath")
+        .to_string();
+    assert_eq!(discovered_file_path, owned_file.display().to_string());
+    assert_ne!(discovered_file_path, unowned_file.display().to_string());
+
+    let diagnostics_backend = spawn_scripted_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("composition-diagnostics.sock"),
+        vec![
+            (
+                "raw/workspace-refresh",
+                serde_json::json!({
+                    "refreshedFiles": [discovered_file_path],
+                    "removedFiles": [],
+                    "fullRefresh": false,
+                    "fileStatuses": [{
+                        "filePath": discovered_file_path,
+                        "fileSystemDiscovery": "DISCOVERED",
+                        "sourceModuleOwnership": "OWNED",
+                        "indexAdmission": "ADMITTED",
+                        "analysisAvailability": "AVAILABLE",
+                        "analysisStatus": {"filePath": discovered_file_path, "state": "ANALYZED"}
+                    }],
+                    "semanticOutcome": "COMPLETE",
+                    "requestedFileCount": 1,
+                    "analyzedFileCount": 1,
+                    "skippedFileCount": 0,
+                    "removedFileCount": 0,
+                    "attemptCount": 1,
+                    "elapsedMillis": 0,
+                    "schemaVersion": 3
+                }),
+            ),
+            (
+                "raw/diagnostics",
+                serde_json::json!({
+                    "diagnostics": [],
+                    "fileStatuses": [{"filePath": discovered_file_path, "state": "ANALYZED"}],
+                    "semanticOutcome": "COMPLETE",
+                    "requestedFileCount": 1,
+                    "analyzedFileCount": 1,
+                    "skippedFileCount": 0,
+                    "severityCounts": {"error": 0, "warning": 0, "info": 0, "total": 0},
+                    "cardinality": {"type": "EXACT", "totalCount": 0}
+                }),
+            ),
+        ],
+    );
+    let diagnostics_output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "diagnostics",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--file-path",
+            &discovered_file_path,
+        ])
+        .output()
+        .expect("composed diagnostics");
+    assert!(
+        diagnostics_output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&diagnostics_output.stdout),
+        String::from_utf8_lossy(&diagnostics_output.stderr),
+    );
+    let diagnostics_requests = diagnostics_backend.join().expect("diagnostics backend");
+    assert_eq!(
+        diagnostics_requests
+            .iter()
+            .find(|request| request["method"] == "raw/diagnostics")
+            .expect("diagnostics request")["params"]["filePaths"],
+        serde_json::json!([discovered_file_path])
+    );
+
+    let symbol_backend = spawn_scripted_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("composition-symbol.sock"),
+        vec![(
+            "symbol/resolve",
+            serde_json::json!({
+                "type": "RESOLVE_SUCCESS",
+                "ok": true,
+                "source": "compiler",
+                "symbol": {
+                    "fqName": "sample.Source0000",
+                    "kind": "CLASS",
+                    "location": {
+                        "filePath": discovered_file_path,
+                        "startOffset": 15,
+                        "endOffset": 25,
+                        "startLine": 2,
+                        "startColumn": 7,
+                        "preview": "Source0000"
+                    }
+                }
+            }),
+        )],
+    );
+    let symbol_output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "symbol",
+            "--query",
+            "sample.Source0000",
+            "--file-hint",
+            &discovered_file_path,
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+        ])
+        .output()
+        .expect("composed exact symbol lookup");
+    assert!(
+        symbol_output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&symbol_output.stdout),
+        String::from_utf8_lossy(&symbol_output.stderr),
+    );
+    let symbol: serde_json::Value =
+        serde_json::from_slice(&symbol_output.stdout).expect("symbol JSON");
+    assert_eq!(symbol["result"]["mode"], "exact", "{symbol:#}");
+    assert_eq!(symbol["result"]["outcome"], "RESOLVED", "{symbol:#}");
+    let symbol_requests = symbol_backend.join().expect("symbol backend");
+    assert_eq!(
+        symbol_requests[2]["params"]["fileHint"], discovered_file_path,
+        "exact lookup must consume the discovery filePath verbatim"
     );
 }
 

--- a/cli-rs/tests/agent_workspace_files_smoke.rs
+++ b/cli-rs/tests/agent_workspace_files_smoke.rs
@@ -86,10 +86,14 @@ fn create_workspace_index(
         .chars()
         .take(80)
         .collect::<String>();
-    let database_path = workspaces_data
-        .join("local")
-        .join(format!("{sanitized_workspace}--{workspace_id}"))
-        .join("cache/source-index.db");
+    let database_path = if workspace.starts_with(std::env::temp_dir()) {
+        workspace.join(".gradle/kast/cache/source-index.db")
+    } else {
+        workspaces_data
+            .join("local")
+            .join(format!("{sanitized_workspace}--{workspace_id}"))
+            .join("cache/source-index.db")
+    };
     let index =
         workspace_files::WorkspaceIndexFixture::at_database_path(&workspace, &database_path);
     index.seed_high_cardinality_sources(source_count);

--- a/cli-rs/tests/agent_workspace_files_smoke.rs
+++ b/cli-rs/tests/agent_workspace_files_smoke.rs
@@ -110,6 +110,26 @@ fn spawn_paged_workspace_files_backend(
     consumed_state: Option<serde_json::Value>,
     issued_token: Option<&'static str>,
 ) -> std::thread::JoinHandle<Vec<serde_json::Value>> {
+    let mut responses = workspace_files_session_responses(workspace);
+    if let Some(state) = consumed_state {
+        responses.push((
+            "raw/workspace-files-continuation",
+            serde_json::json!({"type": "CONSUMED", "state": state}),
+        ));
+    }
+    append_paged_workspace_files_collection(&mut responses, workspace, "snapshot-500");
+    if let Some(page_token) = issued_token {
+        responses.push((
+            "raw/workspace-files-continuation",
+            serde_json::json!({"type": "ISSUED", "pageToken": page_token}),
+        ));
+    }
+    spawn_sequenced_idea_backend(home, config_home, workspace, socket, responses)
+}
+
+fn workspace_files_session_responses(
+    workspace: &std::path::Path,
+) -> Vec<(&'static str, serde_json::Value)> {
     let runtime = serde_json::json!({
         "state": "READY",
         "healthy": true,
@@ -133,6 +153,14 @@ fn spawn_paged_workspace_files_backend(
         },
         "schemaVersion": 3
     });
+    vec![("runtime/status", runtime), ("capabilities", capabilities)]
+}
+
+fn append_paged_workspace_files_collection(
+    responses: &mut Vec<(&'static str, serde_json::Value)>,
+    workspace: &std::path::Path,
+    revalidation_snapshot_token: &str,
+) {
     let source_root = workspace.join("src/main/kotlin");
     let page = |range: std::ops::Range<usize>, next_page_token: Option<&str>| {
         let files = range
@@ -159,18 +187,16 @@ fn spawn_paged_workspace_files_backend(
             "schemaVersion": 3
         })
     };
-    let validation = serde_json::json!({
+    let collection_validation = serde_json::json!({
         "snapshotToken": "snapshot-500",
         "modules": [],
         "schemaVersion": 3
     });
-    let mut responses = vec![("runtime/status", runtime), ("capabilities", capabilities)];
-    if let Some(state) = consumed_state {
-        responses.push((
-            "raw/workspace-files-continuation",
-            serde_json::json!({"type": "CONSUMED", "state": state}),
-        ));
-    }
+    let barrier_validation = serde_json::json!({
+        "snapshotToken": revalidation_snapshot_token,
+        "modules": [],
+        "schemaVersion": 3
+    });
     responses.extend([
         (
             "raw/workspace-files",
@@ -193,16 +219,9 @@ fn spawn_paged_workspace_files_backend(
         ("raw/workspace-files", page(0..200, Some("raw-page-2"))),
         ("raw/workspace-files", page(200..400, Some("raw-page-3"))),
         ("raw/workspace-files", page(400..500, None)),
-        ("raw/workspace-files", validation.clone()),
-        ("raw/workspace-files", validation),
+        ("raw/workspace-files", collection_validation),
+        ("raw/workspace-files", barrier_validation),
     ]);
-    if let Some(page_token) = issued_token {
-        responses.push((
-            "raw/workspace-files-continuation",
-            serde_json::json!({"type": "ISSUED", "pageToken": page_token}),
-        ));
-    }
-    spawn_sequenced_idea_backend(home, config_home, workspace, socket, responses)
 }
 
 fn run_workspace_files_page(
@@ -773,6 +792,54 @@ fn public_continuations_return_five_hundred_files_as_200_200_100_without_gaps() 
 }
 
 #[test]
+fn malformed_issued_continuation_token_fails_closed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let _index = create_workspace_index(&home, &workspace, "malformed-token", 500);
+    let server = spawn_paged_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("malformed-token.sock"),
+        None,
+        Some("not-a-canonical-uuid-v4"),
+    );
+
+    let output = run_workspace_files_page(&home, &config_home, &workspace, None);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("workspace-files JSON error");
+    assert_eq!(
+        stdout["error"]["code"], "AGENT_RESULT_INVALID",
+        "{stdout:#}"
+    );
+
+    let requests = server.join().expect("malformed-token backend");
+    assert!(
+        requests.iter().any(|request| {
+            request["method"] == "raw/workspace-files-continuation"
+                && request["params"]["action"] == "ISSUE"
+        }),
+        "{requests:#?}"
+    );
+}
+
+#[test]
 fn high_cardinality_default_compact_page_stays_within_agent_budget() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -1055,6 +1122,145 @@ fn public_continuations_reject_query_mismatch_and_stale_evidence_without_restart
 }
 
 #[test]
+fn consumed_continuation_reports_stale_before_disappeared_authorities() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "disappeared-authorities", 500);
+
+    let seed_backend = spawn_paged_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("disappeared-authorities-seed.sock"),
+        None,
+        Some("550e8400-e29b-41d4-a716-446655440011"),
+    );
+    let seed_output = run_workspace_files_page(&home, &config_home, &workspace, None);
+    assert!(seed_output.status.success());
+    let seed_state = workspace_files_issue_state(
+        &seed_backend
+            .join()
+            .expect("disappeared-authorities seed backend"),
+    );
+
+    std::fs::remove_file(index.database_path()).expect("remove source-index authority");
+    let mut responses = workspace_files_session_responses(&workspace);
+    responses.push((
+        "raw/workspace-files-continuation",
+        serde_json::json!({"type": "CONSUMED", "state": seed_state}),
+    ));
+    responses.extend([
+        ("raw/workspace-files", serde_json::json!({})),
+        ("raw/workspace-files", serde_json::json!({})),
+    ]);
+    let backend = spawn_sequenced_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("disappeared-authorities.sock"),
+        responses,
+    );
+
+    let output = run_workspace_files_page(
+        &home,
+        &config_home,
+        &workspace,
+        Some("550e8400-e29b-41d4-a716-446655440011"),
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stale continuation JSON");
+    assert_eq!(
+        stdout["error"]["code"], "STALE_WORKSPACE_FILES_PAGE",
+        "{stdout:#}"
+    );
+    backend.join().expect("disappeared-authorities backend");
+}
+
+#[test]
+fn consumed_continuation_rejects_cross_lane_instability() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let _index = create_workspace_index(&home, &workspace, "unstable-continuation", 500);
+
+    let seed_backend = spawn_paged_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("unstable-continuation-seed.sock"),
+        None,
+        Some("550e8400-e29b-41d4-a716-446655440012"),
+    );
+    let seed_output = run_workspace_files_page(&home, &config_home, &workspace, None);
+    assert!(seed_output.status.success());
+    let seed_state = workspace_files_issue_state(
+        &seed_backend
+            .join()
+            .expect("unstable-continuation seed backend"),
+    );
+
+    let mut responses = workspace_files_session_responses(&workspace);
+    responses.push((
+        "raw/workspace-files-continuation",
+        serde_json::json!({"type": "CONSUMED", "state": seed_state}),
+    ));
+    append_paged_workspace_files_collection(&mut responses, &workspace, "snapshot-moved");
+    append_paged_workspace_files_collection(&mut responses, &workspace, "snapshot-moved");
+    let backend = spawn_sequenced_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("unstable-continuation.sock"),
+        responses,
+    );
+
+    let output = run_workspace_files_page(
+        &home,
+        &config_home,
+        &workspace,
+        Some("550e8400-e29b-41d4-a716-446655440012"),
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("unstable continuation JSON");
+    assert_eq!(
+        stdout["error"]["code"], "STALE_WORKSPACE_FILES_PAGE",
+        "{stdout:#}"
+    );
+    backend.join().expect("unstable-continuation backend");
+}
+
+#[test]
 fn stable_partial_inventory_can_continue_known_matches() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -1174,6 +1380,228 @@ fn complete_index_evidence_publishes_backend_only_source_as_not_indexed() {
     assert_eq!(
         stdout["result"]["cardinality"],
         serde_json::json!({"type": "EXACT", "totalCount": 1})
+    );
+
+    let count_backend = spawn_single_owned_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("not-indexed-count.sock"),
+        &backend_only,
+    );
+    let count_output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--kind",
+            "source",
+            "--count",
+        ])
+        .output()
+        .expect("not-indexed count");
+    assert!(
+        count_output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&count_output.stdout),
+        String::from_utf8_lossy(&count_output.stderr),
+    );
+    count_backend.join().expect("not-indexed count backend");
+    let count_stdout: serde_json::Value =
+        serde_json::from_slice(&count_output.stdout).expect("not-indexed count JSON");
+    assert_eq!(
+        grouped_cardinality(&count_stdout, "index", "NOT_INDEXED")["cardinality"],
+        serde_json::json!({"type": "EXACT", "totalCount": 1}),
+        "count projection must agree with the detailed index state: {count_stdout:#}"
+    );
+}
+
+#[test]
+fn incomplete_index_evidence_counts_backend_only_source_as_unknown() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "unknown-index", 0);
+    index.seed_progress("app", "INDEXING", 0, 1);
+    let backend_only = workspace.join("src/main/kotlin/sample/BackendOnly.kt");
+    std::fs::create_dir_all(backend_only.parent().expect("source parent")).expect("source parent");
+    std::fs::write(&backend_only, "package sample\nclass BackendOnly\n")
+        .expect("backend-only source");
+    let backend = spawn_single_owned_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("unknown-index-count.sock"),
+        &backend_only,
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--kind",
+            "source",
+            "--count",
+        ])
+        .output()
+        .expect("unknown index count");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    backend.join().expect("unknown index count backend");
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("unknown index count JSON");
+    assert_eq!(
+        grouped_cardinality(&stdout, "index", "UNKNOWN")["cardinality"],
+        serde_json::json!({"type": "KNOWN_MINIMUM", "knownMinimumCount": 1}),
+        "incomplete source-index evidence must remain UNKNOWN: {stdout:#}"
+    );
+}
+
+#[test]
+fn gradle_module_filter_is_partial_when_candidate_ownership_is_unknown() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "unknown-gradle-owner", 0);
+    index.seed_progress("app", "INDEXING", 0, 1);
+    let backend_only = workspace.join("src/main/kotlin/sample/BackendOnly.kt");
+    std::fs::create_dir_all(backend_only.parent().expect("source parent")).expect("source parent");
+    std::fs::write(&backend_only, "package sample\nclass BackendOnly\n")
+        .expect("backend-only source");
+    let backend = spawn_single_owned_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("unknown-gradle-owner.sock"),
+        &backend_only,
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--kind",
+            "source",
+            "--module",
+            "gradle:.#:app",
+        ])
+        .output()
+        .expect("unknown Gradle owner filter");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    backend.join().expect("unknown Gradle owner backend");
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("unknown Gradle owner JSON");
+    assert_eq!(
+        stdout["result"]["coverage"]["filterEvidence"], "PARTIAL",
+        "unknown indexed Gradle ownership cannot prove a negative match: {stdout:#}"
+    );
+    assert_eq!(
+        stdout["result"]["cardinality"],
+        serde_json::json!({"type": "KNOWN_MINIMUM", "knownMinimumCount": 0}),
+        "unknown indexed Gradle ownership cannot produce exact zero: {stdout:#}"
+    );
+}
+
+#[test]
+fn gradle_module_filter_is_exact_when_complete_index_proves_candidates_have_no_owner() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(workspace.join("src/main/kotlin/sample")).expect("workspace sources");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let source = workspace.join("src/main/kotlin/sample/Source0000.kt");
+    std::fs::write(&source, "package sample\nclass Source0000\n").expect("Kotlin source");
+    let script = workspace.join("src/main/kotlin/sample/Script.kts");
+    std::fs::write(&script, "println(\"fixture\")\n").expect("Kotlin script");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "proven-no-gradle-owner", 0);
+    index.seed_progress("app", "COMPLETE", 0, 0);
+    let backend = spawn_small_mixed_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("proven-no-gradle-owner.sock"),
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--module",
+            "gradle:.#:app",
+        ])
+        .output()
+        .expect("proven absent Gradle owner filter");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    backend.join().expect("proven absent Gradle owner backend");
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("proven absent Gradle owner JSON");
+    assert_eq!(
+        stdout["result"]["coverage"]["filterEvidence"], "COMPLETE",
+        "complete index and script non-applicability prove both negative matches: {stdout:#}"
+    );
+    assert_eq!(
+        stdout["result"]["cardinality"],
+        serde_json::json!({"type": "EXACT", "totalCount": 0}),
+        "proven negative Gradle ownership must retain exact zero: {stdout:#}"
     );
 }
 

--- a/cli-rs/tests/agent_workspace_files_smoke.rs
+++ b/cli-rs/tests/agent_workspace_files_smoke.rs
@@ -1549,6 +1549,97 @@ fn gradle_module_filter_is_partial_when_candidate_ownership_is_unknown() {
 }
 
 #[test]
+fn backend_module_filter_is_partial_when_backend_page_is_incomplete() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let _index = create_workspace_index(&home, &workspace, "partial-backend-owner", 1);
+    let source = workspace.join("src/main/kotlin/sample/Source0000.kt");
+    let source_root = workspace.join("src/main/kotlin");
+    let module = |files: serde_json::Value, returned_file_count: usize| {
+        serde_json::json!({
+            "snapshotToken": "snapshot-partial-backend-owner",
+            "modules": [{
+                "name": "fixture.main",
+                "sourceRoots": [source_root.display().to_string()],
+                "contentRoots": [workspace.display().to_string()],
+                "dependencyModuleNames": [],
+                "files": files,
+                "returnedFileCount": returned_file_count,
+                "filesTruncated": false,
+                "fileCount": 2,
+                "nextPageToken": null
+            }],
+            "schemaVersion": 3
+        })
+    };
+    let validation = serde_json::json!({
+        "snapshotToken": "snapshot-partial-backend-owner",
+        "modules": [],
+        "schemaVersion": 3
+    });
+    let backend = spawn_scripted_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("partial-backend-owner.sock"),
+        vec![
+            ("raw/workspace-files", module(serde_json::json!([]), 0)),
+            (
+                "raw/workspace-files",
+                module(serde_json::json!([source.display().to_string()]), 1),
+            ),
+            ("raw/workspace-files", validation.clone()),
+            ("raw/workspace-files", validation),
+        ],
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--kind",
+            "source",
+            "--module",
+            "backend:fixture.main",
+        ])
+        .output()
+        .expect("partial backend owner filter");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    backend.join().expect("partial backend owner backend");
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("partial backend owner JSON");
+    assert_eq!(
+        stdout["result"]["coverage"]["filterEvidence"], "PARTIAL",
+        "partial backend coverage cannot prove a negative module match: {stdout:#}"
+    );
+    assert_eq!(
+        stdout["result"]["cardinality"],
+        serde_json::json!({"type": "KNOWN_MINIMUM", "knownMinimumCount": 0}),
+        "partial backend coverage cannot produce exact zero: {stdout:#}"
+    );
+}
+
+#[test]
 fn gradle_module_filter_is_exact_when_complete_index_proves_candidates_have_no_owner() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/cli-rs/tests/agent_workspace_files_smoke.rs
+++ b/cli-rs/tests/agent_workspace_files_smoke.rs
@@ -31,9 +31,13 @@ fn assert_typed_boundary(extra_args: &[&str]) -> serde_json::Value {
     );
     let stdout: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("workspace-files JSON error");
-    assert_eq!(
-        stdout["error"]["code"], "WORKSPACE_FILE_DISCOVERY_UNAVAILABLE",
-        "{stdout:#}"
+    assert!(
+        stdout["error"]["code"].is_string(),
+        "typed admission must return a structured error: {stdout:#}"
+    );
+    assert!(
+        stdout["error"]["details"]["admittedQuery"].is_object(),
+        "typed query admission must precede exact-root runtime admission: {stdout:#}"
     );
     stdout
 }
@@ -50,6 +54,780 @@ fn assert_usage_error(extra_args: &[&str]) {
     let stdout: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("workspace-files usage JSON");
     assert_eq!(stdout["code"], "CLI_USAGE", "{stdout:#}");
+}
+
+fn create_workspace_index(
+    home: &std::path::Path,
+    workspace: &std::path::Path,
+    workspace_id: &str,
+    source_count: usize,
+) -> workspace_files::WorkspaceIndexFixture {
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let workspaces_data = default_install_root(home).join("state/workspaces");
+    std::fs::create_dir_all(workspaces_data.join("local")).expect("local workspace data");
+    std::fs::write(
+        workspaces_data.join("local-workspaces.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            workspace.display().to_string(): workspace_id
+        }))
+        .expect("workspace registry JSON"),
+    )
+    .expect("workspace registry");
+    let mut sanitized_workspace = String::new();
+    for character in workspace.display().to_string().chars() {
+        if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
+            sanitized_workspace.push(character);
+        } else if !sanitized_workspace.ends_with('-') {
+            sanitized_workspace.push('-');
+        }
+    }
+    let sanitized_workspace = sanitized_workspace
+        .trim_matches('-')
+        .chars()
+        .take(80)
+        .collect::<String>();
+    let database_path = workspaces_data
+        .join("local")
+        .join(format!("{sanitized_workspace}--{workspace_id}"))
+        .join("cache/source-index.db");
+    let index =
+        workspace_files::WorkspaceIndexFixture::at_database_path(&workspace, &database_path);
+    index.seed_high_cardinality_sources(source_count);
+    index.seed_progress(
+        "app",
+        "COMPLETE",
+        i64::try_from(source_count).expect("fixture source count fits i64"),
+        i64::try_from(source_count).expect("fixture source count fits i64"),
+    );
+    index
+}
+
+fn spawn_paged_workspace_files_backend(
+    home: &std::path::Path,
+    config_home: &std::path::Path,
+    workspace: &std::path::Path,
+    socket: &std::path::Path,
+    consumed_state: Option<serde_json::Value>,
+    issued_token: Option<&'static str>,
+) -> std::thread::JoinHandle<Vec<serde_json::Value>> {
+    let runtime = serde_json::json!({
+        "state": "READY",
+        "healthy": true,
+        "active": true,
+        "indexing": false,
+        "backendName": "idea",
+        "backendVersion": "scripted-test",
+        "workspaceRoot": workspace.display().to_string(),
+        "schemaVersion": 3
+    });
+    let capabilities = serde_json::json!({
+        "backendName": "idea",
+        "backendVersion": "scripted-test",
+        "workspaceRoot": workspace.display().to_string(),
+        "readCapabilities": ["WORKSPACE_FILES"],
+        "mutationCapabilities": [],
+        "limits": {
+            "requestTimeoutMillis": 60000,
+            "maxResults": 1000,
+            "maxConcurrentRequests": 4
+        },
+        "schemaVersion": 3
+    });
+    let source_root = workspace.join("src/main/kotlin");
+    let page = |range: std::ops::Range<usize>, next_page_token: Option<&str>| {
+        let files = range
+            .map(|index| {
+                source_root
+                    .join(format!("sample/Source{index:04}.kt"))
+                    .display()
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        serde_json::json!({
+            "snapshotToken": "snapshot-500",
+            "modules": [{
+                "name": "fixture.main",
+                "sourceRoots": [source_root.display().to_string()],
+                "contentRoots": [workspace.display().to_string()],
+                "dependencyModuleNames": [],
+                "returnedFileCount": files.len(),
+                "filesTruncated": next_page_token.is_some(),
+                "fileCount": 500,
+                "nextPageToken": next_page_token,
+                "files": files
+            }],
+            "schemaVersion": 3
+        })
+    };
+    let validation = serde_json::json!({
+        "snapshotToken": "snapshot-500",
+        "modules": [],
+        "schemaVersion": 3
+    });
+    let mut responses = vec![("runtime/status", runtime), ("capabilities", capabilities)];
+    if let Some(state) = consumed_state {
+        responses.push((
+            "raw/workspace-files-continuation",
+            serde_json::json!({"type": "CONSUMED", "state": state}),
+        ));
+    }
+    responses.extend([
+        (
+            "raw/workspace-files",
+            serde_json::json!({
+                "snapshotToken": "snapshot-500",
+                "modules": [{
+                    "name": "fixture.main",
+                    "sourceRoots": [source_root.display().to_string()],
+                    "contentRoots": [workspace.display().to_string()],
+                    "dependencyModuleNames": [],
+                    "returnedFileCount": 0,
+                    "filesTruncated": false,
+                    "fileCount": 500,
+                    "nextPageToken": null,
+                    "files": []
+                }],
+                "schemaVersion": 3
+            }),
+        ),
+        ("raw/workspace-files", page(0..200, Some("raw-page-2"))),
+        ("raw/workspace-files", page(200..400, Some("raw-page-3"))),
+        ("raw/workspace-files", page(400..500, None)),
+        ("raw/workspace-files", validation.clone()),
+        ("raw/workspace-files", validation),
+    ]);
+    if let Some(page_token) = issued_token {
+        responses.push((
+            "raw/workspace-files-continuation",
+            serde_json::json!({"type": "ISSUED", "pageToken": page_token}),
+        ));
+    }
+    spawn_sequenced_idea_backend(home, config_home, workspace, socket, responses)
+}
+
+fn run_workspace_files_page(
+    home: &std::path::Path,
+    config_home: &std::path::Path,
+    workspace: &std::path::Path,
+    page_token: Option<&str>,
+) -> std::process::Output {
+    let mut command = kast(home, config_home);
+    command.args([
+        "--output",
+        "json",
+        "agent",
+        "workspace-files",
+        "--workspace-root",
+        workspace.to_str().expect("UTF-8 workspace"),
+        "--backend",
+        "idea",
+        "--kind",
+        "source",
+        "--limit",
+        "200",
+        "--verbose",
+    ]);
+    if let Some(page_token) = page_token {
+        command.args(["--page-token", page_token]);
+    }
+    command.output().expect("workspace-files page")
+}
+
+fn workspace_files_issue_state(requests: &[serde_json::Value]) -> serde_json::Value {
+    requests
+        .iter()
+        .find(|request| {
+            request["method"] == "raw/workspace-files-continuation"
+                && request["params"]["action"] == "ISSUE"
+        })
+        .unwrap_or_else(|| panic!("missing workspace-files continuation issue: {requests:#?}"))
+        ["params"]["state"]
+        .clone()
+}
+
+fn spawn_small_mixed_workspace_files_backend(
+    home: &std::path::Path,
+    config_home: &std::path::Path,
+    workspace: &std::path::Path,
+    socket: &std::path::Path,
+) -> std::thread::JoinHandle<Vec<serde_json::Value>> {
+    let source_root = workspace.join("src/main/kotlin");
+    let module = |files: serde_json::Value, returned_file_count: usize| {
+        serde_json::json!({
+            "snapshotToken": "snapshot-mixed",
+            "modules": [{
+                "name": "fixture.main",
+                "sourceRoots": [source_root.display().to_string()],
+                "contentRoots": [workspace.display().to_string()],
+                "dependencyModuleNames": [],
+                "files": files,
+                "returnedFileCount": returned_file_count,
+                "filesTruncated": false,
+                "fileCount": 2,
+                "nextPageToken": null
+            }],
+            "schemaVersion": 3
+        })
+    };
+    let validation = serde_json::json!({
+        "snapshotToken": "snapshot-mixed",
+        "modules": [],
+        "schemaVersion": 3
+    });
+    spawn_scripted_idea_backend(
+        home,
+        config_home,
+        workspace,
+        socket,
+        vec![
+            ("raw/workspace-files", module(serde_json::json!([]), 0)),
+            (
+                "raw/workspace-files",
+                module(
+                    serde_json::json!([
+                        source_root.join("sample/Script.kts").display().to_string(),
+                        source_root
+                            .join("sample/Source0000.kt")
+                            .display()
+                            .to_string()
+                    ]),
+                    2,
+                ),
+            ),
+            ("raw/workspace-files", validation.clone()),
+            ("raw/workspace-files", validation),
+        ],
+    )
+}
+
+fn grouped_cardinality<'a>(
+    output: &'a serde_json::Value,
+    group: &str,
+    value: &str,
+) -> &'a serde_json::Value {
+    output["result"]["groupedCardinalities"][group]
+        .as_array()
+        .expect("grouped cardinalities")
+        .iter()
+        .find(|entry| entry["value"] == value)
+        .unwrap_or_else(|| panic!("missing {group}={value} group: {output:#}"))
+}
+
+#[test]
+fn exact_root_inventory_returns_a_bounded_compact_public_result() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let _index = create_workspace_index(&home, &workspace, "exact-inventory", 1);
+    let source = workspace.join("src/main/kotlin/sample/Source0000.kt");
+    let socket = temp.path().join("workspace-files.sock");
+    let module = |files: serde_json::Value, include_files: bool| {
+        serde_json::json!({
+            "snapshotToken": "snapshot-one",
+            "modules": [{
+                "name": "fixture.main",
+                "sourceRoots": [workspace.join("src/main/kotlin").display().to_string()],
+                "contentRoots": [workspace.display().to_string()],
+                "dependencyModuleNames": [],
+                "files": files,
+                "returnedFileCount": if include_files { 1 } else { 0 },
+                "filesTruncated": false,
+                "fileCount": 1,
+                "nextPageToken": null
+            }],
+            "schemaVersion": 3
+        })
+    };
+    let server = spawn_scripted_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket,
+        vec![
+            ("raw/workspace-files", module(serde_json::json!([]), false)),
+            (
+                "raw/workspace-files",
+                module(serde_json::json!([source.display().to_string()]), true),
+            ),
+            (
+                "raw/workspace-files",
+                serde_json::json!({
+                    "snapshotToken": "snapshot-one",
+                    "modules": [],
+                    "schemaVersion": 3
+                }),
+            ),
+            (
+                "raw/workspace-files",
+                serde_json::json!({
+                    "snapshotToken": "snapshot-one",
+                    "modules": [],
+                    "schemaVersion": 3
+                }),
+            ),
+        ],
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--kind",
+            "source",
+            "--limit",
+            "1",
+        ])
+        .output()
+        .expect("workspace-files command");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("workspace-files JSON result");
+    assert_eq!(stdout["method"], "agent/workspace-files", "{stdout:#}");
+    assert_eq!(
+        stdout["result"]["cardinality"]["type"], "EXACT",
+        "{stdout:#}"
+    );
+    assert_eq!(
+        stdout["result"]["cardinality"]["totalCount"], 1,
+        "{stdout:#}"
+    );
+    assert_eq!(stdout["result"]["returnedCount"], 1, "{stdout:#}");
+    assert_eq!(
+        stdout["result"]["files"][0]["relativePath"], "src/main/kotlin/sample/Source0000.kt",
+        "{stdout:#}"
+    );
+    assert_eq!(
+        stdout["result"]["files"][0]["kind"], "KOTLIN_SOURCE",
+        "{stdout:#}"
+    );
+    assert_eq!(
+        stdout["result"]["files"][0]["package"]["type"], "PROVEN_NAMED",
+        "{stdout:#}"
+    );
+    assert_eq!(
+        stdout["result"]["files"][0]["package"]["name"], "sample",
+        "{stdout:#}"
+    );
+    assert!(
+        !stdout["result"]["truncated"].as_bool().unwrap_or(true),
+        "{stdout:#}"
+    );
+
+    let requests = server.join().expect("scripted backend");
+    assert_eq!(requests.len(), 6, "one admitted raw session: {requests:#?}");
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request["method"] == "raw/workspace-files")
+            .count(),
+        4,
+        "{requests:#?}"
+    );
+}
+
+#[test]
+fn public_continuations_return_five_hundred_files_as_200_200_100_without_gaps() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let _index = create_workspace_index(&home, &workspace, "paged-inventory", 500);
+
+    let first_server = spawn_paged_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("page-1.sock"),
+        None,
+        Some("550e8400-e29b-41d4-a716-446655440001"),
+    );
+    let first_output = run_workspace_files_page(&home, &config_home, &workspace, None);
+    assert!(
+        first_output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&first_output.stdout),
+        String::from_utf8_lossy(&first_output.stderr),
+    );
+    let first: serde_json::Value =
+        serde_json::from_slice(&first_output.stdout).expect("first workspace-files page");
+    let first_requests = first_server.join().expect("first workspace-files backend");
+    let first_state = workspace_files_issue_state(&first_requests);
+
+    let second_server = spawn_paged_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("page-2.sock"),
+        Some(first_state),
+        Some("550e8400-e29b-41d4-a716-446655440002"),
+    );
+    let second_output = run_workspace_files_page(
+        &home,
+        &config_home,
+        &workspace,
+        Some("550e8400-e29b-41d4-a716-446655440001"),
+    );
+    assert!(
+        second_output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&second_output.stdout),
+        String::from_utf8_lossy(&second_output.stderr),
+    );
+    let second: serde_json::Value =
+        serde_json::from_slice(&second_output.stdout).expect("second workspace-files page");
+    let second_requests = second_server
+        .join()
+        .expect("second workspace-files backend");
+    let second_state = workspace_files_issue_state(&second_requests);
+
+    let third_server = spawn_paged_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("page-3.sock"),
+        Some(second_state),
+        None,
+    );
+    let third_output = run_workspace_files_page(
+        &home,
+        &config_home,
+        &workspace,
+        Some("550e8400-e29b-41d4-a716-446655440002"),
+    );
+    assert!(
+        third_output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&third_output.stdout),
+        String::from_utf8_lossy(&third_output.stderr),
+    );
+    let third: serde_json::Value =
+        serde_json::from_slice(&third_output.stdout).expect("third workspace-files page");
+    third_server.join().expect("third workspace-files backend");
+
+    let pages = [&first, &second, &third];
+    assert_eq!(
+        pages.map(|page| page["result"]["returnedCount"].as_u64()),
+        [Some(200), Some(200), Some(100)]
+    );
+    assert_eq!(
+        first["result"]["nextPageToken"],
+        "550e8400-e29b-41d4-a716-446655440001"
+    );
+    assert_eq!(
+        second["result"]["nextPageToken"],
+        "550e8400-e29b-41d4-a716-446655440002"
+    );
+    assert!(third["result"].get("nextPageToken").is_none(), "{third:#}");
+    for page in pages {
+        assert_eq!(page["result"]["cardinality"]["type"], "EXACT", "{page:#}");
+        assert_eq!(page["result"]["cardinality"]["totalCount"], 500, "{page:#}");
+        assert_eq!(
+            page["result"]["returnedCount"].as_u64(),
+            page["result"]["files"]
+                .as_array()
+                .map(|files| files.len() as u64),
+            "{page:#}"
+        );
+    }
+    let relative_paths = pages
+        .into_iter()
+        .flat_map(|page| {
+            page["result"]["files"]
+                .as_array()
+                .expect("workspace files")
+                .iter()
+                .map(|file| {
+                    file["relativePath"]
+                        .as_str()
+                        .expect("relative path")
+                        .to_string()
+                })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(relative_paths.len(), 500);
+    assert!(relative_paths.windows(2).all(|pair| pair[0] < pair[1]));
+    assert_eq!(
+        relative_paths.first().map(String::as_str),
+        Some("src/main/kotlin/sample/Source0000.kt")
+    );
+    assert_eq!(
+        relative_paths.last().map(String::as_str),
+        Some("src/main/kotlin/sample/Source0499.kt")
+    );
+}
+
+#[test]
+fn high_cardinality_default_compact_page_stays_within_agent_budget() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let _index = create_workspace_index(&home, &workspace, "compact-budget", 500);
+    let server = spawn_paged_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("compact-budget.sock"),
+        None,
+        Some("550e8400-e29b-41d4-a716-446655440003"),
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--kind",
+            "source",
+        ])
+        .output()
+        .expect("compact workspace-files page");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    server.join().expect("compact budget backend");
+    let raw = String::from_utf8(output.stdout).expect("compact UTF-8");
+    let stdout: serde_json::Value =
+        toon_format::decode_default(&raw).expect("compact default TOON");
+    assert_eq!(stdout["result"]["returnedCount"], 20);
+    let lines = raw.lines().count();
+    let tokens = tiktoken_rs::cl100k_base()
+        .expect("cl100k tokenizer")
+        .encode_with_special_tokens(&raw)
+        .len();
+    assert!(
+        lines <= 120,
+        "compact page used {lines} lines and {tokens} cl100k tokens; budgets are 120/1500"
+    );
+    assert!(
+        tokens <= 1_500,
+        "compact page used {tokens} cl100k tokens; budget is 1500"
+    );
+}
+
+#[test]
+fn mixed_count_keeps_the_script_group_exact_when_source_inventory_is_partial() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "mixed-count", 1);
+    index.seed_progress("app", "INDEXING", 1, 2);
+    let script = workspace.join("src/main/kotlin/sample/Script.kts");
+    std::fs::write(&script, "println(\"fixture\")\n").expect("Kotlin script");
+    let server = spawn_small_mixed_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("mixed-count.sock"),
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--count",
+        ])
+        .output()
+        .expect("mixed workspace-file count");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    server.join().expect("mixed count backend");
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("mixed count JSON");
+    assert_eq!(stdout["result"]["type"], "KAST_AGENT_WORKSPACE_FILES_COUNT");
+    assert_eq!(stdout["result"]["cardinality"]["type"], "KNOWN_MINIMUM");
+    assert_eq!(stdout["result"]["cardinality"]["knownMinimumCount"], 2);
+    assert_eq!(stdout["result"]["returnedCount"], 0);
+    assert!(stdout["result"].get("files").is_none(), "{stdout:#}");
+    assert_eq!(
+        grouped_cardinality(&stdout, "kind", "KOTLIN_SOURCE")["cardinality"]["type"],
+        "KNOWN_MINIMUM"
+    );
+    assert_eq!(
+        grouped_cardinality(&stdout, "kind", "KOTLIN_SCRIPT")["cardinality"],
+        serde_json::json!({"type": "EXACT", "totalCount": 1})
+    );
+    assert_eq!(
+        grouped_cardinality(&stdout, "index", "NOT_APPLICABLE")["cardinality"],
+        serde_json::json!({"type": "EXACT", "totalCount": 1})
+    );
+}
+
+#[test]
+fn selected_verbose_and_explain_views_add_only_their_typed_evidence() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "projection-views", 1);
+    index.seed_progress("app", "INDEXING", 1, 2);
+    std::fs::write(
+        workspace.join("src/main/kotlin/sample/Script.kts"),
+        "println(\"fixture\")\n",
+    )
+    .expect("Kotlin script");
+
+    for (view_name, view_args) in [
+        ("fields", vec!["--fields", "path,kind"]),
+        ("verbose", vec!["--verbose"]),
+        ("explain", vec!["--explain"]),
+    ] {
+        let server = spawn_small_mixed_workspace_files_backend(
+            &home,
+            &config_home,
+            &workspace,
+            &temp.path().join(format!("{view_name}.sock")),
+        );
+        let output = kast(&home, &config_home)
+            .args([
+                "--output",
+                "json",
+                "agent",
+                "workspace-files",
+                "--workspace-root",
+                workspace.to_str().expect("UTF-8 workspace"),
+                "--backend",
+                "idea",
+            ])
+            .args(view_args)
+            .output()
+            .expect("workspace-file projection");
+        assert!(
+            output.status.success(),
+            "view={view_name} stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        server.join().expect("projection backend");
+        let stdout: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("workspace-file projection JSON");
+        assert_eq!(
+            stdout["result"]["returnedCount"].as_u64(),
+            stdout["result"]["files"]
+                .as_array()
+                .map(|files| files.len() as u64),
+            "{stdout:#}"
+        );
+        match view_name {
+            "fields" => {
+                assert_eq!(
+                    stdout["result"]["type"],
+                    "KAST_AGENT_WORKSPACE_FILES_SELECTION"
+                );
+                for file in stdout["result"]["files"]
+                    .as_array()
+                    .expect("selected files")
+                {
+                    let keys = file
+                        .as_object()
+                        .expect("selected file")
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    assert_eq!(keys, vec!["filePath", "relativePath", "kind"]);
+                }
+                assert!(stdout["result"].get("backendPageCoverage").is_none());
+            }
+            "verbose" => {
+                assert_eq!(stdout["result"]["view"], "VERBOSE");
+                assert_eq!(
+                    stdout["result"]["backendPageCoverage"]["workspace"],
+                    "COMPLETE"
+                );
+                assert_eq!(
+                    stdout["result"]["backendPageCoverage"]["modules"][0],
+                    serde_json::json!({
+                        "moduleName": "fixture.main",
+                        "declaredFileCount": 2,
+                        "coverage": "COMPLETE"
+                    })
+                );
+                assert!(stdout["result"].get("classificationEvidence").is_none());
+                assert!(stdout["result"].get("normalizedQuery").is_none());
+            }
+            "explain" => {
+                assert_eq!(stdout["result"]["view"], "EXPLAIN");
+                assert!(stdout["result"]["normalizedQuery"].is_string());
+                assert!(stdout["result"]["compositionDigest"].is_string());
+                assert_eq!(
+                    stdout["result"]["classificationEvidence"]
+                        .as_array()
+                        .map(Vec::len),
+                    Some(2)
+                );
+                assert_eq!(
+                    stdout["result"]["classificationEvidence"][1]["package"],
+                    "PROVEN_NAMED"
+                );
+            }
+            _ => unreachable!("closed projection fixture"),
+        }
+    }
 }
 
 #[test]
@@ -461,8 +1239,10 @@ fn unavailable_error_has_structured_next_action_and_toon_stdout_discipline() {
     );
     let document: serde_json::Value =
         toon_format::decode_default(toon).expect("workspace-files TOON");
+    assert_eq!(document["error"]["code"], "SEMANTIC_WORKSPACE_UNSUPPORTED");
     assert_eq!(
-        document["error"]["code"], "WORKSPACE_FILE_DISCOVERY_UNAVAILABLE",
+        document["error"]["details"]["semanticWorkspace"]["nextActions"],
+        serde_json::json!([]),
         "{document:#}"
     );
     assert_eq!(

--- a/docs/reference/agent-commands.md
+++ b/docs/reference/agent-commands.md
@@ -113,9 +113,9 @@ filter-evidence `coverage`, typed `limitations`, and a schema version. Compact
 output is budgeted below 120 lines and 1,500 estimated tokens for the standard
 high-cardinality fixture.
 
-Each file contains:
+`files` groups only consecutive globally path-sorted records with identical
+typed evidence. Each group contains:
 
-- absolute `filePath` and workspace-relative `relativePath`;
 - every sorted backend owner and build-qualified indexed Gradle owner;
 - `KOTLIN_SOURCE` or `KOTLIN_SCRIPT`;
 - discriminated model-proven or unproven source-set evidence;
@@ -125,7 +125,12 @@ Each file contains:
 - `NONE`, `FILESYSTEM_ONLY`, `INDEX_ONLY`, `MISSING_ON_DISK`,
   `NOT_APPLICABLE`, or `UNKNOWN` drift;
 - typed clean, dirty, unknown, or not-applicable Git state; and
-- evidence sources when the selected projection requests them.
+- a `paths` array with the absolute `filePath` and workspace-relative
+  `relativePath` for each file sharing that evidence.
+
+Flattening `files[group].paths` reproduces the globally sorted page. Equal
+evidence separated by a different record remains in separate groups, so
+grouping never changes path order. `returnedCount` counts path rows, not groups.
 
 Candidate coverage is complete only when every authority relevant to the
 selected kind could add no path. Filter coverage is complete only when every
@@ -145,11 +150,11 @@ declaration semantics remain a separate Gradle DSL index surface.
 ### Result views
 
 `--fields` accepts `path,module,source-set,kind,package,index,drift,dirty,evidence`
-and keeps the common result metadata. `--count` removes file payloads and
-returns typed overall and grouped cardinalities. `--verbose` preserves the
-complete validated workspace-file evidence. `--explain` adds the normalized
-query and classification/coverage evidence. These four view choices are
-mutually exclusive.
+and returns flat per-file records with the common result metadata. `--count`
+removes file payloads and returns typed overall and grouped cardinalities.
+`--verbose` preserves flat per-file complete validated workspace-file evidence.
+`--explain` adds the normalized query and classification/coverage evidence.
+These four view choices are mutually exclusive.
 
 ### Public continuation failures
 
@@ -185,8 +190,10 @@ candidate authority is usable, the command fails with
 `WORKSPACE_FILE_DISCOVERY_UNAVAILABLE` instead of returning a false empty
 success.
 
-`filePath` is the direct input for `kast agent diagnostics --file-path <path>`
-and for `kast agent symbol --query <name> --file-hint <path>`.
+Use `files[group].paths[i].filePath` from the compact default, or select a flat
+record with `--fields path`. That `filePath` is the direct input for
+`kast agent diagnostics --file-path <path>` and for
+`kast agent symbol --query <name> --file-hint <path>`.
 
 ## Workspace-relative file paths
 

--- a/docs/use/inspect-kotlin.md
+++ b/docs/use/inspect-kotlin.md
@@ -20,8 +20,11 @@ kast agent workspace-files --workspace-root "$PWD"
 ```
 
 The default compact page contains at most 20 compiler/project-model or Kotlin
-source-index candidates. Narrow the inventory before paging. Filters combine
-with AND semantics:
+source-index candidates. It groups consecutive, globally path-sorted files that
+share identical typed evidence; each file path remains explicit at
+`files[group].paths[i].filePath` and
+`files[group].paths[i].relativePath`. Narrow the inventory before paging.
+Filters combine with AND semantics:
 
 ```console
 kast agent workspace-files \
@@ -65,7 +68,8 @@ not applicable: unrelated `.kt` indexing progress does not reduce a
 script-only result, while mixed results keep source and script coverage
 separate.
 
-Use the selected record without translating its path dialect:
+Use `files[group].paths[i].filePath` without translating its path dialect. For
+a flat per-file projection, add `--fields path` to the discovery command:
 
 ```console
 kast agent diagnostics \


### PR DESCRIPTION
## What

- Expose `kast agent workspace-files` as the public, typed workspace discovery command.
- Preserve exact-root admission, one admitted backend session, typed filters, continuation identity, and fail-closed limitation mapping.
- Add compact/count/selected/verbose/explain projections with globally sorted, evidence-preserving compact groups.
- Keep count and record projections consistent for `INDEXED`, complete-evidence `NOT_INDEXED`, and `NOT_APPLICABLE` states.
- Require complete backend coverage before a `backend:<module>` filter can claim complete negative-match evidence.
- Prove Gradle-module filter exactness only when typed index evidence can establish ownership or a definitive non-match.
- Reject malformed issued UUIDv4 tokens and stale/unstable resumed pages before availability classification or projection.
- Make indexed fixtures and post-admission typed error details portable across Linux and macOS.

## Why

This is stack 2 of 3 for #338. Agents need a stable semantic workspace-file surface instead of beginning with `rg`, `find`, or Git-only file lists.

Head: `d684ee0a36c61cf2996f0d0b27c65c12167bc8eb`
Base: `35c375fc125e60795aee1e85e42655b598f6f5bb`, including the macOS cache and mutation-status CI repairs.

## Verification

- TDD regression: a partial terminal backend page plus an index-supplied candidate now reports `filterEvidence: PARTIAL` and `KNOWN_MINIMUM(0)` for `backend:<module>`
- focused result projection: 13/13
- focused workspace-file surface: 32/32
- `cargo fmt --check`
- locked full-feature clippy with `-D warnings`
- full `cargo test --locked`
- `./gradlew test --no-daemon`
- `./gradlew buildIdeaPlugin --no-daemon`
- generated contract check: 143/143
- packaged content and source-index schema smoke tests
- Homebrew formula, Copilot, LSP pivot, routing 10/10, docs content/navigation, and Zensical build gates
- prior decisive CI run `29340232419`: green
- corrected-head CI: queued

The ambient macOS LSP probe first exposed external installed-authority drift (`MACOS_HOMEBREW_RECEIPT_VERSION_MISMATCH`). The checkout-authoritative rerun isolated the stale receipt without mutating global state and passed with the expected fail-closed `MACOS_PLUGIN_WORKSPACE_REQUIRED` outcome. Exact-root Kast semantic verification is unavailable because this linked worktree is not prepared by the IntelliJ plugin; no setup mutation was attempted.

Part of #338. Catalog wire-contract hardening remains in #357.