### PR TITLE
feat: prepare typed runtime compatibility negotiation

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -24,8 +24,10 @@ For CLI terminal command or executable example changes, run
 `.github/scripts/test-terminal-command-contract.sh`.
 
 The signed JetBrains repository source lives at
-`packaging/jetbrains/plugin-repository.json`. The authored renderer and GitHub
-Release adapter live in `.github/scripts/`; release and docs workflows may
+`packaging/jetbrains/plugin-repository.json`. Runtime pair and IDEA build-range
+truth lives separately at `packaging/jetbrains/runtime-compatibility.json`.
+The authored renderers and GitHub Release adapters live in `.github/scripts/`;
+release and docs workflows may
 publish only their verified generated Pages output. A stable release may
 advance the feed only after GitHub proves the release immutable and the
 downloaded ZIP passes signer-bound cryptographic verification. A docs deploy
@@ -33,6 +35,14 @@ may only preserve the already-published feed. Both flows must materialize,
 upload, and deploy under the shared `github-pages` concurrency lock. Never
 hand-author `updatePlugins.xml` or `plugin-repository-manifest.json`, and never
 derive the enrolled signer from a secret or mutable release variable.
+
+The release workflow renders `kast-runtime-compatibility.json` from the
+authored matrix using the exact release tag and commit, records a dedicated CI
+artifact ledger and provenance entry, and uploads it immutably. Release
+verification must validate that asset's source-owned IDEA range, positive
+revisions, capability arrays, and same-release IDEA row. Run the dedicated
+runtime compatibility contract whenever source, rendering, metadata parsing,
+release wiring, or this ownership boundary changes.
 
 Publishable CI artifacts are single-producer per commit. Producer jobs must
 write a `scripts/verify-ci-artifact-ledger.py` receipt for the artifact they
@@ -75,6 +85,7 @@ For signed JetBrains repository or Pages publication changes, run:
 
 ```console
 .github/scripts/test-jetbrains-plugin-repository-contract.sh
+.github/scripts/test-runtime-compatibility-contract.sh
 .github/scripts/test-idea-plugin-signing-contract.sh
 .github/scripts/test-release-workflow-contract.sh
 ```

--- a/.github/scripts/materialize-jetbrains-plugin-repository-pages.sh
+++ b/.github/scripts/materialize-jetbrains-plugin-repository-pages.sh
@@ -10,6 +10,7 @@ usage() {
   cat >&2 <<'USAGE'
 Usage: materialize-jetbrains-plugin-repository-pages.sh \
   --source <plugin-repository.json> \
+  [--compatibility-source <runtime-compatibility.json>] \
   --output-directory <site/jetbrains> \
   (--tag <vX.Y.Z> | --latest-stable | --published-release) \
   [--allow-unconfigured] [--allow-unpublished] \
@@ -30,6 +31,7 @@ resolve_repo_root() {
 repo_root="$(resolve_repo_root)"
 renderer="${repo_root}/.github/scripts/render-jetbrains-plugin-repository.py"
 source_file=""
+compatibility_source="${repo_root}/packaging/jetbrains/runtime-compatibility.json"
 output_directory=""
 tag=""
 latest_stable=false
@@ -47,6 +49,11 @@ while [[ $# -gt 0 ]]; do
     --source)
       [[ $# -ge 2 ]] || usage
       source_file="$2"
+      shift 2
+      ;;
+    --compatibility-source)
+      [[ $# -ge 2 ]] || usage
+      compatibility_source="$2"
       shift 2
       ;;
     --output-directory)
@@ -107,6 +114,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n "$source_file" ]] || usage
+[[ -f "$compatibility_source" ]] || die "Runtime compatibility source does not exist: $compatibility_source"
 [[ -n "$output_directory" ]] || usage
 mode_count=0
 [[ -n "$tag" ]] && mode_count=$((mode_count + 1))
@@ -120,8 +128,9 @@ if [[ "$allow_unpublished" == true && "$published_release" != true ]]; then
 fi
 [[ -x "$renderer" ]] || die "JetBrains repository renderer is not executable: $renderer"
 
-"$renderer" validate-source --source "$source_file"
-signing_state="$("$renderer" signing-state --source "$source_file")"
+source_args=(--source "$source_file" --compatibility-source "$compatibility_source")
+"$renderer" validate-source "${source_args[@]}"
+signing_state="$("$renderer" signing-state "${source_args[@]}")"
 if [[ "$signing_state" == "unconfigured" ]]; then
   if [[ "$allow_unconfigured" == true ]]; then
     rm -rf -- "$output_directory"
@@ -130,7 +139,7 @@ if [[ "$signing_state" == "unconfigured" ]]; then
   fi
   die "JetBrains repository publication requires a configured production signer"
 fi
-"$renderer" validate-source --source "$source_file" --require-configured
+"$renderer" validate-source "${source_args[@]}" --require-configured
 
 scratch_dir="$(mktemp -d)"
 trap 'rm -rf "$scratch_dir"' EXIT
@@ -138,8 +147,8 @@ if [[ "$published_release" == true ]]; then
   command -v "$curl_bin" >/dev/null 2>&1 || die "curl is required: $curl_bin"
   published_manifest="${scratch_dir}/published-plugin-repository-manifest.json"
   published_xml="${scratch_dir}/published-updatePlugins.xml"
-  published_manifest_url="$("$renderer" manifest-url --source "$source_file")"
-  published_feed_url="$("$renderer" feed-url --source "$source_file")"
+  published_manifest_url="$("$renderer" manifest-url "${source_args[@]}")"
+  published_feed_url="$("$renderer" feed-url "${source_args[@]}")"
   set +e
   http_status="$($curl_bin \
     --silent \
@@ -172,7 +181,7 @@ if [[ "$published_release" == true ]]; then
   [[ "$xml_http_status" == "200" ]] \
     || die "Published JetBrains repository XML returned HTTP ${xml_http_status}"
   tag="$("$renderer" verify-published \
-    --source "$source_file" \
+    "${source_args[@]}" \
     --manifest "$published_manifest" \
     --xml "$published_xml")"
   rm -rf -- "$output_directory"
@@ -216,7 +225,7 @@ immutable="$($gh_bin api "repos/amichne/kast/releases/tags/${tag}" --jq '.immuta
   || die "GitHub Release is not immutable: ${tag}; enable repository release immutability before publishing"
 "$gh_bin" release verify "$tag" --repo amichne/kast >/dev/null
 
-asset_name="$("$renderer" asset-name --source "$source_file" --tag "$tag")"
+asset_name="$("$renderer" asset-name "${source_args[@]}" --tag "$tag")"
 "$gh_bin" release download "$tag" --dir "$scratch_dir" --pattern "$asset_name"
 "$gh_bin" release download "$tag" --dir "$scratch_dir" --pattern build-provenance.json
 [[ -f "${scratch_dir}/${asset_name}" ]] || die "Finalized plugin asset was not downloaded: $asset_name"
@@ -229,7 +238,7 @@ tag_sha="$($gh_bin api "repos/amichne/kast/commits/${tag}" --jq '.sha')"
 
 rm -rf -- "$output_directory"
 "$renderer" render \
-  --source "$source_file" \
+  "${source_args[@]}" \
   --plugin-zip "${scratch_dir}/${asset_name}" \
   --provenance "${scratch_dir}/build-provenance.json" \
   --certificate-chain "$certificate_chain" \

--- a/.github/scripts/render-jetbrains-plugin-repository.py
+++ b/.github/scripts/render-jetbrains-plugin-repository.py
@@ -23,6 +23,12 @@ IDEA_PLATFORM_ID = "idea"
 RELEASE_ASSET_URL_TEMPLATE = (
     "https://github.com/amichne/kast/releases/download/{tag}/kast-idea-{tag}.zip"
 )
+DEFAULT_COMPATIBILITY_SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "packaging"
+    / "jetbrains"
+    / "runtime-compatibility.json"
+)
 RELEASE_TAG_PATTERN = re.compile(r"v[0-9A-Za-z][0-9A-Za-z._-]*")
 VERSION_PATTERN = re.compile(r"[0-9A-Za-z][0-9A-Za-z._-]*")
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
@@ -218,13 +224,16 @@ class RepositoryPolicy:
     idea_build_range: IdeaBuildRange
 
     @classmethod
-    def parse(cls, raw: object) -> "RepositoryPolicy":
+    def parse(
+        cls,
+        raw: object,
+        *,
+        idea_build_range: IdeaBuildRange,
+    ) -> "RepositoryPolicy":
         payload = require_object(
             raw,
             field="repository",
-            keys=frozenset(
-                ("feedUrl", "pluginId", "releaseAssetUrlTemplate", "ideaBuildRange")
-            ),
+            keys=frozenset(("feedUrl", "pluginId", "releaseAssetUrlTemplate")),
         )
         feed_url = payload["feedUrl"]
         plugin_id = payload["pluginId"]
@@ -269,10 +278,7 @@ class RepositoryPolicy:
             feed_url=feed_url,
             plugin_id=plugin_id,
             asset_url_template=asset_template,
-            idea_build_range=IdeaBuildRange.parse(
-                payload["ideaBuildRange"],
-                field="repository.ideaBuildRange",
-            ),
+            idea_build_range=idea_build_range,
         )
 
     def asset_url(self, tag: str) -> str:
@@ -303,7 +309,7 @@ class RepositorySource:
     signing: SigningPolicy
 
     @classmethod
-    def load(cls, path: Path) -> "RepositorySource":
+    def load(cls, path: Path, *, compatibility_path: Path) -> "RepositorySource":
         payload = require_object(
             read_json(path, description="JetBrains repository source"),
             field="JetBrains repository source",
@@ -312,9 +318,29 @@ class RepositorySource:
         if payload["schemaVersion"] != SCHEMA_VERSION:
             fail(f"JetBrains repository source schemaVersion must be {SCHEMA_VERSION}")
         return cls(
-            repository=RepositoryPolicy.parse(payload["repository"]),
+            repository=RepositoryPolicy.parse(
+                payload["repository"],
+                idea_build_range=load_compatibility_idea_build_range(compatibility_path),
+            ),
             signing=SigningPolicy.parse(payload["signing"]),
         )
+
+
+def load_compatibility_idea_build_range(path: Path) -> IdeaBuildRange:
+    payload = require_object(
+        read_json(path, description="runtime compatibility source"),
+        field="runtime compatibility source",
+        keys=frozenset(("schemaVersion", "ideaBuildRange", "supportedPairs")),
+    )
+    if payload["schemaVersion"] != SCHEMA_VERSION:
+        fail(f"runtime compatibility source schemaVersion must be {SCHEMA_VERSION}")
+    pairs = payload["supportedPairs"]
+    if not isinstance(pairs, list) or not pairs:
+        fail("runtime compatibility source supportedPairs must be a non-empty array")
+    return IdeaBuildRange.parse(
+        payload["ideaBuildRange"],
+        field="runtime compatibility source ideaBuildRange",
+    )
 
 
 def manifest_url(source: RepositorySource) -> str:
@@ -703,17 +729,17 @@ def write_output(
 
 
 def validate_source_command(args: argparse.Namespace) -> None:
-    source = RepositorySource.load(Path(args.source))
+    source = repository_source(args)
     source.signing.enrolled_signers(require_configured=args.require_configured)
     print(f"Validated JetBrains repository source ({source.signing.state})")
 
 
 def signing_state_command(args: argparse.Namespace) -> None:
-    print(RepositorySource.load(Path(args.source)).signing.state)
+    print(repository_source(args).signing.state)
 
 
 def enrolled_signers_command(args: argparse.Namespace) -> None:
-    source = RepositorySource.load(Path(args.source))
+    source = repository_source(args)
     for signer in source.signing.enrolled_signers(
         require_configured=args.require_configured
     ):
@@ -721,20 +747,20 @@ def enrolled_signers_command(args: argparse.Namespace) -> None:
 
 
 def asset_name_command(args: argparse.Namespace) -> None:
-    source = RepositorySource.load(Path(args.source))
+    source = repository_source(args)
     print(source.repository.asset_name(args.tag))
 
 
 def manifest_url_command(args: argparse.Namespace) -> None:
-    print(manifest_url(RepositorySource.load(Path(args.source))))
+    print(manifest_url(repository_source(args)))
 
 
 def feed_url_command(args: argparse.Namespace) -> None:
-    print(feed_url(RepositorySource.load(Path(args.source))))
+    print(feed_url(repository_source(args)))
 
 
 def published_release_tag_command(args: argparse.Namespace) -> None:
-    source = RepositorySource.load(Path(args.source))
+    source = repository_source(args)
     print(published_release_tag(source=source, manifest_path=Path(args.manifest)))
 
 
@@ -743,7 +769,7 @@ def provenance_release_sha_command(args: argparse.Namespace) -> None:
 
 
 def verify_published_command(args: argparse.Namespace) -> None:
-    source = RepositorySource.load(Path(args.source))
+    source = repository_source(args)
     print(
         verify_published_repository(
             source=source,
@@ -754,7 +780,7 @@ def verify_published_command(args: argparse.Namespace) -> None:
 
 
 def render_command(args: argparse.Namespace) -> None:
-    source = RepositorySource.load(Path(args.source))
+    source = repository_source(args)
     provenance = IdeaProvenance.load(Path(args.provenance))
     plugin_zip = Path(args.plugin_zip)
     verify_finalized_signature(
@@ -776,6 +802,17 @@ def render_command(args: argparse.Namespace) -> None:
 
 def add_source_argument(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--source", required=True)
+    parser.add_argument(
+        "--compatibility-source",
+        default=str(DEFAULT_COMPATIBILITY_SOURCE),
+    )
+
+
+def repository_source(args: argparse.Namespace) -> RepositorySource:
+    return RepositorySource.load(
+        Path(args.source),
+        compatibility_path=Path(args.compatibility_source),
+    )
 
 
 def parse_args() -> argparse.Namespace:

--- a/.github/scripts/render-runtime-compatibility.py
+++ b/.github/scripts/render-runtime-compatibility.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SOURCE_SCHEMA_VERSION = 1
+MANIFEST_SCHEMA_VERSION = 1
+RELEASE_VERSION_TEMPLATE = "{releaseVersion}"
+RELEASE_TAG_PATTERN = re.compile(r"v[0-9A-Za-z][0-9A-Za-z._-]*")
+VERSION_PATTERN = re.compile(r"[0-9A-Za-z][0-9A-Za-z._-]*")
+GIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+BUILD_PATTERN = re.compile(r"[0-9]+(?:\.[0-9]+)*")
+UNTIL_BUILD_PATTERN = re.compile(r"[0-9]+(?:\.[0-9]+)*(?:\.\*)?")
+
+READ_CAPABILITIES = frozenset(
+    (
+        "RESOLVE_SYMBOL",
+        "FIND_REFERENCES",
+        "CALL_HIERARCHY",
+        "TYPE_HIERARCHY",
+        "SEMANTIC_INSERTION_POINT",
+        "DIAGNOSTICS",
+        "FILE_OUTLINE",
+        "WORKSPACE_SYMBOL_SEARCH",
+        "WORKSPACE_SEARCH",
+        "WORKSPACE_FILES",
+        "IMPLEMENTATIONS",
+        "CODE_ACTIONS",
+        "COMPLETIONS",
+    )
+)
+MUTATION_CAPABILITIES = frozenset(
+    (
+        "RENAME",
+        "APPLY_EDITS",
+        "FILE_OPERATIONS",
+        "OPTIMIZE_IMPORTS",
+        "REFRESH_WORKSPACE",
+    )
+)
+BACKEND_KINDS = frozenset(("IDEA", "HEADLESS"))
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require_object(raw: object, *, field: str, keys: frozenset[str]) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        fail(f"{field} must be a JSON object")
+    payload: dict[str, Any] = raw
+    actual = frozenset(payload)
+    if actual != keys:
+        fail(
+            f"{field} keys must be exactly {sorted(keys)}; "
+            f"missing={sorted(keys - actual)} unexpected={sorted(actual - keys)}"
+        )
+    return payload
+
+
+def read_json(path: Path) -> object:
+    if not path.is_file():
+        fail(f"runtime compatibility source does not exist: {path}")
+    try:
+        return json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicate_object_keys,
+        )
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        fail(f"runtime compatibility source is not valid UTF-8 JSON: {error}")
+
+
+def reject_duplicate_object_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate object key: {key}")
+        value[key] = item
+    return value
+
+
+def require_positive_revision(raw: object, *, field: str) -> int:
+    if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+        fail(f"{field} must be a positive integer")
+    return raw
+
+
+def require_version(raw: object, *, field: str, allow_template: bool) -> str:
+    if raw == RELEASE_VERSION_TEMPLATE and allow_template:
+        return RELEASE_VERSION_TEMPLATE
+    if not isinstance(raw, str) or VERSION_PATTERN.fullmatch(raw) is None:
+        fail(f"{field} must be a release version")
+    return raw
+
+
+@dataclass(frozen=True, order=True)
+class Capability:
+    kind: str
+    name: str
+
+    @classmethod
+    def parse(cls, raw: object, *, field: str) -> "Capability":
+        payload = require_object(
+            raw,
+            field=field,
+            keys=frozenset(("kind", "name")),
+        )
+        kind = payload["kind"]
+        name = payload["name"]
+        if kind == "READ":
+            allowed = READ_CAPABILITIES
+        elif kind == "MUTATION":
+            allowed = MUTATION_CAPABILITIES
+        else:
+            fail(f"{field}.kind must be READ or MUTATION")
+        if not isinstance(name, str) or name not in allowed:
+            fail(f"{field}.name is not a known {kind} capability: {name}")
+        return cls(kind=kind, name=name)
+
+    def value(self) -> dict[str, str]:
+        return {"kind": self.kind, "name": self.name}
+
+
+def parse_capabilities(raw: object, *, field: str) -> tuple[Capability, ...]:
+    if not isinstance(raw, list):
+        fail(f"{field} must be a JSON array")
+    capabilities = tuple(Capability.parse(value, field=f"{field}[{index}]") for index, value in enumerate(raw))
+    if len(set(capabilities)) != len(capabilities):
+        fail(f"{field} must not contain duplicates")
+    if tuple(sorted(capabilities, key=lambda value: (value.kind != "READ", value.name))) != capabilities:
+        fail(f"{field} must use deterministic kind/name ordering")
+    return capabilities
+
+
+@dataclass(frozen=True)
+class IdeaBuildRange:
+    since_build: str
+    until_build: str | None
+
+    @classmethod
+    def parse(cls, raw: object) -> "IdeaBuildRange":
+        payload = require_object(
+            raw,
+            field="ideaBuildRange",
+            keys=frozenset(("sinceBuild", "untilBuild")),
+        )
+        since_build = payload["sinceBuild"]
+        until_build = payload["untilBuild"]
+        if not isinstance(since_build, str) or BUILD_PATTERN.fullmatch(since_build) is None:
+            fail("ideaBuildRange.sinceBuild must be a numeric JetBrains build")
+        if until_build is not None and (
+            not isinstance(until_build, str)
+            or UNTIL_BUILD_PATTERN.fullmatch(until_build) is None
+        ):
+            fail("ideaBuildRange.untilBuild must be null or a numeric JetBrains build range")
+        result = cls(since_build=since_build, until_build=until_build)
+        result.require_ordered()
+        return result
+
+    def require_ordered(self) -> None:
+        if self.until_build is None:
+            return
+        since_parts = tuple(int(part) for part in self.since_build.split("."))
+        wildcard = self.until_build.endswith(".*")
+        raw_until = self.until_build.removesuffix(".*") if wildcard else self.until_build
+        until_parts = tuple(int(part) for part in raw_until.split("."))
+        if wildcard:
+            if until_parts < since_parts[: len(until_parts)]:
+                fail("ideaBuildRange.untilBuild is below sinceBuild")
+            return
+        width = max(len(since_parts), len(until_parts))
+        if until_parts + (0,) * (width - len(until_parts)) < since_parts + (0,) * (width - len(since_parts)):
+            fail("ideaBuildRange.untilBuild is below sinceBuild")
+
+    def value(self) -> dict[str, str | None]:
+        return {"sinceBuild": self.since_build, "untilBuild": self.until_build}
+
+
+@dataclass(frozen=True)
+class RuntimeIdentityTemplate:
+    implementation_version: str
+    backend_kind: str
+
+    @classmethod
+    def parse(
+        cls,
+        raw: object,
+        *,
+        field: str,
+        allow_template: bool,
+    ) -> "RuntimeIdentityTemplate":
+        payload = require_object(
+            raw,
+            field=field,
+            keys=frozenset(("implementationVersion", "backendKind")),
+        )
+        backend_kind = payload["backendKind"]
+        if backend_kind not in BACKEND_KINDS:
+            fail(f"{field}.backendKind must be one of {sorted(BACKEND_KINDS)}")
+        return cls(
+            implementation_version=require_version(
+                payload["implementationVersion"],
+                field=f"{field}.implementationVersion",
+                allow_template=allow_template,
+            ),
+            backend_kind=backend_kind,
+        )
+
+
+@dataclass(frozen=True)
+class SupportedPair:
+    relation: str
+    plugin_version: str
+    cli_version: str
+    protocol_revision: int
+    workspace_metadata_revision: int
+    runtime: RuntimeIdentityTemplate
+    required_capabilities: tuple[Capability, ...]
+    optional_capabilities: tuple[Capability, ...]
+    evidence: tuple[str, ...]
+
+    @classmethod
+    def parse(
+        cls,
+        raw: object,
+        *,
+        index: int,
+        repo_root: Path | None,
+        release_version: str | None,
+    ) -> "SupportedPair":
+        field = f"supportedPairs[{index}]"
+        payload = require_object(
+            raw,
+            field=field,
+            keys=frozenset(
+                (
+                    "relation",
+                    "pluginVersion",
+                    "cliVersion",
+                    "protocolRevision",
+                    "workspaceMetadataRevision",
+                    "runtime",
+                    "requiredCapabilities",
+                    "optionalCapabilities",
+                    "evidence",
+                )
+            ),
+        )
+        relation = payload["relation"]
+        if relation not in ("same-release", "adjacent-release"):
+            fail(f"{field}.relation must be same-release or adjacent-release")
+        plugin_version = require_version(
+            payload["pluginVersion"],
+            field=f"{field}.pluginVersion",
+            allow_template=release_version is None,
+        )
+        cli_version = require_version(
+            payload["cliVersion"],
+            field=f"{field}.cliVersion",
+            allow_template=release_version is None,
+        )
+        runtime = RuntimeIdentityTemplate.parse(
+            payload["runtime"],
+            field=f"{field}.runtime",
+            allow_template=release_version is None,
+        )
+        if relation == "same-release":
+            expected_version = RELEASE_VERSION_TEMPLATE if release_version is None else release_version
+            if (plugin_version, cli_version, runtime.implementation_version) != (expected_version,) * 3:
+                fail(f"{field} same-release versions must all equal {expected_version}")
+        else:
+            if RELEASE_VERSION_TEMPLATE in (
+                plugin_version,
+                cli_version,
+                runtime.implementation_version,
+            ):
+                fail(f"{field} adjacent-release versions must be explicit")
+            if plugin_version == cli_version:
+                fail(f"{field} adjacent-release plugin and CLI versions must differ")
+            if runtime.implementation_version not in (plugin_version, cli_version):
+                fail(f"{field} adjacent runtime version must equal the plugin or CLI version")
+
+        required = parse_capabilities(
+            payload["requiredCapabilities"], field=f"{field}.requiredCapabilities"
+        )
+        optional = parse_capabilities(
+            payload["optionalCapabilities"], field=f"{field}.optionalCapabilities"
+        )
+        if set(required) & set(optional):
+            fail(f"{field} required and optional capabilities must be disjoint")
+        expected_capabilities = {
+            *(Capability("READ", name) for name in READ_CAPABILITIES),
+            *(Capability("MUTATION", name) for name in MUTATION_CAPABILITIES),
+        }
+        if set(required) | set(optional) != expected_capabilities:
+            fail(f"{field} must classify every known capability exactly once")
+
+        evidence_raw = payload["evidence"]
+        if not isinstance(evidence_raw, list) or not evidence_raw:
+            fail(f"{field}.evidence must be a non-empty JSON array")
+        if not all(isinstance(value, str) and value for value in evidence_raw):
+            fail(f"{field}.evidence entries must be non-empty repository-relative paths")
+        evidence = tuple(evidence_raw)
+        if len(set(evidence)) != len(evidence) or tuple(sorted(evidence)) != evidence:
+            fail(f"{field}.evidence must be unique and sorted")
+        for path in evidence:
+            candidate = Path(path)
+            if candidate.is_absolute() or ".." in candidate.parts:
+                fail(f"{field}.evidence must be repository-relative: {path}")
+            if repo_root is not None and not (repo_root / candidate).is_file():
+                fail(f"{field}.evidence does not name an existing repository file: {path}")
+
+        return cls(
+            relation=relation,
+            plugin_version=plugin_version,
+            cli_version=cli_version,
+            protocol_revision=require_positive_revision(
+                payload["protocolRevision"], field=f"{field}.protocolRevision"
+            ),
+            workspace_metadata_revision=require_positive_revision(
+                payload["workspaceMetadataRevision"],
+                field=f"{field}.workspaceMetadataRevision",
+            ),
+            runtime=runtime,
+            required_capabilities=required,
+            optional_capabilities=optional,
+            evidence=evidence,
+        )
+
+    def key(self) -> tuple[object, ...]:
+        return (
+            self.plugin_version,
+            self.cli_version,
+            self.protocol_revision,
+            self.workspace_metadata_revision,
+            self.runtime,
+        )
+
+    def sort_key(self) -> tuple[object, ...]:
+        return (
+            self.plugin_version,
+            self.cli_version,
+            self.protocol_revision,
+            self.workspace_metadata_revision,
+            self.runtime.implementation_version,
+            self.runtime.backend_kind,
+        )
+
+    def render(self, release_version: str) -> dict[str, object]:
+        def resolve(value: str) -> str:
+            return release_version if value == RELEASE_VERSION_TEMPLATE else value
+
+        return {
+            "relation": self.relation,
+            "pluginVersion": resolve(self.plugin_version),
+            "cliVersion": resolve(self.cli_version),
+            "protocolRevision": self.protocol_revision,
+            "workspaceMetadataRevision": self.workspace_metadata_revision,
+            "runtime": {
+                "implementationVersion": resolve(self.runtime.implementation_version),
+                "backendKind": self.runtime.backend_kind,
+            },
+            "requiredCapabilities": [value.value() for value in self.required_capabilities],
+            "optionalCapabilities": [value.value() for value in self.optional_capabilities],
+            "evidence": list(self.evidence),
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeCompatibilitySource:
+    idea_build_range: IdeaBuildRange
+    supported_pairs: tuple[SupportedPair, ...]
+
+    @classmethod
+    def load(cls, path: Path) -> "RuntimeCompatibilitySource":
+        payload = require_object(
+            read_json(path),
+            field="runtime compatibility source",
+            keys=frozenset(("schemaVersion", "ideaBuildRange", "supportedPairs")),
+        )
+        if payload["schemaVersion"] != SOURCE_SCHEMA_VERSION:
+            fail(f"runtime compatibility source schemaVersion must be {SOURCE_SCHEMA_VERSION}")
+        pairs_raw = payload["supportedPairs"]
+        if not isinstance(pairs_raw, list) or not pairs_raw:
+            fail("supportedPairs must be a non-empty JSON array")
+        repo_root = Path(__file__).resolve().parents[2]
+        pairs = tuple(
+            SupportedPair.parse(
+                raw,
+                index=index,
+                repo_root=repo_root,
+                release_version=None,
+            )
+            for index, raw in enumerate(pairs_raw)
+        )
+        if len({pair.key() for pair in pairs}) != len(pairs):
+            fail("supportedPairs must not contain duplicate negotiation rows")
+        if not any(
+            pair.relation == "same-release" and pair.runtime.backend_kind == "IDEA"
+            for pair in pairs
+        ):
+            fail("supportedPairs must contain the tested same-release IDEA row")
+        return cls(
+            idea_build_range=IdeaBuildRange.parse(payload["ideaBuildRange"]),
+            supported_pairs=pairs,
+        )
+
+
+@dataclass(frozen=True)
+class RuntimeCompatibilityManifest:
+    release_tag: str
+    release_sha: str
+    idea_build_range: IdeaBuildRange
+    supported_pairs: tuple[SupportedPair, ...]
+
+    @classmethod
+    def load(cls, path: Path, *, expected_release_tag: str) -> "RuntimeCompatibilityManifest":
+        payload = require_object(
+            read_json(path),
+            field="runtime compatibility manifest",
+            keys=frozenset(
+                (
+                    "schemaVersion",
+                    "releaseTag",
+                    "releaseSha",
+                    "ideaBuildRange",
+                    "supportedPairs",
+                )
+            ),
+        )
+        if payload["schemaVersion"] != MANIFEST_SCHEMA_VERSION:
+            fail(f"runtime compatibility manifest schemaVersion must be {MANIFEST_SCHEMA_VERSION}")
+        release_tag = payload["releaseTag"]
+        if not isinstance(release_tag, str) or require_release_tag(release_tag) != expected_release_tag:
+            fail("runtime compatibility manifest releaseTag does not match the expected release tag")
+        release_sha = payload["releaseSha"]
+        if not isinstance(release_sha, str) or GIT_SHA_PATTERN.fullmatch(release_sha) is None:
+            fail("runtime compatibility manifest releaseSha must be 40 lowercase hexadecimal characters")
+        pairs_raw = payload["supportedPairs"]
+        if not isinstance(pairs_raw, list) or not pairs_raw:
+            fail("runtime compatibility manifest supportedPairs must be a non-empty array")
+        release_version = release_tag.removeprefix("v")
+        pairs = tuple(
+            SupportedPair.parse(
+                raw,
+                index=index,
+                repo_root=None,
+                release_version=release_version,
+            )
+            for index, raw in enumerate(pairs_raw)
+        )
+        if len({pair.key() for pair in pairs}) != len(pairs):
+            fail("runtime compatibility manifest supportedPairs contain duplicate negotiation rows")
+        if pairs != tuple(sorted(pairs, key=SupportedPair.sort_key)):
+            fail("runtime compatibility manifest supportedPairs are not deterministically ordered")
+        if not any(
+            pair.relation == "same-release" and pair.runtime.backend_kind == "IDEA"
+            for pair in pairs
+        ):
+            fail("runtime compatibility manifest must contain the tested same-release IDEA row")
+        return cls(
+            release_tag=release_tag,
+            release_sha=release_sha,
+            idea_build_range=IdeaBuildRange.parse(payload["ideaBuildRange"]),
+            supported_pairs=pairs,
+        )
+
+
+def require_release_tag(raw: str) -> str:
+    if RELEASE_TAG_PATTERN.fullmatch(raw) is None:
+        fail("release tag must start with v and contain only tag-safe characters")
+    return raw
+
+
+def render_manifest(
+    source: RuntimeCompatibilitySource,
+    *,
+    release_tag: str,
+    release_sha: str,
+) -> dict[str, object]:
+    require_release_tag(release_tag)
+    if GIT_SHA_PATTERN.fullmatch(release_sha) is None:
+        fail("release SHA must be 40 lowercase hexadecimal characters")
+    release_version = release_tag.removeprefix("v")
+    pairs = [pair.render(release_version) for pair in source.supported_pairs]
+    pairs.sort(key=rendered_pair_sort_key)
+    return {
+        "schemaVersion": MANIFEST_SCHEMA_VERSION,
+        "releaseTag": release_tag,
+        "releaseSha": release_sha,
+        "ideaBuildRange": source.idea_build_range.value(),
+        "supportedPairs": pairs,
+    }
+
+
+def rendered_pair_sort_key(pair: dict[str, object]) -> tuple[object, ...]:
+    runtime = pair["runtime"]
+    if not isinstance(runtime, dict):
+        fail("rendered runtime identity must be an object")
+    return (
+        str(pair["pluginVersion"]),
+        str(pair["cliVersion"]),
+        int(pair["protocolRevision"]),
+        int(pair["workspaceMetadataRevision"]),
+        str(runtime["implementationVersion"]),
+        str(runtime["backendKind"]),
+    )
+
+
+def validate_source_command(args: argparse.Namespace) -> None:
+    source = RuntimeCompatibilitySource.load(Path(args.source))
+    print(f"Validated runtime compatibility source ({len(source.supported_pairs)} row(s))")
+
+
+def validate_manifest_command(args: argparse.Namespace) -> None:
+    manifest = RuntimeCompatibilityManifest.load(
+        Path(args.manifest),
+        expected_release_tag=args.release_tag,
+    )
+    print(
+        "Validated runtime compatibility manifest "
+        f"({len(manifest.supported_pairs)} row(s))"
+    )
+
+
+def render_command(args: argparse.Namespace) -> None:
+    source = RuntimeCompatibilitySource.load(Path(args.source))
+    output = Path(args.output)
+    if output.exists():
+        fail(f"output already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = render_manifest(
+        source,
+        release_tag=args.release_tag,
+        release_sha=args.release_sha,
+    )
+    output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Rendered runtime compatibility manifest for {args.release_tag}")
+
+
+def idea_build_range_command(args: argparse.Namespace) -> None:
+    value = RuntimeCompatibilitySource.load(Path(args.source)).idea_build_range.value()[args.field]
+    if value is not None:
+        print(value)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and render Kast's typed runtime compatibility matrix."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate-source")
+    validate.add_argument("--source", required=True)
+    validate.set_defaults(handler=validate_source_command)
+
+    validate_manifest = subparsers.add_parser("validate-manifest")
+    validate_manifest.add_argument("--manifest", required=True)
+    validate_manifest.add_argument("--release-tag", required=True)
+    validate_manifest.set_defaults(handler=validate_manifest_command)
+
+    render = subparsers.add_parser("render")
+    render.add_argument("--source", required=True)
+    render.add_argument("--release-tag", required=True)
+    render.add_argument("--release-sha", required=True)
+    render.add_argument("--output", required=True)
+    render.set_defaults(handler=render_command)
+
+    idea_range = subparsers.add_parser("idea-build-range")
+    idea_range.add_argument("--source", required=True)
+    idea_range.add_argument("--field", choices=("sinceBuild", "untilBuild"), required=True)
+    idea_range.set_defaults(handler=idea_build_range_command)
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test-jetbrains-plugin-repository-contract.sh
+++ b/.github/scripts/test-jetbrains-plugin-repository-contract.sh
@@ -137,10 +137,6 @@ source = {
         "releaseAssetUrlTemplate": (
             "https://github.com/amichne/kast/releases/download/{tag}/kast-idea-{tag}.zip"
         ),
-        "ideaBuildRange": {
-            "sinceBuild": "253",
-            "untilBuild": None,
-        },
     },
     "signing": {
         "activeSignerSha256": signer,
@@ -201,10 +197,6 @@ bad_url["repository"]["releaseAssetUrlTemplate"] = (
     "http://github.com/amichne/kast/releases/download/{tag}/kast-idea-{tag}.zip"
 )
 dump("bad-url.json", bad_url)
-
-bad_range = deepcopy(source)
-bad_range["repository"]["ideaBuildRange"]["sinceBuild"] = "252"
-dump("bad-range.json", bad_range)
 
 bad_rotation = deepcopy(source)
 bad_rotation["signing"]["rotation"] = {
@@ -396,13 +388,6 @@ expect_failure invalid-plugin-version \
     --output-directory "${scratch_dir}/bad-plugin-version-output"
 expect_failure invalid-url \
   "$renderer" validate-source --source "${scratch_dir}/bad-url.json" --require-configured
-expect_failure invalid-build-range \
-  "$renderer" render \
-    --source "${scratch_dir}/bad-range.json" \
-    --plugin-zip "${scratch_dir}/kast-idea-v1.2.3.zip" \
-    --provenance "${scratch_dir}/provenance.json" \
-    "${verification_args[@]}" \
-    --output-directory "${scratch_dir}/bad-range-output"
 expect_failure invalid-rotation-state \
   "$renderer" validate-source --source "${scratch_dir}/bad-rotation.json" --require-configured
 expect_failure invalid-schema \

--- a/.github/scripts/test-release-asset-verifier.sh
+++ b/.github/scripts/test-release-asset-verifier.sh
@@ -85,6 +85,13 @@ payload = {
 }
 manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 PY
+  rm -f "${release_dir}/kast-runtime-compatibility.json"
+  "${repo_root}/.github/scripts/render-runtime-compatibility.py" render \
+    --source "${repo_root}/packaging/jetbrains/runtime-compatibility.json" \
+    --release-tag "$tag" \
+    --release-sha "0123456789abcdef0123456789abcdef01234567" \
+    --output "${release_dir}/kast-runtime-compatibility.json" \
+    >/dev/null
   printf '%s  %s\n' \
     "$(compute_sha256 "${release_dir}/kast-headless-linux-x64.tar.zst")" \
     "kast-headless-linux-x64.tar.zst" \
@@ -131,6 +138,7 @@ entries = [
     ("headless-linux-x64", "kast-headless-linux-x64.tar.zst"),
     ("openapi", "openapi.yaml"),
     ("runtime-manifest", "kast-runtime-manifest.json"),
+    ("runtime-compatibility", "kast-runtime-compatibility.json"),
     ("ubuntu-debian-headless-x86_64", f"kast-ubuntu-debian-headless-x86_64-{tag}.tar.gz"),
     ("idea", f"kast-idea-{tag}.zip"),
 ]
@@ -186,6 +194,7 @@ assets=(
   "kast-headless-linux-x64.tar.zst"
   "openapi.yaml"
   "kast-runtime-manifest.json"
+  "kast-runtime-compatibility.json"
   "kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz"
   "kast-idea-${tag}.zip"
 )
@@ -195,6 +204,26 @@ write_sha256sums "$release_dir" "${assets[@]}"
 write_provenance
 
 "$verifier" --release-dir "$release_dir" --tag "$tag"
+
+python3 - "${release_dir}/kast-runtime-compatibility.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["supportedPairs"][0]["requiredCapabilities"][0]["name"] = "UNKNOWN_CAPABILITY"
+path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+write_sha256sums "$release_dir" "${assets[@]}"
+write_provenance
+if "$verifier" --release-dir "$release_dir" --tag "$tag" \
+  >"${scratch_dir}/compatibility-schema.out" \
+  2>"${scratch_dir}/compatibility-schema.err"; then
+  die "release with an unknown runtime capability unexpectedly verified"
+fi
+grep -Fq "known READ capability" "${scratch_dir}/compatibility-schema.err" \
+  || die "invalid runtime compatibility failure did not name the capability contract"
 
 rm -rf "$release_dir"
 mkdir -p "$release_dir"
@@ -207,6 +236,7 @@ core_assets=(
   "kast-headless-linux-x64.tar.zst"
   "openapi.yaml"
   "kast-runtime-manifest.json"
+  "kast-runtime-compatibility.json"
   "kast-idea-${tag}.zip"
 )
 write_expected_assets

--- a/.github/scripts/test-release-provenance-assembler.sh
+++ b/.github/scripts/test-release-provenance-assembler.sh
@@ -97,6 +97,10 @@ write_provenance \
   "runtime-manifest" \
   "kast-runtime-manifest.json"
 write_provenance \
+  "${scratch_dir}/provenance-runtime-compatibility/dist/build-provenance-runtime-compatibility.json" \
+  "runtime-compatibility" \
+  "kast-runtime-compatibility.json"
+write_provenance \
   "${scratch_dir}/provenance-ubuntu-debian-headless/dist/build-provenance-ubuntu-debian-headless.json" \
   "ubuntu-debian-headless-x86_64" \
   "kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz"
@@ -114,6 +118,7 @@ output="${scratch_dir}/dist/build-provenance.json"
   "${scratch_dir}/provenance-idea" \
   "${scratch_dir}/provenance-openapi" \
   "${scratch_dir}/provenance-runtime-manifest" \
+  "${scratch_dir}/provenance-runtime-compatibility" \
   "${scratch_dir}/provenance-ubuntu-debian-headless"
 
 python3 - "$output" <<'PY'
@@ -132,6 +137,7 @@ expected = [
     "headless-linux-x64",
     "idea",
     "openapi",
+    "runtime-compatibility",
     "runtime-manifest",
     "ubuntu-debian-headless-x86_64",
 ]
@@ -151,10 +157,11 @@ PY
   "${scratch_dir}/provenance-idea" \
   "${scratch_dir}/provenance-openapi" \
   "${scratch_dir}/provenance-runtime-manifest" \
+  "${scratch_dir}/provenance-runtime-compatibility" \
   "${scratch_dir}/provenance-ubuntu-debian-headless"
 
 rm "${scratch_dir}/provenance-idea/dist/build-provenance-idea.json"
-if "$assembler" --output "$output" --tag "$tag" "${scratch_dir}/provenance-cli-linux-arm64" "${scratch_dir}/provenance-cli-linux-x64" "${scratch_dir}/provenance-cli-macos-arm64" "${scratch_dir}/provenance-cli-macos-x64" "${scratch_dir}/provenance-gradle-ro-cache" "${scratch_dir}/provenance-headless-linux-x64" "${scratch_dir}/provenance-idea" "${scratch_dir}/provenance-openapi" "${scratch_dir}/provenance-runtime-manifest" "${scratch_dir}/provenance-ubuntu-debian-headless" \
+if "$assembler" --output "$output" --tag "$tag" "${scratch_dir}/provenance-cli-linux-arm64" "${scratch_dir}/provenance-cli-linux-x64" "${scratch_dir}/provenance-cli-macos-arm64" "${scratch_dir}/provenance-cli-macos-x64" "${scratch_dir}/provenance-gradle-ro-cache" "${scratch_dir}/provenance-headless-linux-x64" "${scratch_dir}/provenance-idea" "${scratch_dir}/provenance-openapi" "${scratch_dir}/provenance-runtime-manifest" "${scratch_dir}/provenance-runtime-compatibility" "${scratch_dir}/provenance-ubuntu-debian-headless" \
   >"${scratch_dir}/missing.out" 2>"${scratch_dir}/missing.err"; then
   die "assembler unexpectedly passed with missing idea provenance"
 fi

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -125,6 +125,9 @@ idea_plugin_signing_contract="${repo_root}/.github/scripts/test-idea-plugin-sign
 idea_plugin_repository_contract="${repo_root}/.github/scripts/test-jetbrains-plugin-repository-contract.sh"
 idea_plugin_repository_source="${repo_root}/packaging/jetbrains/plugin-repository.json"
 idea_plugin_repository_renderer="${repo_root}/.github/scripts/render-jetbrains-plugin-repository.py"
+runtime_compatibility_contract="${repo_root}/.github/scripts/test-runtime-compatibility-contract.sh"
+runtime_compatibility_source="${repo_root}/packaging/jetbrains/runtime-compatibility.json"
+runtime_compatibility_renderer="${repo_root}/.github/scripts/render-runtime-compatibility.py"
 release_state_verifier="${repo_root}/scripts/verify-release-state.sh"
 maven_central_verifier="${repo_root}/scripts/verify-maven-central.sh"
 ubuntu_debian_validator="${repo_root}/scripts/validate-ubuntu-debian-bundle-in-docker.sh"
@@ -162,6 +165,9 @@ for path in \
   "$idea_plugin_repository_contract" \
   "$idea_plugin_repository_source" \
   "$idea_plugin_repository_renderer" \
+  "$runtime_compatibility_contract" \
+  "$runtime_compatibility_source" \
+  "$runtime_compatibility_renderer" \
   "$release_state_verifier" \
   "$maven_central_verifier" \
   "$ubuntu_debian_validator" \
@@ -217,6 +223,8 @@ require_contains "$ci_workflow" "Maven publication metadata" "CI must validate M
 require_contains "$ci_workflow" 'group: ci-${{ github.event.pull_request.number || github.ref }}' "CI must cancel superseded branch or PR validation runs"
 require_contains "$ci_workflow" "runtime-contracts:" "CI must isolate runtime command and bundle contracts from the static preflight"
 require_contains "$ci_workflow" "Runtime command and bundle contracts" "CI must retain runtime command and bundle contract coverage"
+require_contains "$ci_workflow" "Runtime compatibility matrix" "CI must execute the typed runtime compatibility gate"
+require_contains "$ci_workflow" "test-runtime-compatibility-contract.sh" "CI must call the dedicated runtime compatibility gate"
 require_block_contains "$ci_workflow" "  runtime-contracts:" "  maven-publication-contract:" "    needs: workflow-contracts" "CI runtime contracts must wait for the static workflow preflight"
 require_block_contains "$ci_workflow" "  runtime-contracts:" "  maven-publication-contract:" "      - name: Test terminal command contract" "CI runtime contracts must own the terminal command contract"
 require_block_contains "$ci_workflow" "  runtime-contracts:" "  maven-publication-contract:" "      - name: Test Kast Copilot plugin package" "CI runtime contracts must reuse the terminal build for the Copilot package contract"
@@ -333,6 +341,11 @@ require_contains "$release_workflow" "Validate JVM and Maven publications" "Rele
 require_contains "$release_workflow" "release-artifact-ledger-maven-publication" "Release must pass Maven validation by ledger artifact"
 require_contains "$release_workflow" "Verify release Maven validation ledger" "Release Maven publication must verify the validation ledger before publishing"
 require_contains "$release_workflow" "Build OpenAPI spec" "Release must build the generated OpenAPI artifact"
+require_contains "$release_workflow" "Build runtime compatibility manifest" "Release must build the generated runtime compatibility manifest"
+require_contains "$release_workflow" "render-runtime-compatibility.py" "Release must render compatibility from its typed source"
+require_contains "$release_workflow" "dist/kast-runtime-compatibility.json" "Release must publish the runtime compatibility manifest"
+require_contains "$release_workflow" "build-provenance-runtime-compatibility.json" "Release must produce runtime compatibility provenance"
+require_contains "$release_workflow" "build-ledger-runtime-compatibility.json" "Release must ledger the runtime compatibility manifest"
 require_contains "$release_workflow" "stageOpenApiSpec" "Release must stage OpenAPI from the generated protocol source"
 require_contains "$release_workflow" "dist/openapi.yaml" "Release must publish the OpenAPI YAML asset"
 require_contains "$release_workflow" "build-provenance-openapi.json" "Release must produce OpenAPI provenance"
@@ -414,6 +427,7 @@ require_order "$release_workflow" "Free disk for headless backend release" "Cach
 require_contains "$publishing_conventions" "publishTarget != PublishTarget.Github" "Publishing convention must not require Maven signatures for GitHub Packages"
 require_contains "$release_workflow" "needs.validate-jvm.result == 'success'" "Release publication must require local JVM and Maven validation"
 require_contains "$release_workflow" "needs.build-openapi-spec.result == 'success'" "Release publication must require the OpenAPI artifact"
+require_contains "$release_workflow" "needs.build-runtime-compatibility-manifest.result == 'success'" "Release publication must require the compatibility manifest"
 require_contains "$release_workflow" "needs.publish-release.result" "Final release verification must read the publish-release result"
 require_contains "$release_workflow" "needs.deploy-jetbrains-plugin-repository-pages.result" "Final release verification must read the stable Pages deployment result"
 require_contains "$ci_workflow" "Test JetBrains plugin repository contract" "CI must execute the feed-to-asset consistency gate"
@@ -450,6 +464,7 @@ require_contains "$release_workflow" "kast-headless-linux-x64.tar.zst" "Default 
 require_contains "$release_workflow" "kast-headless-linux-x64.sha256" "Default release must publish the headless runtime checksum"
 require_contains "$release_workflow" "(cd dist && sha256sum -c kast-headless-linux-x64.sha256)" "Release workflow must verify runtime sidecars from the artifact directory"
 require_contains "$release_workflow" "kast-runtime-manifest.json" "Default release must publish the runtime manifest sidecar"
+require_contains "$release_workflow" "kast-runtime-compatibility.json" "Default release must publish the runtime compatibility manifest"
 require_contains "$release_workflow" "openapi.yaml" "Default release must publish the generated OpenAPI YAML"
 require_contains "$release_workflow" "gradle-ro-dep-cache.tar.zst" "Default release must publish the Gradle read-only cache tarball"
 require_contains "$release_workflow" "gradle-ro-dep-cache.sha256" "Default release must publish the Gradle read-only cache checksum"
@@ -457,6 +472,7 @@ require_contains "$release_workflow" "scripts/validate-ubuntu-debian-bundle-in-d
 require_contains "$release_workflow" "provenance-linux-headless" "Default release provenance must include the Linux headless tarball"
 require_contains "$release_workflow" "headless-linux-x64" "Default release provenance must include the headless runtime tarball"
 require_contains "$release_workflow" "runtime-manifest" "Default release provenance must include the runtime manifest sidecar"
+require_contains "$release_workflow" "runtime-compatibility" "Default release provenance must include the compatibility manifest"
 require_contains "$release_workflow" "gradle-ro-cache" "Default release provenance must include the Gradle read-only cache"
 require_contains "$release_workflow" "release-ubuntu-debian-headless-x86_64" "Default release ledgers must include the Linux headless tarball"
 require_contains "$release_workflow" "release-headless-linux-x64" "Default release ledgers must include the headless runtime tarball"
@@ -481,6 +497,7 @@ require_contains "$release_provenance_assembler" '"cli-macos-arm64"' "Release pr
 require_contains "$release_provenance_assembler" '"gradle-ro-cache"' "Release provenance must include the Gradle read-only cache"
 require_contains "$release_provenance_assembler" '"headless-linux-x64"' "Release provenance must include the headless runtime tarball"
 require_contains "$release_provenance_assembler" '"runtime-manifest"' "Release provenance must include the runtime manifest"
+require_contains "$release_provenance_assembler" '"runtime-compatibility"' "Release provenance must include the compatibility manifest"
 require_contains "$release_provenance_assembler" '"ubuntu-debian-headless-x86_64"' "Release provenance must include the Linux headless tarball"
 require_not_contains "$release_provenance_assembler" '"headless"' "Release provenance must not include a standalone headless backend asset"
 require_contains "$ci_artifact_ledger_verifier" "schemaVersion" "CI artifact ledger verifier must enforce schema versions"
@@ -493,6 +510,8 @@ require_contains "$release_asset_verifier" 'kast-{tag}-macos-arm64.zip' "Release
 require_contains "$release_asset_verifier" 'gradle-ro-dep-cache.tar.zst' "Release verifier must require the Gradle read-only cache tarball"
 require_contains "$release_asset_verifier" 'kast-headless-linux-x64.tar.zst' "Release verifier must require the headless runtime tarball"
 require_contains "$release_asset_verifier" 'kast-runtime-manifest.json' "Release verifier must require the runtime manifest"
+require_contains "$release_asset_verifier" 'kast-runtime-compatibility.json' "Release verifier must require the runtime compatibility manifest"
+require_contains "$release_asset_verifier" 'validate-manifest' "Release verifier must apply the shared strict runtime compatibility schema"
 require_contains "$release_asset_verifier" 'openapi.yaml' "Release verifier must require the OpenAPI artifact"
 require_contains "$release_asset_verifier" 'kast-ubuntu-debian-headless-x86_64-{tag}.tar.gz' "Release verifier must require the Linux headless tarball"
 require_not_contains "$release_asset_verifier" 'kast-headless-{tag}.zip' "Release verifier must not accept a standalone headless backend asset"

--- a/.github/scripts/test-runtime-compatibility-contract.sh
+++ b/.github/scripts/test-runtime-compatibility-contract.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+fail() {
+  echo "runtime compatibility contract: $*" >&2
+  exit 1
+}
+
+required_paths=(
+  "packaging/jetbrains/runtime-compatibility.json"
+  ".github/scripts/render-runtime-compatibility.py"
+  "analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityFacts.kt"
+  "analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityMatrix.kt"
+  "analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityOutcome.kt"
+  "analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityMatrixTest.kt"
+  "cli-rs/tests/runtime_compatibility_metadata_smoke.rs"
+)
+
+for required_path in "${required_paths[@]}"; do
+  [[ -f "$required_path" ]] || fail "missing required implementation owner: $required_path"
+done
+
+renderer=".github/scripts/render-runtime-compatibility.py"
+source_file="packaging/jetbrains/runtime-compatibility.json"
+release_tag="v0.13.0"
+release_sha="0123456789abcdef0123456789abcdef01234567"
+scratch_dir="$(mktemp -d)"
+trap 'rm -rf "$scratch_dir"' EXIT
+
+"$renderer" validate-source --source "$source_file"
+python3 -m py_compile "$renderer"
+"$renderer" render \
+  --source "$source_file" \
+  --release-tag "$release_tag" \
+  --release-sha "$release_sha" \
+  --output "$scratch_dir/manifest-a.json"
+"$renderer" render \
+  --source "$source_file" \
+  --release-tag "$release_tag" \
+  --release-sha "$release_sha" \
+  --output "$scratch_dir/manifest-b.json"
+cmp "$scratch_dir/manifest-a.json" "$scratch_dir/manifest-b.json"
+"$renderer" validate-manifest \
+  --manifest "$scratch_dir/manifest-a.json" \
+  --release-tag "$release_tag"
+
+python3 - "$scratch_dir/manifest-a.json" "$scratch_dir" <<'PY'
+import copy
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+scratch = Path(sys.argv[2])
+
+def write(name, mutate):
+    value = copy.deepcopy(manifest)
+    mutate(value)
+    (scratch / f"invalid-manifest-{name}.json").write_text(
+        json.dumps(value, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+write("unknown-capability", lambda value: value["supportedPairs"][0]["requiredCapabilities"][0].__setitem__("name", "UNKNOWN"))
+write("missing-capability", lambda value: value["supportedPairs"][0]["optionalCapabilities"].pop())
+write("bad-build-range", lambda value: value["ideaBuildRange"].__setitem__("untilBuild", "252"))
+write("unsafe-evidence", lambda value: value["supportedPairs"][0].__setitem__("evidence", ["../evidence"]))
+PY
+
+for invalid_manifest in "$scratch_dir"/invalid-manifest-*.json; do
+  if "$renderer" validate-manifest \
+    --manifest "$invalid_manifest" \
+    --release-tag "$release_tag" \
+    >"$invalid_manifest.out" 2>&1; then
+    fail "invalid manifest unexpectedly passed validation: $(basename "$invalid_manifest")"
+  fi
+done
+
+python3 - "$scratch_dir/manifest-a.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if manifest.get("releaseTag") != "v0.13.0":
+    raise SystemExit("rendered compatibility manifest releaseTag drifted")
+if manifest.get("releaseSha") != "0123456789abcdef0123456789abcdef01234567":
+    raise SystemExit("rendered compatibility manifest releaseSha drifted")
+pairs = manifest.get("supportedPairs")
+if not isinstance(pairs, list) or not pairs:
+    raise SystemExit("rendered compatibility manifest must contain supported pairs")
+if any(pair.get("pluginVersion") != "0.13.0" for pair in pairs):
+    raise SystemExit("same-release plugin template was not resolved")
+if any(pair.get("cliVersion") != "0.13.0" for pair in pairs):
+    raise SystemExit("same-release CLI template was not resolved")
+PY
+
+python3 - "$source_file" "$scratch_dir" <<'PY'
+import copy
+import json
+import sys
+from pathlib import Path
+
+source = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+scratch = Path(sys.argv[2])
+
+def write(name, mutate):
+    value = copy.deepcopy(source)
+    mutate(value)
+    (scratch / f"invalid-{name}.json").write_text(
+        json.dumps(value, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+write("zero-protocol", lambda value: value["supportedPairs"][0].__setitem__("protocolRevision", 0))
+write("unknown-capability", lambda value: value["supportedPairs"][0]["requiredCapabilities"][0].__setitem__("name", "UNKNOWN"))
+write("missing-capability", lambda value: value["supportedPairs"][0]["optionalCapabilities"].pop())
+write("invalid-build-range", lambda value: value["ideaBuildRange"].__setitem__("untilBuild", "252"))
+write("missing-same-release", lambda value: value.__setitem__("supportedPairs", []))
+write("duplicate-pair", lambda value: value["supportedPairs"].append(copy.deepcopy(value["supportedPairs"][0])))
+PY
+
+python3 - "$source_file" "$scratch_dir/invalid-duplicate-key.json" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+Path(sys.argv[2]).write_text(
+    source.replace('"schemaVersion": 1,', '"schemaVersion": 1,\n  "schemaVersion": 1,', 1),
+    encoding="utf-8",
+)
+PY
+
+for invalid_source in "$scratch_dir"/invalid-*.json; do
+  if "$renderer" validate-source --source "$invalid_source" >"$invalid_source.out" 2>&1; then
+    fail "invalid source unexpectedly passed validation: $(basename "$invalid_source")"
+  fi
+done
+
+./scripts/ci-gradle-retry.sh ./gradlew \
+  :analysis-api:test \
+  --tests '*RuntimeCompatibilityMatrixTest*' \
+  --tests '*RuntimeCompatibilitySourceContractTest*' \
+  --tests '*AnalysisOpenApiDocumentTest*' \
+  --tests '*DocFieldCoverageTest*' \
+  --no-daemon
+
+./scripts/ci-gradle-retry.sh ./gradlew \
+  :backend-idea:test \
+  --tests '*KastProjectOpenProfileAutoInitTest*' \
+  --no-daemon
+
+cargo test \
+  --manifest-path cli-rs/Cargo.toml \
+  --locked \
+  --test runtime_compatibility_metadata_smoke
+
+.github/scripts/test-jetbrains-plugin-repository-contract.sh
+.github/scripts/test-release-provenance-assembler.sh
+.github/scripts/test-release-asset-verifier.sh
+.github/scripts/test-release-workflow-contract.sh
+
+echo "runtime compatibility contract: ok"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,29 @@ jobs:
         shell: bash
         run: ./scripts/smoke-ubuntu-debian-bundle.sh
 
+  runtime-compatibility-contract:
+    name: Runtime compatibility matrix
+    runs-on: macos-latest
+    needs: workflow-contracts
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-cleanup: always
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Test runtime compatibility contract
+        shell: bash
+        run: ./.github/scripts/test-runtime-compatibility-contract.sh
+
   maven-publication-contract:
     name: Maven publication metadata
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,6 +85,7 @@ jobs:
         run: >
           .github/scripts/materialize-jetbrains-plugin-repository-pages.sh
           --source packaging/jetbrains/plugin-repository.json
+          --compatibility-source packaging/jetbrains/runtime-compatibility.json
           --output-directory site/jetbrains
           --published-release
           --allow-unconfigured

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
           .github/scripts/render-jetbrains-plugin-repository.py
           validate-source
           --source packaging/jetbrains/plugin-repository.json
+          --compatibility-source packaging/jetbrains/runtime-compatibility.json
           --require-configured
 
       - name: Require immutable GitHub Releases
@@ -373,6 +374,93 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: openapi-spec-${{ github.run_id }}
+          path: dist/
+          if-no-files-found: error
+
+  build-runtime-compatibility-manifest:
+    name: Build runtime compatibility manifest
+    needs:
+      - prepare-release
+      - validate-jvm
+    if: always() && needs.prepare-release.result == 'success' && needs.validate-jvm.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Render runtime compatibility manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          .github/scripts/render-runtime-compatibility.py validate-source \
+            --source packaging/jetbrains/runtime-compatibility.json
+          .github/scripts/render-runtime-compatibility.py render \
+            --source packaging/jetbrains/runtime-compatibility.json \
+            --release-tag "${{ needs.prepare-release.outputs.release_tag }}" \
+            --release-sha "$GITHUB_SHA" \
+            --output dist/kast-runtime-compatibility.json
+
+      - name: Generate runtime compatibility provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - "dist/kast-runtime-compatibility.json" "dist/build-provenance-runtime-compatibility.json" <<'PY'
+          import hashlib
+          import json
+          import os
+          import sys
+          from pathlib import Path
+          asset = Path(sys.argv[1])
+          payload = {
+              "runId": os.environ["GITHUB_RUN_ID"],
+              "runNumber": os.environ["GITHUB_RUN_NUMBER"],
+              "runAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
+              "sha": os.environ["GITHUB_SHA"],
+              "ref": os.environ["GITHUB_REF"],
+              "workflowRef": os.environ["GITHUB_WORKFLOW_REF"],
+              "actor": os.environ["GITHUB_ACTOR"],
+              "platformId": "runtime-compatibility",
+              "assetName": asset.name,
+              "assetDigest": "sha256:" + hashlib.sha256(asset.read_bytes()).hexdigest(),
+          }
+          Path(sys.argv[2]).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+          PY
+          scripts/verify-ci-artifact-ledger.py record \
+            --output dist/build-ledger-runtime-compatibility.json \
+            --git-sha "$GITHUB_SHA" \
+            --source-ref "refs/tags/${{ needs.prepare-release.outputs.release_tag }}" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --artifact-kind release-runtime-compatibility \
+            --artifact-name kast-runtime-compatibility.json \
+            --artifact-path dist/kast-runtime-compatibility.json \
+            --producer-job build-runtime-compatibility-manifest \
+            --build-command-id release-render-runtime-compatibility
+
+      - name: Upload runtime compatibility release asset
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          scripts/verify-ci-artifact-ledger.py verify \
+            --ledger dist/build-ledger-runtime-compatibility.json \
+            --git-sha "$GITHUB_SHA" \
+            --require-kind release-runtime-compatibility \
+            --artifact release-runtime-compatibility=dist/kast-runtime-compatibility.json
+          .github/scripts/upload-immutable-release-asset.sh \
+            --tag "$tag" \
+            --asset dist/kast-runtime-compatibility.json
+
+      - name: Upload runtime compatibility workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: runtime-compatibility-${{ github.run_id }}
           path: dist/
           if-no-files-found: error
 
@@ -759,6 +847,7 @@ jobs:
             .github/scripts/render-jetbrains-plugin-repository.py \
               enrolled-signers \
               --source packaging/jetbrains/plugin-repository.json \
+              --compatibility-source packaging/jetbrains/runtime-compatibility.json \
               --require-configured
           )
           [[ "${#enrolled_signers[@]}" -gt 0 ]] || {
@@ -1226,11 +1315,12 @@ jobs:
       - prepare-release
       - validate-jvm
       - build-openapi-spec
+      - build-runtime-compatibility-manifest
       - build-cli
       - build-idea-plugin
       - build-headless-backend
       - build-linux-headless-tarball
-    if: always() && needs.prepare-release.result == 'success' && needs.validate-jvm.result == 'success' && needs.build-openapi-spec.result == 'success' && needs.build-cli.result == 'success' && needs.build-idea-plugin.result == 'success' && needs.build-headless-backend.result == 'success' && needs.build-linux-headless-tarball.result == 'success'
+    if: always() && needs.prepare-release.result == 'success' && needs.validate-jvm.result == 'success' && needs.build-openapi-spec.result == 'success' && needs.build-runtime-compatibility-manifest.result == 'success' && needs.build-cli.result == 'success' && needs.build-idea-plugin.result == 'success' && needs.build-headless-backend.result == 'success' && needs.build-linux-headless-tarball.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1265,6 +1355,13 @@ jobs:
           pattern: openapi-spec-*
           merge-multiple: true
 
+      - name: Download runtime compatibility provenance
+        uses: actions/download-artifact@v7
+        with:
+          path: provenance-runtime-compatibility
+          pattern: runtime-compatibility-*
+          merge-multiple: true
+
       - name: Verify release build ledgers
         shell: bash
         run: |
@@ -1282,6 +1379,7 @@ jobs:
             --ledger provenance-linux-headless/build-ledger-runtime-manifest.json \
             --ledger provenance-linux-headless/build-ledger-gradle-ro-cache.json \
             --ledger provenance-openapi/build-ledger-openapi.json \
+            --ledger provenance-runtime-compatibility/build-ledger-runtime-compatibility.json \
             --git-sha "$GITHUB_SHA" \
             --require-kind release-cli-linux-x64 \
             --require-kind release-cli-linux-arm64 \
@@ -1294,6 +1392,7 @@ jobs:
             --require-kind release-runtime-manifest \
             --require-kind release-gradle-ro-cache \
             --require-kind release-openapi \
+            --require-kind release-runtime-compatibility \
             --artifact "release-cli-linux-x64=provenance-cli/kast-${tag}-linux-x64.zip" \
             --artifact "release-cli-linux-arm64=provenance-cli/kast-${tag}-linux-arm64.zip" \
             --artifact "release-cli-macos-x64=provenance-cli/kast-${tag}-macos-x64.zip" \
@@ -1304,7 +1403,8 @@ jobs:
             --artifact "release-headless-linux-x64=provenance-linux-headless/kast-headless-linux-x64.tar.zst" \
             --artifact "release-runtime-manifest=provenance-linux-headless/kast-runtime-manifest.json" \
             --artifact "release-gradle-ro-cache=provenance-linux-headless/gradle-ro-dep-cache.tar.zst" \
-            --artifact "release-openapi=provenance-openapi/openapi.yaml"
+            --artifact "release-openapi=provenance-openapi/openapi.yaml" \
+            --artifact "release-runtime-compatibility=provenance-runtime-compatibility/kast-runtime-compatibility.json"
 
       - name: Upload Gradle read-only cache release asset
         env:
@@ -1334,7 +1434,8 @@ jobs:
             provenance-cli \
             provenance-linux-headless \
             provenance-idea \
-            provenance-openapi
+            provenance-openapi \
+            provenance-runtime-compatibility
 
       - name: Upload combined provenance
         env:
@@ -1362,6 +1463,7 @@ jobs:
           gh release download "$tag" --dir release-assets --pattern '*.sha256' || true
           gh release download "$tag" --dir release-assets --pattern 'openapi.yaml'
           gh release download "$tag" --dir release-assets --pattern 'kast-runtime-manifest.json'
+          gh release download "$tag" --dir release-assets --pattern 'kast-runtime-compatibility.json'
           gh release download "$tag" --dir release-assets --pattern 'build-provenance.json'
           mapfile -t expected_assets < <(python3 - release-assets/build-provenance.json <<'PY'
           import json
@@ -1564,6 +1666,7 @@ jobs:
             --artifact release-idea-signature-verifier=idea-verification/marketplace-zip-signer-cli.jar
           .github/scripts/materialize-jetbrains-plugin-repository-pages.sh \
             --source packaging/jetbrains/plugin-repository.json \
+            --compatibility-source packaging/jetbrains/runtime-compatibility.json \
             --output-directory site/jetbrains \
             --tag "${{ needs.prepare-release.outputs.release_tag }}" \
             --certificate-chain "${{ steps.idea-repository-certificate.outputs.path }}" \

--- a/analysis-api/AGENTS.md
+++ b/analysis-api/AGENTS.md
@@ -13,6 +13,13 @@ Keep this unit small, stable, and reusable across every runtime host.
   `AnalysisTransport`, JSON-RPC wire models, descriptor discovery helpers,
   `ServerLaunchOptions`, shared error types, capability enums,
   `ServerInstanceDescriptor`, and edit-plan validation semantics.
+- Own the host-agnostic runtime compatibility vocabulary under
+  `contract/compatibility`: positive protocol and exact-root metadata
+  revisions, implementation and runtime identities, capability advertisements,
+  explicit supported pairs, and closed compatible/update-required/
+  missing-capability outcomes. Optional capability absence may disable only
+  that operation; revision, required-capability, and identity mismatches fail
+  closed as typed update requirements.
 - Keep shared startup helpers quiet for callers. `KastConfig.load`,
   descriptor discovery, and similar shared entry points report through typed
   results because CLI JSON commands and IDEA startup use these APIs inside
@@ -82,6 +89,10 @@ Keep this unit small, stable, and reusable across every runtime host.
 Validate the contract locally before you rely on downstream failures.
 
 - Run `./gradlew :analysis-api:test` for local changes.
+- Runtime compatibility changes also require
+  `.github/scripts/test-runtime-compatibility-contract.sh`; regenerate the
+  checked-in OpenAPI components through
+  `./gradlew :analysis-api:generateOpenApiSpec`.
 - If you change public models, capabilities, or descriptor schema, also run
   `./gradlew :analysis-server:test`.
 - For public workspace-file continuation changes, start with

--- a/analysis-api/build.gradle.kts
+++ b/analysis-api/build.gradle.kts
@@ -22,11 +22,21 @@ dependencies {
 val workspaceFilesContinuationSamples = rootProject.layout.projectDirectory.dir(
     "cli-rs/resources/kast-skill/references/requests/raw/workspace-files-continuation",
 )
+val runtimeCompatibilitySource = rootProject.layout.projectDirectory.file(
+    "packaging/jetbrains/runtime-compatibility.json",
+)
 
 tasks.named<Test>("test") {
     inputs.dir(workspaceFilesContinuationSamples)
         .withPropertyName("workspaceFilesContinuationSamples")
         .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.file(runtimeCompatibilitySource)
+        .withPropertyName("runtimeCompatibilitySource")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    systemProperty(
+        "kast.runtimeCompatibilitySource",
+        runtimeCompatibilitySource.asFile.absolutePath,
+    )
 }
 
 tasks.register<JavaExec>("generateOpenApiSpec") {

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/CliImplementationVersion.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/CliImplementationVersion.kt
@@ -1,0 +1,18 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.Serializable
+
+@JvmInline
+@Serializable
+value class CliImplementationVersion(
+    @DocField(description = "CLI release version participating in compatibility negotiation.")
+    val value: String,
+) {
+    init {
+        require(value.isNotBlank()) { "CLI implementation version must not be blank" }
+        require(value.none(Char::isWhitespace)) {
+            "CLI implementation version must not contain whitespace"
+        }
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/PluginImplementationVersion.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/PluginImplementationVersion.kt
@@ -1,0 +1,18 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.Serializable
+
+@JvmInline
+@Serializable
+value class PluginImplementationVersion(
+    @DocField(description = "IDEA plugin release version participating in compatibility negotiation.")
+    val value: String,
+) {
+    init {
+        require(value.isNotBlank()) { "Plugin implementation version must not be blank" }
+        require(value.none(Char::isWhitespace)) {
+            "Plugin implementation version must not contain whitespace"
+        }
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/ProtocolRevision.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/ProtocolRevision.kt
@@ -1,0 +1,19 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.Serializable
+
+@JvmInline
+@Serializable
+value class ProtocolRevision(
+    @DocField(description = "Positive revision of the compatibility negotiation protocol.")
+    val value: Int,
+) {
+    init {
+        require(value > 0) { "Protocol revision must be positive" }
+    }
+
+    companion object {
+        val CURRENT = ProtocolRevision(1)
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeBackendKind.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeBackendKind.kt
@@ -1,0 +1,9 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class RuntimeBackendKind {
+    IDEA,
+    HEADLESS,
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCapability.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCapability.kt
@@ -1,0 +1,24 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.contract.MutationCapability
+import io.github.amichne.kast.api.contract.ReadCapability
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface RuntimeCapability {
+    @Serializable
+    @SerialName("READ")
+    data class Read(
+        @DocField(description = "Read operation advertised by the runtime.")
+        val capability: ReadCapability,
+    ) : RuntimeCapability
+
+    @Serializable
+    @SerialName("MUTATION")
+    data class Mutation(
+        @DocField(description = "Mutation operation advertised by the runtime.")
+        val capability: MutationCapability,
+    ) : RuntimeCapability
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityFacts.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityFacts.kt
@@ -1,0 +1,30 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.contract.MutationCapability
+import io.github.amichne.kast.api.contract.ReadCapability
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RuntimeCompatibilityFacts(
+    @DocField(description = "IDEA plugin release version reported by the workspace.")
+    val pluginVersion: PluginImplementationVersion,
+    @DocField(description = "CLI release version reported by the workspace.")
+    val cliVersion: CliImplementationVersion,
+    @DocField(description = "Negotiation protocol revision reported by the workspace.")
+    val protocolRevision: ProtocolRevision,
+    @DocField(description = "Revision of the exact-workspace-root metadata document.")
+    val workspaceMetadataRevision: WorkspaceMetadataRevision,
+    @DocField(description = "Read operations advertised by the runtime.")
+    val readCapabilities: Set<ReadCapability>,
+    @DocField(description = "Mutation operations advertised by the runtime.")
+    val mutationCapabilities: Set<MutationCapability>,
+    @DocField(description = "Implementation and backend identity of the runtime host.")
+    val runtimeIdentity: RuntimeIdentity,
+) {
+    fun advertises(capability: RuntimeCapability): Boolean =
+        when (capability) {
+            is RuntimeCapability.Read -> capability.capability in readCapabilities
+            is RuntimeCapability.Mutation -> capability.capability in mutationCapabilities
+        }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityMatrix.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityMatrix.kt
@@ -1,0 +1,108 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RuntimeCompatibilityMatrix(
+    @DocField(description = "Explicit release and runtime combinations supported by this release.")
+    val supportedPairs: Set<SupportedRuntimeCompatibilityPair>,
+) {
+    init {
+        require(supportedPairs.map { pair -> pair.facts.compatibilityKey() }.toSet().size == supportedPairs.size) {
+            "Runtime compatibility rows must have unique negotiation facts"
+        }
+    }
+
+    fun assess(
+        facts: RuntimeCompatibilityFacts,
+        operationCapability: RuntimeCapability? = null,
+    ): RuntimeCompatibilityOutcome {
+        val releaseRows = supportedPairs.filter { pair ->
+            pair.facts.pluginVersion == facts.pluginVersion &&
+                pair.facts.cliVersion == facts.cliVersion
+        }
+        if (releaseRows.isEmpty()) {
+            return RuntimeCompatibilityOutcome.UpdateRequired(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair(
+                    pluginVersion = facts.pluginVersion,
+                    cliVersion = facts.cliVersion,
+                ),
+            )
+        }
+
+        val protocolRows = releaseRows.filter { pair ->
+            pair.facts.protocolRevision == facts.protocolRevision
+        }
+        if (protocolRows.isEmpty()) {
+            return RuntimeCompatibilityOutcome.UpdateRequired(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision(
+                    actual = facts.protocolRevision,
+                    supported = releaseRows.mapTo(linkedSetOf()) { pair ->
+                        pair.facts.protocolRevision
+                    },
+                ),
+            )
+        }
+
+        val metadataRows = protocolRows.filter { pair ->
+            pair.facts.workspaceMetadataRevision == facts.workspaceMetadataRevision
+        }
+        if (metadataRows.isEmpty()) {
+            return RuntimeCompatibilityOutcome.UpdateRequired(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision(
+                    actual = facts.workspaceMetadataRevision,
+                    supported = protocolRows.mapTo(linkedSetOf()) { pair ->
+                        pair.facts.workspaceMetadataRevision
+                    },
+                ),
+            )
+        }
+
+        val runtimeRows = metadataRows.filter { pair ->
+            pair.facts.runtimeIdentity == facts.runtimeIdentity
+        }
+        if (runtimeRows.isEmpty()) {
+            return RuntimeCompatibilityOutcome.UpdateRequired(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity(
+                    actual = facts.runtimeIdentity,
+                    supported = metadataRows.mapTo(linkedSetOf()) { pair ->
+                        pair.facts.runtimeIdentity
+                    },
+                ),
+            )
+        }
+
+        val supportedPair = runtimeRows.single()
+        val missingRequiredCapability = supportedPair.requiredCapabilities
+            .firstOrNull { capability -> !facts.advertises(capability) }
+        if (missingRequiredCapability != null) {
+            return RuntimeCompatibilityOutcome.UpdateRequired(
+                RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability(
+                    missingRequiredCapability,
+                ),
+            )
+        }
+        if (operationCapability != null && !facts.advertises(operationCapability)) {
+            return RuntimeCompatibilityOutcome.MissingCapability(operationCapability)
+        }
+        return RuntimeCompatibilityOutcome.Compatible(facts)
+    }
+}
+
+private data class RuntimeCompatibilityKey(
+    val pluginVersion: PluginImplementationVersion,
+    val cliVersion: CliImplementationVersion,
+    val protocolRevision: ProtocolRevision,
+    val workspaceMetadataRevision: WorkspaceMetadataRevision,
+    val runtimeIdentity: RuntimeIdentity,
+)
+
+private fun RuntimeCompatibilityFacts.compatibilityKey(): RuntimeCompatibilityKey =
+    RuntimeCompatibilityKey(
+        pluginVersion = pluginVersion,
+        cliVersion = cliVersion,
+        protocolRevision = protocolRevision,
+        workspaceMetadataRevision = workspaceMetadataRevision,
+        runtimeIdentity = runtimeIdentity,
+    )

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityOutcome.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityOutcome.kt
@@ -1,0 +1,29 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface RuntimeCompatibilityOutcome {
+    @Serializable
+    @SerialName("COMPATIBLE")
+    data class Compatible(
+        @DocField(description = "Compatibility facts accepted by an explicit matrix row.")
+        val facts: RuntimeCompatibilityFacts,
+    ) : RuntimeCompatibilityOutcome
+
+    @Serializable
+    @SerialName("UPDATE_REQUIRED")
+    data class UpdateRequired(
+        @DocField(description = "Typed reason that a supported update is required.")
+        val requirement: RuntimeCompatibilityUpdateRequirement,
+    ) : RuntimeCompatibilityOutcome
+
+    @Serializable
+    @SerialName("MISSING_CAPABILITY")
+    data class MissingCapability(
+        @DocField(description = "Optional operation unavailable from the compatible runtime.")
+        val capability: RuntimeCapability,
+    ) : RuntimeCompatibilityOutcome
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityUpdateRequirement.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityUpdateRequirement.kt
@@ -1,0 +1,66 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface RuntimeCompatibilityUpdateRequirement {
+    @Serializable
+    @SerialName("UNSUPPORTED_RELEASE_PAIR")
+    data class UnsupportedReleasePair(
+        @DocField(description = "IDEA plugin release version that has no explicit compatibility row.")
+        val pluginVersion: PluginImplementationVersion,
+        @DocField(description = "CLI release version that has no explicit compatibility row.")
+        val cliVersion: CliImplementationVersion,
+    ) : RuntimeCompatibilityUpdateRequirement
+
+    @Serializable
+    @SerialName("UNSUPPORTED_PROTOCOL_REVISION")
+    data class UnsupportedProtocolRevision(
+        @DocField(description = "Protocol revision reported by the workspace.")
+        val actual: ProtocolRevision,
+        @DocField(description = "Protocol revisions supported for the reported release pair.")
+        val supported: Set<ProtocolRevision>,
+    ) : RuntimeCompatibilityUpdateRequirement {
+        init {
+            require(supported.isNotEmpty()) { "Supported protocol revisions must not be empty" }
+            require(actual !in supported) { "Actual protocol revision must be unsupported" }
+        }
+    }
+
+    @Serializable
+    @SerialName("UNSUPPORTED_WORKSPACE_METADATA_REVISION")
+    data class UnsupportedWorkspaceMetadataRevision(
+        @DocField(description = "Workspace metadata revision reported by the workspace.")
+        val actual: WorkspaceMetadataRevision,
+        @DocField(description = "Workspace metadata revisions supported for the reported release pair.")
+        val supported: Set<WorkspaceMetadataRevision>,
+    ) : RuntimeCompatibilityUpdateRequirement {
+        init {
+            require(supported.isNotEmpty()) { "Supported workspace metadata revisions must not be empty" }
+            require(actual !in supported) { "Actual workspace metadata revision must be unsupported" }
+        }
+    }
+
+    @Serializable
+    @SerialName("UNSUPPORTED_RUNTIME_IDENTITY")
+    data class UnsupportedRuntimeIdentity(
+        @DocField(description = "Runtime identity reported by the workspace.")
+        val actual: RuntimeIdentity,
+        @DocField(description = "Runtime identities supported for the reported release and revisions.")
+        val supported: Set<RuntimeIdentity>,
+    ) : RuntimeCompatibilityUpdateRequirement {
+        init {
+            require(supported.isNotEmpty()) { "Supported runtime identities must not be empty" }
+            require(actual !in supported) { "Actual runtime identity must be unsupported" }
+        }
+    }
+
+    @Serializable
+    @SerialName("MISSING_REQUIRED_CAPABILITY")
+    data class MissingRequiredCapability(
+        @DocField(description = "Matrix-required capability absent from the runtime advertisement.")
+        val capability: RuntimeCapability,
+    ) : RuntimeCompatibilityUpdateRequirement
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeIdentity.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeIdentity.kt
@@ -1,0 +1,12 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RuntimeIdentity(
+    @DocField(description = "Implementation version of the runtime host.")
+    val implementationVersion: RuntimeImplementationVersion,
+    @DocField(description = "Backend kind hosting semantic operations.")
+    val backendKind: RuntimeBackendKind,
+)

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeImplementationVersion.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeImplementationVersion.kt
@@ -1,0 +1,18 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.Serializable
+
+@JvmInline
+@Serializable
+value class RuntimeImplementationVersion(
+    @DocField(description = "Runtime host implementation version reported by the workspace.")
+    val value: String,
+) {
+    init {
+        require(value.isNotBlank()) { "Runtime implementation version must not be blank" }
+        require(value.none(Char::isWhitespace)) {
+            "Runtime implementation version must not contain whitespace"
+        }
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/SupportedRuntimeCompatibilityPair.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/SupportedRuntimeCompatibilityPair.kt
@@ -1,0 +1,18 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SupportedRuntimeCompatibilityPair(
+    @DocField(description = "Exact release, revision, capability, and runtime facts for this row.")
+    val facts: RuntimeCompatibilityFacts,
+    @DocField(description = "Capabilities whose absence makes this row incompatible.")
+    val requiredCapabilities: Set<RuntimeCapability>,
+) {
+    init {
+        require(requiredCapabilities.all(facts::advertises)) {
+            "Required capabilities must be advertised by the supported pair"
+        }
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/WorkspaceMetadataRevision.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/compatibility/WorkspaceMetadataRevision.kt
@@ -1,0 +1,19 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.Serializable
+
+@JvmInline
+@Serializable
+value class WorkspaceMetadataRevision(
+    @DocField(description = "Positive revision of the exact-workspace-root metadata document.")
+    val value: Int,
+) {
+    init {
+        require(value > 0) { "Workspace metadata revision must be positive" }
+    }
+
+    companion object {
+        val CURRENT = WorkspaceMetadataRevision(2)
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/DocsDocument.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/DocsDocument.kt
@@ -3,6 +3,7 @@
 package io.github.amichne.kast.api.docs
 
 import io.github.amichne.kast.api.contract.*
+import io.github.amichne.kast.api.contract.compatibility.*
 import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
 import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
 import io.github.amichne.kast.api.contract.query.CodeActionsQuery
@@ -99,6 +100,35 @@ object DocsDocument {
         "FileHash" to FileHash.serializer(),
         "OutlineSymbol" to OutlineSymbol.serializer(),
         "WorkspaceModule" to WorkspaceModule.serializer(),
+        // Runtime compatibility negotiation vocabulary
+        "ProtocolRevision" to ProtocolRevision.serializer(),
+        "WorkspaceMetadataRevision" to WorkspaceMetadataRevision.serializer(),
+        "PluginImplementationVersion" to PluginImplementationVersion.serializer(),
+        "CliImplementationVersion" to CliImplementationVersion.serializer(),
+        "RuntimeImplementationVersion" to RuntimeImplementationVersion.serializer(),
+        "RuntimeBackendKind" to RuntimeBackendKind.serializer(),
+        "RuntimeCapability" to RuntimeCapability.serializer(),
+        "RuntimeCapability.Read" to RuntimeCapability.Read.serializer(),
+        "RuntimeCapability.Mutation" to RuntimeCapability.Mutation.serializer(),
+        "RuntimeIdentity" to RuntimeIdentity.serializer(),
+        "RuntimeCompatibilityFacts" to RuntimeCompatibilityFacts.serializer(),
+        "SupportedRuntimeCompatibilityPair" to SupportedRuntimeCompatibilityPair.serializer(),
+        "RuntimeCompatibilityMatrix" to RuntimeCompatibilityMatrix.serializer(),
+        "RuntimeCompatibilityUpdateRequirement" to RuntimeCompatibilityUpdateRequirement.serializer(),
+        "RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair" to
+            RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair.serializer(),
+        "RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision" to
+            RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision.serializer(),
+        "RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision" to
+            RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision.serializer(),
+        "RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity" to
+            RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity.serializer(),
+        "RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability" to
+            RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability.serializer(),
+        "RuntimeCompatibilityOutcome" to RuntimeCompatibilityOutcome.serializer(),
+        "RuntimeCompatibilityOutcome.Compatible" to RuntimeCompatibilityOutcome.Compatible.serializer(),
+        "RuntimeCompatibilityOutcome.UpdateRequired" to RuntimeCompatibilityOutcome.UpdateRequired.serializer(),
+        "RuntimeCompatibilityOutcome.MissingCapability" to RuntimeCompatibilityOutcome.MissingCapability.serializer(),
         // Read queries & results
         "SymbolQuery" to SymbolQuery.serializer(),
         "SymbolResult" to SymbolResult.serializer(),

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/OpenApiDocument.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/OpenApiDocument.kt
@@ -22,6 +22,7 @@ import io.github.amichne.kast.api.contract.SemanticInsertionResult
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.contract.Symbol
 import io.github.amichne.kast.api.contract.TextEdit
+import io.github.amichne.kast.api.contract.compatibility.*
 import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
 import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
 import io.github.amichne.kast.api.contract.query.CodeActionsQuery
@@ -204,6 +205,55 @@ object OpenApiDocument {
         registry.register("FileHash", FileHash.serializer())
         registry.register("OutlineSymbol", OutlineSymbol.serializer())
         registry.register("WorkspaceModule", WorkspaceModule.serializer())
+
+        // Runtime compatibility negotiation vocabulary
+        registry.register("ProtocolRevision", ProtocolRevision.serializer())
+        registry.register("WorkspaceMetadataRevision", WorkspaceMetadataRevision.serializer())
+        registry.register("PluginImplementationVersion", PluginImplementationVersion.serializer())
+        registry.register("CliImplementationVersion", CliImplementationVersion.serializer())
+        registry.register("RuntimeImplementationVersion", RuntimeImplementationVersion.serializer())
+        registry.register("RuntimeBackendKind", RuntimeBackendKind.serializer())
+        registry.register("RuntimeCapability", RuntimeCapability.serializer())
+        registry.register("RuntimeCapability.Read", RuntimeCapability.Read.serializer())
+        registry.register("RuntimeCapability.Mutation", RuntimeCapability.Mutation.serializer())
+        registry.register("RuntimeIdentity", RuntimeIdentity.serializer())
+        registry.register("RuntimeCompatibilityFacts", RuntimeCompatibilityFacts.serializer())
+        registry.register("SupportedRuntimeCompatibilityPair", SupportedRuntimeCompatibilityPair.serializer())
+        registry.register("RuntimeCompatibilityMatrix", RuntimeCompatibilityMatrix.serializer())
+        registry.register(
+            "RuntimeCompatibilityUpdateRequirement",
+            RuntimeCompatibilityUpdateRequirement.serializer(),
+        )
+        registry.register(
+            "RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair",
+            RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair.serializer(),
+        )
+        registry.register(
+            "RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision",
+            RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision.serializer(),
+        )
+        registry.register(
+            "RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision",
+            RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision.serializer(),
+        )
+        registry.register(
+            "RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity",
+            RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity.serializer(),
+        )
+        registry.register(
+            "RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability",
+            RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability.serializer(),
+        )
+        registry.register("RuntimeCompatibilityOutcome", RuntimeCompatibilityOutcome.serializer())
+        registry.register("RuntimeCompatibilityOutcome.Compatible", RuntimeCompatibilityOutcome.Compatible.serializer())
+        registry.register(
+            "RuntimeCompatibilityOutcome.UpdateRequired",
+            RuntimeCompatibilityOutcome.UpdateRequired.serializer(),
+        )
+        registry.register(
+            "RuntimeCompatibilityOutcome.MissingCapability",
+            RuntimeCompatibilityOutcome.MissingCapability.serializer(),
+        )
 
         // Read queries & results
         registry.register("SymbolQuery", SymbolQuery.serializer())
@@ -645,10 +695,7 @@ internal class SchemaRegistry {
         } else when (descriptor.kind) {
             is PrimitiveKind -> primitiveSchema(descriptor.kind as PrimitiveKind)
             StructureKind.CLASS, StructureKind.OBJECT -> objectSchema(descriptor)
-            StructureKind.LIST -> linkedMapOf(
-                "type" to "array",
-                "items" to inlineSchema(descriptor.getElementDescriptor(0)),
-            )
+            StructureKind.LIST -> collectionSchema(descriptor)
             StructureKind.MAP -> linkedMapOf(
                 "type" to "object",
                 "additionalProperties" to inlineSchema(descriptor.getElementDescriptor(1)),
@@ -683,6 +730,16 @@ internal class SchemaRegistry {
             "additionalProperties" to false,
         ).also { if (required.isNotEmpty()) it["required"] = required }
     }
+
+    private fun collectionSchema(descriptor: SerialDescriptor): Map<String, Any?> =
+        linkedMapOf<String, Any?>(
+            "type" to "array",
+            "items" to inlineSchema(descriptor.getElementDescriptor(0)),
+        ).also { schema ->
+            if (descriptor.serialName.endsWith("HashSet") || descriptor.serialName.endsWith(".Set")) {
+                schema["uniqueItems"] = true
+            }
+        }
 
     private fun inlineSchema(descriptor: SerialDescriptor): Any =
         when (descriptor.kind) {
@@ -777,6 +834,73 @@ internal class SchemaRegistry {
                 WorkspaceFilesContinuationResult.Consumed.serializer(),
                 discriminatorValue = "CONSUMED",
             )
+            "RuntimeCapability" -> discriminatedUnion(
+                "type",
+                "READ" to "RuntimeCapability.Read",
+                "MUTATION" to "RuntimeCapability.Mutation",
+            )
+            "RuntimeCapability.Read" -> subtypeWithDiscriminator(
+                RuntimeCapability.Read.serializer(),
+                discriminatorValue = "READ",
+            )
+            "RuntimeCapability.Mutation" -> subtypeWithDiscriminator(
+                RuntimeCapability.Mutation.serializer(),
+                discriminatorValue = "MUTATION",
+            )
+            "RuntimeCompatibilityUpdateRequirement" -> discriminatedUnion(
+                "type",
+                "UNSUPPORTED_RELEASE_PAIR" to
+                    "RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair",
+                "UNSUPPORTED_PROTOCOL_REVISION" to
+                    "RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision",
+                "UNSUPPORTED_WORKSPACE_METADATA_REVISION" to
+                    "RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision",
+                "UNSUPPORTED_RUNTIME_IDENTITY" to
+                    "RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity",
+                "MISSING_REQUIRED_CAPABILITY" to
+                    "RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability",
+            )
+            "RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair" -> subtypeWithDiscriminator(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair.serializer(),
+                discriminatorValue = "UNSUPPORTED_RELEASE_PAIR",
+            )
+            "RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision" -> subtypeWithDiscriminator(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision.serializer(),
+                discriminatorValue = "UNSUPPORTED_PROTOCOL_REVISION",
+                nonEmptyCollections = setOf("supported"),
+            )
+            "RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision" -> subtypeWithDiscriminator(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision.serializer(),
+                discriminatorValue = "UNSUPPORTED_WORKSPACE_METADATA_REVISION",
+                nonEmptyCollections = setOf("supported"),
+            )
+            "RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity" -> subtypeWithDiscriminator(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity.serializer(),
+                discriminatorValue = "UNSUPPORTED_RUNTIME_IDENTITY",
+                nonEmptyCollections = setOf("supported"),
+            )
+            "RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability" -> subtypeWithDiscriminator(
+                RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability.serializer(),
+                discriminatorValue = "MISSING_REQUIRED_CAPABILITY",
+            )
+            "RuntimeCompatibilityOutcome" -> discriminatedUnion(
+                "type",
+                "COMPATIBLE" to "RuntimeCompatibilityOutcome.Compatible",
+                "UPDATE_REQUIRED" to "RuntimeCompatibilityOutcome.UpdateRequired",
+                "MISSING_CAPABILITY" to "RuntimeCompatibilityOutcome.MissingCapability",
+            )
+            "RuntimeCompatibilityOutcome.Compatible" -> subtypeWithDiscriminator(
+                RuntimeCompatibilityOutcome.Compatible.serializer(),
+                discriminatorValue = "COMPATIBLE",
+            )
+            "RuntimeCompatibilityOutcome.UpdateRequired" -> subtypeWithDiscriminator(
+                RuntimeCompatibilityOutcome.UpdateRequired.serializer(),
+                discriminatorValue = "UPDATE_REQUIRED",
+            )
+            "RuntimeCompatibilityOutcome.MissingCapability" -> subtypeWithDiscriminator(
+                RuntimeCompatibilityOutcome.MissingCapability.serializer(),
+                discriminatorValue = "MISSING_CAPABILITY",
+            )
             else -> null
         }
 
@@ -798,6 +922,7 @@ internal class SchemaRegistry {
     private fun subtypeWithDiscriminator(
         serializer: KSerializer<*>,
         discriminatorValue: String,
+        nonEmptyCollections: Set<String> = emptySet(),
     ): Map<String, Any?> {
         val base = objectSchema(serializer.descriptor) as LinkedHashMap<String, Any?>
 
@@ -806,6 +931,12 @@ internal class SchemaRegistry {
         val typeProperty = linkedMapOf<String, Any?>("type" to "string", "const" to discriminatorValue)
         val withType = linkedMapOf<String, Any?>("type" to typeProperty)
         withType.putAll(props)
+        nonEmptyCollections.forEach { field ->
+            @Suppress("UNCHECKED_CAST")
+            val collection = withType[field] as? LinkedHashMap<String, Any?>
+                ?: error("Non-empty collection field is not an array schema: $field")
+            collection["minItems"] = 1
+        }
         base["properties"] = withType
         @Suppress("UNCHECKED_CAST")
         val required = (base["required"] as? MutableList<String>) ?: mutableListOf()
@@ -840,6 +971,11 @@ internal class SchemaRegistry {
         val valueDescriptor = descriptor.getElementDescriptor(0)
         val schema = LinkedHashMap(primitiveSchema(valueDescriptor.kind as PrimitiveKind))
         when (componentName) {
+            "ProtocolRevision", "WorkspaceMetadataRevision" -> schema["minimum"] = 1
+            "PluginImplementationVersion", "CliImplementationVersion", "RuntimeImplementationVersion" -> {
+                schema["minLength"] = 1
+                schema["pattern"] = "^\\S+$"
+            }
             "WorkspaceRoot", "BackendName", "NormalizedQuery", "Projection" -> schema["minLength"] = 1
             "Limit" -> {
                 schema["minimum"] = 1

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/AnalysisOpenApiDocumentTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/AnalysisOpenApiDocumentTest.kt
@@ -180,6 +180,43 @@ class AnalysisOpenApiDocumentTest {
     }
 
     @Test
+    fun `runtime compatibility schemas preserve typed revisions and disjoint outcomes`() {
+        val yaml = OpenApiDocument.renderYaml()
+        val facts = yaml.componentSchema("RuntimeCompatibilityFacts")
+        val capability = yaml.componentSchema("RuntimeCapability")
+        val requirement = yaml.componentSchema("RuntimeCompatibilityUpdateRequirement")
+        val unsupportedProtocol = yaml.componentSchema(
+            "RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision",
+        )
+        val outcome = yaml.componentSchema("RuntimeCompatibilityOutcome")
+
+        assertTrue(facts.contains("ProtocolRevision"))
+        assertTrue(facts.contains("WorkspaceMetadataRevision"))
+        assertTrue(facts.contains("RuntimeIdentity"))
+        assertTrue(facts.contains("uniqueItems: true"))
+        assertTrue(yaml.componentSchema("ProtocolRevision").contains("minimum: 1"))
+        assertTrue(yaml.componentSchema("WorkspaceMetadataRevision").contains("minimum: 1"))
+        assertTrue(yaml.componentSchema("PluginImplementationVersion").contains("minLength: 1"))
+        assertTrue(yaml.componentSchema("PluginImplementationVersion").contains("pattern: ^\\S+${'$'}"))
+
+        assertTrue(capability.contains("oneOf:"))
+        assertTrue(capability.contains("propertyName: type"))
+        assertTrue(capability.contains("READ: \"#/components/schemas/RuntimeCapability.Read\""))
+        assertTrue(capability.contains("MUTATION: \"#/components/schemas/RuntimeCapability.Mutation\""))
+
+        assertTrue(requirement.contains("oneOf:"))
+        assertTrue(requirement.contains("UNSUPPORTED_PROTOCOL_REVISION"))
+        assertTrue(requirement.contains("UNSUPPORTED_WORKSPACE_METADATA_REVISION"))
+        assertTrue(requirement.contains("MISSING_REQUIRED_CAPABILITY"))
+        assertTrue(unsupportedProtocol.contains("minItems: 1"))
+
+        assertTrue(outcome.contains("oneOf:"))
+        assertTrue(outcome.contains("COMPATIBLE: \"#/components/schemas/RuntimeCompatibilityOutcome.Compatible\""))
+        assertTrue(outcome.contains("UPDATE_REQUIRED"))
+        assertTrue(outcome.contains("MISSING_CAPABILITY"))
+    }
+
+    @Test
     fun `workspace file continuation inline schemas match scalar wire values and constraints`() {
         val identity = WorkspaceFilesPublicContinuationIdentity(
             workspaceRoot = WorkspaceFilesPublicContinuationIdentity.WorkspaceRoot.parse("/workspace"),

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DocFieldCoverageTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DocFieldCoverageTest.kt
@@ -3,6 +3,7 @@
 package io.github.amichne.kast.api.docs
 
 import io.github.amichne.kast.api.contract.*
+import io.github.amichne.kast.api.contract.compatibility.*
 import io.github.amichne.kast.api.contract.query.ApplyEditsQuery
 import io.github.amichne.kast.api.contract.query.CallHierarchyQuery
 import io.github.amichne.kast.api.contract.query.CodeActionsQuery
@@ -101,6 +102,30 @@ class DocFieldCoverageTest {
         "FileHash" to FileHash.serializer(),
         "OutlineSymbol" to OutlineSymbol.serializer(),
         "WorkspaceModule" to WorkspaceModule.serializer(),
+
+        // Runtime compatibility negotiation vocabulary
+        "RuntimeCapability" to RuntimeCapability.serializer(),
+        "RuntimeCapability.Read" to RuntimeCapability.Read.serializer(),
+        "RuntimeCapability.Mutation" to RuntimeCapability.Mutation.serializer(),
+        "RuntimeIdentity" to RuntimeIdentity.serializer(),
+        "RuntimeCompatibilityFacts" to RuntimeCompatibilityFacts.serializer(),
+        "SupportedRuntimeCompatibilityPair" to SupportedRuntimeCompatibilityPair.serializer(),
+        "RuntimeCompatibilityMatrix" to RuntimeCompatibilityMatrix.serializer(),
+        "RuntimeCompatibilityUpdateRequirement" to RuntimeCompatibilityUpdateRequirement.serializer(),
+        "RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair" to
+            RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair.serializer(),
+        "RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision" to
+            RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision.serializer(),
+        "RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision" to
+            RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision.serializer(),
+        "RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity" to
+            RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity.serializer(),
+        "RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability" to
+            RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability.serializer(),
+        "RuntimeCompatibilityOutcome" to RuntimeCompatibilityOutcome.serializer(),
+        "RuntimeCompatibilityOutcome.Compatible" to RuntimeCompatibilityOutcome.Compatible.serializer(),
+        "RuntimeCompatibilityOutcome.UpdateRequired" to RuntimeCompatibilityOutcome.UpdateRequired.serializer(),
+        "RuntimeCompatibilityOutcome.MissingCapability" to RuntimeCompatibilityOutcome.MissingCapability.serializer(),
 
         // Read queries & results
         "SymbolQuery" to SymbolQuery.serializer(),

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityMatrixTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityMatrixTest.kt
@@ -1,0 +1,177 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.contract.MutationCapability
+import io.github.amichne.kast.api.contract.ReadCapability
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Test
+
+class RuntimeCompatibilityMatrixTest {
+    @Test
+    fun `same-release facts are compatible only when their exact row is present`() {
+        val matrix = RuntimeCompatibilityMatrix(setOf(supportedPair()))
+
+        assertTrue(matrix.assess(facts()) is RuntimeCompatibilityOutcome.Compatible)
+
+        val absentAdjacent = facts(cliVersion = CliImplementationVersion("0.12.9"))
+        assertEquals(
+            RuntimeCompatibilityOutcome.UpdateRequired(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair(
+                    pluginVersion = CURRENT_PLUGIN,
+                    cliVersion = CliImplementationVersion("0.12.9"),
+                ),
+            ),
+            matrix.assess(absentAdjacent),
+        )
+    }
+
+    @Test
+    fun `an explicitly listed adjacent-release row is compatible`() {
+        val adjacentCli = CliImplementationVersion("0.12.9")
+        val matrix = RuntimeCompatibilityMatrix(
+            setOf(
+                supportedPair(),
+                supportedPair(cliVersion = adjacentCli),
+            ),
+        )
+
+        assertTrue(
+            matrix.assess(facts(cliVersion = adjacentCli)) is
+                RuntimeCompatibilityOutcome.Compatible,
+        )
+    }
+
+    @Test
+    fun `unsupported protocol and metadata revisions fail closed with typed updates`() {
+        val matrix = RuntimeCompatibilityMatrix(setOf(supportedPair()))
+
+        assertEquals(
+            RuntimeCompatibilityOutcome.UpdateRequired(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision(
+                    actual = ProtocolRevision(2),
+                    supported = setOf(CURRENT_PROTOCOL),
+                ),
+            ),
+            matrix.assess(facts(protocolRevision = ProtocolRevision(2))),
+        )
+        assertEquals(
+            RuntimeCompatibilityOutcome.UpdateRequired(
+                RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision(
+                    actual = WorkspaceMetadataRevision(3),
+                    supported = setOf(CURRENT_METADATA),
+                ),
+            ),
+            matrix.assess(facts(workspaceMetadataRevision = WorkspaceMetadataRevision(3))),
+        )
+    }
+
+    @Test
+    fun `missing optional capability disables only its operation`() {
+        val matrix = RuntimeCompatibilityMatrix(setOf(supportedPair()))
+        val withoutOptionalRename = facts(mutationCapabilities = emptySet())
+
+        assertEquals(
+            RuntimeCompatibilityOutcome.MissingCapability(RENAME),
+            matrix.assess(withoutOptionalRename, operationCapability = RENAME),
+        )
+        assertTrue(
+            matrix.assess(withoutOptionalRename, operationCapability = DIAGNOSTICS) is
+                RuntimeCompatibilityOutcome.Compatible,
+        )
+    }
+
+    @Test
+    fun `missing matrix-required capability requests an update`() {
+        val matrix = RuntimeCompatibilityMatrix(setOf(supportedPair()))
+
+        assertEquals(
+            RuntimeCompatibilityOutcome.UpdateRequired(
+                RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability(DIAGNOSTICS),
+            ),
+            matrix.assess(facts(readCapabilities = emptySet())),
+        )
+    }
+
+    @Test
+    fun `typed update requirements reject empty supported evidence`() {
+        assertThrows<IllegalArgumentException> {
+            RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision(
+                actual = ProtocolRevision(2),
+                supported = emptySet(),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision(
+                actual = WorkspaceMetadataRevision(3),
+                supported = emptySet(),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity(
+                actual = CURRENT_RUNTIME,
+                supported = emptySet(),
+            )
+        }
+    }
+
+    @Test
+    fun `typed update requirements reject an actual value listed as supported`() {
+        assertThrows<IllegalArgumentException> {
+            RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision(
+                actual = CURRENT_PROTOCOL,
+                supported = setOf(CURRENT_PROTOCOL),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision(
+                actual = CURRENT_METADATA,
+                supported = setOf(CURRENT_METADATA),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity(
+                actual = CURRENT_RUNTIME,
+                supported = setOf(CURRENT_RUNTIME),
+            )
+        }
+    }
+
+    private fun supportedPair(
+        cliVersion: CliImplementationVersion = CURRENT_CLI,
+    ): SupportedRuntimeCompatibilityPair = SupportedRuntimeCompatibilityPair(
+        facts = facts(cliVersion = cliVersion),
+        requiredCapabilities = setOf(DIAGNOSTICS),
+    )
+
+    private fun facts(
+        pluginVersion: PluginImplementationVersion = CURRENT_PLUGIN,
+        cliVersion: CliImplementationVersion = CURRENT_CLI,
+        protocolRevision: ProtocolRevision = CURRENT_PROTOCOL,
+        workspaceMetadataRevision: WorkspaceMetadataRevision = CURRENT_METADATA,
+        readCapabilities: Set<ReadCapability> = setOf(ReadCapability.DIAGNOSTICS),
+        mutationCapabilities: Set<MutationCapability> = setOf(MutationCapability.RENAME),
+        runtimeIdentity: RuntimeIdentity = CURRENT_RUNTIME,
+    ): RuntimeCompatibilityFacts = RuntimeCompatibilityFacts(
+        pluginVersion = pluginVersion,
+        cliVersion = cliVersion,
+        protocolRevision = protocolRevision,
+        workspaceMetadataRevision = workspaceMetadataRevision,
+        readCapabilities = readCapabilities,
+        mutationCapabilities = mutationCapabilities,
+        runtimeIdentity = runtimeIdentity,
+    )
+
+    private companion object {
+        val CURRENT_PLUGIN = PluginImplementationVersion("0.13.0")
+        val CURRENT_CLI = CliImplementationVersion("0.13.0")
+        val CURRENT_PROTOCOL = ProtocolRevision(1)
+        val CURRENT_METADATA = WorkspaceMetadataRevision(2)
+        val CURRENT_RUNTIME = RuntimeIdentity(
+            implementationVersion = RuntimeImplementationVersion("0.13.0"),
+            backendKind = RuntimeBackendKind.IDEA,
+        )
+        val DIAGNOSTICS = RuntimeCapability.Read(ReadCapability.DIAGNOSTICS)
+        val RENAME = RuntimeCapability.Mutation(MutationCapability.RENAME)
+    }
+}

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilitySourceContractTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilitySourceContractTest.kt
@@ -1,0 +1,188 @@
+package io.github.amichne.kast.api.contract.compatibility
+
+import io.github.amichne.kast.api.contract.MutationCapability
+import io.github.amichne.kast.api.contract.ReadCapability
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class RuntimeCompatibilitySourceContractTest {
+    @Test
+    fun `authored matrix matches the typed revision and capability vocabulary`() {
+        val sourcePath = Path.of(
+            requireNotNull(System.getProperty(SOURCE_PATH_PROPERTY)) {
+                "Missing runtime compatibility source test input"
+            },
+        )
+        val source = Json.parseToJsonElement(Files.readString(sourcePath)).jsonObject
+        val pairs = source.getValue("supportedPairs").jsonArray
+
+        assertTrue(pairs.isNotEmpty(), "The compatibility source must name a supported row")
+        val sameReleaseIdea = pairs
+            .map { element -> element.jsonObject }
+            .single { pair ->
+                pair.string("relation") == "same-release" &&
+                    pair.getValue("runtime").jsonObject.string("backendKind") == "IDEA" &&
+                    pair.getValue("protocolRevision").jsonPrimitive.int == ProtocolRevision.CURRENT.value &&
+                    pair.getValue("workspaceMetadataRevision").jsonPrimitive.int ==
+                    WorkspaceMetadataRevision.CURRENT.value
+            }
+        assertEquals(
+            ProtocolRevision.CURRENT.value,
+            sameReleaseIdea.getValue("protocolRevision").jsonPrimitive.int,
+        )
+        assertEquals(
+            WorkspaceMetadataRevision.CURRENT.value,
+            sameReleaseIdea.getValue("workspaceMetadataRevision").jsonPrimitive.int,
+        )
+        assertEquals("{releaseVersion}", sameReleaseIdea.string("pluginVersion"))
+        assertEquals("{releaseVersion}", sameReleaseIdea.string("cliVersion"))
+        assertEquals(
+            "{releaseVersion}",
+            sameReleaseIdea.getValue("runtime").jsonObject.string("implementationVersion"),
+        )
+
+        val classifiedCapabilities = (
+            sameReleaseIdea.getValue("requiredCapabilities").jsonArray +
+                sameReleaseIdea.getValue("optionalCapabilities").jsonArray
+            )
+            .map { element ->
+                val capability = element.jsonObject
+                "${capability.string("kind")}:${capability.string("name")}"
+            }
+            .toSet()
+        val typedCapabilities = buildSet {
+            ReadCapability.entries.forEach { capability ->
+                add("READ:${capability.name}")
+            }
+            MutationCapability.entries.forEach { capability ->
+                add("MUTATION:${capability.name}")
+            }
+        }
+        assertEquals(typedCapabilities, classifiedCapabilities)
+    }
+
+    @Test
+    fun `every authored row has a typed matrix result and optional skew stays local`() {
+        val source = readSource()
+        val authoredRows = source.getValue("supportedPairs").jsonArray
+            .map { element -> element.jsonObject.toSupportedPair() }
+            .toSet()
+        val matrix = RuntimeCompatibilityMatrix(authoredRows)
+
+        authoredRows.forEach { row ->
+            assertEquals(RuntimeCompatibilityOutcome.Compatible(row.facts), matrix.assess(row.facts))
+        }
+
+        val currentRow = authoredRows.single { row ->
+            row.facts.pluginVersion == PluginImplementationVersion(TEST_RELEASE_VERSION) &&
+                row.facts.cliVersion == CliImplementationVersion(TEST_RELEASE_VERSION) &&
+                row.facts.protocolRevision == ProtocolRevision.CURRENT &&
+                row.facts.workspaceMetadataRevision == WorkspaceMetadataRevision.CURRENT &&
+                row.facts.runtimeIdentity.backendKind == RuntimeBackendKind.IDEA
+        }
+        val optionalCapability = readSource().getValue("supportedPairs").jsonArray
+            .map { element -> element.jsonObject }
+            .single { pair ->
+                pair.string("relation") == "same-release" &&
+                    pair.getValue("runtime").jsonObject.string("backendKind") == "IDEA" &&
+                    pair.getValue("protocolRevision").jsonPrimitive.int == ProtocolRevision.CURRENT.value &&
+                    pair.getValue("workspaceMetadataRevision").jsonPrimitive.int ==
+                    WorkspaceMetadataRevision.CURRENT.value
+            }
+            .getValue("optionalCapabilities")
+            .jsonArray
+            .first()
+            .jsonObject
+            .toRuntimeCapability()
+        val factsWithoutOptional = currentRow.facts.without(optionalCapability)
+
+        assertEquals(
+            RuntimeCompatibilityOutcome.MissingCapability(optionalCapability),
+            matrix.assess(factsWithoutOptional, operationCapability = optionalCapability),
+        )
+        assertTrue(
+            matrix.assess(
+                currentRow.facts.copy(pluginVersion = PluginImplementationVersion("__unsupported__")),
+            ) is RuntimeCompatibilityOutcome.UpdateRequired,
+        )
+    }
+
+    private fun JsonObject.toSupportedPair(): SupportedRuntimeCompatibilityPair {
+        val classified = (
+            getValue("requiredCapabilities").jsonArray +
+                getValue("optionalCapabilities").jsonArray
+            )
+            .map { element -> element.jsonObject.toRuntimeCapability() }
+            .toSet()
+        val runtime = getValue("runtime").jsonObject
+        return SupportedRuntimeCompatibilityPair(
+            facts = RuntimeCompatibilityFacts(
+                pluginVersion = PluginImplementationVersion(resolveVersion(string("pluginVersion"))),
+                cliVersion = CliImplementationVersion(resolveVersion(string("cliVersion"))),
+                protocolRevision = ProtocolRevision(getValue("protocolRevision").jsonPrimitive.int),
+                workspaceMetadataRevision = WorkspaceMetadataRevision(
+                    getValue("workspaceMetadataRevision").jsonPrimitive.int,
+                ),
+                readCapabilities = classified.filterIsInstance<RuntimeCapability.Read>()
+                    .mapTo(linkedSetOf()) { capability -> capability.capability },
+                mutationCapabilities = classified.filterIsInstance<RuntimeCapability.Mutation>()
+                    .mapTo(linkedSetOf()) { capability -> capability.capability },
+                runtimeIdentity = RuntimeIdentity(
+                    implementationVersion = RuntimeImplementationVersion(
+                        resolveVersion(runtime.string("implementationVersion")),
+                    ),
+                    backendKind = RuntimeBackendKind.valueOf(runtime.string("backendKind")),
+                ),
+            ),
+            requiredCapabilities = getValue("requiredCapabilities").jsonArray
+                .mapTo(linkedSetOf()) { element -> element.jsonObject.toRuntimeCapability() },
+        )
+    }
+
+    private fun JsonObject.toRuntimeCapability(): RuntimeCapability =
+        when (string("kind")) {
+            "READ" -> RuntimeCapability.Read(ReadCapability.valueOf(string("name")))
+            "MUTATION" -> RuntimeCapability.Mutation(MutationCapability.valueOf(string("name")))
+            else -> error("Unknown runtime capability kind: ${string("kind")}")
+        }
+
+    private fun RuntimeCompatibilityFacts.without(
+        capability: RuntimeCapability,
+    ): RuntimeCompatibilityFacts =
+        when (capability) {
+            is RuntimeCapability.Read -> copy(readCapabilities = readCapabilities - capability.capability)
+            is RuntimeCapability.Mutation -> copy(
+                mutationCapabilities = mutationCapabilities - capability.capability,
+            )
+        }
+
+    private fun readSource(): JsonObject {
+        val sourcePath = Path.of(
+            requireNotNull(System.getProperty(SOURCE_PATH_PROPERTY)) {
+                "Missing runtime compatibility source test input"
+            },
+        )
+        return Json.parseToJsonElement(Files.readString(sourcePath)).jsonObject
+    }
+
+    private fun resolveVersion(value: String): String =
+        if (value == RELEASE_VERSION_TEMPLATE) TEST_RELEASE_VERSION else value
+
+    private fun JsonObject.string(field: String): String =
+        getValue(field).jsonPrimitive.content
+
+    private companion object {
+        const val SOURCE_PATH_PROPERTY = "kast.runtimeCompatibilitySource"
+        const val RELEASE_VERSION_TEMPLATE = "{releaseVersion}"
+        const val TEST_RELEASE_VERSION = "0.13.0"
+    }
+}

--- a/backend-idea/AGENTS.md
+++ b/backend-idea/AGENTS.md
@@ -22,6 +22,13 @@ than producing an unsigned artifact.
 
 ## Workspace inventory authority
 
+`KastProjectOpenProfileAutoInit` owns revisioned exact-root workspace metadata.
+It serializes the shared `analysis-api` compatibility facts for the plugin,
+CLI, protocol, metadata, capability, and IDEA runtime identity alongside the
+existing fields. This slice is preparation only: do not make those facts a
+second active admission rule before ADR 0023's negotiation cutover. The current
+exact-version admission remains authoritative until that later change.
+
 `IdeaProjectModelWorkspaceFileInventory` owns complete raw `.kt` and `.kts`
 candidate discovery for the IDEA host. Collect candidates through
 `FileTypeIndex`, IDEA module source/content scopes, and the linked Gradle model;
@@ -107,6 +114,10 @@ contract tests. Relationship changes also require state-cap rejection,
 generation validation, `ObservedAnalysisBackend` delegation, opaque
 continuation resume, absent-versus-stale classification, deterministic
 no-overlap paging, and the complete subject-kind zero-work matrix.
+
+Exact-root compatibility metadata changes also require
+`.github/scripts/test-runtime-compatibility-contract.sh` and the focused
+`KastProjectOpenProfileAutoInitTest`.
 
 Workspace inventory changes also require:
 

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastProjectOpenProfileAutoInit.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastProjectOpenProfileAutoInit.kt
@@ -4,11 +4,23 @@ import com.intellij.openapi.diagnostic.Logger
 import io.github.amichne.kast.api.client.KastConfig
 import io.github.amichne.kast.api.client.defaultSocketPath
 import io.github.amichne.kast.api.client.fields.ProjectOpenProfileKind
+import io.github.amichne.kast.api.contract.MutationCapability
+import io.github.amichne.kast.api.contract.ReadCapability
+import io.github.amichne.kast.api.contract.compatibility.CliImplementationVersion
+import io.github.amichne.kast.api.contract.compatibility.PluginImplementationVersion
+import io.github.amichne.kast.api.contract.compatibility.ProtocolRevision
+import io.github.amichne.kast.api.contract.compatibility.RuntimeBackendKind
+import io.github.amichne.kast.api.contract.compatibility.RuntimeCompatibilityFacts
+import io.github.amichne.kast.api.contract.compatibility.RuntimeIdentity
+import io.github.amichne.kast.api.contract.compatibility.RuntimeImplementationVersion
+import io.github.amichne.kast.api.contract.compatibility.WorkspaceMetadataRevision
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
 import java.time.Instant
 import java.time.format.DateTimeFormatter
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 object KastProjectOpenProfileAutoInit {
     fun execute(
@@ -165,7 +177,7 @@ sealed class ProjectOpenProfileAutoInitResult {
 }
 
 object PluginWorkspaceBootstrap {
-    private const val SCHEMA_VERSION = 1
+    private val SCHEMA_VERSION = WorkspaceMetadataRevision.CURRENT.value
     private const val REQUIRED_SKILL_RELATIVE = ".agents/skills/kast/SKILL.md"
     private const val METADATA_RELATIVE = ".kast/setup/workspace.json"
     private const val KAST_MANAGED_FENCE_START = "<kast>"
@@ -414,6 +426,20 @@ object PluginWorkspaceBootstrap {
         val artifacts = requiredArtifacts.joinToString(",\n") { artifact ->
             "    ${jsonString(artifact)}"
         }
+        val compatibility = Json.encodeToString(
+            RuntimeCompatibilityFacts(
+                pluginVersion = PluginImplementationVersion(request.pluginVersion.value),
+                cliVersion = CliImplementationVersion(request.pluginVersion.value),
+                protocolRevision = ProtocolRevision.CURRENT,
+                workspaceMetadataRevision = WorkspaceMetadataRevision.CURRENT,
+                readCapabilities = ReadCapability.entries.toSet(),
+                mutationCapabilities = MutationCapability.entries.toSet(),
+                runtimeIdentity = RuntimeIdentity(
+                    implementationVersion = RuntimeImplementationVersion(request.pluginVersion.value),
+                    backendKind = RuntimeBackendKind.IDEA,
+                ),
+            ),
+        )
         return """
         |{
         |  "schemaVersion": $SCHEMA_VERSION,
@@ -424,6 +450,7 @@ object PluginWorkspaceBootstrap {
         |  "cliBinary": ${jsonString(request.cliBinary.toString())},
         |  "backend": "idea",
         |  "socketPath": ${jsonString(defaultSocketPath(request.workspaceRoot).toString())},
+        |  "compatibility": $compatibility,
         |  "requiredArtifacts": [
         |$artifacts
         |  ]

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastProjectOpenProfileAutoInitTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastProjectOpenProfileAutoInitTest.kt
@@ -8,6 +8,11 @@ import io.github.amichne.kast.api.client.fields.ProjectOpenAutoExcludeGit
 import io.github.amichne.kast.api.client.fields.ProjectOpenGradleLoadEnabled
 import io.github.amichne.kast.api.client.fields.ProjectOpenProfile
 import io.github.amichne.kast.api.client.fields.ProjectOpenProfileAutoInit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -84,6 +89,20 @@ class KastProjectOpenProfileAutoInitTest {
         val metadata = Files.readString(installed.metadataPath)
         assertTrue(metadata.contains("\"preparedBy\": \"kast-intellij-plugin\""), metadata)
         assertTrue(metadata.contains("\"cliBinary\": \"${binary.toString().jsonEscaped()}\""), metadata)
+        val metadataObject = Json.parseToJsonElement(metadata).jsonObject
+        assertEquals(2, metadataObject.getValue("schemaVersion").jsonPrimitive.int)
+        val compatibility = metadataObject.getValue("compatibility").jsonObject
+        assertEquals(1, compatibility.getValue("protocolRevision").jsonPrimitive.int)
+        assertEquals(2, compatibility.getValue("workspaceMetadataRevision").jsonPrimitive.int)
+        assertEquals("IDEA", compatibility.getValue("runtimeIdentity").jsonObject.getValue("backendKind").jsonPrimitive.content)
+        assertTrue(
+            compatibility.getValue("readCapabilities").jsonArray
+                .any { capability -> capability.jsonPrimitive.content == "DIAGNOSTICS" },
+        )
+        assertTrue(
+            compatibility.getValue("mutationCapabilities").jsonArray
+                .any { capability -> capability.jsonPrimitive.content == "RENAME" },
+        )
     }
 
     @Test

--- a/cli-rs/AGENTS.md
+++ b/cli-rs/AGENTS.md
@@ -28,6 +28,12 @@ resources.
   limitations used by `agent workspace-files` and Gradle DSL consumers.
 - `src/install.rs`, `src/manifest.rs`, and `src/self_mgmt.rs` own install
   state, managed resource records, doctor checks, and repair behavior.
+- `src/self_mgmt.rs` parses revisioned exact-root compatibility facts strictly
+  before applying the current exact CLI/plugin/running-version admission rule.
+  Unknown fields, unknown capabilities, zero revisions, and inconsistent
+  duplicated identity fields fail closed. Until ADR 0023's negotiation
+  cutover, parsed protocol or capability differences must not become a second
+  admission rule or a compatibility fallback.
 - `resources/kast-skill/` owns the packaged `SKILL.md` and internal catalog
   source material used by release checks and generated artifacts.
 - `resources/plugin/` owns package source material used by release validation.
@@ -95,6 +101,9 @@ cockpit authority live in
   them through the contract generator.
 - Generated protocol markdown, OpenAPI YAML, and example fixtures live under
   `protocol/`; regenerate them through the Gradle docs generators.
+- Runtime compatibility release truth lives in
+  `../packaging/jetbrains/runtime-compatibility.json`; the Rust metadata parser
+  consumes exact-root facts but does not own supported-pair policy.
 
 ## Verify
 
@@ -105,6 +114,7 @@ contracts move:
 cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
 cargo test --manifest-path cli-rs/Cargo.toml --locked
+.github/scripts/test-runtime-compatibility-contract.sh
 ```
 
 For any workspace-files, packaged guidance, resource, or catalog change, run

--- a/cli-rs/protocol/openapi.yaml
+++ b/cli-rs/protocol/openapi.yaml
@@ -818,10 +818,12 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/ReadCapability"
+          uniqueItems: true
         mutationCapabilities:
           type: array
           items:
             "$ref": "#/components/schemas/MutationCapability"
+          uniqueItems: true
         limits:
           "$ref": "#/components/schemas/ServerLimits"
         schemaVersion:
@@ -1159,6 +1161,278 @@ components:
         - sourceRoots
         - dependencyModuleNames
         - fileCount
+    ProtocolRevision:
+      type: integer
+      format: int32
+      minimum: 1
+    WorkspaceMetadataRevision:
+      type: integer
+      format: int32
+      minimum: 1
+    PluginImplementationVersion:
+      type: string
+      minLength: 1
+      pattern: ^\S+$
+    CliImplementationVersion:
+      type: string
+      minLength: 1
+      pattern: ^\S+$
+    RuntimeImplementationVersion:
+      type: string
+      minLength: 1
+      pattern: ^\S+$
+    RuntimeBackendKind:
+      type: string
+      enum:
+        - IDEA
+        - HEADLESS
+    RuntimeCapability:
+      oneOf:
+        - "$ref": "#/components/schemas/RuntimeCapability.Read"
+        - "$ref": "#/components/schemas/RuntimeCapability.Mutation"
+      discriminator:
+        propertyName: type
+        mapping:
+          READ: "#/components/schemas/RuntimeCapability.Read"
+          MUTATION: "#/components/schemas/RuntimeCapability.Mutation"
+    RuntimeCapability.Read:
+      type: object
+      properties:
+        type:
+          type: string
+          const: READ
+        capability:
+          "$ref": "#/components/schemas/ReadCapability"
+      additionalProperties: false
+      required:
+        - type
+        - capability
+    RuntimeCapability.Mutation:
+      type: object
+      properties:
+        type:
+          type: string
+          const: MUTATION
+        capability:
+          "$ref": "#/components/schemas/MutationCapability"
+      additionalProperties: false
+      required:
+        - type
+        - capability
+    RuntimeIdentity:
+      type: object
+      properties:
+        implementationVersion:
+          "$ref": "#/components/schemas/RuntimeImplementationVersion"
+        backendKind:
+          "$ref": "#/components/schemas/RuntimeBackendKind"
+      additionalProperties: false
+      required:
+        - implementationVersion
+        - backendKind
+    RuntimeCompatibilityFacts:
+      type: object
+      properties:
+        pluginVersion:
+          "$ref": "#/components/schemas/PluginImplementationVersion"
+        cliVersion:
+          "$ref": "#/components/schemas/CliImplementationVersion"
+        protocolRevision:
+          "$ref": "#/components/schemas/ProtocolRevision"
+        workspaceMetadataRevision:
+          "$ref": "#/components/schemas/WorkspaceMetadataRevision"
+        readCapabilities:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ReadCapability"
+          uniqueItems: true
+        mutationCapabilities:
+          type: array
+          items:
+            "$ref": "#/components/schemas/MutationCapability"
+          uniqueItems: true
+        runtimeIdentity:
+          "$ref": "#/components/schemas/RuntimeIdentity"
+      additionalProperties: false
+      required:
+        - pluginVersion
+        - cliVersion
+        - protocolRevision
+        - workspaceMetadataRevision
+        - readCapabilities
+        - mutationCapabilities
+        - runtimeIdentity
+    SupportedRuntimeCompatibilityPair:
+      type: object
+      properties:
+        facts:
+          "$ref": "#/components/schemas/RuntimeCompatibilityFacts"
+        requiredCapabilities:
+          type: array
+          items:
+            "$ref": "#/components/schemas/RuntimeCapability"
+          uniqueItems: true
+      additionalProperties: false
+      required:
+        - facts
+        - requiredCapabilities
+    RuntimeCompatibilityMatrix:
+      type: object
+      properties:
+        supportedPairs:
+          type: array
+          items:
+            "$ref": "#/components/schemas/SupportedRuntimeCompatibilityPair"
+          uniqueItems: true
+      additionalProperties: false
+      required:
+        - supportedPairs
+    RuntimeCompatibilityUpdateRequirement:
+      oneOf:
+        - "$ref": "#/components/schemas/RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair"
+        - "$ref": "#/components/schemas/RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision"
+        - "$ref": "#/components/schemas/RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision"
+        - "$ref": "#/components/schemas/RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity"
+        - "$ref": "#/components/schemas/RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability"
+      discriminator:
+        propertyName: type
+        mapping:
+          UNSUPPORTED_RELEASE_PAIR: "#/components/schemas/RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair"
+          UNSUPPORTED_PROTOCOL_REVISION: "#/components/schemas/RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision"
+          UNSUPPORTED_WORKSPACE_METADATA_REVISION: "#/components/schemas/RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision"
+          UNSUPPORTED_RUNTIME_IDENTITY: "#/components/schemas/RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity"
+          MISSING_REQUIRED_CAPABILITY: "#/components/schemas/RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability"
+    RuntimeCompatibilityUpdateRequirement.UnsupportedReleasePair:
+      type: object
+      properties:
+        type:
+          type: string
+          const: UNSUPPORTED_RELEASE_PAIR
+        pluginVersion:
+          "$ref": "#/components/schemas/PluginImplementationVersion"
+        cliVersion:
+          "$ref": "#/components/schemas/CliImplementationVersion"
+      additionalProperties: false
+      required:
+        - type
+        - pluginVersion
+        - cliVersion
+    RuntimeCompatibilityUpdateRequirement.UnsupportedProtocolRevision:
+      type: object
+      properties:
+        type:
+          type: string
+          const: UNSUPPORTED_PROTOCOL_REVISION
+        actual:
+          "$ref": "#/components/schemas/ProtocolRevision"
+        supported:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ProtocolRevision"
+          uniqueItems: true
+          minItems: 1
+      additionalProperties: false
+      required:
+        - type
+        - actual
+        - supported
+    RuntimeCompatibilityUpdateRequirement.UnsupportedWorkspaceMetadataRevision:
+      type: object
+      properties:
+        type:
+          type: string
+          const: UNSUPPORTED_WORKSPACE_METADATA_REVISION
+        actual:
+          "$ref": "#/components/schemas/WorkspaceMetadataRevision"
+        supported:
+          type: array
+          items:
+            "$ref": "#/components/schemas/WorkspaceMetadataRevision"
+          uniqueItems: true
+          minItems: 1
+      additionalProperties: false
+      required:
+        - type
+        - actual
+        - supported
+    RuntimeCompatibilityUpdateRequirement.UnsupportedRuntimeIdentity:
+      type: object
+      properties:
+        type:
+          type: string
+          const: UNSUPPORTED_RUNTIME_IDENTITY
+        actual:
+          "$ref": "#/components/schemas/RuntimeIdentity"
+        supported:
+          type: array
+          items:
+            "$ref": "#/components/schemas/RuntimeIdentity"
+          uniqueItems: true
+          minItems: 1
+      additionalProperties: false
+      required:
+        - type
+        - actual
+        - supported
+    RuntimeCompatibilityUpdateRequirement.MissingRequiredCapability:
+      type: object
+      properties:
+        type:
+          type: string
+          const: MISSING_REQUIRED_CAPABILITY
+        capability:
+          "$ref": "#/components/schemas/RuntimeCapability"
+      additionalProperties: false
+      required:
+        - type
+        - capability
+    RuntimeCompatibilityOutcome:
+      oneOf:
+        - "$ref": "#/components/schemas/RuntimeCompatibilityOutcome.Compatible"
+        - "$ref": "#/components/schemas/RuntimeCompatibilityOutcome.UpdateRequired"
+        - "$ref": "#/components/schemas/RuntimeCompatibilityOutcome.MissingCapability"
+      discriminator:
+        propertyName: type
+        mapping:
+          COMPATIBLE: "#/components/schemas/RuntimeCompatibilityOutcome.Compatible"
+          UPDATE_REQUIRED: "#/components/schemas/RuntimeCompatibilityOutcome.UpdateRequired"
+          MISSING_CAPABILITY: "#/components/schemas/RuntimeCompatibilityOutcome.MissingCapability"
+    RuntimeCompatibilityOutcome.Compatible:
+      type: object
+      properties:
+        type:
+          type: string
+          const: COMPATIBLE
+        facts:
+          "$ref": "#/components/schemas/RuntimeCompatibilityFacts"
+      additionalProperties: false
+      required:
+        - type
+        - facts
+    RuntimeCompatibilityOutcome.UpdateRequired:
+      type: object
+      properties:
+        type:
+          type: string
+          const: UPDATE_REQUIRED
+        requirement:
+          "$ref": "#/components/schemas/RuntimeCompatibilityUpdateRequirement"
+      additionalProperties: false
+      required:
+        - type
+        - requirement
+    RuntimeCompatibilityOutcome.MissingCapability:
+      type: object
+      properties:
+        type:
+          type: string
+          const: MISSING_CAPABILITY
+        capability:
+          "$ref": "#/components/schemas/RuntimeCapability"
+      additionalProperties: false
+      required:
+        - type
+        - capability
     SymbolQuery:
       type: object
       properties:

--- a/cli-rs/src/AGENTS.md
+++ b/cli-rs/src/AGENTS.md
@@ -12,3 +12,9 @@ use names tied to the typed contract they expose.
 
 Keep visibility and ownership boundaries explicit so the compiler forces every
 caller through the modeled contract.
+
+`self_mgmt.rs` owns strict deserialization and internal consistency checks for
+revisioned exact-root workspace compatibility metadata. Keep preparation and
+admission separate: metadata schema/revision/capability parsing may fail closed,
+but active runtime admission remains the existing exact implementation-version
+equality until the dedicated negotiation cutover.

--- a/cli-rs/src/self_mgmt.rs
+++ b/cli-rs/src/self_mgmt.rs
@@ -8,8 +8,12 @@ use crate::manifest;
 #[cfg(target_os = "macos")]
 use serde::Deserialize;
 use serde::Serialize;
+#[cfg(target_os = "macos")]
+use std::collections::BTreeSet;
 use std::env;
 use std::fs;
+#[cfg(target_os = "macos")]
+use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 
 pub use crate::manifest::{
@@ -21,7 +25,7 @@ const MANAGED_RESOURCE_HISTORY_LIMIT: usize = 5;
 #[cfg(target_os = "macos")]
 const MACOS_PLUGIN_WORKSPACE_METADATA_RELATIVE: &str = ".kast/setup/workspace.json";
 #[cfg(target_os = "macos")]
-const MACOS_PLUGIN_WORKSPACE_SCHEMA_VERSION: u32 = 1;
+const MACOS_PLUGIN_WORKSPACE_SCHEMA_VERSION: u32 = 2;
 #[cfg(target_os = "macos")]
 const MACOS_PLUGIN_WORKSPACE_PREPARED_BY: &str = "kast-intellij-plugin";
 #[cfg(target_os = "macos")]
@@ -453,7 +457,7 @@ fn apply_macos_plugin_workspace_check(
 
 #[cfg(target_os = "macos")]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct MacosPluginWorkspaceMetadata {
     schema_version: u32,
     prepared_by: String,
@@ -463,7 +467,87 @@ struct MacosPluginWorkspaceMetadata {
     cli_binary: PathBuf,
     backend: String,
     socket_path: PathBuf,
+    compatibility: MacosPluginWorkspaceCompatibility,
     required_artifacts: Vec<PathBuf>,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct MacosPluginWorkspaceCompatibility {
+    plugin_version: String,
+    cli_version: String,
+    protocol_revision: ProtocolRevision,
+    workspace_metadata_revision: WorkspaceMetadataRevision,
+    read_capabilities: Vec<WorkspaceReadCapability>,
+    mutation_capabilities: Vec<WorkspaceMutationCapability>,
+    runtime_identity: WorkspaceRuntimeIdentity,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(transparent)]
+struct ProtocolRevision(NonZeroU32);
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(transparent)]
+struct WorkspaceMetadataRevision(NonZeroU32);
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkspaceReadCapability {
+    ResolveSymbol,
+    FindReferences,
+    CallHierarchy,
+    TypeHierarchy,
+    SemanticInsertionPoint,
+    Diagnostics,
+    FileOutline,
+    WorkspaceSymbolSearch,
+    WorkspaceSearch,
+    WorkspaceFiles,
+    Implementations,
+    CodeActions,
+    Completions,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkspaceMutationCapability {
+    Rename,
+    ApplyEdits,
+    FileOperations,
+    OptimizeImports,
+    RefreshWorkspace,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct WorkspaceRuntimeIdentity {
+    implementation_version: String,
+    backend_kind: WorkspaceRuntimeBackendKind,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkspaceRuntimeBackendKind {
+    Idea,
+    Headless,
+}
+
+#[cfg(target_os = "macos")]
+impl WorkspaceRuntimeBackendKind {
+    fn metadata_name(self) -> &'static str {
+        match self {
+            Self::Idea => "idea",
+            Self::Headless => "headless",
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -512,6 +596,7 @@ fn validate_macos_plugin_workspace_metadata(
             metadata_path.display()
         )));
     }
+    validate_prepared_compatibility_metadata(metadata_path, &metadata)?;
     let current_version = cli::version();
     if metadata.plugin_version != current_version || metadata.cli_version != current_version {
         return Err(macos_plugin_workspace_error(format!(
@@ -546,6 +631,69 @@ fn validate_macos_plugin_workspace_metadata(
     }
     validate_macos_plugin_cli_binary(&metadata.cli_binary)?;
     validate_macos_plugin_required_artifacts(workspace_root, &metadata.required_artifacts)
+}
+
+#[cfg(target_os = "macos")]
+fn validate_prepared_compatibility_metadata(
+    metadata_path: &Path,
+    metadata: &MacosPluginWorkspaceMetadata,
+) -> Result<()> {
+    let facts = &metadata.compatibility;
+    if facts.workspace_metadata_revision.0.get() != metadata.schema_version {
+        return Err(macos_plugin_workspace_error(format!(
+            "macOS Kast workspace compatibility metadata revision {} does not match schemaVersion {} at {}",
+            facts.workspace_metadata_revision.0,
+            metadata.schema_version,
+            metadata_path.display(),
+        )));
+    }
+    if facts.plugin_version != metadata.plugin_version || facts.cli_version != metadata.cli_version
+    {
+        return Err(macos_plugin_workspace_error(format!(
+            "macOS Kast workspace compatibility versions do not match their legacy admission fields at {}",
+            metadata_path.display(),
+        )));
+    }
+    if facts
+        .runtime_identity
+        .implementation_version
+        .chars()
+        .any(char::is_whitespace)
+        || facts.runtime_identity.implementation_version.is_empty()
+    {
+        return Err(macos_plugin_workspace_error(format!(
+            "macOS Kast workspace runtime identity has an invalid implementation version at {}",
+            metadata_path.display(),
+        )));
+    }
+    if facts.runtime_identity.backend_kind.metadata_name() != metadata.backend {
+        return Err(macos_plugin_workspace_error(format!(
+            "macOS Kast workspace runtime identity backend does not match metadata backend at {}",
+            metadata_path.display(),
+        )));
+    }
+    if facts
+        .read_capabilities
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>()
+        .len()
+        != facts.read_capabilities.len()
+        || facts
+            .mutation_capabilities
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>()
+            .len()
+            != facts.mutation_capabilities.len()
+    {
+        return Err(macos_plugin_workspace_error(format!(
+            "macOS Kast workspace compatibility capabilities contain duplicates at {}",
+            metadata_path.display(),
+        )));
+    }
+    let _advertised_protocol_revision = facts.protocol_revision.0;
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
@@ -982,6 +1130,20 @@ mod tests {
                 cli_binary: env::current_exe().expect("current exe"),
                 backend: MACOS_PLUGIN_WORKSPACE_BACKEND.to_string(),
                 socket_path,
+                compatibility: MacosPluginWorkspaceCompatibility {
+                    plugin_version: cli::version().to_string(),
+                    cli_version: cli::version().to_string(),
+                    protocol_revision: ProtocolRevision(NonZeroU32::new(1).expect("revision")),
+                    workspace_metadata_revision: WorkspaceMetadataRevision(
+                        NonZeroU32::new(MACOS_PLUGIN_WORKSPACE_SCHEMA_VERSION).expect("revision"),
+                    ),
+                    read_capabilities: vec![WorkspaceReadCapability::Diagnostics],
+                    mutation_capabilities: vec![WorkspaceMutationCapability::Rename],
+                    runtime_identity: WorkspaceRuntimeIdentity {
+                        implementation_version: cli::version().to_string(),
+                        backend_kind: WorkspaceRuntimeBackendKind::Idea,
+                    },
+                },
                 required_artifacts: vec![
                     PathBuf::from(MACOS_PLUGIN_REQUIRED_SKILL_RELATIVE),
                     PathBuf::from(MACOS_PLUGIN_WORKSPACE_METADATA_RELATIVE),

--- a/cli-rs/tests/runtime_compatibility_metadata_smoke.rs
+++ b/cli-rs/tests/runtime_compatibility_metadata_smoke.rs
@@ -1,0 +1,113 @@
+mod support;
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::support::*;
+
+    #[test]
+    fn revisioned_metadata_parses_negotiation_facts_without_replacing_active_admission() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let config_home = temp.path().join("config");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::create_dir_all(&config_home).expect("config home");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        write_macos_plugin_workspace_metadata(&workspace);
+
+        let valid = status(&home, &config_home, &workspace);
+        assert!(
+            valid.status.success(),
+            "valid revisioned metadata should parse: stdout={}, stderr={}",
+            String::from_utf8_lossy(&valid.stdout),
+            String::from_utf8_lossy(&valid.stderr),
+        );
+
+        let metadata_path = workspace.join(".kast/setup/workspace.json");
+        let mut metadata = read_metadata(&metadata_path);
+        metadata["compatibility"]["protocolRevision"] = serde_json::json!(999);
+        metadata["compatibility"]["mutationCapabilities"] = serde_json::json!([]);
+        write_metadata(&metadata_path, &metadata);
+
+        let prepared_skew = status(&home, &config_home, &workspace);
+        assert!(
+            prepared_skew.status.success(),
+            "inactive preparation must not create a second admission rule: stdout={}, stderr={}",
+            String::from_utf8_lossy(&prepared_skew.stdout),
+            String::from_utf8_lossy(&prepared_skew.stderr),
+        );
+    }
+
+    #[test]
+    fn malformed_revision_and_unknown_capability_fail_closed_at_the_metadata_boundary() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let config_home = temp.path().join("config");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::create_dir_all(&config_home).expect("config home");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        write_macos_plugin_workspace_metadata(&workspace);
+
+        let metadata_path = workspace.join(".kast/setup/workspace.json");
+        let original = read_metadata(&metadata_path);
+
+        let mut zero_revision = original.clone();
+        zero_revision["compatibility"]["workspaceMetadataRevision"] = serde_json::json!(0);
+        write_metadata(&metadata_path, &zero_revision);
+        assert_metadata_rejected(status(&home, &config_home, &workspace));
+
+        let mut unknown_capability = original;
+        unknown_capability["compatibility"]["readCapabilities"] =
+            serde_json::json!(["UNKNOWN_CAPABILITY"]);
+        write_metadata(&metadata_path, &unknown_capability);
+        assert_metadata_rejected(status(&home, &config_home, &workspace));
+
+        let mut invalid_runtime_version = read_metadata(&metadata_path);
+        invalid_runtime_version["compatibility"]["readCapabilities"] =
+            serde_json::json!(["DIAGNOSTICS"]);
+        invalid_runtime_version["compatibility"]["runtimeIdentity"]["implementationVersion"] =
+            serde_json::json!("invalid runtime version");
+        write_metadata(&metadata_path, &invalid_runtime_version);
+        assert_metadata_rejected(status(&home, &config_home, &workspace));
+    }
+
+    fn status(home: &Path, config_home: &Path, workspace: &Path) -> std::process::Output {
+        kast(home, config_home)
+            .args([
+                "--output",
+                "json",
+                "status",
+                "--workspace-root",
+                workspace.to_str().expect("workspace path"),
+            ])
+            .output()
+            .expect("status")
+    }
+
+    fn read_metadata(path: &Path) -> serde_json::Value {
+        serde_json::from_slice(&std::fs::read(path).expect("metadata bytes"))
+            .expect("metadata JSON")
+    }
+
+    fn write_metadata(path: &Path, metadata: &serde_json::Value) {
+        std::fs::write(
+            path,
+            serde_json::to_vec_pretty(metadata).expect("metadata JSON"),
+        )
+        .expect("metadata file");
+    }
+
+    fn assert_metadata_rejected(output: std::process::Output) {
+        assert!(
+            !output.status.success(),
+            "malformed metadata must fail closed"
+        );
+        let payload: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("status error JSON");
+        assert_eq!(
+            payload["code"], "MACOS_PLUGIN_WORKSPACE_REQUIRED",
+            "{payload:#}"
+        );
+    }
+}

--- a/cli-rs/tests/support/mod.rs
+++ b/cli-rs/tests/support/mod.rs
@@ -126,7 +126,7 @@ pub(crate) fn write_macos_plugin_workspace_metadata(workspace: &Path) {
         std::fs::write(
             metadata,
             serde_json::to_string_pretty(&serde_json::json!({
-                "schemaVersion": 1,
+                "schemaVersion": 2,
                 "preparedBy": "kast-intellij-plugin",
                 "pluginVersion": env!("CARGO_PKG_VERSION"),
                 "cliVersion": env!("CARGO_PKG_VERSION"),
@@ -134,6 +134,38 @@ pub(crate) fn write_macos_plugin_workspace_metadata(workspace: &Path) {
                 "cliBinary": env!("CARGO_BIN_EXE_kast"),
                 "backend": "idea",
                 "socketPath": default_socket_path_for_test(&workspace).display().to_string(),
+                "compatibility": {
+                    "pluginVersion": env!("CARGO_PKG_VERSION"),
+                    "cliVersion": env!("CARGO_PKG_VERSION"),
+                    "protocolRevision": 1,
+                    "workspaceMetadataRevision": 2,
+                    "readCapabilities": [
+                        "RESOLVE_SYMBOL",
+                        "FIND_REFERENCES",
+                        "CALL_HIERARCHY",
+                        "TYPE_HIERARCHY",
+                        "SEMANTIC_INSERTION_POINT",
+                        "DIAGNOSTICS",
+                        "FILE_OUTLINE",
+                        "WORKSPACE_SYMBOL_SEARCH",
+                        "WORKSPACE_SEARCH",
+                        "WORKSPACE_FILES",
+                        "IMPLEMENTATIONS",
+                        "CODE_ACTIONS",
+                        "COMPLETIONS"
+                    ],
+                    "mutationCapabilities": [
+                        "RENAME",
+                        "APPLY_EDITS",
+                        "FILE_OPERATIONS",
+                        "OPTIMIZE_IMPORTS",
+                        "REFRESH_WORKSPACE"
+                    ],
+                    "runtimeIdentity": {
+                        "implementationVersion": env!("CARGO_PKG_VERSION"),
+                        "backendKind": "IDEA"
+                    }
+                },
                 "requiredArtifacts": [
                     ".agents/skills/kast/SKILL.md",
                     ".kast/setup/workspace.json"

--- a/packaging/jetbrains/AGENTS.md
+++ b/packaging/jetbrains/AGENTS.md
@@ -3,14 +3,23 @@
 This directory owns the authored configuration for Kast's off-Marketplace
 JetBrains plugin repository.
 
-`plugin-repository.json` is the only checked-in owner for the stable feed URL,
-plugin identity, immutable GitHub Release asset URL template, IDEA build range,
-active signing certificate fingerprint, and explicit certificate-rotation
-state. Keep the production signer unconfigured until its public certificate
-fingerprint is known; never substitute a fixture, secret, or workflow variable.
+`plugin-repository.json` is the checked-in owner for the stable feed URL,
+plugin identity, immutable GitHub Release asset URL template, active signing
+certificate fingerprint, and explicit certificate-rotation state. Keep the
+production signer unconfigured until its public certificate fingerprint is
+known; never substitute a fixture, secret, or workflow variable.
+
+`runtime-compatibility.json` is the only checked-in owner for the IDEA build
+range and explicit runtime compatibility pairs. A pair names exact plugin and
+CLI releases or an explicitly adjacent pair, positive protocol and workspace
+metadata revisions, runtime identity, and a complete disjoint classification
+of required and optional capabilities. Do not infer a range, wildcard releases,
+or compatibility fallback from the repository feed source.
 
 `updatePlugins.xml` and `plugin-repository-manifest.json` are generated Pages
-outputs. Do not check them in or edit them by hand. The renderer must validate
+outputs. `kast-runtime-compatibility.json` is a generated immutable release
+asset with its own artifact ledger and release provenance. Do not edit any of
+these outputs by hand. The renderers must validate
 the finalized signed ZIP cryptographically against its public certificate and
 signer-bound release provenance before either file is emitted. Feed advancement
 also requires GitHub's immutable-release attestation and an exact tag-to-commit
@@ -21,6 +30,7 @@ After changing this boundary, run:
 
 ```console
 .github/scripts/test-jetbrains-plugin-repository-contract.sh
+.github/scripts/test-runtime-compatibility-contract.sh
 .github/scripts/test-idea-plugin-signing-contract.sh
 .github/scripts/test-release-workflow-contract.sh
 ```

--- a/packaging/jetbrains/plugin-repository.json
+++ b/packaging/jetbrains/plugin-repository.json
@@ -3,11 +3,7 @@
   "repository": {
     "feedUrl": "https://kast.michne.com/jetbrains/updatePlugins.xml",
     "pluginId": "io.github.amichne.kast",
-    "releaseAssetUrlTemplate": "https://github.com/amichne/kast/releases/download/{tag}/kast-idea-{tag}.zip",
-    "ideaBuildRange": {
-      "sinceBuild": "253",
-      "untilBuild": null
-    }
+    "releaseAssetUrlTemplate": "https://github.com/amichne/kast/releases/download/{tag}/kast-idea-{tag}.zip"
   },
   "signing": {
     "activeSignerSha256": null,

--- a/packaging/jetbrains/runtime-compatibility.json
+++ b/packaging/jetbrains/runtime-compatibility.json
@@ -1,0 +1,101 @@
+{
+  "schemaVersion": 1,
+  "ideaBuildRange": {
+    "sinceBuild": "253",
+    "untilBuild": null
+  },
+  "supportedPairs": [
+    {
+      "relation": "same-release",
+      "pluginVersion": "{releaseVersion}",
+      "cliVersion": "{releaseVersion}",
+      "protocolRevision": 1,
+      "workspaceMetadataRevision": 2,
+      "runtime": {
+        "implementationVersion": "{releaseVersion}",
+        "backendKind": "IDEA"
+      },
+      "requiredCapabilities": [
+        {
+          "kind": "READ",
+          "name": "DIAGNOSTICS"
+        },
+        {
+          "kind": "READ",
+          "name": "RESOLVE_SYMBOL"
+        },
+        {
+          "kind": "READ",
+          "name": "WORKSPACE_FILES"
+        },
+        {
+          "kind": "MUTATION",
+          "name": "APPLY_EDITS"
+        },
+        {
+          "kind": "MUTATION",
+          "name": "REFRESH_WORKSPACE"
+        },
+        {
+          "kind": "MUTATION",
+          "name": "RENAME"
+        }
+      ],
+      "optionalCapabilities": [
+        {
+          "kind": "READ",
+          "name": "CALL_HIERARCHY"
+        },
+        {
+          "kind": "READ",
+          "name": "CODE_ACTIONS"
+        },
+        {
+          "kind": "READ",
+          "name": "COMPLETIONS"
+        },
+        {
+          "kind": "READ",
+          "name": "FILE_OUTLINE"
+        },
+        {
+          "kind": "READ",
+          "name": "FIND_REFERENCES"
+        },
+        {
+          "kind": "READ",
+          "name": "IMPLEMENTATIONS"
+        },
+        {
+          "kind": "READ",
+          "name": "SEMANTIC_INSERTION_POINT"
+        },
+        {
+          "kind": "READ",
+          "name": "TYPE_HIERARCHY"
+        },
+        {
+          "kind": "READ",
+          "name": "WORKSPACE_SEARCH"
+        },
+        {
+          "kind": "READ",
+          "name": "WORKSPACE_SYMBOL_SEARCH"
+        },
+        {
+          "kind": "MUTATION",
+          "name": "FILE_OPERATIONS"
+        },
+        {
+          "kind": "MUTATION",
+          "name": "OPTIMIZE_IMPORTS"
+        }
+      ],
+      "evidence": [
+        ".github/scripts/test-runtime-compatibility-contract.sh",
+        "analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/compatibility/RuntimeCompatibilityMatrixTest.kt",
+        "cli-rs/tests/runtime_compatibility_metadata_smoke.rs"
+      ]
+    }
+  ]
+}

--- a/scripts/assemble-release-provenance.py
+++ b/scripts/assemble-release-provenance.py
@@ -15,6 +15,7 @@ REQUIRED_PLATFORMS = {
     "idea",
     "openapi",
     "runtime-manifest",
+    "runtime-compatibility",
     "ubuntu-debian-headless-x86_64",
 }
 OPTIONAL_PLATFORMS: set[str] = set()

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -44,6 +44,14 @@ done
 [[ -f "${release_dir}/SHA256SUMS" ]] || die "SHA256SUMS not found in $release_dir"
 [[ -f "${release_dir}/build-provenance.json" ]] || die "build-provenance.json not found in $release_dir"
 
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+compatibility_renderer="${repo_root}/.github/scripts/render-runtime-compatibility.py"
+[[ -x "$compatibility_renderer" ]] \
+  || die "Runtime compatibility renderer is missing or not executable: $compatibility_renderer"
+"$compatibility_renderer" validate-manifest \
+  --manifest "${release_dir}/kast-runtime-compatibility.json" \
+  --release-tag "$tag"
+
 python3 - "$release_dir" "$tag" <<'PY'
 import hashlib
 import json
@@ -64,6 +72,7 @@ required = {
     "idea": f"kast-idea-{tag}.zip",
     "openapi": "openapi.yaml",
     "runtime-manifest": "kast-runtime-manifest.json",
+    "runtime-compatibility": "kast-runtime-compatibility.json",
     "ubuntu-debian-headless-x86_64": f"kast-ubuntu-debian-headless-x86_64-{tag}.tar.gz",
 }
 optional = {}
@@ -79,7 +88,7 @@ actual_assets = {
         path.name.endswith(".zip")
         or path.name.endswith(".tar.gz")
         or path.name.endswith(".tar.zst")
-        or path.name == "kast-runtime-manifest.json"
+        or path.name in ("kast-runtime-manifest.json", "kast-runtime-compatibility.json")
         or path.name == "openapi.yaml"
     )
     and not path.name.endswith(".tar.gz.sha256")
@@ -251,6 +260,12 @@ if not isinstance(manifest["artifactSha256"], str) or not re.fullmatch(r"[0-9a-f
 runtime_asset = "kast-headless-linux-x64.tar.zst"
 if manifest["artifactSha256"] != sha_entries.get(runtime_asset):
     fail("runtime manifest artifactSha256 must match kast-headless-linux-x64.tar.zst")
+
+compatibility = json.loads(
+    (release_dir / "kast-runtime-compatibility.json").read_text(encoding="utf-8")
+)
+if compatibility["releaseSha"] != release_sha:
+    fail("runtime compatibility manifest releaseSha must match signed IDEA provenance")
 
 print(f"Verified Kast release assets for {tag} in {release_dir}")
 PY

--- a/scripts/verify-release-state.sh
+++ b/scripts/verify-release-state.sh
@@ -145,6 +145,7 @@ gh release download "$tag" --repo "$repository" --dir "$release_dir" --pattern '
 gh release download "$tag" --repo "$repository" --dir "$release_dir" --pattern '*.sha256' || true
 gh release download "$tag" --repo "$repository" --dir "$release_dir" --pattern 'openapi.yaml'
 gh release download "$tag" --repo "$repository" --dir "$release_dir" --pattern 'kast-runtime-manifest.json'
+gh release download "$tag" --repo "$repository" --dir "$release_dir" --pattern 'kast-runtime-compatibility.json'
 gh release download "$tag" --repo "$repository" --dir "$release_dir" --pattern 'build-provenance.json'
 gh release download "$tag" --repo "$repository" --dir "$release_dir" --pattern 'SHA256SUMS'
 "${repo_root}/scripts/verify-release-assets.sh" --release-dir "$release_dir" --tag "$tag"


### PR DESCRIPTION
Closes #380

## Summary

- add typed protocol, metadata, runtime identity, capability, compatibility-row, outcome, and update-requirement models
- add an authored runtime-compatibility source, deterministic resolved release manifest, strict source/manifest validators, and compatibility-owned IDEA build range
- revision exact-worktree metadata and make the Rust reader fail closed on malformed revisions, runtime identities, and capabilities while retaining exact-version equality as the only active admission rule
- generate the compatibility contract into OpenAPI and wire the release asset through checksums, provenance, CI ledger verification, and release-state validation
- add a dedicated contract gate, CI job, source-backed Kotlin/Rust tests, and scoped ownership guidance

This is preparation only: it does not activate #381, introduce compatibility fallback, or weaken the current exact-version admission boundary. Missing optional capabilities degrade only their associated operation in the typed model; that model is not yet used for runtime admission.

## Verification

- `.github/scripts/test-runtime-compatibility-contract.sh`
- `./scripts/ci-gradle-retry.sh ./gradlew test --no-daemon --stacktrace`
- `./scripts/ci-gradle-retry.sh ./gradlew :backend-idea:buildPlugin :backend-idea:verifyPluginStructure :backend-idea:verifyPluginXmlPresent :backend-idea:verifyPlugin --no-daemon --stacktrace`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `.github/scripts/test-idea-plugin-signing-immutability-contract.sh`
- `.github/scripts/test-docs-content-contract.sh`
- `.github/scripts/test-docs-nav.sh`
- `zensical build --clean`

An independent review of the complete scoped diff found no P0-P3 issues. Kast semantic diagnostics returned complete zero-diagnostic backend evidence for every edited Kotlin file, but the current public CLI rejected those responses as malformed completeness evidence; Gradle compilation and tests are therefore the authoritative semantic proof for this slice.
