### PR TITLE
feat: add revision-coherent local development authority

### DIFF
--- a/.agents/adr/0002-agent-resource-and-workflow-source-of-truth.md
+++ b/.agents/adr/0002-agent-resource-and-workflow-source-of-truth.md
@@ -8,7 +8,9 @@ Supersession note: ADR 0005 and ADR 0006 supersede the public agent setup,
 harness selection, Copilot package install, portable instruction install,
 `kast agent tools`, `kast agent call`, raw command, and workflow CLI portions
 of this ADR. This ADR remains authoritative only for manifest-backed trust
-rules not replaced by ADR 0006.
+rules not replaced by ADR 0006. ADR 0024 adds an isolated local-development
+authority whose receipt must prove the same resource-trust facts without
+changing release authority.
 
 This ADR records the current contract for agent-facing Kast resources. It
 exists so future agents can preserve the source of truth for the packaged
@@ -42,6 +44,7 @@ model.
 | Packaged skill | `cli-rs/resources/kast-skill/SKILL.md` | thin installed `kast` skill entrypoint only | CLI smoke tests and packaged content tests |
 | Repo-local agent guidance | `cli-rs/src/install/agent_guidance.rs` | selected context file with one managed `<kast files="*.kt, *.kts" type="instructions" replaceTools="grep,search,write">` region | CLI smoke tests, docs content contract |
 | Repo resource trust | `$HOME/.local/share/kast/install.json` | managed repo resource records with output checksums | `kast --output json ready`, verifier script |
+| Local-development resource trust | `cli-rs/src/local_development/` plus the captured checkout's skill source and independently attested CLI/backend artifacts | one immutable local generation and its strict authority receipt | `.github/scripts/test-local-development-refresh-contract.sh` |
 
 Marker files such as `.kast-version` and `.github/.kast-copilot-version` are
 retired. They may be detected as stale state, but they are not trusted as a
@@ -68,6 +71,15 @@ Agent-facing changes must keep these requirements true:
 - Stale active-binary/resource combinations report incompatibility and require
   upgrade or reinstall. Do not add a compatibility helper just for older
   binaries.
+- A local-development refresh records the canonical checkout snapshot and
+  length-framed component hashes, requires matching CLI/backend artifact
+  provenance, projects resources only into the explicit exact workspace, and
+  fails closed when any effective resource differs from that generation.
+- Local-development runtime state is keyed by source generation, and its
+  installed skill and guidance route only through the receipt-owned local
+  entrypoint.
+- Local-development rollback and removal restore only receipt-owned resource
+  state; they never mutate Homebrew or JetBrains release authority.
 
 ## Instruction topology
 

--- a/.agents/adr/0024-revision-coherent-local-development-authority.md
+++ b/.agents/adr/0024-revision-coherent-local-development-authority.md
@@ -1,0 +1,259 @@
+# ADR 0024: Revision-coherent local development authority
+
+Status: Accepted
+
+Date: 2026-07-15
+
+## Context
+
+Kast needs one release-free path that exercises a checkout through the same
+CLI, backend, skill, guidance, and configuration boundary consumed by an
+agent. The existing `installDevelopmentLocal` task copies `kast-dev`, patches
+machine configuration, and replaces files in a user JetBrains profile as
+independent mutations. It cannot prove that the effective surfaces share one
+source snapshot, and a failure can expose a partial installation.
+
+ADR 0023 makes Homebrew authoritative for the release CLI and JetBrains
+authoritative for signed plugin installation and updates. A developer refresh
+must not weaken those release authorities or recover the removed profile-write
+path under another name.
+
+## Decision
+
+Kast has an explicit `local-development` authority that is independent of the
+release authorities. The supported entrypoint is:
+
+```console
+./gradlew refreshDevelopmentLocal
+```
+
+The task builds the current checkout and asks the typed Rust CLI to stage and
+activate one immutable local generation. It does not publish or consume a new
+GitHub, Homebrew, tap, or JetBrains plugin release.
+
+Each generation contains exactly these revision-coupled surfaces:
+
+- the `kast-dev` implementation binary;
+- the portable headless backend, including its IDEA runtime;
+- the packaged Kast skill;
+- rendered managed agent guidance; and
+- isolated runtime configuration plus a strict authority receipt.
+
+The CLI and backend are each attested independently after their producing
+build task. Their strict provenance records carry the captured source snapshot,
+typed artifact kind, canonical producer path, implementation version, and a
+length-framed SHA-256 of the exact file or tree. The source digest is also
+compiled into the local CLI bytes and packaged inside the exact local headless
+plugin JAR. That JAR additionally embeds a strict producer manifest naming and
+hashing the exact seven repo-built runtime JAR roles in the portable backend.
+The installer rejects missing, duplicate, unexpected, relabeled, or stale
+sibling JARs. Attestation reads those artifact-internal facts; an external
+label cannot turn ordinary Cargo output or an old backend archive into current
+local output. Refresh requires both provenance records to name the same source
+and implementation version and recomputes both artifact hashes before it
+creates the prefix. Runtime launch validates the full installed receipt and
+backend tree again before consuming the selected classpath. Relabeling an old
+artifact, swapping one producer output, or changing bytes after attestation is
+therefore not a valid generation.
+
+The release-free path uses the headless backend. It does not write a JetBrains
+plugin directory, plugin repository, certificate enrollment, or release
+receipt. The ordinary `kast` entrypoint and the Homebrew and JetBrains release
+authorities remain byte-for-byte outside the local transaction.
+
+### Source identity
+
+Before artifact production, the task captures a canonical source snapshot. A
+snapshot consists of the canonical checkout root, Git commit, worktree kind,
+and a length-framed SHA-256 over tracked changes plus untracked, non-ignored
+source content. Entry count, path, kind, executable state, and content length
+are framed so changes in file boundaries cannot produce the same serialized
+hash input.
+The installer recomputes the snapshot after staging. A changed checkout,
+different canonical root, different component identity, or mixed digest fails
+before activation.
+
+Dirty checkouts are supported because the source-content digest, rather than
+the commit alone, is the local generation identity. A linked worktree never
+inherits another checkout's snapshot or prefix implicitly.
+
+### Activation and effective paths
+
+The local prefix has immutable generations plus stable indirection:
+
+```text
+<prefix>/
+  generations/<source-snapshot-id>/
+  current -> generations/<source-snapshot-id>
+  previous -> generations/<previous-source-snapshot-id>
+  authority.json -> current/authority.json
+  install.json -> current/install.json
+  bin/kast-dev -> ../current/entrypoint/kast-dev
+  state/<source-snapshot-id>/{data,cache,runtime,logs,locks,...}
+```
+
+All effective paths used by `kast-dev` resolve through `current`. The installer
+stages and validates a complete generation, receipt, wrapper, and repository
+resource transaction before atomically replacing `current`. Every operation
+after the pointer replacement must be non-fallible or recoverable from the
+already-written transaction journal. A failed pre-activation refresh leaves
+the prior generation effective.
+
+The receipt denies unknown fields and records the source snapshot, authority,
+backend identity, effective and physical targets, SHA-256 for every component,
+workspace root, and prior generation. Machine-readable readiness validates the
+actual bytes at those targets; it does not trust the receipt by existence.
+Runtime descriptors, source-index data, cache, logs, and locks are
+generation-scoped. The stable launcher exports the generation data root for
+the Kotlin backend as well as selecting the same root from the receipt-backed
+Rust manifest. Activating a new source snapshot cannot discover or reuse a
+backend descriptor or source index emitted by an older local generation, even
+when both builds report the same semantic version.
+
+The first headless start is a correctness barrier rather than a process-spawn
+acknowledgement. It adopts an already-running automatic Gradle sync instead of
+scheduling a competing import, waits for IDEA smart mode, and requires every
+module that actually owns Kotlin source to have a resolved SDK, valid order
+entries, the JDK and Kotlin runtime symbols, PSI, and compiler diagnostics
+before reporting the runtime ready. The runtime-status endpoint and semantic
+indexing share one typed compiler-admission state. Public status remains
+`INDEXING` while admission is pending and becomes `DEGRADED` when admission
+fails, so smart mode alone cannot create a false `READY` claim. Java-only
+modules neither weaken nor block that Kotlin readiness proof. Only a newly
+spawned local-development headless runtime receives a five-minute wait budget
+so a healthy cold import is not killed by the shorter ordinary startup
+timeout. Reuse of an existing runtime honors the caller's ordinary timeout;
+release, demo, and normal semantic request budgets remain unchanged. The
+headless JVM disables the signed IDEA plugin's unrelated project-open profile
+hook before application startup; local execution therefore cannot consult
+Homebrew authority or rewrite workspace metadata while a source snapshot is
+being exercised. The installed skill and guidance teach this explicit
+receipt-owned startup before the reuse-only `agent verify` command.
+
+Runtime startup participates in the same canonical prefix authority lock as
+refresh, rollback, and removal. It revalidates the active receipt and all
+components under the lock, spawns the exact headless child, and retains the
+lock until that workspace, backend, and process identifier appears in the
+generation-scoped descriptor ledger. Registration time consumes the existing
+cold-start budget, but waiting to acquire the lock does not. A concurrent
+startup re-inspects under the lock and reuses the process that registered
+first. A child that exits before registration is observed through its retained
+process handle, reaped, and reported without spending the full cold budget. If
+a transition wins the lock first, the stale start fails revalidation before
+spawning; if startup wins first, the transition observes the registered live
+process and refuses to switch authority.
+
+Reference lookup may use a matching generation-scoped source index, but an
+unavailable or empty first index page falls back to compiler/PSI evidence.
+File-scoped private and local declarations begin traversal at their exact
+source file, rather than spending the request budget walking unrelated Gradle
+roots. A reference result is admitted as available only when its search scope
+is complete; partial evidence remains typed as degraded.
+
+A plan-only rename crosses the same installed semantic boundary. The CLI first
+resolves the requested identity to a compiler anchor, then asks the backend for
+a dry-run rename and validates a nonempty typed preview containing edits,
+affected files, and matching pre-edit file hashes. It preserves source bytes;
+the operation type distinguishes this source-read-only preview from an applied
+mutation, so only `--apply` requires applied-mutation authority. A static
+request-shaped plan without backend evidence is rejected.
+
+### Repository resources
+
+The packaged skill comes from the captured checkout rather than the controller
+binary. The local renderer replaces every taught `kast` command with the
+receipt-owned absolute `kast-dev` entrypoint. Managed guidance uses the same
+entrypoint and is projected only into the explicitly selected exact workspace.
+The local transaction owns only its immutable generation surfaces and exact
+guidance symlink. Prefix locking uses canonical path authority, and refresh
+rejects a final prefix symlink so aliases cannot bypass serialization. The
+source-owned root `.gitignore` declares
+`/AGENTS.local.md`; refresh verifies that Git ignores the projection and never
+mutates the shared `.git/info/exclude` file. It preserves unrelated repository
+bytes and removes only owned projections during failure recovery or removal.
+Guidance is accepted only when each bare command path exists and every runnable
+example parses as a complete effective-generation CLI invocation, including
+flags, required arguments, values, and a closed set of normalized documentation
+placeholders. Only a closed set of explicitly denied command-path references
+is exempt as negative guidance; other code spans on the same line remain
+subject to complete invocation parsing.
+
+### Rollback and removal
+
+Rollback requires an explicit generation identifier, selects only that
+validated previous generation, and is idempotent when retried against the now
+current generation. Refresh and rollback refuse any non-idempotent generation
+switch while a generation-owned runtime PID is live. Removal deletes only a
+wholly receipt-owned prefix and its guidance projection, including an owned
+dangling guidance symlink when the prefix is already absent; it likewise
+refuses while a generation-owned runtime PID is live. All three lifecycle
+paths serialize through the canonical prefix namespace lock, including when
+the prefix is missing. The Gradle removal task prefers the installed stable
+controller, then a source-built checkout recovery controller, so missing-prefix
+guidance cleanup remains reachable without rebuilding the checkout.
+Neither operation changes the Homebrew receipt, release CLI, JetBrains
+plugin state, or unrelated user configuration. After removal, release
+authority is again the effective ordinary `kast` authority; it is never copied
+into or inferred by the local prefix.
+
+## Source ownership
+
+| Contract | Authored owner | Validation |
+| --- | --- | --- |
+| Local command and receipt types | `cli-rs/src/local_development/` and `cli-rs/src/cli/local_development.rs` | focused Rust unit and smoke tests |
+| Generation staging, validation, activation, rollback, removal | `cli-rs/src/local_development/` | failure-injection and idempotence tests |
+| Checkout build orchestration | root `build.gradle.kts` and typed tasks under `build-logic/` | `.github/scripts/test-local-development-refresh-contract.sh` |
+| Headless development backend | `backend-headless/` portable distribution | layout verification plus semantic probes |
+| Installed semantic boundary | `.github/scripts/test-local-development-semantic-e2e.sh` | refresh/reuse, readiness, exact semantic reads, plan-only mutation, stop, and removal |
+| Skill source | `cli-rs/resources/kast-skill/SKILL.md` | command/help lockstep contract |
+| Managed local guidance renderer | `cli-rs/src/local_development/` | receipt, command-lockstep, and workspace-preservation tests |
+| Machine-readable readiness | `cli-rs/src/self_mgmt.rs` and `cli-rs/src/output/ready.rs` | local authority smoke tests |
+
+## Required gates
+
+The local authority is not complete until executable checks prove:
+
+- one non-interactive refresh from a primary checkout and an explicitly
+  selected linked worktree or isolated prefix;
+- component and source-digest lockstep, including same-commit dirty drift;
+- framed digest collision resistance and foreign-generation symlink rejection;
+- independent source-bound CLI and backend provenance, per-JAR producer
+  manifests, runtime revalidation, and mixed-artifact rejection;
+- idempotence and failure preservation at each activation boundary;
+- refresh, rollback, and removal refusal in the presence of live
+  generation-owned runtimes, plus missing-prefix removal serialized against
+  concurrent refresh without release or unrelated-content mutation;
+- runtime-start and generation-transition barrier tests in both lock orderings,
+  proving revalidation-before-spawn and registration-before-transition;
+- concurrent-start reuse, prompt failed-child reaping, and post-spawn-only
+  cold-budget accounting;
+- generation-scoped runtime descriptors, source indexes, and caches;
+- cold Gradle import and shared compiler-admission completion before a ready
+  claim, with the extended timeout scoped to local headless startup;
+- installed skill and guidance bare paths exist and every taught runnable
+  invocation parses completely against the effective CLI; and
+- exact symbol resolution, a known nonzero reference query, clean-file
+  diagnostics, and a backend-produced nonzero plan-only mutation preview
+  through the refreshed headless generation.
+
+The focused source gate is:
+
+```console
+.github/scripts/test-local-development-refresh-contract.sh
+.github/scripts/test-local-development-semantic-e2e.sh
+```
+
+Rust formatting, Clippy, focused tests, headless layout verification, and the
+affected documentation contracts remain required in proportion to each slice.
+
+## Consequences
+
+Local refresh becomes larger than copying a debug executable, but every agent
+test can now identify the exact bytes and source snapshot it exercised. The
+release CLI and signed plugin retain their independent trust models. A running
+release IDE is not silently replaced, and local semantic evidence no longer
+depends on whichever plugin or CLI happened to be active on the machine.
+
+This ADR supersedes only the direct user-profile mutation and independent
+side-effect model of the pre-existing development Gradle tasks. It complements,
+and does not relax, ADR 0023's release authority and typed compatibility rules.

--- a/.agents/docs/documentation-journeys.md
+++ b/.agents/docs/documentation-journeys.md
@@ -26,6 +26,7 @@ or navigation.
 | CLI operator | `docs/use/choose-a-command.md` | Choose the high-level command family for inspection, editing, automation, or release work | `docs/reference/commands.md` |
 | Kotlin maintainer | `docs/use/inspect-kotlin.md` | Understand how agents resolve Kotlin symbols, references, callers, diagnostics, and impact before acting | `docs/use/plan-safe-edits.md` |
 | Release or mirror engineer | `docs/distribute/release-and-mirror.md` | Package, verify, mirror, or activate release artifacts | `docs/distribute/runtime-artifact-contract.md` |
+| Kast contributor | `docs/distribute/local-development-refresh.md` | Build and exercise one exact checkout without publishing a release | `docs/reference/runtime-and-output.md` |
 | Stuck reader | `docs/troubleshoot.md` | Separate install drift, backend state, indexing, semantic failures, and mutation planning | Relevant install, use, or reference page |
 | Architecture-curious reader | `docs/design/operating-model.md` | Understand why Kast separates distribution, setup, runtime, semantic commands, and evidence | Relevant journey page |
 
@@ -53,6 +54,7 @@ turning one page into a mixed narrative.
 | `docs/reference/runtime-and-output.md` | Reference | Look up runtime and public output behavior | Mention only readable and JSON output publicly |
 | `docs/troubleshoot.md` | Diagnostic how-to/reference matrix | Diagnose visible install, backend, indexing, semantic, and mutation failures | Keep read-only command sequences collapsed |
 | `docs/distribute/release-and-mirror.md` | How-to guide | Build, verify, mirror, and activate release artifacts | Link runtime manifest facts to contract reference |
+| `docs/distribute/local-development-refresh.md` | How-to guide | Refresh, verify, roll back, or remove one revision-coherent checkout authority | Keep internal attestation commands behind the one Gradle entrypoint |
 | `docs/distribute/runtime-artifact-contract.md` | Reference | Look up bundle, manifest, checksum, and ledger contracts | Keep schema link current |
 | `docs/design/operating-model.md` | Explanation | Understand system boundaries that affect operations | Do not turn into broad architecture essay |
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -25,6 +25,19 @@ plugin cask from the tap; signed plugin ZIP, feed, signer, checksum, and
 provenance verification remain release-owned JetBrains artifacts.
 For CLI terminal command or executable example changes, run
 `.github/scripts/test-terminal-command-contract.sh`.
+The release-free local authority gate lives in
+`.github/scripts/test-local-development-refresh-contract.sh`. Keep it wired in
+CI whenever refresh orchestration, source/artifact provenance, immutable
+generation activation, rollback/removal, local readiness, or installed
+skill/guidance routing changes. Its Gradle graph must remain headless and must
+not include user JetBrains profile or release-configuration mutation.
+The separate `.github/scripts/test-local-development-semantic-e2e.sh` gate
+must exercise the receipt-owned installed entrypoint, not checkout build
+outputs. It owns refresh idempotence plus compiler-backed readiness, exact
+symbol resolution, a known exhaustive nonzero reference, complete clean-file
+diagnostics, plan-only mutation, explicit runtime shutdown, and receipt-owned
+removal. Keep it in its own CI job so the cold IDEA import does not serialize
+unrelated workflow contracts.
 
 The signed JetBrains repository source lives at
 `packaging/jetbrains/plugin-repository.json`. Runtime pair and IDEA build-range
@@ -82,6 +95,13 @@ For terminal commands and executable examples, run:
 
 ```console
 .github/scripts/test-terminal-command-contract.sh
+```
+
+For local-development authority changes, run:
+
+```console
+.github/scripts/test-local-development-refresh-contract.sh
+.github/scripts/test-local-development-semantic-e2e.sh
 ```
 
 For signed JetBrains repository or Pages publication changes, run:

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -31,6 +31,11 @@ CI whenever refresh orchestration, source/artifact provenance, immutable
 generation activation, rollback/removal, local readiness, or installed
 skill/guidance routing changes. Its Gradle graph must remain headless and must
 not include user JetBrains profile or release-configuration mutation.
+The legacy developer install remains covered separately by
+`.github/scripts/test-development-cli-install-contract.sh`. Keep its real IDEA
+plugin task execution wired in CI so explicit-directory, configured-profile,
+running-profile, newest-profile, missing-profile, and configuration-cache
+behavior cannot regress behind dry-run task-graph coverage.
 The separate `.github/scripts/test-local-development-semantic-e2e.sh` gate
 must exercise the receipt-owned installed entrypoint, not checkout build
 outputs. It owns refresh idempotence plus compiler-backed readiness, exact
@@ -101,6 +106,7 @@ For local-development authority changes, run:
 
 ```console
 .github/scripts/test-local-development-refresh-contract.sh
+.github/scripts/test-development-cli-install-contract.sh
 .github/scripts/test-local-development-semantic-e2e.sh
 ```
 

--- a/.github/scripts/test-development-cli-install-contract.sh
+++ b/.github/scripts/test-development-cli-install-contract.sh
@@ -27,6 +27,11 @@ home_dir="${tmp_root}/home"
 config_home="${tmp_root}/config"
 install_bin_dir="${tmp_root}/install-bin"
 mkdir -p "$home_dir" "$config_home" "$install_bin_dir"
+ordinary_cli="${install_bin_dir}/kast"
+ordinary_cli_before="${tmp_root}/ordinary-kast-before"
+printf '%s\n' 'release-authority-sentinel' >"$ordinary_cli"
+chmod 755 "$ordinary_cli"
+cp "$ordinary_cli" "$ordinary_cli_before"
 
 run_install_task() {
   local task_config_home="$1"
@@ -47,7 +52,8 @@ dev_cli="${install_bin_dir}/kast-dev"
 [[ -x "$dev_cli" ]] || die "Expected executable development CLI at ${dev_cli}"
 "$dev_cli" version >/dev/null
 
-[[ ! -e "${install_bin_dir}/kast" ]] || die "installDevelopmentCli must not overwrite the configured kast binary"
+cmp -s "$ordinary_cli_before" "$ordinary_cli" \
+  || die "installDevelopmentCli must leave the ordinary kast authority byte-for-byte unchanged"
 
 profile="${tmp_root}/zshrc"
 shell_install_json="${tmp_root}/shell-install.json"
@@ -106,6 +112,101 @@ HOME="$home_dir" \
 find "${plugins_dir}/backend-idea/lib" -name 'backend-idea-*.jar' -print -quit | grep -q . \
   || die "installDevelopmentIdeaPlugin should install the backend IDEA plugin jar"
 
+fake_bin="${tmp_root}/fake-bin"
+mkdir -p "$fake_bin"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s\n" "${KAST_TEST_PS_OUTPUT:-}"' \
+  >"${fake_bin}/ps"
+chmod 755 "${fake_bin}/ps"
+
+run_profile_install() {
+  local task_config_root="$1"
+  local task_ps_output="$2"
+  shift 2
+  HOME="$home_dir" \
+    CARGO_HOME="$cargo_home" \
+    RUSTUP_HOME="$rustup_home" \
+    GRADLE_USER_HOME="$gradle_user_home" \
+    KAST_CONFIG_HOME="$config_home" \
+    KAST_BIN_DIR="$install_bin_dir" \
+    KAST_TEST_PS_OUTPUT="$task_ps_output" \
+    PATH="${fake_bin}:${restricted_path}" \
+    "${repo_root}/gradlew" installDevelopmentIdeaPlugin \
+      -PkastDevJetBrainsConfigRoot="$task_config_root" \
+      --configuration-cache \
+      --no-daemon \
+      "$@"
+}
+
+jetbrains_config_root="${tmp_root}/jetbrains/config"
+named_profile="IntelliJIdea2025.2"
+newest_profile="IntelliJIdea2026.1"
+mkdir -p \
+  "${jetbrains_config_root}/${named_profile}" \
+  "${jetbrains_config_root}/${newest_profile}"
+
+run_profile_install \
+  "$jetbrains_config_root" \
+  '' \
+  -PkastDevJetBrainsProfile="$named_profile" >/dev/null
+[[ -d "${jetbrains_config_root}/${named_profile}/plugins/backend-idea/lib" ]] \
+  || die "an explicit JetBrains profile name must select its profile plugins directory"
+named_profile_reuse="$(
+  run_profile_install \
+    "$jetbrains_config_root" \
+    '' \
+    -PkastDevJetBrainsProfile="$named_profile"
+)"
+grep -Fq 'Configuration cache entry reused.' <<<"$named_profile_reuse" \
+  || die "an executable named-profile install must reuse configuration cache state"
+
+rm -rf \
+  "${jetbrains_config_root}/${named_profile}/plugins/backend-idea" \
+  "${jetbrains_config_root}/${newest_profile}/plugins/backend-idea"
+run_profile_install "$jetbrains_config_root" '' >/dev/null
+[[ -d "${jetbrains_config_root}/${newest_profile}/plugins/backend-idea/lib" ]] \
+  || die "profile discovery must select the newest available IntelliJ IDEA profile"
+[[ ! -e "${jetbrains_config_root}/${named_profile}/plugins/backend-idea" ]] \
+  || die "newest-profile discovery must not install into an older profile"
+
+rm -rf \
+  "${jetbrains_config_root}/${named_profile}/plugins/backend-idea" \
+  "${jetbrains_config_root}/${newest_profile}/plugins/backend-idea"
+running_process="/Applications/IntelliJ IDEA.app/Contents/JetBrains/${named_profile}/bin/idea"
+run_profile_install "$jetbrains_config_root" "$running_process" >/dev/null
+[[ -d "${jetbrains_config_root}/${named_profile}/plugins/backend-idea/lib" ]] \
+  || die "a running IntelliJ IDEA profile must take precedence over the newest profile"
+[[ ! -e "${jetbrains_config_root}/${newest_profile}/plugins/backend-idea" ]] \
+  || die "running-profile discovery must not also install into the newest profile"
+
+rm -rf \
+  "${jetbrains_config_root}/${named_profile}/plugins/backend-idea" \
+  "${jetbrains_config_root}/${newest_profile}/plugins/backend-idea"
+explicit_plugins_dir="${tmp_root}/jetbrains/explicit-plugins"
+run_profile_install \
+  "$jetbrains_config_root" \
+  "$running_process" \
+  -PkastDevJetBrainsProfile="$newest_profile" \
+  -PkastDevJetBrainsPluginsDir="$explicit_plugins_dir" >/dev/null
+[[ -d "${explicit_plugins_dir}/backend-idea/lib" ]] \
+  || die "an explicit plugins directory must take precedence over every profile selector"
+[[ ! -e "${jetbrains_config_root}/${named_profile}/plugins/backend-idea" ]] \
+  || die "explicit plugins-directory selection must not mutate the running profile"
+[[ ! -e "${jetbrains_config_root}/${newest_profile}/plugins/backend-idea" ]] \
+  || die "explicit plugins-directory selection must not mutate the configured profile"
+
+missing_config_root="${tmp_root}/jetbrains/missing-config"
+mkdir -p "$missing_config_root"
+set +e
+missing_profile_output="$(run_profile_install "$missing_config_root" '' 2>&1)"
+missing_profile_status=$?
+set -e
+[[ "$missing_profile_status" -ne 0 ]] \
+  || die "an executable install without any JetBrains profile must fail"
+grep -Fq 'No IntelliJIdea profile was found under' <<<"$missing_profile_output" \
+  || die "missing-profile failure must retain its actionable profile override guidance"
+
 HOME="$home_dir" \
   CARGO_HOME="$cargo_home" \
   RUSTUP_HOME="$rustup_home" \
@@ -130,7 +231,12 @@ grep -Fq 'enabled = true' "${config_home}/config.toml" \
 
 bin_config_home="${tmp_root}/config-bin-dir"
 custom_bin_dir="${tmp_root}/custom-bin"
-mkdir -p "$bin_config_home"
+mkdir -p "$bin_config_home" "$custom_bin_dir"
+custom_ordinary_cli="${custom_bin_dir}/kast"
+custom_ordinary_cli_before="${tmp_root}/custom-ordinary-kast-before"
+printf '%s\n' 'custom-release-authority-sentinel' >"$custom_ordinary_cli"
+chmod 755 "$custom_ordinary_cli"
+cp "$custom_ordinary_cli" "$custom_ordinary_cli_before"
 
 run_install_task "$bin_config_home" "$custom_bin_dir"
 
@@ -138,6 +244,7 @@ dev_cli="${custom_bin_dir}/kast-dev"
 [[ -x "$dev_cli" ]] || die "Expected executable development CLI at configured binDir ${dev_cli}"
 "$dev_cli" version >/dev/null
 
-[[ ! -e "${custom_bin_dir}/kast" ]] || die "installDevelopmentCli must not overwrite the configured kast binary"
+cmp -s "$custom_ordinary_cli_before" "$custom_ordinary_cli" \
+  || die "configured binDir install must preserve the ordinary kast authority"
 
 printf '%s\n' "Development CLI install contract passed"

--- a/.github/scripts/test-local-development-refresh-contract.sh
+++ b/.github/scripts/test-local-development-refresh-contract.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/../.." && pwd
+}
+
+repo_root="$(resolve_repo_root)"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/kast-local-refresh-contract.XXXXXX")"
+tmp_root="$(cd -- "$tmp_root" && pwd -P)"
+cleanup() {
+  local guidance="${repo_root}/AGENTS.local.md"
+  if [[ -L "$guidance" ]] \
+    && [[ "$(readlink "$guidance")" == "${tmp_root}/missing-prefix/current/guidance/AGENTS.local.md" ]]; then
+    rm -f "$guidance"
+  fi
+  rm -rf "$tmp_root"
+}
+trap cleanup EXIT
+
+refresh_help="$(${repo_root}/gradlew -q help --task refreshDevelopmentLocal)"
+grep -Fq 'Refreshes one revision-coherent local Kast development authority.' <<<"$refresh_help" \
+  || die 'refreshDevelopmentLocal must describe the revision-coherent local authority boundary'
+rollback_help="$(${repo_root}/gradlew -q help --task rollbackDevelopmentLocal)"
+grep -Fq 'Idempotently reactivates the explicitly selected validated previous local generation.' <<<"$rollback_help" \
+  || die 'rollbackDevelopmentLocal must expose validated generation rollback'
+remove_help="$(${repo_root}/gradlew -q help --task removeDevelopmentLocal)"
+grep -Fq 'Removes only receipt-owned local Kast state and restores ordinary authority.' <<<"$remove_help" \
+  || die 'removeDevelopmentLocal must expose receipt-owned removal'
+
+local_help="$(
+  cargo run \
+    --quiet \
+    --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
+    --locked \
+    --bin kast \
+    -- \
+    developer local refresh --help
+)"
+grep -Fq 'Refresh one isolated, revision-coherent local development authority' <<<"$local_help" \
+  || die 'developer local refresh must expose the typed local refresh boundary'
+
+attest_help="$(
+  cargo run \
+    --quiet \
+    --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
+    --locked \
+    --bin kast \
+    -- \
+    developer local attest --help
+)"
+grep -Fq 'Bind one built artifact to the captured source snapshot and its exact bytes' <<<"$attest_help" \
+  || die 'developer local attest must expose source-bound artifact provenance'
+
+rollback_cli_help="$(
+  cargo run \
+    --quiet \
+    --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
+    --locked \
+    --bin kast \
+    -- \
+    developer local rollback --help
+)"
+grep -Fq -- '--to-generation <TO_GENERATION>' <<<"$rollback_cli_help" \
+  || die 'developer local rollback must require an explicit generation target'
+
+grep -Fxq '/AGENTS.local.md' "${repo_root}/.gitignore" \
+  || die 'local guidance must be ignored by the source-owned root .gitignore'
+grep -Fxq '/.kast/' "${repo_root}/.gitignore" \
+  || die 'the default local authority prefix and stable namespace lock must be source-ignored'
+
+snapshot_file="${tmp_root}/source-snapshot.json"
+snapshot_json="$(
+  cargo run \
+    --quiet \
+    --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
+    --locked \
+    --bin kast \
+    -- \
+    --output json \
+    developer local snapshot \
+    --source-root "$repo_root" \
+    --output-file "$snapshot_file"
+)"
+expected_commit="$(git -C "$repo_root" rev-parse HEAD)"
+[[ -f "$snapshot_file" ]] || die 'local snapshot must write the requested strict snapshot file'
+grep -Fq "\"gitCommit\": \"${expected_commit}\"" "$snapshot_file" \
+  || die 'local snapshot must record the exact Git commit'
+grep -Eq '"sourceTreeSha256": "[0-9a-f]{64}"' "$snapshot_file" \
+  || die 'local snapshot must record a SHA-256 over current checkout content'
+grep -Fq '"sourceTreeSha256"' <<<"$snapshot_json" \
+  || die 'local snapshot must print machine-readable source identity'
+
+cli_binary="${repo_root}/cli-rs/target/debug/kast"
+cli_provenance="${tmp_root}/cli-provenance.json"
+set +e
+"$cli_binary" \
+  --output json \
+  developer local attest \
+  --source-root "$repo_root" \
+  --expected-source-snapshot "$snapshot_file" \
+  --artifact-kind cli \
+  --artifact "$cli_binary" \
+  --output-file "$cli_provenance" >"${tmp_root}/attest-output.json" 2>&1
+attest_status=$?
+set -e
+[[ "$attest_status" -ne 0 ]] \
+  || die 'an ordinary Cargo binary must not be relabeled as source-bound local CLI output'
+grep -Fq 'LOCAL_CLI_SOURCE_ATTESTATION_MISSING' "${tmp_root}/attest-output.json" \
+  || die 'ordinary Cargo bytes must fail with typed missing source attestation'
+[[ ! -e "$cli_provenance" ]] \
+  || die 'failed CLI attestation must not publish a provenance record'
+
+dry_run="$(${repo_root}/gradlew -m refreshDevelopmentLocal --no-daemon)"
+for required_task in \
+  buildLocalDevelopmentCli \
+  captureDevelopmentSourceSnapshot \
+  rebuildLocalDevelopmentCli \
+  syncPortableDist \
+  writeLocalBackendComponentManifest \
+  stageDevelopmentBackend \
+  attestDevelopmentCli \
+  attestDevelopmentBackend \
+  refreshDevelopmentLocal; do
+  grep -Fq ":${required_task}" <<<"$dry_run" \
+    || die "refreshDevelopmentLocal must include ${required_task}"
+done
+capture_line="$(grep -nF ':captureDevelopmentSourceSnapshot' <<<"$dry_run" | head -1 | cut -d: -f1)"
+rebuild_line="$(grep -nF ':rebuildLocalDevelopmentCli' <<<"$dry_run" | head -1 | cut -d: -f1)"
+backend_line="$(grep -nF ':backend-headless:syncPortableDist' <<<"$dry_run" | head -1 | cut -d: -f1)"
+[[ "$capture_line" -lt "$rebuild_line" && "$capture_line" -lt "$backend_line" ]] \
+  || die 'CLI and backend producer tasks must run after the captured source snapshot'
+if grep -Eq 'installDevelopmentIdeaPlugin|configureDevelopmentMachineDefaults' <<<"$dry_run"; then
+  die 'local refresh must not mutate a user JetBrains profile or release configuration'
+fi
+grep -Fq '"-Dkast.idea.autostart=false"' "${repo_root}/backend-headless/build.gradle.kts" \
+  || die 'headless startup must disable the unrelated IDEA project-open profile hook before JVM bootstrap'
+
+rollback_dry_run="$(${repo_root}/gradlew -m rollbackDevelopmentLocal -PkastLocalGeneration=test-generation --no-daemon)"
+grep -Fq ':rollbackDevelopmentLocal' <<<"$rollback_dry_run" \
+  || die 'rollbackDevelopmentLocal must remain directly executable'
+if grep -Fq ':buildLocalDevelopmentCli' <<<"$rollback_dry_run"; then
+  die 'rollbackDevelopmentLocal must not rebuild the checkout it is recovering'
+fi
+remove_dry_run="$(${repo_root}/gradlew -m removeDevelopmentLocal --no-daemon)"
+grep -Fq ':removeDevelopmentLocal' <<<"$remove_dry_run" \
+  || die 'removeDevelopmentLocal must remain directly executable'
+if grep -Fq ':buildLocalDevelopmentCli' <<<"$remove_dry_run"; then
+  die 'removeDevelopmentLocal must not rebuild the checkout it is recovering'
+fi
+
+recovery_prefix="${tmp_root}/recovery-prefix"
+recovery_log="${tmp_root}/recovery-args.txt"
+mkdir -p "${recovery_prefix}/bin"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'printf "%s\n" "$@" >"${KAST_RECOVERY_LOG:?}"' \
+  >"${recovery_prefix}/bin/kast-dev"
+chmod 755 "${recovery_prefix}/bin/kast-dev"
+KAST_RECOVERY_LOG="$recovery_log" CARGO="${tmp_root}/unbuildable-cargo" \
+  "${repo_root}/gradlew" rollbackDevelopmentLocal \
+    -PkastLocalPrefix="$recovery_prefix" \
+    -PkastLocalGeneration=test-generation \
+    --no-daemon >/dev/null
+grep -Fxq 'rollback' "$recovery_log" \
+  || die 'rollbackDevelopmentLocal must execute the installed stable controller'
+grep -Fxq 'test-generation' "$recovery_log" \
+  || die 'rollbackDevelopmentLocal must forward the explicit generation'
+KAST_RECOVERY_LOG="$recovery_log" CARGO="${tmp_root}/unbuildable-cargo" \
+  "${repo_root}/gradlew" removeDevelopmentLocal \
+    -PkastLocalPrefix="$recovery_prefix" \
+    -PkastLocalWorkspaceRoot="$repo_root" \
+    --no-daemon >/dev/null
+grep -Fxq 'remove' "$recovery_log" \
+  || die 'removeDevelopmentLocal must execute the installed stable controller'
+
+cargo build \
+  --quiet \
+  --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
+  --locked
+missing_prefix="${tmp_root}/missing-prefix"
+missing_guidance="${repo_root}/AGENTS.local.md"
+ln -s "${missing_prefix}/current/guidance/AGENTS.local.md" "$missing_guidance"
+KAST_RECOVERY_LOG="$recovery_log" CARGO="${tmp_root}/unbuildable-cargo" \
+  "${repo_root}/gradlew" removeDevelopmentLocal \
+    -PkastLocalPrefix="$missing_prefix" \
+    -PkastLocalWorkspaceRoot="$repo_root" \
+    -PkastLocalRecoveryController="${repo_root}/cli-rs/target/debug/kast" \
+    --no-daemon >/dev/null
+[[ ! -e "$missing_guidance" && ! -L "$missing_guidance" ]] \
+  || die 'removeDevelopmentLocal must clean owned dangling guidance after the prefix is missing'
+
+legacy_install_dry_run="$(${repo_root}/gradlew -m installDevelopmentLocal --no-daemon)"
+for required_task in installDevelopmentCli installDevelopmentIdeaPlugin configureDevelopmentMachineDefaults; do
+  grep -Fq ":${required_task}" <<<"$legacy_install_dry_run" \
+    || die "installDevelopmentLocal must preserve its established ${required_task} contract"
+done
+
+cargo test \
+  --quiet \
+  --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
+  --locked \
+  local_development::
+cargo test \
+  --quiet \
+  --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
+  --locked \
+  --test local_development_refresh_smoke
+
+printf '%s\n' 'Local development refresh contract passed'

--- a/.github/scripts/test-local-development-refresh-contract.sh
+++ b/.github/scripts/test-local-development-refresh-contract.sh
@@ -80,6 +80,29 @@ grep -Fxq '/.kotlin/' "${repo_root}/.gitignore" \
 git -C "$repo_root" check-ignore --quiet -- '.kotlin/sessions/kast-contract.salive' \
   || die 'Kotlin compiler session files must be excluded from source snapshots'
 
+source_bound_cli_task="$(
+  sed -n \
+    '/^abstract class BuildSourceBoundCliTask/,/^}/p' \
+    "${repo_root}/build.gradle.kts"
+)"
+grep -Fq 'abstract val targetDirectory: DirectoryProperty' <<<"$source_bound_cli_task" \
+  || die 'the source-bound CLI rebuild must own a typed Cargo target directory'
+grep -Fq '"--target-dir",' <<<"$source_bound_cli_task" \
+  || die 'the source-bound CLI rebuild must override ambient Cargo target configuration'
+grep -Fq 'targetDirectory.get().asFile.absolutePath' <<<"$source_bound_cli_task" \
+  || die 'the source-bound CLI rebuild must write to its declared target directory'
+source_bound_cli_registration="$(
+  sed -n \
+    '/^val rebuildLocalDevelopmentCli:/,/^}/p' \
+    "${repo_root}/build.gradle.kts"
+)"
+grep -Fq 'targetDirectory.set(cliLocalDevelopmentTargetDirectory)' \
+  <<<"$source_bound_cli_registration" \
+  || die 'the source-bound CLI rebuild target must match the attested release binary'
+grep -Fq 'cliLocalDevelopmentTargetDirectory.file("release/kast")' \
+  "${repo_root}/build.gradle.kts" \
+  || die 'the attested release binary must derive from the source-bound Cargo target directory'
+
 snapshot_file="${tmp_root}/source-snapshot.json"
 snapshot_json="$(
   cargo run \

--- a/.github/scripts/test-local-development-refresh-contract.sh
+++ b/.github/scripts/test-local-development-refresh-contract.sh
@@ -75,6 +75,10 @@ grep -Fxq '/AGENTS.local.md' "${repo_root}/.gitignore" \
   || die 'local guidance must be ignored by the source-owned root .gitignore'
 grep -Fxq '/.kast/' "${repo_root}/.gitignore" \
   || die 'the default local authority prefix and stable namespace lock must be source-ignored'
+grep -Fxq '/.kotlin/' "${repo_root}/.gitignore" \
+  || die 'transient Kotlin compiler session state must not perturb source attestation'
+git -C "$repo_root" check-ignore --quiet -- '.kotlin/sessions/kast-contract.salive' \
+  || die 'Kotlin compiler session files must be excluded from source snapshots'
 
 snapshot_file="${tmp_root}/source-snapshot.json"
 snapshot_json="$(
@@ -198,11 +202,22 @@ KAST_RECOVERY_LOG="$recovery_log" CARGO="${tmp_root}/unbuildable-cargo" \
 [[ ! -e "$missing_guidance" && ! -L "$missing_guidance" ]] \
   || die 'removeDevelopmentLocal must clean owned dangling guidance after the prefix is missing'
 
-legacy_install_dry_run="$(${repo_root}/gradlew -m installDevelopmentLocal --no-daemon)"
+profile_free_config_root="${tmp_root}/profile-free-jetbrains-config"
+profile_free_install_args=(
+  -m
+  installDevelopmentLocal
+  -PkastDevJetBrainsConfigRoot="$profile_free_config_root"
+  --configuration-cache
+  --no-daemon
+)
+legacy_install_dry_run="$("${repo_root}/gradlew" "${profile_free_install_args[@]}")"
 for required_task in installDevelopmentCli installDevelopmentIdeaPlugin configureDevelopmentMachineDefaults; do
   grep -Fq ":${required_task}" <<<"$legacy_install_dry_run" \
     || die "installDevelopmentLocal must preserve its established ${required_task} contract"
 done
+legacy_install_reuse="$("${repo_root}/gradlew" "${profile_free_install_args[@]}")"
+grep -Fq 'Configuration cache entry reused.' <<<"$legacy_install_reuse" \
+  || die 'profile-free legacy install planning must reuse configuration cache state'
 
 cargo test \
   --quiet \

--- a/.github/scripts/test-local-development-semantic-e2e.sh
+++ b/.github/scripts/test-local-development-semantic-e2e.sh
@@ -39,7 +39,7 @@ cleanup() {
     if [[ -n "$active_generation" && -d "$local_prefix/state/$active_generation" ]]; then
       find "$local_prefix/state/$active_generation" \
         -type f \
-        -name '*headless-daemon.log' \
+        -name '*.log' \
         -print \
         -exec tail -n 200 {} \; >&2 || true
     fi
@@ -102,9 +102,12 @@ before_source_sha="$(sha256_file "$source_file")"
 before_repository_source_sha="$first_source_sha"
 
 runtime_started=true
-"$kast" --output json developer runtime up \
+if ! "$kast" --output json developer runtime up \
   --workspace-root "$repo_root" \
-  --backend headless >"${tmp_root}/runtime-up.json"
+  --backend headless >"${tmp_root}/runtime-up.json"; then
+  cat "${tmp_root}/runtime-up.json" >&2
+  die 'installed headless runtime failed to start'
+fi
 
 "$kast" --output json agent verify \
   --workspace-root "$repo_root" \

--- a/.github/scripts/test-local-development-semantic-e2e.sh
+++ b/.github/scripts/test-local-development-semantic-e2e.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+resolve_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "${script_dir}/../.." && pwd
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+repo_root="$(resolve_repo_root)"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/kast-local-semantic-e2e.XXXXXX")"
+local_prefix="${repo_root}/.kast/local-development"
+kast="${local_prefix}/bin/kast-dev"
+runtime_started=false
+
+cleanup() {
+  local status=$?
+  if [[ "$runtime_started" == true && -x "$kast" ]]; then
+    "$kast" --output json developer runtime stop \
+      --workspace-root "$repo_root" \
+      --backend headless >/dev/null 2>&1 || true
+  fi
+  if [[ "$status" -ne 0 && -d "$local_prefix/state" ]]; then
+    local active_generation
+    active_generation="$(basename "$(readlink "$local_prefix/current" 2>/dev/null || true)")"
+    if [[ -n "$active_generation" && -d "$local_prefix/state/$active_generation" ]]; then
+      find "$local_prefix/state/$active_generation" \
+        -type f \
+        -name '*headless-daemon.log' \
+        -print \
+        -exec tail -n 200 {} \; >&2 || true
+    fi
+  fi
+  rm -rf "$tmp_root"
+  return "$status"
+}
+trap cleanup EXIT
+
+command -v jq >/dev/null 2>&1 || die 'jq is required for the semantic E2E contract'
+cd -- "$repo_root"
+
+first_refresh_log="${tmp_root}/first-refresh.log"
+if ! ./gradlew refreshDevelopmentLocal --no-daemon >"$first_refresh_log" 2>&1; then
+  cat "$first_refresh_log" >&2
+  die 'the first local-development refresh failed'
+fi
+[[ -x "$kast" ]] || die 'refresh did not install the receipt-owned kast-dev entrypoint'
+
+receipt="${local_prefix}/authority.json"
+first_generation="$(jq -er '.generationId' "$receipt")"
+first_source_sha="$(jq -er '.source.sourceTreeSha256' "$receipt")"
+first_cli_sha="$(jq -er '.components.cli.sha256' "$receipt")"
+first_backend_sha="$(jq -er '.components.backend.sha256' "$receipt")"
+
+second_refresh_log="${tmp_root}/second-refresh.log"
+if ! ./gradlew refreshDevelopmentLocal --no-daemon >"$second_refresh_log" 2>&1; then
+  cat "$second_refresh_log" >&2
+  die 'the idempotent local-development refresh failed'
+fi
+grep -Fq '"skipped": true' "$second_refresh_log" \
+  || die 'the unchanged second refresh must report skipped=true'
+[[ "$(jq -er '.generationId' "$receipt")" == "$first_generation" ]] \
+  || die 'idempotent refresh changed the active generation'
+[[ "$(jq -er '.components.cli.sha256' "$receipt")" == "$first_cli_sha" ]] \
+  || die 'idempotent refresh changed the installed CLI bytes'
+[[ "$(jq -er '.components.backend.sha256' "$receipt")" == "$first_backend_sha" ]] \
+  || die 'idempotent refresh changed the installed backend bytes'
+
+"$kast" --output json ready --for machine --workspace-root "$repo_root" >"${tmp_root}/authority-ready.json"
+jq -e \
+  --arg root "$repo_root" \
+  --arg generation "$first_generation" \
+  --arg source_sha "$first_source_sha" \
+  '.ok == true and
+   .installAuthority == "local-development" and
+   .localDevelopment.workspaceRoot == $root and
+   .localDevelopment.generationId == $generation and
+   .localDevelopment.source.sourceTreeSha256 == $source_sha and
+   .binary.configuredMatchesRunning == true and
+   .configuration.valid == true and
+   (.localDevelopment.components | keys | sort) == ["backend", "cli", "config", "guidance", "manifest", "skill"]' \
+  "${tmp_root}/authority-ready.json" >/dev/null \
+  || die 'machine readiness did not prove the complete local authority'
+
+source_file="${repo_root}/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessWorkspaceKind.kt"
+type_symbol='io.github.amichne.kast.headless.HeadlessWorkspaceKind'
+reference_symbol='io.github.amichne.kast.headless.HeadlessWorkspaceKind.Companion.GRADLE_MARKERS'
+before_source_sha="$(sha256_file "$source_file")"
+before_repository_source_sha="$first_source_sha"
+
+runtime_started=true
+"$kast" --output json developer runtime up \
+  --workspace-root "$repo_root" \
+  --backend headless >"${tmp_root}/runtime-up.json"
+
+"$kast" --output json agent verify \
+  --workspace-root "$repo_root" \
+  --backend headless \
+  --explain >"${tmp_root}/verify.json"
+jq -e \
+  '.ok == true and
+   .result.semanticWorkspace.backendName == "headless" and
+   (.result.semanticWorkspace.workspaceKind == "PRIMARY_CHECKOUT" or
+    .result.semanticWorkspace.workspaceKind == "LINKED_WORKTREE") and
+   .result.semanticWorkspace.evidenceQuality == "COMPILER_BACKED" and
+   (.result.steps[] | select(.name == "runtime-status").result.state) == "READY"' \
+  "${tmp_root}/verify.json" >/dev/null \
+  || die 'installed headless verification did not prove compiler-backed READY state'
+
+"$kast" --output json agent symbol \
+  --query "$type_symbol" \
+  --workspace-root "$repo_root" \
+  --backend headless \
+  --explain >"${tmp_root}/symbol.json"
+jq -e \
+  --arg symbol "$type_symbol" \
+  '.ok == true and
+   .result.outcome.type == "RESOLVED" and
+   .result.outcome.source == "compiler" and
+   .result.outcome.symbol.fqName == $symbol' \
+  "${tmp_root}/symbol.json" >/dev/null \
+  || die 'installed exact lookup did not resolve from the compiler'
+
+"$kast" --output json agent symbol \
+  --query "$reference_symbol" \
+  --workspace-root "$repo_root" \
+  --backend headless \
+  --explain >"${tmp_root}/reference-symbol.json"
+jq -e \
+  --arg symbol "$reference_symbol" \
+  '.ok == true and
+   .result.outcome.type == "RESOLVED" and
+   .result.outcome.source == "compiler" and
+   .result.outcome.symbol.fqName == $symbol and
+   .result.outcome.symbol.kind == "PROPERTY" and
+   .result.outcome.symbol.visibility == "PRIVATE"' \
+  "${tmp_root}/reference-symbol.json" >/dev/null \
+  || die 'known reference anchor did not resolve as the exact private property'
+reference_file="$(jq -er '.result.outcome.symbol.location.filePath' "${tmp_root}/reference-symbol.json")"
+reference_offset="$(jq -er '.result.outcome.symbol.location.startOffset' "${tmp_root}/reference-symbol.json")"
+reference_containing_type="$(jq -er '.result.outcome.symbol.containingDeclaration' "${tmp_root}/reference-symbol.json")"
+
+"$kast" --output json agent references \
+  --symbol "$reference_symbol" \
+  --declaration-file "$reference_file" \
+  --declaration-start-offset "$reference_offset" \
+  --kind property \
+  --containing-type "$reference_containing_type" \
+  --workspace-root "$repo_root" \
+  --backend headless \
+  --limit 100 \
+  --explain >"${tmp_root}/references.json"
+jq -e \
+  '.ok == true and
+   .result.outcome == "AVAILABLE" and
+   .result.page.cardinality.type == "EXACT" and
+   .result.page.cardinality.totalCount > 0 and
+   .result.page.returnedCount > 0 and
+   .result.page.truncated == false and
+   .result.limitations == []' \
+  "${tmp_root}/references.json" >/dev/null \
+  || die 'installed reference lookup was not known, nonzero, exact, and exhaustive'
+
+"$kast" --output json agent diagnostics \
+  --file-path "$source_file" \
+  --workspace-root "$repo_root" \
+  --backend headless \
+  --explain >"${tmp_root}/diagnostics.json"
+jq -e \
+  '.ok == true and
+   (.result.steps[] | select(.name == "diagnostics").result.semanticOutcome) == "COMPLETE" and
+   (.result.steps[] | select(.name == "diagnostics").result.severityCounts.error) == 0' \
+  "${tmp_root}/diagnostics.json" >/dev/null \
+  || die 'installed diagnostics did not completely analyze the clean Kotlin file'
+
+"$kast" --output json agent rename \
+  --symbol "$type_symbol" \
+  --new-name HeadlessWorkspaceKindProof \
+  --workspace-root "$repo_root" \
+  --backend headless \
+  --explain >"${tmp_root}/rename-plan.json"
+jq -e \
+  '.ok == true and
+   .result.type == "KAST_AGENT_RENAME_PLAN" and
+   .result.applyRequired == true and
+   .result.request.method == "symbol/rename" and
+   (.result.preview.edits | length) > 0 and
+   (.result.preview.affectedFiles | length) > 0 and
+   (.result.preview.fileHashes | length) == (.result.preview.affectedFiles | length)' \
+  "${tmp_root}/rename-plan.json" >/dev/null \
+  || die 'installed rename did not return an explicit non-applied mutation plan'
+[[ "$(sha256_file "$source_file")" == "$before_source_sha" ]] \
+  || die 'plan-only rename changed source bytes'
+"$kast" --output json developer local snapshot \
+  --source-root "$repo_root" \
+  --output-file "${tmp_root}/source-after-rename.json" >/dev/null
+[[ "$(jq -er '.sourceTreeSha256' "${tmp_root}/source-after-rename.json")" == "$before_repository_source_sha" ]] \
+  || die 'plan-only rename changed repository source state'
+
+"$kast" --output json developer runtime stop \
+  --workspace-root "$repo_root" \
+  --backend headless >"${tmp_root}/runtime-stop.json"
+runtime_started=false
+jq -e '.stopped == true and .stoppedCount == 1' "${tmp_root}/runtime-stop.json" >/dev/null \
+  || die 'installed headless runtime did not stop explicitly'
+
+state_root="${local_prefix}/state/${first_generation}"
+if grep -R -E --include='*.log' \
+  'Kast project-open workspace setup (failed|prepared)|Homebrew CLI receipt' "$state_root"; then
+  die 'headless startup invoked the unrelated IDEA project-open release-authority path'
+fi
+grep -R -F --include='*.log' \
+  'Kast project-open workspace setup skipped: disabled' "$state_root" >/dev/null \
+  || die 'headless runtime did not receive the local project-open opt-out'
+
+"$kast" --output json ready --for machine --workspace-root "$repo_root" >"${tmp_root}/authority-after.json"
+jq -e \
+  --arg source_sha "$first_source_sha" \
+  '.ok == true and .localDevelopment.source.sourceTreeSha256 == $source_sha' \
+  "${tmp_root}/authority-after.json" >/dev/null \
+  || die 'semantic execution changed or invalidated the active source authority'
+
+if ! ./gradlew removeDevelopmentLocal \
+  -PkastLocalWorkspaceRoot="$repo_root" \
+  --no-daemon >"${tmp_root}/remove.log" 2>&1; then
+  cat "${tmp_root}/remove.log" >&2
+  die 'receipt-owned local authority removal failed'
+fi
+[[ ! -e "$local_prefix" ]] || die 'removal left the receipt-owned local prefix behind'
+[[ ! -e "${repo_root}/AGENTS.local.md" ]] || die 'removal left the receipt-owned guidance projection behind'
+[[ ! -L "${repo_root}/AGENTS.local.md" ]] || die 'removal left a dangling receipt-owned guidance projection behind'
+
+printf '%s\n' 'Local development installed semantic E2E passed'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,10 @@ jobs:
         shell: bash
         run: ./.github/scripts/test-local-development-refresh-contract.sh
 
+      - name: Test development CLI and IDEA profile install contract
+        shell: bash
+        run: ./.github/scripts/test-development-cli-install-contract.sh
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           distribution: temurin
           java-version: "21"
 
+      - name: Install Rust for command-surface contracts
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Test release workflow contract
         shell: bash
         run: ./.github/scripts/test-release-workflow-contract.sh
@@ -51,6 +54,10 @@ jobs:
       - name: Test macOS installer contract
         shell: bash
         run: ./.github/scripts/test-macos-installer-contract.sh
+
+      - name: Test local development refresh contract
+        shell: bash
+        run: ./.github/scripts/test-local-development-refresh-contract.sh
 
       - uses: actions/setup-python@v6
         with:
@@ -101,6 +108,24 @@ jobs:
       - name: Test Homebrew package renderer
         shell: bash
         run: packaging/homebrew/scripts/test-formulas.py
+
+  local-development-semantic-e2e:
+    name: Local development installed semantic E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Exercise refreshed installed semantics
+        shell: bash
+        run: ./.github/scripts/test-local-development-semantic-e2e.sh
 
   runtime-contracts:
     name: Runtime command and bundle contracts

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ gen
 **/build/
 **/target/
 .gradle/
+/.kotlin/
 .run/
 .qodana/
 .intellijPlatform/

--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,8 @@ kast-copilot-plugin/
 .github/instructions/kast-kotlin.md
 .github/instructions/kast-kotlin.instructions.md
 .github/extensions/kast/
+/AGENTS.local.md
+/.kast/
 .agents/skills/kast-api-surface-change/
 .agents/skills/kast-callgraph-review/
 .agents/skills/kast-safe-rename/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ The [macOS install guide](https://kast.michne.com/install/macos/) covers the
 root installer and IDE handoff. The [headless Linux guide](https://kast.michne.com/install/headless-linux/)
 covers server and hosted-agent installs.
 
+## Develop From A Checkout
+
+Kast contributors can build and activate the exact current checkout without
+publishing a release or changing Homebrew and JetBrains release authority.
+
+```console
+./gradlew refreshDevelopmentLocal
+```
+
+The command creates a source-bound headless authority under
+`.kast/local-development/`, including the CLI, backend, skill, agent guidance,
+configuration, and strict receipt. Follow [validate a local
+checkout](https://kast.michne.com/distribute/local-development-refresh/) for
+machine-readable verification, linked-worktree isolation, rollback, and
+removal.
+
 ## Try it on your code
 
 Once the workspace is prepared and its backend is ready, run the read-only
@@ -107,6 +123,7 @@ plugin preparation even when `--backend=headless` is selected.
   or explore your repository with the
   [read-only demo](https://kast.michne.com/learn/repository-demo/).
 - Browse the [command reference](https://kast.michne.com/reference/commands/).
+- Validate an unreleased checkout with the [local development refresh](https://kast.michne.com/distribute/local-development-refresh/).
 - Use [inspect Kotlin](https://kast.michne.com/use/inspect-kotlin/) and
   [plan safe edits](https://kast.michne.com/use/plan-safe-edits/) for common
   CLI workflows.

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspaceDirectoryResolver.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspaceDirectoryResolver.kt
@@ -12,6 +12,7 @@ import java.util.UUID
 
 class WorkspaceDirectoryResolver(
     private val installRoot: () -> Path = ::kastInstallRoot,
+    private val dataRoot: () -> Path = { kastDataRoot(System::getenv, installRoot()) },
     private val gitWorkspaceResolver: (Path) -> GitWorkspace? = GitWorkspaceResolver::discover,
     private val gitRemoteResolver: (Path) -> GitRemote? = GitRemoteParser::origin,
     private val uuidGenerator: () -> UUID = UUID::randomUUID,
@@ -61,7 +62,7 @@ class WorkspaceDirectoryResolver(
         return workspaceRoot.startsWith(tempRoot)
     }
 
-    private fun workspacesRoot(): Path = installRoot().resolve("state/workspaces").toAbsolutePath().normalize()
+    private fun workspacesRoot(): Path = dataRoot().resolve("workspaces").toAbsolutePath().normalize()
 
     private fun gitWorkspaceDataDirectory(workspace: GitWorkspace, remote: GitRemote?): Path {
         val repoRoot = if (remote != null) {

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspacePaths.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspacePaths.kt
@@ -20,6 +20,17 @@ fun kastConfigHome(envLookup: (String) -> String?): Path =
 fun kastInstallRoot(): Path =
     configPath(KastConfig.defaults().paths.installRoot.value)
 
+fun kastDataRoot(): Path = kastDataRoot(System::getenv, kastInstallRoot())
+
+fun kastDataRoot(
+    envLookup: (String) -> String?,
+    installRoot: Path,
+): Path = envLookup("KAST_DATA_HOME")
+    ?.trim()
+    ?.takeIf(String::isNotEmpty)
+    ?.let { Path(it).toAbsolutePath().normalize() }
+    ?: installRoot.resolve("state").toAbsolutePath().normalize()
+
 fun defaultDescriptorDirectory(): Path =
     configPath(KastConfig.defaults().paths.descriptorDir.value)
 

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/SearchScope.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/SearchScope.kt
@@ -9,7 +9,8 @@ import kotlinx.serialization.Serializable
 
 /**
  * Describes the scope and completeness of a reference search or rename operation.
- * LLM consumers can use [exhaustive] to gauge confidence in result completeness.
+ * LLM consumers can use [exhaustive] for result-set completeness and [candidateCoverage]
+ * to distinguish ordinary pagination from an incomplete semantic search.
  */
 @Serializable
 data class SearchScope(
@@ -17,13 +18,21 @@ data class SearchScope(
     val visibility: SymbolVisibility,
     @DocField(description = "The breadth of files examined: FILE, MODULE, or DEPENDENT_MODULES.")
     val scope: SearchScopeKind,
-    @DocField(description = "True when the search covered all candidate files without truncation.")
+    @DocField(description = "True only when candidate coverage completed and no result continuation remains.")
     val exhaustive: Boolean,
+    @DocField(description = "Whether the underlying candidate search completed without a semantic or budget limitation.")
+    val candidateCoverage: CandidateCoverage = if (exhaustive) CandidateCoverage.COMPLETE else CandidateCoverage.PARTIAL,
     @DocField(description = "Total number of files that could contain references.")
     val candidateFileCount: Int,
     @DocField(description = "Number of files actually examined during the search.")
     val searchedFileCount: Int,
-)
+) {
+    @Serializable
+    enum class CandidateCoverage {
+        COMPLETE,
+        PARTIAL,
+    }
+}
 
 /** The breadth of files examined during a reference search. */
 @Serializable

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/DiagnosticsResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/DiagnosticsResult.kt
@@ -8,8 +8,11 @@ import io.github.amichne.kast.api.contract.PageableResult
 import io.github.amichne.kast.api.docs.DocField
 import io.github.amichne.kast.api.protocol.*
 import kotlinx.serialization.ExperimentalSerializationApi
-
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 class DiagnosticsResult private constructor(
@@ -28,6 +31,7 @@ class DiagnosticsResult private constructor(
     @DocField(description = "Exact severity counts across every diagnostic, including records outside this page.")
     val severityCounts: DiagnosticSeverityCounts,
     @DocField(description = "Exact diagnostic cardinality across every page.")
+    @Serializable(with = ExactResultCardinalitySerializer::class)
     val cardinality: ResultCardinality.Exact,
     @DocField(description = "Pagination metadata when results are truncated.")
     override val page: PageInfo? = null,
@@ -148,4 +152,38 @@ class DiagnosticsResult private constructor(
             )
         }
     }
+}
+
+private object ExactResultCardinalitySerializer : KSerializer<ResultCardinality.Exact> {
+    override val descriptor = ExactResultCardinalityWire.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: ResultCardinality.Exact) {
+        encoder.encodeSerializableValue(
+            ExactResultCardinalityWire.serializer(),
+            ExactResultCardinalityWire(
+                type = ExactResultCardinalityWireType.EXACT,
+                totalCount = value.totalCount,
+            ),
+        )
+    }
+
+    override fun deserialize(decoder: Decoder): ResultCardinality.Exact {
+        val wire = decoder.decodeSerializableValue(ExactResultCardinalityWire.serializer())
+        return ResultCardinality.Exact(wire.totalCount)
+    }
+}
+
+@Serializable
+@SerialName("EXACT")
+private data class ExactResultCardinalityWire(
+    @DocField(description = "Wire discriminator proving that the diagnostic count is exact.", serverManaged = true)
+    @SerialName("type")
+    val type: ExactResultCardinalityWireType,
+    @DocField(description = "Exact number of diagnostics across every page.")
+    val totalCount: Int,
+)
+
+@Serializable
+private enum class ExactResultCardinalityWireType {
+    EXACT,
 }

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/SkillContracts.kt
@@ -4,6 +4,7 @@ import io.github.amichne.kast.api.contract.*
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
 import io.github.amichne.kast.api.contract.result.CallHierarchyStats
 import io.github.amichne.kast.api.contract.result.ReferenceOccurrence
+import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.result.SearchMatch
 import io.github.amichne.kast.api.contract.result.TypeHierarchyNode
 import io.github.amichne.kast.api.contract.result.TypeHierarchyStats
@@ -608,6 +609,8 @@ data class KastCandidate(
 data class KastScaffoldReferences(
     val locations: List<ReferenceOccurrence>,
     val count: Int,
+    val cardinality: ResultCardinality,
+    val page: PageInfo? = null,
     val searchScope: SearchScope? = null,
     val declaration: Symbol? = null,
 )

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DiagnosticsResultTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DiagnosticsResultTest.kt
@@ -9,6 +9,9 @@ import io.github.amichne.kast.api.contract.result.FileAnalysisState
 import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
@@ -31,6 +34,22 @@ class DiagnosticsResultTest {
         assertEquals(2, result.requestedFileCount)
         assertEquals(2, result.analyzedFileCount)
         assertEquals(0, result.skippedFileCount)
+    }
+
+    @Test
+    fun `exact diagnostic cardinality carries its wire discriminator`() {
+        val result = DiagnosticsResult.of(
+            diagnostics = emptyList(),
+            fileStatuses = listOf(FileAnalysisStatus.analyzed(first)),
+        )
+
+        val cardinality = Json.encodeToJsonElement(DiagnosticsResult.serializer(), result)
+            .jsonObject
+            .getValue("cardinality")
+            .jsonObject
+
+        assertEquals("EXACT", cardinality.getValue("type").jsonPrimitive.content)
+        assertEquals(0, cardinality.getValue("totalCount").jsonPrimitive.content.toInt())
     }
 
     @Test

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspacePathsTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspacePathsTest.kt
@@ -20,6 +20,28 @@ class WorkspacePathsTest {
     }
 
     @Test
+    fun `kast data root follows explicit environment authority`() {
+        val installRoot = tempDir.resolve("install-root")
+        val dataRoot = tempDir.resolve("generation-data")
+        val env = mapOf(kastDataHomeEnv to dataRoot.toString())
+
+        assertEquals(
+            dataRoot.toAbsolutePath().normalize(),
+            kastDataRoot(env::get, installRoot),
+        )
+    }
+
+    @Test
+    fun `kast data root falls back to install state`() {
+        val installRoot = tempDir.resolve("install-root")
+
+        assertEquals(
+            installRoot.resolve("state").toAbsolutePath().normalize(),
+            kastDataRoot(emptyMap<String, String>()::get, installRoot),
+        )
+    }
+
+    @Test
     fun allPathsResolveFromConfigOnly() {
         val installRoot = Path.of(System.getProperty("user.home"))
             .resolve(".local/share/kast")
@@ -64,6 +86,29 @@ class WorkspacePathsTest {
             installRoot.resolve("state/workspaces/git/github.com/amichne/kast/worktrees/workspace--$worktreeHash"),
             resolver.workspaceDataDirectory(workspaceRoot),
         )
+    }
+
+    @Test
+    fun `workspace data directory honors generation data root independently of install root`() {
+        val installRoot = tempDir.resolve("install-root")
+        val dataRoot = tempDir.resolve("state/generation-a/data")
+        val workspaceRoot = tempDir.resolve("workspace")
+        val gitDir = tempDir.resolve("main.git/worktrees/workspace")
+        val resolver = WorkspaceDirectoryResolver(
+            installRoot = { installRoot },
+            dataRoot = { dataRoot },
+            gitWorkspaceResolver = {
+                GitWorkspace(
+                    toplevel = workspaceRoot,
+                    commonDir = tempDir.resolve("main.git"),
+                    gitDir = gitDir,
+                    remote = GitRemote(host = "github.com", owner = "amichne", repo = "kast"),
+                )
+            },
+        )
+
+        assertTrue(!resolver.workspaceDatabasePath(workspaceRoot).startsWith(installRoot))
+        assertTrue(resolver.workspaceDatabasePath(workspaceRoot).startsWith(dataRoot.resolve("workspaces")))
     }
 
     @Test
@@ -246,6 +291,7 @@ class WorkspacePathsTest {
 
     private companion object {
         val kastConfigHomeEnv: String = env("KAST", "CONFIG", "HOME")
+        val kastDataHomeEnv: String = env("KAST", "DATA", "HOME")
 
         fun env(vararg parts: String): String = parts.joinToString("_")
     }

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
@@ -314,7 +314,7 @@ internal class SkillRpcOrchestrator(
                 )
             }
         }
-        if (completeResult.searchScope?.exhaustive == false) {
+        if (completeResult.searchScope?.candidateCoverage == SearchScope.CandidateCoverage.PARTIAL) {
             return KastReferencesDegradedResponse(
                 selector = request.selector,
                 subject = subject,
@@ -472,6 +472,8 @@ internal class SkillRpcOrchestrator(
             KastScaffoldReferences(
                 locations = result.references,
                 count = result.references.size,
+                cardinality = result.cardinality,
+                page = result.page,
                 searchScope = result.searchScope,
                 declaration = result.declaration,
             )

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
@@ -42,6 +42,9 @@ import io.github.amichne.kast.api.protocol.JsonRpcRequest
 import io.github.amichne.kast.api.protocol.JsonRpcSuccessResponse
 import io.github.amichne.kast.api.protocol.ConflictException
 import io.github.amichne.kast.api.contract.ReadCapability
+import io.github.amichne.kast.api.contract.SearchScope
+import io.github.amichne.kast.api.contract.SearchScopeKind
+import io.github.amichne.kast.api.contract.SymbolVisibility
 import io.github.amichne.kast.api.contract.query.RefreshQuery
 import io.github.amichne.kast.api.contract.result.RefreshResult
 import io.github.amichne.kast.api.contract.result.SemanticAdmissionStatus
@@ -606,6 +609,89 @@ class AnalysisDispatcherTest {
         assertEquals(null, observedQueries[0].pageToken)
         assertEquals(1, observedQueries[1].maxResults.value)
         assertEquals(firstPage.page?.nextPageToken, observedQueries[1].pageToken?.value)
+    }
+
+    @Test
+    fun `symbol references preserves an honest paginated result when candidate coverage is complete`() {
+        val fixture = AnalysisBackendContractFixture.create(tempDir)
+        val delegate = FakeAnalysisBackend.contractFixture(fixture)
+        val backend = object : AnalysisBackend by delegate {
+            override suspend fun findReferences(query: ParsedReferencesQuery): ReferencesResult =
+                delegate.findReferences(query).copy(
+                    searchScope = SearchScope(
+                        visibility = SymbolVisibility.PUBLIC,
+                        scope = SearchScopeKind.DEPENDENT_MODULES,
+                        exhaustive = false,
+                        candidateCoverage = SearchScope.CandidateCoverage.COMPLETE,
+                        candidateFileCount = 2,
+                        searchedFileCount = 1,
+                    ),
+                )
+        }
+        val selector = KastExactSymbolSelector(
+            fqName = fixture.symbolFqName,
+            declarationFile = fixture.declarationLocation.filePath,
+            declarationStartOffset = fixture.declarationLocation.startOffset,
+            kind = SymbolKind.FUNCTION,
+        )
+
+        val result = dispatchSuccessWithBackend<KastReferencesResponse>(
+            backend = backend,
+            method = "symbol/references",
+            params = json.encodeToJsonElement(
+                KastReferencesRequest.serializer(),
+                KastReferencesRequest(
+                    workspaceRoot = tempDir.toString(),
+                    selector = selector,
+                    maxResults = 1,
+                ),
+            ),
+        )
+
+        val available = assertInstanceOf(KastReferencesAvailableResponse::class.java, result)
+        assertFalse(checkNotNull(available.searchScope).exhaustive)
+        assertEquals(SearchScope.CandidateCoverage.COMPLETE, available.searchScope?.candidateCoverage)
+        assertTrue(checkNotNull(available.page).truncated)
+    }
+
+    @Test
+    fun `symbol references degrades when the underlying candidate search is partial`() {
+        val fixture = AnalysisBackendContractFixture.create(tempDir)
+        val delegate = FakeAnalysisBackend.contractFixture(fixture)
+        val backend = object : AnalysisBackend by delegate {
+            override suspend fun findReferences(query: ParsedReferencesQuery): ReferencesResult =
+                delegate.findReferences(query).copy(
+                    searchScope = SearchScope(
+                        visibility = SymbolVisibility.PUBLIC,
+                        scope = SearchScopeKind.DEPENDENT_MODULES,
+                        exhaustive = false,
+                        candidateCoverage = SearchScope.CandidateCoverage.PARTIAL,
+                        candidateFileCount = 2,
+                        searchedFileCount = 1,
+                    ),
+                )
+        }
+        val selector = KastExactSymbolSelector(
+            fqName = fixture.symbolFqName,
+            declarationFile = fixture.declarationLocation.filePath,
+            declarationStartOffset = fixture.declarationLocation.startOffset,
+            kind = SymbolKind.FUNCTION,
+        )
+
+        val result = dispatchSuccessWithBackend<KastReferencesResponse>(
+            backend = backend,
+            method = "symbol/references",
+            params = json.encodeToJsonElement(
+                KastReferencesRequest.serializer(),
+                KastReferencesRequest(
+                    workspaceRoot = tempDir.toString(),
+                    selector = selector,
+                    maxResults = 1,
+                ),
+            ),
+        )
+
+        assertInstanceOf(KastReferencesDegradedResponse::class.java, result)
     }
 
     @Test

--- a/backend-headless/build.gradle.kts
+++ b/backend-headless/build.gradle.kts
@@ -177,6 +177,29 @@ val headlessPluginImplementationJar by tasks.registering(Jar::class) {
     }
 }
 
+val localHeadlessPluginImplementationJar by tasks.registering(Jar::class) {
+    group = "build"
+    description = "Builds source-bound headless plugin bytes for local-development authority."
+    dependsOn(":captureDevelopmentSourceSnapshot", ":writeLocalBackendComponentManifest")
+    archiveFileName.set("backend-headless-local-plugin.jar")
+    destinationDirectory.set(layout.buildDirectory.dir("local-development"))
+    from(sourceSets.named("main").map { it.output }) {
+        exclude("META-INF/plugin.xml")
+    }
+    from(rootProject.layout.buildDirectory.file("local-development/source-snapshot.json")) {
+        into("META-INF/kast")
+        rename { "local-source-snapshot.json" }
+    }
+    from(rootProject.layout.buildDirectory.file("local-development/backend-component-manifest.json")) {
+        into("META-INF/kast")
+        rename { "local-backend-components.json" }
+    }
+    manifest {
+        attributes["Implementation-Title"] = "${project.name}-plugin"
+        attributes["Implementation-Version"] = buildVersion.get()
+    }
+}
+
 val headlessBackendIdeaRuntimeJar by tasks.registering(Jar::class) {
     archiveBaseName.set("backend-idea")
     archiveVersion.set(buildVersion)
@@ -300,6 +323,7 @@ tasks.named<WriteWrapperScriptTask>("writeWrapperScript") {
             "-Djava.system.class.loader=com.intellij.util.lang.PathClassLoader"
             "-Didea.vendor.name=JetBrains"
             "-Didea.paths.selector=KastHeadless"
+            "-Dkast.idea.autostart=false"
             "-Djna.boot.library.path=${dollar}{idea_home}/lib/jna/${dollar}{jna_arch}"
             "-Djna.nosys=true"
             "-Djna.noclasspath=true"

--- a/backend-headless/src/main/java/io/github/amichne/kast/headless/HeadlessGradleProjectImportBridge.java
+++ b/backend-headless/src/main/java/io/github/amichne/kast/headless/HeadlessGradleProjectImportBridge.java
@@ -1,14 +1,34 @@
 package io.github.amichne.kast.headless;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskType;
+import com.intellij.openapi.externalSystem.service.internal.ExternalSystemProcessingManager;
 import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder;
 import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.openapi.observable.operation.core.ObservableOperationStatus;
+import com.intellij.openapi.observable.operation.core.ObservableOperationTrace;
 import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.OrderEntry;
+import com.intellij.openapi.startup.StartupManager;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.search.FileTypeIndex;
+import com.intellij.psi.search.GlobalSearchScope;
 import org.jetbrains.plugins.gradle.service.project.open.GradleProjectImportUtil;
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings;
+import org.jetbrains.plugins.gradle.settings.GradleSettings;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
+import org.jetbrains.plugins.gradle.util.GradleImportingUtil;
 
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -19,30 +39,163 @@ public final class HeadlessGradleProjectImportBridge {
     }
 
     public static boolean canLinkAndRefreshGradleProject(String externalProjectPath, Project project) {
-        return GradleProjectImportUtil.canLinkAndRefreshGradleProject(externalProjectPath, project);
+        return isGradleProjectLinked(project, externalProjectPath)
+            || GradleProjectImportUtil.canLinkAndRefreshGradleProject(externalProjectPath, project, false);
     }
 
     public static void linkAndImportGradleProject(Project project, String externalProjectPath) {
+        awaitStartupActivities(project, externalProjectPath);
+        if (isGradleReloadActive(project)) {
+            awaitGradleModelSettlement(project);
+            return;
+        }
+
         CompletableFuture<Void> importFuture = new CompletableFuture<>();
         try {
-            GradleProjectSettings linkSettings =
-                GradleProjectImportUtil.createLinkSettings(Path.of(externalProjectPath), project);
             ImportSpecBuilder importSpec = new ImportSpecBuilder(project, GradleConstants.SYSTEM_ID)
                 .withCallback(importFuture);
-            ExternalSystemUtil.linkExternalProject(linkSettings, importSpec);
-            importFuture.get(5, TimeUnit.MINUTES);
+            if (isGradleProjectLinked(project, externalProjectPath)) {
+                ExternalSystemUtil.refreshProject(externalProjectPath, importSpec);
+            } else {
+                GradleProjectSettings linkSettings =
+                    GradleProjectImportUtil.createLinkSettings(Path.of(externalProjectPath), project);
+                ExternalSystemUtil.linkExternalProject(linkSettings, importSpec);
+            }
+            awaitImport(importFuture, externalProjectPath);
         } catch (InterruptedException error) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Interrupted while importing Gradle project: " + externalProjectPath, error);
         } catch (ExecutionException error) {
             Throwable cause = error.getCause() == null ? error : error.getCause();
+            if (isGradleReloadActive(project) || isConcurrentGradleSyncFailure(cause)) {
+                awaitGradleModelSettlement(project);
+                return;
+            }
             throw new IllegalStateException("Gradle project import failed: " + externalProjectPath, cause);
         } catch (TimeoutException error) {
             throw new IllegalStateException("Timed out importing Gradle project: " + externalProjectPath, error);
         }
     }
 
-    public static void awaitSmartMode(Project project) {
-        DumbService.getInstance(project).waitForSmartMode();
+    public static boolean hasLinkedProject(
+        Collection<GradleProjectSettings> linkedProjects,
+        String externalProjectPath
+    ) {
+        Path expectedPath = Path.of(externalProjectPath).toAbsolutePath().normalize();
+        return linkedProjects.stream()
+            .map(GradleProjectSettings::getExternalProjectPath)
+            .filter(path -> path != null && !path.isBlank())
+            .map(Path::of)
+            .map(path -> path.toAbsolutePath().normalize())
+            .anyMatch(expectedPath::equals);
+    }
+
+    public static HeadlessGradleModelReadiness inspectProjectModel(Project project) {
+        return DumbService.getInstance(project).runReadActionInSmartMode(() -> {
+            List<Module> modules = Arrays.stream(ModuleManager.getInstance(project).getModules())
+                .filter(module -> !module.isDisposed())
+                .sorted(Comparator.comparing(Module::getName))
+                .toList();
+            List<String> moduleNames = modules.stream().map(Module::getName).toList();
+            List<Module> kotlinSourceModules = modules.stream()
+                .filter(HeadlessGradleProjectImportBridge::hasKotlinSources)
+                .toList();
+            List<String> kotlinSourceModuleNames = kotlinSourceModules.stream().map(Module::getName).toList();
+            List<String> compilerReadyKotlinModuleNames = kotlinSourceModules.stream()
+                .filter(module -> hasUsableKotlinCompilerModel(project, module))
+                .map(Module::getName)
+                .toList();
+            return new HeadlessGradleModelReadiness(
+                moduleNames,
+                kotlinSourceModuleNames,
+                compilerReadyKotlinModuleNames
+            );
+        });
+    }
+
+    private static boolean hasKotlinSources(Module module) {
+        GlobalSearchScope moduleScope = GlobalSearchScope.moduleScope(module);
+        FileTypeManager fileTypes = FileTypeManager.getInstance();
+        FileType kotlinSource = fileTypes.getFileTypeByExtension("kt");
+        FileType kotlinScript = fileTypes.getFileTypeByExtension("kts");
+        return FileTypeIndex.containsFileOfType(kotlinSource, moduleScope)
+            || FileTypeIndex.containsFileOfType(kotlinScript, moduleScope);
+    }
+
+    private static boolean hasUsableKotlinCompilerModel(Project project, Module module) {
+        ModuleRootManager roots = ModuleRootManager.getInstance(module);
+        OrderEntry[] orderEntries = roots.getOrderEntries();
+        boolean everyOrderEntryResolved = Arrays.stream(orderEntries).allMatch(OrderEntry::isValid);
+        GlobalSearchScope compilerScope = GlobalSearchScope.moduleWithDependenciesAndLibrariesScope(module);
+        JavaPsiFacade javaPsi = JavaPsiFacade.getInstance(project);
+        boolean jdkResolvable = javaPsi.findClass("java.nio.file.Path", compilerScope) != null;
+        boolean kotlinRuntimeResolvable = javaPsi.findClass("kotlin.jvm.internal.Intrinsics", compilerScope) != null;
+        return roots.getSdk() != null && everyOrderEntryResolved && jdkResolvable && kotlinRuntimeResolvable;
+    }
+
+    private static boolean isGradleProjectLinked(Project project, String externalProjectPath) {
+        return hasLinkedProject(
+            GradleSettings.getInstance(project).getLinkedProjectsSettings(),
+            externalProjectPath
+        );
+    }
+
+    private static void awaitImport(CompletableFuture<Void> importFuture, String externalProjectPath)
+        throws InterruptedException, ExecutionException, TimeoutException {
+        importFuture.get(5, TimeUnit.MINUTES);
+    }
+
+    public static void awaitGradleModelSettlement(Project project) {
+        awaitStartupActivities(project, project.getBasePath() == null ? project.getName() : project.getBasePath());
+        long deadlineNanos = System.nanoTime() + TimeUnit.MINUTES.toNanos(5);
+        int stableObservations = 0;
+        while (stableObservations < 10) {
+            boolean gradleIdle = !isGradleReloadActive(project);
+            boolean smart = !DumbService.getInstance(project).isDumb();
+            stableObservations = gradleIdle && smart ? stableObservations + 1 : 0;
+            if (stableObservations < 10) {
+                pauseUntilNextObservation(deadlineNanos, "Gradle model settlement");
+            }
+        }
+    }
+
+    static boolean isConcurrentGradleSyncFailure(Throwable failure) {
+        String message = failure.getMessage();
+        return message != null
+            && message.startsWith("Another 'Sync project' task is currently running for the project:");
+    }
+
+    private static boolean isGradleReloadActive(Project project) {
+        ObservableOperationTrace reload = GradleImportingUtil.getGradleProjectReloadOperation(project, project);
+        ObservableOperationStatus status = reload.getStatus();
+        return status == ObservableOperationStatus.SCHEDULED
+            || status == ObservableOperationStatus.IN_PROGRESS
+            || ExternalSystemProcessingManager.getInstance()
+                .hasTaskOfTypeInProgress(ExternalSystemTaskType.RESOLVE_PROJECT, project);
+    }
+
+    private static void awaitStartupActivities(Project project, String externalProjectPath) {
+        StartupManager startup = StartupManager.getInstance(project);
+        long deadlineNanos = System.nanoTime() + TimeUnit.MINUTES.toNanos(5);
+        while (!startup.postStartupActivityPassed()) {
+            if (project.isDisposed()) {
+                throw new IllegalStateException(
+                    "Project was disposed before startup activities completed: " + externalProjectPath
+                );
+            }
+            pauseUntilNextObservation(deadlineNanos, "project startup activities for " + externalProjectPath);
+        }
+    }
+
+    private static void pauseUntilNextObservation(long deadlineNanos, String operation) {
+        if (System.nanoTime() >= deadlineNanos) {
+            throw new IllegalStateException("Timed out waiting for " + operation);
+        }
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException error) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for " + operation, error);
+        }
     }
 }

--- a/backend-headless/src/main/java/io/github/amichne/kast/headless/HeadlessGradleProjectImportBridge.java
+++ b/backend-headless/src/main/java/io/github/amichne/kast/headless/HeadlessGradleProjectImportBridge.java
@@ -22,6 +22,7 @@ import com.intellij.util.execution.ParametersListUtil;
 import org.jetbrains.plugins.gradle.service.project.open.GradleProjectImportUtil;
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings;
 import org.jetbrains.plugins.gradle.settings.GradleSettings;
+import org.jetbrains.plugins.gradle.settings.GradleSystemSettings;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
 import org.jetbrains.plugins.gradle.util.GradleImportingUtil;
 
@@ -34,12 +35,21 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
 public final class HeadlessGradleProjectImportBridge {
     private static final String DISABLE_DEPENDENCY_SOURCE_DOWNLOADS =
         "-Didea.gradle.download.sources.force=false";
 
     private HeadlessGradleProjectImportBridge() {
+    }
+
+    public static void configureHeadlessApplication() {
+        configureHeadlessApplication(enabled -> GradleSystemSettings.getInstance().setDownloadSources(enabled));
+    }
+
+    static void configureHeadlessApplication(Consumer<Boolean> updateDownloadSources) {
+        updateDownloadSources.accept(false);
     }
 
     public static void configureHeadlessImport(Project project) {

--- a/backend-headless/src/main/java/io/github/amichne/kast/headless/HeadlessGradleProjectImportBridge.java
+++ b/backend-headless/src/main/java/io/github/amichne/kast/headless/HeadlessGradleProjectImportBridge.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.startup.StartupManager;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.search.FileTypeIndex;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.util.execution.ParametersListUtil;
 import org.jetbrains.plugins.gradle.service.project.open.GradleProjectImportUtil;
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings;
 import org.jetbrains.plugins.gradle.settings.GradleSettings;
@@ -35,7 +36,26 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public final class HeadlessGradleProjectImportBridge {
+    private static final String DISABLE_DEPENDENCY_SOURCE_DOWNLOADS =
+        "-Didea.gradle.download.sources.force=false";
+
     private HeadlessGradleProjectImportBridge() {
+    }
+
+    public static void configureHeadlessImport(Project project) {
+        GradleSettings settings = GradleSettings.getInstance(project);
+        settings.setGradleVmOptions(withDependencySourceDownloadsDisabled(settings.getGradleVmOptions()));
+    }
+
+    static String withDependencySourceDownloadsDisabled(String currentOptions) {
+        if (currentOptions != null
+            && ParametersListUtil.parse(currentOptions).contains(DISABLE_DEPENDENCY_SOURCE_DOWNLOADS)) {
+            return currentOptions;
+        }
+        if (currentOptions == null || currentOptions.isBlank()) {
+            return DISABLE_DEPENDENCY_SOURCE_DOWNLOADS;
+        }
+        return currentOptions + " " + DISABLE_DEPENDENCY_SOURCE_DOWNLOADS;
     }
 
     public static boolean canLinkAndRefreshGradleProject(String externalProjectPath, Project project) {

--- a/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessGradleModelReadiness.kt
+++ b/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessGradleModelReadiness.kt
@@ -1,0 +1,27 @@
+package io.github.amichne.kast.headless
+
+data class HeadlessGradleModelReadiness(
+    val moduleNames: List<String>,
+    val kotlinSourceModuleNames: List<String>,
+    val compilerReadyKotlinModuleNames: List<String>,
+) {
+    init {
+        require(moduleNames == moduleNames.distinct().sorted()) { "moduleNames must be sorted and unique" }
+        require(kotlinSourceModuleNames == kotlinSourceModuleNames.distinct().sorted()) {
+            "kotlinSourceModuleNames must be sorted and unique"
+        }
+        require(compilerReadyKotlinModuleNames == compilerReadyKotlinModuleNames.distinct().sorted()) {
+            "compilerReadyKotlinModuleNames must be sorted and unique"
+        }
+        require(moduleNames.containsAll(kotlinSourceModuleNames)) { "Kotlin source modules must belong to the imported model" }
+        require(kotlinSourceModuleNames.containsAll(compilerReadyKotlinModuleNames)) {
+            "compiler-ready Kotlin modules must be Kotlin source modules"
+        }
+    }
+
+    val unavailableKotlinModuleNames: List<String>
+        get() = kotlinSourceModuleNames - compilerReadyKotlinModuleNames.toSet()
+
+    val compilerReady: Boolean
+        get() = kotlinSourceModuleNames.isNotEmpty() && unavailableKotlinModuleNames.isEmpty()
+}

--- a/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessGradleModelUnavailableException.kt
+++ b/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessGradleModelUnavailableException.kt
@@ -1,0 +1,3 @@
+package io.github.amichne.kast.headless
+
+class HeadlessGradleModelUnavailableException(message: String) : IllegalStateException(message)

--- a/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessGradleProjectBootstrap.kt
+++ b/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessGradleProjectBootstrap.kt
@@ -1,0 +1,90 @@
+package io.github.amichne.kast.headless
+
+import com.intellij.openapi.project.Project
+import java.nio.file.Path
+
+class HeadlessGradleProjectBootstrap(
+    private val waitForProjectModel: (Project) -> Unit = { project ->
+        HeadlessGradleProjectImportBridge.awaitGradleModelSettlement(project)
+    },
+    private val inspectProjectModel: (Project) -> HeadlessGradleModelReadiness = { project ->
+        HeadlessGradleProjectImportBridge.inspectProjectModel(project)
+    },
+    private val canLinkGradleProject: (String, Project) -> Boolean = { externalProjectPath, project ->
+        HeadlessGradleProjectImportBridge.canLinkAndRefreshGradleProject(externalProjectPath, project)
+    },
+    private val linkAndImportGradleProject: (Project, String) -> Unit = { project, externalProjectPath ->
+        HeadlessGradleProjectImportBridge.linkAndImportGradleProject(project, externalProjectPath)
+    },
+    private val waitBeforeReadinessRetry: () -> Unit = {
+        try {
+            Thread.sleep(MODEL_READINESS_RETRY_MILLIS)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw HeadlessGradleModelUnavailableException("Interrupted while waiting for a compiler-ready Gradle model")
+        }
+    },
+    private val maxReadinessChecks: Int = DEFAULT_MODEL_READINESS_CHECKS,
+) {
+    init {
+        require(maxReadinessChecks > 0) { "maxReadinessChecks must be positive" }
+    }
+
+    fun bootstrap(
+        project: Project,
+        workspaceRoot: Path,
+        workspaceKind: HeadlessWorkspaceKind,
+    ): HeadlessProjectModelBootstrapResult {
+        if (workspaceKind != HeadlessWorkspaceKind.GRADLE) {
+            return HeadlessProjectModelBootstrapResult.Skipped("not a Gradle project")
+        }
+
+        val modelBeforeSync = inspectProjectModel(project)
+        val externalProjectPath = workspaceRoot.toAbsolutePath().normalize().toString()
+        if (!canLinkGradleProject(externalProjectPath, project)) {
+            throw HeadlessGradleModelUnavailableException(
+                "Kast opened a Gradle checkout at $externalProjectPath, but IDEA cannot synchronize it as a Gradle project. " +
+                    "IDEA reported ${modelBeforeSync.moduleNames.size} modules before synchronization. " +
+                    "Kast does not require checked-in .idea/gradle.xml; verify the checkout can be synced by Gradle " +
+                    "and that the packaged headless IDEA home includes the Gradle plugins.",
+            )
+        }
+
+        waitForProjectModel(project)
+        var latestModel = inspectProjectModel(project)
+        if (latestModel.compilerReady) {
+            return HeadlessProjectModelBootstrapResult.Ready(
+                moduleNames = latestModel.moduleNames,
+                linkedGradleProject = true,
+            )
+        }
+
+        linkAndImportGradleProject(project, externalProjectPath)
+        repeat(maxReadinessChecks) { attempt ->
+            waitForProjectModel(project)
+            latestModel = inspectProjectModel(project)
+            if (latestModel.compilerReady) {
+                return HeadlessProjectModelBootstrapResult.Ready(
+                    moduleNames = latestModel.moduleNames,
+                    linkedGradleProject = true,
+                )
+            }
+            if (attempt + 1 < maxReadinessChecks) {
+                waitBeforeReadinessRetry()
+            }
+        }
+        throw HeadlessGradleModelUnavailableException(
+                "Kast synchronized the Gradle checkout at $externalProjectPath, but its compiler model did not become usable. " +
+                "IDEA reported ${latestModel.moduleNames.size} modules, " +
+                "${latestModel.kotlinSourceModuleNames.size} Kotlin source modules, and " +
+                "${latestModel.compilerReadyKotlinModuleNames.size} compiler-ready Kotlin modules. " +
+                "Unready Kotlin modules: ${latestModel.unavailableKotlinModuleNames.joinToString().ifEmpty { "<none discovered>" }}. " +
+                "The headless backend must not advertise READY until Gradle is idle and Kotlin, JDK, SDK, library, and order-entry resolution are coherent.",
+        )
+    }
+
+    private companion object {
+        const val MODEL_READINESS_RETRY_MILLIS: Long = 250L
+        const val DEFAULT_MODEL_READINESS_CHECKS: Int = 240
+    }
+}

--- a/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessGradleProjectBootstrap.kt
+++ b/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessGradleProjectBootstrap.kt
@@ -4,6 +4,9 @@ import com.intellij.openapi.project.Project
 import java.nio.file.Path
 
 class HeadlessGradleProjectBootstrap(
+    private val configureGradleImport: (Project) -> Unit = { project ->
+        HeadlessGradleProjectImportBridge.configureHeadlessImport(project)
+    },
     private val waitForProjectModel: (Project) -> Unit = { project ->
         HeadlessGradleProjectImportBridge.awaitGradleModelSettlement(project)
     },
@@ -39,6 +42,7 @@ class HeadlessGradleProjectBootstrap(
             return HeadlessProjectModelBootstrapResult.Skipped("not a Gradle project")
         }
 
+        configureGradleImport(project)
         val modelBeforeSync = inspectProjectModel(project)
         val externalProjectPath = workspaceRoot.toAbsolutePath().normalize().toString()
         if (!canLinkGradleProject(externalProjectPath, project)) {

--- a/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessProjectModelBootstrapResult.kt
+++ b/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessProjectModelBootstrapResult.kt
@@ -1,0 +1,9 @@
+package io.github.amichne.kast.headless
+
+sealed class HeadlessProjectModelBootstrapResult {
+    data class Skipped(val reason: String) : HeadlessProjectModelBootstrapResult()
+    data class Ready(
+        val moduleNames: List<String>,
+        val linkedGradleProject: Boolean,
+    ) : HeadlessProjectModelBootstrapResult()
+}

--- a/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessProjectOpener.kt
+++ b/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessProjectOpener.kt
@@ -1,10 +1,8 @@
 package io.github.amichne.kast.headless
 
 import com.intellij.ide.impl.OpenProjectTask
-import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ex.ProjectManagerEx
-import java.nio.file.Files
 import java.nio.file.Path
 
 class HeadlessProjectOpener(
@@ -31,85 +29,3 @@ class HeadlessProjectOpener(
         )
     }
 }
-
-enum class HeadlessWorkspaceKind {
-    GRADLE,
-    PLAIN,
-    ;
-
-    companion object {
-        fun detect(workspaceRoot: Path): HeadlessWorkspaceKind =
-            if (GRADLE_MARKERS.any { marker -> Files.isRegularFile(workspaceRoot.resolve(marker)) }) {
-                GRADLE
-            } else {
-                PLAIN
-            }
-
-        private val GRADLE_MARKERS = listOf(
-            "settings.gradle.kts",
-            "settings.gradle",
-            "build.gradle.kts",
-            "build.gradle",
-        )
-    }
-}
-
-class HeadlessGradleProjectBootstrap(
-    private val waitForProjectModel: (Project) -> Unit = { project ->
-        HeadlessGradleProjectImportBridge.awaitSmartMode(project)
-    },
-    private val moduleNames: (Project) -> List<String> = { project ->
-        ModuleManager.getInstance(project).modules.map { module -> module.name }.sorted()
-    },
-    private val canLinkGradleProject: (String, Project) -> Boolean = { externalProjectPath, project ->
-        HeadlessGradleProjectImportBridge.canLinkAndRefreshGradleProject(externalProjectPath, project)
-    },
-    private val linkAndImportGradleProject: (Project, String) -> Unit = { project, externalProjectPath ->
-        HeadlessGradleProjectImportBridge.linkAndImportGradleProject(project, externalProjectPath)
-    },
-) {
-    fun bootstrap(
-        project: Project,
-        workspaceRoot: Path,
-        workspaceKind: HeadlessWorkspaceKind,
-    ): HeadlessProjectModelBootstrapResult {
-        if (workspaceKind != HeadlessWorkspaceKind.GRADLE) {
-            return HeadlessProjectModelBootstrapResult.Skipped("not a Gradle project")
-        }
-
-        val initialModuleNames = moduleNames(project)
-        if (initialModuleNames.isNotEmpty()) {
-            return HeadlessProjectModelBootstrapResult.Ready(moduleNames = initialModuleNames, linkedGradleProject = false)
-        }
-
-        val externalProjectPath = workspaceRoot.toAbsolutePath().normalize().toString()
-        if (!canLinkGradleProject(externalProjectPath, project)) {
-            throw HeadlessGradleModelUnavailableException(
-                "Kast opened a Gradle checkout at $externalProjectPath, but IDEA cannot link it as a Gradle project. " +
-                    "Kast does not require checked-in .idea/gradle.xml; verify the checkout can be synced by Gradle " +
-                    "and that the packaged headless IDEA home includes the Gradle plugins.",
-            )
-        }
-
-        linkAndImportGradleProject(project, externalProjectPath)
-        waitForProjectModel(project)
-        val importedModuleNames = moduleNames(project)
-        if (importedModuleNames.isEmpty()) {
-            throw HeadlessGradleModelUnavailableException(
-                "Kast linked the Gradle checkout at $externalProjectPath, but IDEA still reported no source modules. " +
-                    "The headless backend needs the imported Gradle model and must not run against an empty IDEA project model.",
-            )
-        }
-        return HeadlessProjectModelBootstrapResult.Ready(moduleNames = importedModuleNames, linkedGradleProject = true)
-    }
-}
-
-sealed class HeadlessProjectModelBootstrapResult {
-    data class Skipped(val reason: String) : HeadlessProjectModelBootstrapResult()
-    data class Ready(
-        val moduleNames: List<String>,
-        val linkedGradleProject: Boolean,
-    ) : HeadlessProjectModelBootstrapResult()
-}
-
-class HeadlessGradleModelUnavailableException(message: String) : IllegalStateException(message)

--- a/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessRuntime.kt
+++ b/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessRuntime.kt
@@ -108,6 +108,7 @@ object HeadlessRuntime {
         configureSystemProperties()
         val serverOptions = options.serverOptions
         val workspaceRoot = serverOptions.workspaceRoot
+        HeadlessGradleProjectImportBridge.configureHeadlessApplication()
         val project = projectOpener.openProject(workspaceRoot)
         val config = options.runtimeConfig ?: KastConfig.load(
             workspaceRoot = workspaceRoot,

--- a/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessWorkspaceKind.kt
+++ b/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessWorkspaceKind.kt
@@ -1,0 +1,26 @@
+package io.github.amichne.kast.headless
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+enum class HeadlessWorkspaceKind {
+    GRADLE,
+    PLAIN,
+    ;
+
+    companion object {
+        fun detect(workspaceRoot: Path): HeadlessWorkspaceKind =
+            if (GRADLE_MARKERS.any { marker -> Files.isRegularFile(workspaceRoot.resolve(marker)) }) {
+                GRADLE
+            } else {
+                PLAIN
+            }
+
+        private val GRADLE_MARKERS = listOf(
+            "settings.gradle.kts",
+            "settings.gradle",
+            "build.gradle.kts",
+            "build.gradle",
+        )
+    }
+}

--- a/backend-headless/src/test/kotlin/io/github/amichne/kast/headless/HeadlessServerOptionsTest.kt
+++ b/backend-headless/src/test/kotlin/io/github/amichne/kast/headless/HeadlessServerOptionsTest.kt
@@ -137,6 +137,47 @@ class HeadlessServerOptionsTest {
     }
 
     @Test
+    fun `headless Gradle import disables dependency source downloads without discarding VM options`() {
+        val disableSources = "-Didea.gradle.download.sources.force=false"
+
+        assertEquals(
+            disableSources,
+            HeadlessGradleProjectImportBridge.withDependencySourceDownloadsDisabled(null),
+        )
+        assertEquals(
+            "-Xmx2g $disableSources",
+            HeadlessGradleProjectImportBridge.withDependencySourceDownloadsDisabled("-Xmx2g"),
+        )
+        assertEquals(
+            "-Xmx2g $disableSources",
+            HeadlessGradleProjectImportBridge.withDependencySourceDownloadsDisabled("-Xmx2g $disableSources"),
+        )
+    }
+
+    @Test
+    fun `Gradle bootstrap configures the lean headless import before inspecting the model`() {
+        val workspace = tempDir.resolve("workspace")
+        val phases = mutableListOf<String>()
+        val bootstrap = HeadlessGradleProjectBootstrap(
+            configureGradleImport = { phases += "configure" },
+            waitForProjectModel = {},
+            inspectProjectModel = {
+                phases += "inspect"
+                modelReadiness(moduleNames = listOf(":app"))
+            },
+            canLinkGradleProject = { _, _ -> true },
+        )
+
+        val result = bootstrap.bootstrap(projectStub(), workspace, HeadlessWorkspaceKind.GRADLE)
+
+        assertEquals(
+            HeadlessProjectModelBootstrapResult.Ready(moduleNames = listOf(":app"), linkedGradleProject = true),
+            result,
+        )
+        assertEquals(listOf("configure", "inspect", "inspect"), phases)
+    }
+
+    @Test
     fun `workspace kind detects Gradle marker files`() {
         val workspace = tempDir.resolve("workspace")
         Files.createDirectories(workspace)
@@ -158,6 +199,7 @@ class HeadlessServerOptionsTest {
             ),
         )
         val bootstrap = HeadlessGradleProjectBootstrap(
+            configureGradleImport = {},
             waitForProjectModel = {
                 waitCount += 1
             },
@@ -192,6 +234,7 @@ class HeadlessServerOptionsTest {
             ),
         )
         val bootstrap = HeadlessGradleProjectBootstrap(
+            configureGradleImport = {},
             waitForProjectModel = { waitCount += 1 },
             inspectProjectModel = { modelSnapshots.removeFirst() },
             canLinkGradleProject = { _, _ -> true },
@@ -227,6 +270,7 @@ class HeadlessServerOptionsTest {
             ),
         )
         val bootstrap = HeadlessGradleProjectBootstrap(
+            configureGradleImport = {},
             waitForProjectModel = {
                 waitCount += 1
             },
@@ -315,6 +359,7 @@ class HeadlessServerOptionsTest {
             ),
         )
         val bootstrap = HeadlessGradleProjectBootstrap(
+            configureGradleImport = {},
             waitForProjectModel = { waitCount += 1 },
             inspectProjectModel = { modelSnapshots.removeFirst() },
             canLinkGradleProject = { _, _ -> true },
@@ -337,6 +382,7 @@ class HeadlessServerOptionsTest {
     fun `Gradle bootstrap fails when sync still reports no modules`() {
         val workspace = tempDir.resolve("workspace")
         val bootstrap = HeadlessGradleProjectBootstrap(
+            configureGradleImport = {},
             waitForProjectModel = {},
             inspectProjectModel = { modelReadiness() },
             canLinkGradleProject = { _, _ -> true },

--- a/backend-headless/src/test/kotlin/io/github/amichne/kast/headless/HeadlessServerOptionsTest.kt
+++ b/backend-headless/src/test/kotlin/io/github/amichne/kast/headless/HeadlessServerOptionsTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.jetbrains.plugins.gradle.settings.GradleProjectSettings
 import java.lang.reflect.Proxy
 import java.nio.file.Files
 import java.nio.file.Path
@@ -149,13 +150,19 @@ class HeadlessServerOptionsTest {
         val workspace = tempDir.resolve("workspace")
         val observedPaths = mutableListOf<String>()
         var waitCount = 0
-        val moduleSnapshots = ArrayDeque(listOf(emptyList<String>(), listOf(":app")))
+        val modelSnapshots = ArrayDeque(
+            listOf(
+                modelReadiness(),
+                modelReadiness(),
+                modelReadiness(moduleNames = listOf(":app")),
+            ),
+        )
         val bootstrap = HeadlessGradleProjectBootstrap(
             waitForProjectModel = {
                 waitCount += 1
             },
-            moduleNames = {
-                moduleSnapshots.removeFirst()
+            inspectProjectModel = {
+                modelSnapshots.removeFirst()
             },
             canLinkGradleProject = { _, _ -> true },
             linkAndImportGradleProject = { _, externalProjectPath ->
@@ -170,7 +177,160 @@ class HeadlessServerOptionsTest {
             result,
         )
         assertEquals(listOf(workspace.toAbsolutePath().normalize().toString()), observedPaths)
+        assertEquals(2, waitCount)
+    }
+
+    @Test
+    fun `Gradle bootstrap adopts an automatic startup sync without scheduling another import`() {
+        val workspace = tempDir.resolve("workspace")
+        var waitCount = 0
+        var explicitImportCount = 0
+        val modelSnapshots = ArrayDeque(
+            listOf(
+                modelReadiness(),
+                modelReadiness(moduleNames = listOf(":app")),
+            ),
+        )
+        val bootstrap = HeadlessGradleProjectBootstrap(
+            waitForProjectModel = { waitCount += 1 },
+            inspectProjectModel = { modelSnapshots.removeFirst() },
+            canLinkGradleProject = { _, _ -> true },
+            linkAndImportGradleProject = { _, _ -> explicitImportCount += 1 },
+        )
+
+        val result = bootstrap.bootstrap(projectStub(), workspace, HeadlessWorkspaceKind.GRADLE)
+
+        assertEquals(
+            HeadlessProjectModelBootstrapResult.Ready(moduleNames = listOf(":app"), linkedGradleProject = true),
+            result,
+        )
         assertEquals(1, waitCount)
+        assertEquals(0, explicitImportCount)
+    }
+
+    @Test
+    fun `Gradle bootstrap refreshes a persisted module model before declaring readiness`() {
+        val workspace = tempDir.resolve("workspace")
+        val observedPaths = mutableListOf<String>()
+        var waitCount = 0
+        val modelSnapshots = ArrayDeque(
+            listOf(
+                modelReadiness(
+                    moduleNames = listOf(":stale"),
+                    compilerReadyKotlinModuleNames = emptyList(),
+                ),
+                modelReadiness(
+                    moduleNames = listOf(":stale"),
+                    compilerReadyKotlinModuleNames = emptyList(),
+                ),
+                modelReadiness(moduleNames = listOf(":fresh")),
+            ),
+        )
+        val bootstrap = HeadlessGradleProjectBootstrap(
+            waitForProjectModel = {
+                waitCount += 1
+            },
+            inspectProjectModel = {
+                modelSnapshots.removeFirst()
+            },
+            canLinkGradleProject = { _, _ -> true },
+            linkAndImportGradleProject = { _, externalProjectPath ->
+                observedPaths += externalProjectPath
+            },
+        )
+
+        val result = bootstrap.bootstrap(projectStub(), workspace, HeadlessWorkspaceKind.GRADLE)
+
+        assertEquals(
+            HeadlessProjectModelBootstrapResult.Ready(moduleNames = listOf(":fresh"), linkedGradleProject = true),
+            result,
+        )
+        assertEquals(listOf(workspace.toAbsolutePath().normalize().toString()), observedPaths)
+        assertEquals(2, waitCount)
+    }
+
+    @Test
+    fun `existing Gradle link is recognized without registering the checkout twice`() {
+        val workspace = tempDir.resolve("workspace").toAbsolutePath().normalize()
+        val linkedProject = GradleProjectSettings().apply {
+            externalProjectPath = workspace.resolve(".").toString()
+        }
+
+        assertTrue(
+            HeadlessGradleProjectImportBridge.hasLinkedProject(
+                listOf(linkedProject),
+                workspace.toString(),
+            ),
+        )
+        assertEquals(
+            false,
+            HeadlessGradleProjectImportBridge.hasLinkedProject(
+                listOf(linkedProject),
+                workspace.resolveSibling("other").toString(),
+            ),
+        )
+    }
+
+    @Test
+    fun `concurrent Gradle sync failure is recognized as existing work`() {
+        assertTrue(
+            HeadlessGradleProjectImportBridge.isConcurrentGradleSyncFailure(
+                RuntimeException("Another 'Sync project' task is currently running for the project: /workspace"),
+            ),
+        )
+    }
+
+    @Test
+    fun `Java-only source modules do not weaken Kotlin compiler readiness`() {
+        val readiness = modelReadiness(
+            moduleNames = listOf(":app", ":java-support"),
+            kotlinSourceModuleNames = listOf(":app"),
+            compilerReadyKotlinModuleNames = listOf(":app"),
+        )
+
+        assertTrue(readiness.compilerReady)
+        assertEquals(emptyList<String>(), readiness.unavailableKotlinModuleNames)
+    }
+
+    @Test
+    fun `Gradle bootstrap waits through a recovered but temporarily unusable compiler model`() {
+        val workspace = tempDir.resolve("workspace")
+        var waitCount = 0
+        var retryCount = 0
+        val modelSnapshots = ArrayDeque(
+            listOf(
+                modelReadiness(
+                    moduleNames = listOf(":app"),
+                    compilerReadyKotlinModuleNames = emptyList(),
+                ),
+                modelReadiness(
+                    moduleNames = listOf(":app"),
+                    compilerReadyKotlinModuleNames = emptyList(),
+                ),
+                modelReadiness(
+                    moduleNames = listOf(":app"),
+                    compilerReadyKotlinModuleNames = emptyList(),
+                ),
+                modelReadiness(moduleNames = listOf(":app")),
+            ),
+        )
+        val bootstrap = HeadlessGradleProjectBootstrap(
+            waitForProjectModel = { waitCount += 1 },
+            inspectProjectModel = { modelSnapshots.removeFirst() },
+            canLinkGradleProject = { _, _ -> true },
+            linkAndImportGradleProject = { _, _ -> },
+            waitBeforeReadinessRetry = { retryCount += 1 },
+            maxReadinessChecks = 2,
+        )
+
+        val result = bootstrap.bootstrap(projectStub(), workspace, HeadlessWorkspaceKind.GRADLE)
+
+        assertEquals(
+            HeadlessProjectModelBootstrapResult.Ready(moduleNames = listOf(":app"), linkedGradleProject = true),
+            result,
+        )
+        assertEquals(3, waitCount)
+        assertEquals(1, retryCount)
     }
 
     @Test
@@ -178,15 +338,27 @@ class HeadlessServerOptionsTest {
         val workspace = tempDir.resolve("workspace")
         val bootstrap = HeadlessGradleProjectBootstrap(
             waitForProjectModel = {},
-            moduleNames = { emptyList() },
+            inspectProjectModel = { modelReadiness() },
             canLinkGradleProject = { _, _ -> true },
             linkAndImportGradleProject = { _, _ -> },
+            waitBeforeReadinessRetry = {},
+            maxReadinessChecks = 1,
         )
 
         assertThrows(HeadlessGradleModelUnavailableException::class.java) {
             bootstrap.bootstrap(projectStub(), workspace, HeadlessWorkspaceKind.GRADLE)
         }
     }
+
+    private fun modelReadiness(
+        moduleNames: List<String> = emptyList(),
+        kotlinSourceModuleNames: List<String> = moduleNames,
+        compilerReadyKotlinModuleNames: List<String> = kotlinSourceModuleNames,
+    ): HeadlessGradleModelReadiness = HeadlessGradleModelReadiness(
+        moduleNames = moduleNames.sorted(),
+        kotlinSourceModuleNames = kotlinSourceModuleNames.sorted(),
+        compilerReadyKotlinModuleNames = compilerReadyKotlinModuleNames.sorted(),
+    )
 
     private fun projectStub(): Project =
         Proxy.newProxyInstance(

--- a/backend-headless/src/test/kotlin/io/github/amichne/kast/headless/HeadlessServerOptionsTest.kt
+++ b/backend-headless/src/test/kotlin/io/github/amichne/kast/headless/HeadlessServerOptionsTest.kt
@@ -13,6 +13,7 @@ import org.jetbrains.plugins.gradle.settings.GradleProjectSettings
 import java.lang.reflect.Proxy
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.function.Consumer
 import kotlin.io.path.writeText
 
 class HeadlessServerOptionsTest {
@@ -152,6 +153,15 @@ class HeadlessServerOptionsTest {
             "-Xmx2g $disableSources",
             HeadlessGradleProjectImportBridge.withDependencySourceDownloadsDisabled("-Xmx2g $disableSources"),
         )
+    }
+
+    @Test
+    fun `headless application disables dependency source downloads before project open`() {
+        val observedValues = mutableListOf<Boolean>()
+
+        HeadlessGradleProjectImportBridge.configureHeadlessApplication(Consumer(observedValues::add))
+
+        assertEquals(listOf(false), observedValues)
     }
 
     @Test

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaIndexSemanticAdmission.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaIndexSemanticAdmission.kt
@@ -1,0 +1,177 @@
+package io.github.amichne.kast.idea
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.psi.KtFile
+import java.util.concurrent.CancellationException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+internal class IdeaIndexSemanticAdmission(
+    private val project: Project,
+    private val inspectProject: () -> Inspection = { inspect(project, IdeaSemanticAdmissionOperations.idea()) },
+    private val nanoTime: () -> Long = System::nanoTime,
+    private val pause: (Long) -> Unit = { millis -> Thread.sleep(millis) },
+    private val maxWaitMillis: Long = TimeUnit.MINUTES.toMillis(5),
+    private val pollIntervalMillis: Long = 250L,
+) {
+    private val status = AtomicReference<Status>(Status.Pending("compiler-backed semantic admission has not started"))
+
+    init {
+        require(maxWaitMillis >= 0) { "maxWaitMillis must not be negative" }
+        require(pollIntervalMillis > 0) { "pollIntervalMillis must be positive" }
+    }
+
+    fun await(cancelled: () -> Boolean) {
+        val startedAtNanos = nanoTime()
+        try {
+            while (true) {
+                if (cancelled() || project.isDisposed || Thread.currentThread().isInterrupted) {
+                    throw InterruptedException("Kast source-index semantic admission was cancelled")
+                }
+                val pending = when (val inspection = inspectProject()) {
+                    Inspection.Ready -> {
+                        status.set(Status.Ready)
+                        return
+                    }
+                    is Inspection.Pending -> inspection.also {
+                        status.set(Status.Pending(it.detail))
+                    }
+                }
+                val elapsedMillis = elapsedMillisSince(startedAtNanos)
+                if (elapsedMillis >= maxWaitMillis) {
+                    throw IllegalStateException(
+                        "Kast source index cannot become READY because compiler-backed semantic admission timed out: " +
+                            pending.detail,
+                    )
+                }
+                try {
+                    pause(minOf(pollIntervalMillis, maxWaitMillis - elapsedMillis))
+                } catch (error: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    throw error
+                }
+            }
+        } catch (failure: Throwable) {
+            status.set(
+                Status.Failed(
+                    failure.message?.takeIf(String::isNotBlank)
+                        ?: failure::class.qualifiedName.orEmpty(),
+                ),
+            )
+            throw failure
+        }
+    }
+
+    fun status(): Status = status.get()
+
+    private fun elapsedMillisSince(startedAtNanos: Long): Long =
+        ((nanoTime() - startedAtNanos).coerceAtLeast(0L) / NANOS_PER_MILLISECOND)
+
+    sealed interface Inspection {
+        data object Ready : Inspection
+
+        data class Pending(val detail: String) : Inspection {
+            init {
+                require(detail.isNotBlank()) { "Pending semantic-admission detail must not be blank" }
+            }
+        }
+    }
+
+    sealed interface Status {
+        data object Ready : Status
+
+        data class Pending(val detail: String) : Status {
+            init {
+                require(detail.isNotBlank()) { "Pending semantic-admission detail must not be blank" }
+            }
+        }
+
+        data class Failed(val detail: String) : Status {
+            init {
+                require(detail.isNotBlank()) { "Failed semantic-admission detail must not be blank" }
+            }
+        }
+    }
+
+    private companion object {
+        const val NANOS_PER_MILLISECOND = 1_000_000L
+
+        fun inspect(
+            project: Project,
+            operations: IdeaSemanticAdmissionOperations,
+        ): Inspection = ApplicationManager.getApplication().runReadAction<Inspection> {
+            if (DumbService.isDumb(project)) {
+                return@runReadAction Inspection.Pending("IDEA indexing is still in progress")
+            }
+            val kotlinFileType = FileTypeManager.getInstance().findFileTypeByName("Kotlin")
+                ?: return@runReadAction Inspection.Pending("the Kotlin file type is unavailable")
+            val kotlinModules = ModuleManager.getInstance(project).modules
+                .asSequence()
+                .filterNot(Module::isDisposed)
+                .mapNotNull { module ->
+                    val representative = FileTypeIndex.getFiles(
+                        kotlinFileType,
+                        GlobalSearchScope.moduleScope(module),
+                    ).asSequence()
+                        .filter { file -> file.isValid && !file.isDirectory }
+                        .minByOrNull { file -> file.path }
+                    representative?.let { file -> module to file }
+                }
+                .sortedBy { (module, _) -> module.name }
+                .toList()
+            if (kotlinModules.isEmpty()) {
+                return@runReadAction Inspection.Pending("no Kotlin source module has been admitted to the project model")
+            }
+
+            val javaPsi = JavaPsiFacade.getInstance(project)
+            kotlinModules.forEach { (module, representative) ->
+                val roots = ModuleRootManager.getInstance(module)
+                if (roots.sdk == null) {
+                    return@runReadAction Inspection.Pending("module ${module.name} has no SDK")
+                }
+                if (roots.orderEntries.any { entry -> !entry.isValid }) {
+                    return@runReadAction Inspection.Pending("module ${module.name} has unresolved order entries")
+                }
+                val compilerScope = GlobalSearchScope.moduleWithDependenciesAndLibrariesScope(module)
+                if (javaPsi.findClass("java.nio.file.Path", compilerScope) == null) {
+                    return@runReadAction Inspection.Pending(
+                        "JDK symbol java.nio.file.Path is unresolved in module ${module.name}",
+                    )
+                }
+                if (javaPsi.findClass("kotlin.jvm.internal.Intrinsics", compilerScope) == null) {
+                    return@runReadAction Inspection.Pending(
+                        "Kotlin runtime symbol kotlin.jvm.internal.Intrinsics is unresolved in module ${module.name}",
+                    )
+                }
+                val ktFile = PsiManager.getInstance(project).findFile(representative) as? KtFile
+                    ?: return@runReadAction Inspection.Pending(
+                        "IDEA has not created Kotlin PSI for ${representative.path}",
+                    )
+                try {
+                    operations.collectDiagnostics(ktFile)
+                } catch (error: ProcessCanceledException) {
+                    throw error
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
+                    return@runReadAction Inspection.Pending(
+                        "Kotlin analysis is unavailable for ${representative.path}: " +
+                            (error.message?.takeIf(String::isNotBlank) ?: error::class.qualifiedName),
+                    )
+                }
+            }
+            Inspection.Ready
+        }
+    }
+}

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastIdeaBackendRuntime.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastIdeaBackendRuntime.kt
@@ -96,6 +96,7 @@ object KastIdeaBackendRuntime {
         val diagnostics = KastDiagnosticsService.getInstance(project)
         val limits = ideaServerLimits(config)
         val sourceIndexStore = SqliteSourceIndexStore(workspaceIdentity.workspaceIdentity)
+        val semanticAdmission = IdeaIndexSemanticAdmission(project)
         var pluginBackend: KastPluginBackend? = null
         val backend = try {
             val startedPluginBackend = KastPluginBackend(
@@ -106,6 +107,7 @@ object KastIdeaBackendRuntime {
                 backendName = backendName,
                 workspaceIdentity = workspaceIdentity,
                 referenceIndexLookup = DiagnosticsReferenceIndexLookup(diagnostics, sourceIndexStore),
+                indexSemanticAdmissionStatus = semanticAdmission::status,
             )
             pluginBackend = startedPluginBackend
             ObservedAnalysisBackend(
@@ -159,6 +161,7 @@ object KastIdeaBackendRuntime {
                 config = config,
                 diagnostics = diagnostics,
                 indexStore = sourceIndexStore,
+                semanticAdmission = semanticAdmission,
             ).also { it.start() }
             projectIndexing = startedProjectIndexing
             return RunningKastIdeaBackend(
@@ -190,6 +193,7 @@ internal class KastIdeaProjectIndexing(
     private val config: KastConfig,
     private val diagnostics: KastDiagnosticsService = KastDiagnosticsService.getInstance(project),
     private val indexStore: SqliteSourceIndexStore = SqliteSourceIndexStore(workspaceIdentity.workspaceIdentity),
+    private val semanticAdmission: IdeaIndexSemanticAdmission = IdeaIndexSemanticAdmission(project),
 ) {
     constructor(
         project: Project,
@@ -244,6 +248,9 @@ internal class KastIdeaProjectIndexing(
                         detail = workspaceIdentity.traceDetails(),
                     )
                     diagnostics.recordIndexHydrating()
+                    semanticAdmission.await {
+                        cancelled.get() || Thread.currentThread().isInterrupted || project.isDisposed
+                    }
                     runCatching {
                         SourceIndexHydrator().hydrate(workspaceRoot, config.indexing.remote)
                     }.onFailure { error ->

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
@@ -164,6 +164,9 @@ internal class KastPluginBackend(
     private val psiGeneration: () -> Long = { PsiModificationTracker.getInstance(project).modificationCount },
     private val readEpochObserver: IdeaReadEpochObserver = IdeaReadEpochObserver.Disabled,
     private val referenceTraversalObserver: ReferenceTraversalObserver = ReferenceTraversalObserver.Disabled,
+    private val indexSemanticAdmissionStatus: () -> IdeaIndexSemanticAdmission.Status = {
+        IdeaIndexSemanticAdmission.Status.Ready
+    },
 ) : CloseableAnalysisBackend {
 
     private val readDispatcher = Dispatchers.Default.limitedParallelism(limits.maxConcurrentRequests)
@@ -215,6 +218,15 @@ internal class KastPluginBackend(
         } ?: emptyList()
 
     private fun referenceSearchRoots(plan: ReferenceSearchPlan): List<Path> {
+        val targetFile = plan.target.element
+            ?.containingFile
+            ?.virtualFile
+            ?.path
+            ?.let(Path::of)
+        if (plan.scopeKind == SearchScopeKind.FILE && targetFile != null) {
+            return listOf(targetFile)
+        }
+
         val moduleRoots = ModuleManager.getInstance(project).modules
             .asSequence()
             .flatMap { module -> ModuleRootManager.getInstance(module).sourceRoots.asSequence() }
@@ -225,12 +237,7 @@ internal class KastPluginBackend(
             .toList()
         if (moduleRoots.isNotEmpty()) return moduleRoots
 
-        val targetDirectory = plan.target.element
-            ?.containingFile
-            ?.virtualFile
-            ?.parent
-            ?.path
-            ?.let(Path::of)
+        val targetDirectory = targetFile?.parent
         return listOfNotNull(targetDirectory)
     }
 
@@ -271,20 +278,28 @@ internal class KastPluginBackend(
     override suspend fun runtimeStatus(): RuntimeStatusResponse {
         val caps = capabilities()
         val isDumb = DumbService.isDumb(project)
-        val state = if (isDumb) RuntimeState.INDEXING else RuntimeState.READY
+        val admission = indexSemanticAdmissionStatus()
+        val state = when {
+            admission is IdeaIndexSemanticAdmission.Status.Failed -> RuntimeState.DEGRADED
+            isDumb || admission is IdeaIndexSemanticAdmission.Status.Pending -> RuntimeState.INDEXING
+            else -> RuntimeState.READY
+        }
         val moduleNames = ModuleManager.getInstance(project).modules.map { it.name }.sorted()
         return RuntimeStatusResponse(
             state = state,
-            healthy = true,
+            healthy = state != RuntimeState.DEGRADED,
             active = true,
-            indexing = isDumb,
+            indexing = state == RuntimeState.INDEXING,
             backendName = caps.backendName,
             backendVersion = caps.backendVersion,
             workspaceRoot = caps.workspaceRoot,
-            message = if (isDumb) {
-                "IDEA is indexing — analysis results may be incomplete"
-            } else {
-                "IDEA analysis backend is ready"
+            message = when {
+                admission is IdeaIndexSemanticAdmission.Status.Failed ->
+                    "IDEA compiler-backed semantic admission failed: ${admission.detail}"
+                isDumb -> "IDEA is indexing — analysis results may be incomplete"
+                admission is IdeaIndexSemanticAdmission.Status.Pending ->
+                    "IDEA compiler-backed semantic admission is pending: ${admission.detail}"
+                else -> "IDEA analysis backend is ready"
             },
             sourceModuleNames = moduleNames,
         )
@@ -411,6 +426,11 @@ internal class KastPluginBackend(
                     visibility = plan.visibility,
                     scope = plan.scopeKind,
                     exhaustive = outcome.completion.exhaustive && !outcome.hasMoreEvidence,
+                    candidateCoverage = if (outcome.completion.exhaustive) {
+                        SearchScope.CandidateCoverage.COMPLETE
+                    } else {
+                        SearchScope.CandidateCoverage.PARTIAL
+                    },
                     candidateFileCount = outcome.candidateFileCount,
                     searchedFileCount = outcome.searchedFileCount,
                 ),
@@ -562,6 +582,15 @@ internal class KastPluginBackend(
                             "continuationFailure" to "generationChanged",
                         ),
                     )
+                }
+                if (
+                    continuation == null &&
+                    lookup.page.references.isEmpty() &&
+                    lookup.page.nextOffset == null
+                ) {
+                    indexSpan.setAttribute("kast.references.indexReady", true)
+                    indexSpan.setAttribute("kast.references.indexEmptyFallback", true)
+                    return@child null
                 }
                 val indexedRows = runIdeaReadAction {
                     lookup.page.references.filter { row -> indexedReferenceRowInScope(row, plan.searchScope) }

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaIndexSemanticAdmissionTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/IdeaIndexSemanticAdmissionTest.kt
@@ -1,0 +1,80 @@
+package io.github.amichne.kast.idea
+
+import com.intellij.openapi.project.Project
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Proxy
+
+class IdeaIndexSemanticAdmissionTest {
+    @Test
+    fun `index admission waits until a Kotlin compiler model is semantically usable`() {
+        var nowNanos = 0L
+        var attempts = 0
+        val admission = IdeaIndexSemanticAdmission(
+            project = projectStub(),
+            inspectProject = {
+                attempts += 1
+                if (attempts == 1) {
+                    IdeaIndexSemanticAdmission.Inspection.Pending("kotlin runtime unresolved")
+                } else {
+                    IdeaIndexSemanticAdmission.Inspection.Ready
+                }
+            },
+            nanoTime = { nowNanos },
+            pause = { millis -> nowNanos += millis * 1_000_000L },
+            maxWaitMillis = 1_000,
+            pollIntervalMillis = 25,
+        )
+
+        assertTrue(admission.status() is IdeaIndexSemanticAdmission.Status.Pending)
+
+        admission.await { false }
+
+        assertEquals(2, attempts)
+        assertEquals(25_000_000L, nowNanos)
+        assertEquals(IdeaIndexSemanticAdmission.Status.Ready, admission.status())
+    }
+
+    @Test
+    fun `index admission fails typed instead of publishing ready after timeout`() {
+        var nowNanos = 0L
+        val admission = IdeaIndexSemanticAdmission(
+            project = projectStub(),
+            inspectProject = {
+                IdeaIndexSemanticAdmission.Inspection.Pending("JDK symbol java.nio.file.Path unresolved in :app")
+            },
+            nanoTime = { nowNanos },
+            pause = { millis -> nowNanos += millis * 1_000_000L },
+            maxWaitMillis = 50,
+            pollIntervalMillis = 25,
+        )
+
+        val failure = assertThrows(IllegalStateException::class.java) {
+            admission.await { false }
+        }
+
+        assertTrue(failure.message.orEmpty().contains("java.nio.file.Path"))
+        assertTrue(
+            (admission.status() as IdeaIndexSemanticAdmission.Status.Failed)
+                .detail
+                .contains("java.nio.file.Path"),
+        )
+    }
+
+    private fun projectStub(): Project =
+        Proxy.newProxyInstance(
+            Project::class.java.classLoader,
+            arrayOf(Project::class.java),
+        ) { _, method, _ ->
+            when (method.name) {
+                "getName" -> "stub"
+                "isDisposed" -> false
+                "hashCode" -> 0
+                "equals" -> false
+                "toString" -> "ProjectStub"
+                else -> null
+            }
+        } as Project
+}

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt
@@ -17,9 +17,11 @@ import com.intellij.testFramework.junit5.fixture.psiFileFixture
 import com.intellij.testFramework.junit5.fixture.sourceRootFixture
 import io.github.amichne.kast.api.contract.FilePosition
 import io.github.amichne.kast.api.contract.NonNegativeInt
+import io.github.amichne.kast.api.contract.SearchScope
 import io.github.amichne.kast.api.contract.SearchScopeKind
 import io.github.amichne.kast.api.contract.ServerLimits
 import io.github.amichne.kast.api.contract.SymbolKind
+import io.github.amichne.kast.api.contract.RuntimeState
 import io.github.amichne.kast.api.contract.TypeHierarchyDirection
 import io.github.amichne.kast.api.contract.query.ImplementationsQuery
 import io.github.amichne.kast.api.contract.query.ReferencesQuery
@@ -150,6 +152,9 @@ class KastPluginBackendContractTest {
         psiGeneration: () -> Long = { 1L },
         readEpochObserver: IdeaReadEpochObserver = IdeaReadEpochObserver.Disabled,
         referenceTraversalObserver: ReferenceTraversalObserver = ReferenceTraversalObserver.Disabled,
+        indexSemanticAdmissionStatus: () -> IdeaIndexSemanticAdmission.Status = {
+            IdeaIndexSemanticAdmission.Status.Ready
+        },
     ): KastPluginBackend = KastPluginBackend(
         project = project,
         workspaceRoot = workspaceRoot,
@@ -160,6 +165,7 @@ class KastPluginBackendContractTest {
         psiGeneration = psiGeneration,
         readEpochObserver = readEpochObserver,
         referenceTraversalObserver = referenceTraversalObserver,
+        indexSemanticAdmissionStatus = indexSemanticAdmissionStatus,
     )
 
     private fun ensureProjectReady() {
@@ -197,6 +203,38 @@ class KastPluginBackendContractTest {
         val status = backend().runtimeStatus()
 
         assertEquals(listOf("main", "secondary"), status.sourceModuleNames)
+    }
+
+    @Test
+    fun `runtime cannot report ready while compiler semantic admission is pending`() = runBlocking {
+        ensureProjectReady()
+
+        val status = backend(
+            indexSemanticAdmissionStatus = {
+                IdeaIndexSemanticAdmission.Status.Pending("Kotlin runtime unresolved in :main")
+            },
+        ).runtimeStatus()
+
+        assertEquals(RuntimeState.INDEXING, status.state)
+        assertTrue(status.healthy)
+        assertTrue(status.indexing)
+        assertTrue(status.message.orEmpty().contains("Kotlin runtime unresolved"))
+    }
+
+    @Test
+    fun `runtime degrades when compiler semantic admission fails`() = runBlocking {
+        ensureProjectReady()
+
+        val status = backend(
+            indexSemanticAdmissionStatus = {
+                IdeaIndexSemanticAdmission.Status.Failed("K2 diagnostics unavailable")
+            },
+        ).runtimeStatus()
+
+        assertEquals(RuntimeState.DEGRADED, status.state)
+        assertFalse(status.healthy)
+        assertFalse(status.indexing)
+        assertTrue(status.message.orEmpty().contains("K2 diagnostics unavailable"))
     }
 
     @Test
@@ -480,6 +518,48 @@ class KastPluginBackendContractTest {
     }
 
     @Test
+    fun `empty initial source index page falls back to compiler reference search`() = runBlocking {
+        ensureProjectReady()
+        val referenceData = readAction {
+            val usageFile = sampleUsageFileFixture.get()
+            IndexedReferenceTestData(
+                workspaceRoot = commonWorkspaceRoot(sampleFile.virtualFile.path, usageFile.virtualFile.path),
+                declarationFilePath = sampleFile.virtualFile.path,
+                declarationOffset = sampleFile.text.indexOf("greet"),
+                usageFilePath = usageFile.virtualFile.path,
+                usageOffset = usageFile.text.indexOf("greet(\"idea\")"),
+            )
+        }
+        val emptyReadyIndex = ReferenceIndexLookup { _, _, _ ->
+            IndexedReferenceLookupResult.Ready(
+                page = SymbolReferencePage(references = emptyList(), nextOffset = null),
+                generation = SourceIndexGeneration(1),
+            )
+        }
+
+        val result = backend(
+            workspaceRoot = referenceData.workspaceRoot,
+            referenceIndexLookup = emptyReadyIndex,
+        ).findReferences(
+            ReferencesQuery(
+                position = FilePosition(
+                    filePath = referenceData.declarationFilePath,
+                    offset = referenceData.declarationOffset,
+                ),
+                includeDeclaration = false,
+            ),
+        )
+
+        assertTrue(
+            result.references.any { reference ->
+                reference.location.filePath == referenceData.usageFilePath &&
+                    reference.location.startOffset == referenceData.usageOffset
+            },
+        )
+        assertEquals(ResultCardinality.Exact(result.references.size), result.cardinality)
+    }
+
+    @Test
     fun `indexed reference cursor fails typed when index becomes unavailable`() = runBlocking {
         ensureProjectReady()
         val referenceData = readAction {
@@ -617,6 +697,8 @@ class KastPluginBackendContractTest {
         assertEquals(4, first.references.size)
         assertEquals(4, second.references.size)
         assertTrue(first.cardinality is ResultCardinality.KnownMinimum)
+        assertFalse(first.searchScope?.exhaustive ?: true)
+        assertEquals(SearchScope.CandidateCoverage.COMPLETE, first.searchScope?.candidateCoverage)
         assertEquals(1, indexLookupCount)
         assertTrue(first.references.toSet().intersect(second.references.toSet()).isEmpty())
         val trace = Files.readString(traceFile)
@@ -1123,6 +1205,10 @@ class KastPluginBackendContractTest {
             val position = FilePosition(referenceData.declarationFilePath, referenceData.declarationOffset)
             val first = backend.findReferences(ReferencesQuery(position, maxResults = 1))
 
+            assertEquals(false, first.searchScope?.exhaustive)
+            assertEquals(SearchScope.CandidateCoverage.COMPLETE, first.searchScope?.candidateCoverage)
+            assertEquals(true, first.page?.truncated)
+
             store.clearReferencesFromFile(referenceData.usageFilePath)
 
             val failure = runCatching {
@@ -1224,6 +1310,7 @@ class KastPluginBackendContractTest {
         )
 
         assertFalse(result.searchScope?.exhaustive ?: true)
+        assertEquals(SearchScope.CandidateCoverage.PARTIAL, result.searchScope?.candidateCoverage)
         assertTrue(
             (result.searchScope?.searchedFileCount ?: Int.MAX_VALUE) <=
                 (result.searchScope?.candidateFileCount ?: 0),

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastProjectOpenAutoIndexingTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastProjectOpenAutoIndexingTest.kt
@@ -18,9 +18,18 @@ import io.github.amichne.kast.api.client.fields.ProjectOpenAutoExcludeGit
 import io.github.amichne.kast.api.client.fields.ProjectOpenGradleLoadEnabled
 import io.github.amichne.kast.api.client.fields.ProjectOpenProfile
 import io.github.amichne.kast.api.client.fields.ProjectOpenProfileAutoInit
+import io.github.amichne.kast.api.contract.NonNegativeInt
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.PositiveInt
+import io.github.amichne.kast.api.contract.FilePosition
+import io.github.amichne.kast.api.contract.ServerLimits
+import io.github.amichne.kast.api.contract.query.ReferencesQuery
+import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.indexstore.api.index.FileIndexUpdate
+import io.github.amichne.kast.indexstore.api.reference.ExactReferenceTarget
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import io.github.amichne.kast.indexstore.store.cache.sourceIndexDatabasePath
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -263,6 +272,50 @@ class KastProjectOpenAutoIndexingTest {
             assertEquals(listOf("demo.target"), snapshot.importsByPath.getValue(callerPath))
             assertTrue(store.loadManifest().orEmpty().keys.containsAll(setOf(callerPath, targetPath)))
             assertTrue(store.referencesToSymbol("demo.target").any { row -> row.sourcePath == callerPath })
+            val exactReferences = store.generatedReferencePageToExactSymbol(
+                target = ExactReferenceTarget(
+                    fqName = "demo.target",
+                    declarationFile = NormalizedPath.parse(targetPath),
+                    declarationStartOffset = NonNegativeInt(targetFile.text.indexOf("target")),
+                ),
+                offset = NonNegativeInt(0),
+                maxResults = PositiveInt(10),
+            )
+            assertEquals(2, exactReferences.page.references.size)
+            assertTrue(
+                exactReferences.page.references.all { reference -> reference.sourcePath == callerPath },
+                "reference target offsets must use the same name identity returned by exact symbol resolution",
+            )
+            val lookup = ReferenceIndexLookup { target, offset, maxResults ->
+                val generated = store.generatedReferencePageToExactSymbol(target, offset, maxResults)
+                if (generated.exactIdentityAvailable) {
+                    IndexedReferenceLookupResult.Ready(generated.page, generated.generation)
+                } else {
+                    IndexedReferenceLookupResult.IdentityUnavailable(generated.generation)
+                }
+            }
+            KastPluginBackend(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                limits = ServerLimits(
+                    maxResults = 500,
+                    requestTimeoutMillis = 30_000,
+                    maxConcurrentRequests = 4,
+                ),
+                referenceIndexLookup = lookup,
+            ).use { backend ->
+                val result = runBlocking {
+                    backend.findReferences(
+                        ReferencesQuery(
+                            position = FilePosition(targetPath, targetFile.text.indexOf("target")),
+                            maxResults = 10,
+                        ),
+                    )
+                }
+                assertEquals(ResultCardinality.Exact(2), result.cardinality)
+                assertEquals(2, result.references.size)
+                assertEquals(true, result.searchScope?.exhaustive)
+            }
         }
     }
 

--- a/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiReferenceScanner.kt
+++ b/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiReferenceScanner.kt
@@ -53,7 +53,9 @@ class PsiReferenceScanner(
                                     val resolved = reference.resolve() ?: return@forEach
                                     val (fqName, _) = resolved.targetFqNameAndPackage() ?: return@forEach
                                     val targetPath = recoverRuntimePsiFailure { resolved.resolvedFilePath().value }
-                                    val targetOffset = recoverRuntimePsiFailure { resolved.textRange?.startOffset }
+                                    val targetOffset = recoverRuntimePsiFailure {
+                                        resolved.declarationIdentityOffset()
+                                    }
                                     val sourceElementStart = recoverRuntimePsiFailure {
                                         reference.element.textRange.startOffset
                                     } ?: return@forEach
@@ -168,6 +170,10 @@ class PsiReferenceScanner(
         generateSequence(this as PsiElement?) { it.parent }
             .filterIsInstance<KtNamedDeclaration>()
             .firstNotNullOfOrNull { declaration -> declaration.targetFqNameAndPackage()?.first?.value }
+
+    private fun PsiElement.declarationIdentityOffset(): Int? =
+        (this as? KtNamedDeclaration)?.nameIdentifier?.textRange?.startOffset
+            ?: textRange?.startOffset
 
     private fun PsiElement.edgeKind(): EdgeKind {
         val parents = generateSequence(this as PsiElement?) { it.parent }.take(8).toList()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -178,6 +178,9 @@ abstract class BuildSourceBoundCliTask @Inject constructor(
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val cargoManifest: RegularFileProperty
 
+    @get:OutputDirectory
+    abstract val targetDirectory: DirectoryProperty
+
     @TaskAction
     fun build() {
         val snapshot = sourceSnapshotFile.get().asFile.readText()
@@ -197,6 +200,8 @@ abstract class BuildSourceBoundCliTask @Inject constructor(
                 cargoManifest.get().asFile.absolutePath,
                 "--locked",
                 "--release",
+                "--target-dir",
+                targetDirectory.get().asFile.absolutePath,
             )
         }.assertNormalExitValue()
     }
@@ -444,7 +449,9 @@ fun resolveCargoExecutable(): String {
 val cliDebugBinary: RegularFile = layout.projectDirectory.file("cli-rs/target/debug/kast")
 val cliLocalDevelopmentBootstrapBinary: RegularFile =
     layout.projectDirectory.file("cli-rs/target/local-bootstrap/release/kast")
-val cliLocalDevelopmentBinary: RegularFile = layout.projectDirectory.file("cli-rs/target/release/kast")
+val cliLocalDevelopmentTargetDirectory: Directory = layout.projectDirectory.dir("cli-rs/target")
+val cliLocalDevelopmentBinary: RegularFile =
+    cliLocalDevelopmentTargetDirectory.file("release/kast")
 val resolvedCargoExecutable = resolveCargoExecutable()
 val kastDevBinary = kastBinDirectory.absoluteFile.normalize().resolve("kast-dev")
 
@@ -515,6 +522,7 @@ val rebuildLocalDevelopmentCli: TaskProvider<BuildSourceBoundCliTask> by tasks.r
     cargoExecutable.set(resolvedCargoExecutable)
     implementationVersion.set(project.version.toString())
     cargoManifest.set(layout.projectDirectory.file("cli-rs/Cargo.toml"))
+    targetDirectory.set(cliLocalDevelopmentTargetDirectory)
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,7 @@
 import java.util.zip.ZipInputStream
+import java.security.MessageDigest
+import javax.inject.Inject
+import groovy.json.JsonOutput
 
 plugins {
     base
@@ -55,6 +58,199 @@ abstract class InstallDevelopmentIdeaPluginTask : DefaultTask() {
 
         logger.lifecycle("Installed development IDEA plugin at {}", targetRoot.resolve("backend-idea"))
     }
+}
+
+@DisableCachingByDefault(because = "Cargo owns incremental compilation and the target directory")
+abstract class BuildSourceBoundCliTask @Inject constructor(
+    private val execOperations: ExecOperations,
+) : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val sourceSnapshotFile: RegularFileProperty
+
+    @get:Input
+    abstract val cargoExecutable: Property<String>
+
+    @get:Input
+    abstract val implementationVersion: Property<String>
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val cargoManifest: RegularFileProperty
+
+    @TaskAction
+    fun build() {
+        val snapshot = sourceSnapshotFile.get().asFile.readText()
+        val sourceSha256 = Regex(
+            """"sourceTreeSha256"\s*:\s*"([0-9a-f]{64})"""",
+        ).find(snapshot)?.groupValues?.get(1)
+            ?: throw GradleException(
+                "Local-development source snapshot has no valid sourceTreeSha256",
+            )
+        execOperations.exec {
+            environment("KAST_VERSION", implementationVersion.get())
+            environment("KAST_LOCAL_SOURCE_SHA256", sourceSha256)
+            commandLine(
+                cargoExecutable.get(),
+                "build",
+                "--manifest-path",
+                cargoManifest.get().asFile.absolutePath,
+                "--locked",
+                "--release",
+            )
+        }.assertNormalExitValue()
+    }
+}
+
+@DisableCachingByDefault(because = "Mutates receipt-owned local development state")
+abstract class RemoveDevelopmentLocalTask @Inject constructor(
+    private val execOperations: ExecOperations,
+) : DefaultTask() {
+    @get:Input
+    abstract val prefixPath: Property<String>
+
+    @get:Input
+    abstract val workspaceRootPath: Property<String>
+
+    @get:Input
+    abstract val installedControllerPath: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val recoveryControllerPath: Property<String>
+
+    @get:Input
+    abstract val checkoutControllerPath: Property<String>
+
+    @get:Input
+    abstract val bootstrapControllerPath: Property<String>
+
+    @TaskAction
+    fun remove() {
+        val installedController = java.io.File(installedControllerPath.get())
+        val explicitRecoveryController = recoveryControllerPath.orNull
+            ?.takeIf(String::isNotBlank)
+            ?.let { path -> java.io.File(path) }
+        val checkoutController = java.io.File(checkoutControllerPath.get())
+        val bootstrapController = java.io.File(bootstrapControllerPath.get())
+        val controller = when {
+            installedController.isFile -> installedController
+            explicitRecoveryController != null -> explicitRecoveryController
+            checkoutController.isFile -> checkoutController
+            bootstrapController.isFile -> bootstrapController
+            else -> throw GradleException(
+                "removeDevelopmentLocal cannot find the installed controller or a checkout recovery controller; " +
+                    "expected ${installedController.absolutePath}, ${checkoutController.absolutePath}, " +
+                    "or ${bootstrapController.absolutePath}"
+            )
+        }
+        if (!controller.isFile) {
+            throw GradleException(
+                "kastLocalRecoveryController is not an executable file: ${controller.absolutePath}"
+            )
+        }
+        execOperations.exec {
+            commandLine(
+                controller.absolutePath,
+                "--output",
+                "json",
+                "developer",
+                "local",
+                "remove",
+                "--prefix",
+                prefixPath.get(),
+                "--workspace-root",
+                workspaceRootPath.get(),
+            )
+        }.assertNormalExitValue()
+    }
+}
+
+@CacheableTask
+abstract class WriteLocalBackendComponentManifestTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val sourceSnapshotFile: RegularFileProperty
+
+    @get:Internal
+    abstract val backendDirectory: DirectoryProperty
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val componentFiles: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun writeManifest() {
+        val sourceSnapshot = sourceSnapshotFile.get().asFile.readText()
+        val sourceSha256 = Regex(
+            """"sourceTreeSha256"\s*:\s*"([0-9a-f]{64})"""",
+        ).find(sourceSnapshot)?.groupValues?.get(1)
+            ?: throw GradleException(
+                "Local-development source snapshot has no valid sourceTreeSha256",
+            )
+        val root = backendDirectory.get().asFile.toPath().toAbsolutePath().normalize()
+        val components = componentFiles.files
+            .map { file ->
+                val path = file.toPath().toAbsolutePath().normalize()
+                val relative = root.relativize(path).joinToString("/")
+                mapOf(
+                    "kind" to localBackendComponentKind(file.name),
+                    "path" to relative,
+                    "sha256" to sha256(file.readBytes()),
+                )
+            }
+            .sortedBy { component -> component.getValue("kind") }
+        val expectedKinds = setOf(
+            "analysis-api",
+            "analysis-server",
+            "backend-headless-launcher",
+            "backend-headless-plugin-descriptor",
+            "backend-idea",
+            "backend-shared",
+            "index-store",
+        )
+        val actualKinds = components.map { component -> component.getValue("kind") }
+        if (actualKinds.toSet() != expectedKinds || actualKinds.size != expectedKinds.size) {
+            throw GradleException(
+                "Local backend component manifest found $actualKinds; expected ${expectedKinds.sorted()}",
+            )
+        }
+        outputFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText(
+                JsonOutput.prettyPrint(
+                    JsonOutput.toJson(
+                        mapOf(
+                            "schemaVersion" to 1,
+                            "sourceTreeSha256" to sourceSha256,
+                            "components" to components,
+                        ),
+                    ),
+                ) + "\n",
+            )
+        }
+    }
+
+    private fun localBackendComponentKind(name: String): String = when {
+        name.startsWith("analysis-api-") && name.endsWith(".jar") -> "analysis-api"
+        name.startsWith("analysis-server-") && name.endsWith(".jar") -> "analysis-server"
+        name.startsWith("backend-headless-") && name.endsWith("-launcher.jar") ->
+            "backend-headless-launcher"
+        name.startsWith("backend-headless-") && name.endsWith("-plugin-descriptor.jar") ->
+            "backend-headless-plugin-descriptor"
+        name.startsWith("backend-idea-") && name.endsWith(".jar") -> "backend-idea"
+        name.startsWith("backend-shared-") && name.endsWith(".jar") -> "backend-shared"
+        name.startsWith("index-store-") && name.endsWith(".jar") -> "index-store"
+        else -> throw GradleException("Unexpected producer-owned backend component: $name")
+    }
+
+    private fun sha256(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(bytes)
+            .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
 }
 
 group = providers.gradleProperty("GROUP").get()
@@ -153,7 +349,10 @@ fun resolveCargoExecutable(): String {
 }
 
 val cliDebugBinary: RegularFile = layout.projectDirectory.file("cli-rs/target/debug/kast")
-val cargoExecutable = resolveCargoExecutable()
+val cliLocalDevelopmentBootstrapBinary: RegularFile =
+    layout.projectDirectory.file("cli-rs/target/local-bootstrap/release/kast")
+val cliLocalDevelopmentBinary: RegularFile = layout.projectDirectory.file("cli-rs/target/release/kast")
+val resolvedCargoExecutable = resolveCargoExecutable()
 val kastDevBinary = kastBinDirectory.absoluteFile.normalize().resolve("kast-dev")
 
 val buildDevelopmentCli: TaskProvider<Exec> by tasks.registering(Exec::class) {
@@ -161,11 +360,178 @@ val buildDevelopmentCli: TaskProvider<Exec> by tasks.registering(Exec::class) {
     description = "Builds the repo-local Rust kast CLI in debug mode."
     environment("KAST_VERSION", project.version.toString())
     commandLine(
-        cargoExecutable,
+        resolvedCargoExecutable,
         "build",
         "--manifest-path",
         layout.projectDirectory.file("cli-rs/Cargo.toml").asFile.absolutePath,
         "--locked",
+    )
+}
+
+val buildLocalDevelopmentCli: TaskProvider<Exec> by tasks.registering(Exec::class) {
+    group = "build"
+    description = "Builds the optimized CLI used by revision-coherent local authority."
+    environment("KAST_VERSION", project.version.toString())
+    commandLine(
+        resolvedCargoExecutable,
+        "build",
+        "--manifest-path",
+        layout.projectDirectory.file("cli-rs/Cargo.toml").asFile.absolutePath,
+        "--locked",
+        "--release",
+        "--target-dir",
+        layout.projectDirectory.dir("cli-rs/target/local-bootstrap").asFile.absolutePath,
+    )
+}
+
+val developmentSourceSnapshotFile = layout.buildDirectory.file(
+    "local-development/source-snapshot.json"
+)
+val developmentCliProvenanceFile = layout.buildDirectory.file(
+    "local-development/cli-provenance.json"
+)
+val developmentBackendProvenanceFile = layout.buildDirectory.file(
+    "local-development/backend-provenance.json"
+)
+
+val captureDevelopmentSourceSnapshot: TaskProvider<Exec> by tasks.registering(Exec::class) {
+    group = "build"
+    description = "Captures the exact checkout source identity before local artifact production."
+    dependsOn(buildLocalDevelopmentCli)
+    commandLine(
+        cliLocalDevelopmentBootstrapBinary.asFile.absolutePath,
+        "--output",
+        "json",
+        "developer",
+        "local",
+        "snapshot",
+        "--source-root",
+        rootDir.absolutePath,
+        "--output-file",
+        developmentSourceSnapshotFile.get().asFile.absolutePath,
+    )
+}
+
+val rebuildLocalDevelopmentCli: TaskProvider<BuildSourceBoundCliTask> by tasks.registering(
+    BuildSourceBoundCliTask::class,
+) {
+    group = "build"
+    description = "Rebuilds the local CLI after the source snapshot is fixed."
+    dependsOn(captureDevelopmentSourceSnapshot)
+    sourceSnapshotFile.set(developmentSourceSnapshotFile)
+    cargoExecutable.set(resolvedCargoExecutable)
+    implementationVersion.set(project.version.toString())
+    cargoManifest.set(layout.projectDirectory.file("cli-rs/Cargo.toml"))
+}
+
+subprojects {
+    tasks.configureEach {
+        mustRunAfter(captureDevelopmentSourceSnapshot)
+    }
+}
+
+val writeLocalBackendComponentManifest: TaskProvider<WriteLocalBackendComponentManifestTask> by tasks.registering(
+    WriteLocalBackendComponentManifestTask::class,
+) {
+    group = "build"
+    description = "Binds every repo-produced headless backend JAR to the captured source build."
+    dependsOn(captureDevelopmentSourceSnapshot, ":backend-headless:syncPortableDist")
+    sourceSnapshotFile.set(developmentSourceSnapshotFile)
+    val portableBackend = layout.projectDirectory.dir(
+        "backend-headless/build/portable-dist/backend-headless",
+    )
+    backendDirectory.set(portableBackend)
+    componentFiles.from(
+        fileTree(portableBackend) {
+            include("runtime-libs/backend-headless-*-launcher.jar")
+            include("idea-home/plugins/kast-headless/lib/analysis-api-*.jar")
+            include("idea-home/plugins/kast-headless/lib/analysis-server-*.jar")
+            include("idea-home/plugins/kast-headless/lib/backend-headless-*-plugin-descriptor.jar")
+            include("idea-home/plugins/kast-headless/lib/backend-idea-*.jar")
+            include("idea-home/plugins/kast-headless/lib/backend-shared-*.jar")
+            include("idea-home/plugins/kast-headless/lib/index-store-*.jar")
+        },
+    )
+    outputFile.set(
+        layout.buildDirectory.file("local-development/backend-component-manifest.json"),
+    )
+}
+
+val stageDevelopmentBackend: TaskProvider<Sync> by tasks.registering(Sync::class) {
+    group = "build"
+    description = "Stages the headless backend with producer-emitted local source identity."
+    dependsOn(
+        captureDevelopmentSourceSnapshot,
+        writeLocalBackendComponentManifest,
+        ":backend-headless:syncPortableDist",
+        ":backend-headless:localHeadlessPluginImplementationJar",
+    )
+    from(
+        layout.projectDirectory.dir(
+            "backend-headless/build/portable-dist/backend-headless"
+        )
+    ) {
+        exclude("idea-home/plugins/kast-headless/lib/backend-headless-*-plugin.jar")
+    }
+    from(
+        layout.projectDirectory.file(
+            "backend-headless/build/local-development/backend-headless-local-plugin.jar"
+        )
+    ) {
+        into("idea-home/plugins/kast-headless/lib")
+    }
+    into(layout.buildDirectory.dir("local-development/backend-headless"))
+}
+
+val attestDevelopmentCli: TaskProvider<Exec> by tasks.registering(Exec::class) {
+    group = "build"
+    description = "Binds the exact rebuilt CLI bytes to the captured checkout source."
+    dependsOn(rebuildLocalDevelopmentCli)
+    commandLine(
+        cliLocalDevelopmentBinary.asFile.absolutePath,
+        "--output",
+        "json",
+        "developer",
+        "local",
+        "attest",
+        "--source-root",
+        rootDir.absolutePath,
+        "--expected-source-snapshot",
+        developmentSourceSnapshotFile.get().asFile.absolutePath,
+        "--artifact-kind",
+        "cli",
+        "--artifact",
+        cliLocalDevelopmentBinary.asFile.absolutePath,
+        "--output-file",
+        developmentCliProvenanceFile.get().asFile.absolutePath,
+    )
+}
+
+val attestDevelopmentBackend: TaskProvider<Exec> by tasks.registering(Exec::class) {
+    group = "build"
+    description = "Binds the exact portable headless backend bytes to the captured checkout source."
+    dependsOn(rebuildLocalDevelopmentCli, stageDevelopmentBackend)
+    commandLine(
+        cliLocalDevelopmentBinary.asFile.absolutePath,
+        "--output",
+        "json",
+        "developer",
+        "local",
+        "attest",
+        "--source-root",
+        rootDir.absolutePath,
+        "--expected-source-snapshot",
+        developmentSourceSnapshotFile.get().asFile.absolutePath,
+        "--artifact-kind",
+        "headless-backend",
+        "--artifact",
+        layout.buildDirectory
+            .dir("local-development/backend-headless")
+            .get()
+            .asFile
+            .absolutePath,
+        "--output-file",
+        developmentBackendProvenanceFile.get().asFile.absolutePath,
     )
 }
 
@@ -340,6 +706,105 @@ val installDevelopmentIdeaPlugin: TaskProvider<InstallDevelopmentIdeaPluginTask>
     pluginArchive.set(ideaPluginArchive)
     pluginsDirectory.set(layout.dir(developmentJetBrainsPluginsDir))
     replacedPluginDirectoryNames.set(developmentIdeaPluginDirectoryNames)
+}
+
+fun configuredLocalDevelopmentPrefix(): File =
+    providers.gradleProperty("kastLocalPrefix")
+        .orNull
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+        ?.let(::file)
+    ?: rootDir.resolve(".kast/local-development")
+
+fun configuredLocalDevelopmentWorkspace(): File =
+    providers.gradleProperty("kastLocalWorkspaceRoot")
+        .orNull
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+        ?.let(::file)
+    ?: rootDir
+
+val refreshDevelopmentLocal: TaskProvider<Exec> by tasks.registering(Exec::class) {
+    group = "distribution"
+    description = "Refreshes one revision-coherent local Kast development authority."
+    dependsOn(attestDevelopmentCli, attestDevelopmentBackend)
+    val localPrefix = configuredLocalDevelopmentPrefix()
+    val workspaceRoot = configuredLocalDevelopmentWorkspace()
+    commandLine(
+        cliLocalDevelopmentBinary.asFile.absolutePath,
+        "--output",
+        "json",
+        "developer",
+        "local",
+        "refresh",
+        "--source-root",
+        rootDir.absolutePath,
+        "--workspace-root",
+        workspaceRoot.absoluteFile.normalize().absolutePath,
+        "--prefix",
+        localPrefix.absoluteFile.normalize().absolutePath,
+        "--expected-source-snapshot",
+        developmentSourceSnapshotFile.get().asFile.absolutePath,
+        "--cli-binary",
+        cliLocalDevelopmentBinary.asFile.absolutePath,
+        "--cli-provenance",
+        developmentCliProvenanceFile.get().asFile.absolutePath,
+        "--backend-directory",
+        layout.buildDirectory
+            .dir("local-development/backend-headless")
+            .get()
+            .asFile
+            .absolutePath,
+        "--backend-provenance",
+        developmentBackendProvenanceFile.get().asFile.absolutePath,
+    )
+}
+
+tasks.register<Exec>("rollbackDevelopmentLocal") {
+    group = "distribution"
+    description = "Idempotently reactivates the explicitly selected validated previous local generation."
+    val localPrefix = configuredLocalDevelopmentPrefix().absoluteFile.normalize()
+    val requestedGeneration = providers.gradleProperty("kastLocalGeneration")
+        .map(String::trim)
+        .map { generation ->
+            generation.takeIf(String::isNotEmpty)
+                ?: throw GradleException(
+                    "rollbackDevelopmentLocal requires -PkastLocalGeneration=<generation-id>"
+                )
+        }
+    commandLine(
+        localPrefix.resolve("bin/kast-dev").absolutePath,
+        "--output",
+        "json",
+        "developer",
+        "local",
+        "rollback",
+        "--prefix",
+        localPrefix.absolutePath,
+    )
+    doFirst {
+        val generation = requestedGeneration.orNull
+            ?: throw GradleException(
+                "rollbackDevelopmentLocal requires -PkastLocalGeneration=<generation-id>"
+            )
+        args("--to-generation", generation)
+    }
+}
+
+tasks.register<RemoveDevelopmentLocalTask>("removeDevelopmentLocal") {
+    group = "distribution"
+    description = "Removes only receipt-owned local Kast state and restores ordinary authority."
+    val localPrefix = configuredLocalDevelopmentPrefix().absoluteFile.normalize()
+    prefixPath.set(localPrefix.absolutePath)
+    workspaceRootPath.set(
+        configuredLocalDevelopmentWorkspace().absoluteFile.normalize().absolutePath,
+    )
+    installedControllerPath.set(localPrefix.resolve("bin/kast-dev").absolutePath)
+    recoveryControllerPath.set(
+        providers.gradleProperty("kastLocalRecoveryController").map(String::trim),
+    )
+    checkoutControllerPath.set(cliLocalDevelopmentBinary.asFile.absolutePath)
+    bootstrapControllerPath.set(cliLocalDevelopmentBootstrapBinary.asFile.absolutePath)
 }
 
 tasks.register("installDevelopmentLocal") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.io.ByteArrayOutputStream
 import java.util.zip.ZipInputStream
 import java.security.MessageDigest
 import javax.inject.Inject
@@ -10,7 +11,16 @@ plugins {
 }
 
 @DisableCachingByDefault(because = "Installs into a mutable local JetBrains profile")
-abstract class InstallDevelopmentIdeaPluginTask : DefaultTask() {
+abstract class InstallDevelopmentIdeaPluginTask @Inject constructor(
+    private val execOperations: ExecOperations,
+) : DefaultTask() {
+    private data class JetBrainsProfileCandidate(
+        val profileDirectory: File,
+        val year: Int,
+        val minor: Int,
+        val patch: Int,
+    )
+
     init {
         outputs.upToDateWhen { false }
     }
@@ -18,8 +28,19 @@ abstract class InstallDevelopmentIdeaPluginTask : DefaultTask() {
     @get:InputFile
     abstract val pluginArchive: RegularFileProperty
 
-    @get:Internal
-    abstract val pluginsDirectory: DirectoryProperty
+    @get:Input
+    @get:Optional
+    abstract val configuredPluginsDirectory: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val configuredProfile: Property<String>
+
+    @get:Input
+    abstract val jetBrainsConfigRootPath: Property<String>
+
+    @get:Input
+    abstract val projectDirectoryPath: Property<String>
 
     @get:Input
     abstract val replacedPluginDirectoryNames: ListProperty<String>
@@ -31,7 +52,7 @@ abstract class InstallDevelopmentIdeaPluginTask : DefaultTask() {
             throw GradleException("Development IDEA plugin archive was not built: ${archive.absolutePath}")
         }
 
-        val targetRoot = pluginsDirectory.get().asFile
+        val targetRoot = resolvePluginsDirectory()
         targetRoot.mkdirs()
         replacedPluginDirectoryNames.get().forEach { name ->
             targetRoot.resolve(name).deleteRecursively()
@@ -57,6 +78,85 @@ abstract class InstallDevelopmentIdeaPluginTask : DefaultTask() {
         }
 
         logger.lifecycle("Installed development IDEA plugin at {}", targetRoot.resolve("backend-idea"))
+    }
+
+    private fun resolvePluginsDirectory(): File {
+        configuredPluginsDirectory.orNull
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+            ?.let { return resolveProjectPath(it) }
+
+        val configRoot = File(jetBrainsConfigRootPath.get()).absoluteFile.normalize()
+        configuredProfile.orNull
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+            ?.let { raw ->
+                val profile = resolveProfile(raw, configRoot).absoluteFile.normalize()
+                return if (profile.name == "plugins") profile else profile.resolve("plugins")
+            }
+
+        runningProfile(configRoot)
+            ?.let { return it.resolve("plugins").absoluteFile.normalize() }
+
+        val profile = newestProfile(configRoot)
+            ?: throw GradleException(
+                "No IntelliJIdea profile was found under ${configRoot.absolutePath}. " +
+                    "Pass -PkastDevJetBrainsProfile=<profile> or " +
+                    "-PkastDevJetBrainsPluginsDir=<plugins-dir>."
+            )
+        return profile.resolve("plugins").absoluteFile.normalize()
+    }
+
+    private fun resolveProjectPath(raw: String): File {
+        val candidate = File(raw)
+        return (if (candidate.isAbsolute) candidate else File(projectDirectoryPath.get()).resolve(raw))
+            .absoluteFile
+            .normalize()
+    }
+
+    private fun resolveProfile(raw: String, configRoot: File): File =
+        if (File(raw).isAbsolute || raw.contains('/') || raw.contains('\\')) {
+            resolveProjectPath(raw)
+        } else {
+            configRoot.resolve(raw)
+        }
+
+    private fun runningProfile(configRoot: File): File? {
+        val processArgs = ByteArrayOutputStream()
+        execOperations.exec {
+            commandLine("ps", "-axo", "args")
+            isIgnoreExitValue = true
+            standardOutput = processArgs
+        }
+        return Regex("""/JetBrains/(IntelliJIdea\d{4}\.\d+(?:\.\d+)?)""")
+            .findAll(processArgs.toString(Charsets.UTF_8))
+            .map { match -> configRoot.resolve(match.groupValues[1]).absoluteFile.normalize() }
+            .firstOrNull(File::isDirectory)
+    }
+
+    private fun newestProfile(configRoot: File): File? =
+        configRoot
+            .listFiles()
+            ?.asSequence()
+            ?.filter(File::isDirectory)
+            ?.mapNotNull(::parseProfile)
+            ?.maxWithOrNull(
+                compareBy<JetBrainsProfileCandidate> { it.year }
+                    .thenBy { it.minor }
+                    .thenBy { it.patch }
+                    .thenBy { it.profileDirectory.name }
+            )
+            ?.profileDirectory
+
+    private fun parseProfile(profileDirectory: File): JetBrainsProfileCandidate? {
+        val version = profileDirectory.name.removePrefix("IntelliJIdea")
+        if (version == profileDirectory.name || version.isBlank()) return null
+        val parts = version.split(".")
+        if (parts.size !in 2..3) return null
+        val year = parts.getOrNull(0)?.toIntOrNull() ?: return null
+        val minor = parts.getOrNull(1)?.toIntOrNull() ?: return null
+        val patch = parts.getOrNull(2)?.toIntOrNull() ?: 0
+        return JetBrainsProfileCandidate(profileDirectory, year, minor, patch)
     }
 }
 
@@ -305,13 +405,6 @@ tasks.register<Copy>("stageOpenApiSpec") {
     into(layout.projectDirectory.dir("dist"))
 }
 
-data class JetBrainsProfileCandidate(
-    val profileDirectory: File,
-    val year: Int,
-    val minor: Int,
-    val patch: Int,
-)
-
 val kastHomeDirectory: File = providers.environmentVariable("HOME")
     .orNull
     ?.let(::file)
@@ -537,9 +630,8 @@ val attestDevelopmentBackend: TaskProvider<Exec> by tasks.registering(Exec::clas
 
 tasks.register<Copy>("installDevelopmentCli") {
     group = "distribution"
-    description = "Builds and installs the debug Rust CLI as kast and kast-dev in the configured local Kast bin directory."
+    description = "Builds and installs the debug Rust CLI as kast-dev without replacing ordinary kast authority."
     dependsOn(buildDevelopmentCli)
-    from(cliDebugBinary)
     from(cliDebugBinary) {
         rename("kast", "kast-dev")
     }
@@ -602,93 +694,6 @@ val configureDevelopmentMachineDefaults: TaskProvider<Exec> by tasks.registering
     )
 }
 
-fun parseIntellijIdeaProfile(profileDirectory: File): JetBrainsProfileCandidate? {
-    val version = profileDirectory.name.removePrefix("IntelliJIdea")
-    if (version == profileDirectory.name || version.isBlank()) return null
-    val parts = version.split(".")
-    if (parts.size !in 2..3) return null
-    val year = parts.getOrNull(0)?.toIntOrNull() ?: return null
-    val minor = parts.getOrNull(1)?.toIntOrNull() ?: return null
-    val patch = parts.getOrNull(2)?.toIntOrNull() ?: 0
-    return JetBrainsProfileCandidate(profileDirectory, year, minor, patch)
-}
-
-fun newestIntellijIdeaProfile(configRoot: File): File? =
-    configRoot
-        .listFiles()
-        ?.asSequence()
-        ?.filter(File::isDirectory)
-        ?.mapNotNull(::parseIntellijIdeaProfile)
-        ?.maxWithOrNull(
-            compareBy<JetBrainsProfileCandidate> { it.year }
-                .thenBy { it.minor }
-                .thenBy { it.patch }
-                .thenBy { it.profileDirectory.name }
-        )
-        ?.profileDirectory
-
-fun runningIntellijIdeaProfile(configRoot: File): File? {
-    val processArgs = providers.exec {
-        commandLine("ps", "-axo", "args")
-        isIgnoreExitValue = true
-    }.standardOutput.asText.orNull.orEmpty()
-    return Regex("""/JetBrains/(IntelliJIdea\d{4}\.\d+(?:\.\d+)?)""")
-        .findAll(processArgs)
-        .map { match -> configRoot.resolve(match.groupValues[1]).absoluteFile.normalize() }
-        .firstOrNull(File::isDirectory)
-}
-
-fun jetBrainsConfigRoot(): File =
-    providers.gradleProperty("kastDevJetBrainsConfigRoot")
-        .orNull
-        ?.trim()
-        ?.takeIf(String::isNotEmpty)
-        ?.let(::file)
-    ?: kastHomeDirectory.resolve("Library/Application Support/JetBrains")
-
-fun resolveJetBrainsProfile(
-    raw: String,
-    configRoot: File,
-): File {
-    val candidate = File(raw)
-    return if (candidate.isAbsolute || raw.contains('/') || raw.contains('\\')) {
-        file(raw)
-    } else {
-        configRoot.resolve(raw)
-    }
-}
-
-fun resolveDevelopmentJetBrainsPluginsDir(): File {
-    providers.gradleProperty("kastDevJetBrainsPluginsDir")
-        .orNull
-        ?.trim()
-        ?.takeIf(String::isNotEmpty)
-        ?.let { return file(it).absoluteFile.normalize() }
-
-    val configRoot = jetBrainsConfigRoot()
-    providers.gradleProperty("kastDevJetBrainsProfile")
-        .orNull
-        ?.trim()
-        ?.takeIf(String::isNotEmpty)
-        ?.let { raw ->
-            val profile = resolveJetBrainsProfile(raw, configRoot).absoluteFile.normalize()
-            return if (profile.name == "plugins") profile else profile.resolve("plugins")
-        }
-
-    runningIntellijIdeaProfile(configRoot)
-        ?.let { return it.resolve("plugins").absoluteFile.normalize() }
-
-    val profile = newestIntellijIdeaProfile(configRoot)
-                  ?: throw GradleException(
-                      "No IntelliJIdea profile was found under ${configRoot.absolutePath}. " +
-                      "Pass -PkastDevJetBrainsProfile=<profile> or -PkastDevJetBrainsPluginsDir=<plugins-dir>."
-                  )
-    return profile.resolve("plugins").absoluteFile.normalize()
-}
-
-val developmentJetBrainsPluginsDir: Provider<File> = providers.provider {
-    resolveDevelopmentJetBrainsPluginsDir()
-}
 val ideaPluginArchive = layout.projectDirectory
     .file("backend-idea/build/distributions/backend-idea-${version}.zip")
 val developmentIdeaPluginDirectoryNames = listOf(
@@ -696,6 +701,17 @@ val developmentIdeaPluginDirectoryNames = listOf(
     "io.github.amichne.kast",
     "Kast Analysis Backend",
 )
+val configuredDevelopmentJetBrainsPluginsDirectory =
+    providers.gradleProperty("kastDevJetBrainsPluginsDir").orNull
+val configuredDevelopmentJetBrainsProfile =
+    providers.gradleProperty("kastDevJetBrainsProfile").orNull
+val configuredDevelopmentJetBrainsConfigRoot =
+    providers.gradleProperty("kastDevJetBrainsConfigRoot")
+        .orNull
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+        ?.let { file(it).absoluteFile.normalize().path }
+    ?: kastHomeDirectory.resolve("Library/Application Support/JetBrains").path
 
 val installDevelopmentIdeaPlugin: TaskProvider<InstallDevelopmentIdeaPluginTask> by tasks.registering(
     InstallDevelopmentIdeaPluginTask::class
@@ -704,7 +720,10 @@ val installDevelopmentIdeaPlugin: TaskProvider<InstallDevelopmentIdeaPluginTask>
     description = "Builds and installs the development IDEA plugin into a local JetBrains profile."
     dependsOn(":backend-idea:buildPlugin")
     pluginArchive.set(ideaPluginArchive)
-    pluginsDirectory.set(layout.dir(developmentJetBrainsPluginsDir))
+    configuredDevelopmentJetBrainsPluginsDirectory?.let(configuredPluginsDirectory::set)
+    configuredDevelopmentJetBrainsProfile?.let(configuredProfile::set)
+    jetBrainsConfigRootPath.set(configuredDevelopmentJetBrainsConfigRoot)
+    projectDirectoryPath.set(layout.projectDirectory.asFile.absolutePath)
     replacedPluginDirectoryNames.set(developmentIdeaPluginDirectoryNames)
 }
 

--- a/cli-rs/AGENTS.md
+++ b/cli-rs/AGENTS.md
@@ -29,6 +29,16 @@ resources.
   limitations used by `agent workspace-files` and Gradle DSL consumers.
 - `src/install.rs`, `src/manifest.rs`, and `src/self_mgmt.rs` own install
   state, managed resource records, doctor checks, and repair behavior.
+- `src/local_development.rs` and `src/local_development/` own framed checkout
+  identity, independently attested CLI/backend artifacts, immutable local
+  generations, exact receipt topology, generation-scoped runtime state, and
+  the canonical prefix authority lock shared by runtime registration,
+  activation, rollback, and removal. It also owns local skill/guidance command
+  routing. Keep this boundary separate from Homebrew and JetBrains release
+  authority. Changes require
+  `.github/scripts/test-local-development-refresh-contract.sh` plus focused
+  Rust tests; never accept an artifact label without recomputing its source and
+  byte identity.
 - `src/self_mgmt.rs` parses revision-3 exact-root compatibility facts strictly
   and delegates active admission to the authored typed compatibility matrix.
   Unknown fields, capabilities, revisions, unsupported rows, and missing

--- a/cli-rs/build.rs
+++ b/cli-rs/build.rs
@@ -3,6 +3,15 @@ use std::fs;
 use std::path::PathBuf;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=KAST_LOCAL_SOURCE_SHA256");
+    if let Ok(source_sha256) = env::var("KAST_LOCAL_SOURCE_SHA256") {
+        if source_sha256.len() != 64 || !source_sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
+            panic!("KAST_LOCAL_SOURCE_SHA256 must be exactly 64 hexadecimal characters");
+        }
+        println!("cargo:rustc-env=KAST_LOCAL_SOURCE_SHA256={source_sha256}");
+    }
+
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
     let release_state = manifest_dir

--- a/cli-rs/protocol/api-reference.md
+++ b/cli-rs/protocol/api-reference.md
@@ -898,6 +898,7 @@ daemon, including input/output schemas, examples, and behavioral notes.
                         "total": 0
                     },
                     "cardinality": {
+                        "type": "EXACT",
                         "totalCount": 0
                     },
                     "schemaVersion": 3

--- a/cli-rs/protocol/examples/diagnostics-response.json
+++ b/cli-rs/protocol/examples/diagnostics-response.json
@@ -18,6 +18,7 @@
             "total": 0
         },
         "cardinality": {
+            "type": "EXACT",
             "totalCount": 0
         },
         "schemaVersion": 3

--- a/cli-rs/protocol/openapi.yaml
+++ b/cli-rs/protocol/openapi.yaml
@@ -1061,6 +1061,8 @@ components:
           "$ref": "#/components/schemas/SearchScopeKind"
         exhaustive:
           type: boolean
+        candidateCoverage:
+          "$ref": "#/components/schemas/CandidateCoverage"
         candidateFileCount:
           type: integer
           format: int32
@@ -1080,6 +1082,11 @@ components:
         - FILE
         - MODULE
         - DEPENDENT_MODULES
+    CandidateCoverage:
+      type: string
+      enum:
+        - COMPLETE
+        - PARTIAL
     TextEdit:
       type: object
       properties:

--- a/cli-rs/resources/kast-skill/SKILL.md
+++ b/cli-rs/resources/kast-skill/SKILL.md
@@ -54,8 +54,8 @@ Kast reports and sends their canonical workspace-contained paths.
 Use this section only when a typed `kast agent` command fails, the user asks for
 readiness evidence, or backend state is part of the task.
 
-- `kast ready --for agent|kotlin|release|machine --workspace-root "$PWD"` is read-only readiness.
-- `kast repair --for agent|kotlin|release|machine --workspace-root "$PWD"` is plan-only repair.
+- `kast ready --for agent --workspace-root "$PWD"` is read-only readiness; use `kotlin`, `release`, or `machine` when that is the actual target.
+- `kast repair --for agent --workspace-root "$PWD"` is plan-only repair; use `kotlin`, `release`, or `machine` when that is the actual target.
 - Add `--apply` to `kast repair` only after the repair plan or readiness output asks for install-state mutation.
 - `kast agent verify --workspace-root "$PWD"` proves backend health, runtime status, and capabilities for semantic work.
 - On macOS, Homebrew owns only the CLI and JetBrains owns plugin installation and updates. If metadata is stale, update as needed, reopen the exact project, and refresh it.

--- a/cli-rs/src/agent.rs
+++ b/cli-rs/src/agent.rs
@@ -36,7 +36,7 @@ use crate::{output, runtime, validate};
 use clap::CommandFactory;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path, PathBuf};
 
 include!("agent/types.rs");

--- a/cli-rs/src/agent/dispatch.rs
+++ b/cli-rs/src/agent/dispatch.rs
@@ -183,18 +183,7 @@ fn execute_agent_rename(args: AgentRenameArgs) -> AgentEnvelope {
     }));
     let request = json_rpc_request("symbol/rename", params.clone());
     if !args.mutation.apply {
-        let result = json!({
-            "type": "KAST_AGENT_RENAME_PLAN",
-            "ok": true,
-            "mutates": true,
-            "applyRequired": true,
-            "request": request,
-            "help": [
-                "Run `kast agent rename --symbol <fq-name> --new-name <name> --apply --workspace-root <repo>` to apply this rename."
-            ],
-            "schemaVersion": SCHEMA_VERSION,
-        });
-        return result_envelope("agent/rename".to_string(), result);
+        return execute_agent_rename_preview(args, request);
     }
     let idempotency_key = match applied_idempotency_key(args.mutation) {
         Ok(key) => key,
@@ -213,8 +202,186 @@ fn execute_agent_rename(args: AgentRenameArgs) -> AgentEnvelope {
         request,
         runtime: args.runtime,
         full_response: true,
-        operation: AgentOperation::Mutation,
+        operation: AgentOperation::AppliedMutation,
     })
+}
+
+fn execute_agent_rename_preview(args: AgentRenameArgs, identity_request: Value) -> AgentEnvelope {
+    let resolve_request = json_rpc_request(
+        "symbol/resolve",
+        drop_nulls(json!({
+            "symbol": args.symbol,
+            "kind": args.kind.map(|kind| kind.canonical()),
+            "fileHint": args.file_hint,
+            "containingType": args.containing_type,
+            "includeDeclarationScope": false,
+            "includeDocumentation": false,
+            "includeSurroundingMembers": false,
+        })),
+    );
+    let session = match runtime::raw_rpc_session(
+        args.runtime.workspace_root.clone(),
+        args.runtime.backend_name,
+    ) {
+        Ok(session) => session,
+        Err(error) => {
+            return error_envelope(
+                "agent/rename".to_string(),
+                Some(identity_request),
+                AgentError::from_cli_error(error),
+            );
+        }
+    };
+    let resolution = execute_request_with_session(
+        AgentRequest {
+            method: "symbol/resolve".to_string(),
+            request: resolve_request,
+            runtime: args.runtime.clone(),
+            full_response: true,
+            operation: AgentOperation::ReadOnly,
+        },
+        Some(&session),
+    );
+    if !resolution.ok {
+        return error_envelope(
+            "agent/rename".to_string(),
+            Some(identity_request),
+            resolution.error.unwrap_or_else(|| {
+                agent_error(
+                    "INVALID_RENAME_RESOLUTION",
+                    "Rename target resolution failed without a typed error.",
+                )
+            }),
+        );
+    }
+    let resolved_value = match resolution.result {
+        Some(result) => result,
+        None => {
+            return error_envelope(
+                "agent/rename".to_string(),
+                Some(identity_request),
+                agent_error(
+                    "INVALID_RENAME_RESOLUTION",
+                    "Rename target resolution returned no result.",
+                ),
+            );
+        }
+    };
+    let resolved = match serde_json::from_value::<AgentCompilerResolveResponse>(resolved_value.clone()) {
+        Ok(AgentCompilerResolveResponse::Resolved { symbol }) => symbol,
+        Ok(AgentCompilerResolveResponse::NotFound) => {
+            return error_envelope(
+                "agent/rename".to_string(),
+                Some(identity_request),
+                agent_error("AGENT_RENAME_TARGET_NOT_FOUND", "The requested rename target was not found."),
+            );
+        }
+        Ok(AgentCompilerResolveResponse::Ambiguous { candidates }) => {
+            let mut error = agent_error(
+                "AGENT_RENAME_TARGET_AMBIGUOUS",
+                "The requested rename target was ambiguous.",
+            );
+            error.details.insert("candidates".to_string(), Value::Array(candidates));
+            return error_envelope("agent/rename".to_string(), Some(identity_request), error);
+        }
+        Ok(AgentCompilerResolveResponse::OperationalFailure) => {
+            return error_envelope(
+                "agent/rename".to_string(),
+                Some(identity_request),
+                agent_error(
+                    "AGENT_RENAME_RESOLUTION_FAILED",
+                    "The compiler could not resolve the requested rename target.",
+                ),
+            );
+        }
+        Err(error) => {
+            return error_envelope(
+                "agent/rename".to_string(),
+                Some(identity_request),
+                agent_error(
+                    "INVALID_RENAME_RESOLUTION",
+                    format!("Rename target resolution violated its contract: {error}"),
+                ),
+            );
+        }
+    };
+    let Some(position) = resolved.rename_position() else {
+        return error_envelope(
+            "agent/rename".to_string(),
+            Some(identity_request),
+            agent_error(
+                "AGENT_RENAME_IDENTITY_ANCHOR_UNAVAILABLE",
+                "The compiler-resolved rename target had no usable file and offset anchor.",
+            ),
+        );
+    };
+    let preview_request = json_rpc_request(
+        "raw/rename",
+        json!({
+            "position": position,
+            "newName": args.new_name,
+            "dryRun": true,
+        }),
+    );
+    let preview_envelope = execute_request_with_session(
+        AgentRequest {
+            method: "raw/rename".to_string(),
+            request: preview_request,
+            runtime: args.runtime,
+            full_response: true,
+            operation: AgentOperation::MutationPreview,
+        },
+        Some(&session),
+    );
+    if !preview_envelope.ok {
+        return error_envelope(
+            "agent/rename".to_string(),
+            Some(identity_request),
+            preview_envelope.error.unwrap_or_else(|| {
+                agent_error(
+                    "INVALID_RENAME_PREVIEW",
+                    "The backend rename preview failed without a typed error.",
+                )
+            }),
+        );
+    }
+    let preview = match preview_envelope
+        .result
+        .and_then(|result| serde_json::from_value::<AgentRenamePreview>(result).ok())
+    {
+        Some(preview) => preview,
+        None => {
+            return error_envelope(
+                "agent/rename".to_string(),
+                Some(identity_request),
+                agent_error(
+                    "INVALID_RENAME_PREVIEW",
+                    "The backend rename preview violated the typed edit-plan contract.",
+                ),
+            );
+        }
+    };
+    if let Err(message) = preview.validate() {
+        return error_envelope(
+            "agent/rename".to_string(),
+            Some(identity_request),
+            agent_error("INVALID_RENAME_PREVIEW", message),
+        );
+    }
+    let result = json!({
+        "type": "KAST_AGENT_RENAME_PLAN",
+        "ok": true,
+        "mutates": true,
+        "applyRequired": true,
+        "request": identity_request,
+        "resolution": resolved_value,
+        "preview": preview,
+        "help": [
+            "Run `kast agent rename --symbol <fq-name> --new-name <name> --apply --workspace-root <repo>` to apply this verified rename plan."
+        ],
+        "schemaVersion": SCHEMA_VERSION,
+    });
+    result_envelope("agent/rename".to_string(), result)
 }
 
 fn execute_agent_add_file(args: AgentAddFileArgs) -> AgentEnvelope {
@@ -342,7 +509,7 @@ fn execute_agent_mutation(
         request,
         runtime,
         full_response: true,
-        operation: AgentOperation::Mutation,
+        operation: AgentOperation::AppliedMutation,
     })
 }
 

--- a/cli-rs/src/agent/request.rs
+++ b/cli-rs/src/agent/request.rs
@@ -6,7 +6,7 @@ fn execute_request_with_session(
     request: AgentRequest,
     session: Option<&runtime::RawRpcSession>,
 ) -> AgentEnvelope {
-    if request.operation == AgentOperation::Mutation {
+    if request.operation == AgentOperation::AppliedMutation {
         match runtime::semantic_mutation_workspace_route(
             request.runtime.workspace_root.clone(),
             request.runtime.backend_name,

--- a/cli-rs/src/agent/types.rs
+++ b/cli-rs/src/agent/types.rs
@@ -643,7 +643,8 @@ struct AgentRequest {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AgentOperation {
     ReadOnly,
-    Mutation,
+    MutationPreview,
+    AppliedMutation,
 }
 
 #[derive(Debug, Serialize)]
@@ -742,6 +743,40 @@ struct AgentCompilerSymbolIdentity {
     fields: BTreeMap<String, Value>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentRenamePosition {
+    file_path: String,
+    offset: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AgentRenamePreview {
+    edits: Vec<AgentRenamePreviewEdit>,
+    file_hashes: Vec<AgentRenamePreviewFileHash>,
+    affected_files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    search_scope: Option<Value>,
+    schema_version: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AgentRenamePreviewEdit {
+    file_path: String,
+    start_offset: u32,
+    end_offset: u32,
+    new_text: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AgentRenamePreviewFileHash {
+    file_path: String,
+    hash: String,
+}
+
 impl AgentCompilerSymbolIdentity {
     fn has_complete_anchor(&self) -> bool {
         let location = self.fields.get("location").and_then(Value::as_object);
@@ -759,5 +794,57 @@ impl AgentCompilerSymbolIdentity {
                 .and_then(|location| location.get("startOffset"))
                 .and_then(Value::as_u64)
                 .is_some()
+    }
+
+    fn rename_position(&self) -> Option<AgentRenamePosition> {
+        let location = self.fields.get("location")?.as_object()?;
+        let file_path = location.get("filePath")?.as_str()?.trim();
+        let offset = location.get("startOffset")?.as_u64()?;
+        if file_path.is_empty() || offset > i32::MAX as u64 {
+            return None;
+        }
+        Some(AgentRenamePosition {
+            file_path: file_path.to_string(),
+            offset: offset as u32,
+        })
+    }
+}
+
+impl AgentRenamePreview {
+    fn validate(&self) -> std::result::Result<(), String> {
+        if self.edits.is_empty() {
+            return Err("rename preview contained no edits".to_string());
+        }
+        let mut affected_files = Vec::new();
+        for edit in &self.edits {
+            if edit.file_path.trim().is_empty()
+                || edit.start_offset > edit.end_offset
+                || edit.new_text.is_empty()
+            {
+                return Err("rename preview contained an invalid text edit".to_string());
+            }
+            if !affected_files.contains(&edit.file_path) {
+                affected_files.push(edit.file_path.clone());
+            }
+        }
+        if affected_files != self.affected_files {
+            return Err("rename preview affected files did not match its edits".to_string());
+        }
+        let hashed_files = self
+            .file_hashes
+            .iter()
+            .map(|file_hash| file_hash.file_path.as_str())
+            .collect::<BTreeSet<_>>();
+        if self.file_hashes.len() != self.affected_files.len()
+            || hashed_files.len() != self.affected_files.len()
+            || self.file_hashes.iter().any(|file_hash| {
+                !self.affected_files.contains(&file_hash.file_path)
+                    || file_hash.hash.len() != 64
+                    || !file_hash.hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+            })
+        {
+            return Err("rename preview file hashes did not cover every affected file".to_string());
+        }
+        Ok(())
     }
 }

--- a/cli-rs/src/cli.rs
+++ b/cli-rs/src/cli.rs
@@ -7,6 +7,7 @@ include!("cli/inspect_metrics_demo_rpc.rs");
 include!("cli/agent.rs");
 include!("cli/release_package_generate.rs");
 include!("cli/runtime_lsp.rs");
+include!("cli/local_development.rs");
 include!("cli/command_groups.rs");
 include!("cli/conversions.rs");
 include!("cli/install_machine.rs");

--- a/cli-rs/src/cli/command_groups.rs
+++ b/cli-rs/src/cli/command_groups.rs
@@ -7,6 +7,8 @@ pub struct DeveloperArgs {
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum DeveloperCommand {
+    /// Build and inspect isolated local-development authority.
+    Local(LocalDevelopmentArgs),
     /// Manage backend runtime lifecycle.
     Runtime(RuntimeCommandArgs),
     /// Inspect local Kast state, catalogs, demos, and source-index metrics.

--- a/cli-rs/src/cli/local_development.rs
+++ b/cli-rs/src/cli/local_development.rs
@@ -1,0 +1,103 @@
+#[derive(Debug, Args, Clone)]
+#[command(disable_help_subcommand = true)]
+pub struct LocalDevelopmentArgs {
+    #[command(subcommand)]
+    pub command: LocalDevelopmentCommand,
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum LocalDevelopmentCommand {
+    /// Capture strict source identity for a refresh transaction.
+    Snapshot(LocalDevelopmentSnapshotArgs),
+    /// Bind one built artifact to the captured source snapshot and its exact bytes.
+    Attest(LocalDevelopmentAttestArgs),
+    /// Refresh one isolated, revision-coherent local development authority.
+    Refresh(LocalDevelopmentRefreshArgs),
+    /// Reactivate the validated previous local generation.
+    Rollback(LocalDevelopmentRollbackArgs),
+    /// Remove only receipt-owned local state and restore ordinary authority.
+    Remove(LocalDevelopmentRemoveArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct LocalDevelopmentSnapshotArgs {
+    /// Canonical checkout whose content is captured.
+    #[arg(long)]
+    pub source_root: PathBuf,
+    /// Strict JSON snapshot file to write atomically.
+    #[arg(long)]
+    pub output_file: PathBuf,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct LocalDevelopmentAttestArgs {
+    /// Canonical checkout whose source snapshot produced the artifact.
+    #[arg(long)]
+    pub source_root: PathBuf,
+    /// Captured source snapshot that must still match while hashing the artifact.
+    #[arg(long)]
+    pub expected_source_snapshot: PathBuf,
+    /// Typed artifact surface being attested.
+    #[arg(long, value_enum)]
+    pub artifact_kind: LocalArtifactKindArg,
+    /// Built CLI file or portable headless backend directory.
+    #[arg(long)]
+    pub artifact: PathBuf,
+    /// Strict provenance JSON file to write atomically.
+    #[arg(long)]
+    pub output_file: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum LocalArtifactKindArg {
+    Cli,
+    HeadlessBackend,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct LocalDevelopmentRefreshArgs {
+    /// Canonical checkout whose source snapshot owns the local authority.
+    #[arg(long)]
+    pub source_root: PathBuf,
+    /// Exact workspace that receives the revision-matched agent guidance.
+    #[arg(long)]
+    pub workspace_root: PathBuf,
+    /// Isolated local-development prefix. Defaults to a checkout-derived path.
+    #[arg(long)]
+    pub prefix: Option<PathBuf>,
+    /// Captured source snapshot that must still match after artifact staging.
+    #[arg(long)]
+    pub expected_source_snapshot: PathBuf,
+    /// Built development CLI artifact to install.
+    #[arg(long)]
+    pub cli_binary: PathBuf,
+    /// Source-bound provenance emitted by that exact CLI artifact.
+    #[arg(long)]
+    pub cli_provenance: PathBuf,
+    /// Built portable headless backend directory to install.
+    #[arg(long)]
+    pub backend_directory: PathBuf,
+    /// Source-bound provenance for the exact backend directory bytes.
+    #[arg(long)]
+    pub backend_provenance: PathBuf,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct LocalDevelopmentRollbackArgs {
+    /// Exact isolated local-development prefix to roll back.
+    #[arg(long)]
+    pub prefix: PathBuf,
+    /// Exact previous generation to activate; retries are a no-op once it is current.
+    #[arg(long)]
+    pub to_generation: String,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct LocalDevelopmentRemoveArgs {
+    /// Exact isolated local-development prefix to remove.
+    #[arg(long)]
+    pub prefix: PathBuf,
+    /// Exact workspace whose receipt-owned guidance binding may be removed.
+    #[arg(long)]
+    pub workspace_root: PathBuf,
+}

--- a/cli-rs/src/cli/runtime_lsp.rs
+++ b/cli-rs/src/cli/runtime_lsp.rs
@@ -1,3 +1,5 @@
+pub const DEFAULT_RUNTIME_WAIT_TIMEOUT_MS: u64 = 60_000;
+
 #[derive(Debug, Args, Clone)]
 pub struct RuntimeArgs {
     /// Absolute workspace root for daemon lifecycle and RPC commands.
@@ -10,7 +12,7 @@ pub struct RuntimeArgs {
     #[arg(long, hide = true)]
     pub idea_home: Option<PathBuf>,
     /// Maximum time to wait for a ready daemon when a command needs one.
-    #[arg(long, default_value_t = 60_000, hide = true)]
+    #[arg(long, default_value_t = DEFAULT_RUNTIME_WAIT_TIMEOUT_MS, hide = true)]
     pub wait_timeout_ms: u64,
     /// Allow up to return while the daemon is servable in INDEXING.
     #[arg(long, num_args = 0..=1, default_missing_value = "true", hide = true)]
@@ -140,4 +142,26 @@ pub enum RuntimeCommand {
     Restart(RuntimeArgs),
     /// Print the advertised capabilities for the workspace backend.
     Capabilities(RuntimeArgs),
+}
+
+#[cfg(test)]
+mod runtime_args_tests {
+    use super::*;
+
+    #[test]
+    fn runtime_up_uses_bounded_default_timeout() {
+        let cli = Cli::try_parse_from(["kast", "developer", "runtime", "up"])
+            .expect("runtime up arguments");
+        let Some(Command::Developer(DeveloperArgs {
+            command:
+                DeveloperCommand::Runtime(RuntimeCommandArgs {
+                    command: RuntimeCommand::Up(args),
+                }),
+        })) = cli.command
+        else {
+            panic!("expected developer runtime up command");
+        };
+
+        assert_eq!(args.wait_timeout_ms, 60_000);
+    }
 }

--- a/cli-rs/src/config/model.rs
+++ b/cli-rs/src/config/model.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KastConfig {
     pub server: ServerConfig,
     #[serde(skip_serializing_if = "RuntimeConfig::is_default")]
@@ -268,6 +269,7 @@ pub enum PathResolutionSource {
     Default,
     Env,
     HomebrewReceipt,
+    LocalDevelopmentReceipt,
     Manifest,
 }
 
@@ -277,6 +279,7 @@ impl fmt::Display for PathResolutionSource {
             Self::Default => "default",
             Self::Env => "env",
             Self::HomebrewReceipt => "homebrew-receipt",
+            Self::LocalDevelopmentReceipt => "local-development-receipt",
             Self::Manifest => "manifest",
         };
         formatter.write_str(value)
@@ -307,6 +310,7 @@ impl PathResolutionEntryContext {
         workspace_root: Option<&Path>,
         install_manifest_exists: bool,
         homebrew_receipt_exists: bool,
+        local_development_receipt_active: bool,
     ) -> Self {
         Self::from_states(
             install_manifest_exists,
@@ -314,6 +318,7 @@ impl PathResolutionEntryContext {
             env_present("KAST_INSTALL_ROOT"),
             env_present("KAST_CACHE_HOME"),
             workspace_root.is_some() && env_present("KAST_CACHE_HOME"),
+            local_development_receipt_active,
         )
     }
 
@@ -323,7 +328,21 @@ impl PathResolutionEntryContext {
         install_root_env: bool,
         cache_home_env: bool,
         workspace_cache_environment: bool,
+        local_development_receipt_active: bool,
     ) -> Self {
+        if local_development_receipt_active {
+            return Self {
+                install_root_source: PathResolutionSource::LocalDevelopmentReceipt,
+                bin_dir_source: PathResolutionSource::LocalDevelopmentReceipt,
+                cache_dir_source: PathResolutionSource::LocalDevelopmentReceipt,
+                logs_dir_source: PathResolutionSource::LocalDevelopmentReceipt,
+                logs_dir_parent: None,
+                runtime_dir_source: PathResolutionSource::LocalDevelopmentReceipt,
+                runtime_dir_parent: None,
+                workspace_state_source: PathResolutionSource::LocalDevelopmentReceipt,
+                workspace_state_parent: Some("paths.runtimeDir"),
+            };
+        }
         let install_manifest_active = install_manifest_exists && !homebrew_receipt_exists;
         let install_root_source =
             source_for_manifest_or_env_state(install_manifest_active, install_root_env);

--- a/cli-rs/src/config/path_resolution.rs
+++ b/cli-rs/src/config/path_resolution.rs
@@ -20,8 +20,16 @@ pub fn path_resolution_report(
 ) -> Result<PathResolutionReport> {
     let install_manifest = manifest::default_install_manifest_path();
     let install_manifest_exists = install_manifest.is_file();
+    let local_development_receipt = env::var_os("KAST_LOCAL_DEVELOPMENT_RECEIPT")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let local_development_receipt_active = local_development_receipt.is_some();
     #[cfg(target_os = "macos")]
-    let homebrew_receipt = crate::install::default_macos_homebrew_receipt_path();
+    let homebrew_receipt = if local_development_receipt_active {
+        PathBuf::new()
+    } else {
+        crate::install::default_macos_homebrew_receipt_path()
+    };
     #[cfg(not(target_os = "macos"))]
     let homebrew_receipt = PathBuf::new();
     let homebrew_receipt_exists = homebrew_receipt.is_file();
@@ -42,7 +50,9 @@ pub fn path_resolution_report(
         .chain(workspace_keys.iter())
         .filter(|key| install_owned_config_key(key))
     {
-        let authority = if homebrew_receipt_exists {
+        let authority = if local_development_receipt_active {
+            "the local-development receipt"
+        } else if homebrew_receipt_exists {
             "the macOS Homebrew receipt"
         } else if install_manifest_exists {
             "install.json"
@@ -67,11 +77,13 @@ pub fn path_resolution_report(
         workspace_root,
         install_manifest_exists,
         homebrew_receipt_exists,
+        local_development_receipt_active,
     );
     let entries = path_resolution_entries(config, mode, entry_context);
     Ok(PathResolutionReport {
         root: config.paths.install_root.display().to_string(),
         config_files: config_files(
+            local_development_receipt,
             homebrew_receipt,
             install_manifest,
             global_config,
@@ -239,12 +251,20 @@ fn path_entry(
 }
 
 fn config_files(
+    local_development_receipt: Option<PathBuf>,
     homebrew_receipt: PathBuf,
     install_manifest: PathBuf,
     global_config: PathBuf,
     workspace_config: Option<PathBuf>,
 ) -> Vec<PathResolutionConfigFile> {
     let mut files = Vec::new();
+    if let Some(local_development_receipt) = local_development_receipt {
+        files.push(PathResolutionConfigFile {
+            scope: "local-development-receipt".to_string(),
+            exists: local_development_receipt.is_file(),
+            path: local_development_receipt.display().to_string(),
+        });
+    }
     if !homebrew_receipt.as_os_str().is_empty() {
         files.push(PathResolutionConfigFile {
             scope: "macos-homebrew-receipt".to_string(),

--- a/cli-rs/src/config/tests.rs
+++ b/cli-rs/src/config/tests.rs
@@ -363,7 +363,7 @@ installRoot = "{}"
         let entries = path_resolution_entries(
             &config,
             PathResolutionMode::Cli,
-            PathResolutionEntryContext::from_states(false, false, false, false, false),
+            PathResolutionEntryContext::from_states(false, false, false, false, false, false),
         );
         let entry = |key: &str| report_entry(&entries, key);
 
@@ -411,7 +411,7 @@ installRoot = "{}"
         let entries = path_resolution_entries(
             &config,
             PathResolutionMode::Cli,
-            PathResolutionEntryContext::from_states(true, false, true, true, false),
+            PathResolutionEntryContext::from_states(true, false, true, true, false, false),
         );
         let entry = |key: &str| report_entry(&entries, key);
 
@@ -454,7 +454,7 @@ installRoot = "{}"
         let entries = path_resolution_entries(
             &config,
             PathResolutionMode::Cli,
-            PathResolutionEntryContext::from_states(true, true, false, false, false),
+            PathResolutionEntryContext::from_states(true, true, false, false, false, false),
         );
         let entry = |key: &str| report_entry(&entries, key);
 

--- a/cli-rs/src/daemon.rs
+++ b/cli-rs/src/daemon.rs
@@ -4,11 +4,11 @@ use crate::error::{CliError, Result};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 
 const HEADLESS_MAIN_CLASS: &str = "io.github.amichne.kast.headless.HeadlessMainKt";
 
-pub fn spawn_background(args: DaemonStartArgs, log_file: &Path) -> Result<()> {
+pub fn spawn_background(args: DaemonStartArgs, log_file: &Path) -> Result<Child> {
     let workspace_root = config::resolve_workspace_root(args.workspace_root.clone())?;
     let config = KastConfig::load(&workspace_root)?;
     let backend_name = args.backend_name.unwrap_or(BackendName::Headless);
@@ -27,7 +27,6 @@ pub fn spawn_background(args: DaemonStartArgs, log_file: &Path) -> Result<()> {
         .stdout(Stdio::from(log))
         .stderr(Stdio::from(log_err))
         .spawn()
-        .map(|_| ())
         .map_err(|error| {
             CliError::new(
                 "DAEMON_START_ERROR",
@@ -49,6 +48,7 @@ pub fn java_command(args: &DaemonStartArgs, config: &KastConfig) -> Result<Vec<S
     }
     let runtime_libs_dir =
         config::backend_runtime_libs_dir(config, backend_name, args.runtime_libs_dir.clone())?;
+    crate::local_development::validate_active_local_backend_runtime(&runtime_libs_dir)?;
     let classpath = read_classpath(&runtime_libs_dir)?;
     let java_exec = env::var("JAVA_HOME")
         .ok()
@@ -400,6 +400,7 @@ mod tests {
         config.backends.headless.runtime_libs_dir = Some(headless_libs.clone());
         config.backends.headless.idea_home = Some(idea_home.clone());
         config.server.max_results = 42;
+        config.project_open.profile_auto_init = false;
         let args = DaemonStartArgs {
             workspace_root: Some(temp.path().to_path_buf()),
             backend_name: Some(crate::cli::BackendName::Headless),
@@ -429,6 +430,8 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(config_arg).expect("runtime config json"))
                 .expect("runtime config payload");
         assert_eq!(payload["server"]["maxResults"], 42);
+        assert_eq!(payload["projectOpen"]["profileAutoInit"], false);
+        assert!(payload.get("project_open").is_none());
         assert_eq!(
             payload["paths"]["runtimeDir"],
             runtime_dir.display().to_string()

--- a/cli-rs/src/demo/story.rs
+++ b/cli-rs/src/demo/story.rs
@@ -277,7 +277,7 @@ fn demo_runtime_args(request: &DemoRequest) -> RuntimeArgs {
         workspace_root: Some(request.workspace_root.clone()),
         backend_name: request.backend_name,
         idea_home: None,
-        wait_timeout_ms: 60_000,
+        wait_timeout_ms: crate::cli::DEFAULT_RUNTIME_WAIT_TIMEOUT_MS,
         accept_indexing: Some(false),
         no_auto_start: Some(true),
         socket_path: None,

--- a/cli-rs/src/local_development.rs
+++ b/cli-rs/src/local_development.rs
@@ -1,0 +1,75 @@
+use crate::cli::{LocalDevelopmentCommand, LocalDevelopmentSnapshotArgs, OutputFormat};
+use crate::error::{CliError, Result};
+
+include!("local_development/source_snapshot.rs");
+include!("local_development/types.rs");
+include!("local_development/filesystem.rs");
+include!("local_development/provenance.rs");
+include!("local_development/refresh.rs");
+include!("local_development/lifecycle.rs");
+
+pub fn run(command: LocalDevelopmentCommand, output_format: OutputFormat) -> Result<i32> {
+    match command {
+        LocalDevelopmentCommand::Snapshot(args) => snapshot(args, output_format),
+        LocalDevelopmentCommand::Attest(args) => {
+            let kind = match args.artifact_kind {
+                crate::cli::LocalArtifactKindArg::Cli => LocalArtifactKind::Cli,
+                crate::cli::LocalArtifactKindArg::HeadlessBackend => {
+                    LocalArtifactKind::HeadlessBackend
+                }
+            };
+            let result = attest_local_artifact(LocalArtifactAttestationRequest {
+                source_root: args.source_root,
+                expected_source_snapshot: args.expected_source_snapshot,
+                kind,
+                artifact: args.artifact,
+                output_file: args.output_file,
+            })?;
+            crate::output::print_structured(&result, output_format)?;
+            Ok(0)
+        }
+        LocalDevelopmentCommand::Refresh(args) => {
+            let prefix = args
+                .prefix
+                .unwrap_or_else(|| args.source_root.join(".kast/local-development"));
+            let result = refresh_local_development(LocalDevelopmentRefreshRequest {
+                source_root: args.source_root,
+                workspace_root: args.workspace_root,
+                prefix,
+                expected_source_snapshot: args.expected_source_snapshot,
+                cli_binary: args.cli_binary,
+                cli_provenance: args.cli_provenance,
+                backend_directory: args.backend_directory,
+                backend_provenance: args.backend_provenance,
+            })?;
+            crate::output::print_structured(&result, output_format)?;
+            Ok(0)
+        }
+        LocalDevelopmentCommand::Rollback(args) => {
+            let result = rollback_local_development(LocalDevelopmentRollbackRequest {
+                prefix: args.prefix,
+                to_generation: LocalGenerationId::try_from(args.to_generation)?,
+            })?;
+            crate::output::print_structured(&result, output_format)?;
+            Ok(0)
+        }
+        LocalDevelopmentCommand::Remove(args) => {
+            let result = remove_local_development(LocalDevelopmentRemoveRequest {
+                prefix: args.prefix,
+                workspace_root: args.workspace_root,
+            })?;
+            crate::output::print_structured(&result, output_format)?;
+            Ok(0)
+        }
+    }
+}
+
+fn snapshot(args: LocalDevelopmentSnapshotArgs, output_format: OutputFormat) -> Result<i32> {
+    let snapshot = SourceSnapshot::capture(&args.source_root)?;
+    snapshot.write_atomic(&args.output_file)?;
+    crate::output::print_structured(&snapshot, output_format)?;
+    Ok(0)
+}
+
+#[cfg(test)]
+include!("local_development/tests.rs");

--- a/cli-rs/src/local_development/filesystem.rs
+++ b/cli-rs/src/local_development/filesystem.rs
@@ -1,0 +1,212 @@
+fn copy_directory_tree(source: &Path, target: &Path) -> Result<()> {
+    if !source.is_dir() {
+        return Err(CliError::new(
+            "LOCAL_COMPONENT_MISSING",
+            format!("Local component directory is missing: {}", source.display()),
+        ));
+    }
+    fs::create_dir_all(target)?;
+    let mut entries = fs::read_dir(source)?.collect::<std::io::Result<Vec<_>>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_directory_tree(&source_path, &target_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&source_path, &target_path)?;
+            fs::set_permissions(&target_path, fs::metadata(&source_path)?.permissions())?;
+        } else {
+            return Err(CliError::new(
+                "LOCAL_COMPONENT_ENTRY_UNSUPPORTED",
+                format!(
+                    "Local component refuses non-file, non-directory entry {}.",
+                    source_path.display()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn tree_sha256(root: &Path) -> Result<Sha256Digest> {
+    if root.is_file() {
+        return Sha256Digest::try_from(crate::manifest::sha256_file(root)?);
+    }
+    if !root.is_dir() {
+        return Err(CliError::new(
+            "LOCAL_COMPONENT_MISSING",
+            format!("Local component target is missing: {}", root.display()),
+        ));
+    }
+    let mut paths = Vec::new();
+    collect_tree_paths(root, root, &mut paths)?;
+    paths.sort_by_key(|path| path_identity_bytes(path));
+    let mut digest = Sha256::new();
+    digest.update(b"kast-local-component-v1\0");
+    digest.update((paths.len() as u64).to_be_bytes());
+    for relative in paths {
+        let identity = path_identity_bytes(&relative);
+        update_framed_bytes(&mut digest, &identity);
+        let path = root.join(&relative);
+        let metadata = fs::symlink_metadata(&path)?;
+        let mut entry_digest = Sha256::new();
+        if metadata.is_dir() {
+            entry_digest.update(b"directory\0");
+        } else if metadata.is_file() {
+            entry_digest.update(b"file\0");
+            entry_digest.update([executable_marker(&metadata)]);
+            entry_digest.update(metadata.len().to_be_bytes());
+            let mut file = fs::File::open(&path)?;
+            let mut buffer = [0_u8; 64 * 1024];
+            let mut total = 0_u64;
+            loop {
+                let read = file.read(&mut buffer)?;
+                if read == 0 {
+                    break;
+                }
+                entry_digest.update(&buffer[..read]);
+                total += read as u64;
+            }
+            if total != metadata.len() {
+                return Err(CliError::new(
+                    "LOCAL_COMPONENT_CHANGED",
+                    format!("Component file length changed while hashing {}.", path.display()),
+                ));
+            }
+        } else {
+            return Err(CliError::new(
+                "LOCAL_COMPONENT_ENTRY_UNSUPPORTED",
+                format!("Unsupported installed component entry: {}", path.display()),
+            ));
+        }
+        digest.update(entry_digest.finalize());
+    }
+    Sha256Digest::try_from(hex::encode(digest.finalize()))
+}
+
+fn collect_tree_paths(root: &Path, current: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {
+    let mut entries = fs::read_dir(current)?.collect::<std::io::Result<Vec<_>>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let path = entry.path();
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|error| {
+                CliError::new(
+                    "LOCAL_COMPONENT_PATH_INVALID",
+                    format!("Component path escaped its root: {error}"),
+                )
+            })?
+            .to_path_buf();
+        paths.push(relative);
+        if entry.file_type()?.is_dir() {
+            collect_tree_paths(root, &path, paths)?;
+        }
+    }
+    Ok(())
+}
+
+fn write_bytes(path: &Path, contents: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, contents)?;
+    Ok(())
+}
+
+fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let temporary = path.with_extension(format!("json.tmp-{}", std::process::id()));
+    let result = (|| -> Result<()> {
+        let mut output = fs::File::create(&temporary)?;
+        output.write_all(&serde_json::to_vec_pretty(value)?)?;
+        output.write_all(b"\n")?;
+        output.sync_all()?;
+        fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn replace_file_atomically(path: &Path, contents: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let temporary = path.with_extension(format!("tmp-{}", std::process::id()));
+    let result = (|| -> Result<()> {
+        let mut output = fs::File::create(&temporary)?;
+        output.write_all(contents)?;
+        output.sync_all()?;
+        crate::manifest::make_executable(&temporary)?;
+        fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn replace_plain_file_atomically(path: &Path, contents: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let temporary = path.with_extension(format!("tmp-{}", std::process::id()));
+    let result = (|| -> Result<()> {
+        let mut output = fs::File::create(&temporary)?;
+        output.write_all(contents)?;
+        output.sync_all()?;
+        fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn replace_relative_symlink(path: &Path, target: &Path) -> Result<()> {
+    use std::os::unix::fs::symlink;
+
+    let parent = path.parent().ok_or_else(|| {
+        CliError::new(
+            "LOCAL_PREFIX_INVALID",
+            format!("Local authority link has no parent: {}", path.display()),
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    let temporary = path.with_extension(format!("next-{}", std::process::id()));
+    if fs::symlink_metadata(&temporary).is_ok() {
+        fs::remove_file(&temporary)?;
+    }
+    symlink(target, &temporary)?;
+    fs::rename(&temporary, path)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn replace_relative_symlink(_path: &Path, _target: &Path) -> Result<()> {
+    Err(CliError::new(
+        "LOCAL_DEVELOPMENT_UNSUPPORTED",
+        "Atomic local-development generation links are not implemented on this platform.",
+    ))
+}
+
+fn read_relative_symlink(path: &Path) -> Result<Option<PathBuf>> {
+    match fs::read_link(path) {
+        Ok(target) => Ok(Some(target)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(CliError::new(
+            "LOCAL_AUTHORITY_LINK_INVALID",
+            format!("Could not read local authority link {}: {error}", path.display()),
+        )),
+    }
+}

--- a/cli-rs/src/local_development/filesystem.rs
+++ b/cli-rs/src/local_development/filesystem.rs
@@ -135,25 +135,7 @@ fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     result
 }
 
-fn replace_file_atomically(path: &Path, contents: &[u8]) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let temporary = path.with_extension(format!("tmp-{}", std::process::id()));
-    let result = (|| -> Result<()> {
-        let mut output = fs::File::create(&temporary)?;
-        output.write_all(contents)?;
-        output.sync_all()?;
-        crate::manifest::make_executable(&temporary)?;
-        fs::rename(&temporary, path)?;
-        Ok(())
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(&temporary);
-    }
-    result
-}
-
+#[cfg(test)]
 fn replace_plain_file_atomically(path: &Path, contents: &[u8]) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;

--- a/cli-rs/src/local_development/lifecycle.rs
+++ b/cli-rs/src/local_development/lifecycle.rs
@@ -1,0 +1,433 @@
+pub fn rollback_local_development(
+    request: LocalDevelopmentRollbackRequest,
+) -> Result<LocalDevelopmentRollbackResult> {
+    let prefix = canonical_directory(
+        &absolute_path(request.prefix)?,
+        "local-development prefix",
+    )?;
+    let requested_generation = request.to_generation;
+    with_local_authority_lock(&prefix, || {
+        let current_target = read_generation_link(&prefix.join("current"))?.ok_or_else(|| {
+            CliError::new(
+                "LOCAL_AUTHORITY_INACTIVE",
+                format!("No active local generation exists at {}.", prefix.display()),
+            )
+        })?;
+        let current_generation = prefix.join(&current_target);
+        let current_receipt = read_local_development_receipt(
+            &current_generation.join("authority.json"),
+        )?;
+        validate_receipt_identity(
+            &current_receipt,
+            &prefix,
+            &current_generation,
+            &current_receipt.workspace_root,
+        )?;
+        validate_receipt_components(&current_receipt)?;
+        validate_stable_authority(
+            &prefix.join("authority.json"),
+            &current_receipt,
+            &current_generation,
+        )?;
+        if current_receipt.generation_id == requested_generation {
+            return Ok(LocalDevelopmentRollbackResult {
+                receipt: current_receipt,
+                replaced_generation: None,
+                skipped: true,
+                schema_version: crate::SCHEMA_VERSION,
+            });
+        }
+        reject_live_local_runtimes(&prefix)?;
+
+        let previous_target =
+            read_generation_link(&prefix.join("previous"))?.ok_or_else(|| {
+                CliError::new(
+                    "LOCAL_ROLLBACK_UNAVAILABLE",
+                    format!("No previous local generation exists at {}.", prefix.display()),
+                )
+            })?;
+        if current_target == previous_target {
+            return Err(CliError::new(
+                "LOCAL_ROLLBACK_UNAVAILABLE",
+                "Current and previous local generation targets are identical.",
+            ));
+        }
+        let previous_generation = prefix.join(&previous_target);
+        let previous_receipt = read_local_development_receipt(
+            &previous_generation.join("authority.json"),
+        )?;
+        validate_receipt_identity(
+            &previous_receipt,
+            &prefix,
+            &previous_generation,
+            &current_receipt.workspace_root,
+        )?;
+        validate_receipt_physical_components(&previous_receipt)?;
+        if previous_receipt.generation_id != requested_generation {
+            return Err(CliError::new(
+                "LOCAL_ROLLBACK_TARGET_MISMATCH",
+                format!(
+                    "Requested generation {} is neither current nor the validated previous generation {}.",
+                    requested_generation.as_str(),
+                    previous_receipt.generation_id.as_str(),
+                ),
+            ));
+        }
+        validate_workspace_guidance_target(&current_receipt.workspace_root, &prefix)?;
+
+        let mut transaction = LocalRefreshTransaction::new(
+            &prefix,
+            &current_receipt.workspace_root,
+            Some(current_target.clone()),
+            Some(previous_target.clone()),
+            None,
+            Some(fs::read_link(prefix.join("bin/kast-dev"))?),
+        );
+        let activation = (|| -> Result<LocalDevelopmentRollbackResult> {
+            transaction.stable_entrypoints_installed = true;
+            install_stable_entrypoints(&prefix, &previous_receipt)?;
+            replace_relative_symlink(&prefix.join("previous"), &current_target)?;
+            transaction.previous_changed = true;
+            replace_relative_symlink(&prefix.join("current"), &previous_target)?;
+            transaction.current_changed = true;
+            let receipt = read_local_development_receipt(&prefix.join("authority.json"))?;
+            validate_receipt_identity(
+                &receipt,
+                &prefix,
+                &previous_generation,
+                &current_receipt.workspace_root,
+            )?;
+            validate_receipt_components(&receipt)?;
+            Ok(LocalDevelopmentRollbackResult {
+                receipt,
+                replaced_generation: Some(current_receipt.generation_id.clone()),
+                skipped: false,
+                schema_version: crate::SCHEMA_VERSION,
+            })
+        })();
+        match activation {
+            Ok(result) => Ok(result),
+            Err(mut error) => {
+                if let Err(cleanup) = transaction.rollback() {
+                    error
+                        .details
+                        .insert("rollbackError".to_string(), cleanup.to_string());
+                }
+                Err(error)
+            }
+        }
+    })
+}
+
+pub fn remove_local_development(
+    request: LocalDevelopmentRemoveRequest,
+) -> Result<LocalDevelopmentRemoveResult> {
+    remove_local_development_with_observer(request, |_| Ok(()))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalRemovalPhase {
+    BeforeMissingPrefixCleanup,
+    AfterPrefixRenamed,
+}
+
+fn remove_local_development_with_observer(
+    request: LocalDevelopmentRemoveRequest,
+    mut observe: impl FnMut(LocalRemovalPhase) -> Result<()>,
+) -> Result<LocalDevelopmentRemoveResult> {
+    let workspace_root = canonical_directory(&request.workspace_root, "exact workspace root")?;
+    let requested_prefix = absolute_path(request.prefix)?;
+    let lock_prefix = canonicalize_missing_path(&requested_prefix)?;
+    with_local_authority_lock(&lock_prefix, || {
+        if !requested_prefix.exists() {
+            observe(LocalRemovalPhase::BeforeMissingPrefixCleanup)?;
+            remove_owned_workspace_guidance_link(&workspace_root, &lock_prefix)?;
+            return Ok(LocalDevelopmentRemoveResult {
+                prefix: lock_prefix.clone(),
+                workspace_root: workspace_root.clone(),
+                removed: false,
+                schema_version: crate::SCHEMA_VERSION,
+            });
+        }
+        let prefix = canonical_directory(&requested_prefix, "local-development prefix")?;
+        if fs::symlink_metadata(&requested_prefix)?.file_type().is_symlink() {
+            return Err(CliError::new(
+                "LOCAL_PREFIX_UNSAFE",
+                format!(
+                    "Refusing to remove a local prefix selected through a symlink: {}.",
+                    requested_prefix.display(),
+                ),
+            ));
+        }
+        if prefix != lock_prefix {
+            return Err(CliError::new(
+                "LOCAL_PREFIX_CHANGED",
+                format!(
+                    "Local prefix identity changed while waiting for its authority lock: {}.",
+                    requested_prefix.display(),
+                ),
+            ));
+        }
+        validate_removal_boundary(&prefix, &workspace_root)?;
+        let result_prefix = prefix.clone();
+        let current_target = read_generation_link(&prefix.join("current"))?.ok_or_else(|| {
+            CliError::new(
+                "LOCAL_AUTHORITY_INACTIVE",
+                format!(
+                    "Refusing to remove prefix without an active local receipt: {}.",
+                    prefix.display(),
+                ),
+            )
+        })?;
+        let generation = prefix.join(current_target);
+        let receipt = read_removal_authority(&generation.join("authority.json"))?;
+        if receipt.authority != LocalDevelopmentAuthority::LocalDevelopment
+            || receipt.prefix != prefix
+            || receipt.workspace_root != workspace_root
+            || generation != prefix.join(generation_target(&receipt.generation_id))
+        {
+            return Err(CliError::new(
+                "LOCAL_AUTHORITY_RECEIPT_INVALID",
+                "Removal authority does not match the exact prefix, generation, or workspace.",
+            ));
+        }
+        let metadata = fs::symlink_metadata(&generation)?;
+        if !metadata.is_dir()
+            || metadata.file_type().is_symlink()
+            || fs::canonicalize(&generation)? != generation
+        {
+            return Err(CliError::new(
+                "LOCAL_AUTHORITY_RECEIPT_INVALID",
+                format!(
+                    "Removal generation is not an owned canonical directory: {}.",
+                    generation.display(),
+                ),
+            ));
+        }
+        reject_live_local_runtimes(&prefix)?;
+
+        let parent = prefix.parent().ok_or_else(|| {
+            CliError::new(
+                "LOCAL_PREFIX_INVALID",
+                format!("Local prefix has no parent: {}", prefix.display()),
+            )
+        })?;
+        let name = prefix.file_name().and_then(|name| name.to_str()).ok_or_else(|| {
+            CliError::new(
+                "LOCAL_PREFIX_INVALID",
+                format!("Local prefix has no UTF-8 name: {}", prefix.display()),
+            )
+        })?;
+        let tombstone = parent.join(format!(".{name}.removing-{}", std::process::id()));
+        if fs::symlink_metadata(&tombstone).is_ok() {
+            return Err(CliError::new(
+                "LOCAL_REMOVAL_CONFLICT",
+                format!(
+                    "Refusing to overwrite an existing removal staging path: {}.",
+                    tombstone.display(),
+                ),
+            ));
+        }
+        fs::rename(&prefix, &tombstone)?;
+
+        let cleanup = (|| -> Result<()> {
+            observe(LocalRemovalPhase::AfterPrefixRenamed)?;
+            remove_owned_workspace_guidance_link(&workspace_root, &prefix)?;
+            fs::remove_dir_all(&tombstone)?;
+            Ok(())
+        })();
+        if let Err(mut error) = cleanup {
+            if tombstone.exists() && !prefix.exists() {
+                if let Err(restore) = fs::rename(&tombstone, &prefix) {
+                    error
+                        .details
+                        .insert("restoreError".to_string(), restore.to_string());
+                } else {
+                    let _ = ensure_workspace_guidance_link(&workspace_root, &prefix);
+                }
+            }
+            return Err(error);
+        }
+        Ok(LocalDevelopmentRemoveResult {
+            prefix: result_prefix.clone(),
+            workspace_root: workspace_root.clone(),
+            removed: true,
+            schema_version: crate::SCHEMA_VERSION,
+        })
+    })
+}
+
+fn canonicalize_missing_path(path: &Path) -> Result<PathBuf> {
+    let mut cursor = path;
+    let mut suffix = Vec::new();
+    loop {
+        match fs::symlink_metadata(cursor) {
+            Ok(_) => break,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+        let name = cursor.file_name().ok_or_else(|| {
+            CliError::new(
+                "LOCAL_PREFIX_INVALID",
+                format!("Local prefix has no existing ancestor: {}.", path.display()),
+            )
+        })?;
+        suffix.push(name.to_os_string());
+        cursor = cursor.parent().ok_or_else(|| {
+            CliError::new(
+                "LOCAL_PREFIX_INVALID",
+                format!("Local prefix has no existing ancestor: {}.", path.display()),
+            )
+        })?;
+    }
+    let mut canonical = fs::canonicalize(cursor)?;
+    for name in suffix.into_iter().rev() {
+        canonical.push(name);
+    }
+    Ok(canonical)
+}
+
+fn reject_live_local_runtimes(prefix: &Path) -> Result<()> {
+    let state_root = prefix.join("state");
+    if !state_root.exists() {
+        return Ok(());
+    }
+    let mut pending = vec![state_root];
+    while let Some(directory) = pending.pop() {
+        let metadata = fs::symlink_metadata(&directory)?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            return Err(CliError::new(
+                "LOCAL_RUNTIME_STATE_INVALID",
+                format!(
+                    "Local runtime state must remain an owned directory tree: {}.",
+                    directory.display(),
+                ),
+            ));
+        }
+        for entry in fs::read_dir(&directory)? {
+            let entry = entry?;
+            let path = entry.path();
+            let file_type = entry.file_type()?;
+            if file_type.is_symlink() {
+                return Err(CliError::new(
+                    "LOCAL_RUNTIME_STATE_INVALID",
+                    format!(
+                        "Local runtime state cannot traverse a symlink: {}.",
+                        path.display(),
+                    ),
+                ));
+            }
+            if file_type.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            if file_type.is_file() && entry.file_name() == "daemons.json" {
+                let descriptors: Vec<crate::runtime::ServerInstanceDescriptor> =
+                    serde_json::from_slice(&fs::read(&path)?).map_err(|error| {
+                        CliError::new(
+                            "LOCAL_RUNTIME_STATE_INVALID",
+                            format!(
+                                "Could not validate local runtime descriptors at {}: {error}",
+                                path.display(),
+                            ),
+                        )
+                    })?;
+                if let Some(descriptor) = descriptors
+                    .into_iter()
+                    .find(|descriptor| local_process_is_alive(descriptor.pid))
+                {
+                    let mut error = CliError::new(
+                        "LOCAL_RUNTIME_ACTIVE",
+                        format!(
+                            "Refusing to change local-development authority while PID {} is still registered and live for {}.",
+                            descriptor.pid, descriptor.workspace_root,
+                        ),
+                    );
+                    error
+                        .details
+                        .insert("pid".to_string(), descriptor.pid.to_string());
+                    error.details.insert(
+                        "workspaceRoot".to_string(),
+                        descriptor.workspace_root.clone(),
+                    );
+                    error.details.insert(
+                        "descriptorFile".to_string(),
+                        path.display().to_string(),
+                    );
+                    if matches!(descriptor.backend_name.as_str(), "headless" | "idea") {
+                        error.details.insert(
+                            "stopCommand".to_string(),
+                            format!(
+                                "'{}' developer runtime stop --workspace-root '{}' --backend={}",
+                                shell_single_quote(
+                                    &prefix.join("bin/kast-dev").display().to_string(),
+                                ),
+                                shell_single_quote(&descriptor.workspace_root),
+                                descriptor.backend_name,
+                            ),
+                        );
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn local_process_is_alive(pid: u64) -> bool {
+    if pid == 0 || pid > i32::MAX as u64 {
+        return false;
+    }
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalDevelopmentRemovalAuthority {
+    schema_version: u32,
+    authority: LocalDevelopmentAuthority,
+    generation_id: LocalGenerationId,
+    workspace_root: PathBuf,
+    prefix: PathBuf,
+}
+
+fn read_removal_authority(path: &Path) -> Result<LocalDevelopmentRemovalAuthority> {
+    let authority: LocalDevelopmentRemovalAuthority =
+        serde_json::from_slice(&fs::read(path)?).map_err(|error| {
+            CliError::new(
+                "LOCAL_AUTHORITY_RECEIPT_INVALID",
+                format!(
+                    "Could not read core removal authority at {}: {error}",
+                    path.display(),
+                ),
+            )
+        })?;
+    if authority.schema_version == 0
+        || authority.schema_version > LOCAL_DEVELOPMENT_RECEIPT_SCHEMA_VERSION
+    {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_UNSUPPORTED",
+            format!(
+                "Removal authority schema {} is unsupported; newest supported schema is {}.",
+                authority.schema_version, LOCAL_DEVELOPMENT_RECEIPT_SCHEMA_VERSION,
+            ),
+        ));
+    }
+    Ok(authority)
+}
+
+fn validate_removal_boundary(prefix: &Path, workspace_root: &Path) -> Result<()> {
+    if prefix == Path::new("/") || workspace_root.starts_with(prefix) {
+        return Err(CliError::new(
+            "LOCAL_PREFIX_UNSAFE",
+            format!(
+                "Refusing to remove local prefix {} because it contains the workspace {}.",
+                prefix.display(),
+                workspace_root.display(),
+            ),
+        ));
+    }
+    Ok(())
+}

--- a/cli-rs/src/local_development/provenance.rs
+++ b/cli-rs/src/local_development/provenance.rs
@@ -1,0 +1,422 @@
+pub fn attest_local_artifact(
+    request: LocalArtifactAttestationRequest,
+) -> Result<LocalArtifactProvenance> {
+    let expected = SourceSnapshot::read_strict(&request.expected_source_snapshot)?;
+    let source = SourceSnapshot::capture(&request.source_root)?;
+    if source != expected {
+        return Err(source_snapshot_mismatch(&expected, &source));
+    }
+    let artifact = match request.kind {
+        LocalArtifactKind::Cli => canonical_file(&request.artifact, "development CLI artifact")?,
+        LocalArtifactKind::HeadlessBackend => {
+            let artifact =
+                canonical_directory(&request.artifact, "headless backend artifact")?;
+            validate_backend_distribution(&artifact)?;
+            artifact
+        }
+    };
+    if request.kind == LocalArtifactKind::Cli {
+        let producer = fs::canonicalize(std::env::current_exe()?)?;
+        if producer != artifact {
+            return Err(CliError::new(
+                "LOCAL_CLI_ATTESTER_MISMATCH",
+                format!(
+                    "CLI provenance must be emitted by the exact artifact: producer {}, artifact {}.",
+                    producer.display(),
+                    artifact.display(),
+                ),
+            ));
+        }
+        validate_cli_producer_source_identity(
+            option_env!("KAST_LOCAL_SOURCE_SHA256"),
+            &source.source_tree_sha256,
+        )?;
+    } else {
+        validate_backend_embedded_source_identity(&artifact, &source)?;
+    }
+    let artifact_sha256 = tree_sha256(&artifact)?;
+    let provenance = LocalArtifactProvenance {
+        schema_version: LOCAL_ARTIFACT_PROVENANCE_SCHEMA_VERSION,
+        kind: request.kind,
+        source: source.clone(),
+        artifact,
+        sha256: artifact_sha256,
+        implementation_version: crate::cli::version().to_string(),
+    };
+    let after_hashing = SourceSnapshot::capture(&request.source_root)?;
+    if after_hashing != expected {
+        return Err(source_snapshot_mismatch(&expected, &after_hashing));
+    }
+    write_json_atomic(&request.output_file, &provenance)?;
+    Ok(provenance)
+}
+
+fn read_local_artifact_provenance(path: &Path) -> Result<LocalArtifactProvenance> {
+    let provenance: LocalArtifactProvenance =
+        serde_json::from_slice(&fs::read(path)?).map_err(|error| {
+            CliError::new(
+                "LOCAL_ARTIFACT_PROVENANCE_INVALID",
+                format!("Invalid local artifact provenance at {}: {error}", path.display()),
+            )
+        })?;
+    if provenance.schema_version != LOCAL_ARTIFACT_PROVENANCE_SCHEMA_VERSION {
+        return Err(CliError::new(
+            "LOCAL_ARTIFACT_PROVENANCE_UNSUPPORTED",
+            format!(
+                "Local artifact provenance schema {} is unsupported; expected {}.",
+                provenance.schema_version, LOCAL_ARTIFACT_PROVENANCE_SCHEMA_VERSION,
+            ),
+        ));
+    }
+    Ok(provenance)
+}
+
+fn validate_local_artifact_provenance(
+    provenance: &LocalArtifactProvenance,
+    kind: LocalArtifactKind,
+    source: &SourceSnapshot,
+    artifact: &Path,
+) -> Result<()> {
+    if provenance.kind != kind {
+        return Err(CliError::new(
+            "LOCAL_ARTIFACT_KIND_MISMATCH",
+            format!(
+                "Artifact provenance declares {:?}, but refresh requires {:?}.",
+                provenance.kind, kind,
+            ),
+        ));
+    }
+    if &provenance.source != source {
+        return Err(CliError::new(
+            "LOCAL_ARTIFACT_SOURCE_MISMATCH",
+            format!(
+                "{:?} artifact provenance does not match source snapshot {}.",
+                kind,
+                source.source_tree_sha256.as_str(),
+            ),
+        ));
+    }
+    if provenance.artifact != artifact {
+        return Err(CliError::new(
+            "LOCAL_ARTIFACT_PATH_MISMATCH",
+            format!(
+                "{:?} provenance names {}, but refresh selected {}.",
+                kind,
+                provenance.artifact.display(),
+                artifact.display(),
+            ),
+        ));
+    }
+    let actual = tree_sha256(artifact)?;
+    if actual != provenance.sha256 {
+        return Err(CliError::new(
+            "LOCAL_ARTIFACT_CHECKSUM_MISMATCH",
+            format!(
+                "{:?} artifact bytes changed after provenance at {}.",
+                kind,
+                artifact.display(),
+            ),
+        ));
+    }
+    if provenance.implementation_version.trim().is_empty() {
+        return Err(CliError::new(
+            "LOCAL_ARTIFACT_PROVENANCE_INVALID",
+            format!("{:?} provenance has no implementation version.", kind),
+        ));
+    }
+    if kind == LocalArtifactKind::HeadlessBackend {
+        validate_backend_embedded_source_identity(artifact, source)?;
+    }
+    Ok(())
+}
+
+fn validate_cli_producer_source_identity(
+    embedded_source_sha256: Option<&str>,
+    expected_source_sha256: &Sha256Digest,
+) -> Result<()> {
+    let embedded_source_sha256 = embedded_source_sha256.ok_or_else(|| {
+        CliError::new(
+            "LOCAL_CLI_SOURCE_ATTESTATION_MISSING",
+            "The CLI was not built as a source-bound local-development producer.",
+        )
+    })?;
+    if embedded_source_sha256 != expected_source_sha256.as_str() {
+        return Err(CliError::new(
+            "LOCAL_CLI_SOURCE_MISMATCH",
+            format!(
+                "The CLI embeds source snapshot {embedded_source_sha256}, but attestation requires {}.",
+                expected_source_sha256.as_str(),
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_backend_embedded_source_identity(
+    artifact: &Path,
+    expected: &SourceSnapshot,
+) -> Result<()> {
+    let plugin_jar = backend_plugin_implementation_jar(artifact)?;
+    let file = fs::File::open(&plugin_jar)?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|error| {
+        CliError::new(
+            "LOCAL_BACKEND_SOURCE_ATTESTATION_INVALID",
+            format!("Invalid headless backend plugin jar {}: {error}", plugin_jar.display()),
+        )
+    })?;
+    let bytes = read_backend_attestation_entry(
+        &mut archive,
+        &plugin_jar,
+        LOCAL_BACKEND_SOURCE_SNAPSHOT_ENTRY,
+    )?;
+    let embedded = SourceSnapshot::from_slice(
+        &bytes,
+        &format!("{}!/{LOCAL_BACKEND_SOURCE_SNAPSHOT_ENTRY}", plugin_jar.display()),
+    )
+    .map_err(|error| {
+        CliError::new(
+            "LOCAL_BACKEND_SOURCE_ATTESTATION_INVALID",
+            error.to_string(),
+        )
+    })?;
+    if &embedded != expected {
+        return Err(CliError::new(
+            "LOCAL_BACKEND_SOURCE_MISMATCH",
+            format!(
+                "Headless backend plugin jar {} was produced from source snapshot {}, not {}.",
+                plugin_jar.display(),
+                embedded.source_tree_sha256.as_str(),
+                expected.source_tree_sha256.as_str(),
+            ),
+        ));
+    }
+    let manifest_bytes = read_backend_attestation_entry(
+        &mut archive,
+        &plugin_jar,
+        LOCAL_BACKEND_COMPONENT_MANIFEST_ENTRY,
+    )?;
+    let manifest: LocalBackendComponentManifest =
+        serde_json::from_slice(&manifest_bytes).map_err(|error| {
+            CliError::new(
+                "LOCAL_BACKEND_COMPONENT_MANIFEST_INVALID",
+                format!(
+                    "Invalid producer component manifest in {}: {error}",
+                    plugin_jar.display(),
+                ),
+            )
+        })?;
+    validate_backend_component_manifest(artifact, expected, &manifest)?;
+    Ok(())
+}
+
+fn read_backend_attestation_entry(
+    archive: &mut zip::ZipArchive<fs::File>,
+    plugin_jar: &Path,
+    entry_name: &str,
+) -> Result<Vec<u8>> {
+    let mut entry = archive.by_name(entry_name).map_err(|error| {
+        CliError::new(
+            "LOCAL_BACKEND_SOURCE_ATTESTATION_INVALID",
+            format!(
+                "Headless backend plugin jar {} has no producer-emitted {} entry: {error}",
+                plugin_jar.display(),
+                entry_name,
+            ),
+        )
+    })?;
+    let mut bytes = Vec::new();
+    entry.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+const LOCAL_BACKEND_COMPONENT_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LocalBackendComponentManifest {
+    schema_version: u32,
+    source_tree_sha256: Sha256Digest,
+    components: Vec<LocalBackendProducerComponent>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LocalBackendProducerComponent {
+    kind: LocalBackendProducerComponentKind,
+    path: PathBuf,
+    sha256: Sha256Digest,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(rename_all = "kebab-case")]
+enum LocalBackendProducerComponentKind {
+    AnalysisApi,
+    AnalysisServer,
+    BackendHeadlessLauncher,
+    BackendHeadlessPluginDescriptor,
+    BackendIdea,
+    BackendShared,
+    IndexStore,
+}
+
+fn validate_backend_component_manifest(
+    artifact: &Path,
+    expected: &SourceSnapshot,
+    manifest: &LocalBackendComponentManifest,
+) -> Result<()> {
+    if manifest.schema_version != LOCAL_BACKEND_COMPONENT_MANIFEST_SCHEMA_VERSION {
+        return Err(CliError::new(
+            "LOCAL_BACKEND_COMPONENT_MANIFEST_UNSUPPORTED",
+            format!(
+                "Backend component manifest schema {} is unsupported; expected {}.",
+                manifest.schema_version, LOCAL_BACKEND_COMPONENT_MANIFEST_SCHEMA_VERSION,
+            ),
+        ));
+    }
+    if manifest.source_tree_sha256 != expected.source_tree_sha256 {
+        return Err(CliError::new(
+            "LOCAL_BACKEND_COMPONENT_SOURCE_MISMATCH",
+            "Backend component manifest does not belong to the captured source snapshot.",
+        ));
+    }
+    let expected_kinds = [
+        LocalBackendProducerComponentKind::AnalysisApi,
+        LocalBackendProducerComponentKind::AnalysisServer,
+        LocalBackendProducerComponentKind::BackendHeadlessLauncher,
+        LocalBackendProducerComponentKind::BackendHeadlessPluginDescriptor,
+        LocalBackendProducerComponentKind::BackendIdea,
+        LocalBackendProducerComponentKind::BackendShared,
+        LocalBackendProducerComponentKind::IndexStore,
+    ]
+    .into_iter()
+    .collect::<std::collections::BTreeSet<_>>();
+    let mut manifested = std::collections::BTreeMap::new();
+    for component in &manifest.components {
+        require_safe_relative_path(&component.path)?;
+        if manifested.insert(component.kind, component.path.clone()).is_some() {
+            return Err(CliError::new(
+                "LOCAL_BACKEND_COMPONENT_MANIFEST_INVALID",
+                format!("Backend component kind {:?} appears more than once.", component.kind),
+            ));
+        }
+        let path = artifact.join(&component.path);
+        let metadata = fs::symlink_metadata(&path).map_err(|error| {
+            CliError::new(
+                "LOCAL_BACKEND_COMPONENT_MISSING",
+                format!("Manifested backend component {} is unavailable: {error}.", path.display()),
+            )
+        })?;
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Err(CliError::new(
+                "LOCAL_BACKEND_COMPONENT_MANIFEST_INVALID",
+                format!("Manifested backend component is not an owned regular file: {}.", path.display()),
+            ));
+        }
+        let actual = Sha256Digest::try_from(crate::manifest::sha256_file(&path)?)?;
+        if actual != component.sha256 {
+            return Err(CliError::new(
+                "LOCAL_BACKEND_COMPONENT_CHECKSUM_MISMATCH",
+                format!("Producer-owned backend component changed after build: {}.", path.display()),
+            ));
+        }
+    }
+    let manifested_kinds = manifested.keys().copied().collect::<std::collections::BTreeSet<_>>();
+    if manifested_kinds != expected_kinds {
+        return Err(CliError::new(
+            "LOCAL_BACKEND_COMPONENT_MANIFEST_INVALID",
+            format!(
+                "Backend component manifest covered {:?}; expected {:?}.",
+                manifested_kinds, expected_kinds,
+            ),
+        ));
+    }
+    let actual = owned_backend_components(artifact)?;
+    if actual != manifested {
+        return Err(CliError::new(
+            "LOCAL_BACKEND_COMPONENT_MANIFEST_INVALID",
+            "Staged producer-owned backend JARs do not exactly match the embedded component manifest.",
+        ));
+    }
+    Ok(())
+}
+
+fn owned_backend_components(
+    artifact: &Path,
+) -> Result<std::collections::BTreeMap<LocalBackendProducerComponentKind, PathBuf>> {
+    let candidates = [
+        (artifact.join("runtime-libs"), PathBuf::from("runtime-libs")),
+        (
+            artifact.join("idea-home/plugins/kast-headless/lib"),
+            PathBuf::from("idea-home/plugins/kast-headless/lib"),
+        ),
+    ];
+    let mut components = std::collections::BTreeMap::new();
+    for (directory, relative_directory) in candidates {
+        for entry in fs::read_dir(directory)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_file() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+                continue;
+            };
+            let Some(kind) = backend_component_kind(&name) else {
+                continue;
+            };
+            let relative = relative_directory.join(name);
+            if components.insert(kind, relative).is_some() {
+                return Err(CliError::new(
+                    "LOCAL_BACKEND_COMPONENT_MANIFEST_INVALID",
+                    format!("Backend distribution contains duplicate {:?} components.", kind),
+                ));
+            }
+        }
+    }
+    Ok(components)
+}
+
+fn backend_component_kind(name: &str) -> Option<LocalBackendProducerComponentKind> {
+    use LocalBackendProducerComponentKind as Kind;
+
+    match name {
+        name if name.starts_with("analysis-api-") && name.ends_with(".jar") => Some(Kind::AnalysisApi),
+        name if name.starts_with("analysis-server-") && name.ends_with(".jar") => Some(Kind::AnalysisServer),
+        name if name.starts_with("backend-headless-") && name.ends_with("-launcher.jar") => {
+            Some(Kind::BackendHeadlessLauncher)
+        }
+        name if name.starts_with("backend-headless-") && name.ends_with("-plugin-descriptor.jar") => {
+            Some(Kind::BackendHeadlessPluginDescriptor)
+        }
+        name if name.starts_with("backend-idea-") && name.ends_with(".jar") => Some(Kind::BackendIdea),
+        name if name.starts_with("backend-shared-") && name.ends_with(".jar") => Some(Kind::BackendShared),
+        name if name.starts_with("index-store-") && name.ends_with(".jar") => Some(Kind::IndexStore),
+        _ => None,
+    }
+}
+
+fn backend_plugin_implementation_jar(artifact: &Path) -> Result<PathBuf> {
+    let plugin_lib = artifact.join("idea-home/plugins/kast-headless/lib");
+    let mut candidates = fs::read_dir(&plugin_lib)?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name.starts_with("backend-headless-") && name.ends_with("-plugin.jar")
+                })
+        })
+        .collect::<Vec<_>>();
+    candidates.sort();
+    if candidates.len() != 1 {
+        return Err(CliError::new(
+            "LOCAL_BACKEND_SOURCE_ATTESTATION_INVALID",
+            format!(
+                "Headless backend {} must contain exactly one backend-headless-*-plugin.jar, found {}.",
+                artifact.display(),
+                candidates.len(),
+            ),
+        ));
+    }
+    Ok(candidates.remove(0))
+}

--- a/cli-rs/src/local_development/refresh.rs
+++ b/cli-rs/src/local_development/refresh.rs
@@ -882,6 +882,10 @@ fn shell_single_quote(value: &str) -> String {
     value.replace('\'', "'\"'\"'")
 }
 
+fn shell_single_quoted_path(path: &Path) -> String {
+    format!("'{}'", shell_single_quote(&path.display().to_string()))
+}
+
 fn render_local_skill(source_skill: &Path, entrypoint: &Path) -> Result<String> {
     let bytes = fs::read(source_skill).map_err(|error| {
         CliError::new(
@@ -902,7 +906,8 @@ fn render_local_skill(source_skill: &Path, entrypoint: &Path) -> Result<String> 
         "- Add `--apply` to `kast repair` only after the repair plan or readiness output asks for install-state mutation.",
         "- Do not apply ordinary install repair through local-development authority; rerun the source checkout's `./gradlew refreshDevelopmentLocal` task instead.",
     );
-    let rendered = source.replace("`kast", &format!("`{}", entrypoint.display()));
+    let entrypoint = shell_single_quoted_path(entrypoint);
+    let rendered = source.replace("`kast", &format!("`{entrypoint}"));
     let authority_guidance = if rendered.contains("Do not apply ordinary install repair") {
         String::new()
     } else {
@@ -911,27 +916,28 @@ fn render_local_skill(source_skill: &Path, entrypoint: &Path) -> Result<String> 
     };
     Ok(format!(
         "{rendered}{authority_guidance}\n\n## Local-development backend startup\n\nBefore the reuse-only verification command, start the exact receipt-owned headless backend with `{} developer runtime up --workspace-root \"$PWD\" --backend=headless`. Then run `{} agent verify --workspace-root \"$PWD\" --backend=headless`.\n",
-        entrypoint.display(),
-        entrypoint.display(),
+        entrypoint,
+        entrypoint,
     ))
 }
 
 fn render_local_guidance(skill: &Path, entrypoint: &Path, source: &SourceSnapshot) -> String {
+    let entrypoint = shell_single_quoted_path(entrypoint);
     format!(
         "<kast files=\"*.kt, *.kts\" type=\"instructions\" replaceTools=\"grep,search,write\">\n## Kast local-development routing\nUse `{}` before Kotlin or Gradle semantic work.\nStart the receipt-owned `{} developer runtime up --workspace-root \"$PWD\" --backend=headless` for this exact root, then run `{} agent verify --workspace-root \"$PWD\" --backend=headless` before semantic work.\nUse typed commands such as `{} agent symbol --query <name>`, `{} agent diagnostics --file-path <path>`, and `{} agent rename --symbol <fq-name> --new-name <name> --apply`.\nPrepared source commit: {}\nPrepared source SHA-256: {}\n</kast>\n",
         skill.display(),
-        entrypoint.display(),
-        entrypoint.display(),
-        entrypoint.display(),
-        entrypoint.display(),
-        entrypoint.display(),
+        entrypoint,
+        entrypoint,
+        entrypoint,
+        entrypoint,
+        entrypoint,
         source.git_commit.as_str(),
         source.source_tree_sha256.as_str(),
     )
 }
 
 fn validate_rendered_command_lockstep(rendered: &str, entrypoint: &Path) -> Result<()> {
-    let entrypoint = entrypoint.display().to_string();
+    let entrypoint = shell_single_quoted_path(entrypoint);
     for line in rendered.lines() {
         for (index, code) in line.split('`').enumerate() {
             if index % 2 == 0 {

--- a/cli-rs/src/local_development/refresh.rs
+++ b/cli-rs/src/local_development/refresh.rs
@@ -1,0 +1,1636 @@
+pub fn refresh_local_development(
+    request: LocalDevelopmentRefreshRequest,
+) -> Result<LocalDevelopmentRefreshResult> {
+    refresh_local_development_with_observer(request, |_| Ok(()))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalRefreshPhase {
+    AfterActivation,
+}
+
+fn refresh_local_development_with_observer(
+    request: LocalDevelopmentRefreshRequest,
+    mut observe: impl FnMut(LocalRefreshPhase) -> Result<()>,
+) -> Result<LocalDevelopmentRefreshResult> {
+    let expected = SourceSnapshot::read_strict(&request.expected_source_snapshot)?;
+    let source = SourceSnapshot::capture(&request.source_root)?;
+    if source != expected {
+        return Err(source_snapshot_mismatch(&expected, &source));
+    }
+    let workspace_root = canonical_directory(&request.workspace_root, "exact workspace root")?;
+    let cli_binary = canonical_file(&request.cli_binary, "development CLI binary")?;
+    if cfg!(not(test)) {
+        let controller = fs::canonicalize(std::env::current_exe()?)?;
+        if controller != cli_binary {
+            return Err(CliError::new(
+                "LOCAL_REFRESH_CONTROLLER_MISMATCH",
+                format!(
+                    "Local refresh must be executed by the exact staged CLI: controller {}, staged {}.",
+                    controller.display(),
+                    cli_binary.display(),
+                ),
+            ));
+        }
+    }
+    let backend_directory =
+        canonical_directory(&request.backend_directory, "headless backend distribution")?;
+    validate_backend_distribution(&backend_directory)?;
+    let cli_provenance = read_local_artifact_provenance(&request.cli_provenance)?;
+    validate_local_artifact_provenance(
+        &cli_provenance,
+        LocalArtifactKind::Cli,
+        &source,
+        &cli_binary,
+    )?;
+    let backend_provenance = read_local_artifact_provenance(&request.backend_provenance)?;
+    validate_local_artifact_provenance(
+        &backend_provenance,
+        LocalArtifactKind::HeadlessBackend,
+        &source,
+        &backend_directory,
+    )?;
+    if cli_provenance.implementation_version != backend_provenance.implementation_version {
+        return Err(CliError::new(
+            "LOCAL_ARTIFACT_VERSION_MISMATCH",
+            format!(
+                "CLI version {} and backend version {} do not form one local artifact set.",
+                cli_provenance.implementation_version, backend_provenance.implementation_version,
+            ),
+        ));
+    }
+    let artifacts = LocalDevelopmentArtifactSet {
+        cli: cli_provenance,
+        backend: backend_provenance,
+    };
+
+    let requested_prefix = absolute_path(request.prefix)?;
+    reject_symlink_selected_prefix(&requested_prefix)?;
+    let generation_id = LocalGenerationId::from_source(&source);
+
+    with_local_authority_lock(&requested_prefix, || {
+        fs::create_dir_all(&requested_prefix)?;
+        let prefix = canonical_directory(&requested_prefix, "local-development prefix")?;
+        let generations = prefix.join("generations");
+        let generation = generations.join(generation_id.as_str());
+        fs::create_dir_all(&generations)?;
+        let current_link = prefix.join("current");
+        let current_target = read_generation_link(&current_link)?;
+        let previous_target_before = read_generation_link(&prefix.join("previous"))?;
+        let current_receipt = current_target
+            .as_ref()
+            .map(|target| -> Result<LocalDevelopmentReceipt> {
+                let active_generation = prefix.join(target.as_path());
+                let receipt =
+                    read_local_development_receipt(&active_generation.join("authority.json"))?;
+                validate_receipt_identity(
+                    &receipt,
+                    &prefix,
+                    &active_generation,
+                    &receipt.workspace_root,
+                )?;
+                validate_receipt_fast_components(&receipt)?;
+                validate_stable_authority(
+                    &prefix.join("authority.json"),
+                    &receipt,
+                    &active_generation,
+                )?;
+                Ok(receipt)
+            })
+            .transpose()?;
+        if let Some(receipt) = &current_receipt {
+            if receipt.workspace_root != workspace_root {
+                return Err(CliError::new(
+                    "LOCAL_WORKSPACE_AUTHORITY_MISMATCH",
+                    format!(
+                        "Local-development prefix {} belongs to workspace {}, not {}.",
+                        prefix.display(),
+                        receipt.workspace_root.display(),
+                        workspace_root.display(),
+                    ),
+                ));
+            }
+        } else {
+            reject_unowned_prefix_contents(&prefix, &generation)?;
+        }
+        validate_workspace_guidance_target(&workspace_root, &prefix)?;
+        require_workspace_guidance_ignored(&workspace_root)?;
+        let previous_generation = current_receipt
+            .as_ref()
+            .map(|receipt| receipt.generation_id.clone());
+
+        if current_receipt
+            .as_ref()
+            .is_some_and(|receipt| receipt.generation_id == generation_id)
+        {
+            let current_receipt = current_receipt.expect("checked as present");
+            if !artifact_sets_equivalent(&current_receipt.artifacts, &artifacts) {
+                return Err(CliError::new(
+                    "LOCAL_GENERATION_ARTIFACT_MISMATCH",
+                    "The active source generation was rebuilt with different CLI or backend bytes.",
+                ));
+            }
+            validate_physical_component(&current_receipt.components.backend)?;
+            let after_validation = SourceSnapshot::capture(&request.source_root)?;
+            if after_validation != expected {
+                return Err(source_snapshot_mismatch(&expected, &after_validation));
+            }
+            return Ok(LocalDevelopmentRefreshResult {
+                receipt: current_receipt,
+                skipped: true,
+                schema_version: crate::SCHEMA_VERSION,
+            });
+        }
+        reject_live_local_runtimes(&prefix)?;
+
+        let (generation_created, generation_receipt) = if generation.is_dir() {
+            let receipt = read_local_development_receipt(&generation.join("authority.json"))?;
+            validate_receipt_identity(&receipt, &prefix, &generation, &workspace_root)?;
+            if receipt.source != source {
+                return Err(CliError::new(
+                    "LOCAL_GENERATION_CONFLICT",
+                    format!(
+                        "Generation {} has a different source identity.",
+                        generation.display()
+                    ),
+                ));
+            }
+            validate_receipt_physical_components(&receipt)?;
+            if !artifact_sets_equivalent(&receipt.artifacts, &artifacts) {
+                return Err(CliError::new(
+                    "LOCAL_GENERATION_ARTIFACT_MISMATCH",
+                    "The stored source generation was built with different CLI or backend bytes.",
+                ));
+            }
+            (false, receipt)
+        } else {
+            stage_generation(GenerationStageRequest {
+                prefix: &prefix,
+                generation: &generation,
+                generation_id: &generation_id,
+                source: &source,
+                workspace_root: &workspace_root,
+                cli_binary: &cli_binary,
+                backend_directory: &backend_directory,
+                artifacts: &artifacts,
+                previous_generation: previous_generation.as_ref(),
+            })?;
+            let receipt = read_local_development_receipt(&generation.join("authority.json"))?;
+            validate_receipt_identity(&receipt, &prefix, &generation, &workspace_root)?;
+            (true, receipt)
+        };
+
+        let after_staging = SourceSnapshot::capture(&request.source_root)?;
+        if after_staging != expected {
+            if generation_created {
+                let _ = fs::remove_dir_all(&generation);
+            }
+            return Err(source_snapshot_mismatch(&expected, &after_staging));
+        }
+
+        let stable_entrypoint_before = current_receipt
+            .as_ref()
+            .map(|_| fs::read_link(prefix.join("bin/kast-dev")))
+            .transpose()?;
+        let mut transaction = LocalRefreshTransaction::new(
+            &prefix,
+            &workspace_root,
+            current_target,
+            previous_target_before,
+            generation_created.then_some(generation.clone()),
+            stable_entrypoint_before,
+        );
+        let activation = (|| -> Result<LocalDevelopmentRefreshResult> {
+            transaction.guidance_link_created =
+                ensure_workspace_guidance_link(&workspace_root, &prefix)?;
+            transaction.stable_entrypoints_installed = true;
+            install_stable_entrypoints(&prefix, &generation_receipt)?;
+            if let Some(current_target) = transaction.current_before.as_ref() {
+                replace_relative_symlink(&prefix.join("previous"), current_target.as_path())?;
+                transaction.previous_changed = true;
+            }
+            replace_relative_symlink(&current_link, &generation_target(&generation_id))?;
+            transaction.current_changed = true;
+            observe(LocalRefreshPhase::AfterActivation)?;
+            let receipt = read_local_development_receipt(&prefix.join("authority.json"))?;
+            validate_receipt_identity(&receipt, &prefix, &generation, &workspace_root)?;
+            validate_receipt_fast_components(&receipt)?;
+            Ok(LocalDevelopmentRefreshResult {
+                receipt,
+                skipped: !generation_created,
+                schema_version: crate::SCHEMA_VERSION,
+            })
+        })();
+        match activation {
+            Ok(result) => Ok(result),
+            Err(mut error) => {
+                if let Err(cleanup) = transaction.rollback() {
+                    error
+                        .details
+                        .insert("rollbackError".to_string(), cleanup.to_string());
+                }
+                Err(error)
+            }
+        }
+    })
+}
+
+struct LocalRefreshTransaction {
+    prefix: PathBuf,
+    workspace_root: PathBuf,
+    current_before: Option<PathBuf>,
+    previous_before: Option<PathBuf>,
+    created_generation: Option<PathBuf>,
+    stable_entrypoint_before: Option<PathBuf>,
+    guidance_link_created: bool,
+    stable_entrypoints_installed: bool,
+    previous_changed: bool,
+    current_changed: bool,
+}
+
+impl LocalRefreshTransaction {
+    fn new(
+        prefix: &Path,
+        workspace_root: &Path,
+        current_before: Option<PathBuf>,
+        previous_before: Option<PathBuf>,
+        created_generation: Option<PathBuf>,
+        stable_entrypoint_before: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            prefix: prefix.to_path_buf(),
+            workspace_root: workspace_root.to_path_buf(),
+            current_before,
+            previous_before,
+            created_generation,
+            stable_entrypoint_before,
+            guidance_link_created: false,
+            stable_entrypoints_installed: false,
+            previous_changed: false,
+            current_changed: false,
+        }
+    }
+
+    fn rollback(&self) -> Result<()> {
+        let mut failures = Vec::new();
+        let mut current_restored = !self.current_changed;
+        if self.current_changed {
+            match restore_generation_link(
+                &self.prefix.join("current"),
+                self.current_before.as_deref(),
+            ) {
+                Ok(()) => current_restored = true,
+                Err(error) => failures.push(error.to_string()),
+            }
+        }
+        if self.previous_changed
+            && let Err(error) = restore_generation_link(
+                &self.prefix.join("previous"),
+                self.previous_before.as_deref(),
+            )
+        {
+            failures.push(error.to_string());
+        }
+        if self.guidance_link_created
+            && let Err(error) =
+                remove_owned_workspace_guidance_link(&self.workspace_root, &self.prefix)
+        {
+            failures.push(error.to_string());
+        }
+        if self.stable_entrypoints_installed {
+            if let Some(contents) = &self.stable_entrypoint_before {
+                if let Err(error) =
+                    replace_relative_symlink(&self.prefix.join("bin/kast-dev"), contents)
+                {
+                    failures.push(error.to_string());
+                }
+            } else {
+                for path in [
+                    self.prefix.join("bin/kast-dev"),
+                    self.prefix.join("authority.json"),
+                    self.prefix.join("install.json"),
+                ] {
+                    if let Err(error) = remove_path_if_present(&path) {
+                        failures.push(error.to_string());
+                    }
+                }
+            }
+        }
+        if current_restored
+            && let Some(generation) = &self.created_generation
+            && let Err(error) = fs::remove_dir_all(generation)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            failures.push(error.to_string());
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(CliError::new(
+                "LOCAL_REFRESH_ROLLBACK_FAILED",
+                failures.join("; "),
+            ))
+        }
+    }
+}
+
+struct GenerationStageRequest<'a> {
+    prefix: &'a Path,
+    generation: &'a Path,
+    generation_id: &'a LocalGenerationId,
+    source: &'a SourceSnapshot,
+    workspace_root: &'a Path,
+    cli_binary: &'a Path,
+    backend_directory: &'a Path,
+    artifacts: &'a LocalDevelopmentArtifactSet,
+    previous_generation: Option<&'a LocalGenerationId>,
+}
+
+fn stage_generation(request: GenerationStageRequest<'_>) -> Result<()> {
+    let GenerationStageRequest {
+        prefix,
+        generation,
+        generation_id,
+        source,
+        workspace_root,
+        cli_binary,
+        backend_directory,
+        artifacts,
+        previous_generation,
+    } = request;
+    let staged = prefix.join(format!(".staging-{}", std::process::id()));
+    if staged.exists() {
+        fs::remove_dir_all(&staged)?;
+    }
+    fs::create_dir_all(&staged)?;
+    let result = (|| -> Result<()> {
+        let physical_entrypoint = staged.join("entrypoint/kast-dev");
+        write_bytes(
+            &physical_entrypoint,
+            local_entrypoint_script(prefix).as_bytes(),
+        )?;
+        crate::manifest::make_executable(&physical_entrypoint)?;
+
+        let physical_cli = staged.join("bin/kast");
+        write_bytes(&physical_cli, &fs::read(cli_binary)?)?;
+        crate::manifest::make_executable(&physical_cli)?;
+
+        let physical_backend = staged.join("lib/backends/headless/current");
+        copy_directory_tree(backend_directory, &physical_backend)?;
+        validate_backend_distribution(&physical_backend)?;
+
+        let entrypoint_target = prefix.join("bin/kast-dev");
+        let physical_skill = staged.join("lib/skills/kast/SKILL.md");
+        let source_skill = source
+            .canonical_root
+            .join("cli-rs/resources/kast-skill/SKILL.md");
+        let rendered_skill = render_local_skill(&source_skill, &entrypoint_target)?;
+        validate_rendered_command_lockstep(&rendered_skill, &entrypoint_target)?;
+        write_bytes(&physical_skill, rendered_skill.as_bytes())?;
+        let effective_skill = prefix.join("current/lib/skills/kast/SKILL.md");
+        let physical_guidance = staged.join("guidance/AGENTS.local.md");
+        let rendered_guidance = render_local_guidance(&effective_skill, &entrypoint_target, source);
+        validate_rendered_command_lockstep(&rendered_guidance, &entrypoint_target)?;
+        write_bytes(&physical_guidance, rendered_guidance.as_bytes())?;
+        let physical_config = staged.join("config/config.toml");
+        write_bytes(
+            &physical_config,
+            b"[runtime]\ndefaultBackend = \"headless\"\n\n[projectOpen]\nprofileAutoInit = false\n",
+        )?;
+
+        let install_manifest = local_install_manifest(prefix, source, workspace_root);
+        crate::manifest::write_manifest_atomic(&staged.join("install.json"), &install_manifest)?;
+
+        let components = LocalDevelopmentComponents {
+            cli: component(
+                &physical_cli,
+                &generation.join("bin/kast"),
+                &prefix.join("current/bin/kast"),
+            )?,
+            backend: component(
+                &physical_backend,
+                &generation.join("lib/backends/headless/current"),
+                &prefix.join("current/lib/backends/headless/current"),
+            )?,
+            skill: component(
+                &physical_skill,
+                &generation.join("lib/skills/kast/SKILL.md"),
+                &effective_skill,
+            )?,
+            guidance: component(
+                &physical_guidance,
+                &generation.join("guidance/AGENTS.local.md"),
+                &workspace_root.join("AGENTS.local.md"),
+            )?,
+            config: component(
+                &physical_config,
+                &generation.join("config/config.toml"),
+                &prefix.join("current/config/config.toml"),
+            )?,
+            manifest: component(
+                &staged.join("install.json"),
+                &generation.join("install.json"),
+                &prefix.join("install.json"),
+            )?,
+        };
+        let receipt = LocalDevelopmentReceipt {
+            schema_version: LOCAL_DEVELOPMENT_RECEIPT_SCHEMA_VERSION,
+            authority: LocalDevelopmentAuthority::LocalDevelopment,
+            generation_id: generation_id.clone(),
+            source: source.clone(),
+            workspace_root: workspace_root.to_path_buf(),
+            prefix: prefix.to_path_buf(),
+            entrypoint: LocalDevelopmentEntrypoint {
+                physical_target: generation.join("entrypoint/kast-dev"),
+                effective_target: entrypoint_target.clone(),
+                sha256: Sha256Digest::try_from(crate::manifest::sha256_file(
+                    &physical_entrypoint,
+                )?)?,
+            },
+            backend: LocalDevelopmentBackendIdentity {
+                kind: LocalDevelopmentBackendKind::Headless,
+                implementation_version: artifacts.backend.implementation_version.clone(),
+            },
+            artifacts: artifacts.clone(),
+            components,
+            install_manifest: generation.join("install.json"),
+            previous_generation: previous_generation.cloned(),
+            updated_at: crate::manifest::current_timestamp(),
+        };
+        write_json_atomic(&staged.join("authority.json"), &receipt)?;
+        fs::rename(&staged, generation)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&staged);
+    }
+    result
+}
+
+fn component(
+    staged_target: &Path,
+    physical_target: &Path,
+    effective_target: &Path,
+) -> Result<LocalDevelopmentComponent> {
+    Ok(LocalDevelopmentComponent {
+        physical_target: physical_target.to_path_buf(),
+        effective_target: effective_target.to_path_buf(),
+        sha256: tree_sha256(staged_target)?,
+    })
+}
+
+fn generation_target(generation_id: &LocalGenerationId) -> PathBuf {
+    Path::new("generations").join(generation_id.as_str())
+}
+
+fn read_generation_link(path: &Path) -> Result<Option<PathBuf>> {
+    let Some(target) = read_relative_symlink(path)? else {
+        return Ok(None);
+    };
+    let mut components = target.components();
+    let generation_directory = components.next();
+    let generation_name = components.next();
+    if generation_directory != Some(Component::Normal("generations".as_ref()))
+        || components.next().is_some()
+    {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_LINK_INVALID",
+            format!(
+                "Local authority link {} must target generations/<generation-id>, not {}.",
+                path.display(),
+                target.display(),
+            ),
+        ));
+    }
+    let generation_name = generation_name
+        .and_then(|name| name.as_os_str().to_str())
+        .ok_or_else(|| {
+            CliError::new(
+                "LOCAL_AUTHORITY_LINK_INVALID",
+                format!(
+                    "Local authority link {} has a non-UTF-8 generation.",
+                    path.display()
+                ),
+            )
+        })?;
+    let generation_id = LocalGenerationId::try_from(generation_name.to_string())?;
+    Ok(Some(generation_target(&generation_id)))
+}
+
+fn restore_generation_link(path: &Path, target: Option<&Path>) -> Result<()> {
+    match target {
+        Some(target) => replace_relative_symlink(path, target),
+        None => remove_path_if_present(path),
+    }
+}
+
+fn remove_path_if_present(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            fs::remove_dir_all(path)?;
+            Ok(())
+        }
+        Ok(_) => {
+            fs::remove_file(path)?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn reject_unowned_prefix_contents(prefix: &Path, allowed_generation: &Path) -> Result<()> {
+    let allowed_generation_name = allowed_generation.file_name().ok_or_else(|| {
+        CliError::new(
+            "LOCAL_PREFIX_INVALID",
+            format!(
+                "Local generation has no name: {}.",
+                allowed_generation.display()
+            ),
+        )
+    })?;
+    for entry in fs::read_dir(prefix)? {
+        let entry = entry?;
+        let path = entry.path();
+        match entry.file_name().to_str() {
+            Some("locks") => {
+                let metadata = entry.file_type()?;
+                if !metadata.is_dir() || metadata.is_symlink() {
+                    return Err(unowned_prefix_conflict(&path));
+                }
+                for lock in fs::read_dir(&path)? {
+                    let lock = lock?;
+                    if lock.file_name() != "refresh.lock" || !lock.file_type()?.is_file() {
+                        return Err(unowned_prefix_conflict(&lock.path()));
+                    }
+                }
+            }
+            Some("generations") => {
+                let metadata = entry.file_type()?;
+                if !metadata.is_dir() || metadata.is_symlink() {
+                    return Err(unowned_prefix_conflict(&path));
+                }
+                for generation in fs::read_dir(&path)? {
+                    let generation = generation?;
+                    if generation.file_name() != allowed_generation_name {
+                        return Err(unowned_prefix_conflict(&generation.path()));
+                    }
+                    let generation_type = generation.file_type()?;
+                    if generation_type.is_symlink() {
+                        return Err(CliError::new(
+                            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+                            format!(
+                                "Local generation must be an owned directory, not a symlink: {}.",
+                                generation.path().display(),
+                            ),
+                        ));
+                    }
+                    if !generation_type.is_dir() {
+                        return Err(unowned_prefix_conflict(&generation.path()));
+                    }
+                }
+            }
+            _ => return Err(unowned_prefix_conflict(&path)),
+        }
+    }
+    Ok(())
+}
+
+fn unowned_prefix_conflict(path: &Path) -> CliError {
+    CliError::new(
+        "LOCAL_PREFIX_CONFLICT",
+        format!(
+            "Local-development prefix contains unowned state without an active receipt: {}.",
+            path.display(),
+        ),
+    )
+}
+
+fn validate_receipt_identity(
+    receipt: &LocalDevelopmentReceipt,
+    prefix: &Path,
+    generation: &Path,
+    workspace_root: &Path,
+) -> Result<()> {
+    let expected_generation_id = LocalGenerationId::from_source(&receipt.source);
+    if receipt.generation_id != expected_generation_id {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            "Local-development generation identity does not match its source snapshot.",
+        ));
+    }
+    let expected_generation = prefix
+        .join("generations")
+        .join(receipt.generation_id.as_str());
+    if generation != expected_generation
+        || receipt.prefix != prefix
+        || receipt.workspace_root != workspace_root
+    {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            "Local-development receipt prefix, generation, or workspace does not match its selected authority.",
+        ));
+    }
+    let metadata = fs::symlink_metadata(generation).map_err(|error| {
+        CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            format!(
+                "Could not inspect generation {}: {error}",
+                generation.display()
+            ),
+        )
+    })?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            format!(
+                "Generation is not an owned directory: {}",
+                generation.display()
+            ),
+        ));
+    }
+    if fs::canonicalize(generation)? != generation {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            format!("Generation path is not canonical: {}", generation.display()),
+        ));
+    }
+    let expected_components = [
+        (
+            &receipt.components.cli,
+            generation.join("bin/kast"),
+            prefix.join("current/bin/kast"),
+        ),
+        (
+            &receipt.components.backend,
+            generation.join("lib/backends/headless/current"),
+            prefix.join("current/lib/backends/headless/current"),
+        ),
+        (
+            &receipt.components.skill,
+            generation.join("lib/skills/kast/SKILL.md"),
+            prefix.join("current/lib/skills/kast/SKILL.md"),
+        ),
+        (
+            &receipt.components.guidance,
+            generation.join("guidance/AGENTS.local.md"),
+            workspace_root.join("AGENTS.local.md"),
+        ),
+        (
+            &receipt.components.config,
+            generation.join("config/config.toml"),
+            prefix.join("current/config/config.toml"),
+        ),
+        (
+            &receipt.components.manifest,
+            generation.join("install.json"),
+            prefix.join("install.json"),
+        ),
+    ];
+    for (component, physical, effective) in expected_components {
+        if component.physical_target != physical || component.effective_target != effective {
+            return Err(CliError::new(
+                "LOCAL_AUTHORITY_RECEIPT_INVALID",
+                format!(
+                    "Local component paths escape or disagree with generation {}.",
+                    generation.display(),
+                ),
+            ));
+        }
+    }
+    if receipt.entrypoint.physical_target != generation.join("entrypoint/kast-dev")
+        || receipt.entrypoint.effective_target != prefix.join("bin/kast-dev")
+        || receipt.install_manifest != generation.join("install.json")
+    {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            "Local-development entrypoint or install manifest target is not receipt-owned.",
+        ));
+    }
+    if receipt.artifacts.cli.schema_version != LOCAL_ARTIFACT_PROVENANCE_SCHEMA_VERSION
+        || receipt.artifacts.backend.schema_version != LOCAL_ARTIFACT_PROVENANCE_SCHEMA_VERSION
+        || receipt.artifacts.cli.kind != LocalArtifactKind::Cli
+        || receipt.artifacts.backend.kind != LocalArtifactKind::HeadlessBackend
+        || receipt.artifacts.cli.source != receipt.source
+        || receipt.artifacts.backend.source != receipt.source
+        || receipt.artifacts.cli.sha256 != receipt.components.cli.sha256
+        || receipt.artifacts.backend.sha256 != receipt.components.backend.sha256
+        || receipt.artifacts.cli.implementation_version
+            != receipt.artifacts.backend.implementation_version
+        || receipt.backend.implementation_version
+            != receipt.artifacts.backend.implementation_version
+    {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            "Local-development receipt artifact provenance does not match its source or installed components.",
+        ));
+    }
+    Ok(())
+}
+
+fn artifact_sets_equivalent(
+    left: &LocalDevelopmentArtifactSet,
+    right: &LocalDevelopmentArtifactSet,
+) -> bool {
+    left.cli.kind == right.cli.kind
+        && left.cli.source == right.cli.source
+        && left.cli.sha256 == right.cli.sha256
+        && left.cli.implementation_version == right.cli.implementation_version
+        && left.backend.kind == right.backend.kind
+        && left.backend.source == right.backend.source
+        && left.backend.sha256 == right.backend.sha256
+        && left.backend.implementation_version == right.backend.implementation_version
+}
+
+fn install_stable_entrypoints(prefix: &Path, receipt: &LocalDevelopmentReceipt) -> Result<()> {
+    validate_physical_entrypoint(receipt)?;
+    replace_relative_symlink(
+        &prefix.join("bin/kast-dev"),
+        Path::new("../current/entrypoint/kast-dev"),
+    )?;
+    replace_relative_symlink(
+        &prefix.join("authority.json"),
+        Path::new("current/authority.json"),
+    )?;
+    replace_relative_symlink(
+        &prefix.join("install.json"),
+        Path::new("current/install.json"),
+    )?;
+    Ok(())
+}
+
+fn require_workspace_guidance_ignored(workspace_root: &Path) -> Result<()> {
+    let status = ProcessCommand::new("git")
+        .arg("-C")
+        .arg(workspace_root)
+        .args(["check-ignore", "--quiet", "--", "AGENTS.local.md"])
+        .status()
+        .map_err(|error| {
+            CliError::new(
+                "LOCAL_GUIDANCE_IGNORE_CHECK_FAILED",
+                format!(
+                    "Could not verify local guidance ignore ownership for {}: {error}.",
+                    workspace_root.display(),
+                ),
+            )
+        })?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(CliError::new(
+            "LOCAL_GUIDANCE_NOT_IGNORED",
+            format!(
+                "Workspace {} must source-own an ignore rule for /AGENTS.local.md before local guidance can be projected.",
+                workspace_root.display(),
+            ),
+        ))
+    }
+}
+
+#[cfg(unix)]
+fn validate_workspace_guidance_target(workspace_root: &Path, prefix: &Path) -> Result<()> {
+    let target = workspace_root.join("AGENTS.local.md");
+    let expected = prefix.join("current/guidance/AGENTS.local.md");
+    match fs::symlink_metadata(&target) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let actual = fs::read_link(&target)?;
+            if actual == expected {
+                Ok(())
+            } else {
+                Err(CliError::new(
+                    "LOCAL_GUIDANCE_TARGET_CONFLICT",
+                    format!(
+                        "Workspace guidance symlink {} targets {}, not the selected local authority {}.",
+                        target.display(),
+                        actual.display(),
+                        expected.display()
+                    ),
+                ))
+            }
+        }
+        Ok(_) => Err(CliError::new(
+            "LOCAL_GUIDANCE_TARGET_CONFLICT",
+            format!(
+                "Workspace guidance target already contains unrelated content: {}",
+                target.display()
+            ),
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(not(unix))]
+fn validate_workspace_guidance_target(_workspace_root: &Path, _prefix: &Path) -> Result<()> {
+    Err(CliError::new(
+        "LOCAL_DEVELOPMENT_UNSUPPORTED",
+        "Workspace guidance indirection is not implemented on this platform.",
+    ))
+}
+
+#[cfg(unix)]
+fn ensure_workspace_guidance_link(workspace_root: &Path, prefix: &Path) -> Result<bool> {
+    use std::os::unix::fs::symlink;
+
+    let target = workspace_root.join("AGENTS.local.md");
+    let expected = prefix.join("current/guidance/AGENTS.local.md");
+    validate_workspace_guidance_target(workspace_root, prefix)?;
+    match fs::symlink_metadata(&target) {
+        Ok(_) => Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            symlink(&expected, &target)?;
+            Ok(true)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(not(unix))]
+fn ensure_workspace_guidance_link(_workspace_root: &Path, _prefix: &Path) -> Result<bool> {
+    Err(CliError::new(
+        "LOCAL_DEVELOPMENT_UNSUPPORTED",
+        "Workspace guidance indirection is not implemented on this platform.",
+    ))
+}
+
+fn remove_owned_workspace_guidance_link(workspace_root: &Path, prefix: &Path) -> Result<bool> {
+    let target = workspace_root.join("AGENTS.local.md");
+    let expected = prefix.join("current/guidance/AGENTS.local.md");
+    match fs::symlink_metadata(&target) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            if fs::read_link(&target)? == expected {
+                fs::remove_file(target)?;
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+        Ok(_) => Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn local_entrypoint_script(prefix: &Path) -> String {
+    let prefix = shell_single_quote(&prefix.display().to_string());
+    format!(
+        "#!/bin/sh\nset -eu\nprefix='{prefix}'\ntarget=$(readlink \"$prefix/current\")\ncase \"$target\" in\n  generations/*) generation=${{target#generations/}} ;;\n  *) echo 'kast-dev: invalid local generation authority' >&2; exit 70 ;;\nesac\ncase \"$generation\" in\n  ''|*[!0-9a-f-]*|*-*-*) echo 'kast-dev: invalid local generation identity' >&2; exit 70 ;;\nesac\ngeneration_root=\"$prefix/$target\"\nstate=\"$prefix/state/$generation\"\nexport KAST_LOCAL_DEVELOPMENT_RECEIPT=\"$generation_root/authority.json\"\nexport KAST_INSTALL_ROOT=\"$prefix\"\nexport KAST_CONFIG_HOME=\"$generation_root/config\"\nexport KAST_DATA_HOME=\"$state/data\"\nexport KAST_CACHE_HOME=\"$state/cache\"\nexec \"$generation_root/bin/kast\" \"$@\"\n"
+    )
+}
+
+fn shell_single_quote(value: &str) -> String {
+    value.replace('\'', "'\"'\"'")
+}
+
+fn render_local_skill(source_skill: &Path, entrypoint: &Path) -> Result<String> {
+    let bytes = fs::read(source_skill).map_err(|error| {
+        CliError::new(
+            "LOCAL_SKILL_MISSING",
+            format!(
+                "Could not read source-owned Kast skill {}: {error}",
+                source_skill.display(),
+            ),
+        )
+    })?;
+    let source = std::str::from_utf8(&bytes).map_err(|error| {
+        CliError::new(
+            "LOCAL_SKILL_INVALID",
+            format!("Source-owned Kast skill is not UTF-8: {error}"),
+        )
+    })?;
+    let source = source.replace(
+        "- Add `--apply` to `kast repair` only after the repair plan or readiness output asks for install-state mutation.",
+        "- Do not apply ordinary install repair through local-development authority; rerun the source checkout's `./gradlew refreshDevelopmentLocal` task instead.",
+    );
+    let rendered = source.replace("`kast", &format!("`{}", entrypoint.display()));
+    let authority_guidance = if rendered.contains("Do not apply ordinary install repair") {
+        String::new()
+    } else {
+        "\n\n## Local-development authority\n\nDo not apply ordinary install repair through local-development authority; rerun the source checkout's `./gradlew refreshDevelopmentLocal` task instead."
+            .to_string()
+    };
+    Ok(format!(
+        "{rendered}{authority_guidance}\n\n## Local-development backend startup\n\nBefore the reuse-only verification command, start the exact receipt-owned headless backend with `{} developer runtime up --workspace-root \"$PWD\" --backend=headless`. Then run `{} agent verify --workspace-root \"$PWD\" --backend=headless`.\n",
+        entrypoint.display(),
+        entrypoint.display(),
+    ))
+}
+
+fn render_local_guidance(skill: &Path, entrypoint: &Path, source: &SourceSnapshot) -> String {
+    format!(
+        "<kast files=\"*.kt, *.kts\" type=\"instructions\" replaceTools=\"grep,search,write\">\n## Kast local-development routing\nUse `{}` before Kotlin or Gradle semantic work.\nStart the receipt-owned `{} developer runtime up --workspace-root \"$PWD\" --backend=headless` for this exact root, then run `{} agent verify --workspace-root \"$PWD\" --backend=headless` before semantic work.\nUse typed commands such as `{} agent symbol --query <name>`, `{} agent diagnostics --file-path <path>`, and `{} agent rename --symbol <fq-name> --new-name <name> --apply`.\nPrepared source commit: {}\nPrepared source SHA-256: {}\n</kast>\n",
+        skill.display(),
+        entrypoint.display(),
+        entrypoint.display(),
+        entrypoint.display(),
+        entrypoint.display(),
+        entrypoint.display(),
+        source.git_commit.as_str(),
+        source.source_tree_sha256.as_str(),
+    )
+}
+
+fn validate_rendered_command_lockstep(rendered: &str, entrypoint: &Path) -> Result<()> {
+    let entrypoint = entrypoint.display().to_string();
+    for line in rendered.lines() {
+        for (index, code) in line.split('`').enumerate() {
+            if index % 2 == 0 {
+                continue;
+            }
+            let Some(arguments) = code.strip_prefix(&entrypoint) else {
+                continue;
+            };
+            if explicitly_denied_command_reference(line, arguments) {
+                continue;
+            }
+            validate_rendered_command_path(code, arguments)?;
+        }
+    }
+    Ok(())
+}
+
+fn explicitly_denied_command_reference(line: &str, arguments: &str) -> bool {
+    line.contains("Do not teach")
+        && matches!(
+            arguments.trim(),
+            "agent tools" | "agent call" | "agent workflow" | "rpc"
+        )
+}
+
+fn validate_rendered_command_path(rendered_command: &str, arguments: &str) -> Result<()> {
+    let arguments = normalize_rendered_guidance_arguments(rendered_command, arguments)?;
+    if is_bare_command_path(&arguments) {
+        return Ok(());
+    }
+
+    let mut argv = Vec::with_capacity(arguments.len() + 1);
+    argv.push("kast".to_string());
+    argv.extend(arguments);
+    match <crate::cli::Cli as clap::CommandFactory>::command().try_get_matches_from(argv) {
+        Ok(_) => Ok(()),
+        Err(error)
+            if matches!(
+                error.kind(),
+                clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion
+            ) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(CliError::new(
+            "LOCAL_COMMAND_LOCKSTEP_INVALID",
+            format!(
+                "Rendered local guidance is not a valid staged CLI invocation: `{rendered_command}`: {error}",
+            ),
+        )),
+    }
+}
+
+fn normalize_rendered_guidance_arguments(
+    rendered_command: &str,
+    arguments: &str,
+) -> Result<Vec<String>> {
+    arguments
+        .split_whitespace()
+        .map(|token| {
+            let token = match token {
+                "\"$PWD\"" => "/tmp/kast-workspace",
+                "<name>" => "renamedSymbol",
+                "<fq-name>" => "io.example.Symbol.member",
+                "<path>" | "<snippet.kt>" => "/tmp/KastSnippet.kt",
+                "<stable-key>" => "kast-guidance-key",
+                token => token,
+            };
+            if token.contains(['\'', '"', '$', '<', '>']) {
+                return Err(CliError::new(
+                    "LOCAL_COMMAND_LOCKSTEP_INVALID",
+                    format!(
+                        "Rendered local guidance contains an unsupported argument template in `{rendered_command}`.",
+                    ),
+                ));
+            }
+            Ok(token.to_string())
+        })
+        .collect()
+}
+
+fn is_bare_command_path(arguments: &[String]) -> bool {
+    let mut command = <crate::cli::Cli as clap::CommandFactory>::command();
+    for token in arguments {
+        let Some(subcommand) = command.find_subcommand(token) else {
+            return false;
+        };
+        command = subcommand.clone();
+    }
+    true
+}
+
+fn local_install_manifest(
+    prefix: &Path,
+    source: &SourceSnapshot,
+    workspace_root: &Path,
+) -> crate::manifest::KastInstallManifest {
+    let generation_id = LocalGenerationId::from_source(source);
+    let generation = prefix.join(generation_target(&generation_id));
+    let state = prefix.join("state").join(generation_id.as_str());
+    let now = crate::manifest::current_timestamp();
+    crate::manifest::KastInstallManifest {
+        tool: "kast".to_string(),
+        install_id: generation_id.as_str().to_string(),
+        profile: "local-development".to_string(),
+        active_version: crate::cli::version().to_string(),
+        previous_version: None,
+        created_at: now.clone(),
+        updated_at: now.clone(),
+        roots: crate::manifest::ManifestRoots {
+            install: prefix.display().to_string(),
+            bin: prefix.join("bin").display().to_string(),
+            config: generation.join("config").display().to_string(),
+            data: state.join("data").display().to_string(),
+            cache: state.join("cache").display().to_string(),
+            runtime: state.join("runtime").display().to_string(),
+            logs: state.join("logs").display().to_string(),
+            locks: state.join("locks").display().to_string(),
+        },
+        entrypoints: crate::manifest::ManifestEntrypoints {
+            shim: prefix.join("bin/kast-dev").display().to_string(),
+            active_binary: generation.join("bin/kast").display().to_string(),
+        },
+        schemas: crate::manifest::ManifestSchemas::default(),
+        version: crate::cli::version().to_string(),
+        backend_version: crate::cli::version().to_string(),
+        installed_at: format!("local-development:{}", source.source_tree_sha256.as_str()),
+        platform: format!("local-{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+        components: vec![
+            "cli".to_string(),
+            "headless-backend".to_string(),
+            "skill".to_string(),
+            "agent-guidance".to_string(),
+            "config".to_string(),
+        ],
+        backends: vec![crate::manifest::BackendComponentState {
+            name: "headless".to_string(),
+            version: crate::cli::version().to_string(),
+            install_dir: generation
+                .join("lib/backends/headless/current")
+                .display()
+                .to_string(),
+            runtime_libs_dir: generation
+                .join("lib/backends/headless/current/runtime-libs")
+                .display()
+                .to_string(),
+            idea_home: Some(
+                generation
+                    .join("lib/backends/headless/current/idea-home")
+                    .display()
+                    .to_string(),
+            ),
+        }],
+        managed_paths: vec![
+            "generations".to_string(),
+            format!("state/{}", generation_id.as_str()),
+            "bin/kast-dev".to_string(),
+        ],
+        owned_paths: vec![prefix.display().to_string()],
+        shell_rc_patches: vec![],
+        repos: vec![crate::manifest::ManagedRepo {
+            path: workspace_root.display().to_string(),
+            copilot_package_version: String::new(),
+            resources: vec![],
+        }],
+        schema_version: crate::SCHEMA_VERSION,
+    }
+}
+
+fn validate_backend_distribution(backend: &Path) -> Result<()> {
+    for required in [
+        "runtime-libs/classpath.txt",
+        "idea-home/lib/nio-fs.jar",
+        "idea-home/modules/module-descriptors.dat",
+        "idea-home/plugins/kast-headless",
+    ] {
+        let path = backend.join(required);
+        if !path.exists() {
+            return Err(CliError::new(
+                "LOCAL_BACKEND_INCOMPLETE",
+                format!(
+                    "Headless development backend is missing {}.",
+                    path.display()
+                ),
+            ));
+        }
+    }
+    let runtime_libs = backend.join("runtime-libs");
+    let classpath_file = runtime_libs.join("classpath.txt");
+    let classpath = fs::read_to_string(&classpath_file).map_err(|error| {
+        CliError::new(
+            "LOCAL_BACKEND_INCOMPLETE",
+            format!(
+                "Could not read headless backend classpath {}: {error}.",
+                classpath_file.display(),
+            ),
+        )
+    })?;
+    let mut entry_count = 0_usize;
+    for raw_entry in classpath.lines().filter(|line| !line.is_empty()) {
+        let entry = Path::new(raw_entry);
+        if entry
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+        {
+            return Err(CliError::new(
+                "LOCAL_BACKEND_CLASSPATH_INVALID",
+                format!(
+                    "Headless backend classpath entry must stay inside runtime-libs: {raw_entry:?}.",
+                ),
+            ));
+        }
+        let target = runtime_libs.join(entry);
+        let metadata = fs::symlink_metadata(&target).map_err(|error| {
+            CliError::new(
+                "LOCAL_BACKEND_CLASSPATH_INVALID",
+                format!(
+                    "Headless backend classpath entry {} is unavailable: {error}.",
+                    target.display(),
+                ),
+            )
+        })?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return Err(CliError::new(
+                "LOCAL_BACKEND_CLASSPATH_INVALID",
+                format!(
+                    "Headless backend classpath entry is not an owned regular file: {}.",
+                    target.display(),
+                ),
+            ));
+        }
+        entry_count += 1;
+    }
+    if entry_count == 0 {
+        return Err(CliError::new(
+            "LOCAL_BACKEND_CLASSPATH_INVALID",
+            format!(
+                "Headless backend classpath is empty: {}.",
+                classpath_file.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn active_local_development_receipt() -> Result<Option<LocalDevelopmentReceipt>> {
+    let Some(requested_path) = configured_local_development_receipt_path()? else {
+        return Ok(None);
+    };
+    let receipt = read_local_development_receipt(&requested_path)?;
+    validate_active_receipt(&requested_path, &receipt)?;
+    Ok(Some(receipt))
+}
+
+fn configured_local_development_receipt_path() -> Result<Option<PathBuf>> {
+    let Some(raw_path) = std::env::var_os("KAST_LOCAL_DEVELOPMENT_RECEIPT") else {
+        return Ok(None);
+    };
+    if raw_path.is_empty() {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            "KAST_LOCAL_DEVELOPMENT_RECEIPT must name an absolute receipt path.",
+        ));
+    }
+    let requested_path = PathBuf::from(raw_path);
+    if !requested_path.is_absolute() {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            format!(
+                "KAST_LOCAL_DEVELOPMENT_RECEIPT must be absolute: {}",
+                requested_path.display()
+            ),
+        ));
+    }
+    Ok(Some(requested_path))
+}
+
+pub(crate) fn verified_active_local_development_receipt() -> Result<Option<LocalDevelopmentReceipt>>
+{
+    let Some(receipt) = active_local_development_receipt()? else {
+        return Ok(None);
+    };
+    validate_receipt_components(&receipt)?;
+    Ok(Some(receipt))
+}
+
+pub(crate) fn with_active_local_runtime_start_lock<T>(
+    action: impl FnOnce(bool) -> Result<T>,
+) -> Result<T> {
+    let Some(receipt_path) = configured_local_development_receipt_path()? else {
+        return action(false);
+    };
+    let receipt = read_local_development_receipt(&receipt_path)?;
+    let prefix = receipt.prefix.clone();
+    with_local_runtime_start_lock_after_validation(
+        &prefix,
+        || {
+            verified_active_local_development_receipt()?.ok_or_else(|| {
+                CliError::new(
+                    "LOCAL_AUTHORITY_INACTIVE",
+                    "Local-development authority disappeared while waiting for its runtime-start lock.",
+                )
+            })?;
+            Ok(())
+        },
+        || action(true),
+    )
+}
+
+fn with_local_runtime_start_lock_after_validation<T>(
+    prefix: &Path,
+    validate: impl FnOnce() -> Result<()>,
+    action: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    with_local_authority_lock(prefix, || {
+        validate()?;
+        action()
+    })
+}
+
+pub(crate) fn validate_active_local_backend_runtime(runtime_libs_dir: &Path) -> Result<()> {
+    let Some(receipt) = verified_active_local_development_receipt()? else {
+        return Ok(());
+    };
+    let expected = fs::canonicalize(
+        receipt
+            .components
+            .backend
+            .effective_target
+            .join("runtime-libs"),
+    )?;
+    let selected = fs::canonicalize(runtime_libs_dir)?;
+    if selected != expected {
+        return Err(CliError::new(
+            "LOCAL_BACKEND_RUNTIME_AUTHORITY_MISMATCH",
+            format!(
+                "Local runtime libraries {} are not owned by the active backend {}.",
+                selected.display(),
+                expected.display(),
+            ),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn read_local_development_receipt(path: &Path) -> Result<LocalDevelopmentReceipt> {
+    let receipt: LocalDevelopmentReceipt =
+        serde_json::from_slice(&fs::read(path)?).map_err(|error| {
+            CliError::new(
+                "LOCAL_AUTHORITY_RECEIPT_INVALID",
+                format!(
+                    "Invalid local-development receipt at {}: {error}",
+                    path.display()
+                ),
+            )
+        })?;
+    if receipt.schema_version != LOCAL_DEVELOPMENT_RECEIPT_SCHEMA_VERSION {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_UNSUPPORTED",
+            format!(
+                "Local-development receipt schema {} is unsupported; expected {}.",
+                receipt.schema_version, LOCAL_DEVELOPMENT_RECEIPT_SCHEMA_VERSION
+            ),
+        ));
+    }
+    Ok(receipt)
+}
+
+fn validate_active_receipt(path: &Path, receipt: &LocalDevelopmentReceipt) -> Result<()> {
+    let prefix = canonical_directory(&receipt.prefix, "local-development receipt prefix")?;
+    if prefix != receipt.prefix {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            "Local-development receipt prefix must be canonical.",
+        ));
+    }
+    let generation = prefix
+        .join("generations")
+        .join(receipt.generation_id.as_str());
+    validate_receipt_identity(receipt, &prefix, &generation, &receipt.workspace_root)?;
+    validate_stable_authority(path, receipt, &generation)?;
+    validate_receipt_fast_components(receipt)?;
+    let running_binary = fs::canonicalize(std::env::current_exe()?)?;
+    let receipt_binary = fs::canonicalize(&receipt.components.cli.effective_target)?;
+    if running_binary != receipt_binary {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_BINARY_MISMATCH",
+            format!(
+                "Running CLI {} is not the receipt-owned local binary {}.",
+                running_binary.display(),
+                receipt_binary.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_stable_authority(
+    path: &Path,
+    receipt: &LocalDevelopmentReceipt,
+    expected_generation: &Path,
+) -> Result<()> {
+    let prefix = &receipt.prefix;
+    let active_generation = fs::canonicalize(prefix.join("current")).map_err(|error| {
+        CliError::new(
+            "LOCAL_AUTHORITY_INACTIVE",
+            format!("Local-development current generation cannot be resolved: {error}"),
+        )
+    })?;
+    let expected_generation = canonical_directory(expected_generation, "receipt generation")?;
+    if active_generation != expected_generation {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_INACTIVE",
+            format!(
+                "Receipt generation {} is not the active local generation {}.",
+                expected_generation.display(),
+                active_generation.display()
+            ),
+        ));
+    }
+    let canonical_receipt = fs::canonicalize(path)?;
+    let expected_receipt = fs::canonicalize(expected_generation.join("authority.json"))?;
+    if canonical_receipt != expected_receipt {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            "The selected local-development receipt does not belong to the active generation.",
+        ));
+    }
+    let stable_receipt = fs::canonicalize(prefix.join("authority.json"))?;
+    if stable_receipt != expected_receipt {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            "The stable local-development receipt link does not select the active generation.",
+        ));
+    }
+    let canonical_manifest = fs::canonicalize(&receipt.install_manifest)?;
+    let expected_manifest = fs::canonicalize(expected_generation.join("install.json"))?;
+    if canonical_manifest != expected_manifest {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            "The selected local-development install manifest does not belong to the active generation.",
+        ));
+    }
+    let stable_manifest = fs::canonicalize(prefix.join("install.json"))?;
+    if stable_manifest != expected_manifest {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_RECEIPT_INVALID",
+            "The stable local-development manifest link does not select the active generation.",
+        ));
+    }
+    let entrypoint_target = read_relative_symlink(&receipt.entrypoint.effective_target)?;
+    if entrypoint_target.as_deref() != Some(Path::new("../current/entrypoint/kast-dev"))
+        || fs::canonicalize(&receipt.entrypoint.effective_target)?
+            != fs::canonicalize(&receipt.entrypoint.physical_target)?
+    {
+        return Err(CliError::new(
+            "LOCAL_COMPONENT_TARGET_MISMATCH",
+            "The stable local-development entrypoint does not resolve through the active generation.",
+        ));
+    }
+    let entrypoint_sha = Sha256Digest::try_from(crate::manifest::sha256_file(
+        &receipt.entrypoint.effective_target,
+    )?)?;
+    if entrypoint_sha != receipt.entrypoint.sha256 {
+        return Err(CliError::new(
+            "LOCAL_COMPONENT_CHECKSUM_MISMATCH",
+            format!(
+                "Local-development entrypoint checksum does not match at {}.",
+                receipt.entrypoint.effective_target.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_receipt_fast_components(receipt: &LocalDevelopmentReceipt) -> Result<()> {
+    validate_receipt_effective_topology(receipt)?;
+    validate_physical_entrypoint(receipt)?;
+    for component in [
+        &receipt.components.cli,
+        &receipt.components.skill,
+        &receipt.components.guidance,
+        &receipt.components.config,
+        &receipt.components.manifest,
+    ] {
+        validate_physical_component(component)?;
+    }
+    Ok(())
+}
+
+fn validate_receipt_components(receipt: &LocalDevelopmentReceipt) -> Result<()> {
+    validate_receipt_physical_components(receipt)?;
+    validate_receipt_effective_topology(receipt)
+}
+
+fn validate_receipt_effective_topology(receipt: &LocalDevelopmentReceipt) -> Result<()> {
+    for component in [
+        &receipt.components.cli,
+        &receipt.components.backend,
+        &receipt.components.skill,
+        &receipt.components.guidance,
+        &receipt.components.config,
+        &receipt.components.manifest,
+    ] {
+        let physical = fs::canonicalize(&component.physical_target).map_err(|error| {
+            CliError::new(
+                "LOCAL_COMPONENT_MISSING",
+                format!(
+                    "Could not resolve physical local component {}: {error}",
+                    component.physical_target.display(),
+                ),
+            )
+        })?;
+        let effective = fs::canonicalize(&component.effective_target).map_err(|error| {
+            CliError::new(
+                "LOCAL_COMPONENT_MISSING",
+                format!(
+                    "Could not resolve effective local component {}: {error}",
+                    component.effective_target.display(),
+                ),
+            )
+        })?;
+        if effective != physical {
+            return Err(CliError::new(
+                "LOCAL_COMPONENT_TARGET_MISMATCH",
+                format!(
+                    "Effective local component {} resolves to {}, not its receipt-owned physical target {}.",
+                    component.effective_target.display(),
+                    effective.display(),
+                    physical.display(),
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_receipt_physical_components(receipt: &LocalDevelopmentReceipt) -> Result<()> {
+    validate_physical_entrypoint(receipt)?;
+    for component in [
+        &receipt.components.cli,
+        &receipt.components.backend,
+        &receipt.components.skill,
+        &receipt.components.guidance,
+        &receipt.components.config,
+        &receipt.components.manifest,
+    ] {
+        validate_physical_component(component)?;
+    }
+    Ok(())
+}
+
+fn validate_physical_entrypoint(receipt: &LocalDevelopmentReceipt) -> Result<()> {
+    let actual = Sha256Digest::try_from(crate::manifest::sha256_file(
+        &receipt.entrypoint.physical_target,
+    )?)?;
+    if actual != receipt.entrypoint.sha256 {
+        return Err(CliError::new(
+            "LOCAL_COMPONENT_CHECKSUM_MISMATCH",
+            format!(
+                "Physical local-development entrypoint checksum does not match at {}.",
+                receipt.entrypoint.physical_target.display(),
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_physical_component(component: &LocalDevelopmentComponent) -> Result<()> {
+    let actual = tree_sha256(&component.physical_target)?;
+    if actual != component.sha256 {
+        return Err(CliError::new(
+            "LOCAL_COMPONENT_CHECKSUM_MISMATCH",
+            format!(
+                "Local component checksum does not match receipt at {}.",
+                component.physical_target.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn absolute_path(path: PathBuf) -> Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.components().collect())
+    } else {
+        Ok(std::env::current_dir()?.join(path).components().collect())
+    }
+}
+
+fn canonical_file(path: &Path, label: &str) -> Result<PathBuf> {
+    let path = fs::canonicalize(path).map_err(|error| {
+        CliError::new(
+            "LOCAL_COMPONENT_MISSING",
+            format!("Could not resolve {label} {}: {error}", path.display()),
+        )
+    })?;
+    if path.is_file() {
+        Ok(path)
+    } else {
+        Err(CliError::new(
+            "LOCAL_COMPONENT_MISSING",
+            format!("{label} is not a file: {}", path.display()),
+        ))
+    }
+}
+
+fn source_snapshot_mismatch(expected: &SourceSnapshot, actual: &SourceSnapshot) -> CliError {
+    let mut error = CliError::new(
+        "LOCAL_SOURCE_SNAPSHOT_CHANGED",
+        "The checkout changed after the local-development source snapshot was captured.",
+    );
+    error.details.insert(
+        "expected".to_string(),
+        expected.source_tree_sha256.as_str().to_string(),
+    );
+    error.details.insert(
+        "actual".to_string(),
+        actual.source_tree_sha256.as_str().to_string(),
+    );
+    error
+}
+
+fn with_local_authority_lock<T>(prefix: &Path, action: impl FnOnce() -> Result<T>) -> Result<T> {
+    use std::fs::OpenOptions;
+
+    let parent = prefix.parent().ok_or_else(|| {
+        CliError::new(
+            "LOCAL_PREFIX_INVALID",
+            format!("Local prefix has no parent: {}", prefix.display()),
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    let parent = fs::canonicalize(parent)?;
+    let name = prefix
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            CliError::new(
+                "LOCAL_PREFIX_INVALID",
+                format!("Local prefix has no UTF-8 name: {}", prefix.display()),
+            )
+        })?;
+    let lock_path = parent.join(format!(".{name}.refresh.lock"));
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(lock_path)?;
+    lock_local_file(&file)?;
+    let result = action();
+    unlock_local_file(&file)?;
+    result
+}
+
+fn reject_symlink_selected_prefix(prefix: &Path) -> Result<()> {
+    match fs::symlink_metadata(prefix) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(CliError::new(
+            "LOCAL_PREFIX_UNSAFE",
+            format!(
+                "Refusing a local-development prefix selected through a symlink: {}.",
+                prefix.display(),
+            ),
+        )),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(unix)]
+fn lock_local_file(file: &fs::File) -> Result<()> {
+    use std::os::fd::AsRawFd;
+
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error().into())
+    }
+}
+
+#[cfg(unix)]
+fn unlock_local_file(file: &fs::File) -> Result<()> {
+    use std::os::fd::AsRawFd;
+
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error().into())
+    }
+}
+
+#[cfg(not(unix))]
+fn lock_local_file(_file: &fs::File) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn unlock_local_file(_file: &fs::File) -> Result<()> {
+    Ok(())
+}

--- a/cli-rs/src/local_development/source_snapshot.rs
+++ b/cli-rs/src/local_development/source_snapshot.rs
@@ -1,0 +1,400 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::ffi::OsString;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::process::Command as ProcessCommand;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SourceSnapshot {
+    pub canonical_root: PathBuf,
+    pub worktree_kind: WorktreeKind,
+    pub git_commit: GitCommit,
+    pub source_tree_sha256: Sha256Digest,
+}
+
+impl SourceSnapshot {
+    pub fn capture(requested_root: &Path) -> Result<Self> {
+        let requested_root = canonical_directory(requested_root, "source checkout")?;
+        let repository_root = git_path(&requested_root, &["rev-parse", "--show-toplevel"])?;
+        let canonical_root = canonical_directory(&repository_root, "Git worktree root")?;
+        let git_commit = GitCommit::try_from(git_text(
+            &canonical_root,
+            &["rev-parse", "--verify", "HEAD"],
+        )?)?;
+        let git_directory = resolved_git_directory(
+            &canonical_root,
+            &git_text(&canonical_root, &["rev-parse", "--git-dir"])?
+        )?;
+        let common_git_directory = resolved_git_directory(
+            &canonical_root,
+            &git_text(&canonical_root, &["rev-parse", "--git-common-dir"])?
+        )?;
+        let worktree_kind = if git_directory == common_git_directory {
+            WorktreeKind::Primary
+        } else {
+            WorktreeKind::Linked
+        };
+        let source_tree_sha256 = source_tree_digest(&canonical_root)?;
+        Ok(Self {
+            canonical_root,
+            worktree_kind,
+            git_commit,
+            source_tree_sha256,
+        })
+    }
+
+    pub fn write_atomic(&self, path: &Path) -> Result<()> {
+        let parent = path.parent().ok_or_else(|| {
+            CliError::new(
+                "LOCAL_SOURCE_SNAPSHOT_PATH_INVALID",
+                format!("Source snapshot path has no parent: {}", path.display()),
+            )
+        })?;
+        fs::create_dir_all(parent)?;
+        let temporary = path.with_extension(format!("json.tmp-{}", std::process::id()));
+        let result = (|| -> Result<()> {
+            let mut output = fs::File::create(&temporary)?;
+            output.write_all(&serde_json::to_vec_pretty(self)?)?;
+            output.write_all(b"\n")?;
+            output.sync_all()?;
+            fs::rename(&temporary, path)?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&temporary);
+        }
+        result
+    }
+
+    pub fn read_strict(path: &Path) -> Result<Self> {
+        Self::from_slice(&fs::read(path)?, &path.display().to_string())
+    }
+
+    fn from_slice(bytes: &[u8], source: &str) -> Result<Self> {
+        serde_json::from_slice(bytes).map_err(|error| {
+            CliError::new(
+                "LOCAL_SOURCE_SNAPSHOT_INVALID",
+                format!("Invalid source snapshot at {source}: {error}"),
+            )
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorktreeKind {
+    Primary,
+    Linked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct GitCommit(String);
+
+impl TryFrom<String> for GitCommit {
+    type Error = CliError;
+
+    fn try_from(value: String) -> Result<Self> {
+        let value = value.trim().to_ascii_lowercase();
+        if (40..=64).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            Ok(Self(value))
+        } else {
+            Err(CliError::new(
+                "LOCAL_SOURCE_SNAPSHOT_INVALID",
+                "Git commit identity must be a 40-64 character hexadecimal object ID.",
+            ))
+        }
+    }
+}
+
+impl GitCommit {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<GitCommit> for String {
+    fn from(value: GitCommit) -> Self {
+        value.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct Sha256Digest(String);
+
+impl Sha256Digest {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for Sha256Digest {
+    type Error = CliError;
+
+    fn try_from(value: String) -> Result<Self> {
+        let value = value.trim().to_ascii_lowercase();
+        if value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            Ok(Self(value))
+        } else {
+            Err(CliError::new(
+                "LOCAL_SOURCE_SNAPSHOT_INVALID",
+                "A SHA-256 identity must be exactly 64 hexadecimal characters.",
+            ))
+        }
+    }
+}
+
+impl From<Sha256Digest> for String {
+    fn from(value: Sha256Digest) -> Self {
+        value.0
+    }
+}
+
+fn source_tree_digest(root: &Path) -> Result<Sha256Digest> {
+    let tracked = listed_paths(&git_bytes(root, &["ls-files", "-z", "--cached"])?)?;
+    let tracked_paths = tracked.iter().cloned().collect::<std::collections::HashSet<_>>();
+    let untracked = listed_paths(&git_bytes(
+        root,
+        &["ls-files", "-z", "--others", "--exclude-standard"],
+    )?)?;
+    let mut paths = tracked;
+    paths.extend(untracked);
+    paths.sort_by_key(|path| path_identity_bytes(path));
+    paths.dedup();
+
+    let mut digest = Sha256::new();
+    digest.update(b"kast-local-source-snapshot-v2\0");
+    digest.update((paths.len() as u64).to_be_bytes());
+    for relative in paths {
+        require_safe_relative_path(&relative)?;
+        let identity = path_identity_bytes(&relative);
+        update_framed_bytes(&mut digest, &identity);
+        let mut entry_digest = Sha256::new();
+        hash_source_entry(
+            root,
+            &relative,
+            tracked_paths.contains(&relative),
+            &mut entry_digest,
+        )?;
+        digest.update(entry_digest.finalize());
+    }
+    Sha256Digest::try_from(hex::encode(digest.finalize()))
+}
+
+fn hash_source_entry(
+    root: &Path,
+    relative: &Path,
+    tracked: bool,
+    digest: &mut Sha256,
+) -> Result<()> {
+    let path = root.join(relative);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if tracked && error.kind() == std::io::ErrorKind::NotFound => {
+            digest.update(b"deleted\0");
+            return Ok(());
+        }
+        Err(error) => {
+            return Err(CliError::new(
+                "LOCAL_SOURCE_SNAPSHOT_CHANGED",
+                format!(
+                    "Source entry changed while capturing {}: {error}",
+                    path.display()
+                ),
+            ));
+        }
+    };
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        digest.update(b"symlink\0");
+        let target = fs::read_link(&path)?;
+        let bytes = path_identity_bytes(&target);
+        update_framed_bytes(digest, &bytes);
+        return Ok(());
+    }
+    if file_type.is_file() {
+        digest.update(b"file\0");
+        digest.update([executable_marker(&metadata)]);
+        digest.update(metadata.len().to_be_bytes());
+        let mut file = fs::File::open(&path)?;
+        let mut buffer = [0_u8; 64 * 1024];
+        let mut total = 0_u64;
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+            total += read as u64;
+        }
+        if total != metadata.len() {
+            return Err(CliError::new(
+                "LOCAL_SOURCE_SNAPSHOT_CHANGED",
+                format!("Source file length changed while hashing {}.", path.display()),
+            ));
+        }
+        return Ok(());
+    }
+    if file_type.is_dir() {
+        digest.update(b"gitlink\0");
+        let commit = git_text(&path, &["rev-parse", "--verify", "HEAD"])?;
+        update_framed_bytes(digest, commit.as_bytes());
+        let status = git_bytes(
+            &path,
+            &["status", "--porcelain=v2", "-z", "--untracked-files=all"],
+        )?;
+        update_framed_bytes(digest, &status);
+        return Ok(());
+    }
+    Err(CliError::new(
+        "LOCAL_SOURCE_ENTRY_UNSUPPORTED",
+        format!(
+            "Source snapshot refuses unsupported filesystem entry {}.",
+            path.display()
+        ),
+    ))
+}
+
+fn update_framed_bytes(digest: &mut Sha256, bytes: &[u8]) {
+    digest.update((bytes.len() as u64).to_be_bytes());
+    digest.update(bytes);
+}
+
+fn canonical_directory(path: &Path, label: &str) -> Result<PathBuf> {
+    let canonical = fs::canonicalize(path).map_err(|error| {
+        CliError::new(
+            "LOCAL_SOURCE_ROOT_INVALID",
+            format!("Could not resolve {label} {}: {error}", path.display()),
+        )
+    })?;
+    if canonical.is_dir() {
+        Ok(canonical)
+    } else {
+        Err(CliError::new(
+            "LOCAL_SOURCE_ROOT_INVALID",
+            format!("{label} is not a directory: {}", canonical.display()),
+        ))
+    }
+}
+
+fn resolved_git_directory(root: &Path, raw: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(raw);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        root.join(path)
+    };
+    canonical_directory(&path, "Git metadata directory")
+}
+
+fn git_path(root: &Path, args: &[&str]) -> Result<PathBuf> {
+    Ok(PathBuf::from(git_text(root, args)?))
+}
+
+fn git_text(root: &Path, args: &[&str]) -> Result<String> {
+    let bytes = git_bytes(root, args)?;
+    String::from_utf8(bytes)
+        .map(|text| text.trim().to_string())
+        .map_err(|error| {
+            CliError::new(
+                "LOCAL_SOURCE_GIT_FAILED",
+                format!("Git returned non-UTF-8 text for {:?}: {error}", args),
+            )
+        })
+}
+
+fn git_bytes(root: &Path, args: &[&str]) -> Result<Vec<u8>> {
+    let output = ProcessCommand::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .map_err(|error| {
+            CliError::new(
+                "LOCAL_SOURCE_GIT_FAILED",
+                format!("Could not execute git {:?}: {error}", args),
+            )
+        })?;
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        Err(CliError::new(
+            "LOCAL_SOURCE_GIT_FAILED",
+            format!(
+                "git {:?} failed for {}: {}",
+                args,
+                root.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        ))
+    }
+}
+
+fn listed_paths(output: &[u8]) -> Result<Vec<PathBuf>> {
+    output
+        .split(|byte| *byte == 0)
+        .filter(|raw| !raw.is_empty())
+        .map(path_from_git_bytes)
+        .collect()
+}
+
+#[cfg(unix)]
+fn path_from_git_bytes(raw: &[u8]) -> Result<PathBuf> {
+    use std::os::unix::ffi::OsStringExt;
+
+    Ok(PathBuf::from(OsString::from_vec(raw.to_vec())))
+}
+
+#[cfg(not(unix))]
+fn path_from_git_bytes(raw: &[u8]) -> Result<PathBuf> {
+    String::from_utf8(raw.to_vec())
+        .map(PathBuf::from)
+        .map_err(|error| {
+            CliError::new(
+                "LOCAL_SOURCE_PATH_INVALID",
+                format!("Git source path is not valid UTF-8: {error}"),
+            )
+        })
+}
+
+fn require_safe_relative_path(path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(CliError::new(
+            "LOCAL_SOURCE_PATH_INVALID",
+            format!("Git returned an unsafe source path: {}", path.display()),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn path_identity_bytes(path: &Path) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+
+    path.as_os_str().as_bytes().to_vec()
+}
+
+#[cfg(not(unix))]
+fn path_identity_bytes(path: &Path) -> Vec<u8> {
+    path.to_string_lossy().as_bytes().to_vec()
+}
+
+#[cfg(unix)]
+fn executable_marker(metadata: &fs::Metadata) -> u8 {
+    use std::os::unix::fs::PermissionsExt;
+
+    u8::from(metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn executable_marker(_metadata: &fs::Metadata) -> u8 {
+    0
+}

--- a/cli-rs/src/local_development/tests.rs
+++ b/cli-rs/src/local_development/tests.rs
@@ -176,8 +176,8 @@ mod refresh_tests {
         LocalDevelopmentRefreshRequest, LocalDevelopmentRemoveRequest,
         LocalDevelopmentRollbackRequest, LocalRefreshPhase, LocalRemovalPhase, SourceSnapshot,
         refresh_local_development, refresh_local_development_with_observer,
-        remove_local_development, remove_local_development_with_observer,
-        rollback_local_development, validate_backend_distribution,
+        remove_local_development, remove_local_development_with_observer, render_local_guidance,
+        render_local_skill, rollback_local_development, validate_backend_distribution,
         validate_rendered_command_lockstep, validate_rendered_command_path,
         with_local_authority_lock, with_local_runtime_start_lock_after_validation,
     };
@@ -188,6 +188,44 @@ mod refresh_tests {
     use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
+
+    #[test]
+    fn rendered_local_commands_shell_quote_entrypoints() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let source_skill = fixture.path().join("SKILL.md");
+        fs::write(
+            &source_skill,
+            "---\nname: kast\ndescription: fixture\n---\nRun `kast agent verify --workspace-root \"$PWD\"`.\n",
+        )
+        .expect("source skill");
+        let entrypoint = fixture
+            .path()
+            .join("agent's local authority/bin/kast-dev");
+        let quoted_entrypoint = format!(
+            "'{}'",
+            entrypoint.display().to_string().replace('\'', "'\"'\"'")
+        );
+        let snapshot = SourceSnapshot::capture(repository.path()).expect("source snapshot");
+
+        let rendered_skill =
+            render_local_skill(&source_skill, &entrypoint).expect("rendered skill");
+        let rendered_guidance =
+            render_local_guidance(&source_skill, &entrypoint, &snapshot);
+
+        assert!(
+            rendered_skill.contains(&format!("`{quoted_entrypoint} agent verify")),
+            "rendered skill command must shell-quote the entrypoint: {rendered_skill}",
+        );
+        assert!(
+            rendered_guidance.contains(&format!("`{quoted_entrypoint} developer runtime up")),
+            "rendered guidance command must shell-quote the entrypoint: {rendered_guidance}",
+        );
+        validate_rendered_command_lockstep(&rendered_skill, &entrypoint)
+            .expect("quoted skill commands remain in lockstep");
+        validate_rendered_command_lockstep(&rendered_guidance, &entrypoint)
+            .expect("quoted guidance commands remain in lockstep");
+    }
 
     #[test]
     fn refresh_activates_one_complete_generation_without_touching_release_state() {
@@ -246,13 +284,21 @@ mod refresh_tests {
             "local entrypoint must isolate Kotlin workspace data by generation"
         );
         let canonical_prefix = fs::canonicalize(&prefix).expect("canonical local prefix");
+        let quoted_entrypoint = format!(
+            "'{}'",
+            canonical_prefix
+                .join("bin/kast-dev")
+                .display()
+                .to_string()
+                .replace('\'', "'\"'\"'")
+        );
         let start_command = format!(
             "{} developer runtime up --workspace-root \"$PWD\" --backend=headless",
-            canonical_prefix.join("bin/kast-dev").display(),
+            quoted_entrypoint,
         );
         let verify_command = format!(
             "{} agent verify --workspace-root \"$PWD\" --backend=headless",
-            canonical_prefix.join("bin/kast-dev").display(),
+            quoted_entrypoint,
         );
         for installed_resource in [
             prefix.join("current/lib/skills/kast/SKILL.md"),
@@ -516,7 +562,7 @@ mod refresh_tests {
     fn command_lockstep_checks_positive_invocations_on_a_mixed_negative_guidance_line() {
         let entrypoint = Path::new("/tmp/kast-dev");
         let error = validate_rendered_command_lockstep(
-            "Do not teach `/tmp/kast-dev agent tools`; instead run `/tmp/kast-dev agent imaginary --bad`.",
+            "Do not teach `'/tmp/kast-dev' agent tools`; instead run `'/tmp/kast-dev' agent imaginary --bad`.",
             entrypoint,
         )
         .expect_err("positive stale invocation must not inherit the negative exemption");
@@ -527,7 +573,7 @@ mod refresh_tests {
     #[test]
     fn command_lockstep_accepts_only_the_closed_negative_command_references() {
         validate_rendered_command_lockstep(
-            "Do not teach `/tmp/kast-dev agent tools`, `/tmp/kast-dev agent call`, `/tmp/kast-dev agent workflow`, or `/tmp/kast-dev rpc`.",
+            "Do not teach `'/tmp/kast-dev' agent tools`, `'/tmp/kast-dev' agent call`, `'/tmp/kast-dev' agent workflow`, or `'/tmp/kast-dev' rpc`.",
             Path::new("/tmp/kast-dev"),
         )
         .expect("closed negative references");

--- a/cli-rs/src/local_development/tests.rs
+++ b/cli-rs/src/local_development/tests.rs
@@ -1,0 +1,1941 @@
+#[cfg(test)]
+mod source_snapshot_tests {
+    use super::SourceSnapshot;
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+
+    #[test]
+    fn capture_changes_content_digest_for_dirty_bytes_at_the_same_commit() {
+        let repository = initialized_repository();
+        let first = SourceSnapshot::capture(repository.path()).expect("initial snapshot");
+
+        fs::write(repository.path().join("src.txt"), "changed\n").expect("changed source");
+        let second = SourceSnapshot::capture(repository.path()).expect("changed snapshot");
+
+        assert_eq!(first.git_commit, second.git_commit);
+        assert_ne!(first.source_tree_sha256, second.source_tree_sha256);
+    }
+
+    #[test]
+    fn capture_changes_content_digest_for_untracked_non_ignored_source() {
+        let repository = initialized_repository();
+        let first = SourceSnapshot::capture(repository.path()).expect("initial snapshot");
+
+        fs::write(repository.path().join("new-source.txt"), "new\n").expect("untracked source");
+        let second = SourceSnapshot::capture(repository.path()).expect("changed snapshot");
+
+        assert_ne!(first.source_tree_sha256, second.source_tree_sha256);
+    }
+
+    #[test]
+    fn capture_encodes_a_tracked_deletion_without_requiring_the_deleted_path() {
+        let repository = initialized_repository();
+        let before = SourceSnapshot::capture(repository.path()).expect("initial snapshot");
+
+        fs::remove_file(repository.path().join("src.txt")).expect("delete tracked source");
+        let deleted = SourceSnapshot::capture(repository.path()).expect("deleted snapshot");
+        let repeated =
+            SourceSnapshot::capture(repository.path()).expect("repeated deleted snapshot");
+
+        assert_eq!(
+            deleted, repeated,
+            "stable tracked deletion must be reproducible"
+        );
+        assert_ne!(before.source_tree_sha256, deleted.source_tree_sha256);
+    }
+
+    #[test]
+    fn write_atomic_persists_a_strict_round_trippable_snapshot() {
+        let repository = initialized_repository();
+        let snapshot = SourceSnapshot::capture(repository.path()).expect("snapshot");
+        let output = repository.path().join("state/source-snapshot.json");
+
+        snapshot.write_atomic(&output).expect("write snapshot");
+        let loaded: SourceSnapshot =
+            serde_json::from_slice(&fs::read(&output).expect("snapshot bytes"))
+                .expect("strict snapshot JSON");
+
+        assert_eq!(loaded, snapshot);
+    }
+
+    #[test]
+    fn source_digest_frames_file_content_across_entry_boundaries() {
+        let repository = initialized_repository();
+        let mut colliding_old_encoding = b"left".to_vec();
+        colliding_old_encoding.extend_from_slice(&1_u64.to_be_bytes());
+        colliding_old_encoding.extend_from_slice(b"b");
+        colliding_old_encoding.extend_from_slice(b"file\0");
+        colliding_old_encoding.push(0);
+        colliding_old_encoding.extend_from_slice(b"right");
+        fs::write(repository.path().join("a"), colliding_old_encoding).expect("first shape");
+        run_git(repository.path(), &["add", "a"]);
+        run_git(
+            repository.path(),
+            &["commit", "--quiet", "-m", "collision fixture"],
+        );
+        let one_file = SourceSnapshot::capture(repository.path()).expect("one-file snapshot");
+
+        fs::write(repository.path().join("a"), b"left").expect("shortened first file");
+        fs::write(repository.path().join("b"), b"right").expect("second file");
+        let two_files = SourceSnapshot::capture(repository.path()).expect("two-file snapshot");
+
+        assert_ne!(
+            one_file.source_tree_sha256, two_files.source_tree_sha256,
+            "file boundaries must be part of the source digest"
+        );
+    }
+
+    fn initialized_repository() -> tempfile::TempDir {
+        let repository = tempfile::tempdir().expect("repository");
+        run_git(repository.path(), &["init", "--quiet"]);
+        run_git(
+            repository.path(),
+            &["config", "user.email", "test@example.com"],
+        );
+        run_git(repository.path(), &["config", "user.name", "Kast Test"]);
+        fs::write(repository.path().join("src.txt"), "initial\n").expect("initial source");
+        run_git(repository.path(), &["add", "src.txt"]);
+        run_git(repository.path(), &["commit", "--quiet", "-m", "initial"]);
+        repository
+    }
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[cfg(test)]
+mod component_digest_tests {
+    use super::tree_sha256;
+    use std::fs;
+
+    #[test]
+    fn component_digest_frames_file_content_across_entry_boundaries() {
+        let component = tempfile::tempdir().expect("component");
+        let mut colliding_old_encoding = b"left".to_vec();
+        colliding_old_encoding.extend_from_slice(&1_u64.to_be_bytes());
+        colliding_old_encoding.extend_from_slice(b"b");
+        colliding_old_encoding.extend_from_slice(b"file\0");
+        colliding_old_encoding.push(0);
+        colliding_old_encoding.extend_from_slice(b"right");
+        fs::write(component.path().join("a"), colliding_old_encoding).expect("first shape");
+        let one_file = tree_sha256(component.path()).expect("one-file digest");
+
+        fs::write(component.path().join("a"), b"left").expect("shortened first file");
+        fs::write(component.path().join("b"), b"right").expect("second file");
+        let two_files = tree_sha256(component.path()).expect("two-file digest");
+
+        assert_ne!(
+            one_file, two_files,
+            "file boundaries must be part of the component digest"
+        );
+    }
+}
+
+#[cfg(test)]
+mod provenance_tests {
+    use super::{Sha256Digest, validate_cli_producer_source_identity};
+
+    #[test]
+    fn cli_attestation_rejects_an_unbound_producer() {
+        let expected = Sha256Digest::try_from("a".repeat(64)).expect("digest");
+
+        let error =
+            validate_cli_producer_source_identity(None, &expected).expect_err("unbound producer");
+
+        assert_eq!(error.code, "LOCAL_CLI_SOURCE_ATTESTATION_MISSING");
+    }
+
+    #[test]
+    fn cli_attestation_rejects_bytes_built_for_another_source_snapshot() {
+        let expected = Sha256Digest::try_from("a".repeat(64)).expect("digest");
+
+        let error = validate_cli_producer_source_identity(Some(&"b".repeat(64)), &expected)
+            .expect_err("stale producer");
+
+        assert_eq!(error.code, "LOCAL_CLI_SOURCE_MISMATCH");
+    }
+}
+
+#[cfg(test)]
+mod refresh_tests {
+    use super::{
+        LocalArtifactKind, LocalArtifactProvenance, LocalDevelopmentAuthority,
+        LocalDevelopmentRefreshRequest, LocalDevelopmentRemoveRequest,
+        LocalDevelopmentRollbackRequest, LocalRefreshPhase, LocalRemovalPhase, SourceSnapshot,
+        refresh_local_development, refresh_local_development_with_observer,
+        remove_local_development, remove_local_development_with_observer,
+        rollback_local_development, validate_backend_distribution,
+        validate_rendered_command_lockstep, validate_rendered_command_path,
+        with_local_authority_lock, with_local_runtime_start_lock_after_validation,
+    };
+    use std::fs;
+    use std::io::Write;
+    use std::path::Path;
+    use std::process::Command;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn refresh_activates_one_complete_generation_without_touching_release_state() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let release_sentinel = fixture.path().join("release/kast");
+        write_file(&release_sentinel, b"release-binary\n");
+        let release_before = fs::read(&release_sentinel).expect("release sentinel");
+
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        );
+        let snapshot = SourceSnapshot::read_strict(&request.expected_source_snapshot)
+            .expect("source snapshot");
+        let result = refresh_local_development(request).expect("refresh");
+
+        assert_eq!(
+            result.receipt.authority,
+            LocalDevelopmentAuthority::LocalDevelopment
+        );
+        assert_eq!(result.receipt.source, snapshot);
+        assert!(prefix.join("current/bin/kast").is_file());
+        assert!(
+            prefix
+                .join("current/lib/backends/headless/current/runtime-libs/classpath.txt")
+                .is_file()
+        );
+        assert!(prefix.join("current/lib/skills/kast/SKILL.md").is_file());
+        assert!(prefix.join("current/guidance/AGENTS.local.md").is_file());
+        assert!(repository.path().join("AGENTS.local.md").is_file());
+        assert_eq!(
+            result.receipt.components.guidance.effective_target,
+            fs::canonicalize(repository.path())
+                .expect("canonical repository")
+                .join("AGENTS.local.md")
+        );
+        assert!(prefix.join("current/config/config.toml").is_file());
+        let local_config = fs::read_to_string(prefix.join("current/config/config.toml"))
+            .expect("local authority config");
+        assert!(local_config.contains("defaultBackend = \"headless\""));
+        assert!(
+            local_config.contains("[projectOpen]\nprofileAutoInit = false"),
+            "local headless authority must not invoke release-owned project-open bootstrap",
+        );
+        assert!(prefix.join("current/authority.json").is_file());
+        assert!(prefix.join("bin/kast-dev").is_file());
+        let entrypoint =
+            fs::read_to_string(prefix.join("bin/kast-dev")).expect("local development entrypoint");
+        assert!(
+            entrypoint.contains("export KAST_DATA_HOME=\"$state/data\""),
+            "local entrypoint must isolate Kotlin workspace data by generation"
+        );
+        let canonical_prefix = fs::canonicalize(&prefix).expect("canonical local prefix");
+        let start_command = format!(
+            "{} developer runtime up --workspace-root \"$PWD\" --backend=headless",
+            canonical_prefix.join("bin/kast-dev").display(),
+        );
+        let verify_command = format!(
+            "{} agent verify --workspace-root \"$PWD\" --backend=headless",
+            canonical_prefix.join("bin/kast-dev").display(),
+        );
+        for installed_resource in [
+            prefix.join("current/lib/skills/kast/SKILL.md"),
+            prefix.join("current/guidance/AGENTS.local.md"),
+        ] {
+            let content = fs::read_to_string(&installed_resource).expect("installed resource");
+            let start_offset = content.find(&start_command).unwrap_or_else(|| {
+                panic!("{} must teach local startup", installed_resource.display())
+            });
+            let verify_offset = content.find(&verify_command).unwrap_or_else(|| {
+                panic!(
+                    "{} must teach local verification",
+                    installed_resource.display()
+                )
+            });
+            assert!(
+                start_offset < verify_offset,
+                "{} must start the reuse-only runtime before verification",
+                installed_resource.display(),
+            );
+        }
+        let installed_skill = fs::read_to_string(prefix.join("current/lib/skills/kast/SKILL.md"))
+            .expect("installed skill");
+        assert!(
+            installed_skill.contains("Do not apply ordinary install repair"),
+            "local skill must route repair back through the source refresh task"
+        );
+        assert!(
+            !installed_skill.contains("Add `--apply`"),
+            "local skill must not advertise cross-authority apply repair"
+        );
+        assert_eq!(
+            fs::read(&release_sentinel).expect("preserved release sentinel"),
+            release_before
+        );
+    }
+
+    #[test]
+    fn refresh_is_idempotent_for_an_unchanged_source_snapshot() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        );
+
+        let first = refresh_local_development(request.clone()).expect("first refresh");
+        let current_before = fs::read_link(prefix.join("current")).expect("current link");
+        let second = refresh_local_development(request).expect("second refresh");
+        let current_after = fs::read_link(prefix.join("current")).expect("current link");
+        let generation_count = fs::read_dir(prefix.join("generations"))
+            .expect("generations")
+            .count();
+
+        assert!(!first.skipped);
+        assert!(second.skipped);
+        assert_eq!(current_after, current_before);
+        assert_eq!(generation_count, 1);
+    }
+
+    #[test]
+    fn idempotent_refresh_rejects_a_tampered_generation_manifest() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        );
+        let first = refresh_local_development(request.clone()).expect("first refresh");
+        fs::write(&first.receipt.install_manifest, b"{}\n").expect("tampered manifest");
+
+        let error = refresh_local_development(request).expect_err("tampered manifest");
+
+        assert_eq!(error.code, "LOCAL_COMPONENT_CHECKSUM_MISMATCH");
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("preserved current"),
+            Path::new("generations").join(first.receipt.generation_id.as_str()),
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn idempotent_refresh_rejects_a_stable_launcher_that_bypasses_current_wrapper() {
+        use std::os::unix::fs::symlink;
+
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        );
+        let first = refresh_local_development(request.clone()).expect("first refresh");
+        fs::remove_file(prefix.join("bin/kast-dev")).expect("remove stable launcher");
+        symlink("../current/bin/kast", prefix.join("bin/kast-dev")).expect("bypassing launcher");
+
+        let error = refresh_local_development(request).expect_err("bypassing launcher");
+
+        assert_eq!(error.code, "LOCAL_COMPONENT_TARGET_MISMATCH");
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("preserved current"),
+            Path::new("generations").join(first.receipt.generation_id.as_str()),
+        );
+    }
+
+    #[test]
+    fn refresh_rejects_a_preexisting_unowned_prefix_without_deleting_its_content() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("shared-prefix");
+        write_file(&prefix.join("keep.txt"), b"user-owned\n");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "unowned-prefix",
+        );
+
+        let error = refresh_local_development(request).expect_err("unowned prefix");
+
+        assert_eq!(error.code, "LOCAL_PREFIX_CONFLICT");
+        assert_eq!(
+            fs::read(prefix.join("keep.txt")).expect("preserved sentinel"),
+            b"user-owned\n"
+        );
+        assert!(fs::symlink_metadata(prefix.join("current")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refresh_rejects_a_symlink_alias_for_an_existing_prefix() {
+        use std::os::unix::fs::symlink;
+
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let first = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        ))
+        .expect("first refresh");
+        let alias = fixture.path().join("local-authority-alias");
+        symlink(&prefix, &alias).expect("prefix alias");
+
+        let error = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &alias,
+            "alias",
+        ))
+        .expect_err("symlink-selected prefix");
+
+        assert_eq!(error.code, "LOCAL_PREFIX_UNSAFE");
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("preserved current"),
+            Path::new("generations").join(first.receipt.generation_id.as_str()),
+        );
+    }
+
+    #[test]
+    fn refresh_rejects_source_guidance_that_teaches_a_nonexistent_staged_command() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        fs::write(
+            repository
+                .path()
+                .join("cli-rs/resources/kast-skill/SKILL.md"),
+            "---\nname: kast\ndescription: invalid fixture\n---\nRun `kast agent imaginary`.\n",
+        )
+        .expect("invalid skill");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "invalid-command",
+        );
+
+        let error = refresh_local_development(request).expect_err("stale taught command");
+
+        assert_eq!(error.code, "LOCAL_COMMAND_LOCKSTEP_INVALID");
+        assert!(
+            !prefix.join("current").exists(),
+            "command lockstep rejection must happen before activation",
+        );
+    }
+
+    #[test]
+    fn refresh_rejects_source_guidance_that_teaches_a_stale_command_flag() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        fs::write(
+            repository
+                .path()
+                .join("cli-rs/resources/kast-skill/SKILL.md"),
+            "---\nname: kast\ndescription: invalid fixture\n---\nRun `kast agent verify --workspace-root \"$PWD\" --removed-flag`.\n",
+        )
+        .expect("invalid skill");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "invalid-flag",
+        );
+
+        let error = refresh_local_development(request).expect_err("stale taught flag");
+
+        assert_eq!(error.code, "LOCAL_COMMAND_LOCKSTEP_INVALID");
+        assert!(
+            !prefix.join("current").exists(),
+            "flag lockstep rejection must happen before activation",
+        );
+    }
+
+    #[test]
+    fn command_lockstep_accepts_a_complete_templated_rename_invocation() {
+        validate_rendered_command_path(
+            "/tmp/kast-dev agent rename --symbol <fq-name> --new-name <name> --workspace-root \"$PWD\"",
+            " agent rename --symbol <fq-name> --new-name <name> --workspace-root \"$PWD\"",
+        )
+        .expect("valid templated invocation");
+    }
+
+    #[test]
+    fn command_lockstep_accepts_a_bare_command_path_reference() {
+        validate_rendered_command_path("/tmp/kast-dev agent rename", " agent rename")
+            .expect("valid bare command path");
+    }
+
+    #[test]
+    fn command_lockstep_rejects_an_invocation_missing_a_required_argument() {
+        let error = validate_rendered_command_path(
+            "/tmp/kast-dev agent symbol --workspace-root \"$PWD\"",
+            " agent symbol --workspace-root \"$PWD\"",
+        )
+        .expect_err("missing required query");
+
+        assert_eq!(error.code, "LOCAL_COMMAND_LOCKSTEP_INVALID");
+    }
+
+    #[test]
+    fn command_lockstep_checks_positive_invocations_on_a_mixed_negative_guidance_line() {
+        let entrypoint = Path::new("/tmp/kast-dev");
+        let error = validate_rendered_command_lockstep(
+            "Do not teach `/tmp/kast-dev agent tools`; instead run `/tmp/kast-dev agent imaginary --bad`.",
+            entrypoint,
+        )
+        .expect_err("positive stale invocation must not inherit the negative exemption");
+
+        assert_eq!(error.code, "LOCAL_COMMAND_LOCKSTEP_INVALID");
+    }
+
+    #[test]
+    fn command_lockstep_accepts_only_the_closed_negative_command_references() {
+        validate_rendered_command_lockstep(
+            "Do not teach `/tmp/kast-dev agent tools`, `/tmp/kast-dev agent call`, `/tmp/kast-dev agent workflow`, or `/tmp/kast-dev rpc`.",
+            Path::new("/tmp/kast-dev"),
+        )
+        .expect("closed negative references");
+    }
+
+    #[test]
+    fn backend_classpath_entries_cannot_escape_the_attested_tree() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let backend = fixture.path().join("backend-headless");
+        write_backend_fixture(&backend);
+        write_file(&backend.join("outside.jar"), b"foreign\n");
+        fs::write(
+            backend.join("runtime-libs/classpath.txt"),
+            "../outside.jar\n",
+        )
+        .expect("escaping classpath");
+
+        let error = validate_backend_distribution(&backend).expect_err("escaping classpath");
+
+        assert_eq!(error.code, "LOCAL_BACKEND_CLASSPATH_INVALID");
+    }
+
+    #[test]
+    fn inactive_generation_reuse_rejects_different_rebuilt_artifacts() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first-a",
+        ))
+        .expect("first A refresh");
+
+        fs::write(
+            repository.path().join("settings.gradle.kts"),
+            "rootProject.name = \"second\"\n",
+        )
+        .expect("B source");
+        refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "second-b",
+        ))
+        .expect("B refresh");
+
+        fs::write(
+            repository.path().join("settings.gradle.kts"),
+            "rootProject.name = \"fixture\"\n",
+        )
+        .expect("restore A source");
+        fs::write(fixture.path().join("build/kast"), b"rebuilt A bytes\n")
+            .expect("different rebuilt CLI");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "rebuilt-a",
+        );
+
+        let error = refresh_local_development(request).expect_err("artifact mismatch");
+
+        assert_eq!(error.code, "LOCAL_GENERATION_ARTIFACT_MISMATCH");
+    }
+
+    #[test]
+    fn refresh_rejects_cli_bytes_changed_after_artifact_provenance() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        );
+        fs::write(&request.cli_binary, b"#!/bin/sh\nexit 17\n").expect("changed CLI bytes");
+
+        let error = refresh_local_development(request).expect_err("mixed CLI bytes");
+
+        assert_eq!(error.code, "LOCAL_ARTIFACT_CHECKSUM_MISMATCH");
+        assert!(
+            !prefix.exists(),
+            "artifact rejection must happen before staging"
+        );
+    }
+
+    #[test]
+    fn refresh_rejects_backend_provenance_from_another_source_snapshot() {
+        let repository = initialized_repository();
+        let other_repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        );
+        let mut provenance = super::read_local_artifact_provenance(&request.backend_provenance)
+            .expect("backend provenance");
+        provenance.source =
+            SourceSnapshot::capture(other_repository.path()).expect("other source snapshot");
+        super::write_json_atomic(&request.backend_provenance, &provenance)
+            .expect("mixed provenance");
+
+        let error = refresh_local_development(request).expect_err("mixed backend source");
+
+        assert_eq!(error.code, "LOCAL_ARTIFACT_SOURCE_MISMATCH");
+        assert!(
+            !prefix.exists(),
+            "artifact rejection must happen before staging"
+        );
+    }
+
+    #[test]
+    fn refresh_rejects_a_backend_relabelled_without_producer_emitted_source_identity() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        );
+        fs::write(
+            request
+                .backend_directory
+                .join("idea-home/plugins/kast-headless/lib/backend-headless-test-plugin.jar"),
+            b"relabelled plugin bytes",
+        )
+        .expect("remove producer identity from plugin bytes");
+        let source = SourceSnapshot::read_strict(&request.expected_source_snapshot)
+            .expect("source snapshot");
+        write_artifact_provenance(
+            &request.backend_provenance,
+            LocalArtifactKind::HeadlessBackend,
+            &source,
+            &request.backend_directory,
+        );
+
+        let error = refresh_local_development(request).expect_err("relabeled backend");
+
+        assert_eq!(error.code, "LOCAL_BACKEND_SOURCE_ATTESTATION_INVALID");
+        assert!(
+            !prefix.exists(),
+            "producer rejection must happen before staging"
+        );
+    }
+
+    #[test]
+    fn refresh_rejects_a_relabelled_stale_backend_sibling_jar() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        );
+        fs::write(
+            request
+                .backend_directory
+                .join("idea-home/plugins/kast-headless/lib/analysis-api-test.jar"),
+            b"stale analysis api bytes\n",
+        )
+        .expect("replace producer-owned sibling");
+        let source = SourceSnapshot::read_strict(&request.expected_source_snapshot)
+            .expect("source snapshot");
+        write_artifact_provenance(
+            &request.backend_provenance,
+            LocalArtifactKind::HeadlessBackend,
+            &source,
+            &request.backend_directory,
+        );
+
+        let error = refresh_local_development(request).expect_err("relabelled stale sibling");
+
+        assert_eq!(error.code, "LOCAL_BACKEND_COMPONENT_CHECKSUM_MISMATCH");
+        assert!(
+            !prefix.exists(),
+            "producer rejection must happen before staging"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refresh_rejects_a_generation_symlinked_from_another_prefix() {
+        use std::os::unix::fs::symlink;
+
+        let repository = initialized_repository();
+        let other_workspace = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let first_prefix = fixture.path().join("first-authority");
+        let first = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &first_prefix,
+            "first",
+        ))
+        .expect("first refresh");
+        let second_prefix = fixture.path().join("second-authority");
+        fs::create_dir_all(second_prefix.join("generations")).expect("second generations");
+        symlink(
+            first_prefix
+                .join("generations")
+                .join(first.receipt.generation_id.as_str()),
+            second_prefix
+                .join("generations")
+                .join(first.receipt.generation_id.as_str()),
+        )
+        .expect("foreign generation symlink");
+        let request = refresh_request(
+            repository.path(),
+            other_workspace.path(),
+            fixture.path(),
+            &second_prefix,
+            "second",
+        );
+
+        let error = refresh_local_development(request).expect_err("foreign generation");
+
+        assert_eq!(error.code, "LOCAL_AUTHORITY_RECEIPT_INVALID");
+        assert!(
+            fs::symlink_metadata(second_prefix.join("current")).is_err(),
+            "foreign generation must never become current"
+        );
+    }
+
+    #[test]
+    fn failed_refresh_preserves_the_previously_active_generation() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let first_request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        );
+        let first = refresh_local_development(first_request).expect("first refresh");
+        let current_before = fs::read_link(prefix.join("current")).expect("current link");
+
+        fs::write(
+            repository.path().join("settings.gradle.kts"),
+            "rootProject.name = \"changed\"\n",
+        )
+        .expect("changed source");
+        fs::remove_file(repository.path().join("AGENTS.local.md"))
+            .expect("remove owned guidance link");
+        write_file(
+            &repository.path().join("AGENTS.local.md"),
+            b"user-owned guidance\n",
+        );
+        let second_request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "second",
+        );
+
+        let error = refresh_local_development(second_request).expect_err("guidance conflict");
+
+        assert_eq!(error.code, "LOCAL_COMPONENT_TARGET_MISMATCH");
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("preserved current link"),
+            current_before
+        );
+        let active = super::read_local_development_receipt(&prefix.join("authority.json"))
+            .expect("preserved active receipt");
+        assert_eq!(active.generation_id, first.receipt.generation_id);
+    }
+
+    #[test]
+    fn post_activation_failure_rolls_back_current_previous_and_new_generation() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let first = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        ))
+        .expect("first refresh");
+        let current_before = fs::read_link(prefix.join("current")).expect("current link");
+        let entrypoint_before = fs::read(prefix.join("bin/kast-dev")).expect("entrypoint bytes");
+        fs::write(
+            repository.path().join("settings.gradle.kts"),
+            "rootProject.name = \"changed\"\n",
+        )
+        .expect("changed source");
+        let second_request = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "second",
+        );
+
+        let error = refresh_local_development_with_observer(second_request, |phase| {
+            assert_eq!(phase, LocalRefreshPhase::AfterActivation);
+            fs::write(prefix.join("bin/kast-dev"), b"incompatible wrapper\n")
+                .expect("simulate changed stable entrypoint");
+            Err(super::CliError::new(
+                "TEST_INJECTED_FAILURE",
+                "injected after current moved",
+            ))
+        })
+        .expect_err("injected refresh failure");
+
+        assert_eq!(error.code, "TEST_INJECTED_FAILURE");
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("restored current link"),
+            current_before
+        );
+        assert!(
+            fs::symlink_metadata(prefix.join("previous")).is_err(),
+            "first-generation failure must restore the absent previous link"
+        );
+        assert_eq!(
+            fs::read_dir(prefix.join("generations"))
+                .expect("generations")
+                .count(),
+            1
+        );
+        let active = super::read_local_development_receipt(&prefix.join("authority.json"))
+            .expect("restored active receipt");
+        assert_eq!(active.generation_id, first.receipt.generation_id);
+        assert_eq!(
+            fs::read(prefix.join("bin/kast-dev")).expect("restored entrypoint bytes"),
+            entrypoint_before,
+            "rollback must restore the stable entrypoint owned by the prior receipt"
+        );
+    }
+
+    #[test]
+    fn refresh_rejects_switching_an_existing_prefix_to_another_workspace() {
+        let source = initialized_repository();
+        let other_workspace = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let first_request = refresh_request(
+            source.path(),
+            source.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        );
+        refresh_local_development(first_request).expect("first refresh");
+        let current_before = fs::read_link(prefix.join("current")).expect("current link");
+
+        fs::write(
+            source.path().join("settings.gradle.kts"),
+            "rootProject.name = \"changed\"\n",
+        )
+        .expect("changed source");
+        let second_request = refresh_request(
+            source.path(),
+            other_workspace.path(),
+            fixture.path(),
+            &prefix,
+            "second",
+        );
+
+        let error = refresh_local_development(second_request).expect_err("workspace switch");
+
+        assert_eq!(error.code, "LOCAL_WORKSPACE_AUTHORITY_MISMATCH");
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("preserved current link"),
+            current_before
+        );
+        assert_eq!(
+            fs::read_dir(prefix.join("generations"))
+                .expect("generations")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn rollback_reactivates_the_validated_previous_complete_generation() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let first = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        ))
+        .expect("first refresh");
+        fs::write(
+            repository.path().join("settings.gradle.kts"),
+            "rootProject.name = \"changed\"\n",
+        )
+        .expect("changed source");
+        let second = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "second",
+        ))
+        .expect("second refresh");
+        let first_manifest: serde_json::Value = serde_json::from_slice(
+            &fs::read(
+                prefix
+                    .join("generations")
+                    .join(first.receipt.generation_id.as_str())
+                    .join("install.json"),
+            )
+            .expect("first manifest"),
+        )
+        .expect("first manifest JSON");
+        let second_manifest: serde_json::Value = serde_json::from_slice(
+            &fs::read(
+                prefix
+                    .join("generations")
+                    .join(second.receipt.generation_id.as_str())
+                    .join("install.json"),
+            )
+            .expect("second manifest"),
+        )
+        .expect("second manifest JSON");
+        assert_ne!(
+            first_manifest["roots"]["runtime"], second_manifest["roots"]["runtime"],
+            "runtime descriptors must never cross source generations"
+        );
+        assert!(
+            first_manifest["roots"]["runtime"]
+                .as_str()
+                .expect("first runtime root")
+                .contains(first.receipt.generation_id.as_str())
+        );
+        assert!(
+            second_manifest["roots"]["runtime"]
+                .as_str()
+                .expect("second runtime root")
+                .contains(second.receipt.generation_id.as_str())
+        );
+
+        let rollback = rollback_local_development(LocalDevelopmentRollbackRequest {
+            prefix: prefix.clone(),
+            to_generation: first.receipt.generation_id.clone(),
+        })
+        .expect("rollback");
+
+        assert_eq!(rollback.receipt.generation_id, first.receipt.generation_id);
+        assert_eq!(
+            rollback.replaced_generation,
+            Some(second.receipt.generation_id.clone())
+        );
+        assert!(!rollback.skipped);
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("rolled back current"),
+            Path::new("generations").join(first.receipt.generation_id.as_str())
+        );
+        assert_eq!(
+            fs::read_link(prefix.join("previous")).expect("new rollback target"),
+            Path::new("generations").join(second.receipt.generation_id.as_str())
+        );
+        assert_eq!(
+            fs::read(repository.path().join("AGENTS.local.md")).expect("effective guidance"),
+            fs::read(
+                prefix
+                    .join("generations")
+                    .join(first.receipt.generation_id.as_str())
+                    .join("guidance/AGENTS.local.md")
+            )
+            .expect("first guidance")
+        );
+
+        let retry = rollback_local_development(LocalDevelopmentRollbackRequest {
+            prefix: prefix.clone(),
+            to_generation: first.receipt.generation_id.clone(),
+        })
+        .expect("idempotent rollback retry");
+        assert!(retry.skipped);
+        assert_eq!(retry.replaced_generation, None);
+        assert_eq!(retry.receipt.generation_id, first.receipt.generation_id);
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("retry current"),
+            Path::new("generations").join(first.receipt.generation_id.as_str())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_refuses_to_orphan_a_live_receipt_owned_runtime() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let refreshed = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        ))
+        .expect("refresh");
+        let mut backend = register_live_runtime(
+            &prefix,
+            &refreshed.receipt.generation_id,
+            repository.path(),
+            fixture.path(),
+        );
+
+        let error = remove_local_development(LocalDevelopmentRemoveRequest {
+            prefix: prefix.clone(),
+            workspace_root: repository.path().to_path_buf(),
+        })
+        .expect_err("live runtime must block removal");
+        let _ = backend.kill();
+        let _ = backend.wait();
+
+        assert_eq!(error.code, "LOCAL_RUNTIME_ACTIVE");
+        assert!(prefix.exists(), "blocked removal must preserve authority");
+        assert_eq!(error.details.get("pid"), Some(&backend.id().to_string()),);
+        assert!(
+            error
+                .details
+                .get("stopCommand")
+                .is_some_and(|command| command.contains("developer runtime stop")),
+            "blocked removal must provide the receipt-owned stop command",
+        );
+
+        let removed = remove_local_development(LocalDevelopmentRemoveRequest {
+            prefix: prefix.clone(),
+            workspace_root: repository.path().to_path_buf(),
+        })
+        .expect("remove after backend exit");
+        assert!(removed.removed);
+        assert!(!prefix.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refresh_refuses_to_orphan_a_live_runtime_before_generation_activation() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let first = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        ))
+        .expect("first refresh");
+        let mut backend = register_live_runtime(
+            &prefix,
+            &first.receipt.generation_id,
+            repository.path(),
+            fixture.path(),
+        );
+        fs::write(
+            repository.path().join("settings.gradle.kts"),
+            "rootProject.name = \"changed\"\n",
+        )
+        .expect("changed source");
+
+        let error = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "second",
+        ))
+        .expect_err("live runtime must block generation-changing refresh");
+
+        assert_eq!(error.code, "LOCAL_RUNTIME_ACTIVE");
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("preserved current generation"),
+            Path::new("generations").join(first.receipt.generation_id.as_str()),
+        );
+        assert_eq!(
+            fs::read_dir(prefix.join("generations"))
+                .expect("preserved generations")
+                .count(),
+            1,
+            "blocked refresh must not stage a hidden generation",
+        );
+        let _ = backend.kill();
+        let _ = backend.wait();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rollback_refuses_to_orphan_a_live_current_generation_runtime() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let first = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        ))
+        .expect("first refresh");
+        fs::write(
+            repository.path().join("settings.gradle.kts"),
+            "rootProject.name = \"changed\"\n",
+        )
+        .expect("changed source");
+        let second = refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "second",
+        ))
+        .expect("second refresh");
+        let mut backend = register_live_runtime(
+            &prefix,
+            &second.receipt.generation_id,
+            repository.path(),
+            fixture.path(),
+        );
+
+        let error = rollback_local_development(LocalDevelopmentRollbackRequest {
+            prefix: prefix.clone(),
+            to_generation: first.receipt.generation_id.clone(),
+        })
+        .expect_err("live runtime must block generation-changing rollback");
+
+        assert_eq!(error.code, "LOCAL_RUNTIME_ACTIVE");
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("preserved current generation"),
+            Path::new("generations").join(second.receipt.generation_id.as_str()),
+        );
+        let _ = backend.kill();
+        let _ = backend.wait();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn idempotent_remove_cleans_a_dangling_owned_guidance_projection() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        ))
+        .expect("refresh");
+        let guidance = repository.path().join("AGENTS.local.md");
+        fs::remove_dir_all(&prefix).expect("simulate missing prefix");
+        assert!(fs::symlink_metadata(&guidance).is_ok());
+        assert!(!guidance.exists(), "projection must now be dangling");
+
+        let removed = remove_local_development(LocalDevelopmentRemoveRequest {
+            prefix: prefix.clone(),
+            workspace_root: repository.path().to_path_buf(),
+        })
+        .expect("idempotent removal recovery");
+
+        assert!(!removed.removed);
+        assert!(fs::symlink_metadata(guidance).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn missing_prefix_removal_and_refresh_share_the_namespace_lock() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "initial",
+        ))
+        .expect("initial refresh");
+        fs::remove_dir_all(&prefix).expect("simulate missing prefix");
+        let replacement = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "replacement",
+        );
+
+        let (cleanup_tx, cleanup_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let removal_prefix = prefix.clone();
+        let removal_workspace = repository.path().to_path_buf();
+        let removal = thread::spawn(move || {
+            remove_local_development_with_observer(
+                LocalDevelopmentRemoveRequest {
+                    prefix: removal_prefix,
+                    workspace_root: removal_workspace,
+                },
+                |phase| {
+                    assert_eq!(phase, LocalRemovalPhase::BeforeMissingPrefixCleanup);
+                    cleanup_tx.send(()).expect("announce missing cleanup");
+                    release_rx.recv().expect("release missing cleanup barrier");
+                    Ok(())
+                },
+            )
+        });
+        cleanup_rx.recv().expect("missing cleanup owns lock");
+
+        let (refreshed_tx, refreshed_rx) = mpsc::channel();
+        let refresh = thread::spawn(move || {
+            refreshed_tx
+                .send(refresh_local_development(replacement))
+                .expect("return refresh result");
+        });
+        assert!(
+            refreshed_rx
+                .recv_timeout(Duration::from_millis(200))
+                .is_err(),
+            "refresh must remain blocked while missing-prefix cleanup owns the namespace lock",
+        );
+
+        release_tx.send(()).expect("finish missing cleanup");
+        let removed = removal.join().expect("removal thread").expect("removal");
+        assert!(!removed.removed);
+        let refreshed = refreshed_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("refresh result")
+            .expect("replacement refresh");
+        refresh.join().expect("refresh thread");
+
+        assert!(prefix.exists(), "replacement authority must remain active");
+        assert!(repository.path().join("AGENTS.local.md").is_file());
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("replacement current"),
+            Path::new("generations").join(refreshed.receipt.generation_id.as_str()),
+        );
+    }
+
+    #[test]
+    fn runtime_registration_completes_before_a_waiting_generation_transition() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let registration = fixture.path().join("runtime-registered");
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let startup_prefix = prefix.clone();
+        let startup_registration = registration.clone();
+        let startup = thread::spawn(move || {
+            with_local_runtime_start_lock_after_validation(
+                &startup_prefix,
+                || Ok(()),
+                || {
+                    started_tx.send(()).expect("announce runtime spawn");
+                    release_rx.recv().expect("release registration barrier");
+                    fs::write(&startup_registration, "registered\n")?;
+                    Ok(())
+                },
+            )
+        });
+        started_rx
+            .recv()
+            .expect("runtime start owns authority lock");
+
+        let (transition_tx, transition_rx) = mpsc::channel();
+        let transition_prefix = prefix.clone();
+        let transition_registration = registration.clone();
+        let transition = thread::spawn(move || {
+            let observed_registration = with_local_authority_lock(&transition_prefix, || {
+                Ok(transition_registration.is_file())
+            });
+            transition_tx
+                .send(observed_registration)
+                .expect("return transition observation");
+        });
+        assert!(
+            transition_rx
+                .recv_timeout(Duration::from_millis(200))
+                .is_err(),
+            "generation transition must wait until the spawned runtime is registered",
+        );
+
+        release_tx.send(()).expect("finish runtime registration");
+        startup.join().expect("startup thread").expect("startup");
+        assert!(
+            transition_rx
+                .recv_timeout(Duration::from_secs(10))
+                .expect("transition observation")
+                .expect("transition lock"),
+            "the transition must observe registration before it can inspect live runtimes",
+        );
+        transition.join().expect("transition thread");
+    }
+
+    #[test]
+    fn concurrent_runtime_start_reuses_the_first_registration_instead_of_spawning_twice() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let registration = fixture.path().join("runtime-registered");
+        let (first_started_tx, first_started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let first_prefix = prefix.clone();
+        let first_registration = registration.clone();
+        let first = thread::spawn(move || {
+            with_local_runtime_start_lock_after_validation(
+                &first_prefix,
+                || Ok(()),
+                || {
+                    first_started_tx.send(()).expect("announce first spawn");
+                    release_rx.recv().expect("release first registration");
+                    fs::write(&first_registration, "registered\n")?;
+                    Ok(())
+                },
+            )
+        });
+        first_started_rx
+            .recv()
+            .expect("first start owns authority lock");
+
+        let (duplicate_spawn_tx, duplicate_spawn_rx) = mpsc::channel();
+        let (second_result_tx, second_result_rx) = mpsc::channel();
+        let second_prefix = prefix.clone();
+        let second_registration = registration.clone();
+        let second = thread::spawn(move || {
+            let result = with_local_runtime_start_lock_after_validation(
+                &second_prefix,
+                || Ok(()),
+                || {
+                    if second_registration.is_file() {
+                        Ok(false)
+                    } else {
+                        duplicate_spawn_tx
+                            .send(())
+                            .expect("announce duplicate spawn");
+                        Ok(true)
+                    }
+                },
+            );
+            second_result_tx.send(result).expect("return second start");
+        });
+        assert!(
+            second_result_rx
+                .recv_timeout(Duration::from_millis(200))
+                .is_err(),
+            "second start must wait for the first registration",
+        );
+
+        release_tx.send(()).expect("finish first registration");
+        first
+            .join()
+            .expect("first start thread")
+            .expect("first start");
+        assert!(
+            !second_result_rx
+                .recv_timeout(Duration::from_secs(10))
+                .expect("second start result")
+                .expect("second start lock"),
+            "second start must choose reuse after re-inspecting under the lock",
+        );
+        second.join().expect("second start thread");
+        assert!(
+            duplicate_spawn_rx.try_recv().is_err(),
+            "a concurrently registered runtime must prevent a duplicate spawn",
+        );
+    }
+
+    #[test]
+    fn generation_transition_completes_before_a_waiting_runtime_start_revalidates() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let generation = fixture.path().join("active-generation");
+        fs::write(&generation, "old\n").expect("initial generation");
+        let (transition_tx, transition_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let transition_prefix = prefix.clone();
+        let transition_generation = generation.clone();
+        let transition = thread::spawn(move || {
+            with_local_authority_lock(&transition_prefix, || {
+                transition_tx.send(()).expect("announce transition lock");
+                release_rx.recv().expect("release transition barrier");
+                fs::write(&transition_generation, "new\n")?;
+                Ok(())
+            })
+        });
+        transition_rx
+            .recv()
+            .expect("transition owns authority lock");
+
+        let (spawned_tx, spawned_rx) = mpsc::channel();
+        let (startup_tx, startup_rx) = mpsc::channel();
+        let startup_prefix = prefix.clone();
+        let startup_generation = generation.clone();
+        let startup = thread::spawn(move || {
+            let result = with_local_runtime_start_lock_after_validation(
+                &startup_prefix,
+                || {
+                    if fs::read_to_string(&startup_generation)? == "old\n" {
+                        Ok(())
+                    } else {
+                        Err(super::CliError::new(
+                            "LOCAL_AUTHORITY_INACTIVE",
+                            "Expected generation is no longer active.",
+                        ))
+                    }
+                },
+                || {
+                    spawned_tx.send(()).expect("announce spawn");
+                    Ok(())
+                },
+            );
+            startup_tx.send(result).expect("return startup result");
+        });
+        assert!(
+            startup_rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "runtime start must wait while a generation transition owns the authority lock",
+        );
+
+        release_tx.send(()).expect("finish generation transition");
+        transition
+            .join()
+            .expect("transition thread")
+            .expect("transition");
+        let error = startup_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("startup result")
+            .expect_err("stale runtime start must fail revalidation");
+        startup.join().expect("startup thread");
+
+        assert_eq!(error.code, "LOCAL_AUTHORITY_INACTIVE");
+        assert!(
+            spawned_rx.try_recv().is_err(),
+            "runtime process must not spawn after the expected generation changes",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn linked_worktree_refresh_uses_source_owned_ignore_without_mutating_shared_git_exclude() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let linked = fixture.path().join("linked-worktree");
+        let linked_text = linked.to_str().expect("UTF-8 linked worktree");
+        run_git(
+            repository.path(),
+            &[
+                "worktree",
+                "add",
+                "--quiet",
+                "-b",
+                "feature/local-test",
+                linked_text,
+            ],
+        );
+        let shared_exclude = repository.path().join(".git/info/exclude");
+        let exclude_before = fs::read(&shared_exclude).unwrap_or_default();
+        let prefix = linked.join(".kast/local-development");
+
+        refresh_local_development(refresh_request(
+            &linked,
+            &linked,
+            fixture.path(),
+            &prefix,
+            "linked",
+        ))
+        .expect("linked refresh");
+
+        let ignored = Command::new("git")
+            .arg("-C")
+            .arg(&linked)
+            .args(["check-ignore", "--quiet", "--", "AGENTS.local.md"])
+            .status()
+            .expect("git check-ignore");
+        assert!(
+            ignored.success(),
+            "source-owned .gitignore must cover local guidance"
+        );
+        let local_prefix_ignored = Command::new("git")
+            .arg("-C")
+            .arg(&linked)
+            .args(["check-ignore", "--quiet", "--", ".kast/local-development"])
+            .status()
+            .expect("git check-ignore local prefix");
+        assert!(
+            local_prefix_ignored.success(),
+            "source-owned .gitignore must cover the default local prefix before first refresh",
+        );
+        assert_eq!(
+            fs::read(&shared_exclude).unwrap_or_default(),
+            exclude_before,
+            "linked refresh must not mutate the shared repository-local exclude file",
+        );
+
+        remove_local_development(LocalDevelopmentRemoveRequest {
+            prefix,
+            workspace_root: linked,
+        })
+        .expect("linked removal");
+        assert_eq!(
+            fs::read(&shared_exclude).unwrap_or_default(),
+            exclude_before
+        );
+    }
+
+    #[test]
+    fn remove_restores_release_authority_without_mutating_unrelated_state() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        let release_sentinel = fixture.path().join("release/kast");
+        write_file(&release_sentinel, b"release-binary\n");
+        let release_before = fs::read(&release_sentinel).expect("release sentinel");
+        refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "first",
+        ))
+        .expect("refresh");
+        let authority_path =
+            fs::canonicalize(prefix.join("authority.json")).expect("physical authority receipt");
+        let mut legacy_authority: serde_json::Value =
+            serde_json::from_slice(&fs::read(&authority_path).expect("authority receipt"))
+                .expect("authority JSON");
+        legacy_authority["schemaVersion"] = serde_json::json!(1);
+        legacy_authority
+            .as_object_mut()
+            .expect("authority object")
+            .remove("artifacts");
+        super::replace_plain_file_atomically(
+            &authority_path,
+            &serde_json::to_vec_pretty(&legacy_authority).expect("legacy authority JSON"),
+        )
+        .expect("legacy authority receipt");
+
+        let removed = remove_local_development(LocalDevelopmentRemoveRequest {
+            prefix: prefix.clone(),
+            workspace_root: repository.path().to_path_buf(),
+        })
+        .expect("remove");
+
+        assert!(removed.removed);
+        assert!(!prefix.exists());
+        assert!(!repository.path().join("AGENTS.local.md").exists());
+        assert_eq!(
+            fs::read(&release_sentinel).expect("preserved release sentinel"),
+            release_before
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn removal_and_refresh_share_one_lock_outside_the_renamed_prefix() {
+        let repository = initialized_repository();
+        let fixture = tempfile::tempdir().expect("fixture");
+        let prefix = fixture.path().join("local-authority");
+        refresh_local_development(refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "initial",
+        ))
+        .expect("initial refresh");
+        let replacement = refresh_request(
+            repository.path(),
+            repository.path(),
+            fixture.path(),
+            &prefix,
+            "replacement",
+        );
+
+        let (renamed_tx, renamed_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let removal_prefix = prefix.clone();
+        let removal_workspace = repository.path().to_path_buf();
+        let removal = thread::spawn(move || {
+            remove_local_development_with_observer(
+                LocalDevelopmentRemoveRequest {
+                    prefix: removal_prefix,
+                    workspace_root: removal_workspace,
+                },
+                |phase| {
+                    assert_eq!(phase, LocalRemovalPhase::AfterPrefixRenamed);
+                    renamed_tx.send(()).expect("announce renamed prefix");
+                    release_rx.recv().expect("release removal barrier");
+                    Ok(())
+                },
+            )
+        });
+        renamed_rx.recv().expect("prefix renamed");
+
+        let (refreshed_tx, refreshed_rx) = mpsc::channel();
+        let refresh = thread::spawn(move || {
+            refreshed_tx
+                .send(refresh_local_development(replacement))
+                .expect("return refresh result");
+        });
+        assert!(
+            refreshed_rx
+                .recv_timeout(Duration::from_millis(200))
+                .is_err(),
+            "refresh must remain blocked while removal owns the stable namespace lock",
+        );
+
+        release_tx.send(()).expect("finish removal");
+        let removed = removal.join().expect("removal thread").expect("removal");
+        assert!(removed.removed);
+        let refreshed = refreshed_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("refresh result")
+            .expect("replacement refresh");
+        refresh.join().expect("refresh thread");
+
+        assert!(prefix.exists(), "replacement authority must remain active");
+        assert_eq!(
+            fs::read_link(prefix.join("current")).expect("replacement current"),
+            Path::new("generations").join(refreshed.receipt.generation_id.as_str()),
+        );
+        assert!(
+            prefix
+                .parent()
+                .expect("prefix parent")
+                .join(".local-authority.refresh.lock")
+                .is_file(),
+            "namespace lock must survive prefix replacement",
+        );
+    }
+
+    fn initialized_repository() -> tempfile::TempDir {
+        let repository = tempfile::tempdir().expect("repository");
+        run_git(repository.path(), &["init", "--quiet"]);
+        run_git(
+            repository.path(),
+            &["config", "user.email", "test@example.com"],
+        );
+        run_git(repository.path(), &["config", "user.name", "Kast Test"]);
+        fs::write(
+            repository.path().join("settings.gradle.kts"),
+            "rootProject.name = \"fixture\"\n",
+        )
+        .expect("fixture source");
+        fs::write(
+            repository.path().join(".gitignore"),
+            "/AGENTS.local.md\n/.kast/\n",
+        )
+        .expect("local guidance ignore");
+        write_file(
+            &repository
+                .path()
+                .join("cli-rs/resources/kast-skill/SKILL.md"),
+            b"---\nname: kast\ndescription: fixture\n---\nUse `kast agent verify`.\n",
+        );
+        run_git(repository.path(), &["add", "."]);
+        run_git(repository.path(), &["commit", "--quiet", "-m", "initial"]);
+        repository
+    }
+
+    fn write_backend_fixture(root: &Path) {
+        write_file(&root.join("runtime-libs/classpath.txt"), b"backend.jar\n");
+        write_file(&root.join("runtime-libs/backend.jar"), b"backend\n");
+        write_file(
+            &root.join("runtime-libs/backend-headless-test-launcher.jar"),
+            b"headless launcher\n",
+        );
+        write_file(&root.join("idea-home/lib/nio-fs.jar"), b"nio\n");
+        write_file(
+            &root.join("idea-home/modules/module-descriptors.dat"),
+            b"modules\n",
+        );
+        let plugin_lib = root.join("idea-home/plugins/kast-headless/lib");
+        for (name, bytes) in [
+            ("analysis-api-test.jar", b"analysis api\n".as_slice()),
+            ("analysis-server-test.jar", b"analysis server\n".as_slice()),
+            (
+                "backend-headless-test-plugin-descriptor.jar",
+                b"plugin descriptor\n".as_slice(),
+            ),
+            (
+                "backend-idea-test-headless-runtime.jar",
+                b"backend idea\n".as_slice(),
+            ),
+            ("backend-shared-test.jar", b"backend shared\n".as_slice()),
+            ("index-store-test.jar", b"index store\n".as_slice()),
+        ] {
+            write_file(&plugin_lib.join(name), bytes);
+        }
+    }
+
+    fn refresh_request(
+        source_root: &Path,
+        workspace_root: &Path,
+        fixture: &Path,
+        prefix: &Path,
+        label: &str,
+    ) -> LocalDevelopmentRefreshRequest {
+        let cli_binary = fixture.join("build/kast");
+        if !cli_binary.exists() {
+            write_file(&cli_binary, b"#!/bin/sh\nexit 0\n");
+            make_executable(&cli_binary);
+        }
+        let backend_directory = fixture.join("build/backend-headless");
+        if !backend_directory.exists() {
+            write_backend_fixture(&backend_directory);
+        }
+        let snapshot = SourceSnapshot::capture(source_root).expect("snapshot");
+        write_backend_source_snapshot_jar(&backend_directory, &snapshot);
+        let snapshot_file = fixture.join(format!("source-snapshot-{label}.json"));
+        snapshot
+            .write_atomic(&snapshot_file)
+            .expect("snapshot file");
+        let cli_provenance = fixture.join(format!("cli-provenance-{label}.json"));
+        write_artifact_provenance(
+            &cli_provenance,
+            LocalArtifactKind::Cli,
+            &snapshot,
+            &cli_binary,
+        );
+        let backend_provenance = fixture.join(format!("backend-provenance-{label}.json"));
+        write_artifact_provenance(
+            &backend_provenance,
+            LocalArtifactKind::HeadlessBackend,
+            &snapshot,
+            &backend_directory,
+        );
+        LocalDevelopmentRefreshRequest {
+            source_root: source_root.to_path_buf(),
+            workspace_root: workspace_root.to_path_buf(),
+            prefix: prefix.to_path_buf(),
+            expected_source_snapshot: snapshot_file,
+            cli_binary,
+            cli_provenance,
+            backend_directory,
+            backend_provenance,
+        }
+    }
+
+    fn write_backend_source_snapshot_jar(backend_directory: &Path, snapshot: &SourceSnapshot) {
+        let plugin_jar = backend_directory
+            .join("idea-home/plugins/kast-headless/lib/backend-headless-test-plugin.jar");
+        let file = fs::File::create(plugin_jar).expect("plugin jar");
+        let mut archive = zip::ZipWriter::new(file);
+        archive
+            .start_file(
+                super::LOCAL_BACKEND_SOURCE_SNAPSHOT_ENTRY,
+                zip::write::SimpleFileOptions::default(),
+            )
+            .expect("snapshot jar entry");
+        archive
+            .write_all(&serde_json::to_vec(snapshot).expect("snapshot JSON"))
+            .expect("snapshot jar bytes");
+        archive
+            .start_file(
+                super::LOCAL_BACKEND_COMPONENT_MANIFEST_ENTRY,
+                zip::write::SimpleFileOptions::default(),
+            )
+            .expect("component manifest jar entry");
+        archive
+            .write_all(
+                &serde_json::to_vec(&backend_component_manifest(backend_directory, snapshot))
+                    .expect("component manifest JSON"),
+            )
+            .expect("component manifest jar bytes");
+        archive.finish().expect("finish plugin jar");
+    }
+
+    fn backend_component_manifest(
+        backend_directory: &Path,
+        snapshot: &SourceSnapshot,
+    ) -> serde_json::Value {
+        let components = [
+            (
+                "analysis-api",
+                "idea-home/plugins/kast-headless/lib/analysis-api-test.jar",
+            ),
+            (
+                "analysis-server",
+                "idea-home/plugins/kast-headless/lib/analysis-server-test.jar",
+            ),
+            (
+                "backend-headless-launcher",
+                "runtime-libs/backend-headless-test-launcher.jar",
+            ),
+            (
+                "backend-headless-plugin-descriptor",
+                "idea-home/plugins/kast-headless/lib/backend-headless-test-plugin-descriptor.jar",
+            ),
+            (
+                "backend-idea",
+                "idea-home/plugins/kast-headless/lib/backend-idea-test-headless-runtime.jar",
+            ),
+            (
+                "backend-shared",
+                "idea-home/plugins/kast-headless/lib/backend-shared-test.jar",
+            ),
+            (
+                "index-store",
+                "idea-home/plugins/kast-headless/lib/index-store-test.jar",
+            ),
+        ]
+        .map(|(kind, path)| {
+            serde_json::json!({
+                "kind": kind,
+                "path": path,
+                "sha256": crate::manifest::sha256_file(&backend_directory.join(path))
+                    .expect("component SHA-256"),
+            })
+        });
+        serde_json::json!({
+            "schemaVersion": 1,
+            "sourceTreeSha256": snapshot.source_tree_sha256,
+            "components": components,
+        })
+    }
+
+    fn write_artifact_provenance(
+        output: &Path,
+        kind: LocalArtifactKind,
+        source: &SourceSnapshot,
+        artifact: &Path,
+    ) {
+        let artifact = fs::canonicalize(artifact).expect("canonical artifact");
+        let provenance = LocalArtifactProvenance {
+            schema_version: super::LOCAL_ARTIFACT_PROVENANCE_SCHEMA_VERSION,
+            kind,
+            source: source.clone(),
+            sha256: super::tree_sha256(&artifact).expect("artifact digest"),
+            artifact,
+            implementation_version: "test-version".to_string(),
+        };
+        super::write_json_atomic(output, &provenance).expect("artifact provenance");
+    }
+
+    fn write_file(path: &Path, bytes: &[u8]) {
+        fs::create_dir_all(path.parent().expect("file parent")).expect("create parent");
+        fs::write(path, bytes).expect("write file");
+    }
+
+    #[cfg(unix)]
+    fn register_live_runtime(
+        prefix: &Path,
+        generation_id: &super::LocalGenerationId,
+        workspace_root: &Path,
+        fixture: &Path,
+    ) -> std::process::Child {
+        let backend = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("live backend fixture");
+        let descriptor_file = prefix
+            .join("state")
+            .join(generation_id.as_str())
+            .join("cache/workspace/daemons.json");
+        write_file(
+            &descriptor_file,
+            &serde_json::to_vec_pretty(&serde_json::json!([{
+                "workspaceRoot": workspace_root,
+                "backendName": "headless",
+                "backendVersion": "test",
+                "transport": "uds",
+                "socketPath": fixture.join("backend.sock"),
+                "pid": backend.id(),
+                "schemaVersion": crate::SCHEMA_VERSION,
+            }]))
+            .expect("descriptor JSON"),
+        );
+        backend
+    }
+
+    #[cfg(unix)]
+    fn make_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).expect("executable");
+    }
+
+    #[cfg(not(unix))]
+    fn make_executable(_path: &Path) {}
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/cli-rs/src/local_development/types.rs
+++ b/cli-rs/src/local_development/types.rs
@@ -1,0 +1,201 @@
+const LOCAL_DEVELOPMENT_RECEIPT_SCHEMA_VERSION: u32 = 2;
+const LOCAL_ARTIFACT_PROVENANCE_SCHEMA_VERSION: u32 = 1;
+const LOCAL_BACKEND_SOURCE_SNAPSHOT_ENTRY: &str = "META-INF/kast/local-source-snapshot.json";
+const LOCAL_BACKEND_COMPONENT_MANIFEST_ENTRY: &str = "META-INF/kast/local-backend-components.json";
+
+#[derive(Debug, Clone)]
+pub struct LocalDevelopmentRefreshRequest {
+    pub source_root: PathBuf,
+    pub workspace_root: PathBuf,
+    pub prefix: PathBuf,
+    pub expected_source_snapshot: PathBuf,
+    pub cli_binary: PathBuf,
+    pub cli_provenance: PathBuf,
+    pub backend_directory: PathBuf,
+    pub backend_provenance: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalArtifactAttestationRequest {
+    pub source_root: PathBuf,
+    pub expected_source_snapshot: PathBuf,
+    pub kind: LocalArtifactKind,
+    pub artifact: PathBuf,
+    pub output_file: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalDevelopmentRollbackRequest {
+    pub prefix: PathBuf,
+    pub to_generation: LocalGenerationId,
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalDevelopmentRemoveRequest {
+    pub prefix: PathBuf,
+    pub workspace_root: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalDevelopmentRefreshResult {
+    pub receipt: LocalDevelopmentReceipt,
+    pub skipped: bool,
+    pub schema_version: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalDevelopmentRollbackResult {
+    pub receipt: LocalDevelopmentReceipt,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replaced_generation: Option<LocalGenerationId>,
+    pub skipped: bool,
+    pub schema_version: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalDevelopmentRemoveResult {
+    pub prefix: PathBuf,
+    pub workspace_root: PathBuf,
+    pub removed: bool,
+    pub schema_version: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocalDevelopmentReceipt {
+    pub schema_version: u32,
+    pub authority: LocalDevelopmentAuthority,
+    pub generation_id: LocalGenerationId,
+    pub source: SourceSnapshot,
+    pub workspace_root: PathBuf,
+    pub prefix: PathBuf,
+    pub entrypoint: LocalDevelopmentEntrypoint,
+    pub backend: LocalDevelopmentBackendIdentity,
+    pub artifacts: LocalDevelopmentArtifactSet,
+    pub components: LocalDevelopmentComponents,
+    pub install_manifest: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_generation: Option<LocalGenerationId>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocalArtifactProvenance {
+    pub schema_version: u32,
+    pub kind: LocalArtifactKind,
+    pub source: SourceSnapshot,
+    pub artifact: PathBuf,
+    pub sha256: Sha256Digest,
+    pub implementation_version: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LocalArtifactKind {
+    Cli,
+    HeadlessBackend,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocalDevelopmentArtifactSet {
+    pub cli: LocalArtifactProvenance,
+    pub backend: LocalArtifactProvenance,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LocalDevelopmentAuthority {
+    LocalDevelopment,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct LocalGenerationId(String);
+
+impl LocalGenerationId {
+    pub fn from_source(source: &SourceSnapshot) -> Self {
+        Self(format!(
+            "{}-{}",
+            &source.git_commit.as_str()[..12],
+            source.source_tree_sha256.as_str()
+        ))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for LocalGenerationId {
+    type Error = CliError;
+
+    fn try_from(value: String) -> Result<Self> {
+        let mut parts = value.split('-');
+        let commit = parts.next().unwrap_or_default();
+        let digest = parts.next().unwrap_or_default();
+        if parts.next().is_none()
+            && commit.len() == 12
+            && commit.bytes().all(|byte| byte.is_ascii_hexdigit())
+            && digest.len() == 64
+            && digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
+            Ok(Self(value.to_ascii_lowercase()))
+        } else {
+            Err(CliError::new(
+                "LOCAL_GENERATION_ID_INVALID",
+                "Local generation identity must contain a 12-character commit prefix and SHA-256 digest.",
+            ))
+        }
+    }
+}
+
+impl From<LocalGenerationId> for String {
+    fn from(value: LocalGenerationId) -> Self {
+        value.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocalDevelopmentEntrypoint {
+    pub physical_target: PathBuf,
+    pub effective_target: PathBuf,
+    pub sha256: Sha256Digest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocalDevelopmentBackendIdentity {
+    pub kind: LocalDevelopmentBackendKind,
+    pub implementation_version: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LocalDevelopmentBackendKind {
+    Headless,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocalDevelopmentComponents {
+    pub cli: LocalDevelopmentComponent,
+    pub backend: LocalDevelopmentComponent,
+    pub skill: LocalDevelopmentComponent,
+    pub guidance: LocalDevelopmentComponent,
+    pub config: LocalDevelopmentComponent,
+    pub manifest: LocalDevelopmentComponent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocalDevelopmentComponent {
+    pub physical_target: PathBuf,
+    pub effective_target: PathBuf,
+    pub sha256: Sha256Digest,
+}

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -10,6 +10,7 @@ mod daemon;
 mod demo;
 mod error;
 mod install;
+mod local_development;
 mod lsp;
 mod manifest;
 mod metrics;
@@ -174,7 +175,7 @@ fn default_runtime_args() -> cli::RuntimeArgs {
         workspace_root: None,
         backend_name: None,
         idea_home: None,
-        wait_timeout_ms: 60_000,
+        wait_timeout_ms: cli::DEFAULT_RUNTIME_WAIT_TIMEOUT_MS,
         accept_indexing: None,
         no_auto_start: None,
         socket_path: None,
@@ -410,6 +411,12 @@ fn run_repair(args: cli::RepairArgs, output_format: OutputFormat) -> Result<i32>
         apply,
         jetbrains_config_root,
     };
+    if apply && local_development::active_local_development_receipt()?.is_some() {
+        return Err(CliError::new(
+            "LOCAL_AUTHORITY_REPAIR_UNSUPPORTED",
+            "Local-development authority cannot mutate release install state; rerun the source checkout's refreshDevelopmentLocal task instead.",
+        ));
+    }
     if apply && !install::macos_homebrew_repair_authority_is_provable()? {
         manifest::install_current_executable()?;
     }
@@ -614,6 +621,7 @@ fn run_runtime(command: cli::RuntimeCommand, output_format: OutputFormat) -> Res
 
 fn run_developer(command: cli::DeveloperCommand, output_format: OutputFormat) -> Result<i32> {
     match command {
+        cli::DeveloperCommand::Local(args) => local_development::run(args.command, output_format),
         cli::DeveloperCommand::Runtime(args) => run_runtime(args.command, output_format),
         cli::DeveloperCommand::Inspect(args) => run_inspect(args.command, output_format),
         cli::DeveloperCommand::Machine(args) => run_machine(args.command, output_format),

--- a/cli-rs/src/manifest.rs
+++ b/cli-rs/src/manifest.rs
@@ -207,6 +207,9 @@ pub struct ResolvedKastPaths {
 }
 
 pub fn resolve_paths() -> Result<ResolvedKastPaths> {
+    if let Some(receipt) = crate::local_development::active_local_development_receipt()? {
+        return paths_from_manifest(&read_manifest_at(&receipt.install_manifest)?);
+    }
     #[cfg(target_os = "macos")]
     if let Some(receipt) = crate::install::read_macos_homebrew_receipt()? {
         let mut paths = default_resolved_paths();

--- a/cli-rs/src/output/ready.rs
+++ b/cli-rs/src/output/ready.rs
@@ -62,6 +62,20 @@ fn print_self_check(title: &str, result: &SelfDoctorResult) -> Result<()> {
             receipt.cli.version
         );
     }
+    if let Some(receipt) = &result.local_development {
+        mdln!(document);
+        mdln!(document, "## Local-development authority");
+        mdln!(document, "- Source root: `{}`", receipt.source.canonical_root.display());
+        mdln!(document, "- Git commit: `{}`", receipt.source.git_commit.as_str());
+        mdln!(
+            document,
+            "- Source SHA-256: `{}`",
+            receipt.source.source_tree_sha256.as_str()
+        );
+        mdln!(document, "- Backend: `headless` (`{}`)", receipt.backend.implementation_version);
+        mdln!(document, "- Skill: `{}`", receipt.components.skill.effective_target.display());
+        mdln!(document, "- Guidance: `{}`", receipt.components.guidance.effective_target.display());
+    }
     if let Some(shadow) = &result.legacy_shadow {
         mdln!(document);
         mdln!(document, "## Legacy PATH shadow");
@@ -122,6 +136,7 @@ fn print_self_check(title: &str, result: &SelfDoctorResult) -> Result<()> {
 
 fn install_authority_label(authority: crate::self_mgmt::InstallAuthority) -> &'static str {
     match authority {
+        crate::self_mgmt::InstallAuthority::LocalDevelopment => "local-development",
         crate::self_mgmt::InstallAuthority::MacosHomebrew => "macos-homebrew",
         crate::self_mgmt::InstallAuthority::ManagedLocal => "managed-local",
         crate::self_mgmt::InstallAuthority::Missing => "missing",

--- a/cli-rs/src/runtime/descriptors.rs
+++ b/cli-rs/src/runtime/descriptors.rs
@@ -1,9 +1,16 @@
 fn read_descriptors(descriptor_directory: &Path) -> Result<Vec<ServerInstanceDescriptor>> {
     let path = descriptor_directory.join("daemons.json");
-    if !path.is_file() {
-        return Ok(vec![]);
+    parse_descriptor_registry_read(fs::read_to_string(path))
+}
+
+fn parse_descriptor_registry_read(
+    read: std::io::Result<String>,
+) -> Result<Vec<ServerInstanceDescriptor>> {
+    match read {
+        Ok(contents) => Ok(serde_json::from_str(&contents).unwrap_or_default()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(vec![]),
+        Err(error) => Err(error.into()),
     }
-    Ok(serde_json::from_str(&fs::read_to_string(path)?).unwrap_or_default())
 }
 
 fn delete_descriptor(

--- a/cli-rs/src/runtime/descriptors.rs
+++ b/cli-rs/src/runtime/descriptors.rs
@@ -57,9 +57,32 @@ fn workspace_root(value: Option<PathBuf>) -> Result<PathBuf> {
     config::resolve_workspace_root(value)
 }
 
+fn shell_single_quoted_path(path: &Path) -> String {
+    format!(
+        "'{}'",
+        path.display().to_string().replace('\'', "'\"'\"'")
+    )
+}
+
 fn no_backend_error(workspace_root: &Path, backend_name: Option<BackendName>) -> CliError {
     let backend_name = backend_name.unwrap_or(BackendName::Headless);
+    let local_entrypoint = (backend_name == BackendName::Headless)
+        .then(crate::local_development::active_local_development_receipt)
+        .transpose()
+        .ok()
+        .flatten()
+        .flatten()
+        .map(|receipt| receipt.entrypoint.effective_target);
     let mut error = match backend_name {
+        BackendName::Headless if let Some(entrypoint) = &local_entrypoint => CliError::new(
+            "NO_BACKEND_AVAILABLE",
+            format!(
+                "The local-development headless backend is installed but not running for {}. Start the receipt-owned backend with: {} developer runtime up --workspace-root {} --backend=headless",
+                workspace_root.display(),
+                shell_single_quoted_path(entrypoint),
+                shell_single_quoted_path(workspace_root),
+            ),
+        ),
         BackendName::Headless => CliError::new(
             "NO_BACKEND_AVAILABLE",
             format!(
@@ -77,14 +100,29 @@ fn no_backend_error(workspace_root: &Path, backend_name: Option<BackendName>) ->
     };
     match backend_name {
         BackendName::Headless => {
-            error.details.insert(
-                "supportedDistribution".to_string(),
-                "linux-headless-tarball".to_string(),
-            );
-            error.details.insert(
-                "installHint".to_string(),
-                "Install and extract the Linux headless tarball; standalone headless backend installation is not a supported distribution path.".to_string(),
-            );
+            if let Some(entrypoint) = local_entrypoint {
+                error.details.insert(
+                    "authority".to_string(),
+                    "local-development".to_string(),
+                );
+                error.details.insert(
+                    "startCommand".to_string(),
+                    format!(
+                        "{} developer runtime up --workspace-root {} --backend=headless",
+                        shell_single_quoted_path(&entrypoint),
+                        shell_single_quoted_path(workspace_root),
+                    ),
+                );
+            } else {
+                error.details.insert(
+                    "supportedDistribution".to_string(),
+                    "linux-headless-tarball".to_string(),
+                );
+                error.details.insert(
+                    "installHint".to_string(),
+                    "Install and extract the Linux headless tarball; standalone headless backend installation is not a supported distribution path.".to_string(),
+                );
+            }
         }
         BackendName::Idea => {
             error.details.insert(

--- a/cli-rs/src/runtime/rpc.rs
+++ b/cli-rs/src/runtime/rpc.rs
@@ -49,7 +49,7 @@ fn raw_rpc_session_with_auto_start(
         workspace_root: Some(workspace_root),
         backend_name,
         idea_home: None,
-        wait_timeout_ms: 60_000,
+        wait_timeout_ms: crate::cli::DEFAULT_RUNTIME_WAIT_TIMEOUT_MS,
         accept_indexing: Some(true),
         no_auto_start: Some(!auto_start),
         socket_path: None,

--- a/cli-rs/src/runtime/tests.rs
+++ b/cli-rs/src/runtime/tests.rs
@@ -11,7 +11,7 @@ mod tests {
                 true,
                 RuntimeWaitPhase::SpawnedRuntime,
             ),
-            300_000,
+            600_000,
         );
         assert_eq!(
             runtime_wait_timeout(

--- a/cli-rs/src/runtime/tests.rs
+++ b/cli-rs/src/runtime/tests.rs
@@ -2,6 +2,75 @@
 mod tests {
     use super::*;
 
+    #[test]
+    fn only_a_newly_spawned_local_headless_runtime_receives_the_cold_import_budget() {
+        assert_eq!(
+            runtime_wait_timeout(
+                60_000,
+                BackendName::Headless,
+                true,
+                RuntimeWaitPhase::SpawnedRuntime,
+            ),
+            300_000,
+        );
+        assert_eq!(
+            runtime_wait_timeout(
+                60_000,
+                BackendName::Headless,
+                true,
+                RuntimeWaitPhase::ExistingRuntime,
+            ),
+            60_000,
+        );
+        assert_eq!(
+            runtime_wait_timeout(
+                60_000,
+                BackendName::Idea,
+                true,
+                RuntimeWaitPhase::SpawnedRuntime,
+            ),
+            60_000,
+        );
+        assert_eq!(
+            runtime_wait_timeout(
+                60_000,
+                BackendName::Headless,
+                false,
+                RuntimeWaitPhase::SpawnedRuntime,
+            ),
+            60_000,
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn registration_wait_reaps_a_child_that_exits_before_publishing_a_descriptor() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let workspace = fixture.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("workspace");
+        let mut child = Command::new("sh")
+            .args(["-c", "exit 23"])
+            .spawn()
+            .expect("short-lived child");
+        let started = Instant::now();
+
+        let error = wait_for_runtime_registration(
+            &fixture.path().join("descriptors"),
+            &workspace,
+            BackendName::Headless,
+            &mut child,
+            10_000,
+        )
+        .expect_err("exited child cannot register");
+
+        assert_eq!(error.code, "DAEMON_START_ERROR");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "an exited child must be reaped promptly instead of consuming the cold-start budget",
+        );
+        assert!(child.try_wait().expect("reaped child status").is_some());
+    }
+
     fn candidate(name: &str, state: RuntimeState, indexing: bool) -> RuntimeCandidateStatus {
         RuntimeCandidateStatus {
             descriptor_path: format!("{name}:1"),
@@ -103,6 +172,14 @@ mod tests {
         };
 
         assert!(!descriptor_matches_workspace(&descriptor, requested_root));
+    }
+
+    #[test]
+    fn actionable_shell_paths_quote_spaces_and_single_quotes() {
+        assert_eq!(
+            shell_single_quoted_path(Path::new("/work/agent's checkout")),
+            "'/work/agent'\"'\"'s checkout'",
+        );
     }
 
     #[test]
@@ -350,10 +427,9 @@ mod tests {
         assert!(matches!(
             assess_runtime_compatibility(&facts, None).expect("missing required assessment"),
             RuntimeCompatibilityAssessment::UpdateRequired {
-                requirement:
-                    RuntimeCompatibilityUpdateRequirement::MissingRequiredCapability {
-                        capability: RuntimeCapability::Read(WorkspaceReadCapability::Diagnostics),
-                    },
+                requirement: RuntimeCompatibilityUpdateRequirement::MissingRequiredCapability {
+                    capability: RuntimeCapability::Read(WorkspaceReadCapability::Diagnostics),
+                },
                 ..
             }
         ));

--- a/cli-rs/src/runtime/tests.rs
+++ b/cli-rs/src/runtime/tests.rs
@@ -3,6 +3,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn descriptor_registry_disappearance_is_an_empty_registry() {
+        let descriptors = parse_descriptor_registry_read(Err(std::io::Error::from(
+            std::io::ErrorKind::NotFound,
+        )))
+        .expect("a concurrently removed descriptor registry is empty");
+
+        assert!(descriptors.is_empty());
+    }
+
+    #[test]
+    fn descriptor_registry_preserves_non_missing_io_failures() {
+        let error = parse_descriptor_registry_read(Err(std::io::Error::from(
+            std::io::ErrorKind::PermissionDenied,
+        )))
+        .expect_err("permission failures must remain explicit");
+
+        assert_eq!(error.code, "IO_ERROR");
+    }
+
+    #[test]
     fn only_a_newly_spawned_local_headless_runtime_receives_the_cold_import_budget() {
         assert_eq!(
             runtime_wait_timeout(

--- a/cli-rs/src/runtime/workspace.rs
+++ b/cli-rs/src/runtime/workspace.rs
@@ -33,6 +33,8 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
         config::PathResolutionMode::Cli,
     )?;
     let preference = runtime_backend_preference(&config, args.backend_name);
+    let local_authority_active =
+        crate::local_development::active_local_development_receipt()?.is_some();
     validate_macos_workspace_for_preference(&workspace_root, preference)?;
     let stale_descriptor_policy = if args.no_auto_start.unwrap_or(false) {
         StaleDescriptorPolicy::Preserve
@@ -104,13 +106,18 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
         ));
     };
 
-    if launch_backend == BackendName::Headless {
+    if launch_backend == BackendName::Headless && !local_authority_active {
         if select_servable(&inspection.candidates, Some(launch_backend), true).is_some()
             && let Ok(selected) = wait_for_servable(
                 &workspace_root,
                 Some(launch_backend),
                 args.accept_indexing.unwrap_or(false),
-                args.wait_timeout_ms,
+                runtime_wait_timeout(
+                    args.wait_timeout_ms,
+                    launch_backend,
+                    local_authority_active,
+                    RuntimeWaitPhase::ExistingRuntime,
+                ),
             )
         {
             return Ok(WorkspaceEnsureResult {
@@ -151,16 +158,75 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
         runtime_libs_dir: Some(runtime_libs_dir),
         ..DaemonStartArgs::from(args.clone())
     };
-    daemon::spawn_background(daemon_args, &log_file)?;
+    let spawned_wait_timeout = runtime_wait_timeout(
+        args.wait_timeout_ms,
+        launch_backend,
+        local_authority_active,
+        RuntimeWaitPhase::SpawnedRuntime,
+    );
+    let launch =
+        crate::local_development::with_active_local_runtime_start_lock(|local_authority| {
+            if local_authority {
+                let locked_inspection = inspect_workspace_with_config(
+                    &workspace_root,
+                    &config,
+                    RuntimeBackendPreference::Fixed(launch_backend),
+                    StaleDescriptorPolicy::Prune,
+                )?;
+                if locked_inspection.candidates.iter().any(|candidate| {
+                    candidate.pid_alive
+                        && candidate.descriptor.backend_name == launch_backend.canonical()
+                }) {
+                    return Ok(RuntimeLaunch::ReusedRegistered);
+                }
+            }
+
+            let mut child = daemon::spawn_background(daemon_args, &log_file)?;
+            let spawned_at = Instant::now();
+            if local_authority
+                && let Err(error) = wait_for_runtime_registration(
+                    &inspection.descriptor_directory,
+                    &workspace_root,
+                    launch_backend,
+                    &mut child,
+                    remaining_runtime_wait_timeout(spawned_at, spawned_wait_timeout),
+                )
+            {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            }
+            thread::spawn(move || {
+                let _ = child.wait();
+            });
+            Ok(RuntimeLaunch::Spawned { spawned_at })
+        })?;
+    let (remaining_wait_timeout, started, note) = match launch {
+        RuntimeLaunch::ReusedRegistered => (
+            runtime_wait_timeout(
+                args.wait_timeout_ms,
+                launch_backend,
+                local_authority_active,
+                RuntimeWaitPhase::ExistingRuntime,
+            ),
+            false,
+            Some("Reused a concurrently registered headless runtime.".to_string()),
+        ),
+        RuntimeLaunch::Spawned { spawned_at } => (
+            remaining_runtime_wait_timeout(spawned_at, spawned_wait_timeout),
+            true,
+            None,
+        ),
+    };
     let selected = match wait_for_servable(
         &workspace_root,
         Some(launch_backend),
         args.accept_indexing.unwrap_or(false),
-        args.wait_timeout_ms,
+        remaining_wait_timeout,
     ) {
         Ok(selected) => selected,
         Err(error) => {
-            if launch_backend == BackendName::Headless {
+            if launch_backend == BackendName::Headless && started {
                 let _ = stop_backend_candidates(
                     &workspace_root,
                     RuntimeBackendPreference::Fixed(launch_backend),
@@ -175,12 +241,89 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
         workspace_root: workspace_root.display().to_string(),
         descriptor_directory: inspection.descriptor_directory.display().to_string(),
         path_resolution,
-        started: true,
-        log_file: Some(log_file.display().to_string()),
+        started,
+        log_file: started.then(|| log_file.display().to_string()),
         selected,
-        note: None,
+        note,
         schema_version: SCHEMA_VERSION,
     })
+}
+
+fn wait_for_runtime_registration(
+    descriptor_directory: &Path,
+    workspace_root: &Path,
+    backend_name: BackendName,
+    child: &mut std::process::Child,
+    wait_timeout_ms: u64,
+) -> Result<()> {
+    let pid = u64::from(child.id());
+    let deadline = Instant::now() + Duration::from_millis(wait_timeout_ms);
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Err(CliError::new(
+                "DAEMON_START_ERROR",
+                format!(
+                    "The spawned {} runtime process {pid} exited with {status} before registering for {}.",
+                    backend_name.canonical(),
+                    workspace_root.display(),
+                ),
+            ));
+        }
+        let registered = read_descriptors(descriptor_directory)?
+            .into_iter()
+            .any(|descriptor| {
+                descriptor.pid == pid
+                    && descriptor.backend_name == backend_name.canonical()
+                    && config::normalize(PathBuf::from(descriptor.workspace_root)) == workspace_root
+            });
+        if registered {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(CliError::new(
+                "RUNTIME_REGISTRATION_TIMEOUT",
+                format!(
+                    "Timed out waiting for spawned {} runtime process {pid} to register for {}.",
+                    backend_name.canonical(),
+                    workspace_root.display(),
+                ),
+            ));
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn remaining_runtime_wait_timeout(started_at: Instant, total_wait_timeout_ms: u64) -> u64 {
+    let elapsed_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+    total_wait_timeout_ms.saturating_sub(elapsed_ms).max(1)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeLaunch {
+    ReusedRegistered,
+    Spawned { spawned_at: Instant },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeWaitPhase {
+    ExistingRuntime,
+    SpawnedRuntime,
+}
+
+fn runtime_wait_timeout(
+    requested_timeout_ms: u64,
+    backend_name: BackendName,
+    local_authority_active: bool,
+    phase: RuntimeWaitPhase,
+) -> u64 {
+    if local_authority_active
+        && backend_name == BackendName::Headless
+        && phase == RuntimeWaitPhase::SpawnedRuntime
+    {
+        requested_timeout_ms.max(300_000)
+    } else {
+        requested_timeout_ms
+    }
 }
 
 pub fn workspace_stop(args: RuntimeArgs) -> Result<DaemonStopResult> {

--- a/cli-rs/src/runtime/workspace.rs
+++ b/cli-rs/src/runtime/workspace.rs
@@ -310,6 +310,8 @@ enum RuntimeWaitPhase {
     SpawnedRuntime,
 }
 
+const LOCAL_DEVELOPMENT_HEADLESS_COLD_START_WAIT_TIMEOUT_MS: u64 = 600_000;
+
 fn runtime_wait_timeout(
     requested_timeout_ms: u64,
     backend_name: BackendName,
@@ -320,7 +322,7 @@ fn runtime_wait_timeout(
         && backend_name == BackendName::Headless
         && phase == RuntimeWaitPhase::SpawnedRuntime
     {
-        requested_timeout_ms.max(300_000)
+        requested_timeout_ms.max(LOCAL_DEVELOPMENT_HEADLESS_COLD_START_WAIT_TIMEOUT_MS)
     } else {
         requested_timeout_ms
     }

--- a/cli-rs/src/self_mgmt.rs
+++ b/cli-rs/src/self_mgmt.rs
@@ -2,7 +2,7 @@ use crate::SCHEMA_VERSION;
 use crate::cli;
 use crate::cli::{InstallRepairArgs, ReadyTarget};
 use crate::config::{self, PathResolutionReport};
-use crate::error::Result;
+use crate::error::{CliError, Result};
 use crate::install::{self, InstallRepairResult};
 use crate::manifest;
 #[cfg(target_os = "macos")]
@@ -83,6 +83,7 @@ pub struct DeveloperMachineDefaultsResult {
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum InstallAuthority {
+    LocalDevelopment,
     MacosHomebrew,
     ManagedLocal,
     Missing,
@@ -105,6 +106,8 @@ pub struct SelfDoctorResult {
     pub target: ReadyTarget,
     pub installed: bool,
     pub install_authority: InstallAuthority,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_development: Option<crate::local_development::LocalDevelopmentReceipt>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub homebrew_install: Option<install::MacosHomebrewInstallReceipt>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -131,11 +134,18 @@ pub fn doctor(
     target: ReadyTarget,
     workspace_root: Option<&Path>,
 ) -> Result<SelfDoctorResult> {
+    let local_development = crate::local_development::verified_active_local_development_receipt()?;
     let config_path = config::global_config_path();
     let manifest_path = manifest::default_install_manifest_path();
     let mut issues = vec![];
     let mut warnings = vec![];
     let repair_result = if repair {
+        if local_development.is_some() {
+            return Err(CliError::new(
+                "LOCAL_AUTHORITY_REPAIR_UNSUPPORTED",
+                "Local-development authority cannot apply ordinary install repair; refresh its source checkout instead.",
+            ));
+        }
         let repair_args = InstallRepairArgs {
             apply: true,
             jetbrains_config_root: None,
@@ -148,7 +158,11 @@ pub fn doctor(
         None
     };
     #[cfg(target_os = "macos")]
-    let homebrew_install = install::read_macos_homebrew_receipt()?;
+    let homebrew_install = if local_development.is_some() {
+        None
+    } else {
+        install::read_macos_homebrew_receipt()?
+    };
     #[cfg(not(target_os = "macos"))]
     let homebrew_install = None;
     let global_config = match config::KastConfig::load_global() {
@@ -237,16 +251,27 @@ pub fn doctor(
                     backend_label, backend.runtime_libs_dir
                 ));
             }
-            match version_meets_minimum(&backend.version, minimum_backend_version) {
-                Some(true) => {}
-                Some(false) => issues.push(format!(
-                    "{} backend {} is older than required minimum {}",
-                    backend_label, backend.version, minimum_backend_version
-                )),
-                None => warnings.push(format!(
-                    "{} backend version {} cannot be compared to required minimum {}",
-                    backend_label, backend.version, minimum_backend_version
-                )),
+            if let Some(local) = &local_development {
+                if backend.name != "headless"
+                    || backend.version != local.backend.implementation_version
+                {
+                    issues.push(format!(
+                        "Local backend identity {}/{} does not match receipt headless/{}",
+                        backend.name, backend.version, local.backend.implementation_version
+                    ));
+                }
+            } else {
+                match version_meets_minimum(&backend.version, minimum_backend_version) {
+                    Some(true) => {}
+                    Some(false) => issues.push(format!(
+                        "{} backend {} is older than required minimum {}",
+                        backend_label, backend.version, minimum_backend_version
+                    )),
+                    None => warnings.push(format!(
+                        "{} backend version {} cannot be compared to required minimum {}",
+                        backend_label, backend.version, minimum_backend_version
+                    )),
+                }
             }
         }
         for repo in install
@@ -297,14 +322,17 @@ pub fn doctor(
     );
     Ok(SelfDoctorResult {
         target,
-        installed: homebrew_install.is_some() || install.is_some(),
-        install_authority: if homebrew_install.is_some() {
+        installed: local_development.is_some() || homebrew_install.is_some() || install.is_some(),
+        install_authority: if local_development.is_some() {
+            InstallAuthority::LocalDevelopment
+        } else if homebrew_install.is_some() {
             InstallAuthority::MacosHomebrew
         } else if install.is_some() {
             InstallAuthority::ManagedLocal
         } else {
             InstallAuthority::Missing
         },
+        local_development,
         homebrew_install,
         legacy_shadow,
         config_path: config_path.display().to_string(),

--- a/cli-rs/tests/agent_command_surface_smoke.rs
+++ b/cli-rs/tests/agent_command_surface_smoke.rs
@@ -24,6 +24,24 @@ fn symbol_result(workspace: &Path, fq_name: &str) -> Value {
     })
 }
 
+fn rename_preview(workspace: &Path, new_name: &str) -> Value {
+    let file_path = workspace.join("Keywords.kt").display().to_string();
+    json!({
+        "edits": [{
+            "filePath": file_path,
+            "startOffset": 10,
+            "endOffset": 16,
+            "newText": new_name,
+        }],
+        "fileHashes": [{
+            "filePath": file_path,
+            "hash": "a".repeat(64),
+        }],
+        "affectedFiles": [file_path],
+        "schemaVersion": 3,
+    })
+}
+
 fn run_agent_symbol(
     home: &Path,
     config_home: &Path,
@@ -457,11 +475,36 @@ fn removed_agent_workflow_write_validate_fails_before_mutation() {
 }
 
 #[test]
-fn agent_rename_without_apply_returns_identity_first_plan() {
+fn agent_rename_without_apply_returns_identity_first_plan_without_applied_mutation_authority() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let config_home = temp.path().join("config");
-
+    let workspace = temp.path().join("workspace");
+    let socket_path = temp.path().join("idea.sock");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"rename-preview\"\n",
+    )
+    .expect("Gradle workspace marker");
+    std::fs::write(
+        workspace.join("Keywords.kt"),
+        "package io.example\nclass OrderService { fun process() = Unit }\n",
+    )
+    .expect("Kotlin rename fixture");
+    let backend = spawn_scripted_headless_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        vec![
+            (
+                "symbol/resolve",
+                symbol_result(&workspace, "io.example.OrderService.process"),
+            ),
+            ("raw/rename", rename_preview(&workspace, "processSafely")),
+        ],
+    );
     let plan = kast(&home, &config_home)
         .args([
             "--output",
@@ -474,6 +517,9 @@ fn agent_rename_without_apply_returns_identity_first_plan() {
             "processSafely",
             "--kind",
             "function",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+            "--explain",
         ])
         .output()
         .expect("agent rename plan");
@@ -487,28 +533,138 @@ fn agent_rename_without_apply_returns_identity_first_plan() {
     let stdout: serde_json::Value = serde_json::from_slice(&plan.stdout).expect("plan json");
     assert_eq!(stdout["method"], "agent/rename", "{stdout}");
     assert_eq!(
-        stdout["result"]["type"], "KAST_AGENT_MUTATION_RESULT",
+        stdout["result"]["type"], "KAST_AGENT_RENAME_PLAN",
         "{stdout}"
     );
     assert_eq!(
-        stdout["result"]["operation"]["state"], "PLANNED",
-        "{stdout}"
-    );
-    let plan = &stdout["result"]["plan"];
-    assert_eq!(plan["method"], "symbol/rename", "{stdout}");
-    assert_eq!(
-        stdout["result"]["operation"]["mutationKind"], "RENAME_BY_SYMBOL_REQUEST",
+        stdout["result"]["request"]["method"], "symbol/rename",
         "{stdout}"
     );
     assert_eq!(
-        plan["symbol"], "io.example.OrderService.process",
+        stdout["result"]["request"]["params"]["type"], "RENAME_BY_SYMBOL_REQUEST",
         "{stdout}"
     );
-    assert_eq!(plan["kind"], "function", "{stdout}");
+    assert_eq!(
+        stdout["result"]["request"]["params"]["symbol"], "io.example.OrderService.process",
+        "{stdout}"
+    );
+    assert_eq!(
+        stdout["result"]["preview"]["edits"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        stdout["result"]["preview"]["affectedFiles"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        stdout["result"]["preview"]["edits"][0]["newText"],
+        "processSafely"
+    );
+    let requests = backend.join().expect("scripted backend");
+    assert_eq!(requests[2]["method"], "symbol/resolve");
+    assert_eq!(requests[3]["method"], "raw/rename");
+    assert_eq!(requests[3]["params"]["dryRun"], true);
+    assert_eq!(
+        requests[3]["params"]["position"]["startOffset"],
+        Value::Null
+    );
+    assert_eq!(requests[3]["params"]["position"]["offset"], 10);
     assert!(
-        !plan.to_string().contains("offset"),
-        "public rename plan must not expose offsets: {stdout}"
+        !stdout["result"]["request"].to_string().contains("offset"),
+        "public identity request must not depend on a caller-provided offset: {stdout}"
     );
+}
+
+#[test]
+fn agent_rename_preview_rejects_duplicate_hash_rows_that_leave_an_affected_file_uncovered() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let socket_path = temp.path().join("headless.sock");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"rename-preview\"\n",
+    )
+    .expect("Gradle workspace marker");
+    std::fs::write(
+        workspace.join("Keywords.kt"),
+        "package io.example\nclass OrderService { fun process() = Unit }\n",
+    )
+    .expect("Kotlin rename fixture");
+    let first_file = workspace.join("Keywords.kt").display().to_string();
+    let second_file = workspace.join("Usage.kt").display().to_string();
+    let duplicate_hash_preview = json!({
+        "edits": [
+            {
+                "filePath": first_file,
+                "startOffset": 10,
+                "endOffset": 16,
+                "newText": "processSafely",
+            },
+            {
+                "filePath": second_file,
+                "startOffset": 20,
+                "endOffset": 26,
+                "newText": "processSafely",
+            },
+        ],
+        "fileHashes": [
+            {"filePath": first_file, "hash": "a".repeat(64)},
+            {"filePath": first_file, "hash": "b".repeat(64)},
+        ],
+        "affectedFiles": [first_file, second_file],
+        "schemaVersion": 3,
+    });
+    let backend = spawn_scripted_headless_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        vec![
+            (
+                "symbol/resolve",
+                symbol_result(&workspace, "io.example.OrderService.process"),
+            ),
+            ("raw/rename", duplicate_hash_preview),
+        ],
+    );
+
+    let plan = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "rename",
+            "--symbol",
+            "io.example.OrderService.process",
+            "--new-name",
+            "processSafely",
+            "--kind",
+            "function",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+            "--explain",
+        ])
+        .output()
+        .expect("agent rename plan");
+
+    assert!(
+        !plan.status.success(),
+        "duplicate hash rows must not satisfy exact affected-file coverage: {}",
+        String::from_utf8_lossy(&plan.stdout),
+    );
+    let stdout: Value = serde_json::from_slice(&plan.stdout).expect("plan failure json");
+    assert_eq!(
+        stdout["error"]["code"], "INVALID_RENAME_PREVIEW",
+        "{stdout}"
+    );
+    backend.join().expect("scripted backend");
 }
 
 #[test]

--- a/cli-rs/tests/agent_output_format_smoke.rs
+++ b/cli-rs/tests/agent_output_format_smoke.rs
@@ -2,6 +2,69 @@ mod support;
 
 use support::*;
 
+fn rename_backend(
+    home: &Path,
+    config_home: &Path,
+    workspace: &Path,
+    socket_path: &Path,
+) -> std::thread::JoinHandle<Vec<serde_json::Value>> {
+    std::fs::create_dir_all(workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"rename-output\"\n",
+    )
+    .expect("Gradle marker");
+    let file_path = workspace.join("OrderService.kt");
+    std::fs::write(
+        &file_path,
+        "package io.example\nclass OrderService { fun process() = Unit }\n",
+    )
+    .expect("Kotlin fixture");
+    let file_path = file_path.display().to_string();
+    spawn_scripted_idea_backend(
+        home,
+        config_home,
+        workspace,
+        socket_path,
+        vec![
+            (
+                "symbol/resolve",
+                serde_json::json!({
+                    "type": "RESOLVE_SUCCESS",
+                    "ok": true,
+                    "source": "compiler",
+                    "symbol": {
+                        "fqName": "io.example.OrderService.process",
+                        "kind": "FUNCTION",
+                        "location": {
+                            "filePath": file_path,
+                            "startOffset": 44,
+                            "endOffset": 51,
+                        },
+                    },
+                }),
+            ),
+            (
+                "raw/rename",
+                serde_json::json!({
+                    "edits": [{
+                        "filePath": file_path,
+                        "startOffset": 44,
+                        "endOffset": 51,
+                        "newText": "processSafely",
+                    }],
+                    "fileHashes": [{
+                        "filePath": file_path,
+                        "hash": "a".repeat(64),
+                    }],
+                    "affectedFiles": [file_path],
+                    "schemaVersion": 3,
+                }),
+            ),
+        ],
+    )
+}
+
 fn decode_toon(bytes: &[u8]) -> serde_json::Value {
     let output = std::str::from_utf8(bytes).expect("toon output should be utf-8");
     toon_format::decode_default(output.trim()).expect("toon output should decode")
@@ -12,7 +75,9 @@ fn agent_rename_plan_default_toon_matches_explicit_json() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let config_home = temp.path().join("config");
-    std::fs::create_dir_all(&home).expect("home");
+    let workspace = temp.path().join("workspace");
+    let socket_path = temp.path().join("idea.sock");
+    let json_backend = rename_backend(&home, &config_home, &workspace, &socket_path);
 
     let json = kast(&home, &config_home)
         .args([
@@ -24,6 +89,8 @@ fn agent_rename_plan_default_toon_matches_explicit_json() {
             "io.example.OrderService.process",
             "--new-name",
             "processSafely",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
         ])
         .output()
         .expect("agent rename json");
@@ -35,6 +102,9 @@ fn agent_rename_plan_default_toon_matches_explicit_json() {
     );
     let json_value: serde_json::Value =
         serde_json::from_slice(&json.stdout).expect("agent rename json");
+    json_backend.join().expect("JSON rename backend");
+    std::fs::remove_file(&socket_path).expect("remove first socket");
+    let toon_backend = rename_backend(&home, &config_home, &workspace, &socket_path);
 
     let toon = kast(&home, &config_home)
         .args([
@@ -44,6 +114,8 @@ fn agent_rename_plan_default_toon_matches_explicit_json() {
             "io.example.OrderService.process",
             "--new-name",
             "processSafely",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
         ])
         .output()
         .expect("agent rename toon");
@@ -58,6 +130,7 @@ fn agent_rename_plan_default_toon_matches_explicit_json() {
         "toon output should not be parseable as JSON"
     );
     let toon_value = decode_toon(&toon.stdout);
+    toon_backend.join().expect("TOON rename backend");
 
     assert_eq!(toon_value, json_value);
     assert!(
@@ -99,7 +172,10 @@ fn agent_rename_plan_is_read_only_until_apply() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let config_home = temp.path().join("config");
-    std::fs::create_dir_all(&home).expect("home");
+    let workspace = temp.path().join("workspace");
+    let socket_path = temp.path().join("idea.sock");
+    let backend = rename_backend(&home, &config_home, &workspace, &socket_path);
+    let source_before = std::fs::read(workspace.join("OrderService.kt")).expect("source before");
 
     let plan = kast(&home, &config_home)
         .args([
@@ -111,12 +187,14 @@ fn agent_rename_plan_is_read_only_until_apply() {
             "io.example.OrderService.process",
             "--new-name",
             "processSafely",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
         ])
         .output()
         .expect("agent rename plan");
     assert!(
         plan.status.success(),
-        "rename plan should succeed without backend dispatch: stdout={}, stderr={}",
+        "rename plan should succeed through backend dry-run dispatch: stdout={}, stderr={}",
         String::from_utf8_lossy(&plan.stdout),
         String::from_utf8_lossy(&plan.stderr)
     );
@@ -138,5 +216,13 @@ fn agent_rename_plan_is_read_only_until_apply() {
     assert!(
         !output["result"]["plan"].to_string().contains("offset"),
         "{output:#}"
+    );
+    let requests = backend.join().expect("rename backend");
+    assert_eq!(requests[2]["method"], "symbol/resolve");
+    assert_eq!(requests[3]["method"], "raw/rename");
+    assert_eq!(requests[3]["params"]["dryRun"], true);
+    assert_eq!(
+        std::fs::read(workspace.join("OrderService.kt")).expect("source after"),
+        source_before,
     );
 }

--- a/cli-rs/tests/cli_core_smoke.rs
+++ b/cli-rs/tests/cli_core_smoke.rs
@@ -163,51 +163,6 @@ fn smoke_core_cli_commands() {
         "{agent_tools_json:#}"
     );
 
-    let rename_plan = kast(&home, &config_home)
-        .args([
-            "--output",
-            "json",
-            "agent",
-            "rename",
-            "--symbol",
-            "com.example.Target",
-            "--new-name",
-            "RenamedTarget",
-        ])
-        .output()
-        .expect("agent rename plan");
-    assert!(
-        rename_plan.status.success(),
-        "agent rename without --apply should be plan-only: stdout={}, stderr={}",
-        String::from_utf8_lossy(&rename_plan.stdout),
-        String::from_utf8_lossy(&rename_plan.stderr)
-    );
-    let rename_plan_json: serde_json::Value =
-        serde_json::from_slice(&rename_plan.stdout).expect("rename plan json");
-    assert_eq!(rename_plan_json["ok"], true, "{rename_plan_json:#}");
-    assert_eq!(rename_plan_json["method"], "agent/rename");
-    assert_eq!(
-        rename_plan_json["result"]["type"],
-        "KAST_AGENT_MUTATION_RESULT"
-    );
-    assert_eq!(rename_plan_json["result"]["operation"]["state"], "PLANNED");
-    assert_eq!(
-        rename_plan_json["result"]["operation"]["editApplicationState"],
-        "NOT_STARTED"
-    );
-    assert_eq!(
-        rename_plan_json["result"]["plan"]["method"],
-        "symbol/rename"
-    );
-    assert_eq!(
-        rename_plan_json["result"]["plan"]["symbol"],
-        "com.example.Target"
-    );
-    assert!(
-        rename_plan_json.get("request").is_none(),
-        "{rename_plan_json:#}"
-    );
-
     if cfg!(target_os = "macos") {
         let setup = kast(&home, &config_home)
             .args([

--- a/cli-rs/tests/local_development_refresh_smoke.rs
+++ b/cli-rs/tests/local_development_refresh_smoke.rs
@@ -1,0 +1,569 @@
+mod support;
+
+use sha2::{Digest, Sha256};
+use std::io::{Read, Write};
+use support::*;
+
+#[test]
+fn local_wrapper_ready_uses_explicit_local_authority_even_with_invalid_homebrew_state() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("release-config");
+    let repository = temp.path().join("repository with spaces");
+    let prefix = temp.path().join("local-authority");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    initialize_repository(&repository);
+
+    let stale_homebrew_receipt =
+        home.join("Library/Application Support/Kast/homebrew-install.json");
+    write_file(
+        &stale_homebrew_receipt,
+        br#"{"schemaVersion":1,"authority":"macos-homebrew","plugin":{}}"#,
+    );
+    let backend = temp.path().join("backend-headless");
+    write_backend_fixture(&backend);
+    let snapshot = temp.path().join("source-snapshot.json");
+    let cli_provenance = temp.path().join("cli-provenance.json");
+    let backend_provenance = temp.path().join("backend-provenance.json");
+
+    let snapshot_output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "local",
+            "snapshot",
+            "--source-root",
+        ])
+        .arg(&repository)
+        .arg("--output-file")
+        .arg(&snapshot)
+        .output()
+        .expect("source snapshot");
+    assert!(
+        snapshot_output.status.success(),
+        "snapshot failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&snapshot_output.stdout),
+        String::from_utf8_lossy(&snapshot_output.stderr)
+    );
+    let snapshot_bytes = std::fs::read(&snapshot).expect("captured source snapshot");
+    write_backend_source_snapshot_jar(&backend, &snapshot_bytes);
+
+    let attest_cli = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "local",
+            "attest",
+            "--source-root",
+        ])
+        .arg(&repository)
+        .arg("--expected-source-snapshot")
+        .arg(&snapshot)
+        .args(["--artifact-kind", "cli", "--artifact"])
+        .arg(env!("CARGO_BIN_EXE_kast"))
+        .arg("--output-file")
+        .arg(&cli_provenance)
+        .output()
+        .expect("CLI provenance");
+    assert!(
+        !attest_cli.status.success(),
+        "ordinary Cargo test bytes must not impersonate a source-bound local producer"
+    );
+    let unbound_failure: serde_json::Value =
+        serde_json::from_slice(&attest_cli.stdout).expect("unbound CLI failure JSON");
+    assert_eq!(
+        unbound_failure["code"], "LOCAL_CLI_SOURCE_ATTESTATION_MISSING",
+        "{unbound_failure}",
+    );
+    write_artifact_provenance(
+        &cli_provenance,
+        "cli",
+        &snapshot_bytes,
+        std::path::Path::new(env!("CARGO_BIN_EXE_kast")),
+    );
+    let attest_backend = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "local",
+            "attest",
+            "--source-root",
+        ])
+        .arg(&repository)
+        .arg("--expected-source-snapshot")
+        .arg(&snapshot)
+        .args(["--artifact-kind", "headless-backend", "--artifact"])
+        .arg(&backend)
+        .arg("--output-file")
+        .arg(&backend_provenance)
+        .output()
+        .expect("backend provenance");
+    assert!(
+        attest_backend.status.success(),
+        "backend provenance failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&attest_backend.stdout),
+        String::from_utf8_lossy(&attest_backend.stderr)
+    );
+
+    let refresh = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "local",
+            "refresh",
+            "--source-root",
+        ])
+        .arg(&repository)
+        .arg("--workspace-root")
+        .arg(&repository)
+        .arg("--prefix")
+        .arg(&prefix)
+        .arg("--expected-source-snapshot")
+        .arg(&snapshot)
+        .arg("--cli-binary")
+        .arg(env!("CARGO_BIN_EXE_kast"))
+        .arg("--cli-provenance")
+        .arg(&cli_provenance)
+        .arg("--backend-directory")
+        .arg(&backend)
+        .arg("--backend-provenance")
+        .arg(&backend_provenance)
+        .output()
+        .expect("local refresh");
+    assert!(
+        refresh.status.success(),
+        "refresh failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&refresh.stdout),
+        String::from_utf8_lossy(&refresh.stderr)
+    );
+
+    let inactive_runtime = std::process::Command::new(prefix.join("bin/kast-dev"))
+        .env("HOME", &home)
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "runtime",
+            "up",
+            "--workspace-root",
+        ])
+        .arg(&repository)
+        .args(["--backend=headless", "--no-auto-start=true"])
+        .output()
+        .expect("inactive local runtime");
+    assert!(
+        !inactive_runtime.status.success(),
+        "the fixture backend is intentionally not running"
+    );
+    let inactive_payload: serde_json::Value =
+        serde_json::from_slice(&inactive_runtime.stdout).expect("inactive local runtime JSON");
+    let canonical_prefix = std::fs::canonicalize(&prefix).expect("canonical local prefix");
+    assert_eq!(
+        inactive_payload["details"]["startCommand"],
+        format!(
+            "'{}' developer runtime up --workspace-root '{}' --backend=headless",
+            canonical_prefix.join("bin/kast-dev").display(),
+            repository.display(),
+        ),
+        "inactive local authority must teach a shell-safe receipt-owned start command: {inactive_payload}"
+    );
+    assert!(
+        !inactive_payload
+            .to_string()
+            .contains("Linux headless tarball"),
+        "inactive local authority must not send agents to release installation: {inactive_payload}"
+    );
+
+    let ready = std::process::Command::new(prefix.join("bin/kast-dev"))
+        .env("HOME", &home)
+        .args(["--output", "json", "ready", "--for", "machine"])
+        .output()
+        .expect("local ready");
+    assert!(
+        ready.status.success(),
+        "local readiness must not consume Homebrew state: stdout={}, stderr={}",
+        String::from_utf8_lossy(&ready.stdout),
+        String::from_utf8_lossy(&ready.stderr)
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&ready.stdout).expect("local readiness JSON");
+    assert_eq!(
+        payload["installAuthority"], "local-development",
+        "{payload}"
+    );
+    assert_eq!(
+        payload["localDevelopment"]["source"]["canonicalRoot"],
+        std::fs::canonicalize(&repository)
+            .expect("canonical repository")
+            .display()
+            .to_string(),
+        "{payload}"
+    );
+    assert_eq!(
+        payload["binary"]["configuredMatchesRunning"], true,
+        "{payload}"
+    );
+    assert!(
+        payload["pathResolution"]["configFiles"]
+            .as_array()
+            .expect("config files")
+            .iter()
+            .all(|file| file["scope"] != "macos-homebrew-receipt"),
+        "local readiness must not project inactive Homebrew state: {payload}"
+    );
+    let bin_source = payload["pathResolution"]["entries"]
+        .as_array()
+        .expect("path entries")
+        .iter()
+        .find(|entry| entry["key"] == "paths.binDir")
+        .expect("binDir entry")["source"]
+        .as_str();
+    assert_eq!(bin_source, Some("local-development-receipt"), "{payload}");
+    assert!(repository.join("AGENTS.local.md").is_file());
+    assert_eq!(
+        payload["localDevelopment"]["components"]["guidance"]["effectiveTarget"],
+        std::fs::canonicalize(&repository)
+            .expect("canonical repository")
+            .join("AGENTS.local.md")
+            .display()
+            .to_string(),
+        "{payload}"
+    );
+    let local_skill = std::fs::read_to_string(prefix.join("current/lib/skills/kast/SKILL.md"))
+        .expect("local skill");
+    assert!(
+        local_skill.contains(&format!(
+            "`{} agent",
+            canonical_prefix.join("bin/kast-dev").display()
+        )),
+        "local skill must route every command through the receipt-owned entrypoint"
+    );
+    assert!(
+        !local_skill.contains("`kast "),
+        "local skill must not route agents back to release authority"
+    );
+
+    let release_receipt_before =
+        std::fs::read(&stale_homebrew_receipt).expect("release receipt before repair");
+    let rejected_repair = std::process::Command::new(prefix.join("bin/kast-dev"))
+        .env("HOME", &home)
+        .args(["--output", "json", "repair", "--for", "machine", "--apply"])
+        .output()
+        .expect("rejected local repair apply");
+    assert!(
+        !rejected_repair.status.success(),
+        "local authority must reject release-state mutation"
+    );
+    let repair_failure: serde_json::Value =
+        serde_json::from_slice(&rejected_repair.stdout).expect("local repair failure JSON");
+    assert_eq!(
+        repair_failure["code"], "LOCAL_AUTHORITY_REPAIR_UNSUPPORTED",
+        "{repair_failure}"
+    );
+    assert_eq!(
+        std::fs::read(&stale_homebrew_receipt).expect("preserved release receipt"),
+        release_receipt_before,
+    );
+    assert!(
+        !home.join(".local/share/kast/install.json").exists(),
+        "rejected local repair must not create managed release state"
+    );
+
+    let installed_backend_jar =
+        prefix.join("current/lib/backends/headless/current/runtime-libs/backend.jar");
+    std::fs::write(&installed_backend_jar, b"tampered backend\n")
+        .expect("tampered installed backend");
+    let tampered_runtime = std::process::Command::new(prefix.join("bin/kast-dev"))
+        .env("HOME", &home)
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "runtime",
+            "up",
+            "--workspace-root",
+        ])
+        .arg(&repository)
+        .arg("--backend=headless")
+        .output()
+        .expect("tampered local runtime launch");
+    assert!(
+        !tampered_runtime.status.success(),
+        "runtime launch must reject backend bytes changed after refresh"
+    );
+    let tampered_runtime_payload: serde_json::Value =
+        serde_json::from_slice(&tampered_runtime.stdout).expect("tampered runtime JSON");
+    assert_eq!(
+        tampered_runtime_payload["code"], "LOCAL_COMPONENT_CHECKSUM_MISMATCH",
+        "{tampered_runtime_payload}"
+    );
+    std::fs::write(&installed_backend_jar, b"backend\n")
+        .expect("restored installed backend fixture");
+
+    std::fs::write(
+        prefix.join("current/lib/skills/kast/SKILL.md"),
+        "tampered mixed authority\n",
+    )
+    .expect("tampered skill");
+    let tampered = std::process::Command::new(prefix.join("bin/kast-dev"))
+        .env("HOME", &home)
+        .args(["--output", "json", "ready", "--for", "machine"])
+        .output()
+        .expect("tampered readiness");
+    assert!(
+        !tampered.status.success(),
+        "tampered local authority must fail"
+    );
+    let failure: serde_json::Value =
+        serde_json::from_slice(&tampered.stdout).expect("tamper failure JSON");
+    assert_eq!(
+        failure["code"], "LOCAL_COMPONENT_CHECKSUM_MISMATCH",
+        "{failure}"
+    );
+}
+
+fn initialize_repository(root: &std::path::Path) {
+    std::fs::create_dir_all(root).expect("repository");
+    run_git(root, &["init", "--quiet"]);
+    run_git(root, &["config", "user.email", "test@example.com"]);
+    run_git(root, &["config", "user.name", "Kast Test"]);
+    write_file(
+        &root.join("settings.gradle.kts"),
+        b"rootProject.name = \"fixture\"\n",
+    );
+    write_file(&root.join(".gitignore"), b"/AGENTS.local.md\n/.kast/\n");
+    write_file(
+        &root.join("cli-rs/resources/kast-skill/SKILL.md"),
+        b"---\nname: kast\ndescription: fixture\n---\nUse `kast agent verify`.\n",
+    );
+    run_git(root, &["add", "."]);
+    run_git(root, &["commit", "--quiet", "-m", "initial"]);
+}
+
+fn write_backend_fixture(root: &std::path::Path) {
+    write_file(&root.join("runtime-libs/classpath.txt"), b"backend.jar\n");
+    write_file(&root.join("runtime-libs/backend.jar"), b"backend\n");
+    write_file(
+        &root.join("runtime-libs/backend-headless-test-launcher.jar"),
+        b"headless launcher\n",
+    );
+    write_file(&root.join("idea-home/lib/nio-fs.jar"), b"nio\n");
+    write_file(
+        &root.join("idea-home/modules/module-descriptors.dat"),
+        b"modules\n",
+    );
+    let plugin_lib = root.join("idea-home/plugins/kast-headless/lib");
+    for (name, bytes) in [
+        ("analysis-api-test.jar", b"analysis api\n".as_slice()),
+        ("analysis-server-test.jar", b"analysis server\n".as_slice()),
+        (
+            "backend-headless-test-plugin-descriptor.jar",
+            b"plugin descriptor\n".as_slice(),
+        ),
+        (
+            "backend-idea-test-headless-runtime.jar",
+            b"backend idea\n".as_slice(),
+        ),
+        ("backend-shared-test.jar", b"backend shared\n".as_slice()),
+        ("index-store-test.jar", b"index store\n".as_slice()),
+    ] {
+        write_file(&plugin_lib.join(name), bytes);
+    }
+}
+
+fn write_backend_source_snapshot_jar(root: &std::path::Path, snapshot: &[u8]) {
+    let plugin_jar =
+        root.join("idea-home/plugins/kast-headless/lib/backend-headless-test-plugin.jar");
+    let file = std::fs::File::create(plugin_jar).expect("plugin jar");
+    let mut archive = zip::ZipWriter::new(file);
+    archive
+        .start_file(
+            "META-INF/kast/local-source-snapshot.json",
+            zip::write::SimpleFileOptions::default(),
+        )
+        .expect("snapshot jar entry");
+    archive.write_all(snapshot).expect("snapshot jar bytes");
+    let source: serde_json::Value = serde_json::from_slice(snapshot).expect("source snapshot JSON");
+    let components = [
+        (
+            "analysis-api",
+            "idea-home/plugins/kast-headless/lib/analysis-api-test.jar",
+        ),
+        (
+            "analysis-server",
+            "idea-home/plugins/kast-headless/lib/analysis-server-test.jar",
+        ),
+        (
+            "backend-headless-launcher",
+            "runtime-libs/backend-headless-test-launcher.jar",
+        ),
+        (
+            "backend-headless-plugin-descriptor",
+            "idea-home/plugins/kast-headless/lib/backend-headless-test-plugin-descriptor.jar",
+        ),
+        (
+            "backend-idea",
+            "idea-home/plugins/kast-headless/lib/backend-idea-test-headless-runtime.jar",
+        ),
+        (
+            "backend-shared",
+            "idea-home/plugins/kast-headless/lib/backend-shared-test.jar",
+        ),
+        (
+            "index-store",
+            "idea-home/plugins/kast-headless/lib/index-store-test.jar",
+        ),
+    ]
+    .map(|(kind, path)| {
+        serde_json::json!({
+            "kind": kind,
+            "path": path,
+            "sha256": component_sha256(&root.join(path)),
+        })
+    });
+    archive
+        .start_file(
+            "META-INF/kast/local-backend-components.json",
+            zip::write::SimpleFileOptions::default(),
+        )
+        .expect("component manifest jar entry");
+    archive
+        .write_all(
+            &serde_json::to_vec(&serde_json::json!({
+                "schemaVersion": 1,
+                "sourceTreeSha256": source["sourceTreeSha256"],
+                "components": components,
+            }))
+            .expect("component manifest JSON"),
+        )
+        .expect("component manifest jar bytes");
+    archive.finish().expect("finish plugin jar");
+}
+
+fn write_artifact_provenance(
+    output: &std::path::Path,
+    kind: &str,
+    snapshot: &[u8],
+    artifact: &std::path::Path,
+) {
+    let source: serde_json::Value = serde_json::from_slice(snapshot).expect("source snapshot JSON");
+    let artifact = std::fs::canonicalize(artifact).expect("canonical artifact");
+    write_file(
+        output,
+        &serde_json::to_vec_pretty(&serde_json::json!({
+            "schemaVersion": 1,
+            "kind": kind,
+            "source": source,
+            "artifact": artifact,
+            "sha256": component_sha256(&artifact),
+            "implementationVersion": env!("CARGO_PKG_VERSION"),
+        }))
+        .expect("artifact provenance JSON"),
+    );
+}
+
+fn component_sha256(root: &std::path::Path) -> String {
+    if root.is_file() {
+        let mut digest = Sha256::new();
+        digest.update(std::fs::read(root).expect("artifact bytes"));
+        return hex::encode(digest.finalize());
+    }
+    let mut paths = Vec::new();
+    collect_component_paths(root, root, &mut paths);
+    paths.sort_by_key(|path| path_bytes(path));
+    let mut digest = Sha256::new();
+    digest.update(b"kast-local-component-v1\0");
+    digest.update((paths.len() as u64).to_be_bytes());
+    for relative in paths {
+        let identity = path_bytes(&relative);
+        digest.update((identity.len() as u64).to_be_bytes());
+        digest.update(identity);
+        let path = root.join(relative);
+        let metadata = std::fs::symlink_metadata(&path).expect("component metadata");
+        let mut entry = Sha256::new();
+        if metadata.is_dir() {
+            entry.update(b"directory\0");
+        } else {
+            entry.update(b"file\0");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                entry.update([u8::from(metadata.permissions().mode() & 0o111 != 0)]);
+            }
+            #[cfg(not(unix))]
+            entry.update([0]);
+            entry.update(metadata.len().to_be_bytes());
+            let mut file = std::fs::File::open(&path).expect("component file");
+            let mut buffer = [0_u8; 64 * 1024];
+            loop {
+                let read = file.read(&mut buffer).expect("component read");
+                if read == 0 {
+                    break;
+                }
+                entry.update(&buffer[..read]);
+            }
+        }
+        digest.update(entry.finalize());
+    }
+    hex::encode(digest.finalize())
+}
+
+fn collect_component_paths(
+    root: &std::path::Path,
+    current: &std::path::Path,
+    paths: &mut Vec<std::path::PathBuf>,
+) {
+    let mut entries = std::fs::read_dir(current)
+        .expect("component directory")
+        .collect::<std::io::Result<Vec<_>>>()
+        .expect("component entries");
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    for entry in entries {
+        let path = entry.path();
+        paths.push(
+            path.strip_prefix(root)
+                .expect("component relative")
+                .to_path_buf(),
+        );
+        if entry.file_type().expect("component type").is_dir() {
+            collect_component_paths(root, &path, paths);
+        }
+    }
+}
+
+fn path_bytes(path: &std::path::Path) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        path.as_os_str().as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        path.to_string_lossy().as_bytes().to_vec()
+    }
+}
+
+fn write_file(path: &std::path::Path, bytes: &[u8]) {
+    std::fs::create_dir_all(path.parent().expect("file parent")).expect("parent");
+    std::fs::write(path, bytes).expect("file");
+}
+
+fn run_git(root: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/cli-rs/tests/local_development_refresh_smoke.rs
+++ b/cli-rs/tests/local_development_refresh_smoke.rs
@@ -236,11 +236,16 @@ fn local_wrapper_ready_uses_explicit_local_authority_even_with_invalid_homebrew_
     );
     let local_skill = std::fs::read_to_string(prefix.join("current/lib/skills/kast/SKILL.md"))
         .expect("local skill");
+    let quoted_entrypoint = format!(
+        "'{}'",
+        canonical_prefix
+            .join("bin/kast-dev")
+            .display()
+            .to_string()
+            .replace('\'', "'\"'\"'")
+    );
     assert!(
-        local_skill.contains(&format!(
-            "`{} agent",
-            canonical_prefix.join("bin/kast-dev").display()
-        )),
+        local_skill.contains(&format!("`{quoted_entrypoint} agent")),
         "local skill must route every command through the receipt-owned entrypoint"
     );
     assert!(

--- a/cli-rs/tests/packaged_content_smoke.rs
+++ b/cli-rs/tests/packaged_content_smoke.rs
@@ -71,7 +71,9 @@ fn packaged_skill_stays_usage_first_and_public_agent_only() {
         "{skill}"
     );
     assert!(
-        skill.contains("`kast repair --for agent|kotlin|release|machine"),
+        skill.contains("`kast ready --for agent --workspace-root \"$PWD\"`")
+            && skill.contains("`kast repair --for agent --workspace-root \"$PWD\"`")
+            && !skill.contains("--for agent|"),
         "{skill}"
     );
     assert!(

--- a/cli-rs/tests/support/mod.rs
+++ b/cli-rs/tests/support/mod.rs
@@ -196,22 +196,57 @@ pub(crate) fn spawn_scripted_idea_backend(
     socket_path: &Path,
     scripted_results: Vec<(&'static str, serde_json::Value)>,
 ) -> std::thread::JoinHandle<Vec<serde_json::Value>> {
+    write_macos_plugin_workspace_metadata(workspace);
+    spawn_scripted_backend(
+        home,
+        config_home,
+        workspace,
+        socket_path,
+        "idea",
+        scripted_results,
+    )
+}
+
+pub(crate) fn spawn_scripted_headless_backend(
+    home: &Path,
+    config_home: &Path,
+    workspace: &Path,
+    socket_path: &Path,
+    scripted_results: Vec<(&'static str, serde_json::Value)>,
+) -> std::thread::JoinHandle<Vec<serde_json::Value>> {
+    spawn_scripted_backend(
+        home,
+        config_home,
+        workspace,
+        socket_path,
+        "headless",
+        scripted_results,
+    )
+}
+
+fn spawn_scripted_backend(
+    home: &Path,
+    config_home: &Path,
+    workspace: &Path,
+    socket_path: &Path,
+    backend_name: &str,
+    scripted_results: Vec<(&'static str, serde_json::Value)>,
+) -> std::thread::JoinHandle<Vec<serde_json::Value>> {
     let descriptor_dir = default_descriptor_dir(home);
     std::fs::create_dir_all(home).expect("home");
     std::fs::create_dir_all(workspace).expect("workspace");
     std::fs::create_dir_all(config_home).expect("config home");
     std::fs::create_dir_all(&descriptor_dir).expect("descriptor dir");
-    write_macos_plugin_workspace_metadata(workspace);
     std::fs::write(
         config_home.join("config.toml"),
-        "[runtime]\ndefaultBackend = \"idea\"\n",
+        format!("[runtime]\ndefaultBackend = \"{backend_name}\"\n"),
     )
     .expect("config");
     std::fs::write(
         descriptor_dir.join("daemons.json"),
         serde_json::to_vec_pretty(&serde_json::json!([{
             "workspaceRoot": workspace.display().to_string(),
-            "backendName": "idea",
+            "backendName": backend_name,
             "backendVersion": "scripted-test",
             "transport": "uds",
             "socketPath": socket_path.display().to_string(),
@@ -227,6 +262,7 @@ pub(crate) fn spawn_scripted_idea_backend(
         .set_nonblocking(true)
         .expect("nonblocking scripted backend");
     let server_workspace = workspace.to_path_buf();
+    let server_backend_name = backend_name.to_string();
     thread::spawn(move || {
         let mut requests = Vec::new();
         let mut scripted_results = scripted_results.into_iter();
@@ -256,13 +292,13 @@ pub(crate) fn spawn_scripted_idea_backend(
                     "healthy": true,
                     "active": true,
                     "indexing": false,
-                    "backendName": "idea",
+                    "backendName": server_backend_name.as_str(),
                     "backendVersion": "scripted-test",
                     "workspaceRoot": server_workspace.display().to_string(),
                     "schemaVersion": 3
                 }),
                 "capabilities" => serde_json::json!({
-                    "backendName": "idea",
+                    "backendName": server_backend_name.as_str(),
                     "backendVersion": "scripted-test",
                     "workspaceRoot": server_workspace.display().to_string(),
                     "readCapabilities": [

--- a/docs/distribute/local-development-refresh.md
+++ b/docs/distribute/local-development-refresh.md
@@ -1,0 +1,210 @@
+---
+title: Validate A Local Checkout
+description: Build and exercise one revision-coherent Kast checkout without publishing a release.
+icon: lucide/refresh-cw
+---
+
+# Validate A Local Checkout
+
+Use this how-to when you are developing Kast itself and need agents to exercise
+the current checkout before a release exists. The workflow creates a separate
+headless `local-development` authority; it does not replace release `kast`, a
+Homebrew receipt, or a JetBrains-installed plugin.
+
+## Prerequisites
+
+Run the workflow from the exact primary checkout or linked worktree you want to
+test. The checkout needs JDK 21, Rust, and the repository Gradle wrapper's usual
+build dependencies.
+
+## Refresh The Local Generation
+
+Build, attest, stage, and activate the current checkout with one non-interactive
+command from the repository root.
+
+```console title="Build and activate the current checkout"
+./gradlew refreshDevelopmentLocal
+```
+
+The task captures the commit and current tracked plus non-ignored source bytes,
+builds the Rust CLI and portable headless backend, attests both artifacts, and
+activates them with the checkout's skill, guidance, and configuration. The
+default authority is isolated under `.kast/local-development/`.
+
+The command succeeds only after every component belongs to the same source
+snapshot and its checksum matches. Repeating it without source or artifact
+changes is idempotent. If staging or activation fails, the previously active
+generation remains selected.
+
+The CLI source digest is compiled into the local executable. The exact local
+plugin JAR carries the backend source digest plus a producer manifest that
+names and hashes every repo-built runtime JAR in the portable distribution.
+Refresh rejects an ordinary Cargo binary, a relabeled backend, a stale sibling
+JAR, an incomplete component set, or bytes changed after attestation.
+
+## Verify What Agents Will Use
+
+Ask the receipt-owned launcher for machine-readable readiness before relying on
+the local generation.
+
+```console title="Inspect the active source and component authority"
+./.kast/local-development/bin/kast-dev \
+  --output json \
+  ready \
+  --for machine \
+  --workspace-root "$PWD"
+```
+
+The response identifies `local-development` authority, the canonical checkout,
+commit, source SHA-256, active binary and backend, physical and effective skill
+and guidance targets, and every component checksum. A mixed or modified
+component fails readiness instead of falling back to release state.
+
+Start the real semantic path through the refreshed headless generation for the
+exact checkout. Runtime launch revalidates the full receipt, including backend
+bytes, before it consumes the selected classpath.
+
+```console title="Start the exact local headless backend"
+./.kast/local-development/bin/kast-dev developer runtime up \
+  --workspace-root "$PWD" \
+  --backend=headless
+```
+
+A first start performs a real Gradle import and waits until every Kotlin source
+module has an SDK, valid dependencies, JDK and Kotlin runtime symbols, PSI, and
+compiler diagnostics before reporting ready. The public runtime status and
+semantic requests share that same compiler-admission state: status remains
+`INDEXING` while admission is pending and becomes `DEGRADED` if it fails. If
+IDEA already started an automatic sync, Kast waits for and adopts that sync
+instead of racing it with a second import. Only a newly spawned local headless
+runtime receives the five-minute cold-import allowance. Reusing an existing
+runtime honors the caller's ordinary timeout, and release, demo, and normal
+semantic request budgets remain unchanged. Later starts normally reuse
+generation-scoped state. Source-index data is isolated with the generation
+too, so a refreshed checkout cannot inherit semantic rows from older local
+bytes.
+
+Local runtime startup shares the prefix authority lock with refresh, rollback,
+and removal. It revalidates the active receipt under that lock and retains the
+lock until the exact spawned process ID registers for this workspace. A
+concurrent generation transition therefore either finishes first and makes the
+stale start fail before spawn, or observes the registered live runtime and
+refuses the transition; it cannot orphan a process between those states. Two
+concurrent start commands re-inspect under the lock, so the second reuses the
+first registered process instead of spawning a duplicate. Lock-wait time does
+not consume the post-spawn cold-import budget, and a child that exits before
+registration is reaped and reported immediately.
+
+The local headless process disables the signed plugin's project-open setup
+hook before IDEA starts. It does not read Homebrew release authority, install a
+JetBrains profile, or rewrite workspace setup metadata.
+
+Then verify backend identity, health, and compiler-backed workspace evidence.
+
+```console title="Verify headless semantic capabilities"
+./.kast/local-development/bin/kast-dev agent verify \
+  --workspace-root "$PWD" \
+  --backend=headless \
+  --explain
+```
+
+Require `state: READY`, `workspaceKind` matching the exact checkout, and
+`evidenceQuality: COMPILER_BACKED` before using semantic results. Exact symbol
+lookup and diagnostics then run through the installed generation, not a
+checkout build output.
+
+```console title="Exercise exact compiler evidence"
+./.kast/local-development/bin/kast-dev agent symbol \
+  --query io.github.amichne.kast.headless.HeadlessWorkspaceKind \
+  --workspace-root "$PWD" \
+  --backend=headless \
+  --explain
+
+./.kast/local-development/bin/kast-dev agent diagnostics \
+  --file-path backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessWorkspaceKind.kt \
+  --workspace-root "$PWD" \
+  --backend=headless \
+  --explain
+```
+
+Exact references fall back to compiler/PSI search when the generation-scoped
+source index is unavailable or has no evidence. Kast reports a reference page
+as available only when it can prove the searched scope complete; partial
+evidence remains explicitly degraded.
+
+A plan-only rename is also a real semantic request. Kast resolves the symbol to
+a compiler anchor, asks the refreshed backend for a dry-run rename, and reports
+the resulting nonzero edits, affected files, and pre-edit file hashes without
+writing source bytes. It is typed separately from an applied mutation, so only
+`--apply` requires applied-mutation authority. A static command-shaped plan is
+not accepted as proof.
+
+The exact workspace receives an `AGENTS.local.md` symlink to the active
+generation. The source-owned root `.gitignore` keeps that projection local;
+refresh fails closed when the selected workspace does not ignore it. Both that
+guidance and its installed skill teach the absolute receipt-owned startup and
+verification sequence, so an agent cannot silently cross back to ordinary
+`kast` or another generation's runtime. Refresh parses every taught invocation
+against the staged CLI, including flags, required arguments, values, and the
+small supported set of documentation placeholders. Bare command-path
+references remain valid, but a stale flag or incomplete runnable example
+fails before activation. Only the closed set of explicitly prohibited command
+references is exempt as negative guidance; a positive invocation on that same
+line is still parsed.
+
+## Keep Linked Worktrees Isolated
+
+Run the refresh inside each linked worktree. Its default prefix lives inside
+that worktree, so source identity, runtime descriptors, caches, skill, and
+guidance are not borrowed from another checkout.
+
+Use explicit properties when a worker needs an external isolated prefix.
+
+```console title="Select an exact workspace and prefix"
+./gradlew refreshDevelopmentLocal \
+  -PkastLocalWorkspaceRoot="$PWD" \
+  -PkastLocalPrefix="/absolute/path/to/worker-kast-local"
+```
+
+Keep the prefix dedicated to that exact workspace. Refresh canonicalizes its
+lock authority and rejects an attempt to switch an existing prefix to a
+different workspace or reach an existing prefix through a final symlink.
+
+## Roll Back Or Remove The Local Authority
+
+Reactivate the validated previous generation when a new checkout build is not
+usable.
+
+```console title="Roll back one generation"
+./gradlew rollbackDevelopmentLocal \
+  -PkastLocalGeneration="<generation-id>"
+```
+
+Select the exact `generationId` reported by readiness or a preceding refresh.
+Repeating the same targeted rollback is a no-op; an implicit second toggle is
+never allowed. A refresh or rollback that would switch the active generation
+refuses while any generation-owned backend PID is live and reports the exact
+receipt-owned stop command. An unchanged idempotent refresh or rollback does
+not disturb that runtime.
+
+Remove the local prefix and its owned workspace guidance when testing is
+finished.
+
+```console title="Restore ordinary release authority"
+./gradlew removeDevelopmentLocal
+```
+
+Removal preserves unrelated repository ignore rules, source files, Homebrew
+state, release binaries, user configuration, and JetBrains plugin state. It
+also removes its exact owned guidance projection even when the prefix was
+already deleted, including a dangling symlink. Use the same
+`kastLocalWorkspaceRoot` and `kastLocalPrefix` properties for rollback or
+removal when the refresh used explicit values. Gradle uses the installed stable
+controller while it exists; after the prefix is already gone, it uses a
+surviving source-built checkout controller so cleanup remains reachable. If
+that build output was moved, select it explicitly with
+`-PkastLocalRecoveryController=/absolute/path/to/kast`. Missing-prefix removal
+shares the same canonical namespace lock as refresh, so concurrent cleanup
+cannot delete a newly activated projection. Removal also refuses while any
+generation-owned backend PID is still live and reports the exact
+receipt-owned `developer runtime stop` command to run first.

--- a/zensical.toml
+++ b/zensical.toml
@@ -38,6 +38,7 @@ nav = [
   ]},
   { "Troubleshoot" = "troubleshoot.md" },
   { "Distribute" = [
+    { "Validate a local checkout" = "distribute/local-development-refresh.md" },
     { "Release and mirror workflow" = "distribute/release-and-mirror.md" },
     { "Runtime artifact contract" = "distribute/runtime-artifact-contract.md" },
   ]},


### PR DESCRIPTION
## Callouts

- This is a deliberately cross-layer foundation: Gradle, Rust CLI, Kotlin backends, agent resources, docs, and CI move together under one revision-coherent authority.
- It does not mutate Homebrew, release artifacts, or JetBrains profile state.
- The linked-worktree `AGENTS.md` routing change remains local and is not part of this PR.

## What changed

- Adds one source-bound, release-free `./gradlew refreshDevelopmentLocal` workflow with immutable generations, atomic activation, strict receipts, readiness, rollback, and removal.
- Attests the CLI, backend component manifest, agent resources, and source revision as one coherent local authority.
- Proves the installed headless runtime through compiler-ready symbol, reference, diagnostics, and backend rename workflows.
- Interlocks refresh, rollback, removal, and runtime startup so live generations cannot be replaced or double-spawned.
- Adds contract, semantic E2E, documentation, navigation, and CI coverage.

Independent review found no remaining P0, P1, or P2 findings.

## Verification

- `.github/scripts/test-local-development-refresh-contract.sh`
- `.github/scripts/test-local-development-semantic-e2e.sh`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `./gradlew check --rerun-tasks --no-daemon`
- `.github/scripts/test-docs-content-contract.sh`
- `.github/scripts/test-docs-navigation-contract.sh`
- `zensical build --clean`
- `.github/scripts/test-macos-installer-contract.sh`
- `.github/scripts/test-terminal-command-contract.sh`
- `.github/scripts/test-kast-build-contract.sh`

Fixes #390