### PR TITLE
fix: harden workspace file RPC catalog

### DIFF
--- a/.github/scripts/render-rpc-contract-summary.py
+++ b/.github/scripts/render-rpc-contract-summary.py
@@ -163,6 +163,54 @@ def required_fields(spec: dict[str, Any]) -> set[str]:
     return set(required)
 
 
+def request_variants(spec: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    variants = spec.get("variants")
+    if variants is None:
+        return {}
+    if not isinstance(variants, dict) or not variants:
+        raise ValueError(f"{spec.get('method')} variants must be a non-empty object")
+    if not all(
+        isinstance(name, str) and name and isinstance(request, dict)
+        for name, request in variants.items()
+    ):
+        raise ValueError(f"{spec.get('method')} variants must map names to request objects")
+    return variants
+
+
+def variant_param_rows(spec: dict[str, Any]) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for variant_name, request in request_variants(spec).items():
+        context = {"method": f"{spec.get('method')}.{variant_name}", "request": request}
+        fields = fields_for(context)
+        required = required_fields(context)
+        rows.append(
+            [
+                f"`{variant_name}`",
+                param_list([name for name in fields if name in required]),
+                param_list([name for name in fields if name not in required]),
+            ]
+        )
+    return rows
+
+
+def summarized_required_params(
+    spec: dict[str, Any],
+    fields: dict[str, Any],
+    required: set[str],
+) -> str:
+    values = [f"`{name}`" for name in fields if name in required]
+    for variant_name, variant_request in request_variants(spec).items():
+        context = {
+            "method": f"{spec.get('method')}.{variant_name}",
+            "request": variant_request,
+        }
+        variant_fields = fields_for(context)
+        variant_required = required_fields(context)
+        names = ", ".join(f"`{name}`" for name in variant_fields if name in variant_required)
+        values.append(f"`{variant_name}`: {names or 'none'}")
+    return "<br>".join(values) if values else "none"
+
+
 def type_label(field: dict[str, Any]) -> str:
     base = str(field.get("type", "unknown"))
     if base == "array":
@@ -309,7 +357,7 @@ def render_summary(catalog: dict[str, Any]) -> str:
                 f"`{spec.get('category', '')}`",
                 spec.get("dataSource", ""),
                 spec.get("summary", ""),
-                param_list([name for name in fields if name in required]),
+                summarized_required_params(spec, fields, required),
                 param_list(optional),
                 f"`{spec.get('responseType', 'none')}`",
                 response_variants(spec),
@@ -367,6 +415,16 @@ def render_summary(catalog: dict[str, Any]) -> str:
             lines.extend(render_table(["Field", "Type", "Required", "Nullable", "Values"], detail_rows))
         else:
             lines.append("No request parameters.")
+        variant_rows = variant_param_rows(spec)
+        if variant_rows:
+            lines.extend(
+                [
+                    "",
+                    "Request variants:",
+                    "",
+                    *render_table(["Variant", "Required params", "Optional params"], variant_rows),
+                ]
+            )
         lines.extend(
             [
                 "",

--- a/analysis-api/build.gradle.kts
+++ b/analysis-api/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.testing.Test
+
 plugins {
     id("kast.published-library")
     id("kast.kotlin-serialization")
@@ -14,6 +17,16 @@ dependencies {
     implementation(libs.bundles.coroutines)
     testImplementation(libs.json.schema.validator)
     testFixturesImplementation(libs.jimfs)
+}
+
+val workspaceFilesContinuationSamples = rootProject.layout.projectDirectory.dir(
+    "cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation",
+)
+
+tasks.named<Test>("test") {
+    inputs.dir(workspaceFilesContinuationSamples)
+        .withPropertyName("workspaceFilesContinuationSamples")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
 tasks.register<JavaExec>("generateOpenApiSpec") {

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspaceFilesContinuationContractTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspaceFilesContinuationContractTest.kt
@@ -9,6 +9,7 @@ import io.github.amichne.kast.api.protocol.InvalidWorkspaceFilesPageTokenExcepti
 import io.github.amichne.kast.api.validation.WorkspaceFilesPublicPageToken
 import java.nio.file.Path
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -27,6 +28,29 @@ class WorkspaceFilesContinuationContractTest {
         }
         assertThrows(IllegalArgumentException::class.java) {
             Json.decodeFromString(WorkspaceFilesPublicPageToken.serializer(), "\"not-a-handle\"")
+        }
+    }
+
+    @Test
+    fun `generated continuation request samples cross the typed request boundary`() {
+        val repoRoot = generateSequence(Path.of("").toAbsolutePath()) { it.parent }
+            .first { java.nio.file.Files.isDirectory(it.resolve("cli-rs")) }
+        val samplesRoot = repoRoot.resolve(
+            "cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation",
+        )
+
+        for (variant in listOf("ISSUE", "CONSUME")) {
+            for (shape in listOf("minimal", "maximal")) {
+                val request = Json.parseToJsonElement(
+                    java.nio.file.Files.readString(samplesRoot.resolve("$variant/$shape.json")),
+                ).jsonObject
+                val query = Json.decodeFromString(
+                    WorkspaceFilesContinuationQuery.serializer(),
+                    request.getValue("params").toString(),
+                )
+
+                query.parsed()
+            }
         }
     }
 

--- a/cli-rs/protocol/api-specification.md
+++ b/cli-rs/protocol/api-specification.md
@@ -86,17 +86,17 @@ uses a discriminated response envelope.
 | `runtime/shutdown` | `system` | backend | Ask the runtime host to shut down after this response is flushed | none | none | `RuntimeLifecycleResponse` | single result |
 | `runtime/restart` | `system` | backend | Ask the runtime host to restart after this response is flushed | none | none | `RuntimeLifecycleResponse` | single result |
 | `capabilities` | `system` | backend | Advertised read and mutation capabilities | none | none | `BackendCapabilities` | single result |
-| `mutation/submit` | `mutation` | backend | Submit an idempotent semantic mutation and return its stable operation identity | `type` | none | `KastMutationSubmissionReceipt` | single result |
-| `mutation/status` | `mutation` | backend | Retrieve retained semantic mutation state by operation identity or idempotency key | `type` | none | `KastMutationOperationSnapshot` | single result |
-| `mutation/cancel` | `mutation` | backend | Request cooperative cancellation and retrieve the latest semantic mutation state | `type` | none | `KastMutationOperationSnapshot` | single result |
+| `mutation/submit` | `mutation` | backend | Submit an idempotent semantic mutation and return its stable operation identity | `type`<br>`RENAME`: `idempotencyKey`, `request`<br>`ADD_FILE`: `idempotencyKey`, `request`<br>`ADD_DECLARATION`: `idempotencyKey`, `request`<br>`ADD_IMPLEMENTATION`: `idempotencyKey`, `request`<br>`ADD_STATEMENT`: `idempotencyKey`, `request`<br>`REPLACE_DECLARATION`: `idempotencyKey`, `request` | none | `KastMutationSubmissionReceipt` | single result |
+| `mutation/status` | `mutation` | backend | Retrieve retained semantic mutation state by operation identity or idempotency key | `type`<br>`BY_OPERATION_ID`: `operationId`<br>`BY_IDEMPOTENCY_KEY`: `idempotencyKey` | none | `KastMutationOperationSnapshot` | single result |
+| `mutation/cancel` | `mutation` | backend | Request cooperative cancellation and retrieve the latest semantic mutation state | `type`<br>`BY_OPERATION_ID`: `operationId`<br>`BY_IDEMPOTENCY_KEY`: `idempotencyKey` | none | `KastMutationOperationSnapshot` | single result |
 | `symbol/scaffold` | `symbol` | backend | Gather structural generation context for a Kotlin file | `targetFile` | `workspaceRoot`<br>`targetSymbol`<br>`mode`<br>`kind` | `KastScaffoldResponse` | `SCAFFOLD_SUCCESS`<br>`SCAFFOLD_FAILURE` |
 | `symbol/discover` | `symbol` | backend | Rank candidate declarations for a simple symbol name | `symbol` | `workspaceRoot`<br>`fileHint`<br>`line`<br>`codeSnippet`<br>`kind`<br>`containingType`<br>`maxResults`<br>`includeDeclarationScope` | `KastDiscoverResponse` | `DISCOVER_SUCCESS`<br>`DISCOVER_FAILURE` |
 | `symbol/query` | `symbol` | sqlite | Query compiler-indexed declarations with symbolic hard filters, fielded lexical/name matching, bounded graph relationship evidence, and optional semantic discovery evidence | `query` | `workspaceRoot`<br>`modes`<br>`filters`<br>`anchor`<br>`graph`<br>`semantic`<br>`limit`<br>`includeEvidence`<br>`includeNextRequests` | `KastSymbolQueryResponse` | `SYMBOL_QUERY_SUCCESS`<br>`SYMBOL_QUERY_FAILURE` |
 | `symbol/resolve` | `symbol` | backend | Resolve an exact simple or fully-qualified symbol identity with hard constraints and typed expected outcomes | `symbol` | `workspaceRoot`<br>`fileHint`<br>`kind`<br>`containingType`<br>`includeDeclarationScope`<br>`includeDocumentation`<br>`surroundingLines`<br>`includeSurroundingMembers` | `KastResolveResponse` | `RESOLVE_SUCCESS`<br>`RESOLVE_NOT_FOUND`<br>`RESOLVE_AMBIGUOUS`<br>`RESOLVE_FAILURE` |
 | `symbol/references` | `symbol` | backend | Find every usage of a Kotlin symbol | `symbol` | `workspaceRoot`<br>`fileHint`<br>`kind`<br>`containingType`<br>`includeDeclaration`<br>`maxResults`<br>`pageToken` | `KastReferencesResponse` | `REFERENCES_SUCCESS`<br>`REFERENCES_FAILURE` |
 | `symbol/callers` | `symbol` | backend | Expand an incoming or outgoing call hierarchy | `symbol` | `workspaceRoot`<br>`fileHint`<br>`kind`<br>`containingType`<br>`direction`<br>`depth`<br>`maxTotalCalls`<br>`maxChildrenPerNode`<br>`timeoutMillis` | `KastCallersResponse` | `CALLERS_SUCCESS`<br>`CALLERS_FAILURE` |
-| `symbol/rename` | `symbol` | backend | Resolve or target a symbol and apply a rename | `type` | none | `KastRenameResponse` | `RENAME_SUCCESS`<br>`RENAME_FAILURE` |
-| `symbol/write-and-validate` | `symbol` | backend | Apply generated Kotlin code and validate the result | `type` | none | `KastWriteAndValidateResponse` | `WRITE_AND_VALIDATE_SUCCESS`<br>`WRITE_AND_VALIDATE_FAILURE` |
+| `symbol/rename` | `symbol` | backend | Resolve or target a symbol and apply a rename | `type`<br>`RENAME_BY_SYMBOL_REQUEST`: `symbol`, `newName`<br>`RENAME_BY_OFFSET_REQUEST`: `filePath`, `offset`, `newName` | none | `KastRenameResponse` | `RENAME_SUCCESS`<br>`RENAME_FAILURE` |
+| `symbol/write-and-validate` | `symbol` | backend | Apply generated Kotlin code and validate the result | `type`<br>`CREATE_FILE_REQUEST`: `filePath`<br>`INSERT_AT_OFFSET_REQUEST`: `filePath`, `offset`<br>`REPLACE_RANGE_REQUEST`: `filePath`, `startOffset`, `endOffset` | none | `KastWriteAndValidateResponse` | `WRITE_AND_VALIDATE_SUCCESS`<br>`WRITE_AND_VALIDATE_FAILURE` |
 | `symbol/add-file` | `symbol` | backend | Create a Kotlin file from a content file and validate the result | `filePath`<br>`contentFile` | `workspaceRoot` | `KastScopeMutationResponse` | `SCOPE_MUTATION_SUCCESS`<br>`SCOPE_MUTATION_FAILURE` |
 | `symbol/add-declaration` | `symbol` | backend | Insert declaration content into a file or named Kotlin scope and validate the result | `placement`<br>`contentFile` | `workspaceRoot` | `KastScopeMutationResponse` | `SCOPE_MUTATION_SUCCESS`<br>`SCOPE_MUTATION_FAILURE` |
 | `symbol/add-implementation` | `symbol` | backend | Insert implementation content into a file or named Kotlin scope and validate the result | `placement`<br>`contentFile` | `workspaceRoot` | `KastScopeMutationResponse` | `SCOPE_MUTATION_SUCCESS`<br>`SCOPE_MUTATION_FAILURE` |
@@ -116,7 +116,7 @@ uses a discriminated response envelope.
 | `raw/workspace-symbol` | `raw` | backend | Search the workspace for symbols by name pattern | `pattern` | `kind`<br>`maxResults`<br>`regex`<br>`includeDeclarationScope` | `WorkspaceSymbolResult` | single result |
 | `raw/workspace-search` | `raw` | backend | Search workspace file contents by text or regex | `pattern` | `regex`<br>`maxResults`<br>`fileGlob`<br>`caseSensitive` | `WorkspaceSearchResult` | single result |
 | `raw/workspace-files` | `raw` | backend | List generation-bound workspace modules and Kotlin file pages | none | `kindDomain`<br>`moduleName`<br>`includeFiles`<br>`maxFilesPerModule`<br>`snapshotToken`<br>`pageToken` | `WorkspaceFilesResult` | single result |
-| `raw/workspace-files-continuation` | `raw` | backend | Issue or consume server-held public workspace-file continuation state | `action` | none | `WorkspaceFilesContinuationResult` | `ISSUED`<br>`CONSUMED` |
+| `raw/workspace-files-continuation` | `raw` | backend | Issue or consume server-held public workspace-file continuation state | `action`<br>`ISSUE`: `identity`, `state`<br>`CONSUME`: `identity`, `pageToken` | none | `WorkspaceFilesContinuationResult` | `ISSUED`<br>`CONSUMED` |
 | `raw/implementations` | `raw` | backend | Find concrete implementations and subclasses for a declaration | `position` | `maxResults` | `ImplementationsResult` | single result |
 | `raw/code-actions` | `raw` | backend | Return available code actions at a file position | `position` | `diagnosticCode` | `CodeActionsResult` | single result |
 | `raw/completions` | `raw` | backend | Return completion candidates available at a file position | `position` | `maxResults`<br>`kindFilter` | `CompletionsResult` | single result |
@@ -178,6 +178,17 @@ Response type: `BackendCapabilities`.
 | --- | --- | --- | --- | --- |
 | `type` | `string` | yes | no | `RENAME`<br>`ADD_FILE`<br>`ADD_DECLARATION`<br>`ADD_IMPLEMENTATION`<br>`ADD_STATEMENT`<br>`REPLACE_DECLARATION` |
 
+Request variants:
+
+| Variant | Required params | Optional params |
+| --- | --- | --- |
+| `RENAME` | `idempotencyKey`<br>`request` | none |
+| `ADD_FILE` | `idempotencyKey`<br>`request` | none |
+| `ADD_DECLARATION` | `idempotencyKey`<br>`request` | none |
+| `ADD_IMPLEMENTATION` | `idempotencyKey`<br>`request` | none |
+| `ADD_STATEMENT` | `idempotencyKey`<br>`request` | none |
+| `REPLACE_DECLARATION` | `idempotencyKey`<br>`request` | none |
+
 Response type: `KastMutationSubmissionReceipt`.
 
 </details>
@@ -189,6 +200,13 @@ Response type: `KastMutationSubmissionReceipt`.
 | --- | --- | --- | --- | --- |
 | `type` | `string` | yes | no | `BY_OPERATION_ID`<br>`BY_IDEMPOTENCY_KEY` |
 
+Request variants:
+
+| Variant | Required params | Optional params |
+| --- | --- | --- |
+| `BY_OPERATION_ID` | `operationId` | none |
+| `BY_IDEMPOTENCY_KEY` | `idempotencyKey` | none |
+
 Response type: `KastMutationOperationSnapshot`.
 
 </details>
@@ -199,6 +217,13 @@ Response type: `KastMutationOperationSnapshot`.
 | Field | Type | Required | Nullable | Values |
 | --- | --- | --- | --- | --- |
 | `type` | `string` | yes | no | `BY_OPERATION_ID`<br>`BY_IDEMPOTENCY_KEY` |
+
+Request variants:
+
+| Variant | Required params | Optional params |
+| --- | --- | --- |
+| `BY_OPERATION_ID` | `operationId` | none |
+| `BY_IDEMPOTENCY_KEY` | `idempotencyKey` | none |
 
 Response type: `KastMutationOperationSnapshot`.
 
@@ -363,6 +388,13 @@ Notes:
 | --- | --- | --- | --- | --- |
 | `type` | `string` | yes | no | `RENAME_BY_SYMBOL_REQUEST`<br>`RENAME_BY_OFFSET_REQUEST` |
 
+Request variants:
+
+| Variant | Required params | Optional params |
+| --- | --- | --- |
+| `RENAME_BY_SYMBOL_REQUEST` | `symbol`<br>`newName` | `workspaceRoot`<br>`fileHint`<br>`kind`<br>`containingType` |
+| `RENAME_BY_OFFSET_REQUEST` | `filePath`<br>`offset`<br>`newName` | `workspaceRoot` |
+
 Response type: `KastRenameResponse`.
 Result variants: `RENAME_SUCCESS`, `RENAME_FAILURE`.
 
@@ -374,6 +406,14 @@ Result variants: `RENAME_SUCCESS`, `RENAME_FAILURE`.
 | Field | Type | Required | Nullable | Values |
 | --- | --- | --- | --- | --- |
 | `type` | `string` | yes | no | `CREATE_FILE_REQUEST`<br>`INSERT_AT_OFFSET_REQUEST`<br>`REPLACE_RANGE_REQUEST` |
+
+Request variants:
+
+| Variant | Required params | Optional params |
+| --- | --- | --- |
+| `CREATE_FILE_REQUEST` | `filePath` | `workspaceRoot`<br>`content`<br>`contentFile` |
+| `INSERT_AT_OFFSET_REQUEST` | `filePath`<br>`offset` | `workspaceRoot`<br>`content`<br>`contentFile` |
+| `REPLACE_RANGE_REQUEST` | `filePath`<br>`startOffset`<br>`endOffset` | `workspaceRoot`<br>`content`<br>`contentFile` |
 
 Response type: `KastWriteAndValidateResponse`.
 Result variants: `WRITE_AND_VALIDATE_SUCCESS`, `WRITE_AND_VALIDATE_FAILURE`.
@@ -667,6 +707,13 @@ Notes:
 | Field | Type | Required | Nullable | Values |
 | --- | --- | --- | --- | --- |
 | `action` | `string` | yes | no | `ISSUE`<br>`CONSUME` |
+
+Request variants:
+
+| Variant | Required params | Optional params |
+| --- | --- | --- |
+| `ISSUE` | `identity`<br>`state` | none |
+| `CONSUME` | `identity`<br>`pageToken` | none |
 
 Response type: `WorkspaceFilesContinuationResult`.
 Result variants: `ISSUED`, `CONSUMED`.

--- a/cli-rs/resources/kast-skill/references/commands.json
+++ b/cli-rs/resources/kast-skill/references/commands.json
@@ -2105,13 +2105,15 @@
             "type": "string",
             "optional": true,
             "nullable": true,
-            "description": "Opaque reusable generation-bound workspace snapshot handle returned by the metadata request."
+            "description": "Opaque reusable generation-bound workspace snapshot handle returned by the metadata request.",
+            "sample": "00000000-0000-4000-8000-000000000338"
           },
           "pageToken": {
             "type": "string",
             "optional": true,
             "nullable": true,
-            "description": "Opaque single-use exact-module page handle returned as nextPageToken by the preceding page."
+            "description": "Opaque single-use exact-module page handle returned as nextPageToken by the preceding page.",
+            "sample": "00000000-0000-4000-8000-000000000339"
           }
         }
       },
@@ -2208,7 +2210,8 @@
                   ]
                 },
                 "compositionStampDigest": {
-                  "type": "string"
+                  "type": "string",
+                  "sample": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 },
                 "lastRelativePath": {
                   "type": "string"
@@ -2260,7 +2263,8 @@
               ]
             },
             "pageToken": {
-              "type": "string"
+              "type": "string",
+              "sample": "00000000-0000-4000-8000-000000000340"
             }
           },
           "required": [

--- a/cli-rs/resources/kast-skill/references/commands.schema.json
+++ b/cli-rs/resources/kast-skill/references/commands.schema.json
@@ -89,6 +89,7 @@
         },
         "variants": {
           "type": "object",
+          "minProperties": 1,
           "additionalProperties": {
             "$ref": "#/$defs/request"
           }
@@ -103,7 +104,17 @@
         "tool": {
           "$ref": "#/$defs/tool"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["variantDiscriminator"]
+          },
+          "then": {
+            "required": ["variants"]
+          }
+        }
+      ]
     },
     "request": {
       "type": "object",
@@ -178,6 +189,9 @@
             "$ref": "#/$defs/fieldName"
           },
           "uniqueItems": true
+        },
+        "sample": {
+          "description": "Concrete value used by generated request samples when the field shape alone cannot produce a valid wire value."
         }
       }
     },

--- a/cli-rs/resources/kast-skill/references/commands.schema.json
+++ b/cli-rs/resources/kast-skill/references/commands.schema.json
@@ -74,6 +74,15 @@
           "type": "string",
           "pattern": "^[A-Z][A-Z0-9_]*$"
         },
+        "failureReasons": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Z0-9_]*$"
+          }
+        },
         "responseVariants": {
           "type": "array",
           "minItems": 1,

--- a/cli-rs/resources/kast-skill/references/commands.yaml
+++ b/cli-rs/resources/kast-skill/references/commands.yaml
@@ -669,11 +669,13 @@ commands:
           description: Opaque single-use exact-module page handle returned as nextPageToken by the preceding page.
           nullable: true
           optional: true
+          sample: 00000000-0000-4000-8000-000000000339
           type: string
         snapshotToken:
           description: Opaque reusable generation-bound workspace snapshot handle returned by the metadata request.
           nullable: true
           optional: true
+          sample: 00000000-0000-4000-8000-000000000338
           type: string
     responseType: WorkspaceFilesResult
     summary: List generation-bound workspace modules and Kotlin file pages
@@ -726,6 +728,7 @@ commands:
             - limit
             type: object
           pageToken:
+            sample: 00000000-0000-4000-8000-000000000340
             type: string
         required:
         - identity
@@ -754,6 +757,7 @@ commands:
           state:
             fields:
               compositionStampDigest:
+                sample: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
                 type: string
               cumulativeReturnedCount:
                 type: integer

--- a/cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation/CONSUME/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation/CONSUME/maximal.json
@@ -11,6 +11,6 @@
       "projection": "example-projection",
       "workspaceRoot": "/absolute/path/to/workspace"
     },
-    "pageToken": "example-pageToken"
+    "pageToken": "00000000-0000-4000-8000-000000000340"
   }
 }

--- a/cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation/CONSUME/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation/CONSUME/minimal.json
@@ -11,6 +11,6 @@
       "projection": "example-projection",
       "workspaceRoot": "/absolute/path/to/workspace"
     },
-    "pageToken": "example-pageToken"
+    "pageToken": "00000000-0000-4000-8000-000000000340"
   }
 }

--- a/cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation/ISSUE/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation/ISSUE/maximal.json
@@ -12,7 +12,7 @@
       "workspaceRoot": "/absolute/path/to/workspace"
     },
     "state": {
-      "compositionStampDigest": "example-compositionStampDigest",
+      "compositionStampDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "cumulativeReturnedCount": 1,
       "identity": {
         "backendName": "example-backendName",

--- a/cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation/ISSUE/minimal.json
+++ b/cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation/ISSUE/minimal.json
@@ -12,7 +12,7 @@
       "workspaceRoot": "/absolute/path/to/workspace"
     },
     "state": {
-      "compositionStampDigest": "example-compositionStampDigest",
+      "compositionStampDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "cumulativeReturnedCount": 1,
       "identity": {
         "backendName": "example-backendName",

--- a/cli-rs/resources/kast-skill/references/requests/raw/workspace-files/maximal.json
+++ b/cli-rs/resources/kast-skill/references/requests/raw/workspace-files/maximal.json
@@ -7,7 +7,7 @@
     "kindDomain": "MIXED",
     "maxFilesPerModule": 25,
     "moduleName": ":analysis-api",
-    "pageToken": "example-pageToken",
-    "snapshotToken": "example-snapshotToken"
+    "pageToken": "00000000-0000-4000-8000-000000000339",
+    "snapshotToken": "00000000-0000-4000-8000-000000000338"
   }
 }

--- a/cli-rs/src/catalog_schema.rs
+++ b/cli-rs/src/catalog_schema.rs
@@ -54,6 +54,19 @@ pub fn request_schema_for_command(method: &str, command: &Value) -> Result<Value
 }
 
 fn params_schema(command: &Value, method: &str) -> Result<Value> {
+    if command.get("variantDiscriminator").is_some()
+        && command
+            .get("variants")
+            .and_then(Value::as_object)
+            .is_none_or(Map::is_empty)
+    {
+        return Err(CliError::new(
+            "RPC_CATALOG_INVALID",
+            format!(
+                "Variant method `{method}` with an explicit variantDiscriminator must define non-empty variants."
+            ),
+        ));
+    }
     match command.get("variants").and_then(Value::as_object) {
         Some(variants) if !variants.is_empty() => {
             let discriminator = variant_discriminator(command, method)?;
@@ -192,7 +205,10 @@ pub(crate) fn variant_discriminator(command: &Value, method: &str) -> Result<Str
             )
         })?;
     let variant_names = variants.keys().map(String::as_str).collect();
-    if enum_names != variant_names {
+    if enum_names.len() != enum_values.len()
+        || enum_names.len() != variants.len()
+        || enum_names != variant_names
+    {
         return Err(CliError::new(
             "RPC_CATALOG_INVALID",
             format!(
@@ -602,6 +618,74 @@ mod tests {
             assert_eq!(error.code, "RPC_CATALOG_INVALID");
             assert!(error.message.contains("non-empty string"));
         }
+    }
+
+    #[test]
+    fn explicit_variant_discriminator_requires_a_non_empty_variant_map() {
+        for (description, variants) in [
+            ("missing", None),
+            ("empty", Some(json!({}))),
+            ("non-object", Some(json!([]))),
+        ] {
+            let mut command = json!({
+                "variantDiscriminator": "action",
+                "request": {
+                    "fields": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["ISSUE"]
+                        }
+                    },
+                    "required": ["action"]
+                }
+            });
+            if let Some(variants) = variants {
+                command["variants"] = variants;
+            }
+            let catalog = json!({
+                "commands": {
+                    "raw/workspace-files-continuation": command
+                }
+            });
+
+            let failure = format!("{description} variants must fail closed");
+            let error =
+                request_schema(&catalog, "raw/workspace-files-continuation").expect_err(&failure);
+
+            assert_eq!(error.code, "RPC_CATALOG_INVALID", "{description}");
+            assert!(error.message.contains("non-empty variants"), "{error:?}");
+        }
+    }
+
+    #[test]
+    fn variant_discriminator_enum_rejects_duplicate_variant_names() {
+        let catalog = json!({
+            "commands": {
+                "raw/workspace-files-continuation": {
+                    "variantDiscriminator": "action",
+                    "request": {
+                        "fields": {
+                            "action": {
+                                "type": "string",
+                                "enum": ["ISSUE", "ISSUE"]
+                            }
+                        },
+                        "required": ["action"]
+                    },
+                    "variants": {
+                        "ISSUE": {
+                            "fields": {}
+                        }
+                    }
+                }
+            }
+        });
+
+        let error = request_schema(&catalog, "raw/workspace-files-continuation")
+            .expect_err("duplicate variant enum entries must fail closed");
+
+        assert_eq!(error.code, "RPC_CATALOG_INVALID");
+        assert!(error.message.contains("exactly once"), "{error:?}");
     }
 
     #[test]

--- a/cli-rs/tests/rpc_catalog_smoke.rs
+++ b/cli-rs/tests/rpc_catalog_smoke.rs
@@ -247,6 +247,8 @@ fn command_catalog_is_schema_backed_and_self_consistent() {
     );
 
     let catalog = catalog();
+    let catalog_schema = schema_value("resources/kast-skill/references/commands.schema.json");
+    assert_valid(&catalog_schema, &catalog);
     assert_eq!(catalog["$schema"], "./commands.schema.json");
 
     let commands = catalog["commands"].as_object().expect("commands object");
@@ -480,6 +482,77 @@ fn workspace_files_continuation_catalog_declares_issue_and_consume_variants() {
         assert_eq!(sample["params"]["action"], expected_action);
         assert!(sample["params"].get("type").is_none());
     }
+}
+
+#[test]
+fn workspace_file_catalog_samples_use_typed_token_and_digest_wire_values() {
+    let raw_maximal =
+        schema_value("resources/kast-skill/references/requests/raw/workspace-files/maximal.json");
+    assert_canonical_uuid(
+        &raw_maximal["params"]["snapshotToken"],
+        "raw snapshot token",
+    );
+    assert_canonical_uuid(&raw_maximal["params"]["pageToken"], "raw page token");
+
+    for variant in ["minimal", "maximal"] {
+        let issue = schema_value(&format!(
+            "resources/kast-skill/references/requests/raw/workspace-files-continuation/ISSUE/{variant}.json"
+        ));
+        assert_lowercase_sha256(
+            &issue["params"]["state"]["compositionStampDigest"],
+            "continuation composition stamp",
+        );
+
+        let consume = schema_value(&format!(
+            "resources/kast-skill/references/requests/raw/workspace-files-continuation/CONSUME/{variant}.json"
+        ));
+        assert_canonical_uuid(&consume["params"]["pageToken"], "public continuation token");
+    }
+}
+
+#[test]
+fn api_specification_documents_variant_specific_required_fields() {
+    let specification = include_str!("../protocol/api-specification.md");
+    let continuation = specification
+        .split_once(
+            "<summary><code>raw/workspace-files-continuation</code> - Issue or consume server-held public workspace-file continuation state</summary>",
+        )
+        .expect("workspace-files continuation details")
+        .1
+        .split_once("</details>")
+        .expect("workspace-files continuation details end")
+        .0;
+
+    assert!(
+        continuation.contains("| `ISSUE` | `identity`<br>`state` | none |"),
+        "ISSUE requirements must be rendered: {continuation}"
+    );
+    assert!(
+        continuation.contains("| `CONSUME` | `identity`<br>`pageToken` | none |"),
+        "CONSUME requirements must be rendered: {continuation}"
+    );
+}
+
+fn assert_canonical_uuid(value: &Value, context: &str) {
+    let value = value
+        .as_str()
+        .unwrap_or_else(|| panic!("{context} must be a string: {value}"));
+    let parsed = uuid::Uuid::parse_str(value)
+        .unwrap_or_else(|error| panic!("{context} must be a UUID: {value}: {error}"));
+    assert_eq!(parsed.to_string(), value, "{context} must be canonical");
+}
+
+fn assert_lowercase_sha256(value: &Value, context: &str) {
+    let value = value
+        .as_str()
+        .unwrap_or_else(|| panic!("{context} must be a string: {value}"));
+    assert_eq!(value.len(), 64, "{context} must contain 64 hex digits");
+    assert!(
+        value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "{context} must be lowercase hexadecimal: {value}"
+    );
 }
 
 #[test]

--- a/cli-rs/tests/rpc_catalog_smoke.rs
+++ b/cli-rs/tests/rpc_catalog_smoke.rs
@@ -300,6 +300,19 @@ fn command_catalog_is_schema_backed_and_self_consistent() {
 }
 
 #[test]
+fn command_catalog_schema_rejects_unrecognized_command_properties() {
+    let catalog_schema = schema_value("resources/kast-skill/references/commands.schema.json");
+    let validator = jsonschema::validator_for(&catalog_schema).expect("schema compiles");
+    let mut invalid_catalog = catalog();
+    invalid_catalog["commands"]["symbol/query"]["unrecognized"] = Value::Bool(true);
+
+    assert!(
+        validator.validate(&invalid_catalog).is_err(),
+        "declaring failureReasons must not weaken command additional-property checks"
+    );
+}
+
+#[test]
 fn symbol_query_catalog_documents_relevance_filters() {
     let catalog = catalog();
     let filters = &catalog["commands"]["symbol/query"]["request"]["fields"]["filters"]["fields"];
@@ -624,6 +637,15 @@ fn agent_tool_surface_exposes_navigation_without_internal_transport_leaks() {
             && metrics_description.contains("impact questions"),
         "database/metrics should disclose source-index database access: {metrics_description}"
     );
+}
+
+#[test]
+fn installed_skill_teaches_public_workspace_files_without_raw_continuation() {
+    let skill = include_str!("../resources/kast-skill/SKILL.md");
+
+    assert!(skill.contains("kast agent workspace-files"));
+    assert!(!skill.contains("raw/workspace-files"));
+    assert!(!skill.contains("raw/workspace-files-continuation"));
 }
 
 #[test]


### PR DESCRIPTION
## Status

Draft, rebased onto `main` after #356.

Head: `47853caa56be5a4d375de053f0d9364bd275176d`

Completes the remaining RPC catalog-hardening acceptance for #338.

## What changed

- Enforces strict command-level `failureReasons` and explicit variant discriminators without weakening closed-object validation.
- Regenerates canonical UUID/digest request samples and variant-specific required-field documentation.
- Checks generated continuation samples at the typed Kotlin request boundary.
- Declares the exact generated continuation sample tree as a relative path-sensitive input to `analysis-api:test`, preventing stale Gradle cache hits.
- Guards the installed public skill from exposing raw workspace continuation routes.
- Preserves #356's separate metadata and page response fixture assertions.

## Validation

- Contract summary and generated contract checks pass; 143 generated files verified.
- Rust format, clippy, full test suite, and `rpc_catalog_smoke` (16/16) pass.
- Focused Kotlin continuation contract, full Gradle tests, and `buildIdeaPlugin` pass.
- Gradle cache contract proved red/green: a valid fixture-only change was incorrectly `UP-TO-DATE` before the fix and executed `analysis-api:test` after the relative input was wired.
- Packaged-content, source-index schema, Homebrew formula, Copilot package, LSP pivot, routing eval, docs contracts, and Zensical build pass.
- LSP smoke was run with machine install state isolated; it failed closed as expected with `MACOS_PLUGIN_WORKSPACE_REQUIRED`.

## Notes

The plugin-managed root `AGENTS.md` worktree change remains uncommitted and untouched. Fresh PR CI is the remaining readiness gate.
