### PR TITLE
feat: publish signed IDEA plugin repository

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -23,6 +23,17 @@ For release workflow changes, run `.github/scripts/test-release-workflow-contrac
 For CLI terminal command or executable example changes, run
 `.github/scripts/test-terminal-command-contract.sh`.
 
+The signed JetBrains repository source lives at
+`packaging/jetbrains/plugin-repository.json`. The authored renderer and GitHub
+Release adapter live in `.github/scripts/`; release and docs workflows may
+publish only their verified generated Pages output. A stable release may
+advance the feed only after GitHub proves the release immutable and the
+downloaded ZIP passes signer-bound cryptographic verification. A docs deploy
+may only preserve the already-published feed. Both flows must materialize,
+upload, and deploy under the shared `github-pages` concurrency lock. Never
+hand-author `updatePlugins.xml` or `plugin-repository-manifest.json`, and never
+derive the enrolled signer from a secret or mutable release variable.
+
 Publishable CI artifacts are single-producer per commit. Producer jobs must
 write a `scripts/verify-ci-artifact-ledger.py` receipt for the artifact they
 built, and downstream packaging or publication jobs must verify that receipt
@@ -58,6 +69,14 @@ For terminal commands and executable examples, run:
 
 ```console
 .github/scripts/test-terminal-command-contract.sh
+```
+
+For signed JetBrains repository or Pages publication changes, run:
+
+```console
+.github/scripts/test-jetbrains-plugin-repository-contract.sh
+.github/scripts/test-idea-plugin-signing-contract.sh
+.github/scripts/test-release-workflow-contract.sh
 ```
 
 For plugin-eval metric pack changes, run the script that owns the changed pack,

--- a/.github/scripts/materialize-jetbrains-plugin-repository-pages.sh
+++ b/.github/scripts/materialize-jetbrains-plugin-repository-pages.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: materialize-jetbrains-plugin-repository-pages.sh \
+  --source <plugin-repository.json> \
+  --output-directory <site/jetbrains> \
+  (--tag <vX.Y.Z> | --latest-stable | --published-release) \
+  [--allow-unconfigured] [--allow-unpublished] \
+  [--certificate-chain <chain.crt>] \
+  [--signature-verifier-jar <marketplace-zip-signer-cli.jar>] \
+  [--artifact-verifier <verify-idea-plugin-artifact.py>] \
+  [--gh-bin <path>] [--curl-bin <path>]
+USAGE
+  exit 2
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/../.." && pwd
+}
+
+repo_root="$(resolve_repo_root)"
+renderer="${repo_root}/.github/scripts/render-jetbrains-plugin-repository.py"
+source_file=""
+output_directory=""
+tag=""
+latest_stable=false
+published_release=false
+allow_unconfigured=false
+allow_unpublished=false
+gh_bin="gh"
+curl_bin="curl"
+certificate_chain=""
+signature_verifier_jar=""
+artifact_verifier="${repo_root}/scripts/verify-idea-plugin-artifact.py"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source)
+      [[ $# -ge 2 ]] || usage
+      source_file="$2"
+      shift 2
+      ;;
+    --output-directory)
+      [[ $# -ge 2 ]] || usage
+      output_directory="$2"
+      shift 2
+      ;;
+    --tag)
+      [[ $# -ge 2 ]] || usage
+      tag="$2"
+      shift 2
+      ;;
+    --latest-stable)
+      latest_stable=true
+      shift
+      ;;
+    --published-release)
+      published_release=true
+      shift
+      ;;
+    --allow-unconfigured)
+      allow_unconfigured=true
+      shift
+      ;;
+    --allow-unpublished)
+      allow_unpublished=true
+      shift
+      ;;
+    --gh-bin)
+      [[ $# -ge 2 ]] || usage
+      gh_bin="$2"
+      shift 2
+      ;;
+    --curl-bin)
+      [[ $# -ge 2 ]] || usage
+      curl_bin="$2"
+      shift 2
+      ;;
+    --certificate-chain)
+      [[ $# -ge 2 ]] || usage
+      certificate_chain="$2"
+      shift 2
+      ;;
+    --signature-verifier-jar)
+      [[ $# -ge 2 ]] || usage
+      signature_verifier_jar="$2"
+      shift 2
+      ;;
+    --artifact-verifier)
+      [[ $# -ge 2 ]] || usage
+      artifact_verifier="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+[[ -n "$source_file" ]] || usage
+[[ -n "$output_directory" ]] || usage
+mode_count=0
+[[ -n "$tag" ]] && mode_count=$((mode_count + 1))
+[[ "$latest_stable" == true ]] && mode_count=$((mode_count + 1))
+[[ "$published_release" == true ]] && mode_count=$((mode_count + 1))
+if [[ "$mode_count" -ne 1 ]]; then
+  usage
+fi
+if [[ "$allow_unpublished" == true && "$published_release" != true ]]; then
+  usage
+fi
+[[ -x "$renderer" ]] || die "JetBrains repository renderer is not executable: $renderer"
+
+"$renderer" validate-source --source "$source_file"
+signing_state="$("$renderer" signing-state --source "$source_file")"
+if [[ "$signing_state" == "unconfigured" ]]; then
+  if [[ "$allow_unconfigured" == true ]]; then
+    rm -rf -- "$output_directory"
+    printf 'JetBrains repository publication is disabled until the production signer is configured.\n'
+    exit 0
+  fi
+  die "JetBrains repository publication requires a configured production signer"
+fi
+"$renderer" validate-source --source "$source_file" --require-configured
+
+scratch_dir="$(mktemp -d)"
+trap 'rm -rf "$scratch_dir"' EXIT
+if [[ "$published_release" == true ]]; then
+  command -v "$curl_bin" >/dev/null 2>&1 || die "curl is required: $curl_bin"
+  published_manifest="${scratch_dir}/published-plugin-repository-manifest.json"
+  published_xml="${scratch_dir}/published-updatePlugins.xml"
+  published_manifest_url="$("$renderer" manifest-url --source "$source_file")"
+  published_feed_url="$("$renderer" feed-url --source "$source_file")"
+  set +e
+  http_status="$($curl_bin \
+    --silent \
+    --show-error \
+    --location \
+    --proto '=https' \
+    --tlsv1.2 \
+    --output "$published_manifest" \
+    --write-out '%{http_code}' \
+    "$published_manifest_url")"
+  curl_status=$?
+  set -e
+  [[ "$curl_status" -eq 0 ]] || die "Published JetBrains repository manifest request failed"
+  if [[ "$http_status" == "404" && "$allow_unpublished" == true ]]; then
+    rm -rf -- "$output_directory"
+    printf 'JetBrains repository has no previously published feed to preserve.\n'
+    exit 0
+  fi
+  [[ "$http_status" == "200" ]] \
+    || die "Published JetBrains repository manifest returned HTTP ${http_status}"
+  xml_http_status="$($curl_bin \
+    --silent \
+    --show-error \
+    --location \
+    --proto '=https' \
+    --tlsv1.2 \
+    --output "$published_xml" \
+    --write-out '%{http_code}' \
+    "$published_feed_url")"
+  [[ "$xml_http_status" == "200" ]] \
+    || die "Published JetBrains repository XML returned HTTP ${xml_http_status}"
+  tag="$("$renderer" verify-published \
+    --source "$source_file" \
+    --manifest "$published_manifest" \
+    --xml "$published_xml")"
+  rm -rf -- "$output_directory"
+  mkdir -p -- "$output_directory"
+  cp -- "$published_manifest" "${output_directory}/plugin-repository-manifest.json"
+  cp -- "$published_xml" "${output_directory}/updatePlugins.xml"
+  printf 'Preserved validated JetBrains plugin repository for %s.\n' "$tag"
+  exit 0
+fi
+
+command -v "$gh_bin" >/dev/null 2>&1 || die "GitHub CLI is required: $gh_bin"
+[[ -n "$certificate_chain" ]] || die "Feed advancement requires --certificate-chain"
+[[ -n "$signature_verifier_jar" ]] || die "Feed advancement requires --signature-verifier-jar"
+[[ -f "$certificate_chain" ]] || die "Public certificate chain does not exist: $certificate_chain"
+[[ -f "$signature_verifier_jar" ]] \
+  || die "Marketplace ZIP Signer CLI does not exist: $signature_verifier_jar"
+[[ -f "$artifact_verifier" ]] || die "IDEA plugin artifact verifier does not exist: $artifact_verifier"
+if [[ "$latest_stable" == true ]]; then
+  tag="$($gh_bin release list \
+    --repo amichne/kast \
+    --exclude-drafts \
+    --exclude-pre-releases \
+    --limit 1 \
+    --json tagName \
+    --jq '.[0].tagName // empty')"
+  [[ -n "$tag" ]] || die "No finalized stable GitHub Release is available"
+fi
+[[ "$tag" =~ ^v[0-9A-Za-z][0-9A-Za-z._-]*$ ]] || die "Invalid release tag: $tag"
+[[ "$tag" != *-* ]] || die "The stable JetBrains repository cannot publish a prerelease tag"
+
+release_state="$($gh_bin release view "$tag" \
+  --repo amichne/kast \
+  --json tagName,isDraft,isPrerelease \
+  --jq '[.tagName, .isDraft, .isPrerelease] | @tsv')"
+IFS=$'\t' read -r actual_tag is_draft is_prerelease <<< "$release_state"
+[[ "$actual_tag" == "$tag" ]] || die "GitHub Release tag mismatch: ${actual_tag:-<missing>}"
+[[ "$is_draft" == "false" ]] || die "GitHub Release is still a draft: $tag"
+[[ "$is_prerelease" == "false" ]] || die "GitHub Release is not stable: $tag"
+immutable="$($gh_bin api "repos/amichne/kast/releases/tags/${tag}" --jq '.immutable')"
+[[ "$immutable" == "true" ]] \
+  || die "GitHub Release is not immutable: ${tag}; enable repository release immutability before publishing"
+"$gh_bin" release verify "$tag" --repo amichne/kast >/dev/null
+
+asset_name="$("$renderer" asset-name --source "$source_file" --tag "$tag")"
+"$gh_bin" release download "$tag" --dir "$scratch_dir" --pattern "$asset_name"
+"$gh_bin" release download "$tag" --dir "$scratch_dir" --pattern build-provenance.json
+[[ -f "${scratch_dir}/${asset_name}" ]] || die "Finalized plugin asset was not downloaded: $asset_name"
+[[ -f "${scratch_dir}/build-provenance.json" ]] || die "Finalized release provenance was not downloaded"
+provenance_sha="$("$renderer" provenance-release-sha \
+  --provenance "${scratch_dir}/build-provenance.json")"
+tag_sha="$($gh_bin api "repos/amichne/kast/commits/${tag}" --jq '.sha')"
+[[ "$provenance_sha" == "$tag_sha" ]] \
+  || die "IDEA release provenance SHA does not match immutable release tag target"
+
+rm -rf -- "$output_directory"
+"$renderer" render \
+  --source "$source_file" \
+  --plugin-zip "${scratch_dir}/${asset_name}" \
+  --provenance "${scratch_dir}/build-provenance.json" \
+  --certificate-chain "$certificate_chain" \
+  --signature-verifier-jar "$signature_verifier_jar" \
+  --artifact-verifier "$artifact_verifier" \
+  --output-directory "$output_directory"

--- a/.github/scripts/render-jetbrains-plugin-repository.py
+++ b/.github/scripts/render-jetbrains-plugin-repository.py
@@ -1,0 +1,855 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import SplitResult, urlsplit, urlunsplit
+from xml.etree import ElementTree
+
+
+SCHEMA_VERSION = 1
+PLUGIN_ID = "io.github.amichne.kast"
+IDEA_PLATFORM_ID = "idea"
+RELEASE_ASSET_URL_TEMPLATE = (
+    "https://github.com/amichne/kast/releases/download/{tag}/kast-idea-{tag}.zip"
+)
+RELEASE_TAG_PATTERN = re.compile(r"v[0-9A-Za-z][0-9A-Za-z._-]*")
+VERSION_PATTERN = re.compile(r"[0-9A-Za-z][0-9A-Za-z._-]*")
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+GIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+SINCE_BUILD_PATTERN = re.compile(r"[0-9]+(?:\.[0-9]+)*")
+UNTIL_BUILD_PATTERN = re.compile(r"[0-9]+(?:\.[0-9]+)*(?:\.\*)?")
+SIGNATURE_VERIFICATION_TASKS = (
+    ":backend-idea:verifyPluginStructure",
+    ":backend-idea:verifyPluginXmlPresent",
+    ":backend-idea:verifyPlugin",
+    ":backend-idea:verifyPluginSignature",
+)
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require_object(raw: object, *, field: str, keys: frozenset[str]) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        fail(f"{field} must be a JSON object")
+    payload: dict[str, Any] = raw
+    actual_keys = frozenset(payload)
+    if actual_keys != keys:
+        fail(
+            f"{field} keys must be exactly {sorted(keys)}; "
+            f"missing={sorted(keys - actual_keys)} unexpected={sorted(actual_keys - keys)}"
+        )
+    return payload
+
+
+def read_json(path: Path, *, description: str) -> object:
+    if not path.is_file():
+        fail(f"{description} does not exist: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"{description} is not valid UTF-8 JSON: {error}")
+
+
+@dataclass(frozen=True)
+class Sha256:
+    value: str
+
+    @classmethod
+    def parse(cls, raw: object, *, field: str) -> "Sha256":
+        if not isinstance(raw, str) or SHA256_PATTERN.fullmatch(raw) is None:
+            fail(f"{field} must be 64 lowercase hexadecimal characters")
+        return cls(raw)
+
+    @classmethod
+    def of_file(cls, path: Path) -> "Sha256":
+        if not path.is_file():
+            fail(f"plugin ZIP does not exist: {path}")
+        return cls(hashlib.sha256(path.read_bytes()).hexdigest())
+
+
+@dataclass(frozen=True)
+class IdeaBuildRange:
+    since_build: str
+    until_build: str | None
+
+    @classmethod
+    def parse(cls, raw: object, *, field: str) -> "IdeaBuildRange":
+        payload = require_object(
+            raw,
+            field=field,
+            keys=frozenset(("sinceBuild", "untilBuild")),
+        )
+        since_build = payload["sinceBuild"]
+        until_build = payload["untilBuild"]
+        if not isinstance(since_build, str) or SINCE_BUILD_PATTERN.fullmatch(since_build) is None:
+            fail(f"{field}.sinceBuild must be a numeric JetBrains build")
+        if until_build is not None and (
+            not isinstance(until_build, str)
+            or UNTIL_BUILD_PATTERN.fullmatch(until_build) is None
+        ):
+            fail(f"{field}.untilBuild must be null or a numeric JetBrains build range")
+        result = cls(since_build=since_build, until_build=until_build)
+        result.require_ordered(field=field)
+        return result
+
+    @classmethod
+    def from_descriptor(cls, element: ElementTree.Element) -> "IdeaBuildRange":
+        allowed_attributes = frozenset(("since-build", "until-build"))
+        actual_attributes = frozenset(element.attrib)
+        if not actual_attributes <= allowed_attributes:
+            fail(
+                "plugin descriptor idea-version has unsupported attributes: "
+                f"{sorted(actual_attributes - allowed_attributes)}"
+            )
+        return cls.parse(
+            {
+                "sinceBuild": element.attrib.get("since-build"),
+                "untilBuild": element.attrib.get("until-build"),
+            },
+            field="plugin descriptor idea-version",
+        )
+
+    def require_ordered(self, *, field: str) -> None:
+        if self.until_build is None:
+            return
+        since_parts = tuple(int(part) for part in self.since_build.split("."))
+        wildcard = self.until_build.endswith(".*")
+        raw_until = self.until_build.removesuffix(".*") if wildcard else self.until_build
+        until_parts = tuple(int(part) for part in raw_until.split("."))
+        if wildcard:
+            compared_since = since_parts[: len(until_parts)]
+            if until_parts < compared_since:
+                fail(f"{field}.untilBuild is below sinceBuild")
+            return
+        width = max(len(since_parts), len(until_parts))
+        padded_since = since_parts + (0,) * (width - len(since_parts))
+        padded_until = until_parts + (0,) * (width - len(until_parts))
+        if padded_until < padded_since:
+            fail(f"{field}.untilBuild is below sinceBuild")
+
+    def xml_attributes(self) -> dict[str, str]:
+        attributes = {"since-build": self.since_build}
+        if self.until_build is not None:
+            attributes["until-build"] = self.until_build
+        return attributes
+
+    def manifest_value(self) -> dict[str, str | None]:
+        return {
+            "sinceBuild": self.since_build,
+            "untilBuild": self.until_build,
+        }
+
+
+@dataclass(frozen=True)
+class SigningPolicy:
+    state: str
+    active_signer: Sha256 | None
+    next_signer: Sha256 | None
+
+    @classmethod
+    def parse(cls, raw: object) -> "SigningPolicy":
+        payload = require_object(
+            raw,
+            field="signing",
+            keys=frozenset(("activeSignerSha256", "rotation")),
+        )
+        rotation = require_object(
+            payload["rotation"],
+            field="signing.rotation",
+            keys=frozenset(("state", "nextSignerSha256")),
+        )
+        state = rotation["state"]
+        if state not in ("unconfigured", "stable", "overlap"):
+            fail("signing.rotation.state must be unconfigured, stable, or overlap")
+        active_raw = payload["activeSignerSha256"]
+        next_raw = rotation["nextSignerSha256"]
+        active = None if active_raw is None else Sha256.parse(
+            active_raw,
+            field="signing.activeSignerSha256",
+        )
+        next_signer = None if next_raw is None else Sha256.parse(
+            next_raw,
+            field="signing.rotation.nextSignerSha256",
+        )
+        if state == "unconfigured" and (active is not None or next_signer is not None):
+            fail("unconfigured signing state must not name an active or rotation signer")
+        if state == "stable" and (active is None or next_signer is not None):
+            fail("stable signing state requires one active signer and no rotation signer")
+        if state == "overlap" and (active is None or next_signer is None):
+            fail("overlap signing state requires active and next signer fingerprints")
+        if active is not None and active == next_signer:
+            fail("rotation signer must differ from the active signer")
+        return cls(state=state, active_signer=active, next_signer=next_signer)
+
+    def enrolled_signers(self, *, require_configured: bool) -> tuple[Sha256, ...]:
+        if self.state == "unconfigured":
+            if require_configured:
+                fail(
+                    "production signing identity is unconfigured; add the enrolled public "
+                    "certificate fingerprint to packaging/jetbrains/plugin-repository.json"
+                )
+            return ()
+        if self.active_signer is None:
+            fail("configured signing state has no active signer")
+        if self.next_signer is None:
+            return (self.active_signer,)
+        return (self.active_signer, self.next_signer)
+
+
+@dataclass(frozen=True)
+class RepositoryPolicy:
+    feed_url: str
+    plugin_id: str
+    asset_url_template: str
+    idea_build_range: IdeaBuildRange
+
+    @classmethod
+    def parse(cls, raw: object) -> "RepositoryPolicy":
+        payload = require_object(
+            raw,
+            field="repository",
+            keys=frozenset(
+                ("feedUrl", "pluginId", "releaseAssetUrlTemplate", "ideaBuildRange")
+            ),
+        )
+        feed_url = payload["feedUrl"]
+        plugin_id = payload["pluginId"]
+        asset_template = payload["releaseAssetUrlTemplate"]
+        if not isinstance(feed_url, str):
+            fail("repository.feedUrl must be a string")
+        require_https_url(feed_url, field="repository.feedUrl")
+        if not urlsplit(feed_url).path.endswith("/jetbrains/updatePlugins.xml"):
+            fail("repository.feedUrl must end with /jetbrains/updatePlugins.xml")
+        if plugin_id != PLUGIN_ID:
+            fail(f"repository.pluginId must be {PLUGIN_ID}")
+        if not isinstance(asset_template, str):
+            fail("repository.releaseAssetUrlTemplate must be a string")
+        remaining_template = asset_template.replace("{tag}", "")
+        if (
+            asset_template.count("{tag}") != 2
+            or "{" in remaining_template
+            or "}" in remaining_template
+        ):
+            fail("repository.releaseAssetUrlTemplate must contain exactly two {tag} fields")
+        sample_url = asset_template.replace("{tag}", "v1.2.3")
+        parsed_sample = require_https_url(
+            sample_url,
+            field="repository.releaseAssetUrlTemplate",
+        )
+        if parsed_sample.hostname != "github.com":
+            fail("repository.releaseAssetUrlTemplate must use github.com")
+        if re.fullmatch(
+            r"/[^/]+/[^/]+/releases/download/v1\.2\.3/kast-idea-v1\.2\.3\.zip",
+            parsed_sample.path,
+        ) is None:
+            fail(
+                "repository.releaseAssetUrlTemplate must name an immutable GitHub Release "
+                "kast-idea-{tag}.zip asset"
+            )
+        if asset_template != RELEASE_ASSET_URL_TEMPLATE:
+            fail(
+                "repository.releaseAssetUrlTemplate must name the amichne/kast immutable "
+                "release asset"
+            )
+        return cls(
+            feed_url=feed_url,
+            plugin_id=plugin_id,
+            asset_url_template=asset_template,
+            idea_build_range=IdeaBuildRange.parse(
+                payload["ideaBuildRange"],
+                field="repository.ideaBuildRange",
+            ),
+        )
+
+    def asset_url(self, tag: str) -> str:
+        require_release_tag(tag)
+        return self.asset_url_template.replace("{tag}", tag)
+
+    def asset_name(self, tag: str) -> str:
+        return Path(urlsplit(self.asset_url(tag)).path).name
+
+
+def require_https_url(raw: str, *, field: str) -> SplitResult:
+    parsed = urlsplit(raw)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        fail(f"{field} must be an absolute HTTPS URL without credentials, query, or fragment")
+    return parsed
+
+
+@dataclass(frozen=True)
+class RepositorySource:
+    repository: RepositoryPolicy
+    signing: SigningPolicy
+
+    @classmethod
+    def load(cls, path: Path) -> "RepositorySource":
+        payload = require_object(
+            read_json(path, description="JetBrains repository source"),
+            field="JetBrains repository source",
+            keys=frozenset(("schemaVersion", "repository", "signing")),
+        )
+        if payload["schemaVersion"] != SCHEMA_VERSION:
+            fail(f"JetBrains repository source schemaVersion must be {SCHEMA_VERSION}")
+        return cls(
+            repository=RepositoryPolicy.parse(payload["repository"]),
+            signing=SigningPolicy.parse(payload["signing"]),
+        )
+
+
+def manifest_url(source: RepositorySource) -> str:
+    parsed = urlsplit(source.repository.feed_url)
+    manifest_path = str(Path(parsed.path).with_name("plugin-repository-manifest.json"))
+    return urlunsplit((parsed.scheme, parsed.netloc, manifest_path, "", ""))
+
+
+def feed_url(source: RepositorySource) -> str:
+    return source.repository.feed_url
+
+
+def published_release_tag(*, source: RepositorySource, manifest_path: Path) -> str:
+    payload = require_object(
+        read_json(manifest_path, description="published JetBrains repository manifest"),
+        field="published JetBrains repository manifest",
+        keys=frozenset(("schemaVersion", "feedUrl", "releaseTag", "releaseSha", "entries")),
+    )
+    if payload["schemaVersion"] != SCHEMA_VERSION:
+        fail(f"published JetBrains repository manifest schemaVersion must be {SCHEMA_VERSION}")
+    if payload["feedUrl"] != source.repository.feed_url:
+        fail("published JetBrains repository manifest feedUrl does not match source")
+    release_tag = payload["releaseTag"]
+    if not isinstance(release_tag, str):
+        fail("published JetBrains repository manifest releaseTag must be a string")
+    require_release_tag(release_tag)
+    release_sha = payload["releaseSha"]
+    if not isinstance(release_sha, str) or GIT_SHA_PATTERN.fullmatch(release_sha) is None:
+        fail("published JetBrains repository manifest releaseSha must be a full Git SHA")
+    entries = payload["entries"]
+    if not isinstance(entries, list) or len(entries) != 1:
+        fail("published JetBrains repository manifest must contain exactly one entry")
+    entry = require_object(
+        entries[0],
+        field="published JetBrains repository manifest entry",
+        keys=frozenset(
+            (
+                "pluginId",
+                "version",
+                "url",
+                "sha256",
+                "signerSha256",
+                "ideaBuildRange",
+            )
+        ),
+    )
+    if entry["pluginId"] != source.repository.plugin_id:
+        fail("published JetBrains repository manifest pluginId does not match source")
+    if entry["version"] != release_tag.removeprefix("v"):
+        fail("published JetBrains repository manifest version does not match releaseTag")
+    if entry["url"] != source.repository.asset_url(release_tag):
+        fail("published JetBrains repository manifest URL does not match source")
+    Sha256.parse(entry["sha256"], field="published manifest entry sha256")
+    signer = Sha256.parse(
+        entry["signerSha256"],
+        field="published manifest entry signerSha256",
+    )
+    if signer not in source.signing.enrolled_signers(require_configured=True):
+        fail("published JetBrains repository manifest signer is not enrolled")
+    published_range = IdeaBuildRange.parse(
+        entry["ideaBuildRange"],
+        field="published manifest entry ideaBuildRange",
+    )
+    if published_range != source.repository.idea_build_range:
+        fail("published JetBrains repository manifest IDEA build range does not match source")
+    return release_tag
+
+
+@dataclass(frozen=True)
+class PluginDescriptor:
+    plugin_id: str
+    version: str
+    idea_build_range: IdeaBuildRange
+
+    @classmethod
+    def from_zip(cls, path: Path) -> "PluginDescriptor":
+        if not path.is_file():
+            fail(f"plugin ZIP does not exist: {path}")
+        descriptors: list[bytes] = []
+        try:
+            with zipfile.ZipFile(path) as archive:
+                for name in sorted(archive.namelist()):
+                    if name == "META-INF/plugin.xml" or name.endswith("/META-INF/plugin.xml"):
+                        descriptors.append(archive.read(name))
+                for jar_name in sorted(name for name in archive.namelist() if name.endswith(".jar")):
+                    with zipfile.ZipFile(io.BytesIO(archive.read(jar_name))) as jar:
+                        if "META-INF/plugin.xml" in jar.namelist():
+                            descriptors.append(jar.read("META-INF/plugin.xml"))
+        except (KeyError, OSError, zipfile.BadZipFile) as error:
+            fail(f"plugin ZIP is invalid: {error}")
+        if len(descriptors) != 1:
+            fail(f"plugin ZIP must contain exactly one plugin.xml, found {len(descriptors)}")
+        try:
+            root = ElementTree.fromstring(descriptors[0])
+        except ElementTree.ParseError as error:
+            fail(f"plugin descriptor is invalid XML: {error}")
+        plugin_id = root.findtext("id")
+        version = root.findtext("version")
+        idea_versions = root.findall("idea-version")
+        if plugin_id != PLUGIN_ID:
+            fail(f"plugin descriptor id must be {PLUGIN_ID}")
+        if not isinstance(version, str) or VERSION_PATTERN.fullmatch(version) is None:
+            fail("plugin descriptor version must be a tag-safe version")
+        if len(idea_versions) != 1:
+            fail("plugin descriptor must contain exactly one idea-version element")
+        return cls(
+            plugin_id=plugin_id,
+            version=version,
+            idea_build_range=IdeaBuildRange.from_descriptor(idea_versions[0]),
+        )
+
+
+@dataclass(frozen=True)
+class IdeaProvenance:
+    release_tag: str
+    release_sha: str
+    asset_name: str
+    asset_digest: Sha256
+    plugin_id: str
+    signer: Sha256
+    raw_payload: dict[str, Any]
+
+    @classmethod
+    def load(cls, path: Path) -> "IdeaProvenance":
+        raw = read_json(path, description="release provenance")
+        if not isinstance(raw, dict):
+            fail("release provenance must be a JSON object")
+        payload: dict[str, Any] = raw
+        if "builds" in payload:
+            builds = payload["builds"]
+            if not isinstance(builds, list) or not all(isinstance(entry, dict) for entry in builds):
+                fail("combined release provenance builds must be a list of objects")
+            platform_ids = [entry.get("platformId") for entry in builds]
+            if not all(isinstance(platform_id, str) for platform_id in platform_ids):
+                fail("combined release provenance platformId values must be strings")
+            if len(set(platform_ids)) != len(platform_ids):
+                fail("combined release provenance platformId values must be unique")
+            if platform_ids != sorted(platform_ids, key=lambda value: str(value)):
+                fail("combined release provenance builds must be ordered by platformId")
+            idea_entries = [entry for entry in builds if entry.get("platformId") == IDEA_PLATFORM_ID]
+            if len(idea_entries) != 1:
+                fail("combined release provenance must contain exactly one IDEA entry")
+            payload = idea_entries[0]
+        if payload.get("platformId") != IDEA_PLATFORM_ID:
+            fail("IDEA release provenance platformId must be idea")
+        if payload.get("pluginId") != PLUGIN_ID:
+            fail(f"IDEA release provenance pluginId must be {PLUGIN_ID}")
+        if payload.get("signatureVerified") is not True:
+            fail("IDEA release provenance signatureVerified must be true")
+        if payload.get("verificationTasks") != list(SIGNATURE_VERIFICATION_TASKS):
+            fail("IDEA release provenance does not carry the complete signed compatibility gate")
+        ref = payload.get("ref")
+        if not isinstance(ref, str) or not ref.startswith("refs/tags/"):
+            fail("IDEA release provenance ref must name a release tag")
+        release_tag = ref.removeprefix("refs/tags/")
+        require_release_tag(release_tag)
+        release_sha = payload.get("sha")
+        if not isinstance(release_sha, str) or GIT_SHA_PATTERN.fullmatch(release_sha) is None:
+            fail("IDEA release provenance sha must be a full lowercase Git SHA")
+        asset_name = payload.get("assetName")
+        if not isinstance(asset_name, str) or Path(asset_name).name != asset_name:
+            fail("IDEA release provenance assetName must be a filename")
+        asset_digest = payload.get("assetDigest")
+        if not isinstance(asset_digest, str) or not asset_digest.startswith("sha256:"):
+            fail("IDEA release provenance assetDigest must use sha256")
+        return cls(
+            release_tag=release_tag,
+            release_sha=release_sha,
+            asset_name=asset_name,
+            asset_digest=Sha256.parse(
+                asset_digest.removeprefix("sha256:"),
+                field="IDEA release provenance assetDigest",
+            ),
+            plugin_id=PLUGIN_ID,
+            signer=Sha256.parse(
+                payload.get("signerCertificateSha256"),
+                field="IDEA release provenance signerCertificateSha256",
+            ),
+            raw_payload=payload.copy(),
+        )
+
+
+def require_release_tag(tag: str) -> None:
+    if RELEASE_TAG_PATTERN.fullmatch(tag) is None:
+        fail("release tag must start with v and contain only tag-safe characters")
+
+
+@dataclass(frozen=True)
+class RepositoryEntry:
+    plugin_id: str
+    version: str
+    url: str
+    digest: Sha256
+    signer: Sha256
+    idea_build_range: IdeaBuildRange
+
+
+def verified_entry(
+    *,
+    source: RepositorySource,
+    plugin_zip: Path,
+    provenance: IdeaProvenance,
+) -> RepositoryEntry:
+    enrolled_signers = source.signing.enrolled_signers(require_configured=True)
+    if provenance.signer not in enrolled_signers:
+        fail(f"IDEA release provenance signer is not enrolled: {provenance.signer.value}")
+    digest = Sha256.of_file(plugin_zip)
+    if provenance.asset_digest != digest:
+        fail("IDEA release provenance digest does not match finalized plugin ZIP bytes")
+    expected_asset_name = source.repository.asset_name(provenance.release_tag)
+    if provenance.asset_name != expected_asset_name:
+        fail("IDEA release provenance assetName does not match repository URL template")
+    if plugin_zip.name != expected_asset_name:
+        fail("finalized plugin ZIP filename does not match repository URL template")
+    descriptor = PluginDescriptor.from_zip(plugin_zip)
+    if descriptor.plugin_id != source.repository.plugin_id or provenance.plugin_id != descriptor.plugin_id:
+        fail("plugin identity differs across source, provenance, and finalized ZIP")
+    expected_version = provenance.release_tag.removeprefix("v")
+    if descriptor.version != expected_version:
+        fail("plugin descriptor version does not match finalized release tag")
+    if descriptor.idea_build_range != source.repository.idea_build_range:
+        fail("plugin descriptor IDEA build range does not match repository source")
+    url = source.repository.asset_url(provenance.release_tag)
+    if Path(urlsplit(url).path).name != provenance.asset_name:
+        fail("rendered release URL does not name the finalized plugin asset")
+    return RepositoryEntry(
+        plugin_id=descriptor.plugin_id,
+        version=descriptor.version,
+        url=url,
+        digest=digest,
+        signer=provenance.signer,
+        idea_build_range=descriptor.idea_build_range,
+    )
+
+
+def verify_finalized_signature(
+    *,
+    source: RepositorySource,
+    plugin_zip: Path,
+    provenance: IdeaProvenance,
+    certificate_chain: Path,
+    signature_verifier_jar: Path,
+    artifact_verifier: Path,
+) -> None:
+    for path, description in (
+        (certificate_chain, "public certificate chain"),
+        (signature_verifier_jar, "Marketplace ZIP Signer CLI"),
+        (artifact_verifier, "IDEA plugin artifact verifier"),
+    ):
+        if not path.is_file():
+            fail(f"{description} does not exist: {path}")
+    with tempfile.TemporaryDirectory(prefix="kast-idea-repository-") as temporary:
+        direct_provenance = Path(temporary) / "idea-build-provenance.json"
+        direct_provenance.write_text(
+            json.dumps(provenance.raw_payload, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        command = [
+            str(artifact_verifier),
+            "verify",
+            "--plugin-zip",
+            str(plugin_zip),
+            "--certificate-chain",
+            str(certificate_chain),
+            "--signature-verifier-jar",
+            str(signature_verifier_jar),
+            "--release-tag",
+            provenance.release_tag,
+            "--release-sha",
+            provenance.release_sha,
+            "--provenance",
+            str(direct_provenance),
+        ]
+        for signer in source.signing.enrolled_signers(require_configured=True):
+            command.extend(("--expected-signer-sha256", signer.value))
+        try:
+            result = subprocess.run(
+                command,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except OSError as error:
+            fail(f"IDEA plugin artifact verifier could not run: {error}")
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip().splitlines()
+            suffix = f": {detail[-1]}" if detail else ""
+            fail(f"finalized plugin ZIP failed cryptographic signature verification{suffix}")
+
+
+def render_xml(entry: RepositoryEntry) -> bytes:
+    root = ElementTree.Element("plugins")
+    root.append(
+        ElementTree.Comment(
+            f" sha256={entry.digest.value}; signer-sha256={entry.signer.value} "
+        )
+    )
+    plugin = ElementTree.SubElement(
+        root,
+        "plugin",
+        {
+            "id": entry.plugin_id,
+            "url": entry.url,
+            "version": entry.version,
+        },
+    )
+    ElementTree.SubElement(plugin, "idea-version", entry.idea_build_range.xml_attributes())
+    ElementTree.indent(root, space="  ")
+    return ElementTree.tostring(root, encoding="utf-8", xml_declaration=True) + b"\n"
+
+
+def verify_published_repository(
+    *,
+    source: RepositorySource,
+    manifest_path: Path,
+    xml_path: Path,
+) -> str:
+    release_tag = published_release_tag(source=source, manifest_path=manifest_path)
+    raw = read_json(manifest_path, description="published JetBrains repository manifest")
+    if not isinstance(raw, dict):
+        fail("published JetBrains repository manifest must be a JSON object")
+    raw_entries = raw.get("entries")
+    if not isinstance(raw_entries, list) or len(raw_entries) != 1:
+        fail("published JetBrains repository manifest must contain exactly one entry")
+    raw_entry = raw_entries[0]
+    if not isinstance(raw_entry, dict):
+        fail("published JetBrains repository manifest entry must be a JSON object")
+    entry = RepositoryEntry(
+        plugin_id=str(raw_entry["pluginId"]),
+        version=str(raw_entry["version"]),
+        url=str(raw_entry["url"]),
+        digest=Sha256.parse(raw_entry["sha256"], field="published manifest entry sha256"),
+        signer=Sha256.parse(
+            raw_entry["signerSha256"],
+            field="published manifest entry signerSha256",
+        ),
+        idea_build_range=IdeaBuildRange.parse(
+            raw_entry["ideaBuildRange"],
+            field="published manifest entry ideaBuildRange",
+        ),
+    )
+    if not xml_path.is_file():
+        fail(f"published JetBrains repository XML does not exist: {xml_path}")
+    try:
+        actual_xml = xml_path.read_bytes()
+    except OSError as error:
+        fail(f"published JetBrains repository XML could not be read: {error}")
+    expected_xml = render_xml(entry)
+    if actual_xml != expected_xml:
+        fail("published updatePlugins.xml does not match its validated manifest")
+    return release_tag
+
+
+def write_output(
+    *,
+    output_directory: Path,
+    source: RepositorySource,
+    provenance: IdeaProvenance,
+    entry: RepositoryEntry,
+) -> None:
+    if output_directory.exists() and any(output_directory.iterdir()):
+        fail(f"output directory must be absent or empty: {output_directory}")
+    output_directory.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schemaVersion": SCHEMA_VERSION,
+        "feedUrl": source.repository.feed_url,
+        "releaseTag": provenance.release_tag,
+        "releaseSha": provenance.release_sha,
+        "entries": [
+            {
+                "pluginId": entry.plugin_id,
+                "version": entry.version,
+                "url": entry.url,
+                "sha256": entry.digest.value,
+                "signerSha256": entry.signer.value,
+                "ideaBuildRange": entry.idea_build_range.manifest_value(),
+            }
+        ],
+    }
+    xml_path = output_directory / "updatePlugins.xml"
+    manifest_path = output_directory / "plugin-repository-manifest.json"
+    xml_path.write_bytes(render_xml(entry))
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"Rendered finalized JetBrains plugin repository for {provenance.release_tag}")
+
+
+def validate_source_command(args: argparse.Namespace) -> None:
+    source = RepositorySource.load(Path(args.source))
+    source.signing.enrolled_signers(require_configured=args.require_configured)
+    print(f"Validated JetBrains repository source ({source.signing.state})")
+
+
+def signing_state_command(args: argparse.Namespace) -> None:
+    print(RepositorySource.load(Path(args.source)).signing.state)
+
+
+def enrolled_signers_command(args: argparse.Namespace) -> None:
+    source = RepositorySource.load(Path(args.source))
+    for signer in source.signing.enrolled_signers(
+        require_configured=args.require_configured
+    ):
+        print(signer.value)
+
+
+def asset_name_command(args: argparse.Namespace) -> None:
+    source = RepositorySource.load(Path(args.source))
+    print(source.repository.asset_name(args.tag))
+
+
+def manifest_url_command(args: argparse.Namespace) -> None:
+    print(manifest_url(RepositorySource.load(Path(args.source))))
+
+
+def feed_url_command(args: argparse.Namespace) -> None:
+    print(feed_url(RepositorySource.load(Path(args.source))))
+
+
+def published_release_tag_command(args: argparse.Namespace) -> None:
+    source = RepositorySource.load(Path(args.source))
+    print(published_release_tag(source=source, manifest_path=Path(args.manifest)))
+
+
+def provenance_release_sha_command(args: argparse.Namespace) -> None:
+    print(IdeaProvenance.load(Path(args.provenance)).release_sha)
+
+
+def verify_published_command(args: argparse.Namespace) -> None:
+    source = RepositorySource.load(Path(args.source))
+    print(
+        verify_published_repository(
+            source=source,
+            manifest_path=Path(args.manifest),
+            xml_path=Path(args.xml),
+        )
+    )
+
+
+def render_command(args: argparse.Namespace) -> None:
+    source = RepositorySource.load(Path(args.source))
+    provenance = IdeaProvenance.load(Path(args.provenance))
+    plugin_zip = Path(args.plugin_zip)
+    verify_finalized_signature(
+        source=source,
+        plugin_zip=plugin_zip,
+        provenance=provenance,
+        certificate_chain=Path(args.certificate_chain),
+        signature_verifier_jar=Path(args.signature_verifier_jar),
+        artifact_verifier=Path(args.artifact_verifier),
+    )
+    entry = verified_entry(source=source, plugin_zip=plugin_zip, provenance=provenance)
+    write_output(
+        output_directory=Path(args.output_directory),
+        source=source,
+        provenance=provenance,
+        entry=entry,
+    )
+
+
+def add_source_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--source", required=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and render Kast's signed custom JetBrains plugin repository."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate-source")
+    add_source_argument(validate_parser)
+    validate_parser.add_argument("--require-configured", action="store_true")
+    validate_parser.set_defaults(handler=validate_source_command)
+
+    state_parser = subparsers.add_parser("signing-state")
+    add_source_argument(state_parser)
+    state_parser.set_defaults(handler=signing_state_command)
+
+    signers_parser = subparsers.add_parser("enrolled-signers")
+    add_source_argument(signers_parser)
+    signers_parser.add_argument("--require-configured", action="store_true")
+    signers_parser.set_defaults(handler=enrolled_signers_command)
+
+    asset_parser = subparsers.add_parser("asset-name")
+    add_source_argument(asset_parser)
+    asset_parser.add_argument("--tag", required=True)
+    asset_parser.set_defaults(handler=asset_name_command)
+
+    manifest_url_parser = subparsers.add_parser("manifest-url")
+    add_source_argument(manifest_url_parser)
+    manifest_url_parser.set_defaults(handler=manifest_url_command)
+
+    feed_url_parser = subparsers.add_parser("feed-url")
+    add_source_argument(feed_url_parser)
+    feed_url_parser.set_defaults(handler=feed_url_command)
+
+    published_tag_parser = subparsers.add_parser("published-release-tag")
+    add_source_argument(published_tag_parser)
+    published_tag_parser.add_argument("--manifest", required=True)
+    published_tag_parser.set_defaults(handler=published_release_tag_command)
+
+    provenance_sha_parser = subparsers.add_parser("provenance-release-sha")
+    provenance_sha_parser.add_argument("--provenance", required=True)
+    provenance_sha_parser.set_defaults(handler=provenance_release_sha_command)
+
+    verify_published_parser = subparsers.add_parser("verify-published")
+    add_source_argument(verify_published_parser)
+    verify_published_parser.add_argument("--manifest", required=True)
+    verify_published_parser.add_argument("--xml", required=True)
+    verify_published_parser.set_defaults(handler=verify_published_command)
+
+    render_parser = subparsers.add_parser("render")
+    add_source_argument(render_parser)
+    render_parser.add_argument("--plugin-zip", required=True)
+    render_parser.add_argument("--provenance", required=True)
+    render_parser.add_argument("--certificate-chain", required=True)
+    render_parser.add_argument("--signature-verifier-jar", required=True)
+    render_parser.add_argument(
+        "--artifact-verifier",
+        default=str(
+            Path(__file__).resolve().parents[2]
+            / "scripts"
+            / "verify-idea-plugin-artifact.py"
+        ),
+    )
+    render_parser.add_argument("--output-directory", required=True)
+    render_parser.set_defaults(handler=render_command)
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test-idea-plugin-signing-contract.sh
+++ b/.github/scripts/test-idea-plugin-signing-contract.sh
@@ -170,6 +170,8 @@ idea_build_file="${repo_root}/backend-idea/build.gradle.kts"
 uploader="${repo_root}/.github/scripts/upload-immutable-release-asset.sh"
 artifact_verifier="${repo_root}/scripts/verify-idea-plugin-artifact.py"
 release_asset_verifier="${repo_root}/scripts/verify-release-assets.sh"
+repository_source="${repo_root}/packaging/jetbrains/plugin-repository.json"
+repository_renderer="${repo_root}/.github/scripts/render-jetbrains-plugin-repository.py"
 
 for path in \
   "$release_workflow" \
@@ -177,13 +179,16 @@ for path in \
   "$idea_build_file" \
   "$uploader" \
   "$artifact_verifier" \
-  "$release_asset_verifier"
+  "$release_asset_verifier" \
+  "$repository_source" \
+  "$repository_renderer"
 do
   [[ -f "$path" ]] || die "Required IDEA plugin signing file is missing: $path"
 done
 
 [[ -x "$uploader" ]] || die "Immutable release uploader is not executable: $uploader"
 [[ -x "$artifact_verifier" ]] || die "IDEA plugin artifact verifier is not executable: $artifact_verifier"
+[[ -x "$repository_renderer" ]] || die "JetBrains repository renderer is not executable: $repository_renderer"
 
 require_contains "$idea_build_file" 'providers.environmentVariable("PRIVATE_KEY")' "IDEA signing must read the private key from the environment"
 require_contains "$idea_build_file" 'providers.environmentVariable("PRIVATE_KEY_PASSWORD")' "IDEA signing must read the private-key password from the environment"
@@ -196,13 +201,21 @@ require_block_contains "$release_workflow" "  release-preflight:" "  bump-versio
 require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_PRIVATE_KEY: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY }}' "Release preflight must require the signing key"
 # shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
 require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_PRIVATE_KEY_PASSWORD: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY_PASSWORD }}' "Release preflight must require the signing password"
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" "render-jetbrains-plugin-repository.py" "Release preflight must validate the typed signer owner"
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" "--require-configured" "Release preflight must reject an unconfigured signer"
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" "repos/amichne/kast/immutable-releases" "Release preflight must reject disabled GitHub Release immutability before tag creation"
 # shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
-require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_SIGNER_SHA256 }}' "Release preflight must require the enrolled signer fingerprint"
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}' "Immutability preflight must require the admin-capable release token"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_not_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_SIGNER_SHA256 }}' "Release preflight must not duplicate signer authority in a repository variable"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:verifyPlugin" "Release must run JetBrains compatibility verification"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:signPlugin" "Release must sign the IDEA plugin"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:verifyPluginSignature" "Release must verify the IDEA plugin signature"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:stageIdeaPluginSignatureVerifier" "Release must stage the JetBrains verifier used for the published bytes"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "scripts/verify-idea-plugin-artifact.py record" "Release must record signer-bound provenance"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "enrolled-signers" "Release verification must consume signer identities from the typed repository source"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "packaging/jetbrains/plugin-repository.json" "Release verification must use the checked-in signer owner"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "release-idea-signature-verifier" "Release must receipt the Marketplace verifier consumed by Pages"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ".github/scripts/upload-immutable-release-asset.sh" "Release must use the immutable uploader"
 # shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" 'tag_sha="$(git rev-list -n1 "$tag")"' "Release must resolve the checked-out tag target"
@@ -218,6 +231,10 @@ require_block_not_contains "$release_workflow" "  build-idea-plugin:" "  build-h
 ! grep -Fq -- "--clobber" "$release_workflow" \
   || die "Release workflow must not contain any mutable asset upload"
 require_contains "$ci_workflow" "Test IDEA plugin signing and immutability contract" "CI must execute the signing contract gate"
+require_contains "$ci_workflow" "Test JetBrains plugin repository contract" "CI must execute the feed-to-asset contract gate"
+require_contains "$repository_source" '"activeSignerSha256": null' "Repository source must not invent a production signer"
+require_contains "$repository_source" '"state": "unconfigured"' "Repository source must fail closed until signer enrollment"
+require_contains "$repository_renderer" "rotation signer must differ" "Repository renderer must reject invalid rotation overlap"
 require_contains "$release_asset_verifier" 'signerCertificateSha256' "Downloaded release verification must require signer identity"
 require_contains "$release_asset_verifier" 'signatureVerified' "Downloaded release verification must require signature evidence"
 require_contains "$release_asset_verifier" 'pluginId' "Downloaded release verification must require plugin identity"
@@ -323,6 +340,30 @@ GITHUB_ACTOR=contract-test \
   --release-sha "$release_sha" \
   --provenance "$provenance" \
   --expected-signer-sha256 "$fingerprint_a"
+
+configured_repository_source="${scratch_dir}/plugin-repository.json"
+python3 - "$repository_source" "$configured_repository_source" "$fingerprint_a" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+
+source = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+source["signing"] = {
+    "activeSignerSha256": sys.argv[3],
+    "rotation": {"state": "stable", "nextSignerSha256": None},
+}
+Path(sys.argv[2]).write_text(json.dumps(source, indent=2) + "\n", encoding="utf-8")
+PY
+"$repository_renderer" render \
+  --source "$configured_repository_source" \
+  --plugin-zip "$signed_release_archive" \
+  --provenance "$provenance" \
+  --certificate-chain "${scratch_dir}/signer-a/chain.crt" \
+  --signature-verifier-jar "$signature_verifier_jar" \
+  --output-directory "${scratch_dir}/signed-repository"
+[[ -f "${scratch_dir}/signed-repository/updatePlugins.xml" ]] \
+  || die "Cryptographically verified signed plugin did not render a repository feed"
 
 unsigned_archive="${scratch_dir}/kast-idea-v0.0.0-unsigned.zip"
 cp "${repo_root}/backend-idea/build/distributions/backend-idea-${version}.zip" "$unsigned_archive"

--- a/.github/scripts/test-jetbrains-plugin-repository-contract.sh
+++ b/.github/scripts/test-jetbrains-plugin-repository-contract.sh
@@ -1,0 +1,782 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/../.." && pwd
+}
+
+require_contains() {
+  local file_path="$1"
+  local expected="$2"
+  local description="$3"
+  grep -Fq -- "$expected" "$file_path" \
+    || die "${description}: missing '${expected}' in ${file_path}"
+}
+
+require_block_contains() {
+  local file_path="$1"
+  local block_start="$2"
+  local block_end="$3"
+  local expected="$4"
+  local description="$5"
+  local block
+  block="$({
+    awk -v block_start="$block_start" -v block_end="$block_end" '
+      index($0, block_start) { in_block = 1 }
+      in_block && index($0, block_end) && !index($0, block_start) { exit }
+      in_block { print }
+    ' "$file_path"
+  })"
+  [[ -n "$block" ]] || die "${description}: missing block '${block_start}' in ${file_path}"
+  grep -Fq -- "$expected" <<< "$block" \
+    || die "${description}: missing '${expected}' in '${block_start}' block"
+}
+
+require_order() {
+  local file_path="$1"
+  local earlier="$2"
+  local later="$3"
+  local description="$4"
+  local earlier_line
+  local later_line
+  earlier_line="$(grep -nF -- "$earlier" "$file_path" | head -1 | cut -d: -f1)"
+  later_line="$(grep -nF -- "$later" "$file_path" | head -1 | cut -d: -f1)"
+  [[ -n "$earlier_line" ]] || die "${description}: missing earlier marker '${earlier}'"
+  [[ -n "$later_line" ]] || die "${description}: missing later marker '${later}'"
+  [[ "$earlier_line" -lt "$later_line" ]] \
+    || die "${description}: '${earlier}' must appear before '${later}'"
+}
+
+expect_failure() {
+  local label="$1"
+  shift
+  if "$@" >"${scratch_dir}/${label}.out" 2>"${scratch_dir}/${label}.err"; then
+    die "${label} unexpectedly succeeded"
+  fi
+  [[ -s "${scratch_dir}/${label}.err" ]] \
+    || die "${label} did not explain its failure on stderr"
+}
+
+repo_root="$(resolve_repo_root)"
+renderer="${repo_root}/.github/scripts/render-jetbrains-plugin-repository.py"
+materializer="${repo_root}/.github/scripts/materialize-jetbrains-plugin-repository-pages.sh"
+source_file="${repo_root}/packaging/jetbrains/plugin-repository.json"
+packaging_guide="${repo_root}/packaging/jetbrains/AGENTS.md"
+github_guide="${repo_root}/.github/AGENTS.md"
+release_workflow="${repo_root}/.github/workflows/release.yml"
+docs_workflow="${repo_root}/.github/workflows/docs.yml"
+
+for path in \
+  "$renderer" \
+  "$materializer" \
+  "$source_file" \
+  "$packaging_guide" \
+  "$github_guide" \
+  "$release_workflow" \
+  "$docs_workflow"
+do
+  [[ -f "$path" ]] || die "Required JetBrains repository contract file is missing: $path"
+done
+
+[[ -x "$renderer" ]] || die "JetBrains repository renderer is not executable: $renderer"
+[[ -x "$materializer" ]] || die "JetBrains Pages materializer is not executable: $materializer"
+
+scratch_dir="$(mktemp -d)"
+trap 'rm -rf "$scratch_dir"' EXIT
+
+python3 - "$scratch_dir" <<'PY'
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import zipfile
+from copy import deepcopy
+from pathlib import Path
+
+
+root = Path(sys.argv[1])
+plugin_id = "io.github.amichne.kast"
+tag = "v1.2.3"
+version = "1.2.3"
+asset_name = f"kast-idea-{tag}.zip"
+signer = "a" * 64
+release_sha = "1" * 40
+
+
+def write_plugin(path: Path, *, plugin_version: str = version) -> None:
+    descriptor = f"""<?xml version="1.0" encoding="UTF-8"?>
+<idea-plugin>
+  <id>{plugin_id}</id>
+  <name>Kast</name>
+  <version>{plugin_version}</version>
+  <idea-version since-build="253"/>
+</idea-plugin>
+"""
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("META-INF/plugin.xml", descriptor)
+
+
+plugin_zip = root / asset_name
+write_plugin(plugin_zip)
+write_plugin(root / "wrong-version.zip", plugin_version="1.2.4")
+digest = hashlib.sha256(plugin_zip.read_bytes()).hexdigest()
+
+source = {
+    "schemaVersion": 1,
+    "repository": {
+        "feedUrl": "https://kast.michne.com/jetbrains/updatePlugins.xml",
+        "pluginId": plugin_id,
+        "releaseAssetUrlTemplate": (
+            "https://github.com/amichne/kast/releases/download/{tag}/kast-idea-{tag}.zip"
+        ),
+        "ideaBuildRange": {
+            "sinceBuild": "253",
+            "untilBuild": None,
+        },
+    },
+    "signing": {
+        "activeSignerSha256": signer,
+        "rotation": {
+            "state": "stable",
+            "nextSignerSha256": None,
+        },
+    },
+}
+provenance = {
+    "sha": release_sha,
+    "ref": f"refs/tags/{tag}",
+    "platformId": "idea",
+    "assetName": asset_name,
+    "assetDigest": f"sha256:{digest}",
+    "pluginId": plugin_id,
+    "signerCertificateSha256": signer,
+    "signatureVerified": True,
+    "verificationTasks": [
+        ":backend-idea:verifyPluginStructure",
+        ":backend-idea:verifyPluginXmlPresent",
+        ":backend-idea:verifyPlugin",
+        ":backend-idea:verifyPluginSignature",
+    ],
+}
+
+
+def dump(name: str, payload: object) -> None:
+    (root / name).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+dump("source.json", source)
+dump("provenance.json", provenance)
+dump("build-provenance.json", {"builds": [provenance]})
+
+bad_order = {
+    "builds": [
+        {"platformId": "z-last"},
+        provenance,
+    ]
+}
+dump("bad-order.json", bad_order)
+
+bad_digest = deepcopy(provenance)
+bad_digest["assetDigest"] = f"sha256:{'0' * 64}"
+dump("bad-digest.json", bad_digest)
+
+bad_signer = deepcopy(provenance)
+bad_signer["signerCertificateSha256"] = "b" * 64
+dump("bad-signer.json", bad_signer)
+
+bad_tag = deepcopy(provenance)
+bad_tag["ref"] = "refs/tags/v1.2.4"
+dump("bad-version.json", bad_tag)
+
+bad_url = deepcopy(source)
+bad_url["repository"]["releaseAssetUrlTemplate"] = (
+    "http://github.com/amichne/kast/releases/download/{tag}/kast-idea-{tag}.zip"
+)
+dump("bad-url.json", bad_url)
+
+bad_range = deepcopy(source)
+bad_range["repository"]["ideaBuildRange"]["sinceBuild"] = "252"
+dump("bad-range.json", bad_range)
+
+bad_rotation = deepcopy(source)
+bad_rotation["signing"]["rotation"] = {
+    "state": "overlap",
+    "nextSignerSha256": None,
+}
+dump("bad-rotation.json", bad_rotation)
+
+bad_schema = deepcopy(source)
+bad_schema["schemaVersion"] = 2
+dump("bad-schema.json", bad_schema)
+PY
+
+fake_artifact_verifier="${scratch_dir}/verify-idea-plugin-artifact.py"
+python3 - "$fake_artifact_verifier" <<'PY'
+from __future__ import annotations
+
+import stat
+import sys
+from pathlib import Path
+
+
+path = Path(sys.argv[1])
+path.write_text(
+    """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$KAST_TEST_ARTIFACT_VERIFIER_LOG"
+[[ "$1" == "verify" ]]
+[[ " $* " == *" --plugin-zip "* ]]
+[[ " $* " == *" --certificate-chain "* ]]
+[[ " $* " == *" --signature-verifier-jar "* ]]
+[[ " $* " == *" --expected-signer-sha256 "* ]]
+[[ "${KAST_TEST_ARTIFACT_VERIFIER_REJECT:-0}" != "1" ]]
+""",
+    encoding="utf-8",
+)
+path.chmod(path.stat().st_mode | stat.S_IXUSR)
+PY
+certificate_chain="${scratch_dir}/chain.crt"
+signature_verifier_jar="${scratch_dir}/marketplace-zip-signer-cli.jar"
+printf 'test certificate boundary\n' > "$certificate_chain"
+printf 'test verifier boundary\n' > "$signature_verifier_jar"
+export KAST_TEST_ARTIFACT_VERIFIER_LOG="${scratch_dir}/artifact-verifier.log"
+verification_args=(
+  --certificate-chain "$certificate_chain"
+  --signature-verifier-jar "$signature_verifier_jar"
+  --artifact-verifier "$fake_artifact_verifier"
+)
+
+"$renderer" validate-source --source "$source_file"
+[[ "$("$renderer" signing-state --source "$source_file")" == "unconfigured" ]] \
+  || die "Checked-in repository source must honestly report its unconfigured production signer state"
+expect_failure production-source-not-enrolled \
+  "$renderer" enrolled-signers --source "$source_file" --require-configured
+
+"$renderer" validate-source --source "${scratch_dir}/source.json" --require-configured
+[[ "$("$renderer" signing-state --source "${scratch_dir}/source.json")" == "stable" ]] \
+  || die "Configured repository fixture did not report stable signing state"
+[[ "$("$renderer" asset-name --source "${scratch_dir}/source.json" --tag v1.2.3)" == "kast-idea-v1.2.3.zip" ]] \
+  || die "Repository source did not deterministically derive the release asset name"
+[[ "$("$renderer" manifest-url --source "${scratch_dir}/source.json")" == "https://kast.michne.com/jetbrains/plugin-repository-manifest.json" ]] \
+  || die "Repository source did not deterministically derive the published manifest URL"
+
+"$renderer" render \
+  --source "${scratch_dir}/source.json" \
+  --plugin-zip "${scratch_dir}/kast-idea-v1.2.3.zip" \
+  --provenance "${scratch_dir}/provenance.json" \
+  "${verification_args[@]}" \
+  --output-directory "${scratch_dir}/output-a"
+"$renderer" render \
+  --source "${scratch_dir}/source.json" \
+  --plugin-zip "${scratch_dir}/kast-idea-v1.2.3.zip" \
+  --provenance "${scratch_dir}/provenance.json" \
+  "${verification_args[@]}" \
+  --output-directory "${scratch_dir}/output-b"
+
+require_contains \
+  "$KAST_TEST_ARTIFACT_VERIFIER_LOG" \
+  "verify --plugin-zip" \
+  "Rendering must invoke signed-byte verification before emitting a feed"
+expect_failure rejected-signature \
+  env KAST_TEST_ARTIFACT_VERIFIER_REJECT=1 \
+  "$renderer" render \
+    --source "${scratch_dir}/source.json" \
+    --plugin-zip "${scratch_dir}/kast-idea-v1.2.3.zip" \
+    --provenance "${scratch_dir}/provenance.json" \
+    "${verification_args[@]}" \
+    --output-directory "${scratch_dir}/rejected-signature-output"
+
+cmp "${scratch_dir}/output-a/updatePlugins.xml" "${scratch_dir}/output-b/updatePlugins.xml"
+cmp \
+  "${scratch_dir}/output-a/plugin-repository-manifest.json" \
+  "${scratch_dir}/output-b/plugin-repository-manifest.json"
+[[ "$("$renderer" published-release-tag \
+  --source "${scratch_dir}/source.json" \
+  --manifest "${scratch_dir}/output-a/plugin-repository-manifest.json")" == "v1.2.3" ]] \
+  || die "Published manifest did not preserve its finalized release tag"
+[[ "$("$renderer" verify-published \
+  --source "${scratch_dir}/source.json" \
+  --manifest "${scratch_dir}/output-a/plugin-repository-manifest.json" \
+  --xml "${scratch_dir}/output-a/updatePlugins.xml")" == "v1.2.3" ]] \
+  || die "Published feed did not validate against its manifest"
+cp "${scratch_dir}/output-a/updatePlugins.xml" "${scratch_dir}/tampered-updatePlugins.xml"
+printf '<!-- stale or tampered -->\n' >> "${scratch_dir}/tampered-updatePlugins.xml"
+expect_failure mismatched-published-xml \
+  "$renderer" verify-published \
+    --source "${scratch_dir}/source.json" \
+    --manifest "${scratch_dir}/output-a/plugin-repository-manifest.json" \
+    --xml "${scratch_dir}/tampered-updatePlugins.xml"
+
+python3 - "${scratch_dir}/output-a" "${scratch_dir}/kast-idea-v1.2.3.zip" <<'PY'
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+output = Path(sys.argv[1])
+plugin_zip = Path(sys.argv[2])
+names = sorted(path.name for path in output.iterdir())
+assert names == ["plugin-repository-manifest.json", "updatePlugins.xml"], names
+xml_path = output / "updatePlugins.xml"
+xml_text = xml_path.read_text(encoding="utf-8")
+root = ElementTree.parse(xml_path).getroot()
+assert root.tag == "plugins"
+plugins = root.findall("plugin")
+assert len(plugins) == 1
+plugin = plugins[0]
+assert plugin.attrib == {
+    "id": "io.github.amichne.kast",
+    "url": "https://github.com/amichne/kast/releases/download/v1.2.3/kast-idea-v1.2.3.zip",
+    "version": "1.2.3",
+}
+idea_version = plugin.find("idea-version")
+assert idea_version is not None
+assert idea_version.attrib == {"since-build": "253"}
+assert "sha256=" in xml_text
+assert "signer-sha256=" in xml_text
+
+manifest = json.loads((output / "plugin-repository-manifest.json").read_text(encoding="utf-8"))
+assert manifest["schemaVersion"] == 1
+assert manifest["feedUrl"] == "https://kast.michne.com/jetbrains/updatePlugins.xml"
+assert manifest["releaseTag"] == "v1.2.3"
+assert manifest["releaseSha"] == "1" * 40
+assert len(manifest["entries"]) == 1
+entry = manifest["entries"][0]
+assert entry == {
+    "pluginId": "io.github.amichne.kast",
+    "version": "1.2.3",
+    "url": "https://github.com/amichne/kast/releases/download/v1.2.3/kast-idea-v1.2.3.zip",
+    "sha256": hashlib.sha256(plugin_zip.read_bytes()).hexdigest(),
+    "signerSha256": "a" * 64,
+    "ideaBuildRange": {"sinceBuild": "253", "untilBuild": None},
+}
+assert len(entry["sha256"]) == 64
+assert set(entry["sha256"]) <= set("0123456789abcdef")
+PY
+
+expect_failure invalid-digest \
+  "$renderer" render \
+    --source "${scratch_dir}/source.json" \
+    --plugin-zip "${scratch_dir}/kast-idea-v1.2.3.zip" \
+    --provenance "${scratch_dir}/bad-digest.json" \
+    "${verification_args[@]}" \
+    --output-directory "${scratch_dir}/bad-digest-output"
+expect_failure invalid-signer \
+  "$renderer" render \
+    --source "${scratch_dir}/source.json" \
+    --plugin-zip "${scratch_dir}/kast-idea-v1.2.3.zip" \
+    --provenance "${scratch_dir}/bad-signer.json" \
+    "${verification_args[@]}" \
+    --output-directory "${scratch_dir}/bad-signer-output"
+expect_failure invalid-version \
+  "$renderer" render \
+    --source "${scratch_dir}/source.json" \
+    --plugin-zip "${scratch_dir}/kast-idea-v1.2.3.zip" \
+    --provenance "${scratch_dir}/bad-version.json" \
+    "${verification_args[@]}" \
+    --output-directory "${scratch_dir}/bad-version-output"
+expect_failure invalid-plugin-version \
+  "$renderer" render \
+    --source "${scratch_dir}/source.json" \
+    --plugin-zip "${scratch_dir}/wrong-version.zip" \
+    --provenance "${scratch_dir}/provenance.json" \
+    "${verification_args[@]}" \
+    --output-directory "${scratch_dir}/bad-plugin-version-output"
+expect_failure invalid-url \
+  "$renderer" validate-source --source "${scratch_dir}/bad-url.json" --require-configured
+expect_failure invalid-build-range \
+  "$renderer" render \
+    --source "${scratch_dir}/bad-range.json" \
+    --plugin-zip "${scratch_dir}/kast-idea-v1.2.3.zip" \
+    --provenance "${scratch_dir}/provenance.json" \
+    "${verification_args[@]}" \
+    --output-directory "${scratch_dir}/bad-range-output"
+expect_failure invalid-rotation-state \
+  "$renderer" validate-source --source "${scratch_dir}/bad-rotation.json" --require-configured
+expect_failure invalid-schema \
+  "$renderer" validate-source --source "${scratch_dir}/bad-schema.json" --require-configured
+expect_failure invalid-ordering \
+  "$renderer" render \
+    --source "${scratch_dir}/source.json" \
+    --plugin-zip "${scratch_dir}/kast-idea-v1.2.3.zip" \
+    --provenance "${scratch_dir}/bad-order.json" \
+    "${verification_args[@]}" \
+    --output-directory "${scratch_dir}/bad-order-output"
+
+fake_gh="${scratch_dir}/gh"
+python3 - "$fake_gh" <<'PY'
+from __future__ import annotations
+
+import stat
+import sys
+from pathlib import Path
+
+
+path = Path(sys.argv[1])
+path.write_text(
+    """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$KAST_TEST_GH_LOG"
+case "$1 $2" in
+  "release list")
+    printf '%s\\n' "$KAST_TEST_RELEASE_TAG"
+    ;;
+  "release view")
+    printf '%s\\t%s\\t%s\\n' \\
+      "$KAST_TEST_RELEASE_TAG" \\
+      "${KAST_TEST_RELEASE_DRAFT:-false}" \\
+      "${KAST_TEST_RELEASE_PRERELEASE:-false}"
+    ;;
+  "release verify")
+    [[ "${KAST_TEST_RELEASE_VERIFY_FAILURE:-0}" != "1" ]]
+    ;;
+  "release download")
+    destination=""
+    pattern=""
+    shift 3
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --dir) destination="$2"; shift 2 ;;
+        --pattern) pattern="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [[ -n "$destination" && -n "$pattern" ]]
+    mkdir -p "$destination"
+    cp "$KAST_TEST_RELEASE_DIRECTORY/$pattern" "$destination/$pattern"
+    ;;
+  "api repos/amichne/kast/releases/tags/$KAST_TEST_RELEASE_TAG")
+    printf '%s\n' "${KAST_TEST_RELEASE_IMMUTABLE:-true}"
+    ;;
+  "api repos/amichne/kast/commits/$KAST_TEST_RELEASE_TAG")
+    printf '%s\n' "${KAST_TEST_RELEASE_SHA:-1111111111111111111111111111111111111111}"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+""",
+    encoding="utf-8",
+)
+path.chmod(path.stat().st_mode | stat.S_IXUSR)
+PY
+
+release_directory="${scratch_dir}/release"
+mkdir -p "$release_directory"
+cp "${scratch_dir}/kast-idea-v1.2.3.zip" "$release_directory/"
+cp "${scratch_dir}/build-provenance.json" "$release_directory/"
+
+env \
+  KAST_TEST_GH_LOG="${scratch_dir}/gh.log" \
+  KAST_TEST_RELEASE_TAG=v1.2.3 \
+  KAST_TEST_RELEASE_DIRECTORY="$release_directory" \
+  "$materializer" \
+    --source "${scratch_dir}/source.json" \
+    --output-directory "${scratch_dir}/materialized" \
+    --tag v1.2.3 \
+    "${verification_args[@]}" \
+    --gh-bin "$fake_gh"
+cmp \
+  "${scratch_dir}/output-a/updatePlugins.xml" \
+  "${scratch_dir}/materialized/updatePlugins.xml"
+cmp \
+  "${scratch_dir}/output-a/plugin-repository-manifest.json" \
+  "${scratch_dir}/materialized/plugin-repository-manifest.json"
+
+env \
+  KAST_TEST_GH_LOG="${scratch_dir}/latest-gh.log" \
+  KAST_TEST_RELEASE_TAG=v1.2.3 \
+  KAST_TEST_RELEASE_DIRECTORY="$release_directory" \
+  "$materializer" \
+    --source "${scratch_dir}/source.json" \
+    --output-directory "${scratch_dir}/latest-materialized" \
+    --latest-stable \
+    "${verification_args[@]}" \
+    --gh-bin "$fake_gh"
+require_contains \
+  "${scratch_dir}/latest-gh.log" \
+  "release list --repo amichne/kast --exclude-drafts --exclude-pre-releases" \
+  "Latest-feed materialization must select a finalized stable release"
+
+fake_curl="${scratch_dir}/curl"
+python3 - "$fake_curl" <<'PY'
+from __future__ import annotations
+
+import stat
+import sys
+from pathlib import Path
+
+
+path = Path(sys.argv[1])
+path.write_text(
+    """#!/usr/bin/env bash
+set -euo pipefail
+output=""
+url="${!#}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+status="${KAST_TEST_HTTP_STATUS:-200}"
+if [[ "$status" == "200" ]]; then
+  case "$url" in
+    */plugin-repository-manifest.json)
+      cp "$KAST_TEST_PUBLISHED_MANIFEST" "$output"
+      ;;
+    */updatePlugins.xml)
+      cp "$KAST_TEST_PUBLISHED_XML" "$output"
+      ;;
+    *)
+      exit 2
+      ;;
+  esac
+fi
+printf '%s' "$status"
+""",
+    encoding="utf-8",
+)
+path.chmod(path.stat().st_mode | stat.S_IXUSR)
+PY
+
+rm -f "${scratch_dir}/published-gh.log"
+env \
+  KAST_TEST_PUBLISHED_MANIFEST="${scratch_dir}/output-a/plugin-repository-manifest.json" \
+  KAST_TEST_PUBLISHED_XML="${scratch_dir}/output-a/updatePlugins.xml" \
+  "$materializer" \
+    --source "${scratch_dir}/source.json" \
+    --output-directory "${scratch_dir}/published-materialized" \
+    --published-release \
+    --curl-bin "$fake_curl"
+cmp \
+  "${scratch_dir}/output-a/updatePlugins.xml" \
+  "${scratch_dir}/published-materialized/updatePlugins.xml"
+cmp \
+  "${scratch_dir}/output-a/plugin-repository-manifest.json" \
+  "${scratch_dir}/published-materialized/plugin-repository-manifest.json"
+[[ ! -e "${scratch_dir}/published-gh.log" ]] \
+  || die "Published-feed preservation unexpectedly queried or advanced a GitHub Release"
+
+env \
+  KAST_TEST_HTTP_STATUS=404 \
+  KAST_TEST_PUBLISHED_MANIFEST="${scratch_dir}/output-a/plugin-repository-manifest.json" \
+  KAST_TEST_PUBLISHED_XML="${scratch_dir}/output-a/updatePlugins.xml" \
+  "$materializer" \
+    --source "${scratch_dir}/source.json" \
+    --output-directory "${scratch_dir}/unpublished-materialized" \
+    --published-release \
+    --allow-unpublished \
+    --curl-bin "$fake_curl"
+[[ ! -e "${scratch_dir}/unpublished-materialized" ]] \
+  || die "Missing published feed unexpectedly emitted repository output"
+
+expect_failure draft-release \
+  env \
+    KAST_TEST_GH_LOG="${scratch_dir}/draft-gh.log" \
+    KAST_TEST_RELEASE_TAG=v1.2.3 \
+    KAST_TEST_RELEASE_DRAFT=true \
+    KAST_TEST_RELEASE_DIRECTORY="$release_directory" \
+    "$materializer" \
+      --source "${scratch_dir}/source.json" \
+      --output-directory "${scratch_dir}/draft-materialized" \
+      --tag v1.2.3 \
+      "${verification_args[@]}" \
+      --gh-bin "$fake_gh"
+
+expect_failure mutable-release \
+  env \
+    KAST_TEST_GH_LOG="${scratch_dir}/mutable-gh.log" \
+    KAST_TEST_RELEASE_TAG=v1.2.3 \
+    KAST_TEST_RELEASE_IMMUTABLE=false \
+    KAST_TEST_RELEASE_DIRECTORY="$release_directory" \
+    "$materializer" \
+      --source "${scratch_dir}/source.json" \
+      --output-directory "${scratch_dir}/mutable-materialized" \
+      --tag v1.2.3 \
+      "${verification_args[@]}" \
+      --gh-bin "$fake_gh"
+
+expect_failure mismatched-release-sha \
+  env \
+    KAST_TEST_GH_LOG="${scratch_dir}/sha-gh.log" \
+    KAST_TEST_RELEASE_TAG=v1.2.3 \
+    KAST_TEST_RELEASE_SHA=2222222222222222222222222222222222222222 \
+    KAST_TEST_RELEASE_DIRECTORY="$release_directory" \
+    "$materializer" \
+      --source "${scratch_dir}/source.json" \
+      --output-directory "${scratch_dir}/sha-materialized" \
+      --tag v1.2.3 \
+      "${verification_args[@]}" \
+      --gh-bin "$fake_gh"
+
+tampered_release_directory="${scratch_dir}/tampered-release"
+mkdir -p "$tampered_release_directory"
+cp "${scratch_dir}/kast-idea-v1.2.3.zip" "$tampered_release_directory/"
+cp "${scratch_dir}/build-provenance.json" "$tampered_release_directory/"
+printf 'tampered' >> "$tampered_release_directory/kast-idea-v1.2.3.zip"
+expect_failure tampered-finalized-asset \
+  env \
+    KAST_TEST_GH_LOG="${scratch_dir}/tampered-gh.log" \
+    KAST_TEST_RELEASE_TAG=v1.2.3 \
+    KAST_TEST_RELEASE_DIRECTORY="$tampered_release_directory" \
+    "$materializer" \
+      --source "${scratch_dir}/source.json" \
+      --output-directory "${scratch_dir}/tampered-materialized" \
+      --tag v1.2.3 \
+      "${verification_args[@]}" \
+      --gh-bin "$fake_gh"
+
+rm -f "${scratch_dir}/unconfigured-gh.log"
+"$materializer" \
+  --source "$source_file" \
+  --output-directory "${scratch_dir}/unconfigured-materialized" \
+  --tag v1.2.3 \
+  --allow-unconfigured \
+  --gh-bin "$fake_gh"
+[[ ! -e "${scratch_dir}/unconfigured-materialized" ]] \
+  || die "Unconfigured production source unexpectedly emitted a feed"
+[[ ! -e "${scratch_dir}/unconfigured-gh.log" ]] \
+  || die "Unconfigured production source unexpectedly queried GitHub"
+
+require_block_contains \
+  "$release_workflow" \
+  "  build-jetbrains-plugin-repository-pages:" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "      - publish-release" \
+  "JetBrains documentation build must wait for finalized release publication"
+require_block_contains \
+  "$release_workflow" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "  verify-release-state:" \
+  ".github/scripts/materialize-jetbrains-plugin-repository-pages.sh" \
+  "JetBrains Pages deployment must verify and render the finalized release asset under its lock"
+require_block_contains \
+  "$release_workflow" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "  verify-release-state:" \
+  "      group: github-pages" \
+  "Release Pages materialization and deployment must share the global Pages lock"
+require_block_contains \
+  "$release_workflow" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "  verify-release-state:" \
+  "      - build-jetbrains-plugin-repository-pages" \
+  "JetBrains Pages deployment must consume the built documentation artifact"
+require_block_contains \
+  "$release_workflow" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "  verify-release-state:" \
+  '          name: idea-plugin-${{ github.run_id }}' \
+  "JetBrains Pages deployment must consume the verifier captured with the signed plugin build"
+require_block_contains \
+  "$release_workflow" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "  verify-release-state:" \
+  "--certificate-chain" \
+  "JetBrains Pages deployment must reverify the finalized signed ZIP"
+require_block_contains \
+  "$release_workflow" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "  verify-release-state:" \
+  "release-idea-signature-verifier" \
+  "JetBrains Pages deployment must verify the producer receipt for its signature verifier"
+require_block_contains \
+  "$release_workflow" \
+  "  release-preflight:" \
+  "  bump-version:" \
+  "repos/amichne/kast/immutable-releases" \
+  "Release preflight must reject disabled immutability before creating a tag or release"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_contains \
+  "$release_workflow" \
+  "  release-preflight:" \
+  "  bump-version:" \
+  'GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}' \
+  "Immutability preflight must use the admin-capable release token without a GITHUB_TOKEN fallback"
+require_block_contains \
+  "$release_workflow" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "  verify-release-state:" \
+  "      pages: write" \
+  "JetBrains Pages deployment must have Pages write permission"
+require_block_contains \
+  "$release_workflow" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "  verify-release-state:" \
+  "      id-token: write" \
+  "JetBrains Pages deployment must have OIDC permission"
+require_block_contains \
+  "$release_workflow" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "  verify-release-state:" \
+  "      name: github-pages" \
+  "JetBrains Pages deployment must use the protected Pages environment"
+require_order \
+  "$release_workflow" \
+  "  publish-release:" \
+  "  build-jetbrains-plugin-repository-pages:" \
+  "Release publication must precede JetBrains repository rendering"
+require_order \
+  "$release_workflow" \
+  "  build-jetbrains-plugin-repository-pages:" \
+  "  deploy-jetbrains-plugin-repository-pages:" \
+  "JetBrains repository rendering must precede Pages deployment"
+require_block_contains \
+  "$docs_workflow" \
+  "  deploy:" \
+  "      - uses: actions/deploy-pages@v5" \
+  ".github/scripts/materialize-jetbrains-plugin-repository-pages.sh" \
+  "Documentation deployments must retain the latest finalized JetBrains feed"
+require_block_contains \
+  "$docs_workflow" \
+  "  deploy:" \
+  "      - uses: actions/deploy-pages@v5" \
+  "--published-release" \
+  "Documentation deployments must preserve the previously published feed instead of advancing it"
+require_block_contains \
+  "$docs_workflow" \
+  "  deploy:" \
+  "      - uses: actions/deploy-pages@v5" \
+  "      group: github-pages" \
+  "Documentation preservation and deployment must share the global Pages lock"
+require_block_contains \
+  "$docs_workflow" \
+  "  deploy:" \
+  "      - uses: actions/deploy-pages@v5" \
+  "      - uses: actions/upload-pages-artifact@v5" \
+  "Documentation must resolve the published feed only after acquiring the Pages lock"
+require_contains \
+  "$materializer" \
+  "GitHub Release is not immutable" \
+  "Feed advancement must reject mutable GitHub Releases"
+require_contains \
+  "$materializer" \
+  'release verify "$tag"' \
+  "Feed advancement must verify GitHub's immutable release attestation"
+require_contains \
+  "$packaging_guide" \
+  "plugin-repository.json" \
+  "JetBrains packaging guide must name the authored source"
+require_contains \
+  "$packaging_guide" \
+  "updatePlugins.xml" \
+  "JetBrains packaging guide must name the generated feed boundary"
+require_contains \
+  "$github_guide" \
+  "test-jetbrains-plugin-repository-contract.sh" \
+  "GitHub guide must name the feed-to-asset gate"
+
+printf 'JetBrains plugin repository contract passed.\n'

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -122,6 +122,9 @@ release_asset_verifier="${repo_root}/scripts/verify-release-assets.sh"
 idea_plugin_artifact_verifier="${repo_root}/scripts/verify-idea-plugin-artifact.py"
 immutable_release_asset_uploader="${repo_root}/.github/scripts/upload-immutable-release-asset.sh"
 idea_plugin_signing_contract="${repo_root}/.github/scripts/test-idea-plugin-signing-contract.sh"
+idea_plugin_repository_contract="${repo_root}/.github/scripts/test-jetbrains-plugin-repository-contract.sh"
+idea_plugin_repository_source="${repo_root}/packaging/jetbrains/plugin-repository.json"
+idea_plugin_repository_renderer="${repo_root}/.github/scripts/render-jetbrains-plugin-repository.py"
 release_state_verifier="${repo_root}/scripts/verify-release-state.sh"
 maven_central_verifier="${repo_root}/scripts/verify-maven-central.sh"
 ubuntu_debian_validator="${repo_root}/scripts/validate-ubuntu-debian-bundle-in-docker.sh"
@@ -156,6 +159,9 @@ for path in \
   "$idea_plugin_artifact_verifier" \
   "$immutable_release_asset_uploader" \
   "$idea_plugin_signing_contract" \
+  "$idea_plugin_repository_contract" \
+  "$idea_plugin_repository_source" \
+  "$idea_plugin_repository_renderer" \
   "$release_state_verifier" \
   "$maven_central_verifier" \
   "$ubuntu_debian_validator" \
@@ -366,13 +372,21 @@ require_block_contains "$release_workflow" "  release-preflight:" "  bump-versio
 require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_PRIVATE_KEY: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY }}' "Release preflight must require the IDEA signing key"
 # shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
 require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_PRIVATE_KEY_PASSWORD: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY_PASSWORD }}' "Release preflight must require the IDEA signing password"
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" "render-jetbrains-plugin-repository.py" "Release preflight must validate the typed signer owner"
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" "--require-configured" "Release preflight must reject an unconfigured signer"
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" "repos/amichne/kast/immutable-releases" "Release preflight must reject disabled GitHub Release immutability before tag creation"
 # shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
-require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_SIGNER_SHA256 }}' "Release preflight must require the enrolled signer fingerprint"
+require_block_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}' "Immutability preflight must require the admin-capable release token"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_not_contains "$release_workflow" "  release-preflight:" "  bump-version:" 'IDEA_PLUGIN_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_SIGNER_SHA256 }}' "Release preflight must not duplicate signer authority in a repository variable"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:verifyPlugin" "Release must verify IDEA compatibility"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:signPlugin" "Release must sign the IDEA plugin"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:verifyPluginSignature" "Release must verify the IDEA plugin signature"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ":backend-idea:stageIdeaPluginSignatureVerifier" "Release must stage the JetBrains verifier used for the published bytes"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "scripts/verify-idea-plugin-artifact.py record" "Release must record signer-bound IDEA provenance"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "enrolled-signers" "Release must consume signer identities from the typed repository source"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "packaging/jetbrains/plugin-repository.json" "Release must use the checked-in signer owner"
+require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" "release-idea-signature-verifier" "Release must receipt the Marketplace verifier consumed by Pages"
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" ".github/scripts/upload-immutable-release-asset.sh" "Release must upload the IDEA plugin immutably"
 # shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
 require_block_contains "$release_workflow" "  build-idea-plugin:" "  build-headless-backend:" 'tag_sha="$(git rev-list -n1 "$tag")"' "Release must resolve the checked-out tag target"
@@ -401,6 +415,10 @@ require_contains "$publishing_conventions" "publishTarget != PublishTarget.Githu
 require_contains "$release_workflow" "needs.validate-jvm.result == 'success'" "Release publication must require local JVM and Maven validation"
 require_contains "$release_workflow" "needs.build-openapi-spec.result == 'success'" "Release publication must require the OpenAPI artifact"
 require_contains "$release_workflow" "needs.publish-release.result" "Final release verification must read the publish-release result"
+require_contains "$release_workflow" "needs.deploy-jetbrains-plugin-repository-pages.result" "Final release verification must read the stable Pages deployment result"
+require_contains "$ci_workflow" "Test JetBrains plugin repository contract" "CI must execute the feed-to-asset consistency gate"
+require_contains "$idea_plugin_repository_source" '"state": "unconfigured"' "Repository source must fail closed until production signer enrollment"
+require_contains "$idea_plugin_repository_renderer" "combined release provenance builds must be ordered" "Repository renderer must reject nondeterministic provenance ordering"
 require_contains "$release_workflow" "Publish release finished with result" "Final release verification must fail when publication did not complete"
 require_not_contains "$release_workflow" "publish-setup-kast-action:" "Kast releases must not publish the separate kast-action tag"
 require_not_contains "$release_workflow" 'action_tag="v1"' "Kast releases must not own the stable setup action tag"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         shell: bash
         run: ./.github/scripts/test-release-workflow-contract.sh
 
+      - name: Test JetBrains plugin repository contract
+        shell: bash
+        run: ./.github/scripts/test-jetbrains-plugin-repository-contract.sh
+
       - name: Test Kast build contract
         shell: bash
         run: ./.github/scripts/test-kast-build-contract.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,11 @@ on:
       - ".github/scripts/render-rpc-contract-summary.py"
       - ".github/scripts/test-docs-navigation-contract.sh"
       - ".github/scripts/test-docs-content-contract.sh"
+      - ".github/scripts/materialize-jetbrains-plugin-repository-pages.sh"
+      - ".github/scripts/render-jetbrains-plugin-repository.py"
+      - ".github/scripts/test-jetbrains-plugin-repository-contract.sh"
       - "docs/**"
+      - "packaging/jetbrains/**"
       - "cli-rs/protocol/**"
       - "cli-rs/resources/kast-skill/references/commands.json"
       - "requirements-docs.txt"
@@ -20,7 +24,11 @@ on:
       - ".github/scripts/render-rpc-contract-summary.py"
       - ".github/scripts/test-docs-navigation-contract.sh"
       - ".github/scripts/test-docs-content-contract.sh"
+      - ".github/scripts/materialize-jetbrains-plugin-repository-pages.sh"
+      - ".github/scripts/render-jetbrains-plugin-repository.py"
+      - ".github/scripts/test-jetbrains-plugin-repository-contract.sh"
       - "docs/**"
+      - "packaging/jetbrains/**"
       - "cli-rs/protocol/**"
       - "cli-rs/resources/kast-skill/references/commands.json"
       - "requirements-docs.txt"
@@ -40,7 +48,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v6
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
@@ -51,17 +58,39 @@ jobs:
       - run: ./.github/scripts/test-docs-navigation-contract.sh
       - run: ./.github/scripts/test-docs-content-contract.sh
       - run: zensical build --clean
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
+          name: documentation-site-${{ github.run_id }}
           path: site
+          if-no-files-found: error
 
   deploy:
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     needs: build
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v7
+        with:
+          name: documentation-site-${{ github.run_id }}
+          path: site
+      - uses: actions/configure-pages@v6
+      - name: Preserve the validated published JetBrains plugin repository
+        run: >
+          .github/scripts/materialize-jetbrains-plugin-repository-pages.sh
+          --source packaging/jetbrains/plugin-repository.json
+          --output-directory site/jetbrains
+          --published-release
+          --allow-unconfigured
+          --allow-unpublished
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
       - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,31 @@ jobs:
     name: Preflight stable release automation
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate enrolled IDEA plugin repository identity
+        run: >
+          .github/scripts/render-jetbrains-plugin-repository.py
+          validate-source
+          --source packaging/jetbrains/plugin-repository.json
+          --require-configured
+
+      - name: Require immutable GitHub Releases
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "$GH_TOKEN" ]] || {
+            echo "::error::RELEASE_GITHUB_TOKEN with repository Administration read access is required."
+            exit 1
+          }
+          immutable_releases="$(gh api repos/amichne/kast/immutable-releases --jq '.enabled')"
+          [[ "$immutable_releases" == "true" ]] || {
+            echo "::error::GitHub Release immutability must be enabled before creating a release."
+            exit 1
+          }
+
       - name: Classify release
         id: classify
         env:
@@ -78,8 +103,6 @@ jobs:
           IDEA_PLUGIN_CERTIFICATE_CHAIN: ${{ secrets.IDEA_PLUGIN_CERTIFICATE_CHAIN }}
           IDEA_PLUGIN_PRIVATE_KEY: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY }}
           IDEA_PLUGIN_PRIVATE_KEY_PASSWORD: ${{ secrets.IDEA_PLUGIN_PRIVATE_KEY_PASSWORD }}
-          IDEA_PLUGIN_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_SIGNER_SHA256 }}
-          IDEA_PLUGIN_ROTATION_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_ROTATION_SIGNER_SHA256 }}
         shell: bash
         run: |
           set -euo pipefail
@@ -87,29 +110,13 @@ jobs:
           for name in \
             IDEA_PLUGIN_CERTIFICATE_CHAIN \
             IDEA_PLUGIN_PRIVATE_KEY \
-            IDEA_PLUGIN_PRIVATE_KEY_PASSWORD \
-            IDEA_PLUGIN_SIGNER_SHA256
+            IDEA_PLUGIN_PRIVATE_KEY_PASSWORD
           do
             [[ -n "${!name:-}" ]] || missing+=("$name")
           done
           if [[ "${#missing[@]}" -gt 0 ]]; then
             printf '::error::Missing required IDEA plugin signing inputs: %s\n' "${missing[*]}"
             exit 1
-          fi
-          fingerprint_pattern='^[0-9a-f]{64}$'
-          [[ "$IDEA_PLUGIN_SIGNER_SHA256" =~ $fingerprint_pattern ]] || {
-            echo "::error::IDEA_PLUGIN_SIGNER_SHA256 must be 64 lowercase hexadecimal characters."
-            exit 1
-          }
-          if [[ -n "$IDEA_PLUGIN_ROTATION_SIGNER_SHA256" ]]; then
-            [[ "$IDEA_PLUGIN_ROTATION_SIGNER_SHA256" =~ $fingerprint_pattern ]] || {
-              echo "::error::IDEA_PLUGIN_ROTATION_SIGNER_SHA256 must be 64 lowercase hexadecimal characters."
-              exit 1
-            }
-            [[ "$IDEA_PLUGIN_ROTATION_SIGNER_SHA256" != "$IDEA_PLUGIN_SIGNER_SHA256" ]] || {
-              echo "::error::The rotation signer must differ from the primary enrolled signer."
-              exit 1
-            }
           fi
 
   bump-version:
@@ -721,8 +728,6 @@ jobs:
       - name: Stage and upload immutable signed IDEA plugin asset
         env:
           GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
-          IDEA_PLUGIN_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_SIGNER_SHA256 }}
-          IDEA_PLUGIN_ROTATION_SIGNER_SHA256: ${{ vars.IDEA_PLUGIN_ROTATION_SIGNER_SHA256 }}
         shell: bash
         run: |
           set -euo pipefail
@@ -749,10 +754,21 @@ jobs:
           source_zip="${source_zips[0]}"
           mkdir -p dist
           cp "$source_zip" "dist/${asset_name}"
-          signer_args=(--expected-signer-sha256 "$IDEA_PLUGIN_SIGNER_SHA256")
-          if [[ -n "$IDEA_PLUGIN_ROTATION_SIGNER_SHA256" ]]; then
-            signer_args+=(--expected-signer-sha256 "$IDEA_PLUGIN_ROTATION_SIGNER_SHA256")
-          fi
+          cp "$signature_verifier_jar" dist/marketplace-zip-signer-cli.jar
+          mapfile -t enrolled_signers < <(
+            .github/scripts/render-jetbrains-plugin-repository.py \
+              enrolled-signers \
+              --source packaging/jetbrains/plugin-repository.json \
+              --require-configured
+          )
+          [[ "${#enrolled_signers[@]}" -gt 0 ]] || {
+            echo "No enrolled IDEA plugin signers were provided by the typed repository source" >&2
+            exit 1
+          }
+          signer_args=()
+          for signer in "${enrolled_signers[@]}"; do
+            signer_args+=(--expected-signer-sha256 "$signer")
+          done
           scripts/verify-idea-plugin-artifact.py record \
             --plugin-zip "dist/${asset_name}" \
             --certificate-chain "${{ steps.idea-signing-certificate.outputs.path }}" \
@@ -780,11 +796,24 @@ jobs:
             --artifact-path "dist/${asset_name}" \
             --producer-job build-idea-plugin \
             --build-command-id release-idea-plugin-build
+          scripts/verify-ci-artifact-ledger.py record \
+            --output dist/build-ledger-idea-signature-verifier.json \
+            --git-sha "$release_sha" \
+            --source-ref "refs/tags/${tag}" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --artifact-kind release-idea-signature-verifier \
+            --artifact-name marketplace-zip-signer-cli.jar \
+            --artifact-path dist/marketplace-zip-signer-cli.jar \
+            --producer-job build-idea-plugin \
+            --build-command-id stage-idea-plugin-signature-verifier
           scripts/verify-ci-artifact-ledger.py verify \
             --ledger dist/build-ledger-idea.json \
+            --ledger dist/build-ledger-idea-signature-verifier.json \
             --git-sha "$release_sha" \
             --require-kind release-idea \
-            --artifact "release-idea=dist/${asset_name}"
+            --require-kind release-idea-signature-verifier \
+            --artifact "release-idea=dist/${asset_name}" \
+            --artifact release-idea-signature-verifier=dist/marketplace-zip-signer-cli.jar
           .github/scripts/upload-immutable-release-asset.sh \
             --tag "$tag" \
             --asset "dist/${asset_name}"
@@ -1247,6 +1276,7 @@ jobs:
             --ledger provenance-cli/build-ledger-cli-macos-x64.json \
             --ledger provenance-cli/build-ledger-cli-macos-arm64.json \
             --ledger provenance-idea/build-ledger-idea.json \
+            --ledger provenance-idea/build-ledger-idea-signature-verifier.json \
             --ledger provenance-linux-headless/build-ledger-ubuntu-debian-headless.json \
             --ledger provenance-linux-headless/build-ledger-headless-linux-x64.json \
             --ledger provenance-linux-headless/build-ledger-runtime-manifest.json \
@@ -1258,6 +1288,7 @@ jobs:
             --require-kind release-cli-macos-x64 \
             --require-kind release-cli-macos-arm64 \
             --require-kind release-idea \
+            --require-kind release-idea-signature-verifier \
             --require-kind release-ubuntu-debian-headless-x86_64 \
             --require-kind release-headless-linux-x64 \
             --require-kind release-runtime-manifest \
@@ -1268,6 +1299,7 @@ jobs:
             --artifact "release-cli-macos-x64=provenance-cli/kast-${tag}-macos-x64.zip" \
             --artifact "release-cli-macos-arm64=provenance-cli/kast-${tag}-macos-arm64.zip" \
             --artifact "release-idea=provenance-idea/kast-idea-${tag}.zip" \
+            --artifact release-idea-signature-verifier=provenance-idea/marketplace-zip-signer-cli.jar \
             --artifact "release-ubuntu-debian-headless-x86_64=provenance-linux-headless/kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz" \
             --artifact "release-headless-linux-x64=provenance-linux-headless/kast-headless-linux-x64.tar.zst" \
             --artifact "release-runtime-manifest=provenance-linux-headless/kast-runtime-manifest.json" \
@@ -1440,12 +1472,117 @@ jobs:
           git -C homebrew-tap commit -m "kast ${tag}"
           git -C homebrew-tap push
 
+  build-jetbrains-plugin-repository-pages:
+    name: Build JetBrains plugin repository documentation
+    needs:
+      - prepare-release
+      - publish-release
+    if: always() && needs.prepare-release.result == 'success' && needs.publish-release.result == 'success' && !contains(needs.prepare-release.outputs.release_tag, '-')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - run: pip install -r requirements-docs.txt
+      - run: ./.github/scripts/test-docs-navigation-contract.sh
+      - run: ./.github/scripts/test-docs-content-contract.sh
+      - run: zensical build --clean
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: jetbrains-repository-site-${{ github.run_id }}
+          path: site
+          if-no-files-found: error
+
+  deploy-jetbrains-plugin-repository-pages:
+    name: Deploy finalized JetBrains plugin repository Pages
+    needs:
+      - prepare-release
+      - build-jetbrains-plugin-repository-pages
+    if: always() && needs.prepare-release.result == 'success' && needs.build-jetbrains-plugin-repository-pages.result == 'success'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: jetbrains-repository-site-${{ github.run_id }}
+          path: site
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: idea-plugin-${{ github.run_id }}
+          path: idea-verification
+
+      - uses: actions/configure-pages@v6
+
+      - name: Materialize IDEA plugin signing certificate
+        id: idea-repository-certificate
+        env:
+          IDEA_PLUGIN_CERTIFICATE_CHAIN: ${{ secrets.IDEA_PLUGIN_CERTIFICATE_CHAIN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          certificate_path="${RUNNER_TEMP}/kast-idea-plugin-signing-chain.crt"
+          umask 077
+          printf '%s\n' "$IDEA_PLUGIN_CERTIFICATE_CHAIN" > "$certificate_path"
+          openssl x509 -in "$certificate_path" -noout
+          printf 'path=%s\n' "$certificate_path" >> "$GITHUB_OUTPUT"
+
+      - name: Verify finalized plugin asset and render repository feed
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_sha="$(git rev-parse HEAD)"
+          scripts/verify-ci-artifact-ledger.py verify \
+            --ledger idea-verification/build-ledger-idea-signature-verifier.json \
+            --git-sha "$release_sha" \
+            --require-kind release-idea-signature-verifier \
+            --artifact release-idea-signature-verifier=idea-verification/marketplace-zip-signer-cli.jar
+          .github/scripts/materialize-jetbrains-plugin-repository-pages.sh \
+            --source packaging/jetbrains/plugin-repository.json \
+            --output-directory site/jetbrains \
+            --tag "${{ needs.prepare-release.outputs.release_tag }}" \
+            --certificate-chain "${{ steps.idea-repository-certificate.outputs.path }}" \
+            --signature-verifier-jar idea-verification/marketplace-zip-signer-cli.jar
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+      - uses: actions/deploy-pages@v5
+        id: deployment
+
   verify-release-state:
     name: Verify published release state
     needs:
       - prepare-release
       - publish-maven-central
       - publish-release
+      - deploy-jetbrains-plugin-repository-pages
     if: always() && needs.prepare-release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
@@ -1461,6 +1598,11 @@ jobs:
           set -euo pipefail
           if [[ "${{ needs.publish-release.result }}" != "success" ]]; then
             echo "::error::Publish release finished with result ${{ needs.publish-release.result }}."
+            exit 1
+          fi
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          if [[ "$tag" != *-* && "${{ needs.deploy-jetbrains-plugin-repository-pages.result }}" != "success" ]]; then
+            echo "::error::JetBrains repository Pages deployment finished with result ${{ needs.deploy-jetbrains-plugin-repository-pages.result }}."
             exit 1
           fi
           echo "Maven Central job result: ${{ needs.publish-maven-central.result }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,9 @@ The release tag owns the only production IDEA plugin build. The
 verification, sign exactly one ZIP with protected inputs, verify the signature
 against the file-backed enrolled certificate, and record signer-bound
 provenance before upload. Private keys and passwords remain GitHub secrets;
-certificate fingerprints are explicit repository variables and never derive
-from a shared release version.
+certificate fingerprints are owned by
+`packaging/jetbrains/plugin-repository.json` and never derive from a secret,
+mutable repository variable, or shared release version.
 
 `.github/scripts/upload-immutable-release-asset.sh` owns release-asset replay:
 every asset uploads once, then proves byte identity or fails. Release workflows

--- a/packaging/jetbrains/AGENTS.md
+++ b/packaging/jetbrains/AGENTS.md
@@ -1,0 +1,26 @@
+# JetBrains Repository Packaging Guide
+
+This directory owns the authored configuration for Kast's off-Marketplace
+JetBrains plugin repository.
+
+`plugin-repository.json` is the only checked-in owner for the stable feed URL,
+plugin identity, immutable GitHub Release asset URL template, IDEA build range,
+active signing certificate fingerprint, and explicit certificate-rotation
+state. Keep the production signer unconfigured until its public certificate
+fingerprint is known; never substitute a fixture, secret, or workflow variable.
+
+`updatePlugins.xml` and `plugin-repository-manifest.json` are generated Pages
+outputs. Do not check them in or edit them by hand. The renderer must validate
+the finalized signed ZIP cryptographically against its public certificate and
+signer-bound release provenance before either file is emitted. Feed advancement
+also requires GitHub's immutable-release attestation and an exact tag-to-commit
+match. A rotation overlap must name two distinct enrolled signers; unknown or
+incomplete rotation state fails closed.
+
+After changing this boundary, run:
+
+```console
+.github/scripts/test-jetbrains-plugin-repository-contract.sh
+.github/scripts/test-idea-plugin-signing-contract.sh
+.github/scripts/test-release-workflow-contract.sh
+```

--- a/packaging/jetbrains/plugin-repository.json
+++ b/packaging/jetbrains/plugin-repository.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "repository": {
+    "feedUrl": "https://kast.michne.com/jetbrains/updatePlugins.xml",
+    "pluginId": "io.github.amichne.kast",
+    "releaseAssetUrlTemplate": "https://github.com/amichne/kast/releases/download/{tag}/kast-idea-{tag}.zip",
+    "ideaBuildRange": {
+      "sinceBuild": "253",
+      "untilBuild": null
+    }
+  },
+  "signing": {
+    "activeSignerSha256": null,
+    "rotation": {
+      "state": "unconfigured",
+      "nextSignerSha256": null
+    }
+  }
+}


### PR DESCRIPTION
Closes #379.

## Behavior

- adds `packaging/jetbrains/plugin-repository.json` as the typed source of truth for the feed URL, plugin identity, immutable asset URL, IDE build range, and signer rotation state
- deterministically renders and validates `updatePlugins.xml` plus an audit manifest from finalized release bytes
- refuses feed advancement unless the release is immutable, its tag target matches provenance, and the downloaded ZIP passes Marketplace signature verification against an enrolled certificate
- receipts and re-verifies the Marketplace verifier JAR before executing it downstream
- serializes docs and release Pages materialization/upload/deploy under one `github-pages` lock; docs deployments only preserve an already-published feed
- leaves the checked-in production signer honestly unconfigured until the real public certificate is enrolled

## Verification

- `.github/scripts/test-jetbrains-plugin-repository-contract.sh`
- `.github/scripts/test-release-workflow-contract.sh`
- `.github/scripts/test-idea-plugin-signing-contract.sh`
- `.github/scripts/test-release-asset-verifier.sh`
- `.github/scripts/test-release-provenance-assembler.sh`
- `.github/scripts/test-kast-build-contract.sh`
- `.github/scripts/test-docs-navigation-contract.sh`
- `.github/scripts/test-docs-content-contract.sh`
- `zensical build --clean`
- `./scripts/ci-gradle-retry.sh ./gradlew :backend-idea:verifyPluginStructure :backend-idea:verifyPluginXmlPresent :backend-idea:verifyPlugin`
- shell/Python/YAML syntax, workflow dependency graph, ShellCheck, and `git diff --check`

## Required repository setup before the first signed release

1. Settings -> General -> Releases: enable release immutability. The release preflight fails before tag/draft creation while it is disabled.
2. Ensure `RELEASE_GITHUB_TOKEN` has repository Administration read access so preflight can query the immutable-release setting; there is deliberately no `github.token` fallback.
3. Settings -> Environments -> `github-pages` -> Deployment branches and tags: retain `main` and add tag pattern `v*`.
4. Add `IDEA_PLUGIN_CERTIFICATE_CHAIN`, `IDEA_PLUGIN_PRIVATE_KEY`, and `IDEA_PLUGIN_PRIVATE_KEY_PASSWORD` secrets.
5. Replace the unconfigured signer state in `packaging/jetbrains/plugin-repository.json` with the real public certificate fingerprint in a reviewed commit.

No Marketplace publication, trust enrollment, CLI repository setting, Homebrew setting, or runtime compatibility behavior is added here.
