### PR TITLE
feat: ship immutable signed IDEA plugin assets

### DIFF
--- a/.github/scripts/test-idea-plugin-signing-contract.sh
+++ b/.github/scripts/test-idea-plugin-signing-contract.sh
@@ -215,6 +215,8 @@ require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headl
 require_block_order "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "      - name: Build and verify IDEA plugin" "      - name: Sign and verify IDEA plugin" "Release must verify plugin structure and compatibility before signing"
 require_block_order "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "      - name: Sign and verify IDEA plugin" "      - name: Stage and upload immutable signed IDEA plugin asset" "Release must verify the signature before publishing the plugin"
 require_block_not_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "--clobber" "IDEA plugin release assets must never be overwritten"
+! grep -Fq -- "--clobber" "$release_workflow" \
+  || die "Release workflow must not contain any mutable asset upload"
 require_contains "$ci_workflow" "Test IDEA plugin signing and immutability contract" "CI must execute the signing contract gate"
 require_contains "$release_asset_verifier" 'signerCertificateSha256' "Downloaded release verification must require signer identity"
 require_contains "$release_asset_verifier" 'signatureVerified' "Downloaded release verification must require signature evidence"

--- a/.github/scripts/test-idea-plugin-signing-contract.sh
+++ b/.github/scripts/test-idea-plugin-signing-contract.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/../.." && pwd
+}
+
+require_contains() {
+  local file_path="$1"
+  local expected="$2"
+  local description="$3"
+  grep -Fq -- "$expected" "$file_path" || die "${description}: missing '${expected}' in ${file_path}"
+}
+
+require_block_contains() {
+  local file_path="$1"
+  local block_start="$2"
+  local block_end="$3"
+  local expected="$4"
+  local description="$5"
+  local block
+  block="$(
+    awk -v block_start="$block_start" -v block_end="$block_end" '
+      index($0, block_start) { in_block = 1 }
+      in_block && index($0, block_end) && !index($0, block_start) { exit }
+      in_block { print }
+    ' "$file_path"
+  )"
+  [[ -n "$block" ]] || die "${description}: missing block '${block_start}' in ${file_path}"
+  grep -Fq -- "$expected" <<< "$block" || die "${description}: missing '${expected}' in '${block_start}' block"
+}
+
+require_block_not_contains() {
+  local file_path="$1"
+  local block_start="$2"
+  local block_end="$3"
+  local unexpected="$4"
+  local description="$5"
+  local block
+  block="$(
+    awk -v block_start="$block_start" -v block_end="$block_end" '
+      index($0, block_start) { in_block = 1 }
+      in_block && index($0, block_end) && !index($0, block_start) { exit }
+      in_block { print }
+    ' "$file_path"
+  )"
+  [[ -n "$block" ]] || die "${description}: missing block '${block_start}' in ${file_path}"
+  ! grep -Fq -- "$unexpected" <<< "$block" || die "${description}: found '${unexpected}' in '${block_start}' block"
+}
+
+require_block_order() {
+  local file_path="$1"
+  local block_start="$2"
+  local block_end="$3"
+  local earlier="$4"
+  local later="$5"
+  local description="$6"
+  local block
+  local earlier_line
+  local later_line
+  block="$(
+    awk -v block_start="$block_start" -v block_end="$block_end" '
+      index($0, block_start) { in_block = 1 }
+      in_block && index($0, block_end) && !index($0, block_start) { exit }
+      in_block { print }
+    ' "$file_path"
+  )"
+  [[ -n "$block" ]] || die "${description}: missing block '${block_start}' in ${file_path}"
+  earlier_line="$(grep -nF -- "$earlier" <<< "$block" | head -1 | cut -d: -f1)"
+  later_line="$(grep -nF -- "$later" <<< "$block" | head -1 | cut -d: -f1)"
+  [[ -n "$earlier_line" ]] || die "${description}: missing earlier marker '${earlier}' in '${block_start}' block"
+  [[ -n "$later_line" ]] || die "${description}: missing later marker '${later}' in '${block_start}' block"
+  [[ "$earlier_line" -lt "$later_line" ]] || die "${description}: '${earlier}' must appear before '${later}' in '${block_start}' block"
+}
+
+certificate_fingerprint() {
+  openssl x509 -in "$1" -outform DER \
+    | openssl dgst -sha256 -r \
+    | awk '{ print $1 }'
+}
+
+generate_signer() {
+  local directory="$1"
+  local common_name="$2"
+  mkdir -p "$directory"
+  openssl genpkey \
+    -algorithm RSA \
+    -aes-256-cbc \
+    -pass pass:test-only-password \
+    -pkeyopt rsa_keygen_bits:2048 \
+    -out "${directory}/private.pem" \
+    >/dev/null 2>&1
+  openssl req \
+    -new \
+    -x509 \
+    -sha256 \
+    -days 1 \
+    -subj "/CN=${common_name}" \
+    -key "${directory}/private.pem" \
+    -passin pass:test-only-password \
+    -out "${directory}/chain.crt" \
+    >/dev/null 2>&1
+}
+
+write_fake_gh() {
+  local path="$1"
+  python3 - "$path" <<'PY'
+import os
+import stat
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+path.write_text(
+    """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' \"$*\" >> \"$KAST_TEST_GH_LOG\"
+[[ \"${KAST_TEST_GH_VIEW_FAILURE:-0}\" != \"1\" ]] || {
+  [[ \"$1 $2\" != \"release view\" ]] || exit 19
+}
+case \"$1 $2\" in
+  \"release view\")
+    if [[ -f \"$KAST_TEST_GH_REMOTE_ASSET\" ]]; then
+      basename -- \"$KAST_TEST_GH_REMOTE_ASSET\"
+    fi
+    ;;
+  \"release download\")
+    destination=\"\"
+    pattern=\"\"
+    shift 3
+    while [[ $# -gt 0 ]]; do
+      case \"$1\" in
+        --dir) destination=\"$2\"; shift 2 ;;
+        --pattern) pattern=\"$2\"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [[ -f \"$KAST_TEST_GH_REMOTE_ASSET\" ]] || exit 1
+    [[ \"$pattern\" == \"$(basename -- \"$KAST_TEST_GH_REMOTE_ASSET\")\" ]] || exit 1
+    mkdir -p \"$destination\"
+    cp \"$KAST_TEST_GH_REMOTE_ASSET\" \"$destination/$pattern\"
+    ;;
+  \"release upload\")
+    asset=\"$4\"
+    [[ ! -f \"$KAST_TEST_GH_REMOTE_ASSET\" ]] || exit 1
+    cp \"$asset\" \"$KAST_TEST_GH_REMOTE_ASSET\"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+""",
+    encoding="utf-8",
+)
+path.chmod(path.stat().st_mode | stat.S_IXUSR)
+PY
+}
+
+repo_root="$(resolve_repo_root)"
+release_workflow="${repo_root}/.github/workflows/release.yml"
+ci_workflow="${repo_root}/.github/workflows/ci.yml"
+idea_build_file="${repo_root}/backend-idea/build.gradle.kts"
+uploader="${repo_root}/.github/scripts/upload-immutable-release-asset.sh"
+artifact_verifier="${repo_root}/scripts/verify-idea-plugin-artifact.py"
+release_asset_verifier="${repo_root}/scripts/verify-release-assets.sh"
+
+for path in \
+  "$release_workflow" \
+  "$ci_workflow" \
+  "$idea_build_file" \
+  "$uploader" \
+  "$artifact_verifier" \
+  "$release_asset_verifier"
+do
+  [[ -f "$path" ]] || die "Required IDEA plugin signing file is missing: $path"
+done
+
+[[ -x "$uploader" ]] || die "Immutable release uploader is not executable: $uploader"
+[[ -x "$artifact_verifier" ]] || die "IDEA plugin artifact verifier is not executable: $artifact_verifier"
+
+require_contains "$idea_build_file" 'providers.environmentVariable("PRIVATE_KEY")' "IDEA signing must read the private key from the environment"
+require_contains "$idea_build_file" 'providers.environmentVariable("PRIVATE_KEY_PASSWORD")' "IDEA signing must read the private-key password from the environment"
+require_contains "$idea_build_file" 'kast.idea.signing.certificateChainFile' "IDEA signing must use a file-backed public certificate chain"
+require_contains "$idea_build_file" 'inputArchiveFile.set(signIdeaPlugin.flatMap { it.signedArchiveFile })' "Signature verification must carry the sign task dependency"
+
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_CERTIFICATE_CHAIN: ${{ secrets.IDEA_PLUGIN_CERTIFICATE_CHAIN }}' "Release preflight must require the signing certificate"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_PRIVATE_KEY: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY }}' "Release preflight must require the signing key"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_PRIVATE_KEY_PASSWORD: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY_PASSWORD }}' "Release preflight must require the signing password"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_SIGNER_SHA256 }}' "Release preflight must require the enrolled signer fingerprint"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:verifyPlugin" "Release must run JetBrains compatibility verification"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:signPlugin" "Release must sign the IDEA plugin"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:verifyPluginSignature" "Release must verify the IDEA plugin signature"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:stageIdeaPluginSignatureVerifier" "Release must stage the JetBrains verifier used for the published bytes"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "scripts/verify-idea-plugin-artifact.py record" "Release must record signer-bound provenance"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ".github/scripts/upload-immutable-release-asset.sh" "Release must use the immutable uploader"
+# shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" 'tag_sha="$(git rev-list -n1 "$tag")"' "Release must resolve the checked-out tag target"
+# shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" '--signature-verifier-jar "$signature_verifier_jar"' "Published-byte verification must execute the staged JetBrains verifier"
+# shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" '--release-tag "$tag"' "IDEA provenance must use the prepared release tag"
+# shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" '--release-sha "$release_sha"' "IDEA provenance must use the checked-out release commit"
+require_block_order "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "      - name: Build and verify IDEA plugin" "      - name: Sign and verify IDEA plugin" "Release must verify plugin structure and compatibility before signing"
+require_block_order "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "      - name: Sign and verify IDEA plugin" "      - name: Stage and upload immutable signed IDEA plugin asset" "Release must verify the signature before publishing the plugin"
+require_block_not_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "--clobber" "IDEA plugin release assets must never be overwritten"
+require_contains "$ci_workflow" "Test IDEA plugin signing and immutability contract" "CI must execute the signing contract gate"
+require_contains "$release_asset_verifier" 'signerCertificateSha256' "Downloaded release verification must require signer identity"
+require_contains "$release_asset_verifier" 'signatureVerified' "Downloaded release verification must require signature evidence"
+require_contains "$release_asset_verifier" 'pluginId' "Downloaded release verification must require plugin identity"
+
+scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/kast-idea-signing-contract.XXXXXX")"
+cleanup() {
+  rm -rf "$scratch_dir"
+  rm -f "${repo_root}/backend-idea/build/distributions/"*"0.0.0-signing-contract"*.zip
+  rm -f "${repo_root}/backend-idea/build/distributions/"*"0.0.0-signing-rotation"*.zip
+}
+trap cleanup EXIT
+
+mkdir -p "${scratch_dir}/bin" "${scratch_dir}/remote"
+write_fake_gh "${scratch_dir}/bin/gh"
+local_asset="${scratch_dir}/kast-idea-v0.0.0-test.zip"
+remote_asset="${scratch_dir}/remote/kast-idea-v0.0.0-test.zip"
+gh_log="${scratch_dir}/gh.log"
+printf '%s\n' "first immutable payload" > "$local_asset"
+: > "$gh_log"
+
+export PATH="${scratch_dir}/bin:${PATH}"
+export KAST_TEST_GH_LOG="$gh_log"
+export KAST_TEST_GH_REMOTE_ASSET="$remote_asset"
+
+"$uploader" --tag v0.0.0-test --asset "$local_asset"
+cmp -s "$local_asset" "$remote_asset" || die "First immutable upload did not preserve bytes"
+
+"$uploader" --tag v0.0.0-test --asset "$local_asset"
+[[ "$(grep -c '^release upload ' "$gh_log")" -eq 1 ]] || die "Byte-identical replay uploaded the plugin twice"
+
+printf '%s\n' "different payload" > "$local_asset"
+if "$uploader" --tag v0.0.0-test --asset "$local_asset" >"${scratch_dir}/mismatch.out" 2>"${scratch_dir}/mismatch.err"; then
+  die "Different immutable plugin bytes unexpectedly replaced the release asset"
+fi
+grep -Fq "differs from immutable release asset" "${scratch_dir}/mismatch.err" \
+  || die "Immutable mismatch did not name the byte-identity failure"
+
+rm -f "$remote_asset"
+export KAST_TEST_GH_VIEW_FAILURE=1
+if "$uploader" --tag v0.0.0-test --asset "$local_asset" >"${scratch_dir}/view.out" 2>"${scratch_dir}/view.err"; then
+  die "Release lookup failure unexpectedly fell through to upload"
+fi
+unset KAST_TEST_GH_VIEW_FAILURE
+[[ "$(grep -c '^release upload ' "$gh_log")" -eq 1 ]] || die "Release lookup failure attempted an upload"
+! grep -Fq -- "--clobber" "$gh_log" || die "Immutable uploader invoked --clobber"
+
+generate_signer "${scratch_dir}/signer-a" "Kast Contract Signer A"
+generate_signer "${scratch_dir}/signer-b" "Kast Contract Signer B"
+fingerprint_a="$(certificate_fingerprint "${scratch_dir}/signer-a/chain.crt")"
+fingerprint_b="$(certificate_fingerprint "${scratch_dir}/signer-b/chain.crt")"
+version="0.0.0-signing-contract"
+
+rm -f "${repo_root}/backend-idea/build/distributions/"*"${version}"*.zip
+"${repo_root}/scripts/ci-gradle-retry.sh" \
+  "${repo_root}/gradlew" \
+  :backend-idea:buildPlugin \
+  :backend-idea:verifyPluginStructure \
+  :backend-idea:verifyPluginXmlPresent \
+  -Pversion="$version" \
+  --no-daemon
+PRIVATE_KEY="$(base64 < "${scratch_dir}/signer-a/private.pem" | tr -d '\n')" \
+PRIVATE_KEY_PASSWORD="test-only-password" \
+  "${repo_root}/scripts/ci-gradle-retry.sh" \
+  "${repo_root}/gradlew" \
+  :backend-idea:signPlugin \
+  :backend-idea:verifyPluginSignature \
+  :backend-idea:stageIdeaPluginSignatureVerifier \
+  -Pkast.idea.signing.certificateChainFile="${scratch_dir}/signer-a/chain.crt" \
+  -Pversion="$version" \
+  --no-daemon
+
+mapfile -t signed_archives < <(find "${repo_root}/backend-idea/build/distributions" -maxdepth 1 -type f -name "*${version}-signed.zip" -print | sort)
+[[ "${#signed_archives[@]}" -eq 1 ]] || die "Expected one signed IDEA plugin archive, found ${#signed_archives[@]}"
+signed_archive="${signed_archives[0]}"
+signed_release_archive="${scratch_dir}/kast-idea-v0.0.0-signing-contract.zip"
+cp "$signed_archive" "$signed_release_archive"
+provenance="${scratch_dir}/build-provenance-idea.json"
+signature_verifier_jar="${repo_root}/backend-idea/build/idea-plugin-signature-verifier/marketplace-zip-signer-cli.jar"
+[[ -f "$signature_verifier_jar" ]] || die "Staged Marketplace ZIP Signer is missing: $signature_verifier_jar"
+release_tag="v0.0.0-signing-contract"
+release_sha="0123456789abcdef0123456789abcdef01234567"
+
+GITHUB_RUN_ID=123 \
+GITHUB_RUN_NUMBER=7 \
+GITHUB_RUN_ATTEMPT=1 \
+GITHUB_WORKFLOW_REF=amichne/kast/.github/workflows/release.yml@refs/tags/v0.0.0-signing-contract \
+GITHUB_ACTOR=contract-test \
+  "$artifact_verifier" record \
+  --plugin-zip "$signed_release_archive" \
+  --certificate-chain "${scratch_dir}/signer-a/chain.crt" \
+  --signature-verifier-jar "$signature_verifier_jar" \
+  --release-tag "$release_tag" \
+  --release-sha "$release_sha" \
+  --output "$provenance" \
+  --asset-name "kast-idea-v0.0.0-signing-contract.zip" \
+  --expected-signer-sha256 "$fingerprint_a"
+
+"$artifact_verifier" verify \
+  --plugin-zip "$signed_release_archive" \
+  --certificate-chain "${scratch_dir}/signer-a/chain.crt" \
+  --signature-verifier-jar "$signature_verifier_jar" \
+  --release-tag "$release_tag" \
+  --release-sha "$release_sha" \
+  --provenance "$provenance" \
+  --expected-signer-sha256 "$fingerprint_a"
+
+unsigned_archive="${scratch_dir}/kast-idea-v0.0.0-unsigned.zip"
+cp "${repo_root}/backend-idea/build/distributions/backend-idea-${version}.zip" "$unsigned_archive"
+if GITHUB_RUN_ID=123 \
+  GITHUB_RUN_NUMBER=7 \
+  GITHUB_RUN_ATTEMPT=1 \
+  GITHUB_WORKFLOW_REF=amichne/kast/.github/workflows/release.yml@refs/tags/v0.0.0-signing-contract \
+  GITHUB_ACTOR=contract-test \
+  "$artifact_verifier" record \
+    --plugin-zip "$unsigned_archive" \
+    --certificate-chain "${scratch_dir}/signer-a/chain.crt" \
+    --signature-verifier-jar "$signature_verifier_jar" \
+    --release-tag "$release_tag" \
+    --release-sha "$release_sha" \
+    --output "${scratch_dir}/unsigned-provenance.json" \
+    --asset-name "$(basename -- "$unsigned_archive")" \
+    --expected-signer-sha256 "$fingerprint_a" \
+    >"${scratch_dir}/unsigned.out" 2>"${scratch_dir}/unsigned.err"
+then
+  die "Unsigned IDEA plugin archive unexpectedly produced signed provenance"
+fi
+grep -Fq "Marketplace ZIP Signer rejected" "${scratch_dir}/unsigned.err" \
+  || die "Unsigned archive failure did not name signature rejection"
+
+if "$artifact_verifier" verify \
+  --plugin-zip "$signed_release_archive" \
+  --certificate-chain "${scratch_dir}/signer-b/chain.crt" \
+  --signature-verifier-jar "$signature_verifier_jar" \
+  --release-tag "$release_tag" \
+  --release-sha "$release_sha" \
+  --provenance "$provenance" \
+  --expected-signer-sha256 "$fingerprint_a" \
+  --expected-signer-sha256 "$fingerprint_b" \
+  >"${scratch_dir}/wrong-certificate.out" 2>"${scratch_dir}/wrong-certificate.err"
+then
+  die "Plugin signed by signer A unexpectedly verified against signer B"
+fi
+grep -Fq "Marketplace ZIP Signer rejected" "${scratch_dir}/wrong-certificate.err" \
+  || die "Wrong-certificate failure did not name signature rejection"
+
+if "$artifact_verifier" verify \
+  --plugin-zip "$signed_release_archive" \
+  --certificate-chain "${scratch_dir}/signer-a/chain.crt" \
+  --signature-verifier-jar "$signature_verifier_jar" \
+  --release-tag "$release_tag" \
+  --release-sha "1123456789abcdef0123456789abcdef01234567" \
+  --provenance "$provenance" \
+  --expected-signer-sha256 "$fingerprint_a" \
+  >"${scratch_dir}/wrong-release.out" 2>"${scratch_dir}/wrong-release.err"
+then
+  die "Plugin provenance unexpectedly verified against a different release commit"
+fi
+grep -Fq "does not match the checked-out release tag and commit" "${scratch_dir}/wrong-release.err" \
+  || die "Wrong-release failure did not name release identity mismatch"
+
+rotation_version="0.0.0-signing-rotation"
+PRIVATE_KEY="$(base64 < "${scratch_dir}/signer-b/private.pem" | tr -d '\n')" \
+PRIVATE_KEY_PASSWORD="test-only-password" \
+  "${repo_root}/scripts/ci-gradle-retry.sh" \
+  "${repo_root}/gradlew" \
+  :backend-idea:signPlugin \
+  :backend-idea:verifyPluginSignature \
+  :backend-idea:stageIdeaPluginSignatureVerifier \
+  -Pkast.idea.signing.certificateChainFile="${scratch_dir}/signer-b/chain.crt" \
+  -Pversion="$rotation_version" \
+  --no-daemon
+
+mapfile -t rotation_archives < <(find "${repo_root}/backend-idea/build/distributions" -maxdepth 1 -type f -name "*${rotation_version}-signed.zip" -print | sort)
+[[ "${#rotation_archives[@]}" -eq 1 ]] || die "Expected one rotation-signed IDEA plugin archive, found ${#rotation_archives[@]}"
+rotation_release_archive="${scratch_dir}/kast-idea-v0.0.0-signing-rotation.zip"
+cp "${rotation_archives[0]}" "$rotation_release_archive"
+rotation_provenance="${scratch_dir}/build-provenance-idea-rotation.json"
+
+GITHUB_RUN_ID=124 \
+GITHUB_RUN_NUMBER=8 \
+GITHUB_RUN_ATTEMPT=1 \
+GITHUB_WORKFLOW_REF=amichne/kast/.github/workflows/release.yml@refs/tags/v0.0.0-signing-rotation \
+GITHUB_ACTOR=contract-test \
+  "$artifact_verifier" record \
+  --plugin-zip "$rotation_release_archive" \
+  --certificate-chain "${scratch_dir}/signer-b/chain.crt" \
+  --signature-verifier-jar "$signature_verifier_jar" \
+  --release-tag "v0.0.0-signing-rotation" \
+  --release-sha "$release_sha" \
+  --output "$rotation_provenance" \
+  --asset-name "kast-idea-v0.0.0-signing-rotation.zip" \
+  --expected-signer-sha256 "$fingerprint_a" \
+  --expected-signer-sha256 "$fingerprint_b"
+
+"$artifact_verifier" verify \
+  --plugin-zip "$rotation_release_archive" \
+  --certificate-chain "${scratch_dir}/signer-b/chain.crt" \
+  --signature-verifier-jar "$signature_verifier_jar" \
+  --release-tag "v0.0.0-signing-rotation" \
+  --release-sha "$release_sha" \
+  --provenance "$rotation_provenance" \
+  --expected-signer-sha256 "$fingerprint_a" \
+  --expected-signer-sha256 "$fingerprint_b"
+
+if "$artifact_verifier" verify \
+  --plugin-zip "$rotation_release_archive" \
+  --certificate-chain "${scratch_dir}/signer-b/chain.crt" \
+  --signature-verifier-jar "$signature_verifier_jar" \
+  --release-tag "v0.0.0-signing-rotation" \
+  --release-sha "$release_sha" \
+  --provenance "$rotation_provenance" \
+  --expected-signer-sha256 "$fingerprint_a" \
+  >"${scratch_dir}/rotation.out" 2>"${scratch_dir}/rotation.err"
+then
+  die "Unenrolled replacement signer unexpectedly verified"
+fi
+grep -Fq "signer certificate is not enrolled" "${scratch_dir}/rotation.err" \
+  || die "Unenrolled signer failure did not name trust enrollment"
+
+if "$artifact_verifier" verify \
+  --plugin-zip "$signed_release_archive" \
+  --certificate-chain "${scratch_dir}/signer-a/chain.crt" \
+  --signature-verifier-jar "$signature_verifier_jar" \
+  --release-tag "$release_tag" \
+  --release-sha "$release_sha" \
+  --provenance "$provenance" \
+  --expected-signer-sha256 invalid \
+  >"${scratch_dir}/invalid.out" 2>"${scratch_dir}/invalid.err"
+then
+  die "Invalid enrolled signer fingerprint unexpectedly verified"
+fi
+grep -Fq "expected signer fingerprint must be 64 lowercase hexadecimal characters" "${scratch_dir}/invalid.err" \
+  || die "Invalid signer fingerprint failure did not name the typed format"
+
+printf '%s\n' "IDEA plugin signing and immutability contract passed (${fingerprint_a}, overlap fixture ${fingerprint_b})"

--- a/.github/scripts/test-release-asset-verifier.sh
+++ b/.github/scripts/test-release-asset-verifier.sh
@@ -134,8 +134,7 @@ entries = [
     ("ubuntu-debian-headless-x86_64", f"kast-ubuntu-debian-headless-x86_64-{tag}.tar.gz"),
     ("idea", f"kast-idea-{tag}.zip"),
 ]
-payload = {
-    "builds": [
+builds = [
         {
             "platformId": platform,
             "assetName": asset,
@@ -143,8 +142,23 @@ payload = {
         }
         for platform, asset in entries
         if (release_dir / asset).is_file()
-    ]
-}
+]
+for entry in builds:
+    if entry["platformId"] == "idea":
+        entry.update({
+            "pluginId": "io.github.amichne.kast",
+            "signerCertificateSha256": "a" * 64,
+            "signatureVerified": True,
+            "sha": "0123456789abcdef0123456789abcdef01234567",
+            "ref": f"refs/tags/{tag}",
+            "verificationTasks": [
+                ":backend-idea:verifyPluginStructure",
+                ":backend-idea:verifyPluginXmlPresent",
+                ":backend-idea:verifyPlugin",
+                ":backend-idea:verifyPluginSignature",
+            ],
+        })
+payload = {"builds": builds}
 (release_dir / "build-provenance.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 PY
 }
@@ -240,6 +254,26 @@ if "$verifier" --release-dir "$release_dir" --tag "$tag" >/dev/null 2>"${scratch
   die "missing provenance unexpectedly verified"
 fi
 grep -Fq "missing provenance" "${scratch_dir}/provenance.err" || die "missing provenance failure did not mention missing provenance"
+
+write_expected_assets
+write_sha256sums "$release_dir" "${assets[@]}"
+write_provenance
+python3 - "${release_dir}/build-provenance.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+idea = next(entry for entry in payload["builds"] if entry.get("platformId") == "idea")
+idea["signatureVerified"] = False
+path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+if "$verifier" --release-dir "$release_dir" --tag "$tag" >/dev/null 2>"${scratch_dir}/signature.err"; then
+  die "unsigned IDEA provenance unexpectedly verified"
+fi
+grep -Fq "signatureVerified" "${scratch_dir}/signature.err" \
+  || die "unsigned IDEA provenance failure did not mention signature verification"
 
 write_expected_assets
 python3 - "${release_dir}/kast-runtime-manifest.json" <<'PY'

--- a/.github/scripts/test-release-provenance-assembler.sh
+++ b/.github/scripts/test-release-provenance-assembler.sh
@@ -18,6 +18,28 @@ write_provenance() {
   local asset="$3"
 
   mkdir -p "$(dirname -- "$path")"
+  if [[ "$platform" == "idea" ]]; then
+    cat > "$path" <<JSON
+{
+  "platformId": "${platform}",
+  "assetName": "${asset}",
+  "assetDigest": "sha256:$(printf '%064d' 1)",
+  "sha": "0123456789abcdef0123456789abcdef01234567",
+  "ref": "refs/tags/v9.8.7",
+  "pluginId": "io.github.amichne.kast",
+  "signerCertificateSha256": "$(printf 'a%.0s' {1..64})",
+  "signatureVerified": true,
+  "verificationTasks": [
+    ":backend-idea:verifyPluginStructure",
+    ":backend-idea:verifyPluginXmlPresent",
+    ":backend-idea:verifyPlugin",
+    ":backend-idea:verifyPluginSignature"
+  ]
+}
+JSON
+    return
+  fi
+
   cat > "$path" <<JSON
 {
   "platformId": "${platform}",
@@ -82,6 +104,7 @@ write_provenance \
 output="${scratch_dir}/dist/build-provenance.json"
 "$assembler" \
   --output "$output" \
+  --tag "$tag" \
   "${scratch_dir}/provenance-cli-linux-arm64" \
   "${scratch_dir}/provenance-cli-linux-x64" \
   "${scratch_dir}/provenance-cli-macos-arm64" \
@@ -118,6 +141,7 @@ PY
 
 "$assembler" \
   --output "$output" \
+  --tag "$tag" \
   "${scratch_dir}/provenance-cli-linux-arm64" \
   "${scratch_dir}/provenance-cli-linux-x64" \
   "${scratch_dir}/provenance-cli-macos-arm64" \
@@ -130,7 +154,7 @@ PY
   "${scratch_dir}/provenance-ubuntu-debian-headless"
 
 rm "${scratch_dir}/provenance-idea/dist/build-provenance-idea.json"
-if "$assembler" --output "$output" "${scratch_dir}/provenance-cli-linux-arm64" "${scratch_dir}/provenance-cli-linux-x64" "${scratch_dir}/provenance-cli-macos-arm64" "${scratch_dir}/provenance-cli-macos-x64" "${scratch_dir}/provenance-gradle-ro-cache" "${scratch_dir}/provenance-headless-linux-x64" "${scratch_dir}/provenance-idea" "${scratch_dir}/provenance-openapi" "${scratch_dir}/provenance-runtime-manifest" "${scratch_dir}/provenance-ubuntu-debian-headless" \
+if "$assembler" --output "$output" --tag "$tag" "${scratch_dir}/provenance-cli-linux-arm64" "${scratch_dir}/provenance-cli-linux-x64" "${scratch_dir}/provenance-cli-macos-arm64" "${scratch_dir}/provenance-cli-macos-x64" "${scratch_dir}/provenance-gradle-ro-cache" "${scratch_dir}/provenance-headless-linux-x64" "${scratch_dir}/provenance-idea" "${scratch_dir}/provenance-openapi" "${scratch_dir}/provenance-runtime-manifest" "${scratch_dir}/provenance-ubuntu-debian-headless" \
   >"${scratch_dir}/missing.out" 2>"${scratch_dir}/missing.err"; then
   die "assembler unexpectedly passed with missing idea provenance"
 fi

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -387,6 +387,7 @@ require_block_order "$release_workflow" "  build-idea-plugin:" "  build-headless
 require_block_not_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "--clobber" "Release must never replace the signed IDEA plugin asset"
 require_not_contains "$release_workflow" 'gh release upload "$tag" dist/build-provenance.json --clobber' "Release must never replace combined provenance"
 require_not_contains "$release_workflow" 'gh release upload "$tag" SHA256SUMS --clobber' "Release must never replace release checksums"
+require_not_contains "$release_workflow" "--clobber" "Release must never replace any existing release asset"
 require_contains "$release_workflow" "Free disk for headless backend release" "Release headless backend build must free unused runner SDKs before copying IntelliJ runtimes"
 require_contains "$release_workflow" "~/.gradle/kast/shared-idea-distributions" "Release must cache the actual shared IntelliJ extraction directory"
 require_contains "$release_workflow" "~/.gradle/kast/backend-idea-distributions" "Release must cache the actual IDEA backend extraction directory"

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -119,6 +119,9 @@ homebrew_test="${repo_root}/packaging/homebrew/scripts/test-formulas.py"
 release_provenance_assembler="${repo_root}/scripts/assemble-release-provenance.py"
 ci_artifact_ledger_verifier="${repo_root}/scripts/verify-ci-artifact-ledger.py"
 release_asset_verifier="${repo_root}/scripts/verify-release-assets.sh"
+idea_plugin_artifact_verifier="${repo_root}/scripts/verify-idea-plugin-artifact.py"
+immutable_release_asset_uploader="${repo_root}/.github/scripts/upload-immutable-release-asset.sh"
+idea_plugin_signing_contract="${repo_root}/.github/scripts/test-idea-plugin-signing-contract.sh"
 release_state_verifier="${repo_root}/scripts/verify-release-state.sh"
 maven_central_verifier="${repo_root}/scripts/verify-maven-central.sh"
 ubuntu_debian_validator="${repo_root}/scripts/validate-ubuntu-debian-bundle-in-docker.sh"
@@ -150,6 +153,9 @@ for path in \
   "$release_provenance_assembler" \
   "$ci_artifact_ledger_verifier" \
   "$release_asset_verifier" \
+  "$idea_plugin_artifact_verifier" \
+  "$immutable_release_asset_uploader" \
+  "$idea_plugin_signing_contract" \
   "$release_state_verifier" \
   "$maven_central_verifier" \
   "$ubuntu_debian_validator" \
@@ -195,6 +201,10 @@ require_contains "${repo_root}/analysis-server/build.gradle.kts" 'artifactId.set
 require_contains "${repo_root}/index-store/build.gradle.kts" 'artifactId.set("kast-index-store")' "index-store must publish the public Maven artifact"
 require_not_contains "${repo_root}/backend-headless/build.gradle.kts" "kastPublishing" "Headless backend must remain release-asset-only"
 require_not_contains "${repo_root}/backend-idea/build.gradle.kts" "kastPublishing" "IDEA plugin must remain release-asset-only"
+require_contains "${repo_root}/backend-idea/build.gradle.kts" 'providers.environmentVariable("PRIVATE_KEY")' "IDEA plugin signing must read the private key only from the environment"
+require_contains "${repo_root}/backend-idea/build.gradle.kts" 'providers.environmentVariable("PRIVATE_KEY_PASSWORD")' "IDEA plugin signing must read the private-key password only from the environment"
+require_contains "${repo_root}/backend-idea/build.gradle.kts" 'kast.idea.signing.certificateChainFile' "IDEA plugin signing must use a file-backed public certificate chain"
+require_contains "${repo_root}/backend-idea/build.gradle.kts" 'inputArchiveFile.set(signIdeaPlugin.flatMap { it.signedArchiveFile })' "Signature verification must consume the sign task output provider"
 require_not_contains "${repo_root}/backend-headless/build.gradle.kts" "reinstall with kast.sh" "Headless launcher hints must not point at retired kast.sh install behavior"
 
 require_contains "$ci_workflow" "Maven publication metadata" "CI must validate Maven publication metadata"
@@ -206,6 +216,7 @@ require_block_contains "$ci_workflow" "  runtime-contracts:" "  maven-publicatio
 require_block_contains "$ci_workflow" "  runtime-contracts:" "  maven-publication-contract:" "      - name: Test Kast Copilot plugin package" "CI runtime contracts must reuse the terminal build for the Copilot package contract"
 require_block_contains "$ci_workflow" "  runtime-contracts:" "  maven-publication-contract:" "      - name: Smoke Ubuntu/Debian bundle contract" "CI runtime contracts must own the Ubuntu/Debian bundle smoke"
 require_contains "$ci_workflow" "Test CI artifact ledger" "CI must test artifact ledger recording and verification"
+require_contains "$ci_workflow" "Test IDEA plugin signing and immutability contract" "CI must execute the signed immutable plugin gate"
 require_contains "$ci_workflow" "ci-artifact-ledger-maven-publication" "CI must upload the Maven publication validation ledger"
 require_contains "$ci_workflow" "ci-artifact-ledger-rust-cli-linux-x64" "CI must upload the Rust CLI build ledger"
 require_contains "$ci_build_and_test_workflow" 'ci-artifact-ledger-headless-${{ inputs.runner }}' "CI must upload headless backend build ledgers"
@@ -349,6 +360,33 @@ require_contains "$release_workflow" "scripts/verify-release-state.sh" "Release 
 require_contains "$release_workflow" "scripts/verify-maven-central.sh" "Release must verify Maven Central coordinates"
 require_contains "$release_workflow" "./scripts/ci-gradle-retry.sh" "Release Gradle steps must use retry helper for transient repository failures"
 require_contains "$release_workflow" "Free disk for IDEA plugin build" "Release IDEA plugin build must free unused runner SDKs before downloading IDEs"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_CERTIFICATE_CHAIN: ${{ secrets.IDEA_PLUGIN_CERTIFICATE_CHAIN }}' "Release preflight must require the IDEA signing certificate"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_PRIVATE_KEY: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY }}' "Release preflight must require the IDEA signing key"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_PRIVATE_KEY_PASSWORD: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY_PASSWORD }}' "Release preflight must require the IDEA signing password"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_SIGNER_SHA256 }}' "Release preflight must require the enrolled signer fingerprint"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:verifyPlugin" "Release must verify IDEA compatibility"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:signPlugin" "Release must sign the IDEA plugin"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:verifyPluginSignature" "Release must verify the IDEA plugin signature"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:stageIdeaPluginSignatureVerifier" "Release must stage the JetBrains verifier used for the published bytes"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "scripts/verify-idea-plugin-artifact.py record" "Release must record signer-bound IDEA provenance"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ".github/scripts/upload-immutable-release-asset.sh" "Release must upload the IDEA plugin immutably"
+# shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" 'tag_sha="$(git rev-list -n1 "$tag")"' "Release must resolve the checked-out tag target"
+# shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" '--signature-verifier-jar "$signature_verifier_jar"' "Published-byte verification must execute the staged JetBrains verifier"
+# shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" '--release-tag "$tag"' "IDEA provenance must use the prepared release tag"
+# shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" '--release-sha "$release_sha"' "IDEA provenance must use the checked-out release commit"
+require_block_order "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "      - name: Build and verify IDEA plugin" "      - name: Sign and verify IDEA plugin" "Release must verify plugin structure and compatibility before signing"
+require_block_order "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "      - name: Sign and verify IDEA plugin" "      - name: Stage and upload immutable signed IDEA plugin asset" "Release must verify the signature before publishing the plugin"
+require_block_not_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "--clobber" "Release must never replace the signed IDEA plugin asset"
+require_not_contains "$release_workflow" 'gh release upload "$tag" dist/build-provenance.json --clobber' "Release must never replace combined provenance"
+require_not_contains "$release_workflow" 'gh release upload "$tag" SHA256SUMS --clobber' "Release must never replace release checksums"
 require_contains "$release_workflow" "Free disk for headless backend release" "Release headless backend build must free unused runner SDKs before copying IntelliJ runtimes"
 require_contains "$release_workflow" "~/.gradle/kast/shared-idea-distributions" "Release must cache the actual shared IntelliJ extraction directory"
 require_contains "$release_workflow" "~/.gradle/kast/backend-idea-distributions" "Release must cache the actual IDEA backend extraction directory"

--- a/.github/scripts/upload-immutable-release-asset.sh
+++ b/.github/scripts/upload-immutable-release-asset.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: .github/scripts/upload-immutable-release-asset.sh --tag <tag> --asset <path>
+
+Upload one GitHub release asset exactly once. If the named asset already exists,
+download it and prove byte identity instead of replacing it.
+USAGE
+}
+
+tag=""
+asset=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      [[ $# -ge 2 ]] || die "Missing value for --tag"
+      tag="$2"
+      shift 2
+      ;;
+    --tag=*)
+      tag="${1#--tag=}"
+      shift
+      ;;
+    --asset)
+      [[ $# -ge 2 ]] || die "Missing value for --asset"
+      asset="$2"
+      shift 2
+      ;;
+    --asset=*)
+      asset="${1#--asset=}"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$tag" ]] || { usage; die "--tag is required"; }
+[[ -n "$asset" ]] || { usage; die "--asset is required"; }
+[[ -f "$asset" ]] || die "Release asset does not exist: $asset"
+command -v gh >/dev/null 2>&1 || die "gh is required to upload release assets"
+
+asset_name="$(basename -- "$asset")"
+asset_names="$(gh release view "$tag" --json assets --jq '.assets[].name')" \
+  || die "Unable to inspect release assets for ${tag}"
+existing_count="$(awk -v name="$asset_name" '$0 == name { count += 1 } END { print count + 0 }' <<< "$asset_names")"
+
+if [[ "$existing_count" -gt 1 ]]; then
+  die "Release ${tag} contains duplicate assets named ${asset_name}"
+fi
+
+if [[ "$existing_count" -eq 1 ]]; then
+  scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/kast-release-asset.XXXXXX")"
+  # shellcheck disable=SC2329 # Invoked indirectly by the EXIT trap.
+  cleanup() {
+    rm -rf "$scratch_dir"
+  }
+  trap cleanup EXIT
+
+  gh release download "$tag" --pattern "$asset_name" --dir "$scratch_dir" \
+    || die "Unable to download immutable release asset ${asset_name} from ${tag}"
+  downloaded_asset="${scratch_dir}/${asset_name}"
+  [[ -f "$downloaded_asset" ]] \
+    || die "Release ${tag} reported ${asset_name}, but the asset could not be downloaded"
+  if ! cmp -s "$asset" "$downloaded_asset"; then
+    local_digest="$(openssl dgst -sha256 -r "$asset" | awk '{ print $1 }')"
+    remote_digest="$(openssl dgst -sha256 -r "$downloaded_asset" | awk '{ print $1 }')"
+    die "Local asset ${asset_name} (${local_digest}) differs from immutable release asset ${tag}/${asset_name} (${remote_digest})"
+  fi
+  printf 'Verified byte-identical immutable release asset %s/%s\n' "$tag" "$asset_name"
+  exit 0
+fi
+
+gh release upload "$tag" "$asset"
+printf 'Uploaded immutable release asset %s/%s\n' "$tag" "$asset_name"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,5 +600,9 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
+      - name: Test IDEA plugin signing and immutability contract
+        shell: bash
+        run: ./.github/scripts/test-idea-plugin-signing-contract.sh
+
       - name: Run IDEA plugin performance baselines
         run: ./scripts/ci-gradle-retry.sh ./gradlew :backend-idea:test -PincludeTags=performance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,45 @@ jobs:
             exit 1
           fi
 
+      - name: Require IDEA plugin signing credentials and enrolled identity
+        env:
+          IDEA_PLUGIN_CERTIFICATE_CHAIN: ${{ secrets.IDEA_PLUGIN_CERTIFICATE_CHAIN }}
+          IDEA_PLUGIN_PRIVATE_KEY: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY }}
+          IDEA_PLUGIN_PRIVATE_KEY_PASSWORD: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY_PASSWORD }}
+          IDEA_PLUGIN_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_SIGNER_SHA256 }}
+          IDEA_PLUGIN_ROTATION_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_ROTATION_SIGNER_SHA256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            IDEA_PLUGIN_CERTIFICATE_CHAIN \
+            IDEA_PLUGIN_PRIVATE_KEY \
+            IDEA_PLUGIN_PRIVATE_KEY_PASSWORD \
+            IDEA_PLUGIN_SIGNER_SHA256
+          do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if [[ "${#missing[@]}" -gt 0 ]]; then
+            printf '::error::Missing required IDEA plugin signing inputs: %s\n' "${missing[*]}"
+            exit 1
+          fi
+          fingerprint_pattern='^[0-9a-f]{64}$'
+          [[ "$IDEA_PLUGIN_SIGNER_SHA256" =~ $fingerprint_pattern ]] || {
+            echo "::error::IDEA_PLUGIN_SIGNER_SHA256 must be 64 lowercase hexadecimal characters."
+            exit 1
+          }
+          if [[ -n "$IDEA_PLUGIN_ROTATION_SIGNER_SHA256" ]]; then
+            [[ "$IDEA_PLUGIN_ROTATION_SIGNER_SHA256" =~ $fingerprint_pattern ]] || {
+              echo "::error::IDEA_PLUGIN_ROTATION_SIGNER_SHA256 must be 64 lowercase hexadecimal characters."
+              exit 1
+            }
+            [[ "$IDEA_PLUGIN_ROTATION_SIGNER_SHA256" != "$IDEA_PLUGIN_SIGNER_SHA256" ]] || {
+              echo "::error::The rotation signer must differ from the primary enrolled signer."
+              exit 1
+            }
+          fi
+
   bump-version:
     name: Bump version (${{ inputs.release_type }})
     needs: [release-preflight]
@@ -639,48 +678,97 @@ jobs:
           restore-keys: |
             release-idea-plugin-inputs-${{ runner.os }}-
 
-      - name: Build IDEA plugin
+      - name: Build and verify IDEA plugin
         run: >
           ./scripts/ci-gradle-retry.sh
           ./gradlew
           :backend-idea:buildPlugin
           :backend-idea:verifyPluginStructure
           :backend-idea:verifyPluginXmlPresent
+          :backend-idea:verifyPlugin
           -Pversion="${{ needs.prepare-release.outputs.release_version }}"
 
-      - name: Upload IDEA plugin asset
+      - name: Materialize IDEA plugin signing certificate
+        id: idea-signing-certificate
+        env:
+          IDEA_PLUGIN_CERTIFICATE_CHAIN: ${{ secrets.IDEA_PLUGIN_CERTIFICATE_CHAIN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          certificate_path="${RUNNER_TEMP}/kast-idea-plugin-signing-chain.crt"
+          umask 077
+          printf '%s\n' "$IDEA_PLUGIN_CERTIFICATE_CHAIN" > "$certificate_path"
+          openssl x509 -in "$certificate_path" -noout
+          printf 'path=%s\n' "$certificate_path" >> "$GITHUB_OUTPUT"
+
+      - name: Sign and verify IDEA plugin
+        env:
+          PRIVATE_KEY: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY_PASSWORD }}
+        run: >
+          ./scripts/ci-gradle-retry.sh
+          ./gradlew
+          :backend-idea:signPlugin
+          :backend-idea:verifyPluginSignature
+          :backend-idea:stageIdeaPluginSignatureVerifier
+          -Pkast.idea.signing.certificateChainFile="${{ steps.idea-signing-certificate.outputs.path }}"
+          -Pversion="${{ needs.prepare-release.outputs.release_version }}"
+
+      - name: Stage and upload immutable signed IDEA plugin asset
         env:
           GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          IDEA_PLUGIN_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_SIGNER_SHA256 }}
+          IDEA_PLUGIN_ROTATION_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_ROTATION_SIGNER_SHA256 }}
         shell: bash
         run: |
           set -euo pipefail
           tag="${{ needs.prepare-release.outputs.release_tag }}"
+          release_sha="$(git rev-parse HEAD)"
+          tag_sha="$(git rev-list -n1 "$tag")"
+          [[ "$release_sha" == "$tag_sha" ]] || {
+            echo "Checked-out HEAD ${release_sha} does not match ${tag} target ${tag_sha}" >&2
+            exit 1
+          }
           asset_name="kast-idea-${tag}.zip"
-          source_zip="$(find backend-idea/build/distributions -maxdepth 1 -name '*.zip' -print -quit)"
-          [[ -n "$source_zip" ]] || { echo "No IDEA plugin zip found" >&2; exit 1; }
+          signature_verifier_jar="backend-idea/build/idea-plugin-signature-verifier/marketplace-zip-signer-cli.jar"
+          [[ -f "$signature_verifier_jar" ]] || {
+            echo "Marketplace ZIP Signer CLI was not staged: ${signature_verifier_jar}" >&2
+            exit 1
+          }
+          mapfile -t source_zips < <(
+            find backend-idea/build/distributions -maxdepth 1 -name '*-signed.zip' -print | sort
+          )
+          [[ "${#source_zips[@]}" -eq 1 ]] || {
+            echo "Expected exactly one signed IDEA plugin zip, found ${#source_zips[@]}" >&2
+            exit 1
+          }
+          source_zip="${source_zips[0]}"
           mkdir -p dist
           cp "$source_zip" "dist/${asset_name}"
-          python3 - "dist/${asset_name}" "dist/build-provenance-idea.json" <<'PY'
-          import hashlib, json, os, sys
-          from pathlib import Path
-          asset = Path(sys.argv[1])
-          payload = {
-              "runId": os.environ["GITHUB_RUN_ID"],
-              "runNumber": os.environ["GITHUB_RUN_NUMBER"],
-              "runAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
-              "sha": os.environ["GITHUB_SHA"],
-              "ref": os.environ["GITHUB_REF"],
-              "workflowRef": os.environ["GITHUB_WORKFLOW_REF"],
-              "actor": os.environ["GITHUB_ACTOR"],
-              "platformId": "idea",
-              "assetName": asset.name,
-              "assetDigest": "sha256:" + hashlib.sha256(asset.read_bytes()).hexdigest(),
-          }
-          Path(sys.argv[2]).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          PY
+          signer_args=(--expected-signer-sha256 "$IDEA_PLUGIN_SIGNER_SHA256")
+          if [[ -n "$IDEA_PLUGIN_ROTATION_SIGNER_SHA256" ]]; then
+            signer_args+=(--expected-signer-sha256 "$IDEA_PLUGIN_ROTATION_SIGNER_SHA256")
+          fi
+          scripts/verify-idea-plugin-artifact.py record \
+            --plugin-zip "dist/${asset_name}" \
+            --certificate-chain "${{ steps.idea-signing-certificate.outputs.path }}" \
+            --signature-verifier-jar "$signature_verifier_jar" \
+            --release-tag "$tag" \
+            --release-sha "$release_sha" \
+            --output dist/build-provenance-idea.json \
+            --asset-name "$asset_name" \
+            "${signer_args[@]}"
+          scripts/verify-idea-plugin-artifact.py verify \
+            --plugin-zip "dist/${asset_name}" \
+            --certificate-chain "${{ steps.idea-signing-certificate.outputs.path }}" \
+            --signature-verifier-jar "$signature_verifier_jar" \
+            --release-tag "$tag" \
+            --release-sha "$release_sha" \
+            --provenance dist/build-provenance-idea.json \
+            "${signer_args[@]}"
           scripts/verify-ci-artifact-ledger.py record \
             --output dist/build-ledger-idea.json \
-            --git-sha "$GITHUB_SHA" \
+            --git-sha "$release_sha" \
             --source-ref "refs/tags/${tag}" \
             --workflow-run-id "$GITHUB_RUN_ID" \
             --artifact-kind release-idea \
@@ -690,10 +778,12 @@ jobs:
             --build-command-id release-idea-plugin-build
           scripts/verify-ci-artifact-ledger.py verify \
             --ledger dist/build-ledger-idea.json \
-            --git-sha "$GITHUB_SHA" \
+            --git-sha "$release_sha" \
             --require-kind release-idea \
             --artifact "release-idea=dist/${asset_name}"
-          gh release upload "$tag" "dist/${asset_name}" --clobber
+          .github/scripts/upload-immutable-release-asset.sh \
+            --tag "$tag" \
+            --asset "dist/${asset_name}"
 
       - name: Upload plugin artifact
         if: always()
@@ -701,7 +791,7 @@ jobs:
         with:
           name: idea-plugin-${{ github.run_id }}
           path: dist/
-          if-no-files-found: warn
+          if-no-files-found: error
 
   build-headless-backend:
     name: Build headless backend
@@ -1199,6 +1289,7 @@ jobs:
           set -euo pipefail
           python3 scripts/assemble-release-provenance.py \
             --output dist/build-provenance.json \
+            --tag "${{ needs.prepare-release.outputs.release_tag }}" \
             provenance-cli \
             provenance-linux-headless \
             provenance-idea \
@@ -1211,7 +1302,9 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ needs.prepare-release.outputs.release_tag }}"
-          gh release upload "$tag" dist/build-provenance.json --clobber
+          .github/scripts/upload-immutable-release-asset.sh \
+            --tag "$tag" \
+            --asset dist/build-provenance.json
 
       - name: Generate and upload SHA256SUMS
         env:
@@ -1257,7 +1350,9 @@ jobs:
           (cd release-assets && sha256sum "${expected_assets[@]}") > SHA256SUMS
           cp SHA256SUMS release-assets/SHA256SUMS
           ./scripts/verify-release-assets.sh --release-dir release-assets --tag "$tag"
-          gh release upload "$tag" SHA256SUMS --clobber
+          .github/scripts/upload-immutable-release-asset.sh \
+            --tag "$tag" \
+            --asset SHA256SUMS
 
       - name: Publish draft release with provenance annotation
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,7 +357,9 @@ jobs:
             --git-sha "$GITHUB_SHA" \
             --require-kind release-openapi \
             --artifact release-openapi=dist/openapi.yaml
-          gh release upload "$tag" dist/openapi.yaml --clobber
+          .github/scripts/upload-immutable-release-asset.sh \
+            --tag "$tag" \
+            --asset dist/openapi.yaml
 
       - name: Upload OpenAPI workflow artifact
         if: always()
@@ -625,7 +627,9 @@ jobs:
             --git-sha "$GITHUB_SHA" \
             --require-kind "release-cli-${{ matrix.asset_id }}" \
             --artifact "release-cli-${{ matrix.asset_id }}=dist/kast-${tag}-${{ matrix.asset_id }}.zip"
-          gh release upload "$tag" "dist/kast-${tag}-${{ matrix.asset_id }}.zip" --clobber
+          .github/scripts/upload-immutable-release-asset.sh \
+            --tag "$tag" \
+            --asset "dist/kast-${tag}-${{ matrix.asset_id }}.zip"
 
       - name: Upload CLI build artifact
         if: always()
@@ -1167,13 +1171,17 @@ jobs:
             --artifact release-headless-linux-x64=dist/kast-headless-linux-x64.tar.zst \
             --artifact release-runtime-manifest=dist/kast-runtime-manifest.json \
             --artifact release-gradle-ro-cache=dist/gradle-ro-dep-cache.tar.zst
-          gh release upload "$tag" \
+          for asset in \
             "$bundle_asset" \
             "${bundle_asset}.sha256" \
             dist/kast-headless-linux-x64.tar.zst \
             dist/kast-headless-linux-x64.sha256 \
-            dist/kast-runtime-manifest.json \
-            --clobber
+            dist/kast-runtime-manifest.json
+          do
+            .github/scripts/upload-immutable-release-asset.sh \
+              --tag "$tag" \
+              --asset "$asset"
+          done
 
       - name: Upload Linux headless tarball artifact
         if: always()
@@ -1278,10 +1286,11 @@ jobs:
           [[ -f "$cache_asset" ]] || { echo "Missing Gradle read-only cache artifact: ${cache_asset}" >&2; exit 1; }
           [[ -f "$cache_sidecar" ]] || { echo "Missing Gradle read-only cache checksum: ${cache_sidecar}" >&2; exit 1; }
           (cd provenance-linux-headless && sha256sum -c gradle-ro-dep-cache.sha256)
-          gh release upload "$tag" \
-            "$cache_asset" \
-            "$cache_sidecar" \
-            --clobber
+          for asset in "$cache_asset" "$cache_sidecar"; do
+            .github/scripts/upload-immutable-release-asset.sh \
+              --tag "$tag" \
+              --asset "$asset"
+          done
 
       - name: Assemble combined provenance
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,26 @@ source ownership, generated outputs, or validation gates, update the nearest
 scoped `AGENTS.md` in the same change. Agent-only ADRs stay under
 `.agents/adr/`; published docs navigation is owned by the docs source.
 
+## Signed IDEA Plugin Release Authority
+
+The release tag owns the only production IDEA plugin build. The
+`build-idea-plugin` release job must run JetBrains structure and compatibility
+verification, sign exactly one ZIP with protected inputs, verify the signature
+against the file-backed enrolled certificate, and record signer-bound
+provenance before upload. Private keys and passwords remain GitHub secrets;
+certificate fingerprints are explicit repository variables and never derive
+from a shared release version.
+
+`.github/scripts/upload-immutable-release-asset.sh` owns plugin-asset replay:
+upload once, then prove byte identity or fail. It must never use `--clobber`.
+`scripts/verify-idea-plugin-artifact.py`, the release provenance assembler, and
+`scripts/verify-release-assets.sh` own the plugin ID, digest, signer, signature,
+and verification-task evidence. Run
+`.github/scripts/test-idea-plugin-signing-contract.sh`,
+`.github/scripts/test-release-workflow-contract.sh`,
+`.github/scripts/test-release-provenance-assembler.sh`, and
+`.github/scripts/test-release-asset-verifier.sh` after changing this boundary.
+
 ## Build, Test, and Development Commands
 
 - `./gradlew test` runs the Kotlin/JVM test suite.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,9 @@ provenance before upload. Private keys and passwords remain GitHub secrets;
 certificate fingerprints are explicit repository variables and never derive
 from a shared release version.
 
-`.github/scripts/upload-immutable-release-asset.sh` owns plugin-asset replay:
-upload once, then prove byte identity or fail. It must never use `--clobber`.
+`.github/scripts/upload-immutable-release-asset.sh` owns release-asset replay:
+every asset uploads once, then proves byte identity or fails. Release workflows
+must never use `--clobber`.
 `scripts/verify-idea-plugin-artifact.py`, the release provenance assembler, and
 `scripts/verify-release-assets.sh` own the plugin ID, digest, signer, signature,
 and verification-task evidence. Run

--- a/backend-idea/AGENTS.md
+++ b/backend-idea/AGENTS.md
@@ -1,5 +1,25 @@
 # IDEA Backend Guidelines
 
+## Signed distribution boundary
+
+`backend-idea/build.gradle.kts` owns the JetBrains signing task wiring. The
+certificate chain is a file-backed Gradle property so signature verification
+uses the same public certificate without exposing it on a command line. The
+private key and password come only from `PRIVATE_KEY` and
+`PRIVATE_KEY_PASSWORD`; do not add checked-in credentials, fallback keys, or
+logging of signing inputs.
+
+`verifyPluginSignature` must consume `signPlugin.signedArchiveFile` through its
+typed task provider. `stageIdeaPluginSignatureVerifier` exports the same
+Gradle-resolved Marketplace ZIP Signer CLI so the staged release bytes are
+verified again against the enrolled certificate before provenance is written.
+Release builds also run `verifyPluginStructure`, `verifyPluginXmlPresent`, and
+`verifyPlugin`, and must prove checked-out `HEAD` equals the peeled release-tag
+target before recording signer-bound provenance. Exercise the real
+ephemeral-key path with `.github/scripts/test-idea-plugin-signing-contract.sh`;
+missing or unenrolled production credentials fail in release preflight rather
+than producing an unsigned artifact.
+
 ## Workspace inventory authority
 
 `IdeaProjectModelWorkspaceFileInventory` owns complete raw `.kt` and `.kts`

--- a/backend-idea/build.gradle.kts
+++ b/backend-idea/build.gradle.kts
@@ -1,7 +1,10 @@
 import VerifyPluginXmlPresentTask
 import WriteBackendVersionTask
+import org.gradle.api.tasks.Sync
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.tasks.SignPluginTask
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginSignatureTask
 
 plugins {
     id("kast.idea-build-helpers")
@@ -26,6 +29,7 @@ kotlin {
 
 private val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
 private val ideaDistributionVersion = catalog.findVersion("idea").get().requiredVersion
+private val signingCertificateChainPath = providers.gradleProperty("kast.idea.signing.certificateChainFile")
 
 val ideaDistribution: Configuration by configurations.creating {
     isCanBeConsumed = false
@@ -108,6 +112,12 @@ intellijPlatform {
             create(IntelliJPlatformType.AndroidStudio, "2025.3.1.7")
         }
     }
+
+    signing {
+        certificateChainFile.set(project.layout.file(signingCertificateChainPath.map(project::file)))
+        privateKey.set(providers.environmentVariable("PRIVATE_KEY"))
+        password.set(providers.environmentVariable("PRIVATE_KEY_PASSWORD"))
+    }
 }
 
 val generatedResourcesDir = layout.buildDirectory.dir("generated-resources")
@@ -140,6 +150,17 @@ tasks.register<VerifyPluginXmlPresentTask>("verifyPluginXmlPresent") {
     distributionsDirectory.set(layout.buildDirectory.dir("distributions"))
     expectedPluginId.set("io.github.amichne.kast")
     rejectedPluginId.set("io.github.amichne.kast.idea")
+}
+
+val signIdeaPlugin = tasks.named<SignPluginTask>("signPlugin")
+val verifyIdeaPluginSignature = tasks.named<VerifyPluginSignatureTask>("verifyPluginSignature") {
+    inputArchiveFile.set(signIdeaPlugin.flatMap { it.signedArchiveFile })
+}
+
+tasks.register<Sync>("stageIdeaPluginSignatureVerifier") {
+    from(verifyIdeaPluginSignature.flatMap { it.zipSignerExecutable })
+    into(layout.buildDirectory.dir("idea-plugin-signature-verifier"))
+    rename { "marketplace-zip-signer-cli.jar" }
 }
 
 tasks.withType<Test>().configureEach {

--- a/scripts/assemble-release-provenance.py
+++ b/scripts/assemble-release-provenance.py
@@ -31,6 +31,7 @@ def parse_args() -> argparse.Namespace:
         description="Assemble release build provenance from downloaded artifact directories."
     )
     parser.add_argument("--output", required=True, help="Path to write combined build-provenance.json")
+    parser.add_argument("--tag", required=True, help="Release tag that every tag-bound entry must prove")
     parser.add_argument("roots", nargs="+", help="Downloaded artifact roots to scan recursively")
     return parser.parse_args()
 
@@ -57,7 +58,7 @@ def stable_values(values: set[object]) -> list[object]:
     return sorted(values, key=lambda value: str(value))
 
 
-def validate(entries: list[dict]) -> None:
+def validate(entries: list[dict], *, release_tag: str) -> None:
     seen_platforms = [entry.get("platformId") for entry in entries]
     platform_set = set(seen_platforms)
     missing_provenance = REQUIRED_PLATFORMS - platform_set
@@ -92,12 +93,36 @@ def validate(entries: list[dict]) -> None:
             or asset_digest == "sha256:"
         ):
             fail(f"provenance entry for {platform} has no SHA-256 assetDigest")
+        if platform == "idea":
+            if entry.get("pluginId") != "io.github.amichne.kast":
+                fail("IDEA provenance must name pluginId io.github.amichne.kast")
+            signer = entry.get("signerCertificateSha256")
+            if not isinstance(signer, str) or len(signer) != 64 or any(
+                character not in "0123456789abcdef" for character in signer
+            ):
+                fail("IDEA provenance signerCertificateSha256 must be lowercase SHA-256")
+            if entry.get("signatureVerified") is not True:
+                fail("IDEA provenance signatureVerified must be true")
+            if entry.get("ref") != f"refs/tags/{release_tag}":
+                fail(f"IDEA provenance ref must be refs/tags/{release_tag}")
+            release_sha = entry.get("sha")
+            if not isinstance(release_sha, str) or len(release_sha) != 40 or any(
+                character not in "0123456789abcdef" for character in release_sha
+            ):
+                fail("IDEA provenance sha must be a full lowercase Git commit SHA")
+            if entry.get("verificationTasks") != [
+                ":backend-idea:verifyPluginStructure",
+                ":backend-idea:verifyPluginXmlPresent",
+                ":backend-idea:verifyPlugin",
+                ":backend-idea:verifyPluginSignature",
+            ]:
+                fail("IDEA provenance must carry the complete signed compatibility gate")
 
 
 def main() -> None:
     args = parse_args()
     entries = load_entries(args.roots)
-    validate(entries)
+    validate(entries, release_tag=args.tag)
     entries.sort(key=lambda item: item["platformId"])
 
     output = Path(args.output)

--- a/scripts/verify-idea-plugin-artifact.py
+++ b/scripts/verify-idea-plugin-artifact.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+
+PLUGIN_ID = "io.github.amichne.kast"
+IDEA_PLATFORM_ID = "idea"
+SIGNATURE_VERIFICATION_TASKS = (
+    ":backend-idea:verifyPluginStructure",
+    ":backend-idea:verifyPluginXmlPresent",
+    ":backend-idea:verifyPlugin",
+    ":backend-idea:verifyPluginSignature",
+)
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+GIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+RELEASE_TAG_PATTERN = re.compile(r"v[0-9A-Za-z][0-9A-Za-z._-]*")
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+@dataclass(frozen=True)
+class Sha256:
+    value: str
+
+    @classmethod
+    def parse(cls, raw: object, *, field: str) -> "Sha256":
+        if not isinstance(raw, str) or SHA256_PATTERN.fullmatch(raw) is None:
+            fail(f"{field} must be 64 lowercase hexadecimal characters")
+        return cls(raw)
+
+    @classmethod
+    def of_file(cls, path: Path) -> "Sha256":
+        return cls(hashlib.sha256(path.read_bytes()).hexdigest())
+
+
+@dataclass(frozen=True)
+class EnrolledSigners:
+    fingerprints: frozenset[Sha256]
+
+    @classmethod
+    def parse(cls, raw_fingerprints: list[str]) -> "EnrolledSigners":
+        if not raw_fingerprints:
+            fail("at least one --expected-signer-sha256 is required")
+        fingerprints = frozenset(
+            Sha256.parse(raw, field="expected signer fingerprint")
+            for raw in raw_fingerprints
+        )
+        if len(fingerprints) != len(raw_fingerprints):
+            fail("expected signer fingerprints must be unique")
+        return cls(fingerprints)
+
+    def require_enrolled(self, signer: Sha256) -> None:
+        if signer not in self.fingerprints:
+            fail(f"signer certificate is not enrolled: {signer.value}")
+
+
+@dataclass(frozen=True)
+class ReleaseIdentity:
+    tag: str
+    sha: str
+
+    @classmethod
+    def parse(cls, *, tag: object, sha: object) -> "ReleaseIdentity":
+        if not isinstance(tag, str) or RELEASE_TAG_PATTERN.fullmatch(tag) is None:
+            fail("release tag must start with v and contain only tag-safe characters")
+        if not isinstance(sha, str) or GIT_SHA_PATTERN.fullmatch(sha) is None:
+            fail("release SHA must be 40 lowercase hexadecimal characters")
+        return cls(tag=tag, sha=sha)
+
+    @classmethod
+    def from_provenance(cls, raw: dict[str, Any]) -> "ReleaseIdentity":
+        ref = raw.get("ref")
+        if not isinstance(ref, str) or not ref.startswith("refs/tags/"):
+            fail("IDEA plugin provenance ref must name a release tag")
+        return cls.parse(tag=ref.removeprefix("refs/tags/"), sha=raw.get("sha"))
+
+    @property
+    def ref(self) -> str:
+        return f"refs/tags/{self.tag}"
+
+
+@dataclass(frozen=True)
+class IdeaPluginProvenance:
+    asset_name: str
+    asset_digest: Sha256
+    signer_certificate_sha256: Sha256
+    release_identity: ReleaseIdentity
+
+    @classmethod
+    def parse(cls, raw: object) -> "IdeaPluginProvenance":
+        if not isinstance(raw, dict):
+            fail("IDEA plugin provenance must be a JSON object")
+        payload: dict[str, Any] = raw
+        if payload.get("platformId") != IDEA_PLATFORM_ID:
+            fail("IDEA plugin provenance platformId must be idea")
+        asset_name = payload.get("assetName")
+        if not isinstance(asset_name, str) or not asset_name.endswith(".zip"):
+            fail("IDEA plugin provenance assetName must name a ZIP")
+        digest = payload.get("assetDigest")
+        if not isinstance(digest, str) or not digest.startswith("sha256:"):
+            fail("IDEA plugin provenance assetDigest must use sha256")
+        if payload.get("pluginId") != PLUGIN_ID:
+            fail(f"IDEA plugin provenance pluginId must be {PLUGIN_ID}")
+        if payload.get("signatureVerified") is not True:
+            fail("IDEA plugin provenance signatureVerified must be true")
+        if payload.get("verificationTasks") != list(SIGNATURE_VERIFICATION_TASKS):
+            fail("IDEA plugin provenance verificationTasks do not prove the signed compatibility gate")
+        return cls(
+            asset_name=asset_name,
+            asset_digest=Sha256.parse(digest.removeprefix("sha256:"), field="assetDigest"),
+            signer_certificate_sha256=Sha256.parse(
+                payload.get("signerCertificateSha256"),
+                field="signerCertificateSha256",
+            ),
+            release_identity=ReleaseIdentity.from_provenance(payload),
+        )
+
+
+def require_file(path: Path, *, description: str) -> None:
+    if not path.is_file():
+        fail(f"{description} does not exist: {path}")
+
+
+def certificate_fingerprint(certificate_chain: Path) -> Sha256:
+    require_file(certificate_chain, description="certificate chain")
+    result = subprocess.run(
+        ["openssl", "x509", "-in", str(certificate_chain), "-outform", "DER"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        fail("certificate chain does not start with a valid X.509 certificate")
+    return Sha256(hashlib.sha256(result.stdout).hexdigest())
+
+
+def verify_signature(plugin_zip: Path, certificate_chain: Path, verifier_jar: Path) -> None:
+    require_file(plugin_zip, description="plugin ZIP")
+    require_file(certificate_chain, description="certificate chain")
+    require_file(verifier_jar, description="Marketplace ZIP Signer CLI")
+    try:
+        result = subprocess.run(
+            [
+                "java",
+                "-jar",
+                str(verifier_jar),
+                "verify",
+                "-in",
+                str(plugin_zip),
+                "-cert",
+                str(certificate_chain),
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        fail("java is required to execute the Marketplace ZIP Signer")
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        suffix = f": {detail[-1]}" if detail else ""
+        fail(f"Marketplace ZIP Signer rejected the plugin archive{suffix}")
+
+
+def plugin_id(plugin_zip: Path) -> str:
+    require_file(plugin_zip, description="plugin ZIP")
+    try:
+        with zipfile.ZipFile(plugin_zip) as archive:
+            descriptors = [
+                archive.read(name)
+                for name in sorted(archive.namelist())
+                if name == "META-INF/plugin.xml" or name.endswith("/META-INF/plugin.xml")
+            ]
+            for jar_name in sorted(name for name in archive.namelist() if name.endswith(".jar")):
+                with zipfile.ZipFile(io.BytesIO(archive.read(jar_name))) as jar:
+                    if "META-INF/plugin.xml" in jar.namelist():
+                        descriptors.append(jar.read("META-INF/plugin.xml"))
+            if len(descriptors) != 1:
+                fail(f"plugin ZIP must contain exactly one META-INF/plugin.xml, found {len(descriptors)}")
+            descriptor = ElementTree.fromstring(descriptors[0])
+    except (ElementTree.ParseError, KeyError, zipfile.BadZipFile) as error:
+        fail(f"plugin ZIP has an invalid plugin descriptor: {error}")
+    identifier = descriptor.findtext("id")
+    if identifier != PLUGIN_ID:
+        fail(f"plugin ZIP id must be {PLUGIN_ID}, got {identifier!r}")
+    return identifier
+
+
+def github_environment() -> dict[str, str]:
+    required = (
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_NUMBER",
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_WORKFLOW_REF",
+        "GITHUB_ACTOR",
+    )
+    missing = [name for name in required if not os.environ.get(name)]
+    if missing:
+        fail(f"missing GitHub provenance environment: {missing}")
+    return {name: os.environ[name] for name in required}
+
+
+def record(args: argparse.Namespace) -> None:
+    plugin_zip = Path(args.plugin_zip)
+    certificate_chain = Path(args.certificate_chain)
+    verifier_jar = Path(args.signature_verifier_jar)
+    release_identity = ReleaseIdentity.parse(tag=args.release_tag, sha=args.release_sha)
+    enrolled_signers = EnrolledSigners.parse(args.expected_signer_sha256)
+    signer = certificate_fingerprint(certificate_chain)
+    enrolled_signers.require_enrolled(signer)
+    verify_signature(plugin_zip, certificate_chain, verifier_jar)
+    identity = plugin_id(plugin_zip)
+    digest = Sha256.of_file(plugin_zip)
+    if args.asset_name != plugin_zip.name:
+        fail("asset name must match the staged plugin ZIP filename")
+    environment = github_environment()
+    payload = {
+        "runId": environment["GITHUB_RUN_ID"],
+        "runNumber": environment["GITHUB_RUN_NUMBER"],
+        "runAttempt": environment["GITHUB_RUN_ATTEMPT"],
+        "sha": release_identity.sha,
+        "ref": release_identity.ref,
+        "workflowRef": environment["GITHUB_WORKFLOW_REF"],
+        "actor": environment["GITHUB_ACTOR"],
+        "platformId": IDEA_PLATFORM_ID,
+        "assetName": args.asset_name,
+        "assetDigest": f"sha256:{digest.value}",
+        "pluginId": identity,
+        "signerCertificateSha256": signer.value,
+        "signatureVerified": True,
+        "verificationTasks": list(SIGNATURE_VERIFICATION_TASKS),
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Recorded signed IDEA plugin provenance for {args.asset_name}")
+
+
+def verify(args: argparse.Namespace) -> None:
+    plugin_zip = Path(args.plugin_zip)
+    certificate_chain = Path(args.certificate_chain)
+    verifier_jar = Path(args.signature_verifier_jar)
+    release_identity = ReleaseIdentity.parse(tag=args.release_tag, sha=args.release_sha)
+    provenance_path = Path(args.provenance)
+    require_file(provenance_path, description="IDEA plugin provenance")
+    enrolled_signers = EnrolledSigners.parse(args.expected_signer_sha256)
+    signer = certificate_fingerprint(certificate_chain)
+    enrolled_signers.require_enrolled(signer)
+    verify_signature(plugin_zip, certificate_chain, verifier_jar)
+    plugin_id(plugin_zip)
+    with provenance_path.open(encoding="utf-8") as handle:
+        provenance = IdeaPluginProvenance.parse(json.load(handle))
+    if provenance.asset_name != plugin_zip.name:
+        fail(
+            "IDEA plugin provenance assetName does not match plugin ZIP: "
+            f"{provenance.asset_name} != {plugin_zip.name}"
+        )
+    digest = Sha256.of_file(plugin_zip)
+    if provenance.asset_digest != digest:
+        fail("IDEA plugin provenance digest does not match plugin ZIP bytes")
+    if provenance.signer_certificate_sha256 != signer:
+        fail("IDEA plugin provenance signer does not match the verified certificate chain")
+    if provenance.release_identity != release_identity:
+        fail("IDEA plugin provenance does not match the checked-out release tag and commit")
+    print(f"Verified signed IDEA plugin artifact {plugin_zip.name} with signer {signer.value}")
+
+
+def add_shared_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--plugin-zip", required=True)
+    parser.add_argument("--certificate-chain", required=True)
+    parser.add_argument("--signature-verifier-jar", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--release-sha", required=True)
+    parser.add_argument(
+        "--expected-signer-sha256",
+        action="append",
+        required=True,
+        help="Enrolled certificate SHA-256. Repeat only for an explicit rotation overlap.",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Record or verify signer-bound provenance for a signed Kast IDEA plugin ZIP."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    record_parser = subparsers.add_parser("record")
+    add_shared_arguments(record_parser)
+    record_parser.add_argument("--output", required=True)
+    record_parser.add_argument("--asset-name", required=True)
+    record_parser.set_defaults(handler=record)
+    verify_parser = subparsers.add_parser("verify")
+    add_shared_arguments(verify_parser)
+    verify_parser.add_argument("--provenance", required=True)
+    verify_parser.set_defaults(handler=verify)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -108,6 +108,27 @@ unexpected_provenance = sorted(set(by_platform) - set(supported))
 if unexpected_provenance:
     fail(f"unexpected provenance for {unexpected_provenance}")
 
+idea_provenance = by_platform["idea"]
+if idea_provenance.get("pluginId") != "io.github.amichne.kast":
+    fail("IDEA plugin provenance pluginId must be io.github.amichne.kast")
+signer_fingerprint = idea_provenance.get("signerCertificateSha256")
+if not isinstance(signer_fingerprint, str) or re.fullmatch(r"[0-9a-f]{64}", signer_fingerprint) is None:
+    fail("IDEA plugin provenance signerCertificateSha256 must be lowercase SHA-256")
+if idea_provenance.get("signatureVerified") is not True:
+    fail("IDEA plugin provenance signatureVerified must be true")
+if idea_provenance.get("ref") != f"refs/tags/{tag}":
+    fail(f"IDEA plugin provenance ref must be refs/tags/{tag}")
+release_sha = idea_provenance.get("sha")
+if not isinstance(release_sha, str) or re.fullmatch(r"[0-9a-f]{40}", release_sha) is None:
+    fail("IDEA plugin provenance sha must be a full lowercase Git commit SHA")
+if idea_provenance.get("verificationTasks") != [
+    ":backend-idea:verifyPluginStructure",
+    ":backend-idea:verifyPluginXmlPresent",
+    ":backend-idea:verifyPlugin",
+    ":backend-idea:verifyPluginSignature",
+]:
+    fail("IDEA plugin provenance must carry the complete signed compatibility gate")
+
 expected_assets = set()
 for platform_id, entry in by_platform.items():
     asset_name = supported[platform_id]


### PR DESCRIPTION
Closes #378

## Outcome

Ships the IDEA plugin release boundary from ADR 0023 as one immutable, signed ZIP with signer-bound and release-tag-bound provenance.

## Changes

- wires Gradle sign and signature verification through typed task providers
- stages and executes JetBrains Marketplace ZIP Signer against the exact published bytes and enrolled certificate
- rejects unsigned archives, wrong certificates, invalid or unenrolled signers, and rotation without explicit overlap
- proves checked-out HEAD matches the peeled release tag target before provenance is recorded
- uploads the plugin, combined provenance, and checksums without clobbering existing release assets
- extends release download and provenance gates plus CI contract coverage

## Red-green evidence

The new focused contract first failed because the immutable uploader did not exist. Independent review later reproduced unsigned ZIP acceptance; the gate was tightened and now rejects unsigned bytes and signed-A/verify-B before recording provenance.

## Validation

- .github/scripts/test-idea-plugin-signing-contract.sh
- .github/scripts/test-release-workflow-contract.sh
- .github/scripts/test-release-provenance-assembler.sh
- .github/scripts/test-release-asset-verifier.sh
- ./scripts/ci-gradle-retry.sh ./gradlew :backend-idea:test :backend-idea:buildPlugin :backend-idea:verifyPluginStructure :backend-idea:verifyPluginXmlPresent :backend-idea:verifyPlugin :backend-idea:stageIdeaPluginSignatureVerifier --no-daemon --stacktrace
- ShellCheck on the new Bash surfaces
- YAML parse for ci.yml and release.yml
- git diff --check

## Release setup

Before the next release, configure repository secrets IDEA_PLUGIN_CERTIFICATE_CHAIN, IDEA_PLUGIN_PRIVATE_KEY, and IDEA_PLUGIN_PRIVATE_KEY_PASSWORD, plus repository variable IDEA_PLUGIN_SIGNER_SHA256. Use IDEA_PLUGIN_ROTATION_SIGNER_SHA256 only for an explicit overlap window.