### PR TITLE
test: ratchet clean mixed-source diagnostics

### DIFF
--- a/.github/scripts/test-local-development-semantic-e2e.sh
+++ b/.github/scripts/test-local-development-semantic-e2e.sh
@@ -96,6 +96,11 @@ jq -e \
   || die 'machine readiness did not prove the complete local authority'
 
 source_file="${repo_root}/backend-headless/src/main/kotlin/io/github/amichne/kast/headless/HeadlessWorkspaceKind.kt"
+diagnostic_files=(
+  "$source_file"
+  "${repo_root}/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DiagnosticsResultTest.kt"
+  "${repo_root}/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/AnalysisBackendContractFixture.kt"
+)
 type_symbol='io.github.amichne.kast.headless.HeadlessWorkspaceKind'
 reference_symbol='io.github.amichne.kast.headless.HeadlessWorkspaceKind.Companion.GRADLE_MARKERS'
 before_source_sha="$(sha256_file "$source_file")"
@@ -177,17 +182,28 @@ jq -e \
   "${tmp_root}/references.json" >/dev/null \
   || die 'installed reference lookup was not known, nonzero, exact, and exhaustive'
 
+diagnostic_file_args=()
+for diagnostic_file in "${diagnostic_files[@]}"; do
+  diagnostic_file_args+=(--file-path "$diagnostic_file")
+done
 "$kast" --output json agent diagnostics \
-  --file-path "$source_file" \
+  "${diagnostic_file_args[@]}" \
   --workspace-root "$repo_root" \
   --backend headless \
   --explain >"${tmp_root}/diagnostics.json"
 jq -e \
+  --argjson requested_file_count "${#diagnostic_files[@]}" \
   '.ok == true and
+   (.result.filePaths | length) == $requested_file_count and
    (.result.steps[] | select(.name == "diagnostics").result.semanticOutcome) == "COMPLETE" and
-   (.result.steps[] | select(.name == "diagnostics").result.severityCounts.error) == 0' \
+   (.result.steps[] | select(.name == "diagnostics").result.requestedFileCount) == $requested_file_count and
+   (.result.steps[] | select(.name == "diagnostics").result.analyzedFileCount) == $requested_file_count and
+   (.result.steps[] | select(.name == "diagnostics").result.skippedFileCount) == 0 and
+   (.result.steps[] | select(.name == "diagnostics").result.severityCounts.total) == 0 and
+   (.result.steps[] | select(.name == "diagnostics").result.cardinality) == {"type": "EXACT", "totalCount": 0} and
+   (.result.steps[] | select(.name == "diagnostics").result.diagnostics) == []' \
   "${tmp_root}/diagnostics.json" >/dev/null \
-  || die 'installed diagnostics did not completely analyze the clean Kotlin file'
+  || die 'installed diagnostics did not completely analyze clean main, test, and test-fixture Kotlin files'
 
 "$kast" --output json agent rename \
   --symbol "$type_symbol" \


### PR DESCRIPTION
## Risk / uncertainty

No production validator is relaxed here. The released 0.13 IDEA backend can still emit legacy cardinality without the required `type: EXACT`; the CLI correctly rejects that stale payload. Current source already serializes and validates exact zero correctly, so this PR closes the remaining installed-backend proof gap instead of adding a compatibility exception.

## What

- exercise one clean `main`, `test`, and `testFixtures` Kotlin file in the existing installed headless diagnostics request
- require all requested files to be analyzed with none skipped
- require zero severity total, exact cardinality zero, and no diagnostic records
- retain the existing single refresh/runtime job rather than adding another long CI path

## Existing boundary proof

- Kotlin `DiagnosticsResultTest` proves exact-zero serialization includes the `EXACT` discriminator
- Rust `agent_diagnostics_smoke` proves clean single-file success, multi-file coherence, compact/field/count agreement, and contradictory payload rejection
- this change adds the real locally installed mixed-source-set proof

## Verification

- `./.github/scripts/test-local-development-semantic-e2e.sh`
- `./gradlew :analysis-api:test --tests io.github.amichne.kast.api.DiagnosticsResultTest --no-daemon`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test agent_diagnostics_smoke relative_file_paths_are_canonical_in_every_compact_json_view -- --exact`
- `shellcheck .github/scripts/test-local-development-semantic-e2e.sh`
- `git diff --check`

Closes #391
