### PR TITLE
test: remove mutation status admission race

### DIFF
--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt
@@ -12,8 +12,10 @@ import io.github.amichne.kast.api.contract.mutation.KastMutationOperationState
 import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
 import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
+import io.github.amichne.kast.api.protocol.JsonRpcErrorResponse
 import io.github.amichne.kast.api.protocol.JsonRpcRequest
 import io.github.amichne.kast.api.protocol.JsonRpcSuccessResponse
+import io.github.amichne.kast.api.protocol.JSON_RPC_SERVER_ERROR_BASE
 import io.github.amichne.kast.api.validation.ParsedApplyEditsQuery
 import io.github.amichne.kast.testing.FakeAnalysisBackend
 import kotlinx.coroutines.CompletableDeferred
@@ -22,6 +24,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -230,6 +233,9 @@ class AnalysisServerSocketTest {
                 descriptorDirectory = tempDir.resolve("instances"),
             ),
         ).start().use {
+            val selector = KastMutationOperationSelector.ByIdempotencyKey(idempotencyKey)
+            val preAdmission = pollMutationStatus(socketPath, selector)
+            assertEquals(MutationStatusPoll.NotAdmitted, preAdmission)
             sendWithoutReadingResponse(
                 socketPath = socketPath,
                 request = JsonRpcRequest(
@@ -238,10 +244,7 @@ class AnalysisServerSocketTest {
                     params = json.encodeToJsonElement(KastSemanticMutation.serializer(), mutation),
                 ),
             )
-            Thread.sleep(25)
-
-            val selector = KastMutationOperationSelector.ByIdempotencyKey(idempotencyKey)
-            val terminal = awaitMutationTerminal(socketPath, selector)
+            val terminal = awaitMutationTerminal(socketPath, selector, preAdmission)
 
             assertTrue(terminal.state is KastMutationOperationState.Completed)
             assertEquals("package sample\n\nclass Reconnected\n", Files.readString(target))
@@ -342,34 +345,83 @@ class AnalysisServerSocketTest {
     private fun awaitMutationTerminal(
         socketPath: Path,
         selector: KastMutationOperationSelector,
+        initialPoll: MutationStatusPoll,
     ): KastMutationOperationSnapshot {
+        var poll = initialPoll
         repeat(200) {
-            val response = callSocket(
-                socketPath = socketPath,
-                request = JsonRpcRequest(
-                    id = JsonPrimitive(2),
-                    method = "mutation/status",
-                    params = json.encodeToJsonElement(KastMutationOperationSelector.serializer(), selector),
-                ),
-            )
-            val success = json.decodeFromString(JsonRpcSuccessResponse.serializer(), response)
-            val snapshot = json.decodeFromJsonElement(KastMutationOperationSnapshot.serializer(), success.result)
-            if (
-                snapshot.state is KastMutationOperationState.Completed ||
-                snapshot.state is KastMutationOperationState.Failed ||
-                snapshot.state is KastMutationOperationState.Cancelled
-            ) {
-                return snapshot
+            when (val current = poll) {
+                MutationStatusPoll.NotAdmitted -> Unit
+                is MutationStatusPoll.Available -> {
+                    val snapshot = current.snapshot
+                    if (
+                        snapshot.state is KastMutationOperationState.Completed ||
+                        snapshot.state is KastMutationOperationState.Failed ||
+                        snapshot.state is KastMutationOperationState.Cancelled
+                    ) {
+                        return snapshot
+                    }
+                }
             }
             Thread.sleep(5)
+            poll = pollMutationStatus(socketPath, selector)
         }
         error("Mutation operation did not become terminal after reconnect")
+    }
+
+    private fun pollMutationStatus(
+        socketPath: Path,
+        selector: KastMutationOperationSelector,
+    ): MutationStatusPoll {
+        val response = callSocket(
+            socketPath = socketPath,
+            request = JsonRpcRequest(
+                id = JsonPrimitive(2),
+                method = "mutation/status",
+                params = json.encodeToJsonElement(KastMutationOperationSelector.serializer(), selector),
+            ),
+        )
+        val responseObject = json.parseToJsonElement(response).jsonObject
+        responseObject["result"]?.let {
+            val success = json.decodeFromJsonElement(JsonRpcSuccessResponse.serializer(), responseObject)
+            return MutationStatusPoll.Available(
+                json.decodeFromJsonElement(KastMutationOperationSnapshot.serializer(), success.result),
+            )
+        }
+
+        val failure = json.decodeFromJsonElement(JsonRpcErrorResponse.serializer(), responseObject)
+        val errorData = failure.error.data
+        check(
+            failure.error.code == JSON_RPC_SERVER_ERROR_BASE - HTTP_NOT_FOUND_STATUS &&
+                errorData?.code == NOT_FOUND_ERROR_CODE &&
+                errorData.details.entries.containsAll(selector.expectedNotFoundDetails().entries),
+        ) {
+            "Unexpected mutation/status failure while awaiting admission: $response"
+        }
+        return MutationStatusPoll.NotAdmitted
+    }
+
+    private fun KastMutationOperationSelector.expectedNotFoundDetails(): Map<String, String> = when (this) {
+        is KastMutationOperationSelector.ByOperationId -> mapOf("operationId" to operationId.value)
+        is KastMutationOperationSelector.ByIdempotencyKey -> mapOf("idempotencyKey" to idempotencyKey.value)
+    }
+
+    private sealed interface MutationStatusPoll {
+        data object NotAdmitted : MutationStatusPoll
+
+        data class Available(
+            val snapshot: KastMutationOperationSnapshot,
+        ) : MutationStatusPoll
     }
 
     private fun awaitClientHandlerCompletion() {
         repeat(50) {
             Thread.sleep(10)
         }
+    }
+
+    private companion object {
+        const val HTTP_NOT_FOUND_STATUS = 404
+        const val NOT_FOUND_ERROR_CODE = "NOT_FOUND"
     }
 
     @Test

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisServerSocketTest.kt
@@ -6,13 +6,17 @@ import io.github.amichne.kast.api.contract.AnalysisTransport
 import io.github.amichne.kast.api.contract.RuntimeLifecycleAction
 import io.github.amichne.kast.api.contract.RuntimeStatusResponse
 import io.github.amichne.kast.api.contract.mutation.KastMutationIdempotencyKey
+import io.github.amichne.kast.api.contract.mutation.KastMutationOperationId
 import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSelector
 import io.github.amichne.kast.api.contract.mutation.KastMutationOperationSnapshot
 import io.github.amichne.kast.api.contract.mutation.KastMutationOperationState
 import io.github.amichne.kast.api.contract.mutation.KastSemanticMutation
+import io.github.amichne.kast.api.contract.mutation.KastSemanticMutationKind
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
 import io.github.amichne.kast.api.contract.skill.KastAddFileRequest
+import io.github.amichne.kast.api.protocol.ApiErrorResponse
 import io.github.amichne.kast.api.protocol.JsonRpcErrorResponse
+import io.github.amichne.kast.api.protocol.JsonRpcErrorObject
 import io.github.amichne.kast.api.protocol.JsonRpcRequest
 import io.github.amichne.kast.api.protocol.JsonRpcSuccessResponse
 import io.github.amichne.kast.api.protocol.JSON_RPC_SERVER_ERROR_BASE
@@ -252,6 +256,70 @@ class AnalysisServerSocketTest {
     }
 
     @Test
+    fun `mutation status polling rejects registry loss after admission`() {
+        val idempotencyKey = KastMutationIdempotencyKey("issue-333-registry-loss")
+        val selector = KastMutationOperationSelector.ByIdempotencyKey(idempotencyKey)
+        val available = MutationStatusPoll.Available(
+            KastMutationOperationSnapshot(
+                operationId = KastMutationOperationId.random(),
+                idempotencyKey = idempotencyKey,
+                mutationKind = KastSemanticMutationKind.ADD_FILE,
+                state = KastMutationOperationState.Queued(),
+            ),
+        )
+        val admitted = MutationStatusAwaitPhase.AwaitingAdmission.observe(available)
+        val matchingNotFound = decodeMutationStatus(
+            mutationNotFoundResponse(mapOf("idempotencyKey" to idempotencyKey.value)),
+            selector,
+        )
+        assertEquals(MutationStatusAwaitPhase.Admitted, admitted)
+        assertEquals(MutationStatusPoll.NotAdmitted, matchingNotFound)
+
+        org.junit.jupiter.api.assertThrows<IllegalStateException> {
+            admitted.observe(matchingNotFound)
+        }
+    }
+
+    @Test
+    fun `mutation status polling rejects wrong and extra not found selector details`() {
+        val idempotencyKey = KastMutationIdempotencyKey("issue-333-closed-error-shape")
+        val selector = KastMutationOperationSelector.ByIdempotencyKey(idempotencyKey)
+        val expectedDetails = mapOf("idempotencyKey" to idempotencyKey.value)
+        val invalidDetails = listOf(
+            mapOf("idempotencyKey" to "another-operation"),
+            expectedDetails + ("operationId" to KastMutationOperationId.random().value),
+        )
+
+        invalidDetails.forEach { details ->
+            org.junit.jupiter.api.assertThrows<IllegalStateException> {
+                decodeMutationStatus(mutationNotFoundResponse(details), selector)
+            }
+        }
+    }
+
+    @Test
+    fun `mutation status polling does not fetch an uninspected response beyond its bound`() {
+        val poll = MutationStatusPoll.Available(
+            KastMutationOperationSnapshot(
+                operationId = KastMutationOperationId.random(),
+                idempotencyKey = KastMutationIdempotencyKey("issue-333-poll-bound"),
+                mutationKind = KastSemanticMutationKind.ADD_FILE,
+                state = KastMutationOperationState.Queued(),
+            ),
+        )
+        var subsequentPolls = 0
+
+        org.junit.jupiter.api.assertThrows<IllegalStateException> {
+            awaitMutationTerminal(poll) {
+                subsequentPolls += 1
+                poll
+            }
+        }
+
+        assertEquals(MAX_MUTATION_STATUS_POLLS - 1, subsequentPolls)
+    }
+
+    @Test
     fun `server close cancels and joins mutation before removing descriptor authority`() {
         val socketPath = tempDir.resolve("run").resolve("c.sock")
         val descriptorDirectory = tempDir.resolve("close-instances")
@@ -346,9 +414,19 @@ class AnalysisServerSocketTest {
         socketPath: Path,
         selector: KastMutationOperationSelector,
         initialPoll: MutationStatusPoll,
+    ): KastMutationOperationSnapshot = awaitMutationTerminal(initialPoll) {
+        Thread.sleep(MUTATION_STATUS_POLL_INTERVAL_MILLIS)
+        pollMutationStatus(socketPath, selector)
+    }
+
+    private fun awaitMutationTerminal(
+        initialPoll: MutationStatusPoll,
+        nextPoll: () -> MutationStatusPoll,
     ): KastMutationOperationSnapshot {
         var poll = initialPoll
-        repeat(200) {
+        var phase: MutationStatusAwaitPhase = MutationStatusAwaitPhase.AwaitingAdmission
+        repeat(MAX_MUTATION_STATUS_POLLS) { pollIndex ->
+            phase = phase.observe(poll)
             when (val current = poll) {
                 MutationStatusPoll.NotAdmitted -> Unit
                 is MutationStatusPoll.Available -> {
@@ -362,8 +440,9 @@ class AnalysisServerSocketTest {
                     }
                 }
             }
-            Thread.sleep(5)
-            poll = pollMutationStatus(socketPath, selector)
+            if (pollIndex < MAX_MUTATION_STATUS_POLLS - 1) {
+                poll = nextPoll()
+            }
         }
         error("Mutation operation did not become terminal after reconnect")
     }
@@ -380,6 +459,13 @@ class AnalysisServerSocketTest {
                 params = json.encodeToJsonElement(KastMutationOperationSelector.serializer(), selector),
             ),
         )
+        return decodeMutationStatus(response, selector)
+    }
+
+    private fun decodeMutationStatus(
+        response: String,
+        selector: KastMutationOperationSelector,
+    ): MutationStatusPoll {
         val responseObject = json.parseToJsonElement(response).jsonObject
         responseObject["result"]?.let {
             val success = json.decodeFromJsonElement(JsonRpcSuccessResponse.serializer(), responseObject)
@@ -393,12 +479,30 @@ class AnalysisServerSocketTest {
         check(
             failure.error.code == JSON_RPC_SERVER_ERROR_BASE - HTTP_NOT_FOUND_STATUS &&
                 errorData?.code == NOT_FOUND_ERROR_CODE &&
-                errorData.details.entries.containsAll(selector.expectedNotFoundDetails().entries),
+                errorData.details == selector.expectedNotFoundDetails(),
         ) {
             "Unexpected mutation/status failure while awaiting admission: $response"
         }
         return MutationStatusPoll.NotAdmitted
     }
+
+    private fun mutationNotFoundResponse(details: Map<String, String>): String = json.encodeToString(
+        JsonRpcErrorResponse.serializer(),
+        JsonRpcErrorResponse(
+            id = JsonPrimitive(2),
+            error = JsonRpcErrorObject(
+                code = JSON_RPC_SERVER_ERROR_BASE - HTTP_NOT_FOUND_STATUS,
+                message = "Mutation operation was not found",
+                data = ApiErrorResponse(
+                    requestId = "2",
+                    code = NOT_FOUND_ERROR_CODE,
+                    message = "Mutation operation was not found",
+                    retryable = false,
+                    details = details,
+                ),
+            ),
+        ),
+    )
 
     private fun KastMutationOperationSelector.expectedNotFoundDetails(): Map<String, String> = when (this) {
         is KastMutationOperationSelector.ByOperationId -> mapOf("operationId" to operationId.value)
@@ -413,6 +517,24 @@ class AnalysisServerSocketTest {
         ) : MutationStatusPoll
     }
 
+    private sealed interface MutationStatusAwaitPhase {
+        data object AwaitingAdmission : MutationStatusAwaitPhase
+
+        data object Admitted : MutationStatusAwaitPhase
+    }
+
+    private fun MutationStatusAwaitPhase.observe(poll: MutationStatusPoll): MutationStatusAwaitPhase = when (this) {
+        MutationStatusAwaitPhase.AwaitingAdmission -> when (poll) {
+            MutationStatusPoll.NotAdmitted -> this
+            is MutationStatusPoll.Available -> MutationStatusAwaitPhase.Admitted
+        }
+
+        MutationStatusAwaitPhase.Admitted -> when (poll) {
+            MutationStatusPoll.NotAdmitted -> error("Mutation status disappeared after admission")
+            is MutationStatusPoll.Available -> this
+        }
+    }
+
     private fun awaitClientHandlerCompletion() {
         repeat(50) {
             Thread.sleep(10)
@@ -421,6 +543,8 @@ class AnalysisServerSocketTest {
 
     private companion object {
         const val HTTP_NOT_FOUND_STATUS = 404
+        const val MAX_MUTATION_STATUS_POLLS = 200
+        const val MUTATION_STATUS_POLL_INTERVAL_MILLIS = 5L
         const val NOT_FOUND_ERROR_CODE = "NOT_FOUND"
     }
 


### PR DESCRIPTION
## What

Make the socket mutation lifecycle test model request admission explicitly instead of assuming a write-only submission is registered within 25 ms. Pre-admission `NOT_FOUND` is accepted only with the exact selector detail shape; after any available snapshot proves admission, disappearance fails immediately. The bounded poll loop inspects every fetched response.

## Why

PR #356 run 29339618709 failed on Ubuntu when a reconnecting status request reached the server before the independently scheduled submission handler inserted the idempotency key. The dispatcher-owned registry remains alive across the client disconnect; the test was asserting scheduler timing rather than lifecycle ownership.

## Current head

- Rebased onto main `20148ca59892cf2cf60b92732a2c57e1797a01ca` after #362.
- Head `2b53423a748abcbf907012a7e28b64745f999d63`.

## Verification

- Full PR CI run 29344799481: 18 passed, 0 failed.
- Independent re-review found no blockers; `range-diff` proved the rebase content-equivalent to the already approved repair.
- Deterministic RED reproduced the Ubuntu `JsonRpcSuccessResponse` decode failure from `-32404`.
- RED/GREEN: available → matching `NOT_FOUND` registry-loss rejection.
- RED/GREEN: wrong and extra selector detail rejection.
- Bound proof: no uninspected response is fetched after the 200-response limit.
- Focused disconnect race: 15/15 green before rebase.
- Focused socket class: 13 tests green after rebase.
- Full `:analysis-server:test --rerun-tasks` green after rebase.
- `git diff --check origin/main...HEAD`.

## Risk

Test-only change. Production mutation ownership and RPC behavior are unchanged.