### PR TITLE
Fail closed on incomplete relationship coverage

### DIFF
--- a/.agents/adr/0026-proof-carrying-relationship-coverage.md
+++ b/.agents/adr/0026-proof-carrying-relationship-coverage.md
@@ -1,0 +1,120 @@
+# ADR 0026: Proof-carrying relationship coverage
+
+Status: Accepted
+
+Date: 2026-07-16
+
+This ADR supersedes ADR 0022 only for relationship completeness, cardinality,
+and degraded-result evidence. ADR 0022's anchored identity, bounded provider
+work, family-specific records, and continuation ownership remain in force. ADR
+0025's backend-bound selector handles remain transport for that anchored
+identity and do not themselves prove relationship coverage. Issue #393
+implements this decision on top of the selector-handle foundation from #392.
+
+## Context
+
+An exact relationship count is a semantic claim about work that did not find
+another relationship. In particular, `EXACT 0` says more than an empty list:
+it says the selected identity, project scope, source-set scope, index
+freshness, semantic backend, and requested relationship family were all
+complete. The current contract can construct `EXACT 0` from an empty provider
+result without carrying any of those facts. Rust projections accept that value
+and `--count` drops the limitations that would let an agent judge it.
+
+Candidate visits, an empty page, and an opaque selector handle are not coverage
+proof. A timeout, cancellation, excluded source set, stale index, incomplete
+backend, or exhausted budget must not be converted into an exact zero.
+
+## Decision
+
+All compiler relationship results carry one closed coverage value with six
+explicit dimensions: `identity`, `projectScope`, `sourceSetScope`,
+`indexFreshness`, `backend`, and `requestedFamily`. Coverage also carries a
+closed limitation list.
+
+Coverage has three nominal states:
+
+- `COMPLETE` proves all six dimensions complete and has no limitations;
+- `RESUMABLE` proves the first five dimensions complete while the requested
+  family is still in progress behind an issued continuation; and
+- `LIMITED` has at least one non-complete dimension and at least one closed
+  limitation explaining it.
+
+Cardinality and coverage travel together in a sealed evidence algebra:
+
+- `Complete` contains only `ResultCardinality.Exact` and `COMPLETE` coverage;
+- `Resumable` contains only `ResultCardinality.KnownMinimum` and `RESUMABLE`
+  coverage; and
+- `Limited` contains only `ResultCardinality.KnownMinimum` and `LIMITED`
+  coverage.
+
+Available results may carry only complete or resumable evidence. Degraded,
+stale, and invalid continuation results carry limited evidence. There is no
+constructor that pairs exact cardinality with resumable or limited coverage.
+When a provider has not established a larger lower bound, the honest known
+minimum is zero.
+
+The IDEA backend is the coverage authority. It may issue complete or resumable
+coverage only when the exact subject is verified, the linked Gradle project
+model accounts for admitted modules and source sets inside the canonical
+workspace, compiler/index admission is ready, the semantic generation is
+stable, and the requested family completed or retained resumable state.
+Relationship code reads those model facts directly; it does not reinterpret
+the public workspace-file inventory as semantic relationship evidence.
+
+Project and source-set completeness comes from IDEA's persisted external
+Gradle graph. Complete coverage requires exact equality between imported and
+loaded Gradle module identities, exact equality between imported and IDEA
+source roots, and complete accounting for every configured linked root.
+Missing, extra, incomplete, or out-of-workspace inventory is limited coverage.
+The backend revalidates selector identity, semantic generation, and coverage
+inside the same read epoch that commits a final result or continuation. A
+change between admission and commit fails closed instead of publishing facts
+proved against an older epoch.
+
+Call, implementation, and hierarchy providers already materialize one bounded
+complete snapshot before paging. Their continuation store therefore preserves
+the snapshot's exact total on every page. References may remain incremental:
+an intermediate page is resumable with a known minimum, while the exhausted
+page becomes complete and exact. A partial provider search cannot issue or
+reissue a continuation because retained paging state is not proof that the
+unsearched family remains recoverable. Any partial, stale, excluded,
+timed-out, cancelled, backend-incomplete, or budget-limited path becomes a
+family-typed degraded or unavailable outcome with limited evidence. Provider
+timeouts and provider-originated cancellation are caught at the relationship
+boundary and remain distinct from cancellation of the enclosing request.
+
+The Rust boundary requires and validates the closed evidence shape before
+projecting an available relationship. Missing coverage, `EXACT` paired with
+anything other than complete coverage, or a malformed limited result is an
+invalid backend contract. Compact, field-selected, and `--count` projections
+retain coverage and limitations; `--count` may omit records and subject detail
+but never the facts qualifying the count. JSON and default TOON are encodings
+of the same projected value.
+
+## Proof
+
+The implementation uses vertical tests:
+
+1. API construction and serialization prove exact, resumable, and limited
+   evidence cannot be interchanged.
+2. Server tests prove incomplete backend evidence becomes a degraded result
+   with a known minimum and closed limitations for every compiler relationship
+   family.
+3. Rust projection tests reject proofless exact zero, admit a genuine complete
+   zero, and preserve coverage in compact and count views.
+4. Backend tests prove incomplete coverage cannot reach an exact page and that
+   complete bounded snapshots keep exact cardinality across paging.
+5. The installed semantic fixture includes production, test, and test-fixture
+   references and proves the real IDEA/Gradle path reports their exact count.
+
+## Consequences
+
+Relationship payloads are intentionally larger by a small fixed coverage
+object. In return, exact zero becomes an auditable compiler-backed statement
+instead of an inference from missing records. Consumers can distinguish a
+genuine zero from a lower bound without knowing provider internals, and compact
+or count output no longer erases the qualification on the result.
+
+Any future coverage dimension, coverage state, limitation, exactness rule, or
+projection that removes coverage or limitations must supersede this ADR.

--- a/.github/scripts/test-local-development-semantic-e2e.sh
+++ b/.github/scripts/test-local-development-semantic-e2e.sh
@@ -182,6 +182,182 @@ jq -e \
   "${tmp_root}/references.json" >/dev/null \
   || die 'installed reference lookup was not known, nonzero, exact, and exhaustive'
 
+coverage_symbol='io.github.amichne.kast.api.coverage.relationshipCoverageAnchor'
+"$kast" --output json agent symbol \
+  --query "$coverage_symbol" \
+  --workspace-root "$repo_root" \
+  --backend headless \
+  --explain >"${tmp_root}/coverage-symbol.json"
+jq -e \
+  --arg symbol "$coverage_symbol" \
+  '.ok == true and
+   .result.outcome.type == "RESOLVED" and
+   .result.outcome.source == "compiler" and
+   .result.outcome.symbol.fqName == $symbol and
+   .result.outcome.symbol.kind == "FUNCTION"' \
+  "${tmp_root}/coverage-symbol.json" >/dev/null \
+  || die 'owned cross-source-set coverage anchor did not resolve from the compiler'
+coverage_file="$(jq -er '.result.outcome.symbol.location.filePath' "${tmp_root}/coverage-symbol.json")"
+coverage_offset="$(jq -er '.result.outcome.symbol.location.startOffset' "${tmp_root}/coverage-symbol.json")"
+coverage_containing_type="$(jq -r '.result.outcome.symbol.containingDeclaration // empty' "${tmp_root}/coverage-symbol.json")"
+coverage_paths="${tmp_root}/coverage-reference-paths.txt"
+coverage_unique_paths="${tmp_root}/coverage-unique-reference-paths.txt"
+coverage_expected_paths="${tmp_root}/coverage-expected-reference-paths.txt"
+: >"$coverage_paths"
+printf '%s\n' \
+  "${repo_root}/analysis-api/src/main/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageMainUse.kt" \
+  "${repo_root}/analysis-api/src/test/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageTestUse.kt" \
+  "${repo_root}/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageTestFixtureUse.kt" \
+  | sort >"$coverage_expected_paths"
+coverage_page_token=''
+coverage_page_number=0
+coverage_returned_total=0
+while :; do
+  coverage_page_number=$((coverage_page_number + 1))
+  [[ "$coverage_page_number" -le 64 ]] \
+    || die 'cross-source-set reference paging did not terminate within 64 pages'
+  coverage_args=(
+    --output json agent references
+    --symbol "$coverage_symbol"
+    --declaration-file "$coverage_file"
+    --declaration-start-offset "$coverage_offset"
+    --kind function
+    --workspace-root "$repo_root"
+    --backend headless
+    --limit 1
+    --explain
+  )
+  if [[ -n "$coverage_containing_type" ]]; then
+    coverage_args+=(--containing-type "$coverage_containing_type")
+  fi
+  if [[ -n "$coverage_page_token" ]]; then
+    coverage_args+=(--page-token "$coverage_page_token")
+  fi
+  coverage_page_file="${tmp_root}/coverage-references-${coverage_page_number}.json"
+  "$kast" "${coverage_args[@]}" >"$coverage_page_file"
+  if ! jq -e \
+    '.ok == true and
+     .result.outcome == "AVAILABLE" and
+     .result.page.returnedCount == (.result.records | length)' \
+    "$coverage_page_file" >/dev/null; then
+    jq . "$coverage_page_file" >&2
+    die "cross-source-set reference page ${coverage_page_number} was not available and internally consistent"
+  fi
+  jq -r '.result.records[]?.location.filePath' "$coverage_page_file" >>"$coverage_paths"
+  coverage_returned_total=$((
+    coverage_returned_total + $(jq -er '.result.page.returnedCount' "$coverage_page_file")
+  ))
+  next_coverage_page_token="$(jq -r '.result.page.nextPageToken // empty' "$coverage_page_file")"
+  if [[ -n "$next_coverage_page_token" ]]; then
+    jq -e \
+      --argjson returned "$coverage_returned_total" \
+      '.result.coverage.type == "RESUMABLE" and
+       .result.page.cardinality.type == "KNOWN_MINIMUM" and
+       .result.page.cardinality.knownMinimumCount >= $returned and
+       .result.coverage.requestedFamily == "IN_PROGRESS" and
+       .result.limitations == ["FAMILY_SEARCH_IN_PROGRESS"]' \
+      "$coverage_page_file" >/dev/null \
+      || die "cross-source-set reference page ${coverage_page_number} lost resumable coverage evidence"
+    coverage_page_token="$next_coverage_page_token"
+    continue
+  fi
+  jq -e \
+    --argjson returned "$coverage_returned_total" \
+    --argjson expected_total 3 \
+    '.result.coverage.type == "COMPLETE" and
+     ([.result.coverage.identity,
+       .result.coverage.projectScope,
+       .result.coverage.sourceSetScope,
+       .result.coverage.indexFreshness,
+       .result.coverage.backend,
+       .result.coverage.requestedFamily] | all(. == "COMPLETE")) and
+     $returned == $expected_total and
+     .result.page.cardinality == {"type": "EXACT", "totalCount": $expected_total} and
+     .result.limitations == []' \
+    "$coverage_page_file" >/dev/null \
+    || die 'final cross-source-set reference page did not prove exact complete coverage'
+  break
+done
+[[ "$coverage_page_number" -gt 1 ]] \
+  || die 'cross-source-set reference proof did not exercise paging'
+sort -u "$coverage_paths" >"$coverage_unique_paths"
+if ! diff -u "$coverage_expected_paths" "$coverage_unique_paths"; then
+  die 'cross-source-set reference proof did not return the exact owned main, test, and test-fixture file set'
+fi
+
+zero_symbol='io.github.amichne.kast.testing.RelationshipCoverageFixture.exactZeroAnchor'
+"$kast" --output json agent symbol \
+  --query "$zero_symbol" \
+  --workspace-root "$repo_root" \
+  --backend headless \
+  --explain >"${tmp_root}/zero-symbol.json"
+jq -e \
+  --arg symbol "$zero_symbol" \
+  '.ok == true and
+   .result.outcome.type == "RESOLVED" and
+   .result.outcome.source == "compiler" and
+   .result.outcome.symbol.fqName == $symbol and
+   .result.outcome.symbol.kind == "FUNCTION"' \
+  "${tmp_root}/zero-symbol.json" >/dev/null \
+  || die 'exact-zero relationship fixture did not resolve from the compiler'
+zero_file="$(jq -er '.result.outcome.symbol.location.filePath' "${tmp_root}/zero-symbol.json")"
+zero_offset="$(jq -er '.result.outcome.symbol.location.startOffset' "${tmp_root}/zero-symbol.json")"
+zero_containing_type="$(jq -er '.result.outcome.symbol.containingDeclaration' "${tmp_root}/zero-symbol.json")"
+zero_page_token=''
+zero_page_number=0
+while :; do
+  zero_page_number=$((zero_page_number + 1))
+  [[ "$zero_page_number" -le 64 ]] \
+    || die 'exact-zero reference paging did not terminate within 64 pages'
+  zero_args=(
+    --output json agent references
+    --symbol "$zero_symbol"
+    --declaration-file "$zero_file"
+    --declaration-start-offset "$zero_offset"
+    --kind function
+    --containing-type "$zero_containing_type"
+    --workspace-root "$repo_root"
+    --backend headless
+    --limit 16
+    --count
+  )
+  if [[ -n "$zero_page_token" ]]; then
+    zero_args+=(--page-token "$zero_page_token")
+  fi
+  zero_page_file="${tmp_root}/zero-references-${zero_page_number}.json"
+  "$kast" "${zero_args[@]}" >"$zero_page_file"
+  jq -e \
+    '.ok == true and
+     .result.outcome == "AVAILABLE" and
+     .result.page.returnedCount == 0' \
+    "$zero_page_file" >/dev/null \
+    || die "exact-zero reference page ${zero_page_number} returned a relationship"
+  next_zero_page_token="$(jq -r '.result.page.nextPageToken // empty' "$zero_page_file")"
+  if [[ -n "$next_zero_page_token" ]]; then
+    jq -e \
+      '.result.page.cardinality == {"type": "KNOWN_MINIMUM", "knownMinimumCount": 0} and
+       .result.coverage.type == "RESUMABLE" and
+       .result.limitations == ["FAMILY_SEARCH_IN_PROGRESS"]' \
+      "$zero_page_file" >/dev/null \
+      || die "exact-zero reference page ${zero_page_number} claimed completeness before exhaustion"
+    zero_page_token="$next_zero_page_token"
+    continue
+  fi
+  jq -e \
+    '.result.page.cardinality == {"type": "EXACT", "totalCount": 0} and
+     .result.coverage.type == "COMPLETE" and
+     ([.result.coverage.identity,
+       .result.coverage.projectScope,
+       .result.coverage.sourceSetScope,
+       .result.coverage.indexFreshness,
+       .result.coverage.backend,
+       .result.coverage.requestedFamily] | all(. == "COMPLETE")) and
+     .result.limitations == []' \
+    "$zero_page_file" >/dev/null \
+    || die 'installed exact-zero relationship did not carry complete coverage proof'
+  break
+done
+
 diagnostic_file_args=()
 for diagnostic_file in "${diagnostic_files[@]}"; do
   diagnostic_file_args+=(--file-path "$diagnostic_file")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,8 +148,11 @@ depend on unfinished shared state, or otherwise be tightly coupled.
 
 <kast>
 ## Kast routing
-Use `/Users/amichne/code/kast/.agents/skills/kast/SKILL.md` before Kotlin or Gradle semantic work.
+Use `/Users/amichne/.codex/worktrees/68b86775-b0bf-43c9-9591-997877217b53/kast/.agents/skills/kast/SKILL.md` before Kotlin or Gradle semantic work.
 Use `kast agent verify --workspace-root "$PWD"` to verify the plugin-prepared workspace.
 Use typed commands such as `kast agent symbol --query <name>`, `kast agent diagnostics --file-path <path>`, and `kast agent rename --symbol <fq-name> --new-name <name> --apply`.
 Do not run `kast setup` on macOS; the IntelliJ plugin owns workspace bootstrap.
+Before each linked worker starts, open the exact worktree root as its own IDE project and run `kast agent verify --workspace-root "$PWD"` from that worktree.
+Never reuse another worktree's Kast runtime, metadata, or semantic evidence.
+Keep the IDE project open while active; close its exact IDE project or window before removing the worktree.
 </kast>

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/CallRelationsResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/CallRelationsResult.kt
@@ -1,6 +1,12 @@
 package io.github.amichne.kast.api.contract.result
 
-data class CallRelationsResult(
-    val records: List<CallRelation>,
-    val page: RelationTraversalPageInfo,
-)
+sealed interface CallRelationsResult {
+    data class Available(
+        val records: List<CallRelation>,
+        val page: RelationTraversalPageInfo,
+    ) : CallRelationsResult
+
+    data class Limited(
+        val evidence: RelationshipResultEvidence.Limited,
+    ) : CallRelationsResult
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/HierarchyRelationsResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/HierarchyRelationsResult.kt
@@ -1,6 +1,12 @@
 package io.github.amichne.kast.api.contract.result
 
-data class HierarchyRelationsResult(
-    val records: List<TypeHierarchyRelation>,
-    val page: RelationTraversalPageInfo,
-)
+sealed interface HierarchyRelationsResult {
+    data class Available(
+        val records: List<TypeHierarchyRelation>,
+        val page: RelationTraversalPageInfo,
+    ) : HierarchyRelationsResult
+
+    data class Limited(
+        val evidence: RelationshipResultEvidence.Limited,
+    ) : HierarchyRelationsResult
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/ImplementationRelationsResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/ImplementationRelationsResult.kt
@@ -1,6 +1,12 @@
 package io.github.amichne.kast.api.contract.result
 
-data class ImplementationRelationsResult(
-    val records: List<ImplementationRelation>,
-    val page: RelationTraversalPageInfo,
-)
+sealed interface ImplementationRelationsResult {
+    data class Available(
+        val records: List<ImplementationRelation>,
+        val page: RelationTraversalPageInfo,
+    ) : ImplementationRelationsResult
+
+    data class Limited(
+        val evidence: RelationshipResultEvidence.Limited,
+    ) : ImplementationRelationsResult
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/ReferencesResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/ReferencesResult.kt
@@ -18,8 +18,8 @@ data class ReferencesResult(
     val declaration: Symbol? = null,
     @DocField(description = "Reference locations with containing-symbol semantic evidence.")
     val references: List<ReferenceOccurrence>,
-    @DocField(description = "Exact or known-minimum cardinality established by bounded reference work.")
-    val cardinality: ResultCardinality,
+    @DocField(description = "Proof-carrying cardinality and coverage established by bounded reference work.")
+    val evidence: RelationshipResultEvidence,
     @DocField(description = "Pagination metadata when results are truncated.")
     override val page: PageInfo? = null,
     @DocField(description = "Describes the scope and exhaustiveness of the search.")
@@ -27,6 +27,9 @@ data class ReferencesResult(
     @DocField(description = "Protocol schema version for forward compatibility.", serverManaged = true)
     val schemaVersion: Int = SCHEMA_VERSION,
 ) : PageableResult<ReferenceOccurrence> {
+    val cardinality: ResultCardinality
+        get() = evidence.cardinality
+
     override val items: List<ReferenceOccurrence>
         get() = references
 

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/RelationTraversalPageInfo.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/RelationTraversalPageInfo.kt
@@ -6,12 +6,16 @@ import kotlinx.serialization.Serializable
 @Serializable
 @ConsistentCopyVisibility
 data class RelationTraversalPageInfo private constructor(
-    val cardinality: ResultCardinality,
+    @Serializable(with = RelationshipResultEvidence.CompleteSerializer::class)
+    val evidence: RelationshipResultEvidence.Complete,
     val returnedCount: Int,
     val visitedCandidateCount: Int,
     val truncated: Boolean,
     val nextHandle: RelationTraversalHandle? = null,
 ) {
+    val cardinality: ResultCardinality
+        get() = evidence.cardinality
+
     init {
         require(returnedCount >= 0) { "Returned relationship count must be non-negative" }
         require(visitedCandidateCount >= 0) {
@@ -32,7 +36,7 @@ data class RelationTraversalPageInfo private constructor(
 
     companion object {
         fun create(
-            cardinality: ResultCardinality,
+            evidence: RelationshipResultEvidence.Complete,
             returnedCount: Int,
             returnedBefore: Int,
             visitedCandidateCount: Int,
@@ -49,6 +53,7 @@ data class RelationTraversalPageInfo private constructor(
                 "Visited relationship candidate count cannot exceed its declared limit"
             }
 
+            val cardinality = evidence.cardinality
             val cumulativeReturned = returnedBefore.toLong() + returnedCount.toLong()
             require(cardinality.knownMinimum().toLong() >= cumulativeReturned) {
                 "Relationship cardinality cannot understate cumulative returned results"
@@ -60,7 +65,7 @@ data class RelationTraversalPageInfo private constructor(
             }
 
             return RelationTraversalPageInfo(
-                cardinality = cardinality,
+                evidence = evidence,
                 returnedCount = returnedCount,
                 visitedCandidateCount = visitedCandidateCount,
                 truncated = nextHandle != null,

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/RelationshipCoverageStatus.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/RelationshipCoverageStatus.kt
@@ -1,0 +1,15 @@
+package io.github.amichne.kast.api.contract.result
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class RelationshipCoverageStatus {
+    COMPLETE,
+    IN_PROGRESS,
+    PARTIAL,
+    STALE,
+    EXCLUDED,
+    TIMED_OUT,
+    CANCELLED,
+    UNAVAILABLE,
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/RelationshipResultEvidence.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/RelationshipResultEvidence.kt
@@ -1,0 +1,166 @@
+package io.github.amichne.kast.api.contract.result
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable
+sealed interface RelationshipResultEvidence {
+    val cardinality: ResultCardinality
+    val coverage: RelationshipSearchCoverage
+
+    @Serializable
+    sealed interface Available {
+        val cardinality: ResultCardinality
+        val coverage: RelationshipSearchCoverage
+    }
+
+    @Serializable
+    @SerialName("COMPLETE")
+    data class Complete(
+        @DocField(description = "Exact relationship cardinality proven across the complete requested family.")
+        @Serializable(with = ExactRelationshipCardinalitySerializer::class)
+        override val cardinality: ResultCardinality.Exact,
+        @DocField(description = "Coverage proof with every relationship completeness dimension satisfied.")
+        @Serializable(with = CompleteRelationshipCoverageSerializer::class)
+        override val coverage: RelationshipSearchCoverage.Complete,
+    ) : RelationshipResultEvidence, Available
+
+    @Serializable
+    @SerialName("RESUMABLE")
+    data class Resumable(
+        @DocField(description = "Relationship count proven so far while complete boundary coverage is retained.")
+        @Serializable(with = KnownMinimumRelationshipCardinalitySerializer::class)
+        override val cardinality: ResultCardinality.KnownMinimum,
+        @DocField(description = "Coverage proof whose requested family remains resumable through a continuation.")
+        @Serializable(with = ResumableRelationshipCoverageSerializer::class)
+        override val coverage: RelationshipSearchCoverage.Resumable,
+    ) : RelationshipResultEvidence, Available
+
+    @Serializable
+    @SerialName("LIMITED")
+    data class Limited(
+        @DocField(description = "Relationship count proven without claiming complete coverage.")
+        @Serializable(with = KnownMinimumRelationshipCardinalitySerializer::class)
+        override val cardinality: ResultCardinality.KnownMinimum,
+        @DocField(description = "Incomplete coverage facts and their canonical limitations.")
+        @Serializable(with = LimitedRelationshipCoverageSerializer::class)
+        override val coverage: RelationshipSearchCoverage.Limited,
+    ) : RelationshipResultEvidence
+
+    object CompleteSerializer : KSerializer<Complete> {
+        override val descriptor = RelationshipResultEvidence.serializer().descriptor
+
+        override fun serialize(encoder: Encoder, value: Complete) {
+            encoder.encodeSerializableValue(RelationshipResultEvidence.serializer(), value)
+        }
+
+        override fun deserialize(decoder: Decoder): Complete =
+            when (val evidence = decoder.decodeSerializableValue(RelationshipResultEvidence.serializer())) {
+                is Complete -> evidence
+                is Resumable,
+                is Limited,
+                -> throw SerializationException("Complete relationship evidence requires the COMPLETE variant")
+            }
+    }
+
+    object LimitedSerializer : KSerializer<Limited> {
+        override val descriptor = RelationshipResultEvidence.serializer().descriptor
+
+        override fun serialize(encoder: Encoder, value: Limited) {
+            encoder.encodeSerializableValue(RelationshipResultEvidence.serializer(), value)
+        }
+
+        override fun deserialize(decoder: Decoder): Limited =
+            when (val evidence = decoder.decodeSerializableValue(RelationshipResultEvidence.serializer())) {
+                is Complete,
+                is Resumable,
+                -> throw SerializationException("Limited relationship evidence requires the LIMITED variant")
+                is Limited -> evidence
+            }
+    }
+}
+
+private object ExactRelationshipCardinalitySerializer : KSerializer<ResultCardinality.Exact> {
+    override val descriptor = ResultCardinality.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: ResultCardinality.Exact) {
+        encoder.encodeSerializableValue(ResultCardinality.serializer(), value)
+    }
+
+    override fun deserialize(decoder: Decoder): ResultCardinality.Exact =
+        when (val cardinality = decoder.decodeSerializableValue(ResultCardinality.serializer())) {
+            is ResultCardinality.Exact -> cardinality
+            is ResultCardinality.KnownMinimum -> throw SerializationException(
+                "Complete relationship evidence requires exact cardinality",
+            )
+        }
+}
+
+private object KnownMinimumRelationshipCardinalitySerializer : KSerializer<ResultCardinality.KnownMinimum> {
+    override val descriptor = ResultCardinality.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: ResultCardinality.KnownMinimum) {
+        encoder.encodeSerializableValue(ResultCardinality.serializer(), value)
+    }
+
+    override fun deserialize(decoder: Decoder): ResultCardinality.KnownMinimum =
+        when (val cardinality = decoder.decodeSerializableValue(ResultCardinality.serializer())) {
+            is ResultCardinality.Exact -> throw SerializationException(
+                "Incomplete relationship evidence cannot claim exact cardinality",
+            )
+            is ResultCardinality.KnownMinimum -> cardinality
+        }
+}
+
+private object CompleteRelationshipCoverageSerializer : KSerializer<RelationshipSearchCoverage.Complete> {
+    override val descriptor = RelationshipSearchCoverage.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: RelationshipSearchCoverage.Complete) {
+        encoder.encodeSerializableValue(RelationshipSearchCoverage.serializer(), value)
+    }
+
+    override fun deserialize(decoder: Decoder): RelationshipSearchCoverage.Complete =
+        when (val coverage = decoder.decodeSerializableValue(RelationshipSearchCoverage.serializer())) {
+            is RelationshipSearchCoverage.Complete -> coverage
+            is RelationshipSearchCoverage.Resumable,
+            is RelationshipSearchCoverage.Limited,
+            -> throw SerializationException("Complete relationship evidence requires complete coverage")
+        }
+}
+
+private object ResumableRelationshipCoverageSerializer : KSerializer<RelationshipSearchCoverage.Resumable> {
+    override val descriptor = RelationshipSearchCoverage.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: RelationshipSearchCoverage.Resumable) {
+        encoder.encodeSerializableValue(RelationshipSearchCoverage.serializer(), value)
+    }
+
+    override fun deserialize(decoder: Decoder): RelationshipSearchCoverage.Resumable =
+        when (val coverage = decoder.decodeSerializableValue(RelationshipSearchCoverage.serializer())) {
+            is RelationshipSearchCoverage.Complete,
+            is RelationshipSearchCoverage.Limited,
+            -> throw SerializationException("Resumable relationship evidence requires resumable coverage")
+            is RelationshipSearchCoverage.Resumable -> coverage
+        }
+}
+
+private object LimitedRelationshipCoverageSerializer : KSerializer<RelationshipSearchCoverage.Limited> {
+    override val descriptor = RelationshipSearchCoverage.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: RelationshipSearchCoverage.Limited) {
+        encoder.encodeSerializableValue(RelationshipSearchCoverage.serializer(), value)
+    }
+
+    override fun deserialize(decoder: Decoder): RelationshipSearchCoverage.Limited =
+        when (val coverage = decoder.decodeSerializableValue(RelationshipSearchCoverage.serializer())) {
+            is RelationshipSearchCoverage.Complete,
+            is RelationshipSearchCoverage.Resumable,
+            -> throw SerializationException("Limited relationship evidence requires limited coverage")
+            is RelationshipSearchCoverage.Limited -> coverage
+        }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/RelationshipSearchCoverage.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/RelationshipSearchCoverage.kt
@@ -1,0 +1,247 @@
+package io.github.amichne.kast.api.contract.result
+
+import io.github.amichne.kast.api.docs.DocField
+import kotlin.ConsistentCopyVisibility
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface RelationshipSearchCoverage {
+    val identity: RelationshipCoverageStatus
+    val projectScope: RelationshipCoverageStatus
+    val sourceSetScope: RelationshipCoverageStatus
+    val indexFreshness: RelationshipCoverageStatus
+    val backend: RelationshipCoverageStatus
+    val requestedFamily: RelationshipCoverageStatus
+    val limitations: List<RelationshipSearchLimitation>
+
+    @Serializable
+    @SerialName("COMPLETE")
+    @ConsistentCopyVisibility
+    data class Complete private constructor(
+        @DocField(description = "Whether the exact subject identity was proven.")
+        override val identity: RelationshipCoverageStatus,
+        @DocField(description = "Whether every project in the requested relationship scope was covered.")
+        override val projectScope: RelationshipCoverageStatus,
+        @DocField(description = "Whether every applicable source set was covered.")
+        override val sourceSetScope: RelationshipCoverageStatus,
+        @DocField(description = "Whether relationship indexes were ready and current.")
+        override val indexFreshness: RelationshipCoverageStatus,
+        @DocField(description = "Whether the semantic backend completed its required work.")
+        override val backend: RelationshipCoverageStatus,
+        @DocField(description = "Whether the requested relationship family completed.")
+        override val requestedFamily: RelationshipCoverageStatus,
+        @DocField(description = "Canonical reasons that qualify relationship completeness.")
+        override val limitations: List<RelationshipSearchLimitation>,
+    ) : RelationshipSearchCoverage {
+        init {
+            require(
+                listOf(
+                    identity,
+                    projectScope,
+                    sourceSetScope,
+                    indexFreshness,
+                    backend,
+                    requestedFamily,
+                ).all { status -> status == RelationshipCoverageStatus.COMPLETE },
+            ) { "Complete relationship coverage requires every dimension to be complete" }
+            require(limitations.isEmpty()) {
+                "Complete relationship coverage cannot carry limitations"
+            }
+        }
+
+        companion object {
+            fun proven(): Complete = Complete(
+                identity = RelationshipCoverageStatus.COMPLETE,
+                projectScope = RelationshipCoverageStatus.COMPLETE,
+                sourceSetScope = RelationshipCoverageStatus.COMPLETE,
+                indexFreshness = RelationshipCoverageStatus.COMPLETE,
+                backend = RelationshipCoverageStatus.COMPLETE,
+                requestedFamily = RelationshipCoverageStatus.COMPLETE,
+                limitations = emptyList(),
+            )
+        }
+    }
+
+    @Serializable
+    @SerialName("RESUMABLE")
+    @ConsistentCopyVisibility
+    data class Resumable private constructor(
+        @DocField(description = "Whether the exact subject identity was proven.")
+        override val identity: RelationshipCoverageStatus,
+        @DocField(description = "Whether every project in the requested relationship scope was covered.")
+        override val projectScope: RelationshipCoverageStatus,
+        @DocField(description = "Whether every applicable source set was covered.")
+        override val sourceSetScope: RelationshipCoverageStatus,
+        @DocField(description = "Whether relationship indexes were ready and current.")
+        override val indexFreshness: RelationshipCoverageStatus,
+        @DocField(description = "Whether the semantic backend completed its required work.")
+        override val backend: RelationshipCoverageStatus,
+        @DocField(description = "Whether the requested relationship family completed.")
+        override val requestedFamily: RelationshipCoverageStatus,
+        @DocField(description = "Canonical reasons that qualify relationship completeness.")
+        override val limitations: List<RelationshipSearchLimitation>,
+    ) : RelationshipSearchCoverage {
+        init {
+            require(
+                listOf(identity, projectScope, sourceSetScope, indexFreshness, backend)
+                    .all { status -> status == RelationshipCoverageStatus.COMPLETE },
+            ) { "Resumable relationship coverage requires complete boundary dimensions" }
+            require(requestedFamily == RelationshipCoverageStatus.IN_PROGRESS) {
+                "Resumable relationship coverage requires an in-progress family search"
+            }
+            require(limitations == listOf(RelationshipSearchLimitation.FAMILY_SEARCH_IN_PROGRESS)) {
+                "Resumable relationship coverage requires only its in-progress limitation"
+            }
+        }
+
+        companion object {
+            fun retained(): Resumable = Resumable(
+                identity = RelationshipCoverageStatus.COMPLETE,
+                projectScope = RelationshipCoverageStatus.COMPLETE,
+                sourceSetScope = RelationshipCoverageStatus.COMPLETE,
+                indexFreshness = RelationshipCoverageStatus.COMPLETE,
+                backend = RelationshipCoverageStatus.COMPLETE,
+                requestedFamily = RelationshipCoverageStatus.IN_PROGRESS,
+                limitations = listOf(RelationshipSearchLimitation.FAMILY_SEARCH_IN_PROGRESS),
+            )
+        }
+    }
+
+    @Serializable
+    @SerialName("LIMITED")
+    @ConsistentCopyVisibility
+    data class Limited private constructor(
+        @DocField(description = "Whether the exact subject identity was proven.")
+        override val identity: RelationshipCoverageStatus,
+        @DocField(description = "Whether every project in the requested relationship scope was covered.")
+        override val projectScope: RelationshipCoverageStatus,
+        @DocField(description = "Whether every applicable source set was covered.")
+        override val sourceSetScope: RelationshipCoverageStatus,
+        @DocField(description = "Whether relationship indexes were ready and current.")
+        override val indexFreshness: RelationshipCoverageStatus,
+        @DocField(description = "Whether the semantic backend completed its required work.")
+        override val backend: RelationshipCoverageStatus,
+        @DocField(description = "Whether the requested relationship family completed.")
+        override val requestedFamily: RelationshipCoverageStatus,
+        @DocField(description = "Canonical reasons that qualify relationship completeness.")
+        override val limitations: List<RelationshipSearchLimitation>,
+    ) : RelationshipSearchCoverage {
+        init {
+            require(limitations.isNotEmpty()) {
+                "Limited relationship coverage requires at least one limitation"
+            }
+            require(limitations == limitations.distinct().sortedBy(RelationshipSearchLimitation::ordinal)) {
+                "Relationship limitations must be unique and canonical"
+            }
+            require(
+                CoverageFacts.from(limitations) == CoverageFacts(
+                    identity,
+                    projectScope,
+                    sourceSetScope,
+                    indexFreshness,
+                    backend,
+                    requestedFamily,
+                ),
+            ) { "Limited relationship coverage facts must agree with their limitations" }
+        }
+
+        companion object {
+            fun from(limitations: Collection<RelationshipSearchLimitation>): Limited {
+                val canonical = limitations.distinct().sortedBy(RelationshipSearchLimitation::ordinal)
+                val facts = CoverageFacts.from(canonical)
+                return Limited(
+                    identity = facts.identity,
+                    projectScope = facts.projectScope,
+                    sourceSetScope = facts.sourceSetScope,
+                    indexFreshness = facts.indexFreshness,
+                    backend = facts.backend,
+                    requestedFamily = facts.requestedFamily,
+                    limitations = canonical,
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun complete(): Complete = Complete.proven()
+
+        fun resumable(): Resumable = Resumable.retained()
+
+        fun limited(
+            first: RelationshipSearchLimitation,
+            vararg additional: RelationshipSearchLimitation,
+        ): Limited = Limited.from(listOf(first) + additional)
+    }
+
+    private data class CoverageFacts(
+        val identity: RelationshipCoverageStatus,
+        val projectScope: RelationshipCoverageStatus,
+        val sourceSetScope: RelationshipCoverageStatus,
+        val indexFreshness: RelationshipCoverageStatus,
+        val backend: RelationshipCoverageStatus,
+        val requestedFamily: RelationshipCoverageStatus,
+    ) {
+        companion object {
+            fun from(limitations: Collection<RelationshipSearchLimitation>): CoverageFacts = CoverageFacts(
+                identity = if (RelationshipSearchLimitation.IDENTITY_UNPROVEN in limitations) {
+                    RelationshipCoverageStatus.UNAVAILABLE
+                } else {
+                    RelationshipCoverageStatus.COMPLETE
+                },
+                projectScope = if (RelationshipSearchLimitation.PROJECT_SCOPE_INCOMPLETE in limitations) {
+                    RelationshipCoverageStatus.PARTIAL
+                } else {
+                    RelationshipCoverageStatus.COMPLETE
+                },
+                sourceSetScope = when {
+                    RelationshipSearchLimitation.SOURCE_SET_EXCLUDED in limitations ->
+                        RelationshipCoverageStatus.EXCLUDED
+                    RelationshipSearchLimitation.SOURCE_SET_SCOPE_INCOMPLETE in limitations ->
+                        RelationshipCoverageStatus.PARTIAL
+                    else -> RelationshipCoverageStatus.COMPLETE
+                },
+                indexFreshness = when {
+                    RelationshipSearchLimitation.INDEX_STALE in limitations ||
+                        RelationshipSearchLimitation.GENERATION_CHANGED in limitations ->
+                        RelationshipCoverageStatus.STALE
+                    RelationshipSearchLimitation.INDEX_NOT_READY in limitations ->
+                        RelationshipCoverageStatus.IN_PROGRESS
+                    else -> RelationshipCoverageStatus.COMPLETE
+                },
+                backend = when {
+                    RelationshipSearchLimitation.CANCELLED in limitations ->
+                        RelationshipCoverageStatus.CANCELLED
+                    limitations.any { limitation ->
+                        limitation in setOf(
+                            RelationshipSearchLimitation.BACKEND_UNAVAILABLE,
+                            RelationshipSearchLimitation.TRAVERSAL_STATE_BUDGET_REACHED,
+                            RelationshipSearchLimitation.CONTINUATION_EXPIRED,
+                            RelationshipSearchLimitation.CONTINUATION_INVALID,
+                        )
+                    } -> RelationshipCoverageStatus.UNAVAILABLE
+                    RelationshipSearchLimitation.BACKEND_INCOMPLETE in limitations ->
+                        RelationshipCoverageStatus.PARTIAL
+                    else -> RelationshipCoverageStatus.COMPLETE
+                },
+                requestedFamily = when {
+                    RelationshipSearchLimitation.TIMED_OUT in limitations ->
+                        RelationshipCoverageStatus.TIMED_OUT
+                    RelationshipSearchLimitation.CANCELLED in limitations ->
+                        RelationshipCoverageStatus.CANCELLED
+                    RelationshipSearchLimitation.FAMILY_SEARCH_IN_PROGRESS in limitations ->
+                        RelationshipCoverageStatus.IN_PROGRESS
+                    limitations.any { limitation ->
+                        limitation in setOf(
+                            RelationshipSearchLimitation.INDEX_NOT_READY,
+                            RelationshipSearchLimitation.BACKEND_UNAVAILABLE,
+                            RelationshipSearchLimitation.CONTINUATION_EXPIRED,
+                            RelationshipSearchLimitation.CONTINUATION_INVALID,
+                        )
+                    } -> RelationshipCoverageStatus.UNAVAILABLE
+                    else -> RelationshipCoverageStatus.PARTIAL
+                },
+            )
+        }
+    }
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/RelationshipSearchLimitation.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/RelationshipSearchLimitation.kt
@@ -1,0 +1,24 @@
+package io.github.amichne.kast.api.contract.result
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class RelationshipSearchLimitation {
+    IDENTITY_UNPROVEN,
+    PROJECT_SCOPE_INCOMPLETE,
+    SOURCE_SET_SCOPE_INCOMPLETE,
+    SOURCE_SET_EXCLUDED,
+    INDEX_NOT_READY,
+    INDEX_STALE,
+    BACKEND_INCOMPLETE,
+    BACKEND_UNAVAILABLE,
+    FAMILY_SEARCH_IN_PROGRESS,
+    FAMILY_SEARCH_INCOMPLETE,
+    CANDIDATE_BUDGET_REACHED,
+    TRAVERSAL_STATE_BUDGET_REACHED,
+    TIMED_OUT,
+    CANCELLED,
+    GENERATION_CHANGED,
+    CONTINUATION_EXPIRED,
+    CONTINUATION_INVALID,
+}

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastCallDegradedReason.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastCallDegradedReason.kt
@@ -8,4 +8,5 @@ enum class KastCallDegradedReason {
     CANDIDATE_BUDGET_REACHED,
     TRAVERSAL_STATE_BUDGET_REACHED,
     TIMEOUT,
+    CANCELLED,
 }

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastCallersResponse.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastCallersResponse.kt
@@ -5,6 +5,7 @@ import io.github.amichne.kast.api.contract.result.CallRelation
 import io.github.amichne.kast.api.contract.result.RelationCursorInvalidReason
 import io.github.amichne.kast.api.contract.result.RelationCursorStaleReason
 import io.github.amichne.kast.api.contract.result.RelationTraversalPageInfo
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
 import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -47,6 +48,8 @@ data class KastCallersDegradedResponse(
     val selector: KastExactSymbolSelector,
     val subject: SymbolIdentity,
     val reason: KastCallDegradedReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastCallersResponse
 
 @Serializable
@@ -54,6 +57,8 @@ data class KastCallersDegradedResponse(
 data class KastCallersCursorStaleResponse(
     val selector: KastExactSymbolSelector,
     val reason: RelationCursorStaleReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastCallersResponse
 
 @Serializable
@@ -61,4 +66,6 @@ data class KastCallersCursorStaleResponse(
 data class KastCallersCursorInvalidResponse(
     val selector: KastExactSymbolSelector,
     val reason: RelationCursorInvalidReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastCallersResponse

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastHierarchyDegradedReason.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastHierarchyDegradedReason.kt
@@ -8,4 +8,5 @@ enum class KastHierarchyDegradedReason {
     CANDIDATE_BUDGET_REACHED,
     TRAVERSAL_STATE_BUDGET_REACHED,
     TIMEOUT,
+    CANCELLED,
 }

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastHierarchyResponse.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastHierarchyResponse.kt
@@ -4,6 +4,7 @@ import io.github.amichne.kast.api.contract.SymbolIdentity
 import io.github.amichne.kast.api.contract.result.RelationCursorInvalidReason
 import io.github.amichne.kast.api.contract.result.RelationCursorStaleReason
 import io.github.amichne.kast.api.contract.result.RelationTraversalPageInfo
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
 import io.github.amichne.kast.api.contract.result.TypeHierarchyRelation
 import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
 import kotlinx.serialization.SerialName
@@ -47,6 +48,8 @@ data class KastHierarchyDegradedResponse(
     val selector: KastExactSymbolSelector,
     val subject: SymbolIdentity,
     val reason: KastHierarchyDegradedReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastHierarchyResponse
 
 @Serializable
@@ -54,6 +57,8 @@ data class KastHierarchyDegradedResponse(
 data class KastHierarchyCursorStaleResponse(
     val selector: KastExactSymbolSelector,
     val reason: RelationCursorStaleReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastHierarchyResponse
 
 @Serializable
@@ -61,4 +66,6 @@ data class KastHierarchyCursorStaleResponse(
 data class KastHierarchyCursorInvalidResponse(
     val selector: KastExactSymbolSelector,
     val reason: RelationCursorInvalidReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastHierarchyResponse

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastImplementationsDegradedReason.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastImplementationsDegradedReason.kt
@@ -8,4 +8,5 @@ enum class KastImplementationsDegradedReason {
     CANDIDATE_BUDGET_REACHED,
     TRAVERSAL_STATE_BUDGET_REACHED,
     TIMEOUT,
+    CANCELLED,
 }

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastImplementationsResponse.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastImplementationsResponse.kt
@@ -5,6 +5,7 @@ import io.github.amichne.kast.api.contract.result.ImplementationRelation
 import io.github.amichne.kast.api.contract.result.RelationCursorInvalidReason
 import io.github.amichne.kast.api.contract.result.RelationCursorStaleReason
 import io.github.amichne.kast.api.contract.result.RelationTraversalPageInfo
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
 import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -47,6 +48,8 @@ data class KastImplementationsDegradedResponse(
     val selector: KastExactSymbolSelector,
     val subject: SymbolIdentity,
     val reason: KastImplementationsDegradedReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastImplementationsResponse
 
 @Serializable
@@ -54,6 +57,8 @@ data class KastImplementationsDegradedResponse(
 data class KastImplementationsCursorStaleResponse(
     val selector: KastExactSymbolSelector,
     val reason: RelationCursorStaleReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastImplementationsResponse
 
 @Serializable
@@ -61,4 +66,6 @@ data class KastImplementationsCursorStaleResponse(
 data class KastImplementationsCursorInvalidResponse(
     val selector: KastExactSymbolSelector,
     val reason: RelationCursorInvalidReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastImplementationsResponse

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastReferencesDegradedReason.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastReferencesDegradedReason.kt
@@ -8,4 +8,6 @@ enum class KastReferencesDegradedReason {
     INDEX_IDENTITY_UNAVAILABLE,
     BOUND_SOURCE_UNAVAILABLE,
     CANDIDATE_BUDGET_REACHED,
+    TIMEOUT,
+    CANCELLED,
 }

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastReferencesResponse.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/skill/KastReferencesResponse.kt
@@ -7,6 +7,7 @@ import io.github.amichne.kast.api.contract.SymbolIdentity
 import io.github.amichne.kast.api.contract.result.ReferenceOccurrence
 import io.github.amichne.kast.api.contract.result.RelationCursorInvalidReason
 import io.github.amichne.kast.api.contract.result.RelationCursorStaleReason
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.protocol.SCHEMA_VERSION
 import kotlinx.serialization.SerialName
@@ -20,12 +21,15 @@ sealed interface KastReferencesResponse
 data class KastReferencesAvailableResponse(
     val subject: SymbolIdentity,
     val references: List<ReferenceOccurrence>,
-    val cardinality: ResultCardinality,
+    val evidence: RelationshipResultEvidence.Available,
     val page: PageInfo? = null,
     val searchScope: SearchScope? = null,
     val declaration: Symbol? = null,
     val schemaVersion: Int = SCHEMA_VERSION,
-) : KastReferencesResponse
+) : KastReferencesResponse {
+    val cardinality: ResultCardinality
+        get() = evidence.cardinality
+}
 
 @Serializable
 @SerialName("SUBJECT_NOT_FOUND")
@@ -53,6 +57,8 @@ data class KastReferencesDegradedResponse(
     val selector: KastExactSymbolSelector,
     val subject: SymbolIdentity,
     val reason: KastReferencesDegradedReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastReferencesResponse
 
 @Serializable
@@ -60,6 +66,8 @@ data class KastReferencesDegradedResponse(
 data class KastReferencesCursorStaleResponse(
     val selector: KastExactSymbolSelector,
     val reason: RelationCursorStaleReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastReferencesResponse
 
 @Serializable
@@ -67,4 +75,6 @@ data class KastReferencesCursorStaleResponse(
 data class KastReferencesCursorInvalidResponse(
     val selector: KastExactSymbolSelector,
     val reason: RelationCursorInvalidReason,
+    @Serializable(with = RelationshipResultEvidence.LimitedSerializer::class)
+    val evidence: RelationshipResultEvidence.Limited,
 ) : KastReferencesResponse

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageAnchor.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageAnchor.kt
@@ -1,0 +1,3 @@
+package io.github.amichne.kast.api.coverage
+
+fun relationshipCoverageAnchor(): Unit = Unit

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageMainUse.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageMainUse.kt
@@ -1,0 +1,3 @@
+package io.github.amichne.kast.api.coverage
+
+internal fun relationshipCoverageMainUse(): Unit = relationshipCoverageAnchor()

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/OpenApiDocument.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/docs/OpenApiDocument.kt
@@ -55,6 +55,10 @@ import io.github.amichne.kast.api.contract.result.FileAnalysisStatus
 import io.github.amichne.kast.api.contract.result.ImplementationsResult
 import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
 import io.github.amichne.kast.api.contract.result.ReferencesResult
+import io.github.amichne.kast.api.contract.result.RelationshipCoverageStatus
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
+import io.github.amichne.kast.api.contract.result.RelationshipSearchLimitation
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.result.RefreshResult
 import io.github.amichne.kast.api.contract.result.SemanticAdmissionStatus
@@ -262,6 +266,34 @@ object OpenApiDocument {
         registry.register("ResultCardinality", ResultCardinality.serializer())
         registry.register("EXACT", ResultCardinality.Exact.serializer())
         registry.register("KNOWN_MINIMUM", ResultCardinality.KnownMinimum.serializer())
+        registry.register("RelationshipCoverageStatus", RelationshipCoverageStatus.serializer())
+        registry.register("RelationshipSearchLimitation", RelationshipSearchLimitation.serializer())
+        registry.register("RelationshipSearchCoverage", RelationshipSearchCoverage.serializer())
+        registry.register(
+            "RelationshipSearchCoverage.Complete",
+            RelationshipSearchCoverage.Complete.serializer(),
+        )
+        registry.register(
+            "RelationshipSearchCoverage.Resumable",
+            RelationshipSearchCoverage.Resumable.serializer(),
+        )
+        registry.register(
+            "RelationshipSearchCoverage.Limited",
+            RelationshipSearchCoverage.Limited.serializer(),
+        )
+        registry.register("RelationshipResultEvidence", RelationshipResultEvidence.serializer())
+        registry.register(
+            "RelationshipResultEvidence.Complete",
+            RelationshipResultEvidence.Complete.serializer(),
+        )
+        registry.register(
+            "RelationshipResultEvidence.Resumable",
+            RelationshipResultEvidence.Resumable.serializer(),
+        )
+        registry.register(
+            "RelationshipResultEvidence.Limited",
+            RelationshipResultEvidence.Limited.serializer(),
+        )
         registry.register("ReferencesResult", ReferencesResult.serializer())
         registry.register("CallHierarchyQuery", CallHierarchyQuery.serializer())
         registry.register("CallHierarchyResult", CallHierarchyResult.serializer())
@@ -806,6 +838,54 @@ internal class SchemaRegistry {
                 ResultCardinality.KnownMinimum.serializer(),
                 discriminatorValue = "KNOWN_MINIMUM",
             )
+            "RelationshipResultEvidence" -> discriminatedUnion(
+                "type",
+                "COMPLETE" to "RelationshipResultEvidence.Complete",
+                "RESUMABLE" to "RelationshipResultEvidence.Resumable",
+                "LIMITED" to "RelationshipResultEvidence.Limited",
+            )
+            "RelationshipResultEvidence.Complete" -> relationshipEvidenceVariant(
+                discriminatorValue = "COMPLETE",
+                cardinalityComponent = "EXACT",
+                coverageComponent = "RelationshipSearchCoverage.Complete",
+            )
+            "RelationshipResultEvidence.Resumable" -> relationshipEvidenceVariant(
+                discriminatorValue = "RESUMABLE",
+                cardinalityComponent = "KNOWN_MINIMUM",
+                coverageComponent = "RelationshipSearchCoverage.Resumable",
+            )
+            "RelationshipResultEvidence.Limited" -> relationshipEvidenceVariant(
+                discriminatorValue = "LIMITED",
+                cardinalityComponent = "KNOWN_MINIMUM",
+                coverageComponent = "RelationshipSearchCoverage.Limited",
+            )
+            "RelationshipSearchCoverage" -> discriminatedUnion(
+                "type",
+                "COMPLETE" to "RelationshipSearchCoverage.Complete",
+                "RESUMABLE" to "RelationshipSearchCoverage.Resumable",
+                "LIMITED" to "RelationshipSearchCoverage.Limited",
+            )
+            "RelationshipSearchCoverage.Complete" -> relationshipCoverageVariant(
+                discriminatorValue = "COMPLETE",
+                fixedStatuses = relationshipCoverageDimensions.associateWith { "COMPLETE" },
+                limitationsMinimum = 0,
+                limitationsMaximum = 0,
+            )
+            "RelationshipSearchCoverage.Resumable" -> relationshipCoverageVariant(
+                discriminatorValue = "RESUMABLE",
+                fixedStatuses = relationshipCoverageDimensions.associateWith { dimension ->
+                    if (dimension == "requestedFamily") "IN_PROGRESS" else "COMPLETE"
+                },
+                limitationsMinimum = 1,
+                limitationsMaximum = 1,
+                fixedLimitation = "FAMILY_SEARCH_IN_PROGRESS",
+            )
+            "RelationshipSearchCoverage.Limited" -> relationshipCoverageVariant(
+                discriminatorValue = "LIMITED",
+                fixedStatuses = emptyMap(),
+                limitationsMinimum = 1,
+                limitationsMaximum = null,
+            )
             "WorkspaceFilesContinuationQuery" -> discriminatedUnion(
                 "action",
                 "ISSUE" to "WorkspaceFilesContinuationQuery.Issue",
@@ -903,6 +983,62 @@ internal class SchemaRegistry {
             )
             else -> null
         }
+
+    private fun relationshipEvidenceVariant(
+        discriminatorValue: String,
+        cardinalityComponent: String,
+        coverageComponent: String,
+    ): Map<String, Any?> = linkedMapOf(
+        "type" to "object",
+        "properties" to linkedMapOf(
+            "type" to linkedMapOf("type" to "string", "const" to discriminatorValue),
+            "cardinality" to refSchema(cardinalityComponent),
+            "coverage" to refSchema(coverageComponent),
+        ),
+        "additionalProperties" to false,
+        "required" to listOf("type", "cardinality", "coverage"),
+    )
+
+    private fun relationshipCoverageVariant(
+        discriminatorValue: String,
+        fixedStatuses: Map<String, String>,
+        limitationsMinimum: Int,
+        limitationsMaximum: Int?,
+        fixedLimitation: String? = null,
+    ): Map<String, Any?> {
+        val properties = linkedMapOf<String, Any?>(
+            "type" to linkedMapOf("type" to "string", "const" to discriminatorValue),
+        )
+        relationshipCoverageDimensions.forEach { dimension ->
+            properties[dimension] = fixedStatuses[dimension]?.let { status ->
+                linkedMapOf("type" to "string", "const" to status)
+            } ?: refSchema("RelationshipCoverageStatus")
+        }
+        properties["limitations"] = linkedMapOf<String, Any?>(
+            "type" to "array",
+            "items" to (fixedLimitation?.let { limitation ->
+                linkedMapOf("type" to "string", "const" to limitation)
+            } ?: refSchema("RelationshipSearchLimitation")),
+            "minItems" to limitationsMinimum,
+        ).also { limitations ->
+            limitationsMaximum?.let { maximum -> limitations["maxItems"] = maximum }
+        }
+        return linkedMapOf(
+            "type" to "object",
+            "properties" to properties,
+            "additionalProperties" to false,
+            "required" to listOf("type") + relationshipCoverageDimensions + "limitations",
+        )
+    }
+
+    private val relationshipCoverageDimensions = listOf(
+        "identity",
+        "projectScope",
+        "sourceSetScope",
+        "indexFreshness",
+        "backend",
+        "requestedFamily",
+    )
 
     private fun continuationQueryVariant(
         action: String,

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/AnalysisOpenApiDocumentTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/AnalysisOpenApiDocumentTest.kt
@@ -300,6 +300,29 @@ class AnalysisOpenApiDocumentTest {
     }
 
     @Test
+    fun `relationship evidence schema preserves proof variants and coverage dimensions`() {
+        val yaml = OpenApiDocument.renderYaml()
+        val evidence = yaml.componentSchema("RelationshipResultEvidence")
+        val completeEvidence = yaml.componentSchema("RelationshipResultEvidence.Complete")
+        val coverage = yaml.componentSchema("RelationshipSearchCoverage")
+        val limitedCoverage = yaml.componentSchema("RelationshipSearchCoverage.Limited")
+
+        assertTrue(evidence.contains("oneOf:"))
+        assertTrue(evidence.contains("RelationshipResultEvidence.Complete"))
+        assertTrue(evidence.contains("RelationshipResultEvidence.Resumable"))
+        assertTrue(evidence.contains("RelationshipResultEvidence.Limited"))
+        assertTrue(completeEvidence.contains("#/components/schemas/EXACT"))
+        assertTrue(completeEvidence.contains("#/components/schemas/RelationshipSearchCoverage.Complete"))
+        assertTrue(coverage.contains("RelationshipSearchCoverage.Complete"))
+        assertTrue(coverage.contains("RelationshipSearchCoverage.Resumable"))
+        assertTrue(coverage.contains("RelationshipSearchCoverage.Limited"))
+        assertTrue(limitedCoverage.contains("sourceSetScope:"))
+        assertTrue(limitedCoverage.contains("indexFreshness:"))
+        assertTrue(limitedCoverage.contains("requestedFamily:"))
+        assertTrue(limitedCoverage.contains("minItems: 1"))
+    }
+
+    @Test
     fun `diagnostics schema admits only exact cardinality`() {
         val yaml = OpenApiDocument.renderYaml()
         val diagnosticsSchema = yaml.substringAfter("    DiagnosticsResult:").substringBefore("    Diagnostic:")

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DocFieldCoverageTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/DocFieldCoverageTest.kt
@@ -37,6 +37,8 @@ import io.github.amichne.kast.api.contract.result.ImportOptimizeResult
 import io.github.amichne.kast.api.contract.result.ReferencesResult
 import io.github.amichne.kast.api.contract.result.ReferenceOccurrence
 import io.github.amichne.kast.api.contract.result.ContainingSymbolEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.result.DiagnosticSeverityCounts
 import io.github.amichne.kast.api.contract.result.RefreshResult
@@ -136,6 +138,12 @@ class DocFieldCoverageTest {
         "ContainingSymbolEvidence" to ContainingSymbolEvidence.serializer(),
         "EXACT" to ResultCardinality.Exact.serializer(),
         "KNOWN_MINIMUM" to ResultCardinality.KnownMinimum.serializer(),
+        "RelationshipSearchCoverage.Complete" to RelationshipSearchCoverage.Complete.serializer(),
+        "RelationshipSearchCoverage.Resumable" to RelationshipSearchCoverage.Resumable.serializer(),
+        "RelationshipSearchCoverage.Limited" to RelationshipSearchCoverage.Limited.serializer(),
+        "RelationshipResultEvidence.Complete" to RelationshipResultEvidence.Complete.serializer(),
+        "RelationshipResultEvidence.Resumable" to RelationshipResultEvidence.Resumable.serializer(),
+        "RelationshipResultEvidence.Limited" to RelationshipResultEvidence.Limited.serializer(),
         "ReferencesResult" to ReferencesResult.serializer(),
         "CallHierarchyQuery" to CallHierarchyQuery.serializer(),
         "CallHierarchyResult" to CallHierarchyResult.serializer(),

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/FakeAnalysisBackendContinuationTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/FakeAnalysisBackendContinuationTest.kt
@@ -1,6 +1,8 @@
 package io.github.amichne.kast.api
 
 import io.github.amichne.kast.api.contract.query.DiagnosticsQuery
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.protocol.ConflictException
 import io.github.amichne.kast.api.validation.parsed
 import io.github.amichne.kast.testing.AnalysisBackendContractFixture
@@ -64,11 +66,14 @@ class FakeAnalysisBackendContinuationTest {
             }.message,
         )
 
-        val nextToken = checkNotNull(
-            backend.findReferences(query.parsed()).page?.nextPageToken,
-        )
+        val firstPage = backend.findReferences(query.parsed())
+        val nextToken = checkNotNull(firstPage.page?.nextPageToken)
+        val resumable = assertInstanceOf(RelationshipResultEvidence.Resumable::class.java, firstPage.evidence)
+        assertEquals(ResultCardinality.KnownMinimum(2), resumable.cardinality)
         val finalPage = backend.findReferences(query.copy(pageToken = nextToken).parsed())
         assertNull(finalPage.page)
+        val complete = assertInstanceOf(RelationshipResultEvidence.Complete::class.java, finalPage.evidence)
+        assertEquals(ResultCardinality.Exact(2), complete.cardinality)
         assertEquals(
             "Unknown or consumed reference continuation token",
             assertConflict {

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/RelationshipModelTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/RelationshipModelTest.kt
@@ -13,11 +13,16 @@ import io.github.amichne.kast.api.contract.result.RelationCursorStaleReason
 import io.github.amichne.kast.api.contract.result.RelationTraversalFamily
 import io.github.amichne.kast.api.contract.result.RelationTraversalHandle
 import io.github.amichne.kast.api.contract.result.RelationTraversalPageInfo
+import io.github.amichne.kast.api.contract.result.RelationshipCoverageStatus
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
+import io.github.amichne.kast.api.contract.result.RelationshipSearchLimitation
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.result.ReferencesResult
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -25,6 +30,86 @@ class RelationshipModelTest {
     private val json = Json {
         encodeDefaults = true
         explicitNulls = false
+    }
+
+    private fun completeEvidence(totalCount: Int): RelationshipResultEvidence.Complete =
+        RelationshipResultEvidence.Complete(
+            cardinality = ResultCardinality.Exact(totalCount),
+            coverage = RelationshipSearchCoverage.complete(),
+        )
+
+    private fun resumableEvidence(knownMinimumCount: Int): RelationshipResultEvidence.Resumable =
+        RelationshipResultEvidence.Resumable(
+            cardinality = ResultCardinality.KnownMinimum(knownMinimumCount),
+            coverage = RelationshipSearchCoverage.resumable(),
+        )
+
+    @Test
+    fun `exact relationship evidence carries complete proof for every coverage dimension`() {
+        val evidence = RelationshipResultEvidence.Complete(
+            cardinality = ResultCardinality.Exact(0),
+            coverage = RelationshipSearchCoverage.complete(),
+        )
+
+        assertEquals(RelationshipCoverageStatus.COMPLETE, evidence.coverage.identity)
+        assertEquals(RelationshipCoverageStatus.COMPLETE, evidence.coverage.projectScope)
+        assertEquals(RelationshipCoverageStatus.COMPLETE, evidence.coverage.sourceSetScope)
+        assertEquals(RelationshipCoverageStatus.COMPLETE, evidence.coverage.indexFreshness)
+        assertEquals(RelationshipCoverageStatus.COMPLETE, evidence.coverage.backend)
+        assertEquals(RelationshipCoverageStatus.COMPLETE, evidence.coverage.requestedFamily)
+        assertEquals(emptyList<RelationshipSearchLimitation>(), evidence.coverage.limitations)
+        val encoded = json.encodeToString(RelationshipResultEvidence.serializer(), evidence)
+        assertTrue(encoded.contains("\"cardinality\":{\"type\":\"EXACT\""), encoded)
+        assertTrue(encoded.contains("\"coverage\":{\"type\":\"COMPLETE\""), encoded)
+        assertEquals(
+            evidence,
+            json.decodeFromString(
+                RelationshipResultEvidence.serializer(),
+                encoded,
+            ),
+        )
+    }
+
+    @Test
+    fun `limited relationship evidence preserves a known minimum and closed limitations`() {
+        val evidence = RelationshipResultEvidence.Limited(
+            cardinality = ResultCardinality.KnownMinimum(3),
+            coverage = RelationshipSearchCoverage.limited(
+                RelationshipSearchLimitation.SOURCE_SET_EXCLUDED,
+                RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+            ),
+        )
+
+        assertEquals(RelationshipCoverageStatus.EXCLUDED, evidence.coverage.sourceSetScope)
+        assertEquals(RelationshipCoverageStatus.PARTIAL, evidence.coverage.requestedFamily)
+        assertEquals(3, evidence.cardinality.knownMinimumCount)
+        assertEquals(
+            listOf(
+                RelationshipSearchLimitation.SOURCE_SET_EXCLUDED,
+                RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+            ),
+            evidence.coverage.limitations,
+        )
+    }
+
+    @Test
+    fun `limited relationship coverage rejects an empty limitation claim at the wire boundary`() {
+        val malformed = """
+            {
+              "type": "LIMITED",
+              "identity": "COMPLETE",
+              "projectScope": "COMPLETE",
+              "sourceSetScope": "COMPLETE",
+              "indexFreshness": "COMPLETE",
+              "backend": "COMPLETE",
+              "requestedFamily": "COMPLETE",
+              "limitations": []
+            }
+        """.trimIndent()
+
+        assertThrows<IllegalArgumentException> {
+            json.decodeFromString(RelationshipSearchCoverage.serializer(), malformed)
+        }
     }
 
     @Test
@@ -72,7 +157,7 @@ class RelationshipModelTest {
 
         val result = ReferencesResult(
             references = listOf(occurrence),
-            cardinality = ResultCardinality.Exact(1),
+            evidence = completeEvidence(1),
         )
         assertEquals(listOf(occurrence), result.items)
     }
@@ -134,7 +219,7 @@ class RelationshipModelTest {
             "rth1_callers_123e4567-e89b-12d3-a456-426614174000",
         )
         val continued = RelationTraversalPageInfo.create(
-            cardinality = ResultCardinality.KnownMinimum(6),
+            evidence = completeEvidence(6),
             returnedCount = 3,
             returnedBefore = 2,
             visitedCandidateCount = 8,
@@ -146,11 +231,12 @@ class RelationshipModelTest {
         assertEquals(true, continued.truncated)
         assertEquals(nextHandle, continued.nextHandle)
         val encoded = json.encodeToString(RelationTraversalPageInfo.serializer(), continued)
+        assertTrue(encoded.contains("\"evidence\":{\"type\":\"COMPLETE\""), encoded)
         assertFalse(encoded.contains("returnedBefore"))
         assertFalse(encoded.contains("candidateVisitLimit"))
 
         val exact = RelationTraversalPageInfo.create(
-            cardinality = ResultCardinality.Exact(5),
+            evidence = completeEvidence(5),
             returnedCount = 3,
             returnedBefore = 2,
             visitedCandidateCount = 3,
@@ -161,7 +247,7 @@ class RelationshipModelTest {
 
         assertThrows<IllegalArgumentException> {
             RelationTraversalPageInfo.create(
-                cardinality = ResultCardinality.Exact(1),
+                evidence = completeEvidence(1),
                 returnedCount = 2,
                 returnedBefore = 0,
                 visitedCandidateCount = 2,
@@ -171,7 +257,7 @@ class RelationshipModelTest {
         }
         assertThrows<IllegalArgumentException> {
             RelationTraversalPageInfo.create(
-                cardinality = ResultCardinality.KnownMinimum(5),
+                evidence = completeEvidence(5),
                 returnedCount = 3,
                 returnedBefore = 2,
                 visitedCandidateCount = 3,
@@ -181,7 +267,7 @@ class RelationshipModelTest {
         }
         assertThrows<IllegalArgumentException> {
             RelationTraversalPageInfo.create(
-                cardinality = ResultCardinality.KnownMinimum(4),
+                evidence = completeEvidence(4),
                 returnedCount = 3,
                 returnedBefore = 0,
                 visitedCandidateCount = 9,
@@ -195,9 +281,9 @@ class RelationshipModelTest {
     fun `relationship page wire form rejects token truncation disagreement`() {
         val handle = "rth1_callers_123e4567-e89b-12d3-a456-426614174000"
         val tokenWithoutTruncation =
-            """{"cardinality":{"type":"KNOWN_MINIMUM","knownMinimumCount":2},"returnedCount":1,"visitedCandidateCount":1,"truncated":false,"nextHandle":"$handle"}"""
+            """{"evidence":{"type":"COMPLETE","cardinality":{"type":"EXACT","totalCount":2},"coverage":{"type":"COMPLETE","identity":"COMPLETE","projectScope":"COMPLETE","sourceSetScope":"COMPLETE","indexFreshness":"COMPLETE","backend":"COMPLETE","requestedFamily":"COMPLETE","limitations":[]}},"returnedCount":1,"visitedCandidateCount":1,"truncated":false,"nextHandle":"$handle"}"""
         val truncationWithoutToken =
-            """{"cardinality":{"type":"KNOWN_MINIMUM","knownMinimumCount":2},"returnedCount":1,"visitedCandidateCount":1,"truncated":true}"""
+            """{"evidence":{"type":"COMPLETE","cardinality":{"type":"EXACT","totalCount":2},"coverage":{"type":"COMPLETE","identity":"COMPLETE","projectScope":"COMPLETE","sourceSetScope":"COMPLETE","indexFreshness":"COMPLETE","backend":"COMPLETE","requestedFamily":"COMPLETE","limitations":[]}},"returnedCount":1,"visitedCandidateCount":1,"truncated":true}"""
 
         assertThrows<IllegalArgumentException> {
             json.decodeFromString(RelationTraversalPageInfo.serializer(), tokenWithoutTruncation)

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/skill/KastReferencesResponseContractTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/contract/skill/KastReferencesResponseContractTest.kt
@@ -10,6 +10,9 @@ import io.github.amichne.kast.api.contract.result.ContainingSymbolEvidence
 import io.github.amichne.kast.api.contract.result.ReferenceOccurrence
 import io.github.amichne.kast.api.contract.result.RelationCursorInvalidReason
 import io.github.amichne.kast.api.contract.result.RelationCursorStaleReason
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
+import io.github.amichne.kast.api.contract.result.RelationshipSearchLimitation
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -57,11 +60,21 @@ class KastReferencesResponseContractTest {
             ),
             containingSymbol = ContainingSymbolEvidence.TopLevel,
         )
+        val resumableEvidence = RelationshipResultEvidence.Resumable(
+            cardinality = ResultCardinality.KnownMinimum(2),
+            coverage = RelationshipSearchCoverage.resumable(),
+        )
+        fun limitedEvidence(
+            limitation: RelationshipSearchLimitation,
+        ): RelationshipResultEvidence.Limited = RelationshipResultEvidence.Limited(
+            cardinality = ResultCardinality.KnownMinimum(0),
+            coverage = RelationshipSearchCoverage.limited(limitation),
+        )
         val responses: Map<String, KastReferencesResponse> = mapOf(
             "AVAILABLE" to KastReferencesAvailableResponse(
                 subject = subject,
                 references = listOf(occurrence),
-                cardinality = ResultCardinality.KnownMinimum(2),
+                evidence = resumableEvidence,
                 page = PageInfo(
                     truncated = true,
                     nextPageToken = "00000000-0000-0000-0000-000000000338",
@@ -74,20 +87,38 @@ class KastReferencesResponseContractTest {
                 selector,
                 subject,
                 KastReferencesDegradedReason.INDEX_IDENTITY_UNAVAILABLE,
+                limitedEvidence(RelationshipSearchLimitation.BACKEND_INCOMPLETE),
             ),
             "CURSOR_STALE" to KastReferencesCursorStaleResponse(
                 selector,
                 RelationCursorStaleReason.GENERATION_CHANGED,
+                limitedEvidence(RelationshipSearchLimitation.GENERATION_CHANGED),
             ),
             "CURSOR_INVALID" to KastReferencesCursorInvalidResponse(
                 selector,
                 RelationCursorInvalidReason.UNKNOWN_HANDLE,
+                limitedEvidence(RelationshipSearchLimitation.CONTINUATION_INVALID),
             ),
         )
 
         responses.forEach { (expectedType, response) ->
             val encoded = json.encodeToString(KastReferencesResponse.serializer(), response)
-            assertEquals(expectedType, json.parseToJsonElement(encoded).jsonObject.getValue("type").jsonPrimitive.content)
+            val encodedObject = json.parseToJsonElement(encoded).jsonObject
+            assertEquals(expectedType, encodedObject.getValue("type").jsonPrimitive.content)
+            when (response) {
+                is KastReferencesAvailableResponse -> assertEquals(
+                    "RESUMABLE",
+                    encodedObject.getValue("evidence").jsonObject.getValue("type").jsonPrimitive.content,
+                )
+                is KastReferencesDegradedResponse,
+                is KastReferencesCursorStaleResponse,
+                is KastReferencesCursorInvalidResponse,
+                -> assertEquals(
+                    "LIMITED",
+                    encodedObject.getValue("evidence").jsonObject.getValue("type").jsonPrimitive.content,
+                )
+                else -> Unit
+            }
             assertEquals(response, json.decodeFromString(KastReferencesResponse.serializer(), encoded))
         }
     }

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageTestUse.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageTestUse.kt
@@ -1,0 +1,3 @@
+package io.github.amichne.kast.api.coverage
+
+internal fun relationshipCoverageTestUse(): Unit = relationshipCoverageAnchor()

--- a/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageTestFixtureUse.kt
+++ b/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/api/coverage/relationshipCoverageTestFixtureUse.kt
@@ -1,0 +1,3 @@
+package io.github.amichne.kast.api.coverage
+
+internal fun relationshipCoverageTestFixtureUse(): Unit = relationshipCoverageAnchor()

--- a/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
+++ b/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/FakeAnalysisBackend.kt
@@ -53,6 +53,9 @@ import io.github.amichne.kast.api.contract.result.SemanticAdmissionStatus
 import io.github.amichne.kast.api.contract.result.ContainingSymbolEvidence
 import io.github.amichne.kast.api.contract.result.ReferenceOccurrence
 import io.github.amichne.kast.api.contract.result.ReferencesResult
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
+import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.result.RenameResult
 import io.github.amichne.kast.api.contract.SemanticInsertionResult
 import io.github.amichne.kast.api.contract.SemanticInsertionTarget
@@ -1155,7 +1158,19 @@ class FakeAnalysisBackend private constructor(
                     containingSymbol = ContainingSymbolEvidence.TopLevel,
                 )
             },
-            cardinality = io.github.amichne.kast.api.contract.result.ResultCardinality.Exact(totalCount),
+            evidence = if (hasMore) {
+                RelationshipResultEvidence.Resumable(
+                    cardinality = ResultCardinality.KnownMinimum(
+                        minOf(totalCount, Math.addExact(nextOffset, 1)),
+                    ),
+                    coverage = RelationshipSearchCoverage.resumable(),
+                )
+            } else {
+                RelationshipResultEvidence.Complete(
+                    cardinality = ResultCardinality.Exact(totalCount),
+                    coverage = RelationshipSearchCoverage.complete(),
+                )
+            },
             page = if (hasMore) {
                 PageInfo(
                     truncated = true,

--- a/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/RelationshipCoverageFixture.kt
+++ b/analysis-api/src/testFixtures/kotlin/io/github/amichne/kast/testing/RelationshipCoverageFixture.kt
@@ -1,0 +1,6 @@
+package io.github.amichne.kast.testing
+
+/** Compiler-visible anchor used by the installed relationship coverage contract. */
+object RelationshipCoverageFixture {
+    fun exactZeroAnchor(): Unit = Unit
+}

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/SkillRpcOrchestrator.kt
@@ -33,8 +33,15 @@ import io.github.amichne.kast.api.contract.query.TypeHierarchyQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceSymbolQuery
 import io.github.amichne.kast.api.contract.result.ApplyEditsResult
 import io.github.amichne.kast.api.contract.result.CallHierarchyStats
+import io.github.amichne.kast.api.contract.result.CallRelationsResult
+import io.github.amichne.kast.api.contract.result.HierarchyRelationsResult
+import io.github.amichne.kast.api.contract.result.ImplementationRelationsResult
 import io.github.amichne.kast.api.contract.result.RelationCursorInvalidReason
 import io.github.amichne.kast.api.contract.result.RelationCursorStaleReason
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
+import io.github.amichne.kast.api.contract.result.RelationshipSearchLimitation
+import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.result.TypeHierarchyNode
 import io.github.amichne.kast.api.contract.result.TypeHierarchyStats
 import io.github.amichne.kast.api.contract.selector.SelectorHandleAuthority
@@ -107,9 +114,12 @@ import io.github.amichne.kast.server.mutation.MutationProgressEvent
 import io.github.amichne.kast.server.mutation.MutationProgressReporter
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.serialization.json.Json
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.CancellationException
 
 internal class SkillRpcOrchestrator(
     private val backend: AnalysisBackend,
@@ -343,47 +353,100 @@ internal class SkillRpcOrchestrator(
                     selector = selector,
                 ).parsed(),
             )
+        } catch (_: TimeoutCancellationException) {
+            return KastReferencesDegradedResponse(
+                selector,
+                subject,
+                KastReferencesDegradedReason.TIMEOUT,
+                limitedRelationshipEvidence(0, RelationshipSearchLimitation.TIMED_OUT),
+            )
+        } catch (failure: CancellationException) {
+            if (!currentCoroutineContext().isActive) throw failure
+            return KastReferencesDegradedResponse(
+                selector,
+                subject,
+                KastReferencesDegradedReason.CANCELLED,
+                limitedRelationshipEvidence(0, RelationshipSearchLimitation.CANCELLED),
+            )
         } catch (failure: ConflictException) {
             return when (failure.details["continuationFailure"]) {
                 "generationChanged" -> KastReferencesCursorStaleResponse(
                     selector,
                     RelationCursorStaleReason.GENERATION_CHANGED,
+                    limitedRelationshipEvidence(
+                        0,
+                        RelationshipSearchLimitation.GENERATION_CHANGED,
+                    ),
                 )
                 "expired" -> KastReferencesCursorStaleResponse(
                     selector,
                     RelationCursorStaleReason.EXPIRED,
+                    limitedRelationshipEvidence(
+                        0,
+                        RelationshipSearchLimitation.CONTINUATION_EXPIRED,
+                    ),
                 )
                 "queryMismatch" -> KastReferencesCursorInvalidResponse(
                     selector,
                     RelationCursorInvalidReason.QUERY_MISMATCH,
+                    limitedRelationshipEvidence(
+                        0,
+                        RelationshipSearchLimitation.CONTINUATION_INVALID,
+                    ),
                 )
                 "boundSourceUnavailable" -> KastReferencesDegradedResponse(
                     selector,
                     subject,
                     KastReferencesDegradedReason.BOUND_SOURCE_UNAVAILABLE,
+                    limitedRelationshipEvidence(
+                        0,
+                        RelationshipSearchLimitation.BACKEND_UNAVAILABLE,
+                    ),
                 )
                 "indexIdentityUnavailable" -> KastReferencesDegradedResponse(
                     selector,
                     subject,
                     KastReferencesDegradedReason.INDEX_IDENTITY_UNAVAILABLE,
+                    limitedRelationshipEvidence(
+                        0,
+                        RelationshipSearchLimitation.BACKEND_INCOMPLETE,
+                    ),
                 )
                 else -> KastReferencesCursorInvalidResponse(
                     selector,
                     RelationCursorInvalidReason.UNKNOWN_HANDLE,
+                    limitedRelationshipEvidence(
+                        0,
+                        RelationshipSearchLimitation.CONTINUATION_INVALID,
+                    ),
                 )
             }
         }
-        if (completeResult.searchScope?.candidateCoverage == SearchScope.CandidateCoverage.PARTIAL) {
-            return KastReferencesDegradedResponse(
+        val evidence = if (
+            completeResult.searchScope?.candidateCoverage == SearchScope.CandidateCoverage.PARTIAL &&
+            completeResult.evidence !is RelationshipResultEvidence.Limited
+        ) {
+            limitedRelationshipEvidence(
+                completeResult.evidence.cardinality.knownMinimum(),
+                RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+            )
+        } else {
+            completeResult.evidence
+        }
+        val availableEvidence: RelationshipResultEvidence.Available = when (evidence) {
+            is RelationshipResultEvidence.Complete -> evidence
+            is RelationshipResultEvidence.Resumable -> evidence
+            is RelationshipResultEvidence.Limited -> return KastReferencesDegradedResponse(
                 selector = selector,
                 subject = subject,
                 reason = KastReferencesDegradedReason.REFERENCES_UNAVAILABLE,
+                evidence = evidence,
             )
         }
         return KastReferencesAvailableResponse(
             subject = subject,
             references = completeResult.references,
-            cardinality = completeResult.cardinality,
+            evidence = availableEvidence,
             page = completeResult.page,
             searchScope = completeResult.searchScope,
             declaration = completeResult.declaration,
@@ -431,18 +494,45 @@ internal class SkillRpcOrchestrator(
                 selector,
                 subject,
                 KastCallDegradedReason.CALL_HIERARCHY_UNAVAILABLE,
+                limitedRelationshipEvidence(
+                    0,
+                    RelationshipSearchLimitation.BACKEND_UNAVAILABLE,
+                ),
             )
         }
         val result = try {
             backend.callRelations(query)
+        } catch (_: TimeoutCancellationException) {
+            return KastCallersDegradedResponse(
+                selector,
+                subject,
+                KastCallDegradedReason.TIMEOUT,
+                limitedRelationshipEvidence(0, RelationshipSearchLimitation.TIMED_OUT),
+            )
+        } catch (failure: CancellationException) {
+            if (!currentCoroutineContext().isActive) throw failure
+            return KastCallersDegradedResponse(
+                selector,
+                subject,
+                KastCallDegradedReason.CANCELLED,
+                limitedRelationshipEvidence(0, RelationshipSearchLimitation.CANCELLED),
+            )
         } catch (failure: ConflictException) {
             return callContinuationOutcome(selector, subject, failure)
         }
-        return KastCallersAvailableResponse(
-            subject = subject,
-            records = result.records,
-            page = result.page,
-        )
+        return when (result) {
+            is CallRelationsResult.Available -> KastCallersAvailableResponse(
+                subject = subject,
+                records = result.records,
+                page = result.page,
+            )
+            is CallRelationsResult.Limited -> KastCallersDegradedResponse(
+                selector = selector,
+                subject = subject,
+                reason = KastCallDegradedReason.CALL_HIERARCHY_UNAVAILABLE,
+                evidence = result.evidence,
+            )
+        }
     }
 
     suspend fun implementations(
@@ -482,14 +572,42 @@ internal class SkillRpcOrchestrator(
                 selector,
                 subject,
                 KastImplementationsDegradedReason.IMPLEMENTATIONS_UNAVAILABLE,
+                limitedRelationshipEvidence(
+                    0,
+                    RelationshipSearchLimitation.BACKEND_UNAVAILABLE,
+                ),
             )
         }
         val result = try {
             backend.implementationRelations(query)
+        } catch (_: TimeoutCancellationException) {
+            return KastImplementationsDegradedResponse(
+                selector,
+                subject,
+                KastImplementationsDegradedReason.TIMEOUT,
+                limitedRelationshipEvidence(0, RelationshipSearchLimitation.TIMED_OUT),
+            )
+        } catch (failure: CancellationException) {
+            if (!currentCoroutineContext().isActive) throw failure
+            return KastImplementationsDegradedResponse(
+                selector,
+                subject,
+                KastImplementationsDegradedReason.CANCELLED,
+                limitedRelationshipEvidence(0, RelationshipSearchLimitation.CANCELLED),
+            )
         } catch (failure: ConflictException) {
             return implementationContinuationOutcome(selector, subject, failure)
         }
-        return KastImplementationsAvailableResponse(subject, result.records, result.page)
+        return when (result) {
+            is ImplementationRelationsResult.Available ->
+                KastImplementationsAvailableResponse(subject, result.records, result.page)
+            is ImplementationRelationsResult.Limited -> KastImplementationsDegradedResponse(
+                selector = selector,
+                subject = subject,
+                reason = KastImplementationsDegradedReason.IMPLEMENTATIONS_UNAVAILABLE,
+                evidence = result.evidence,
+            )
+        }
     }
 
     suspend fun hierarchy(request: KastHierarchyRequest): KastHierarchyResponse {
@@ -529,14 +647,42 @@ internal class SkillRpcOrchestrator(
                 selector,
                 subject,
                 KastHierarchyDegradedReason.TYPE_HIERARCHY_UNAVAILABLE,
+                limitedRelationshipEvidence(
+                    0,
+                    RelationshipSearchLimitation.BACKEND_UNAVAILABLE,
+                ),
             )
         }
         val result = try {
             backend.hierarchyRelations(query)
+        } catch (_: TimeoutCancellationException) {
+            return KastHierarchyDegradedResponse(
+                selector,
+                subject,
+                KastHierarchyDegradedReason.TIMEOUT,
+                limitedRelationshipEvidence(0, RelationshipSearchLimitation.TIMED_OUT),
+            )
+        } catch (failure: CancellationException) {
+            if (!currentCoroutineContext().isActive) throw failure
+            return KastHierarchyDegradedResponse(
+                selector,
+                subject,
+                KastHierarchyDegradedReason.CANCELLED,
+                limitedRelationshipEvidence(0, RelationshipSearchLimitation.CANCELLED),
+            )
         } catch (failure: ConflictException) {
             return hierarchyContinuationOutcome(selector, subject, failure)
         }
-        return KastHierarchyAvailableResponse(subject, result.records, result.page)
+        return when (result) {
+            is HierarchyRelationsResult.Available ->
+                KastHierarchyAvailableResponse(subject, result.records, result.page)
+            is HierarchyRelationsResult.Limited -> KastHierarchyDegradedResponse(
+                selector = selector,
+                subject = subject,
+                reason = KastHierarchyDegradedReason.TYPE_HIERARCHY_UNAVAILABLE,
+                evidence = result.evidence,
+            )
+        }
     }
 
     suspend fun scaffold(request: KastScaffoldRequest): KastScaffoldResponse {
@@ -1869,39 +2015,87 @@ internal class SkillRpcOrchestrator(
         }
     }
 
+    private fun limitedRelationshipEvidence(
+        knownMinimumCount: Int,
+        first: RelationshipSearchLimitation,
+        vararg additional: RelationshipSearchLimitation,
+    ): RelationshipResultEvidence.Limited = RelationshipResultEvidence.Limited(
+        cardinality = ResultCardinality.KnownMinimum(knownMinimumCount),
+        coverage = RelationshipSearchCoverage.limited(first, *additional),
+    )
+
     private fun callContinuationOutcome(
         selector: KastExactSymbolSelector,
         subject: SymbolIdentity,
         failure: ConflictException,
     ): KastCallersResponse = when (failure.details["continuationFailure"]) {
         "generationChanged" -> KastCallersCursorStaleResponse(
-            selector,
-            RelationCursorStaleReason.GENERATION_CHANGED,
+            selector = selector,
+            reason = RelationCursorStaleReason.GENERATION_CHANGED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.GENERATION_CHANGED,
+            ),
         )
-        "expired" -> KastCallersCursorStaleResponse(selector, RelationCursorStaleReason.EXPIRED)
+        "expired" -> KastCallersCursorStaleResponse(
+            selector = selector,
+            reason = RelationCursorStaleReason.EXPIRED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_EXPIRED,
+            ),
+        )
         "familyMismatch" -> KastCallersCursorInvalidResponse(
-            selector,
-            RelationCursorInvalidReason.FAMILY_MISMATCH,
+            selector = selector,
+            reason = RelationCursorInvalidReason.FAMILY_MISMATCH,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_INVALID,
+            ),
         )
         "queryMismatch" -> KastCallersCursorInvalidResponse(
-            selector,
-            RelationCursorInvalidReason.QUERY_MISMATCH,
+            selector = selector,
+            reason = RelationCursorInvalidReason.QUERY_MISMATCH,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_INVALID,
+            ),
         )
         "unknown" -> KastCallersCursorInvalidResponse(
-            selector,
-            RelationCursorInvalidReason.UNKNOWN_HANDLE,
+            selector = selector,
+            reason = RelationCursorInvalidReason.UNKNOWN_HANDLE,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_INVALID,
+            ),
         )
         "candidateBudgetReached" -> KastCallersDegradedResponse(
-            selector,
-            subject,
-            KastCallDegradedReason.CANDIDATE_BUDGET_REACHED,
+            selector = selector,
+            subject = subject,
+            reason = KastCallDegradedReason.CANDIDATE_BUDGET_REACHED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CANDIDATE_BUDGET_REACHED,
+            ),
         )
         "traversalStateBudgetReached" -> KastCallersDegradedResponse(
-            selector,
-            subject,
-            KastCallDegradedReason.TRAVERSAL_STATE_BUDGET_REACHED,
+            selector = selector,
+            subject = subject,
+            reason = KastCallDegradedReason.TRAVERSAL_STATE_BUDGET_REACHED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.TRAVERSAL_STATE_BUDGET_REACHED,
+            ),
         )
-        "timeout" -> KastCallersDegradedResponse(selector, subject, KastCallDegradedReason.TIMEOUT)
+        "timeout" -> KastCallersDegradedResponse(
+            selector = selector,
+            subject = subject,
+            reason = KastCallDegradedReason.TIMEOUT,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.TIMED_OUT,
+            ),
+        )
         else -> throw failure
     }
 
@@ -1911,39 +2105,71 @@ internal class SkillRpcOrchestrator(
         failure: ConflictException,
     ): KastImplementationsResponse = when (failure.details["continuationFailure"]) {
         "generationChanged" -> KastImplementationsCursorStaleResponse(
-            selector,
-            RelationCursorStaleReason.GENERATION_CHANGED,
+            selector = selector,
+            reason = RelationCursorStaleReason.GENERATION_CHANGED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.GENERATION_CHANGED,
+            ),
         )
         "expired" -> KastImplementationsCursorStaleResponse(
-            selector,
-            RelationCursorStaleReason.EXPIRED,
+            selector = selector,
+            reason = RelationCursorStaleReason.EXPIRED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_EXPIRED,
+            ),
         )
         "familyMismatch" -> KastImplementationsCursorInvalidResponse(
-            selector,
-            RelationCursorInvalidReason.FAMILY_MISMATCH,
+            selector = selector,
+            reason = RelationCursorInvalidReason.FAMILY_MISMATCH,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_INVALID,
+            ),
         )
         "queryMismatch" -> KastImplementationsCursorInvalidResponse(
-            selector,
-            RelationCursorInvalidReason.QUERY_MISMATCH,
+            selector = selector,
+            reason = RelationCursorInvalidReason.QUERY_MISMATCH,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_INVALID,
+            ),
         )
         "unknown" -> KastImplementationsCursorInvalidResponse(
-            selector,
-            RelationCursorInvalidReason.UNKNOWN_HANDLE,
+            selector = selector,
+            reason = RelationCursorInvalidReason.UNKNOWN_HANDLE,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_INVALID,
+            ),
         )
         "candidateBudgetReached" -> KastImplementationsDegradedResponse(
-            selector,
-            subject,
-            KastImplementationsDegradedReason.CANDIDATE_BUDGET_REACHED,
+            selector = selector,
+            subject = subject,
+            reason = KastImplementationsDegradedReason.CANDIDATE_BUDGET_REACHED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CANDIDATE_BUDGET_REACHED,
+            ),
         )
         "traversalStateBudgetReached" -> KastImplementationsDegradedResponse(
-            selector,
-            subject,
-            KastImplementationsDegradedReason.TRAVERSAL_STATE_BUDGET_REACHED,
+            selector = selector,
+            subject = subject,
+            reason = KastImplementationsDegradedReason.TRAVERSAL_STATE_BUDGET_REACHED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.TRAVERSAL_STATE_BUDGET_REACHED,
+            ),
         )
         "timeout" -> KastImplementationsDegradedResponse(
-            selector,
-            subject,
-            KastImplementationsDegradedReason.TIMEOUT,
+            selector = selector,
+            subject = subject,
+            reason = KastImplementationsDegradedReason.TIMEOUT,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.TIMED_OUT,
+            ),
         )
         else -> throw failure
     }
@@ -1954,39 +2180,71 @@ internal class SkillRpcOrchestrator(
         failure: ConflictException,
     ): KastHierarchyResponse = when (failure.details["continuationFailure"]) {
         "generationChanged" -> KastHierarchyCursorStaleResponse(
-            selector,
-            RelationCursorStaleReason.GENERATION_CHANGED,
+            selector = selector,
+            reason = RelationCursorStaleReason.GENERATION_CHANGED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.GENERATION_CHANGED,
+            ),
         )
         "expired" -> KastHierarchyCursorStaleResponse(
-            selector,
-            RelationCursorStaleReason.EXPIRED,
+            selector = selector,
+            reason = RelationCursorStaleReason.EXPIRED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_EXPIRED,
+            ),
         )
         "familyMismatch" -> KastHierarchyCursorInvalidResponse(
-            selector,
-            RelationCursorInvalidReason.FAMILY_MISMATCH,
+            selector = selector,
+            reason = RelationCursorInvalidReason.FAMILY_MISMATCH,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_INVALID,
+            ),
         )
         "queryMismatch" -> KastHierarchyCursorInvalidResponse(
-            selector,
-            RelationCursorInvalidReason.QUERY_MISMATCH,
+            selector = selector,
+            reason = RelationCursorInvalidReason.QUERY_MISMATCH,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_INVALID,
+            ),
         )
         "unknown" -> KastHierarchyCursorInvalidResponse(
-            selector,
-            RelationCursorInvalidReason.UNKNOWN_HANDLE,
+            selector = selector,
+            reason = RelationCursorInvalidReason.UNKNOWN_HANDLE,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CONTINUATION_INVALID,
+            ),
         )
         "candidateBudgetReached" -> KastHierarchyDegradedResponse(
-            selector,
-            subject,
-            KastHierarchyDegradedReason.CANDIDATE_BUDGET_REACHED,
+            selector = selector,
+            subject = subject,
+            reason = KastHierarchyDegradedReason.CANDIDATE_BUDGET_REACHED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.CANDIDATE_BUDGET_REACHED,
+            ),
         )
         "traversalStateBudgetReached" -> KastHierarchyDegradedResponse(
-            selector,
-            subject,
-            KastHierarchyDegradedReason.TRAVERSAL_STATE_BUDGET_REACHED,
+            selector = selector,
+            subject = subject,
+            reason = KastHierarchyDegradedReason.TRAVERSAL_STATE_BUDGET_REACHED,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.TRAVERSAL_STATE_BUDGET_REACHED,
+            ),
         )
         "timeout" -> KastHierarchyDegradedResponse(
-            selector,
-            subject,
-            KastHierarchyDegradedReason.TIMEOUT,
+            selector = selector,
+            subject = subject,
+            reason = KastHierarchyDegradedReason.TIMEOUT,
+            evidence = limitedRelationshipEvidence(
+                0,
+                RelationshipSearchLimitation.TIMED_OUT,
+            ),
         )
         else -> throw failure
     }

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/AnalysisDispatcherTest.kt
@@ -51,6 +51,9 @@ import io.github.amichne.kast.api.contract.result.SemanticAdmissionStatus
 import io.github.amichne.kast.api.contract.query.ReferencesQuery
 import io.github.amichne.kast.api.contract.result.ReferencesResult
 import io.github.amichne.kast.api.contract.result.RelationTraversalPageInfo
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
+import io.github.amichne.kast.api.contract.result.RelationshipSearchLimitation
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.selector.SelectorHandleAuthority
 import io.github.amichne.kast.api.contract.selector.SelectorOperationFamily
@@ -92,11 +95,13 @@ import io.github.amichne.kast.testing.AnalysisBackendContractFixture
 import io.github.amichne.kast.testing.FakeAnalysisBackend
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -569,6 +574,11 @@ class AnalysisDispatcherTest {
 
         val degraded = assertInstanceOf(KastCallersDegradedResponse::class.java, result)
         assertEquals(KastCallDegradedReason.CALL_HIERARCHY_UNAVAILABLE, degraded.reason)
+        assertEquals(ResultCardinality.KnownMinimum(0), degraded.evidence.cardinality)
+        assertEquals(
+            listOf(RelationshipSearchLimitation.BACKEND_UNAVAILABLE),
+            degraded.evidence.coverage.limitations,
+        )
         assertEquals(0, backend.callRelationCalls)
     }
 
@@ -627,7 +637,95 @@ class AnalysisDispatcherTest {
 
         val degraded = assertInstanceOf(KastHierarchyDegradedResponse::class.java, result)
         assertEquals(KastHierarchyDegradedReason.CANDIDATE_BUDGET_REACHED, degraded.reason)
+        assertEquals(ResultCardinality.KnownMinimum(0), degraded.evidence.cardinality)
+        assertEquals(
+            listOf(RelationshipSearchLimitation.CANDIDATE_BUDGET_REACHED),
+            degraded.evidence.coverage.limitations,
+        )
         assertEquals(1, backend.hierarchyRelationCalls)
+    }
+
+    @Test
+    fun `relationship provider timeouts return typed zero-work evidence`() {
+        assertRelationshipInterruption(
+            mode = RelationshipInterruptionMode.TIMEOUT,
+            expectedReason = "TIMEOUT",
+            expectedLimitation = RelationshipSearchLimitation.TIMED_OUT,
+        )
+    }
+
+    @Test
+    fun `relationship provider cancellation returns typed zero-work evidence`() {
+        assertRelationshipInterruption(
+            mode = RelationshipInterruptionMode.CANCELLED,
+            expectedReason = "CANCELLED",
+            expectedLimitation = RelationshipSearchLimitation.CANCELLED,
+        )
+    }
+
+    private fun assertRelationshipInterruption(
+        mode: RelationshipInterruptionMode,
+        expectedReason: String,
+        expectedLimitation: RelationshipSearchLimitation,
+    ) {
+        val function = lookupSymbol("sample.Service.run", SymbolKind.FUNCTION, "Service.kt")
+        val type = lookupSymbol("sample.Service", SymbolKind.CLASS, "Service.kt", startOffset = 40)
+        val backend = InterruptingRelationshipsBackend(
+            delegate = ExactLookupBackend(
+                delegate = FakeAnalysisBackend.sample(tempDir),
+                symbols = listOf(function, type),
+            ),
+            mode = mode,
+        )
+        val requests = listOf(
+            "symbol/references" to json.encodeToJsonElement(
+                KastReferencesRequest.serializer(),
+                KastReferencesRequest(tempDir.toString(), selector = function.exactSelector()),
+            ),
+            "symbol/callers" to json.encodeToJsonElement(
+                KastCallersRequest.serializer(),
+                KastCallersRequest(tempDir.toString(), selector = function.exactSelector()),
+            ),
+            "symbol/implementations" to json.encodeToJsonElement(
+                KastImplementationsRequest.serializer(),
+                KastImplementationsRequest(tempDir.toString(), selector = type.exactSelector()),
+            ),
+            "symbol/hierarchy" to json.encodeToJsonElement(
+                KastHierarchyRequest.serializer(),
+                KastHierarchyRequest(
+                    workspaceRoot = tempDir.toString(),
+                    selector = type.exactSelector(),
+                    direction = TypeHierarchyDirection.BOTH,
+                ),
+            ),
+        )
+        val dispatcher = RpcAnalysisDispatcher(backend, AnalysisServerConfig())
+
+        requests.forEachIndexed { index, (method, params) ->
+            val raw = runBlocking {
+                dispatcher.dispatch(
+                    JsonRpcRequest(
+                        method = method,
+                        params = params,
+                        id = JsonPrimitive(index + 1),
+                    ),
+                )
+            }
+            assertTrue("result" in json.parseToJsonElement(raw).jsonObject, raw)
+            val success = json.decodeFromString(JsonRpcSuccessResponse.serializer(), raw)
+            val result = success.result.jsonObject
+            val evidence = checkNotNull(result["evidence"]).jsonObject
+            val cardinality = checkNotNull(evidence["cardinality"]).jsonObject
+            val coverage = checkNotNull(evidence["coverage"]).jsonObject
+            val limitations = checkNotNull(coverage["limitations"]).jsonArray
+                .map { limitation -> (limitation as JsonPrimitive).content }
+
+            assertEquals("DEGRADED", (result["type"] as JsonPrimitive).content, method)
+            assertEquals(expectedReason, (result["reason"] as JsonPrimitive).content, method)
+            assertEquals("KNOWN_MINIMUM", (cardinality["type"] as JsonPrimitive).content, method)
+            assertEquals("0", (cardinality["knownMinimumCount"] as JsonPrimitive).content, method)
+            assertTrue(expectedLimitation.name in limitations, "$method: $limitations")
+        }
     }
 
     @Test
@@ -878,7 +976,7 @@ class AnalysisDispatcherTest {
         )
 
         val firstPage = assertInstanceOf(KastReferencesAvailableResponse::class.java, firstResult)
-        assertEquals(ResultCardinality.Exact(2), firstPage.cardinality)
+        assertEquals(ResultCardinality.KnownMinimum(2), firstPage.cardinality)
         assertEquals(1, firstPage.references.size)
         assertTrue(checkNotNull(firstPage.page).truncated)
         assertTrue(firstPage.page?.nextPageToken != null)
@@ -2323,6 +2421,34 @@ private class DispatcherCancellationHealthBackend(
     override suspend fun health() = throw CancellationException("backend cancelled")
 }
 
+private enum class RelationshipInterruptionMode {
+    TIMEOUT,
+    CANCELLED,
+}
+
+private class InterruptingRelationshipsBackend(
+    private val delegate: AnalysisBackend,
+    private val mode: RelationshipInterruptionMode,
+) : AnalysisBackend by delegate {
+    override suspend fun findReferences(query: ParsedReferencesQuery): ReferencesResult = interrupt()
+
+    override suspend fun callRelations(query: KastCallersQuery): CallRelationsResult = interrupt()
+
+    override suspend fun implementationRelations(
+        query: KastImplementationsQuery,
+    ): ImplementationRelationsResult = interrupt()
+
+    override suspend fun hierarchyRelations(query: KastHierarchyQuery): HierarchyRelationsResult = interrupt()
+
+    private suspend fun interrupt(): Nothing = when (mode) {
+        RelationshipInterruptionMode.TIMEOUT -> withTimeout(1) {
+            delay(100)
+            error("Relationship provider timeout was not enforced")
+        }
+        RelationshipInterruptionMode.CANCELLED -> throw CancellationException("Relationship provider cancelled")
+    }
+}
+
 private class CapturingApplyEditsBackend(
     private val delegate: AnalysisBackend,
 ) : AnalysisBackend by delegate {
@@ -2527,24 +2653,27 @@ private class RecordingPagedRelationshipsBackend(
 
     override suspend fun callRelations(query: KastCallersQuery): CallRelationsResult {
         callRelationCalls += 1
-        return CallRelationsResult(emptyList(), emptyRelationPage())
+        return CallRelationsResult.Available(emptyList(), emptyRelationPage())
     }
 
     override suspend fun implementationRelations(
         query: KastImplementationsQuery,
     ): ImplementationRelationsResult {
         implementationRelationCalls += 1
-        return ImplementationRelationsResult(emptyList(), emptyRelationPage())
+        return ImplementationRelationsResult.Available(emptyList(), emptyRelationPage())
     }
 
     override suspend fun hierarchyRelations(query: KastHierarchyQuery): HierarchyRelationsResult {
         hierarchyRelationCalls += 1
         hierarchyFailure?.let { throw it }
-        return HierarchyRelationsResult(emptyList(), emptyRelationPage())
+        return HierarchyRelationsResult.Available(emptyList(), emptyRelationPage())
     }
 
     private fun emptyRelationPage(): RelationTraversalPageInfo = RelationTraversalPageInfo.create(
-        cardinality = ResultCardinality.Exact(0),
+        evidence = RelationshipResultEvidence.Complete(
+            cardinality = ResultCardinality.Exact(0),
+            coverage = RelationshipSearchCoverage.complete(),
+        ),
         returnedCount = 0,
         returnedBefore = 0,
         visitedCandidateCount = 0,

--- a/backend-idea/src/main/java/io/github/amichne/kast/idea/IdeaGradleProjectLoadBridge.java
+++ b/backend-idea/src/main/java/io/github/amichne/kast/idea/IdeaGradleProjectLoadBridge.java
@@ -2,10 +2,12 @@ package io.github.amichne.kast.idea;
 
 import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder;
 import com.intellij.openapi.externalSystem.model.DataNode;
+import com.intellij.openapi.externalSystem.model.ExternalProjectInfo;
 import com.intellij.openapi.externalSystem.model.ProjectKeys;
 import com.intellij.openapi.externalSystem.model.project.ContentRootData;
 import com.intellij.openapi.externalSystem.model.project.ExternalSystemSourceType;
 import com.intellij.openapi.externalSystem.model.project.ModuleData;
+import com.intellij.openapi.externalSystem.service.project.ProjectDataManager;
 import com.intellij.openapi.externalSystem.service.execution.ProgressExecutionMode;
 import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
 import com.intellij.openapi.project.Project;
@@ -68,10 +70,56 @@ public final class IdeaGradleProjectLoadBridge {
         List<Path> roots = linkedBuildRoots.stream()
             .sorted(Comparator.comparing(Path::toString))
             .toList();
+        LinkedHashSet<GradleModuleIdentity> importedModuleIdentities = new LinkedHashSet<>();
+        LinkedHashSet<Path> importedSourceRoots = new LinkedHashSet<>();
+        boolean[] importedModelComplete = {
+            !ProjectDataManager.getInstance().getExternalProjectsData(project, GradleConstants.SYSTEM_ID).isEmpty()
+        };
+        for (ExternalProjectInfo projectInfo :
+            ProjectDataManager.getInstance().getExternalProjectsData(project, GradleConstants.SYSTEM_ID)) {
+            DataNode<?> projectStructure = projectInfo.getExternalProjectStructure();
+            if (projectStructure == null || !projectStructure.isReady()) {
+                importedModelComplete[0] = false;
+                continue;
+            }
+            if (projectInfo.getLastSuccessfulImportTimestamp() <= 0 ||
+                projectInfo.getLastSuccessfulImportTimestamp() < projectInfo.getLastImportTimestamp()) {
+                importedModelComplete[0] = false;
+            }
+            projectStructure.visit(node -> {
+                if (!(node.getData() instanceof ModuleData moduleData)) {
+                    return;
+                }
+                GradleModuleIdentity identity = moduleIdentity(moduleData);
+                if (identity == null) {
+                    importedModelComplete[0] = false;
+                } else {
+                    importedModuleIdentities.add(identity);
+                }
+                collectModuleSourceRoots(node, importedSourceRoots);
+            });
+        }
+
+        List<LoadedGradleModule> loadedModules = new ArrayList<>();
         List<GradleModuleAssociation> associations = new ArrayList<>();
         for (Module module : ModuleManager.getInstance(project).getModules()) {
+            if (module.isDisposed()) {
+                continue;
+            }
+            DataNode<? extends ModuleData> moduleNode = GradleModuleDataIndex.findModuleNode(module);
+            if (moduleNode != null) {
+                GradleModuleIdentity identity = moduleIdentity(moduleNode.getData());
+                if (identity == null) {
+                    importedModelComplete[0] = false;
+                } else {
+                    loadedModules.add(new LoadedGradleModule(
+                        module.getName(),
+                        identity
+                    ));
+                }
+            }
             GradleModuleData gradleModuleData = GradleModuleDataIndex.findGradleModuleData(module);
-            if (gradleModuleData == null) {
+            if (gradleModuleData == null || moduleNode == null) {
                 continue;
             }
             String gradleProjectDirectory = gradleModuleData.getGradleProjectDir();
@@ -96,22 +144,39 @@ public final class IdeaGradleProjectLoadBridge {
                 gradleProjectPath,
                 gradleProjectPath.equals(":") && projectDirectory.equals(linkedBuildRoot),
                 gradleModuleData.isIncludedBuild(),
-                sourceSets(module)
+                sourceSets(moduleNode)
             ));
         }
+        loadedModules.sort(
+            Comparator.comparing(LoadedGradleModule::ideaModuleName)
+                .thenComparing(module -> module.identity().externalProjectPath().toString())
+                .thenComparing(module -> module.identity().externalModuleId())
+        );
         associations.sort(
             Comparator.comparing(GradleModuleAssociation::ideaModuleName)
                 .thenComparing(association -> association.linkedBuildRoot().toString())
                 .thenComparing(GradleModuleAssociation::gradleProjectPath)
         );
-        return new GradleWorkspaceModel(List.copyOf(roots), List.copyOf(associations));
+        List<GradleModuleIdentity> importedModules = importedModuleIdentities.stream()
+            .sorted(
+                Comparator.comparing((GradleModuleIdentity identity) -> identity.externalProjectPath().toString())
+                    .thenComparing(GradleModuleIdentity::externalModuleId)
+            )
+            .toList();
+        List<Path> sourceRoots = importedSourceRoots.stream()
+            .sorted(Comparator.comparing(Path::toString))
+            .toList();
+        return new GradleWorkspaceModel(
+            List.copyOf(roots),
+            importedModelComplete[0],
+            importedModules,
+            List.copyOf(loadedModules),
+            sourceRoots,
+            List.copyOf(associations)
+        );
     }
 
-    private static List<GradleSourceSetAssociation> sourceSets(Module module) {
-        DataNode<? extends ModuleData> moduleNode = GradleModuleDataIndex.findModuleNode(module);
-        if (moduleNode == null) {
-            return List.of();
-        }
+    private static List<GradleSourceSetAssociation> sourceSets(DataNode<? extends ModuleData> moduleNode) {
         List<GradleSourceSetAssociation> sourceSets = new ArrayList<>();
         moduleNode.visit(node -> {
             if (!(node.getData() instanceof GradleSourceSetData sourceSetData)) {
@@ -133,9 +198,40 @@ public final class IdeaGradleProjectLoadBridge {
             .toList();
     }
 
+    private static GradleModuleIdentity moduleIdentity(ModuleData moduleData) {
+        String externalProjectPath = moduleData.getLinkedExternalProjectPath();
+        String externalModuleId = moduleData.getId();
+        if (externalProjectPath == null || externalProjectPath.isBlank() ||
+            externalModuleId == null || externalModuleId.isBlank()) {
+            return null;
+        }
+        return new GradleModuleIdentity(normalize(Path.of(externalProjectPath)), externalModuleId);
+    }
+
+    private static void collectModuleSourceRoots(DataNode<?> node, LinkedHashSet<Path> sourceRoots) {
+        for (DataNode<?> child : node.getChildren()) {
+            if (child.getData() instanceof ModuleData) {
+                continue;
+            }
+            if (child.getKey().equals(ProjectKeys.CONTENT_ROOT) && child.getData() instanceof ContentRootData contentRoot) {
+                for (ExternalSystemSourceType sourceType : ExternalSystemSourceType.values()) {
+                    if (sourceType.isExcluded() || sourceType.isResource()) {
+                        continue;
+                    }
+                    contentRoot.getPaths(sourceType).stream()
+                        .map(ContentRootData.SourceRoot::getPath)
+                        .map(Path::of)
+                        .map(IdeaGradleProjectLoadBridge::normalize)
+                        .forEach(sourceRoots::add);
+                }
+            }
+            collectModuleSourceRoots(child, sourceRoots);
+        }
+    }
+
     private static void collectSourceRoots(DataNode<?> node, LinkedHashSet<Path> sourceRoots) {
         for (DataNode<?> child : node.getChildren()) {
-            if (child.getKey().equals(GradleSourceSetData.KEY)) {
+            if (child.getData() instanceof ModuleData) {
                 continue;
             }
             if (child.getKey().equals(ProjectKeys.CONTENT_ROOT) && child.getData() instanceof ContentRootData contentRoot) {
@@ -197,7 +293,23 @@ public final class IdeaGradleProjectLoadBridge {
 
     public record GradleWorkspaceModel(
         List<Path> linkedBuildRoots,
+        boolean importedModelComplete,
+        List<GradleModuleIdentity> importedModuleIdentities,
+        List<LoadedGradleModule> loadedModules,
+        List<Path> importedSourceRoots,
         List<GradleModuleAssociation> moduleAssociations
+    ) {
+    }
+
+    public record GradleModuleIdentity(
+        Path externalProjectPath,
+        String externalModuleId
+    ) {
+    }
+
+    public record LoadedGradleModule(
+        String ideaModuleName,
+        GradleModuleIdentity identity
     ) {
     }
 

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaRelationshipCoverageAuthority.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/IdeaRelationshipCoverageAuthority.kt
@@ -1,0 +1,134 @@
+package io.github.amichne.kast.idea
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
+import io.github.amichne.kast.api.contract.result.RelationshipSearchLimitation
+import org.jetbrains.jps.model.java.JavaModuleSourceRootTypes
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal class IdeaRelationshipCoverageAuthority(
+    private val project: Project,
+    private val workspaceIdentity: IdeaWorkspaceIdentity,
+    private val indexSemanticAdmissionStatus: () -> IdeaIndexSemanticAdmission.Status,
+    private val workspaceModelReader: () -> IdeaGradleProjectLoadBridge.GradleWorkspaceModel = {
+        IdeaGradleProjectLoadBridge.readWorkspaceModel(project)
+    },
+) : RelationshipCoverageAuthority {
+    override fun assess(
+        completion: RelationshipCoverageAuthority.FamilyCompletion,
+    ): RelationshipSearchCoverage = ApplicationManager.getApplication().runReadAction<RelationshipSearchCoverage> {
+        val limitations = linkedSetOf<RelationshipSearchLimitation>()
+        if (project.isDisposed) {
+            return@runReadAction RelationshipSearchCoverage.limited(
+                RelationshipSearchLimitation.BACKEND_UNAVAILABLE,
+                RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+            )
+        }
+        if (DumbService.isDumb(project)) {
+            limitations += RelationshipSearchLimitation.INDEX_NOT_READY
+        }
+        when (indexSemanticAdmissionStatus()) {
+            IdeaIndexSemanticAdmission.Status.Ready -> Unit
+            is IdeaIndexSemanticAdmission.Status.Pending ->
+                limitations += RelationshipSearchLimitation.INDEX_NOT_READY
+            is IdeaIndexSemanticAdmission.Status.Failed ->
+                limitations += RelationshipSearchLimitation.BACKEND_INCOMPLETE
+        }
+
+        val workspace = workspaceIdentity.workspaceIdentity
+        val modules = ModuleManager.getInstance(project).modules
+            .filterNot { module -> module.isDisposed }
+        val codeSourceRootsByModule = modules.associateWith { module ->
+            ModuleRootManager.getInstance(module).getSourceRoots(JavaModuleSourceRootTypes.SOURCES)
+        }
+        val sourceModules = modules.filter { module -> codeSourceRootsByModule.getValue(module).isNotEmpty() }
+        val gradleModel = workspaceModelReader()
+        val linkedRoots = gradleModel.linkedBuildRoots()
+            .map(Path::toAbsolutePath)
+            .map(Path::normalize)
+            .toSet()
+        val importedModuleIdentities = gradleModel.importedModuleIdentities().toSet()
+        val loadedModules = gradleModel.loadedModules()
+        val loadedModuleIdentities = loadedModules.mapTo(linkedSetOf()) { loaded -> loaded.identity() }
+
+        if (
+            sourceModules.isEmpty() ||
+            linkedRoots.isEmpty() ||
+            !gradleModel.importedModelComplete() ||
+            importedModuleIdentities.isEmpty() ||
+            loadedModuleIdentities != importedModuleIdentities
+        ) {
+            limitations += RelationshipSearchLimitation.PROJECT_SCOPE_INCOMPLETE
+        }
+        if (linkedRoots.any { root -> !workspace.contains(root) }) {
+            limitations += RelationshipSearchLimitation.SOURCE_SET_EXCLUDED
+        }
+        if (
+            importedModuleIdentities.any { identity ->
+                val externalProjectPath = identity.externalProjectPath().toAbsolutePath().normalize()
+                linkedRoots.none { root ->
+                    externalProjectPath == root || externalProjectPath.startsWith(root)
+                }
+            } ||
+            linkedRoots.any { root ->
+                importedModuleIdentities.none { identity ->
+                    val externalProjectPath = identity.externalProjectPath().toAbsolutePath().normalize()
+                    externalProjectPath == root || externalProjectPath.startsWith(root)
+                }
+            }
+        ) {
+            limitations += RelationshipSearchLimitation.PROJECT_SCOPE_INCOMPLETE
+        }
+
+        val associatedModuleNames = loadedModules.mapTo(linkedSetOf()) { loaded ->
+            loaded.ideaModuleName()
+        }
+        if (sourceModules.any { module -> module.name !in associatedModuleNames }) {
+            limitations += RelationshipSearchLimitation.PROJECT_SCOPE_INCOMPLETE
+        }
+
+        val modelSourceRoots = gradleModel.importedSourceRoots()
+            .map(Path::toAbsolutePath)
+            .map(Path::normalize)
+            .filter(Files::isDirectory)
+            .toSet()
+        if (modelSourceRoots.isEmpty()) {
+            limitations += RelationshipSearchLimitation.SOURCE_SET_SCOPE_INCOMPLETE
+        }
+        if (modelSourceRoots.any { root -> !workspace.contains(root) }) {
+            limitations += RelationshipSearchLimitation.SOURCE_SET_EXCLUDED
+        }
+
+        val ideaSourceRoots = sourceModules
+            .flatMap { module -> codeSourceRootsByModule.getValue(module) }
+            .map { root -> Path.of(root.path).toAbsolutePath().normalize() }
+            .toSet()
+        if (ideaSourceRoots.any { root -> !workspace.contains(root) }) {
+            limitations += RelationshipSearchLimitation.SOURCE_SET_EXCLUDED
+        }
+        if (ideaSourceRoots != modelSourceRoots) {
+            limitations += RelationshipSearchLimitation.SOURCE_SET_SCOPE_INCOMPLETE
+        }
+
+        if (limitations.isNotEmpty()) {
+            return@runReadAction RelationshipSearchCoverage.Limited.from(
+                limitations + RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+            )
+        }
+        when (completion) {
+            RelationshipCoverageAuthority.FamilyCompletion.COMPLETE ->
+                RelationshipSearchCoverage.complete()
+            RelationshipCoverageAuthority.FamilyCompletion.RESUMABLE ->
+                RelationshipSearchCoverage.resumable()
+            RelationshipCoverageAuthority.FamilyCompletion.INCOMPLETE ->
+                RelationshipSearchCoverage.limited(
+                    RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+                )
+        }
+    }
+}

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastPluginBackend.kt
@@ -79,6 +79,9 @@ import io.github.amichne.kast.api.contract.result.ReferencesResult
 import io.github.amichne.kast.api.contract.result.ContainingSymbolEvidence
 import io.github.amichne.kast.api.contract.result.ContainingSymbolUnavailableReason
 import io.github.amichne.kast.api.contract.result.ReferenceOccurrence
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
+import io.github.amichne.kast.api.contract.result.RelationshipSearchLimitation
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.result.RefreshResult
 import io.github.amichne.kast.api.contract.result.SemanticAdmissionStatus
@@ -99,6 +102,7 @@ import io.github.amichne.kast.api.contract.result.TypeHierarchyRelation
 import io.github.amichne.kast.api.contract.result.RelationTraversalFamily
 import io.github.amichne.kast.api.contract.result.RelationTraversalHandle
 import io.github.amichne.kast.api.contract.skill.KastCallersQuery
+import io.github.amichne.kast.api.contract.skill.KastExactSymbolSelector
 import io.github.amichne.kast.api.contract.skill.KastHierarchyQuery
 import io.github.amichne.kast.api.contract.skill.KastImplementationsQuery
 import io.github.amichne.kast.api.contract.result.WorkspaceFilesResult
@@ -170,6 +174,12 @@ internal class KastPluginBackend(
     private val indexSemanticAdmissionStatus: () -> IdeaIndexSemanticAdmission.Status = {
         IdeaIndexSemanticAdmission.Status.Ready
     },
+    private val relationshipCoverageAuthority: RelationshipCoverageAuthority =
+        IdeaRelationshipCoverageAuthority(
+            project = project,
+            workspaceIdentity = workspaceIdentity,
+            indexSemanticAdmissionStatus = indexSemanticAdmissionStatus,
+        ),
 ) : CloseableAnalysisBackend {
 
     private val readDispatcher = Dispatchers.Default.limitedParallelism(limits.maxConcurrentRequests)
@@ -355,8 +365,10 @@ internal class KastPluginBackend(
                     query = identity,
                     transition = ContinuationStateTransition { state ->
                         val page = referenceContinuationPage(query, state, span)
-                        page.outcome.nextPosition?.let { nextPosition ->
-                            state.advanceTo(page.knownCount, nextPosition)
+                        val nextPosition = page.outcome.nextPosition
+                            ?.takeIf { page.outcome.completion is ReferenceSearchCompletion.Exhaustive }
+                        nextPosition?.let {
+                            state.advanceTo(page.knownCount, it)
                             ContinuationTransition.Reissue(page, identity)
                         } ?: ContinuationTransition.Complete(page)
                     },
@@ -384,7 +396,9 @@ internal class KastPluginBackend(
                     ?: ideaReferenceSearch(query, plan, null, span)
                 val knownCount = outcome.references.size
                 val page = ReferenceContinuationProjection(plan, outcome, knownCount)
-                val token = outcome.nextPosition?.let { nextPosition ->
+                val token = outcome.nextPosition
+                    ?.takeIf { outcome.completion is ReferenceSearchCompletion.Exhaustive }
+                    ?.let { nextPosition ->
                     when (val issued = referenceContinuations.issue(
                         query = identity,
                         state = ReferenceContinuationState(
@@ -404,10 +418,19 @@ internal class KastPluginBackend(
             }
             val plan = projection.plan
             val outcome = projection.outcome
-            val cardinality = if (outcome.hasMoreEvidence || !outcome.completion.exhaustive) {
-                ResultCardinality.KnownMinimum(projection.knownCount)
-            } else {
-                ResultCardinality.Exact(projection.knownCount)
+            val evidence = when (val completion = outcome.completion) {
+                ReferenceSearchCompletion.Exhaustive -> relationshipEvidence(
+                    completion = if (outcome.hasMoreEvidence) {
+                        RelationshipCoverageAuthority.FamilyCompletion.RESUMABLE
+                    } else {
+                        RelationshipCoverageAuthority.FamilyCompletion.COMPLETE
+                    },
+                    knownMinimumCount = projection.knownCount,
+                )
+                is ReferenceSearchCompletion.Partial -> limitedReferenceEvidence(
+                    knownMinimumCount = projection.knownCount,
+                    reason = completion.reason,
+                )
             }
             val page = nextPageToken?.let { token ->
                 PageInfo(
@@ -423,7 +446,7 @@ internal class KastPluginBackend(
             span.setAttribute("kast.references.searchedFileCount", outcome.searchedFileCount)
             span.setAttribute("kast.references.evidenceCount", outcome.consumedEvidence)
             span.setAttribute("kast.references.observedEvidenceCount", outcome.observedEvidence)
-            span.setAttribute("kast.references.knownMinimumCount", cardinality.knownMinimum())
+            span.setAttribute("kast.references.knownMinimumCount", evidence.cardinality.knownMinimum())
             span.setAttribute("kast.references.resultCount", outcome.references.size)
             span.setAttribute("kast.references.exhaustive", outcome.completion.exhaustive)
             span.setAttribute("kast.references.partialReason", outcome.completion.partialReason)
@@ -431,7 +454,7 @@ internal class KastPluginBackend(
             ReferencesResult(
                 declaration = plan.declaration,
                 references = outcome.references,
-                cardinality = cardinality,
+                evidence = evidence,
                 page = page,
                 searchScope = SearchScope(
                     visibility = plan.visibility,
@@ -831,11 +854,6 @@ internal class KastPluginBackend(
                             break
                         }
                         if (currentFile == null) {
-                            if (!activePosition.traversal.exhausted && pathProbes >= REFERENCE_DISCOVERY_PATH_LIMIT) {
-                                completion = ReferenceSearchCompletion.Partial(
-                                    ReferencePartialReason.PATH_BUDGET_EXHAUSTED,
-                                )
-                            }
                             break
                         }
                     }
@@ -1099,6 +1117,18 @@ internal class KastPluginBackend(
                 depth = query.depth,
                 limit = query.maxResults,
             )
+            val initialAdmission = timedReadAction(
+                telemetry,
+                IdeaTelemetryScope.CALL_HIERARCHY,
+                "kast.idea.callRelations.admit",
+            ) {
+                completeRelationshipCoverageAdmission(query.selector, RelationshipRootKind.CALLABLE)
+            }
+            val generation = when (initialAdmission) {
+                is CompleteRelationshipCoverageAdmission.Proven -> initialAdmission.generation
+                is CompleteRelationshipCoverageAdmission.Limited ->
+                    return@withContext CallRelationsResult.Limited(initialAdmission.evidence)
+            }
             val handle = query.pageToken?.let(RelationTraversalHandle::parse)
             if (handle != null) {
                 return@withContext timedReadAction(
@@ -1106,15 +1136,25 @@ internal class KastPluginBackend(
                     IdeaTelemetryScope.CALL_HIERARCHY,
                     "kast.idea.callRelations.continue",
                 ) {
-                    relationshipContinuations.calls(
-                        continuationQuery,
-                        handle,
-                        null,
-                        psiGeneration(),
-                    )
+                    when (
+                        val commit = completeRelationshipCoverageAdmission(
+                            query.selector,
+                            RelationshipRootKind.CALLABLE,
+                        )
+                    ) {
+                        is CompleteRelationshipCoverageAdmission.Limited ->
+                            CallRelationsResult.Limited(commit.evidence)
+                        is CompleteRelationshipCoverageAdmission.Proven ->
+                            relationshipContinuations.calls(
+                                continuationQuery,
+                                handle,
+                                null,
+                                commit.generation,
+                                commit.coverage,
+                            )
+                    }
                 }
             }
-            val generation = psiGeneration()
             val direction = when (query.direction) {
                 io.github.amichne.kast.api.contract.skill.WrapperCallDirection.INCOMING ->
                     io.github.amichne.kast.api.contract.CallDirection.INCOMING
@@ -1150,13 +1190,24 @@ internal class KastPluginBackend(
                 IdeaTelemetryScope.CALL_HIERARCHY,
                 "kast.idea.callRelations.commit",
             ) {
-                if (psiGeneration() != generation) throw continuationConflict("generationChanged")
-                relationshipContinuations.calls(
-                    continuationQuery,
-                    null,
-                    records,
-                    generation,
-                )
+                when (
+                    val commit = completeRelationshipCoverageAdmission(
+                        query.selector,
+                        RelationshipRootKind.CALLABLE,
+                        requiredGeneration = generation,
+                    )
+                ) {
+                    is CompleteRelationshipCoverageAdmission.Limited ->
+                        CallRelationsResult.Limited(commit.evidence)
+                    is CompleteRelationshipCoverageAdmission.Proven ->
+                        relationshipContinuations.calls(
+                            continuationQuery,
+                            null,
+                            records,
+                            commit.generation,
+                            commit.coverage,
+                        )
+                }
             }
         }
 
@@ -1190,6 +1241,18 @@ internal class KastPluginBackend(
                 depth = query.depth,
                 limit = query.maxResults,
             )
+            val initialAdmission = timedReadAction(
+                telemetry,
+                IdeaTelemetryScope.TYPE_HIERARCHY,
+                "kast.idea.hierarchyRelations.admit",
+            ) {
+                completeRelationshipCoverageAdmission(query.selector, RelationshipRootKind.TYPE)
+            }
+            val generation = when (initialAdmission) {
+                is CompleteRelationshipCoverageAdmission.Proven -> initialAdmission.generation
+                is CompleteRelationshipCoverageAdmission.Limited ->
+                    return@withContext HierarchyRelationsResult.Limited(initialAdmission.evidence)
+            }
             val handle = query.pageToken?.let(RelationTraversalHandle::parse)
             if (handle != null) {
                 return@withContext timedReadAction(
@@ -1197,15 +1260,25 @@ internal class KastPluginBackend(
                     IdeaTelemetryScope.TYPE_HIERARCHY,
                     "kast.idea.hierarchyRelations.continue",
                 ) {
-                    relationshipContinuations.hierarchy(
-                        continuationQuery,
-                        handle,
-                        null,
-                        psiGeneration(),
-                    )
+                    when (
+                        val commit = completeRelationshipCoverageAdmission(
+                            query.selector,
+                            RelationshipRootKind.TYPE,
+                        )
+                    ) {
+                        is CompleteRelationshipCoverageAdmission.Limited ->
+                            HierarchyRelationsResult.Limited(commit.evidence)
+                        is CompleteRelationshipCoverageAdmission.Proven ->
+                            relationshipContinuations.hierarchy(
+                                continuationQuery,
+                                handle,
+                                null,
+                                commit.generation,
+                                commit.coverage,
+                            )
+                    }
                 }
             }
-            val generation = psiGeneration()
             val directions = when (query.direction) {
                 io.github.amichne.kast.api.contract.TypeHierarchyDirection.SUPERTYPES ->
                     listOf(io.github.amichne.kast.api.contract.TypeHierarchyDirection.SUPERTYPES)
@@ -1248,13 +1321,24 @@ internal class KastPluginBackend(
                 IdeaTelemetryScope.TYPE_HIERARCHY,
                 "kast.idea.hierarchyRelations.commit",
             ) {
-                if (psiGeneration() != generation) throw continuationConflict("generationChanged")
-                relationshipContinuations.hierarchy(
-                    continuationQuery,
-                    null,
-                    records,
-                    generation,
-                )
+                when (
+                    val commit = completeRelationshipCoverageAdmission(
+                        query.selector,
+                        RelationshipRootKind.TYPE,
+                        requiredGeneration = generation,
+                    )
+                ) {
+                    is CompleteRelationshipCoverageAdmission.Limited ->
+                        HierarchyRelationsResult.Limited(commit.evidence)
+                    is CompleteRelationshipCoverageAdmission.Proven ->
+                        relationshipContinuations.hierarchy(
+                            continuationQuery,
+                            null,
+                            records,
+                            commit.generation,
+                            commit.coverage,
+                        )
+                }
             }
         }
 
@@ -1309,6 +1393,18 @@ internal class KastPluginBackend(
             selector = query.selector,
             limit = query.maxResults,
         )
+        val initialAdmission = timedReadAction(
+            telemetry,
+            IdeaTelemetryScope.IMPLEMENTATIONS,
+            "kast.idea.implementationRelations.admit",
+        ) {
+            completeRelationshipCoverageAdmission(query.selector, RelationshipRootKind.TYPE)
+        }
+        val generation = when (initialAdmission) {
+            is CompleteRelationshipCoverageAdmission.Proven -> initialAdmission.generation
+            is CompleteRelationshipCoverageAdmission.Limited ->
+                return@withContext ImplementationRelationsResult.Limited(initialAdmission.evidence)
+        }
         val handle = query.pageToken?.let(RelationTraversalHandle::parse)
         if (handle != null) {
             return@withContext timedReadAction(
@@ -1316,15 +1412,25 @@ internal class KastPluginBackend(
                 IdeaTelemetryScope.IMPLEMENTATIONS,
                 "kast.idea.implementationRelations.continue",
             ) {
-                relationshipContinuations.implementations(
-                    continuationQuery,
-                    handle,
-                    null,
-                    psiGeneration(),
-                )
+                when (
+                    val commit = completeRelationshipCoverageAdmission(
+                        query.selector,
+                        RelationshipRootKind.TYPE,
+                    )
+                ) {
+                    is CompleteRelationshipCoverageAdmission.Limited ->
+                        ImplementationRelationsResult.Limited(commit.evidence)
+                    is CompleteRelationshipCoverageAdmission.Proven ->
+                        relationshipContinuations.implementations(
+                            continuationQuery,
+                            handle,
+                            null,
+                            commit.generation,
+                            commit.coverage,
+                        )
+                }
             }
         }
-        val generation = psiGeneration()
         val result = implementations(
             io.github.amichne.kast.api.contract.query.ImplementationsQuery(
                 position = io.github.amichne.kast.api.contract.FilePosition(
@@ -1349,13 +1455,24 @@ internal class KastPluginBackend(
             IdeaTelemetryScope.IMPLEMENTATIONS,
             "kast.idea.implementationRelations.commit",
         ) {
-            if (psiGeneration() != generation) throw continuationConflict("generationChanged")
-            relationshipContinuations.implementations(
-                continuationQuery,
-                null,
-                records,
-                generation,
-            )
+            when (
+                val commit = completeRelationshipCoverageAdmission(
+                    query.selector,
+                    RelationshipRootKind.TYPE,
+                    requiredGeneration = generation,
+                )
+            ) {
+                is CompleteRelationshipCoverageAdmission.Limited ->
+                    ImplementationRelationsResult.Limited(commit.evidence)
+                is CompleteRelationshipCoverageAdmission.Proven ->
+                    relationshipContinuations.implementations(
+                        continuationQuery,
+                        null,
+                        records,
+                        commit.generation,
+                        commit.coverage,
+                    )
+            }
         }
     }
 
@@ -2233,6 +2350,157 @@ internal class KastPluginBackend(
             containingType = containingDeclaration,
         )
 
+    private fun relationshipEvidence(
+        completion: RelationshipCoverageAuthority.FamilyCompletion,
+        knownMinimumCount: Int,
+    ): RelationshipResultEvidence {
+        val coverage = relationshipCoverageAuthority.assess(completion)
+        return when {
+            completion == RelationshipCoverageAuthority.FamilyCompletion.COMPLETE &&
+                coverage is RelationshipSearchCoverage.Complete -> RelationshipResultEvidence.Complete(
+                cardinality = ResultCardinality.Exact(knownMinimumCount),
+                coverage = coverage,
+            )
+            completion == RelationshipCoverageAuthority.FamilyCompletion.RESUMABLE &&
+                coverage is RelationshipSearchCoverage.Resumable -> RelationshipResultEvidence.Resumable(
+                cardinality = ResultCardinality.KnownMinimum(knownMinimumCount),
+                coverage = coverage,
+            )
+            coverage is RelationshipSearchCoverage.Limited -> RelationshipResultEvidence.Limited(
+                cardinality = ResultCardinality.KnownMinimum(knownMinimumCount),
+                coverage = coverage,
+            )
+            else -> RelationshipResultEvidence.Limited(
+                cardinality = ResultCardinality.KnownMinimum(knownMinimumCount),
+                coverage = RelationshipSearchCoverage.limited(
+                    RelationshipSearchLimitation.BACKEND_INCOMPLETE,
+                    RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+                ),
+            )
+        }
+    }
+
+    private fun limitedReferenceEvidence(
+        knownMinimumCount: Int,
+        reason: ReferencePartialReason,
+    ): RelationshipResultEvidence.Limited {
+        val authorityLimitations = when (
+            val coverage = relationshipCoverageAuthority.assess(
+                RelationshipCoverageAuthority.FamilyCompletion.INCOMPLETE,
+            )
+        ) {
+            is RelationshipSearchCoverage.Limited -> coverage.limitations
+            is RelationshipSearchCoverage.Complete,
+            is RelationshipSearchCoverage.Resumable,
+            -> listOf(RelationshipSearchLimitation.BACKEND_INCOMPLETE)
+        }
+        return RelationshipResultEvidence.Limited(
+            cardinality = ResultCardinality.KnownMinimum(knownMinimumCount),
+            coverage = RelationshipSearchCoverage.Limited.from(
+                authorityLimitations + reason.limitation +
+                    RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+            ),
+        )
+    }
+
+    private fun completeRelationshipCoverageAdmission(
+        selector: KastExactSymbolSelector,
+        rootKind: RelationshipRootKind,
+        requiredGeneration: Long? = null,
+    ): CompleteRelationshipCoverageAdmission {
+        if (requiredGeneration != null && psiGeneration() != requiredGeneration) {
+            return limitedRelationshipCoverageAdmission(RelationshipSearchLimitation.GENERATION_CHANGED)
+        }
+        if (!relationshipSelectorMatches(selector, rootKind)) {
+            return limitedRelationshipCoverageAdmission(RelationshipSearchLimitation.IDENTITY_UNPROVEN)
+        }
+        val coverage = relationshipCoverageAuthority.assess(
+            RelationshipCoverageAuthority.FamilyCompletion.COMPLETE,
+        )
+        val generation = psiGeneration()
+        if (requiredGeneration != null && generation != requiredGeneration) {
+            return limitedRelationshipCoverageAdmission(RelationshipSearchLimitation.GENERATION_CHANGED)
+        }
+        return when (coverage) {
+            is RelationshipSearchCoverage.Complete ->
+                CompleteRelationshipCoverageAdmission.Proven(coverage, generation)
+            is RelationshipSearchCoverage.Limited ->
+                CompleteRelationshipCoverageAdmission.Limited(
+                    RelationshipResultEvidence.Limited(
+                        cardinality = ResultCardinality.KnownMinimum(0),
+                        coverage = coverage,
+                    ),
+                )
+            is RelationshipSearchCoverage.Resumable ->
+                CompleteRelationshipCoverageAdmission.Limited(
+                    RelationshipResultEvidence.Limited(
+                        cardinality = ResultCardinality.KnownMinimum(0),
+                        coverage = RelationshipSearchCoverage.limited(
+                            RelationshipSearchLimitation.BACKEND_INCOMPLETE,
+                            RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+                        ),
+                    ),
+                )
+        }
+    }
+
+    private fun relationshipSelectorMatches(
+        selector: KastExactSymbolSelector,
+        rootKind: RelationshipRootKind,
+    ): Boolean = try {
+        val selectorPath = NormalizedPath.parse(selector.declarationFile)
+        val file = findKtFile(selectorPath.value)
+        val resolved = resolveTarget(file, selector.declarationStartOffset)
+        val target = when (rootKind) {
+            RelationshipRootKind.CALLABLE -> resolved
+            RelationshipRootKind.TYPE -> resolved.typeHierarchyDeclaration() ?: resolved
+        }
+        val symbol = analyze(file) {
+            target.toSymbolModel(
+                containingDeclaration = compilerContainingDeclarationName(target),
+            )
+        }
+        selector.fqName == symbol.fqName &&
+            selectorPath == NormalizedPath.parse(symbol.location.filePath) &&
+            selector.declarationStartOffset == symbol.location.startOffset &&
+            (selector.kind == null || selector.kind == symbol.kind) &&
+            (selector.containingType == null || selector.containingType == symbol.containingDeclaration)
+    } catch (failure: ProcessCanceledException) {
+        throw failure
+    } catch (failure: CancellationException) {
+        throw failure
+    } catch (_: Exception) {
+        false
+    }
+
+    private fun limitedRelationshipCoverageAdmission(
+        limitation: RelationshipSearchLimitation,
+    ): CompleteRelationshipCoverageAdmission.Limited = CompleteRelationshipCoverageAdmission.Limited(
+        RelationshipResultEvidence.Limited(
+            cardinality = ResultCardinality.KnownMinimum(0),
+            coverage = RelationshipSearchCoverage.limited(
+                limitation,
+                RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+            ),
+        ),
+    )
+
+    private enum class RelationshipRootKind {
+        CALLABLE,
+        TYPE,
+    }
+
+    private sealed interface CompleteRelationshipCoverageAdmission {
+        data class Proven(
+            val coverage: RelationshipSearchCoverage.Complete,
+            val generation: Long,
+        ) : CompleteRelationshipCoverageAdmission
+
+        data class Limited(
+            val evidence: RelationshipResultEvidence.Limited,
+        ) : CompleteRelationshipCoverageAdmission
+    }
+
     private fun continuationConflict(reason: String): ConflictException = ConflictException(
         message = "Relationship traversal could not preserve bounded exact evidence",
         details = mapOf("continuationFailure" to reason),
@@ -2467,13 +2735,28 @@ private sealed interface ReferenceSearchCompletion {
 }
 
 private enum class ReferencePartialReason {
-    REQUEST_BUDGET_EXHAUSTED,
-    PATH_BUDGET_EXHAUSTED,
-    PSI_RESOLUTION_FAILED,
-    COMPILER_PROVIDER_LIMIT_EXHAUSTED,
-    FILE_BUDGET_EXHAUSTED,
-    TARGET_INVALIDATED,
-    INDEX_LOCATION_UNRESOLVED,
+    REQUEST_BUDGET_EXHAUSTED {
+        override val limitation: RelationshipSearchLimitation = RelationshipSearchLimitation.TIMED_OUT
+    },
+    PSI_RESOLUTION_FAILED {
+        override val limitation: RelationshipSearchLimitation = RelationshipSearchLimitation.BACKEND_INCOMPLETE
+    },
+    COMPILER_PROVIDER_LIMIT_EXHAUSTED {
+        override val limitation: RelationshipSearchLimitation =
+            RelationshipSearchLimitation.CANDIDATE_BUDGET_REACHED
+    },
+    FILE_BUDGET_EXHAUSTED {
+        override val limitation: RelationshipSearchLimitation = RelationshipSearchLimitation.TIMED_OUT
+    },
+    TARGET_INVALIDATED {
+        override val limitation: RelationshipSearchLimitation = RelationshipSearchLimitation.GENERATION_CHANGED
+    },
+    INDEX_LOCATION_UNRESOLVED {
+        override val limitation: RelationshipSearchLimitation = RelationshipSearchLimitation.INDEX_STALE
+    },
+    ;
+
+    abstract val limitation: RelationshipSearchLimitation
 }
 
 private class ReferenceSearchBudget(

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/RelationshipContinuationStore.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/RelationshipContinuationStore.kt
@@ -19,6 +19,8 @@ import io.github.amichne.kast.api.contract.result.ImplementationRelationsResult
 import io.github.amichne.kast.api.contract.result.RelationTraversalFamily
 import io.github.amichne.kast.api.contract.result.RelationTraversalHandle
 import io.github.amichne.kast.api.contract.result.RelationTraversalPageInfo
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.result.TypeHierarchyRelation
 import io.github.amichne.kast.api.contract.skill.KastExactSymbolSelector
@@ -84,13 +86,14 @@ internal class RelationshipContinuationStore(
         handle: RelationTraversalHandle?,
         initialRecords: List<CallRelation>?,
         generation: Long,
-    ): CallRelationsResult {
+        coverage: RelationshipSearchCoverage.Complete,
+    ): CallRelationsResult.Available {
         val store = when (query.direction) {
             io.github.amichne.kast.api.contract.skill.WrapperCallDirection.INCOMING -> callerStore
             io.github.amichne.kast.api.contract.skill.WrapperCallDirection.OUTGOING -> calleeStore
         }
-        val page = store.page(query, query.limit, handle, initialRecords, generation)
-        return CallRelationsResult(page.records, page.pageInfo)
+        val page = store.page(query, query.limit, handle, initialRecords, generation, coverage)
+        return CallRelationsResult.Available(page.records, page.pageInfo)
     }
 
     fun implementations(
@@ -98,9 +101,10 @@ internal class RelationshipContinuationStore(
         handle: RelationTraversalHandle?,
         initialRecords: List<ImplementationRelation>?,
         generation: Long,
-    ): ImplementationRelationsResult {
-        val page = implementationStore.page(query, query.limit, handle, initialRecords, generation)
-        return ImplementationRelationsResult(page.records, page.pageInfo)
+        coverage: RelationshipSearchCoverage.Complete,
+    ): ImplementationRelationsResult.Available {
+        val page = implementationStore.page(query, query.limit, handle, initialRecords, generation, coverage)
+        return ImplementationRelationsResult.Available(page.records, page.pageInfo)
     }
 
     fun hierarchy(
@@ -108,9 +112,10 @@ internal class RelationshipContinuationStore(
         handle: RelationTraversalHandle?,
         initialRecords: List<TypeHierarchyRelation>?,
         generation: Long,
-    ): HierarchyRelationsResult {
-        val page = hierarchyStore.page(query, query.limit, handle, initialRecords, generation)
-        return HierarchyRelationsResult(page.records, page.pageInfo)
+        coverage: RelationshipSearchCoverage.Complete,
+    ): HierarchyRelationsResult.Available {
+        val page = hierarchyStore.page(query, query.limit, handle, initialRecords, generation, coverage)
+        return HierarchyRelationsResult.Available(page.records, page.pageInfo)
     }
 
     override fun close() {
@@ -155,16 +160,18 @@ internal class RelationshipContinuationStore(
             handle: RelationTraversalHandle?,
             initialRecords: List<Record>?,
             generation: Long,
+            coverage: RelationshipSearchCoverage.Complete,
         ): PublicPage<Record> = if (handle == null) {
             start(
                 query,
                 limit,
                 requireNotNull(initialRecords) { "A first relationship page requires records" },
                 generation,
+                coverage,
             )
         } else {
             require(initialRecords == null) { "A continuation page must not restart provider work" }
-            resume(query, limit, handle, generation)
+            resume(query, limit, handle, generation, coverage)
         }
 
         override fun close() {
@@ -176,6 +183,7 @@ internal class RelationshipContinuationStore(
             limit: Int,
             records: List<Record>,
             generation: Long,
+            coverage: RelationshipSearchCoverage.Complete,
         ): PublicPage<Record> {
             if (records.size > MAX_STATE_RECORDS) {
                 throw traversalStateUnavailable(ContinuationAccessFailure.UnknownToken)
@@ -185,7 +193,7 @@ internal class RelationshipContinuationStore(
             val nextHandle = remaining?.let { rest ->
                 when (val issued = store.issue(
                     query,
-                    State(rest, page.size, generation),
+                    State(rest, page.size, records.size, generation),
                 )) {
                     is ContinuationIssueResult.Issued ->
                         RelationTraversalHandle.create(family, issued.token)
@@ -197,7 +205,9 @@ internal class RelationshipContinuationStore(
                 records = page,
                 returnedBefore = 0,
                 cumulativeReturned = page.size,
+                totalCount = records.size,
                 nextHandle = nextHandle,
+                coverage = coverage,
             )
         }
 
@@ -206,6 +216,7 @@ internal class RelationshipContinuationStore(
             limit: Int,
             handle: RelationTraversalHandle,
             generation: Long,
+            coverage: RelationshipSearchCoverage.Complete,
         ): PublicPage<Record> {
             if (handle.family != family) {
                 throw continuationConflict("familyMismatch")
@@ -226,6 +237,7 @@ internal class RelationshipContinuationStore(
                         records,
                         returnedBefore,
                         cumulativeReturned,
+                        state.totalCount,
                     )
                     if (remaining == null) {
                         ContinuationTransition.Complete(projection)
@@ -239,13 +251,17 @@ internal class RelationshipContinuationStore(
                     records = consumed.output.records,
                     returnedBefore = consumed.output.returnedBefore,
                     cumulativeReturned = consumed.output.cumulativeReturned,
+                    totalCount = consumed.output.totalCount,
                     nextHandle = null,
+                    coverage = coverage,
                 )
                 is ContinuationConsumeResult.Reissued -> publicPage(
                     records = consumed.output.records,
                     returnedBefore = consumed.output.returnedBefore,
                     cumulativeReturned = consumed.output.cumulativeReturned,
+                    totalCount = consumed.output.totalCount,
                     nextHandle = RelationTraversalHandle.create(family, consumed.token),
+                    coverage = coverage,
                 )
                 is ContinuationConsumeResult.Rejected -> throw when (consumed.failure) {
                     ContinuationAccessFailure.ExpiredToken -> continuationConflict("expired")
@@ -262,19 +278,20 @@ internal class RelationshipContinuationStore(
             records: List<Record>,
             returnedBefore: Int,
             cumulativeReturned: Int,
+            totalCount: Int,
             nextHandle: RelationTraversalHandle?,
+            coverage: RelationshipSearchCoverage.Complete,
         ): PublicPage<Record> {
             val hasMore = nextHandle != null
-            val cardinality = if (hasMore) {
-                ResultCardinality.KnownMinimum(Math.addExact(cumulativeReturned, 1))
-            } else {
-                ResultCardinality.Exact(cumulativeReturned)
-            }
+            val evidence = RelationshipResultEvidence.Complete(
+                cardinality = ResultCardinality.Exact(totalCount),
+                coverage = coverage,
+            )
             val visitedCandidateCount = Math.addExact(records.size, if (hasMore) 1 else 0)
             return PublicPage(
                 records,
                 RelationTraversalPageInfo.create(
-                    cardinality = cardinality,
+                    evidence = evidence,
                     returnedCount = records.size,
                     returnedBefore = returnedBefore,
                     visitedCandidateCount = visitedCandidateCount,
@@ -309,8 +326,15 @@ internal class RelationshipContinuationStore(
     private class State<Record : Any>(
         remaining: List<Record>,
         returnedBefore: Int,
+        val totalCount: Int,
         val generation: Long,
     ) : ContinuationOwnedState() {
+        init {
+            require(totalCount >= returnedBefore + remaining.size) {
+                "Relationship snapshot total must cover returned and retained records"
+            }
+        }
+
         var remaining: List<Record> = remaining
             private set
         var returnedBefore: Int = returnedBefore
@@ -329,6 +353,7 @@ internal class RelationshipContinuationStore(
         val records: List<Record>,
         val returnedBefore: Int,
         val cumulativeReturned: Int,
+        val totalCount: Int,
     ) : ContinuationProjection()
 
     private data class PublicPage<Record : Any>(

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/RelationshipCoverageAuthority.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/RelationshipCoverageAuthority.kt
@@ -1,0 +1,26 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
+import io.github.amichne.kast.api.contract.result.RelationshipSearchLimitation
+
+internal fun interface RelationshipCoverageAuthority {
+    fun assess(completion: FamilyCompletion): RelationshipSearchCoverage
+
+    enum class FamilyCompletion {
+        COMPLETE,
+        RESUMABLE,
+        INCOMPLETE,
+    }
+
+    companion object {
+        fun proven(): RelationshipCoverageAuthority = RelationshipCoverageAuthority { completion ->
+            when (completion) {
+                FamilyCompletion.COMPLETE -> RelationshipSearchCoverage.complete()
+                FamilyCompletion.RESUMABLE -> RelationshipSearchCoverage.resumable()
+                FamilyCompletion.INCOMPLETE -> RelationshipSearchCoverage.limited(
+                    RelationshipSearchLimitation.FAMILY_SEARCH_INCOMPLETE,
+                )
+            }
+        }
+    }
+}

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastPluginBackendContractTest.kt
@@ -6,7 +6,9 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.DependencyScope
 import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
 import com.intellij.testFramework.junit5.TestApplication
@@ -31,6 +33,12 @@ import io.github.amichne.kast.api.contract.query.WorkspaceFilesQuery
 import io.github.amichne.kast.api.contract.query.WorkspaceSearchQuery
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.result.ReferenceOccurrence
+import io.github.amichne.kast.api.contract.result.CallRelationsResult
+import io.github.amichne.kast.api.contract.result.HierarchyRelationsResult
+import io.github.amichne.kast.api.contract.result.ImplementationRelationsResult
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
+import io.github.amichne.kast.api.contract.result.RelationshipSearchLimitation
 import io.github.amichne.kast.api.contract.skill.KastCallersQuery
 import io.github.amichne.kast.api.contract.skill.KastExactSymbolSelector
 import io.github.amichne.kast.api.contract.skill.KastHierarchyQuery
@@ -44,6 +52,7 @@ import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import org.jetbrains.jps.model.java.JavaModuleSourceRootTypes
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -155,6 +164,8 @@ class KastPluginBackendContractTest {
         indexSemanticAdmissionStatus: () -> IdeaIndexSemanticAdmission.Status = {
             IdeaIndexSemanticAdmission.Status.Ready
         },
+        relationshipCoverageAuthority: RelationshipCoverageAuthority =
+            RelationshipCoverageAuthority.proven(),
     ): KastPluginBackend = KastPluginBackend(
         project = project,
         workspaceRoot = workspaceRoot,
@@ -166,6 +177,7 @@ class KastPluginBackendContractTest {
         readEpochObserver = readEpochObserver,
         referenceTraversalObserver = referenceTraversalObserver,
         indexSemanticAdmissionStatus = indexSemanticAdmissionStatus,
+        relationshipCoverageAuthority = relationshipCoverageAuthority,
     )
 
     private fun ensureProjectReady() {
@@ -175,6 +187,45 @@ class KastPluginBackendContractTest {
         sampleUsageFileFixture.get()
         hierarchyFileFixture.get()
         waitUntilIndexesAreReady(project)
+    }
+
+    private fun relationshipCoverageAuthority(
+        transform: (IdeaGradleProjectLoadBridge.GradleWorkspaceModel) ->
+            IdeaGradleProjectLoadBridge.GradleWorkspaceModel = { model -> model },
+    ): IdeaRelationshipCoverageAuthority {
+        val sourceRoots = ApplicationManager.getApplication().runReadAction<List<Path>> {
+            listOf(mainModuleFixture.get(), secondaryModuleFixture.get())
+                .flatMap { module ->
+                    ModuleRootManager.getInstance(module)
+                        .getSourceRoots(JavaModuleSourceRootTypes.SOURCES)
+                        .toList()
+                }
+                .map { root -> Path.of(root.path).toAbsolutePath().normalize() }
+                .sortedBy(Path::toString)
+        }
+        val workspaceRoot = commonWorkspaceRoot(
+            sourceRoots.first().toString(),
+            sourceRoots.last().toString(),
+        )
+        val mainIdentity = IdeaGradleProjectLoadBridge.GradleModuleIdentity(workspaceRoot, ":main")
+        val secondaryIdentity = IdeaGradleProjectLoadBridge.GradleModuleIdentity(workspaceRoot, ":secondary")
+        val model = IdeaGradleProjectLoadBridge.GradleWorkspaceModel(
+            listOf(workspaceRoot),
+            true,
+            listOf(mainIdentity, secondaryIdentity),
+            listOf(
+                IdeaGradleProjectLoadBridge.LoadedGradleModule("main", mainIdentity),
+                IdeaGradleProjectLoadBridge.LoadedGradleModule("secondary", secondaryIdentity),
+            ),
+            sourceRoots,
+            emptyList(),
+        )
+        return IdeaRelationshipCoverageAuthority(
+            project = project,
+            workspaceIdentity = IdeaWorkspaceIdentity.fromProject(project, workspaceRoot),
+            indexSemanticAdmissionStatus = { IdeaIndexSemanticAdmission.Status.Ready },
+            workspaceModelReader = { transform(model) },
+        )
     }
 
     private suspend fun ensureInternalVisibilityProjectReady() {
@@ -203,6 +254,101 @@ class KastPluginBackendContractTest {
         val status = backend().runtimeStatus()
 
         assertEquals(listOf("main", "secondary"), status.sourceModuleNames)
+    }
+
+    @Test
+    fun `relationship coverage is complete only for equal Gradle and IDEA inventories`() {
+        ensureProjectReady()
+
+        val coverage = relationshipCoverageAuthority().assess(
+            RelationshipCoverageAuthority.FamilyCompletion.COMPLETE,
+        )
+
+        assertTrue(coverage is RelationshipSearchCoverage.Complete, coverage.toString())
+    }
+
+    @Test
+    fun `relationship coverage rejects a Gradle project omitted from IDEA`() {
+        ensureProjectReady()
+
+        val coverage = relationshipCoverageAuthority { model ->
+            val omitted = IdeaGradleProjectLoadBridge.GradleModuleIdentity(
+                model.linkedBuildRoots().single(),
+                ":omitted",
+            )
+            IdeaGradleProjectLoadBridge.GradleWorkspaceModel(
+                model.linkedBuildRoots(),
+                model.importedModelComplete(),
+                model.importedModuleIdentities() + omitted,
+                model.loadedModules(),
+                model.importedSourceRoots(),
+                model.moduleAssociations(),
+            )
+        }.assess(RelationshipCoverageAuthority.FamilyCompletion.COMPLETE)
+
+        val limited = coverage as RelationshipSearchCoverage.Limited
+        assertTrue(RelationshipSearchLimitation.PROJECT_SCOPE_INCOMPLETE in limited.limitations)
+    }
+
+    @Test
+    fun `relationship coverage rejects a Gradle source root omitted from IDEA`() {
+        ensureProjectReady()
+
+        val coverage = relationshipCoverageAuthority { model ->
+            val materializedOmittedSourceRoot = model.linkedBuildRoots().single()
+                .resolve("omitted/src/testFixtures/kotlin")
+            Files.createDirectories(materializedOmittedSourceRoot)
+            IdeaGradleProjectLoadBridge.GradleWorkspaceModel(
+                model.linkedBuildRoots(),
+                model.importedModelComplete(),
+                model.importedModuleIdentities(),
+                model.loadedModules(),
+                model.importedSourceRoots() + listOf(materializedOmittedSourceRoot),
+                model.moduleAssociations(),
+            )
+        }.assess(RelationshipCoverageAuthority.FamilyCompletion.COMPLETE)
+
+        val limited = coverage as RelationshipSearchCoverage.Limited
+        assertTrue(RelationshipSearchLimitation.SOURCE_SET_SCOPE_INCOMPLETE in limited.limitations)
+    }
+
+    @Test
+    fun `relationship coverage ignores declared source roots absent from the read epoch`() {
+        ensureProjectReady()
+
+        val coverage = relationshipCoverageAuthority { model ->
+            val absentSourceRoot = model.linkedBuildRoots().single().resolve("absent/src/main/java")
+            assertTrue(Files.notExists(absentSourceRoot))
+            IdeaGradleProjectLoadBridge.GradleWorkspaceModel(
+                model.linkedBuildRoots(),
+                model.importedModelComplete(),
+                model.importedModuleIdentities(),
+                model.loadedModules(),
+                model.importedSourceRoots() + listOf(absentSourceRoot),
+                model.moduleAssociations(),
+            )
+        }.assess(RelationshipCoverageAuthority.FamilyCompletion.COMPLETE)
+
+        assertTrue(coverage is RelationshipSearchCoverage.Complete, coverage.toString())
+    }
+
+    @Test
+    fun `relationship coverage rejects an IDEA source root omitted from Gradle inventory`() {
+        ensureProjectReady()
+
+        val coverage = relationshipCoverageAuthority { model ->
+            IdeaGradleProjectLoadBridge.GradleWorkspaceModel(
+                model.linkedBuildRoots(),
+                model.importedModelComplete(),
+                model.importedModuleIdentities(),
+                model.loadedModules(),
+                model.importedSourceRoots().dropLast(1),
+                model.moduleAssociations(),
+            )
+        }.assess(RelationshipCoverageAuthority.FamilyCompletion.COMPLETE)
+
+        val limited = coverage as RelationshipSearchCoverage.Limited
+        assertTrue(RelationshipSearchLimitation.SOURCE_SET_SCOPE_INCOMPLETE in limited.limitations)
     }
 
     @Test
@@ -411,6 +557,76 @@ class KastPluginBackendContractTest {
         assertTrue(searchScope.searchedFileCount <= searchScope.candidateFileCount)
         assertTrue(references.any { reference -> reference.location.preview.contains("greet(\"idea\")") })
         deleteKotlinFiles(irrelevantFiles)
+    }
+
+    @Test
+    fun `fallback discovery checkpoints remain resumable between candidate files`() = runBlocking {
+        ensureProjectReady()
+        val source = """
+            package demo.deepcheckpoint
+
+            fun deepCheckpointAnchor(): Unit = Unit
+
+            fun deepCheckpointUse(): Unit = deepCheckpointAnchor()
+        """.trimIndent()
+        lateinit var deepRoot: VirtualFile
+        lateinit var deepFile: VirtualFile
+        val application = ApplicationManager.getApplication()
+        application.invokeAndWait {
+            application.runWriteAction {
+                deepRoot = mainSourceRootFixture.get().virtualFile.createChildDirectory(this, "DeepCheckpoint")
+                var current = deepRoot
+                repeat(80) { depth ->
+                    current = current.createChildDirectory(this, "level${depth.toString().padStart(3, '0')}")
+                }
+                deepFile = current.createChildData(this, "DeepCheckpoint.kt")
+                VfsUtil.saveText(deepFile, source)
+            }
+        }
+        waitUntilIndexesAreReady(project)
+
+        try {
+            val position = FilePosition(
+                filePath = deepFile.path,
+                offset = source.indexOf("deepCheckpointAnchor"),
+            )
+            val backend = backend(Path.of(mainSourceRootFixture.get().virtualFile.path))
+            var result = backend.findReferences(
+                ReferencesQuery(position = position, includeDeclaration = false, maxResults = 1),
+            )
+            assertTrue(result.references.isEmpty())
+            assertTrue(result.evidence is RelationshipResultEvidence.Resumable, result.evidence.toString())
+            assertNotNull(result.page?.nextPageToken)
+
+            val references = mutableListOf<ReferenceOccurrence>()
+            references += result.references
+            var pageCount = 1
+            while (result.page?.nextPageToken != null) {
+                assertTrue(pageCount < 16, "Candidate discovery did not terminate: $result")
+                result = backend.findReferences(
+                    ReferencesQuery(
+                        position = position,
+                        includeDeclaration = false,
+                        maxResults = 1,
+                        pageToken = result.page?.nextPageToken,
+                    ),
+                )
+                references += result.references
+                pageCount += 1
+            }
+
+            val complete = result.evidence as RelationshipResultEvidence.Complete
+            assertEquals(ResultCardinality.Exact(1), complete.cardinality)
+            assertEquals(1, references.size)
+            assertTrue(references.single().location.preview.contains("deepCheckpointAnchor()"))
+        } finally {
+            application.invokeAndWait {
+                application.runWriteAction {
+                    if (deepRoot.isValid) deepRoot.delete(this)
+                }
+            }
+            waitUntilIndexesAreReady(project)
+        }
     }
 
     @Test
@@ -936,7 +1152,7 @@ class KastPluginBackendContractTest {
     }
 
     @Test
-    fun `reference continuation resumes at the exact reference inside a leaf after budget interruption`() = runBlocking {
+    fun `reference budget interruption fails closed without a continuation`() = runBlocking {
         ensureProjectReady()
         val application = ApplicationManager.getApplication()
         application.invokeAndWait {
@@ -1016,29 +1232,15 @@ class KastPluginBackendContractTest {
             referenceSearchClock = ReferenceSearchClock(clockNanos::get),
             referenceTraversalObserver = observer,
         )
-        val references = mutableListOf<ReferenceOccurrence>()
-        val first = backend.findReferences(
+        val result = backend.findReferences(
             ReferencesQuery(position = testData.position, includeDeclaration = false, maxResults = 50),
         )
-        references += first.references
-        var pageToken: String? = requireNotNull(first.page?.nextPageToken)
-        do {
-            val page = backend.findReferences(
-                ReferencesQuery(
-                    position = testData.position,
-                    includeDeclaration = false,
-                    maxResults = 50,
-                    pageToken = pageToken,
-                ),
-            )
-            references += page.references
-            pageToken = page.page?.nextPageToken
-        } while (pageToken != null)
 
         assertTrue(referencesInLeaf > 1, "test usage leaf did not expose multiple Kotlin references")
-        assertEquals((0 until referencesInLeaf).toList(), processedReferenceIndices)
-        assertEquals(references.distinct(), references)
-        assertEquals(1, references.count { reference -> reference.location.preview.contains("target()") })
+        assertEquals(listOf(0), processedReferenceIndices)
+        assertEquals(null, result.page)
+        val evidence = result.evidence as RelationshipResultEvidence.Limited
+        assertTrue(RelationshipSearchLimitation.TIMED_OUT in evidence.coverage.limitations)
     }
 
     @Test
@@ -1311,6 +1513,9 @@ class KastPluginBackendContractTest {
 
         assertFalse(result.searchScope?.exhaustive ?: true)
         assertEquals(SearchScope.CandidateCoverage.PARTIAL, result.searchScope?.candidateCoverage)
+        assertEquals(null, result.page)
+        val evidence = result.evidence as RelationshipResultEvidence.Limited
+        assertTrue(RelationshipSearchLimitation.TIMED_OUT in evidence.coverage.limitations)
         assertTrue(
             (result.searchScope?.searchedFileCount ?: Int.MAX_VALUE) <=
                 (result.searchScope?.candidateFileCount ?: 0),
@@ -1560,7 +1765,7 @@ class KastPluginBackendContractTest {
         }
         val backend = backend(workspaceRoot)
 
-        val callers = backend.callRelations(
+        val callers = when (val result = backend.callRelations(
             KastCallersQuery(
                 workspaceRoot = workspaceRoot.toString(),
                 selector = greetSelector,
@@ -1568,15 +1773,22 @@ class KastPluginBackendContractTest {
                 depth = 1,
                 maxResults = 4,
             ),
-        )
-        val implementations = backend.implementationRelations(
+        )) {
+            is CallRelationsResult.Available -> result
+            is CallRelationsResult.Limited -> error("Expected complete caller coverage: ${result.evidence}")
+        }
+        val implementations = when (val result = backend.implementationRelations(
             KastImplementationsQuery(
                 workspaceRoot = workspaceRoot.toString(),
                 selector = shapeSelector,
                 maxResults = 4,
             ),
-        )
-        val hierarchy = backend.hierarchyRelations(
+        )) {
+            is ImplementationRelationsResult.Available -> result
+            is ImplementationRelationsResult.Limited ->
+                error("Expected complete implementation coverage: ${result.evidence}")
+        }
+        val hierarchy = when (val result = backend.hierarchyRelations(
             KastHierarchyQuery(
                 workspaceRoot = workspaceRoot.toString(),
                 selector = shapeSelector,
@@ -1584,7 +1796,10 @@ class KastPluginBackendContractTest {
                 depth = 1,
                 maxResults = 4,
             ),
-        )
+        )) {
+            is HierarchyRelationsResult.Available -> result
+            is HierarchyRelationsResult.Limited -> error("Expected complete hierarchy coverage: ${result.evidence}")
+        }
 
         assertEquals(listOf("demo.useGreeting"), callers.records.map { it.relatedSymbol.fqName })
         assertEquals(ResultCardinality.Exact(1), callers.page.cardinality)
@@ -1601,6 +1816,217 @@ class KastPluginBackendContractTest {
     }
 
     @Test
+    fun `relationship queries fail closed when source set coverage is excluded`() = runBlocking {
+        ensureProjectReady()
+        val inputs = readAction {
+            val root = commonWorkspaceRoot(
+                sampleFile.virtualFile.path,
+                hierarchyFile.virtualFile.path,
+            )
+            val greetOffset = sampleFile.text.indexOf("greet")
+            RelationshipCoverageTestInputs(
+                workspaceRoot = root,
+                greetPosition = FilePosition(sampleFile.virtualFile.path, greetOffset),
+                greetSelector = KastExactSymbolSelector(
+                    fqName = "demo.greet",
+                    declarationFile = sampleFile.virtualFile.path,
+                    declarationStartOffset = greetOffset,
+                    kind = SymbolKind.FUNCTION,
+                ),
+                shapeSelector = KastExactSymbolSelector(
+                    fqName = "demo.hierarchy.Shape",
+                    declarationFile = hierarchyFile.virtualFile.path,
+                    declarationStartOffset = hierarchyFile.text.indexOf("Shape"),
+                    kind = SymbolKind.INTERFACE,
+                ),
+            )
+        }
+        val excludedCoverage = RelationshipSearchCoverage.limited(
+            RelationshipSearchLimitation.SOURCE_SET_EXCLUDED,
+        )
+        val backend = backend(
+            workspaceRoot = inputs.workspaceRoot,
+            relationshipCoverageAuthority = RelationshipCoverageAuthority { excludedCoverage },
+        )
+
+        val references = backend.findReferences(ReferencesQuery(position = inputs.greetPosition))
+        val referenceEvidence = when (val evidence = references.evidence) {
+            is RelationshipResultEvidence.Limited -> evidence
+            is RelationshipResultEvidence.Complete,
+            is RelationshipResultEvidence.Resumable,
+            -> error("Expected limited reference evidence, got $evidence")
+        }
+        assertEquals(ResultCardinality.KnownMinimum(references.references.size), referenceEvidence.cardinality)
+        assertEquals(listOf(RelationshipSearchLimitation.SOURCE_SET_EXCLUDED), referenceEvidence.coverage.limitations)
+
+        val callers = backend.callRelations(
+            KastCallersQuery(
+                workspaceRoot = inputs.workspaceRoot.toString(),
+                selector = inputs.greetSelector,
+                direction = WrapperCallDirection.INCOMING,
+                depth = 1,
+                maxResults = 4,
+            ),
+        )
+        val implementations = backend.implementationRelations(
+            KastImplementationsQuery(
+                workspaceRoot = inputs.workspaceRoot.toString(),
+                selector = inputs.shapeSelector,
+                maxResults = 4,
+            ),
+        )
+        val hierarchy = backend.hierarchyRelations(
+            KastHierarchyQuery(
+                workspaceRoot = inputs.workspaceRoot.toString(),
+                selector = inputs.shapeSelector,
+                direction = TypeHierarchyDirection.SUBTYPES,
+                depth = 1,
+                maxResults = 4,
+            ),
+        )
+
+        assertTrue(callers is CallRelationsResult.Limited)
+        assertTrue(implementations is ImplementationRelationsResult.Limited)
+        assertTrue(hierarchy is HierarchyRelationsResult.Limited)
+    }
+
+    @Test
+    fun `relationship queries fail closed when the backend root does not match the exact selector`() = runBlocking {
+        ensureProjectReady()
+        val inputs = readAction {
+            val root = commonWorkspaceRoot(
+                sampleFile.virtualFile.path,
+                hierarchyFile.virtualFile.path,
+            )
+            val greetOffset = sampleFile.text.indexOf("greet")
+            RelationshipCoverageTestInputs(
+                workspaceRoot = root,
+                greetPosition = FilePosition(sampleFile.virtualFile.path, greetOffset),
+                greetSelector = KastExactSymbolSelector(
+                    fqName = "demo.notGreet",
+                    declarationFile = sampleFile.virtualFile.path,
+                    declarationStartOffset = greetOffset,
+                    kind = SymbolKind.FUNCTION,
+                ),
+                shapeSelector = KastExactSymbolSelector(
+                    fqName = "demo.hierarchy.NotShape",
+                    declarationFile = hierarchyFile.virtualFile.path,
+                    declarationStartOffset = hierarchyFile.text.indexOf("Shape"),
+                    kind = SymbolKind.INTERFACE,
+                ),
+            )
+        }
+        val backend = backend(inputs.workspaceRoot)
+
+        val callers = backend.callRelations(
+            KastCallersQuery(
+                workspaceRoot = inputs.workspaceRoot.toString(),
+                selector = inputs.greetSelector,
+                direction = WrapperCallDirection.INCOMING,
+                depth = 1,
+                maxResults = 4,
+            ),
+        ) as CallRelationsResult.Limited
+        val implementations = backend.implementationRelations(
+            KastImplementationsQuery(
+                workspaceRoot = inputs.workspaceRoot.toString(),
+                selector = inputs.shapeSelector,
+                maxResults = 4,
+            ),
+        ) as ImplementationRelationsResult.Limited
+        val hierarchy = backend.hierarchyRelations(
+            KastHierarchyQuery(
+                workspaceRoot = inputs.workspaceRoot.toString(),
+                selector = inputs.shapeSelector,
+                direction = TypeHierarchyDirection.SUBTYPES,
+                depth = 1,
+                maxResults = 4,
+            ),
+        ) as HierarchyRelationsResult.Limited
+
+        listOf(callers.evidence, implementations.evidence, hierarchy.evidence).forEach { evidence ->
+            assertTrue(RelationshipSearchLimitation.IDENTITY_UNPROVEN in evidence.coverage.limitations)
+        }
+    }
+
+    @Test
+    fun `relationship queries reassess coverage in the final commit epoch`() = runBlocking {
+        ensureProjectReady()
+        val inputs = readAction {
+            val root = commonWorkspaceRoot(
+                sampleFile.virtualFile.path,
+                hierarchyFile.virtualFile.path,
+            )
+            val greetOffset = sampleFile.text.indexOf("greet")
+            RelationshipCoverageTestInputs(
+                workspaceRoot = root,
+                greetPosition = FilePosition(sampleFile.virtualFile.path, greetOffset),
+                greetSelector = KastExactSymbolSelector(
+                    fqName = "demo.greet",
+                    declarationFile = sampleFile.virtualFile.path,
+                    declarationStartOffset = greetOffset,
+                    kind = SymbolKind.FUNCTION,
+                ),
+                shapeSelector = KastExactSymbolSelector(
+                    fqName = "demo.hierarchy.Shape",
+                    declarationFile = hierarchyFile.virtualFile.path,
+                    declarationStartOffset = hierarchyFile.text.indexOf("Shape"),
+                    kind = SymbolKind.INTERFACE,
+                ),
+            )
+        }
+        fun changingAuthority(): RelationshipCoverageAuthority {
+            val assessments = AtomicInteger()
+            return RelationshipCoverageAuthority {
+                if (assessments.getAndIncrement() == 0) {
+                    RelationshipSearchCoverage.complete()
+                } else {
+                    RelationshipSearchCoverage.limited(RelationshipSearchLimitation.INDEX_NOT_READY)
+                }
+            }
+        }
+
+        val callers = backend(
+            workspaceRoot = inputs.workspaceRoot,
+            relationshipCoverageAuthority = changingAuthority(),
+        ).callRelations(
+            KastCallersQuery(
+                workspaceRoot = inputs.workspaceRoot.toString(),
+                selector = inputs.greetSelector,
+                direction = WrapperCallDirection.INCOMING,
+                depth = 1,
+                maxResults = 4,
+            ),
+        )
+        val implementations = backend(
+            workspaceRoot = inputs.workspaceRoot,
+            relationshipCoverageAuthority = changingAuthority(),
+        ).implementationRelations(
+            KastImplementationsQuery(
+                workspaceRoot = inputs.workspaceRoot.toString(),
+                selector = inputs.shapeSelector,
+                maxResults = 4,
+            ),
+        )
+        val hierarchy = backend(
+            workspaceRoot = inputs.workspaceRoot,
+            relationshipCoverageAuthority = changingAuthority(),
+        ).hierarchyRelations(
+            KastHierarchyQuery(
+                workspaceRoot = inputs.workspaceRoot.toString(),
+                selector = inputs.shapeSelector,
+                direction = TypeHierarchyDirection.SUBTYPES,
+                depth = 1,
+                maxResults = 4,
+            ),
+        )
+
+        assertTrue(callers is CallRelationsResult.Limited)
+        assertTrue(implementations is ImplementationRelationsResult.Limited)
+        assertTrue(hierarchy is HierarchyRelationsResult.Limited)
+    }
+
+    @Test
     fun `capabilities read backend version from generated resource`() = runBlocking {
         ensureProjectReady()
 
@@ -1613,6 +2039,13 @@ class KastPluginBackendContractTest {
         assertEquals(expectedVersion, backend().capabilities().backendVersion)
     }
 }
+
+private data class RelationshipCoverageTestInputs(
+    val workspaceRoot: Path,
+    val greetPosition: FilePosition,
+    val greetSelector: KastExactSymbolSelector,
+    val shapeSelector: KastExactSymbolSelector,
+)
 
 private data class IndexedReferenceTestData(
     val workspaceRoot: Path,

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastProjectOpenAutoIndexingTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/KastProjectOpenAutoIndexingTest.kt
@@ -303,6 +303,7 @@ class KastProjectOpenAutoIndexingTest {
                     maxConcurrentRequests = 4,
                 ),
                 referenceIndexLookup = lookup,
+                relationshipCoverageAuthority = RelationshipCoverageAuthority.proven(),
             ).use { backend ->
                 val result = runBlocking {
                     backend.findReferences(

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/ObservedAnalysisBackendTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/ObservedAnalysisBackendTest.kt
@@ -7,6 +7,8 @@ import io.github.amichne.kast.api.contract.result.CallRelationsResult
 import io.github.amichne.kast.api.contract.result.HierarchyRelationsResult
 import io.github.amichne.kast.api.contract.result.ImplementationRelationsResult
 import io.github.amichne.kast.api.contract.result.RelationTraversalPageInfo
+import io.github.amichne.kast.api.contract.result.RelationshipResultEvidence
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
 import io.github.amichne.kast.api.contract.result.ResultCardinality
 import io.github.amichne.kast.api.contract.selector.DigestSelectorHandleAuthority
 import io.github.amichne.kast.api.contract.selector.SelectorHandleAuthority
@@ -31,7 +33,10 @@ class ObservedAnalysisBackendTest {
             semanticGeneration = { 0L },
         )
         val page = RelationTraversalPageInfo.create(
-            cardinality = ResultCardinality.Exact(0),
+            evidence = RelationshipResultEvidence.Complete(
+                cardinality = ResultCardinality.Exact(0),
+                coverage = RelationshipSearchCoverage.complete(),
+            ),
             returnedCount = 0,
             returnedBefore = 0,
             visitedCandidateCount = 0,
@@ -39,9 +44,9 @@ class ObservedAnalysisBackendTest {
             nextHandle = null,
         )
         val delegate = RecordingRelationshipBackend(
-            calls = CallRelationsResult(emptyList(), page),
-            implementations = ImplementationRelationsResult(emptyList(), page),
-            hierarchy = HierarchyRelationsResult(emptyList(), page),
+            calls = CallRelationsResult.Available(emptyList(), page),
+            implementations = ImplementationRelationsResult.Available(emptyList(), page),
+            hierarchy = HierarchyRelationsResult.Available(emptyList(), page),
             selectorHandles = selectorHandles,
         )
         val parentDisposable = com.intellij.openapi.util.Disposer.newDisposable()
@@ -59,16 +64,19 @@ class ObservedAnalysisBackendTest {
     @Test
     fun `typed relationship methods delegate exactly once`() = runBlocking {
         val page = RelationTraversalPageInfo.create(
-            cardinality = ResultCardinality.Exact(0),
+            evidence = RelationshipResultEvidence.Complete(
+                cardinality = ResultCardinality.Exact(0),
+                coverage = RelationshipSearchCoverage.complete(),
+            ),
             returnedCount = 0,
             returnedBefore = 0,
             visitedCandidateCount = 0,
             candidateVisitLimit = 16_384,
             nextHandle = null,
         )
-        val expectedCalls = CallRelationsResult(emptyList(), page)
-        val expectedImplementations = ImplementationRelationsResult(emptyList(), page)
-        val expectedHierarchy = HierarchyRelationsResult(emptyList(), page)
+        val expectedCalls = CallRelationsResult.Available(emptyList(), page)
+        val expectedImplementations = ImplementationRelationsResult.Available(emptyList(), page)
+        val expectedHierarchy = HierarchyRelationsResult.Available(emptyList(), page)
         val delegate = RecordingRelationshipBackend(
             calls = expectedCalls,
             implementations = expectedImplementations,

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RelationshipContinuationStoreTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RelationshipContinuationStoreTest.kt
@@ -13,6 +13,7 @@ import io.github.amichne.kast.api.contract.result.ImplementationRelation
 import io.github.amichne.kast.api.contract.result.RelationTraversalFamily
 import io.github.amichne.kast.api.contract.result.RelationTraversalHandle
 import io.github.amichne.kast.api.contract.result.ResultCardinality
+import io.github.amichne.kast.api.contract.result.RelationshipSearchCoverage
 import io.github.amichne.kast.api.contract.result.TypeHierarchyRelation
 import io.github.amichne.kast.api.contract.skill.KastExactSymbolSelector
 import io.github.amichne.kast.api.contract.skill.WrapperCallDirection
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test
 
 class RelationshipContinuationStoreTest {
     @Test
-    fun `relationship pages prove one extra result and never replay or omit records`() {
+    fun `relationship pages preserve exact snapshot count and never replay or omit records`() {
         val store = store()
         try {
             val records = (0 until 5).map(::hierarchyRecord)
@@ -37,10 +38,10 @@ class RelationshipContinuationStoreTest {
             val third = store.hierarchy(query, secondHandle, null, generation = 7)
 
             assertEquals(listOf(0, 1), offsets(first.records))
-            assertEquals(ResultCardinality.KnownMinimum(3), first.page.cardinality)
+            assertEquals(ResultCardinality.Exact(5), first.page.cardinality)
             assertEquals(3, first.page.visitedCandidateCount)
             assertEquals(listOf(2, 3), offsets(second.records))
-            assertEquals(ResultCardinality.KnownMinimum(5), second.page.cardinality)
+            assertEquals(ResultCardinality.Exact(5), second.page.cardinality)
             assertEquals(3, second.page.visitedCandidateCount)
             assertEquals(listOf(4), offsets(third.records))
             assertEquals(ResultCardinality.Exact(5), third.page.cardinality)
@@ -195,14 +196,45 @@ class RelationshipContinuationStoreTest {
         }
     }
 
-    private fun store(): RelationshipContinuationStore = RelationshipContinuationStore(
-        ServerLimits(
-            maxResults = 1_000,
-            requestTimeoutMillis = 60_000,
-            maxConcurrentRequests = 4,
-            continuationCapacity = 16,
+    private fun store(): ProvenRelationshipStore = ProvenRelationshipStore(
+        RelationshipContinuationStore(
+            ServerLimits(
+                maxResults = 1_000,
+                requestTimeoutMillis = 60_000,
+                maxConcurrentRequests = 4,
+                continuationCapacity = 16,
+            ),
         ),
     )
+
+    private class ProvenRelationshipStore(
+        private val delegate: RelationshipContinuationStore,
+    ) : AutoCloseable {
+        private val coverage = RelationshipSearchCoverage.complete()
+
+        fun calls(
+            query: RelationshipContinuationStore.CallQuery,
+            handle: RelationTraversalHandle?,
+            records: List<CallRelation>?,
+            generation: Long,
+        ) = delegate.calls(query, handle, records, generation, coverage)
+
+        fun implementations(
+            query: RelationshipContinuationStore.ImplementationQuery,
+            handle: RelationTraversalHandle?,
+            records: List<ImplementationRelation>?,
+            generation: Long,
+        ) = delegate.implementations(query, handle, records, generation, coverage)
+
+        fun hierarchy(
+            query: RelationshipContinuationStore.HierarchyQuery,
+            handle: RelationTraversalHandle?,
+            records: List<TypeHierarchyRelation>?,
+            generation: Long,
+        ) = delegate.hierarchy(query, handle, records, generation, coverage)
+
+        override fun close() = delegate.close()
+    }
 
     private fun callQuery(
         direction: WrapperCallDirection,

--- a/cli-rs/protocol/api-reference.md
+++ b/cli-rs/protocol/api-reference.md
@@ -429,7 +429,7 @@ daemon, including input/output schemas, examples, and behavioral notes.
             |-----------|-------------|
             | `#!kotlin declaration: Symbol?` | The resolved declaration symbol, included when `includeDeclaration` was set. |
             | `#!kotlin references: List<ReferenceOccurrence>` | Reference locations with containing-symbol semantic evidence. |
-            | `#!kotlin cardinality: ResultCardinality` | Exact or known-minimum cardinality established by bounded reference work. |
+            | `#!kotlin evidence: RelationshipResultEvidence` | Proof-carrying cardinality and coverage established by bounded reference work. |
             | `#!kotlin page: PageInfo?` | Pagination metadata when results are truncated. |
             | `#!kotlin searchScope: SearchScope?` | Describes the scope and exhaustiveness of the search. |
             | `#!kotlin schemaVersion: Int` | Protocol schema version for forward compatibility. |
@@ -499,9 +499,22 @@ daemon, including input/output schemas, examples, and behavioral notes.
                             }
                         }
                     ],
-                    "cardinality": {
-                        "type": "EXACT",
-                        "totalCount": 1
+                    "evidence": {
+                        "type": "COMPLETE",
+                        "cardinality": {
+                            "type": "EXACT",
+                            "totalCount": 1
+                        },
+                        "coverage": {
+                            "type": "COMPLETE",
+                            "identity": "COMPLETE",
+                            "projectScope": "COMPLETE",
+                            "sourceSetScope": "COMPLETE",
+                            "indexFreshness": "COMPLETE",
+                            "backend": "COMPLETE",
+                            "requestedFamily": "COMPLETE",
+                            "limitations": []
+                        }
                     },
                     "schemaVersion": 3
                 },

--- a/cli-rs/protocol/capabilities.md
+++ b/cli-rs/protocol/capabilities.md
@@ -149,7 +149,7 @@ category. Expand any operation to see its input and output schemas.
             |-----------|-------------|
             | `#!kotlin declaration: Symbol?` | The resolved declaration symbol, included when `includeDeclaration` was set. |
             | `#!kotlin references: List<ReferenceOccurrence>` | Reference locations with containing-symbol semantic evidence. |
-            | `#!kotlin cardinality: ResultCardinality` | Exact or known-minimum cardinality established by bounded reference work. |
+            | `#!kotlin evidence: RelationshipResultEvidence` | Proof-carrying cardinality and coverage established by bounded reference work. |
             | `#!kotlin page: PageInfo?` | Pagination metadata when results are truncated. |
             | `#!kotlin searchScope: SearchScope?` | Describes the scope and exhaustiveness of the search. |
             | `#!kotlin schemaVersion: Int` | Protocol schema version for forward compatibility. |

--- a/cli-rs/protocol/examples/findReferences-response.json
+++ b/cli-rs/protocol/examples/findReferences-response.json
@@ -37,9 +37,22 @@
                 }
             }
         ],
-        "cardinality": {
-            "type": "EXACT",
-            "totalCount": 1
+        "evidence": {
+            "type": "COMPLETE",
+            "cardinality": {
+                "type": "EXACT",
+                "totalCount": 1
+            },
+            "coverage": {
+                "type": "COMPLETE",
+                "identity": "COMPLETE",
+                "projectScope": "COMPLETE",
+                "sourceSetScope": "COMPLETE",
+                "indexFreshness": "COMPLETE",
+                "backend": "COMPLETE",
+                "requestedFamily": "COMPLETE",
+                "limitations": []
+            }
         },
         "schemaVersion": 3
     },

--- a/cli-rs/protocol/openapi.yaml
+++ b/cli-rs/protocol/openapi.yaml
@@ -1544,6 +1544,218 @@ components:
       required:
         - type
         - knownMinimumCount
+    RelationshipCoverageStatus:
+      type: string
+      enum:
+        - COMPLETE
+        - IN_PROGRESS
+        - PARTIAL
+        - STALE
+        - EXCLUDED
+        - TIMED_OUT
+        - CANCELLED
+        - UNAVAILABLE
+    RelationshipSearchLimitation:
+      type: string
+      enum:
+        - IDENTITY_UNPROVEN
+        - PROJECT_SCOPE_INCOMPLETE
+        - SOURCE_SET_SCOPE_INCOMPLETE
+        - SOURCE_SET_EXCLUDED
+        - INDEX_NOT_READY
+        - INDEX_STALE
+        - BACKEND_INCOMPLETE
+        - BACKEND_UNAVAILABLE
+        - FAMILY_SEARCH_IN_PROGRESS
+        - FAMILY_SEARCH_INCOMPLETE
+        - CANDIDATE_BUDGET_REACHED
+        - TRAVERSAL_STATE_BUDGET_REACHED
+        - TIMED_OUT
+        - CANCELLED
+        - GENERATION_CHANGED
+        - CONTINUATION_EXPIRED
+        - CONTINUATION_INVALID
+    RelationshipSearchCoverage:
+      oneOf:
+        - "$ref": "#/components/schemas/RelationshipSearchCoverage.Complete"
+        - "$ref": "#/components/schemas/RelationshipSearchCoverage.Resumable"
+        - "$ref": "#/components/schemas/RelationshipSearchCoverage.Limited"
+      discriminator:
+        propertyName: type
+        mapping:
+          COMPLETE: "#/components/schemas/RelationshipSearchCoverage.Complete"
+          RESUMABLE: "#/components/schemas/RelationshipSearchCoverage.Resumable"
+          LIMITED: "#/components/schemas/RelationshipSearchCoverage.Limited"
+    RelationshipSearchCoverage.Complete:
+      type: object
+      properties:
+        type:
+          type: string
+          const: COMPLETE
+        identity:
+          type: string
+          const: COMPLETE
+        projectScope:
+          type: string
+          const: COMPLETE
+        sourceSetScope:
+          type: string
+          const: COMPLETE
+        indexFreshness:
+          type: string
+          const: COMPLETE
+        backend:
+          type: string
+          const: COMPLETE
+        requestedFamily:
+          type: string
+          const: COMPLETE
+        limitations:
+          type: array
+          items:
+            "$ref": "#/components/schemas/RelationshipSearchLimitation"
+          minItems: 0
+          maxItems: 0
+      additionalProperties: false
+      required:
+        - type
+        - identity
+        - projectScope
+        - sourceSetScope
+        - indexFreshness
+        - backend
+        - requestedFamily
+        - limitations
+    RelationshipSearchCoverage.Resumable:
+      type: object
+      properties:
+        type:
+          type: string
+          const: RESUMABLE
+        identity:
+          type: string
+          const: COMPLETE
+        projectScope:
+          type: string
+          const: COMPLETE
+        sourceSetScope:
+          type: string
+          const: COMPLETE
+        indexFreshness:
+          type: string
+          const: COMPLETE
+        backend:
+          type: string
+          const: COMPLETE
+        requestedFamily:
+          type: string
+          const: IN_PROGRESS
+        limitations:
+          type: array
+          items:
+            type: string
+            const: FAMILY_SEARCH_IN_PROGRESS
+          minItems: 1
+          maxItems: 1
+      additionalProperties: false
+      required:
+        - type
+        - identity
+        - projectScope
+        - sourceSetScope
+        - indexFreshness
+        - backend
+        - requestedFamily
+        - limitations
+    RelationshipSearchCoverage.Limited:
+      type: object
+      properties:
+        type:
+          type: string
+          const: LIMITED
+        identity:
+          "$ref": "#/components/schemas/RelationshipCoverageStatus"
+        projectScope:
+          "$ref": "#/components/schemas/RelationshipCoverageStatus"
+        sourceSetScope:
+          "$ref": "#/components/schemas/RelationshipCoverageStatus"
+        indexFreshness:
+          "$ref": "#/components/schemas/RelationshipCoverageStatus"
+        backend:
+          "$ref": "#/components/schemas/RelationshipCoverageStatus"
+        requestedFamily:
+          "$ref": "#/components/schemas/RelationshipCoverageStatus"
+        limitations:
+          type: array
+          items:
+            "$ref": "#/components/schemas/RelationshipSearchLimitation"
+          minItems: 1
+      additionalProperties: false
+      required:
+        - type
+        - identity
+        - projectScope
+        - sourceSetScope
+        - indexFreshness
+        - backend
+        - requestedFamily
+        - limitations
+    RelationshipResultEvidence:
+      oneOf:
+        - "$ref": "#/components/schemas/RelationshipResultEvidence.Complete"
+        - "$ref": "#/components/schemas/RelationshipResultEvidence.Resumable"
+        - "$ref": "#/components/schemas/RelationshipResultEvidence.Limited"
+      discriminator:
+        propertyName: type
+        mapping:
+          COMPLETE: "#/components/schemas/RelationshipResultEvidence.Complete"
+          RESUMABLE: "#/components/schemas/RelationshipResultEvidence.Resumable"
+          LIMITED: "#/components/schemas/RelationshipResultEvidence.Limited"
+    RelationshipResultEvidence.Complete:
+      type: object
+      properties:
+        type:
+          type: string
+          const: COMPLETE
+        cardinality:
+          "$ref": "#/components/schemas/EXACT"
+        coverage:
+          "$ref": "#/components/schemas/RelationshipSearchCoverage.Complete"
+      additionalProperties: false
+      required:
+        - type
+        - cardinality
+        - coverage
+    RelationshipResultEvidence.Resumable:
+      type: object
+      properties:
+        type:
+          type: string
+          const: RESUMABLE
+        cardinality:
+          "$ref": "#/components/schemas/KNOWN_MINIMUM"
+        coverage:
+          "$ref": "#/components/schemas/RelationshipSearchCoverage.Resumable"
+      additionalProperties: false
+      required:
+        - type
+        - cardinality
+        - coverage
+    RelationshipResultEvidence.Limited:
+      type: object
+      properties:
+        type:
+          type: string
+          const: LIMITED
+        cardinality:
+          "$ref": "#/components/schemas/KNOWN_MINIMUM"
+        coverage:
+          "$ref": "#/components/schemas/RelationshipSearchCoverage.Limited"
+      additionalProperties: false
+      required:
+        - type
+        - cardinality
+        - coverage
     ReferencesResult:
       type: object
       properties:
@@ -1555,8 +1767,8 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/ReferenceOccurrence"
-        cardinality:
-          "$ref": "#/components/schemas/ResultCardinality"
+        evidence:
+          "$ref": "#/components/schemas/RelationshipResultEvidence"
         page:
           anyOf:
             - "$ref": "#/components/schemas/PageInfo"
@@ -1571,7 +1783,7 @@ components:
       additionalProperties: false
       required:
         - references
-        - cardinality
+        - evidence
     ReferenceOccurrence:
       type: object
       properties:

--- a/cli-rs/src/agent/projection/relations.rs
+++ b/cli-rs/src/agent/projection/relations.rs
@@ -46,6 +46,362 @@ impl AgentRelationSelectorProjection {
                 .as_ref()
                 .is_none_or(|value| !value.trim().is_empty())
     }
+
+    fn matches_identity(&self, actual: &mut AgentRelationIdentityProjection) -> bool {
+        let declaration_file_matches =
+            declaration_files_match(&self.declaration_file, &actual.declaration_file);
+        if declaration_file_matches {
+            actual.declaration_file.clone_from(&self.declaration_file);
+        }
+        self.fq_name == actual.fq_name
+            && declaration_file_matches
+            && self.declaration_start_offset == actual.declaration_start_offset
+            && self.kind.as_ref().is_none_or(|kind| kind == &actual.kind)
+            && self
+                .containing_type
+                .as_ref()
+                .is_none_or(|containing_type| {
+                    actual.containing_type.as_ref() == Some(containing_type)
+                })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum AgentRelationshipCoverageStatus {
+    Complete,
+    InProgress,
+    Partial,
+    Stale,
+    Excluded,
+    TimedOut,
+    Cancelled,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum AgentRelationshipSearchLimitation {
+    IdentityUnproven,
+    ProjectScopeIncomplete,
+    SourceSetScopeIncomplete,
+    SourceSetExcluded,
+    IndexNotReady,
+    IndexStale,
+    BackendIncomplete,
+    BackendUnavailable,
+    FamilySearchInProgress,
+    FamilySearchIncomplete,
+    CandidateBudgetReached,
+    TraversalStateBudgetReached,
+    TimedOut,
+    Cancelled,
+    GenerationChanged,
+    ContinuationExpired,
+    ContinuationInvalid,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all_fields = "camelCase")]
+enum AgentRelationshipCoverageInput {
+    #[serde(rename = "COMPLETE")]
+    Complete {
+        identity: AgentRelationshipCoverageStatus,
+        project_scope: AgentRelationshipCoverageStatus,
+        source_set_scope: AgentRelationshipCoverageStatus,
+        index_freshness: AgentRelationshipCoverageStatus,
+        backend: AgentRelationshipCoverageStatus,
+        requested_family: AgentRelationshipCoverageStatus,
+        limitations: Vec<AgentRelationshipSearchLimitation>,
+    },
+    #[serde(rename = "RESUMABLE")]
+    Resumable {
+        identity: AgentRelationshipCoverageStatus,
+        project_scope: AgentRelationshipCoverageStatus,
+        source_set_scope: AgentRelationshipCoverageStatus,
+        index_freshness: AgentRelationshipCoverageStatus,
+        backend: AgentRelationshipCoverageStatus,
+        requested_family: AgentRelationshipCoverageStatus,
+        limitations: Vec<AgentRelationshipSearchLimitation>,
+    },
+    #[serde(rename = "LIMITED")]
+    Limited {
+        identity: AgentRelationshipCoverageStatus,
+        project_scope: AgentRelationshipCoverageStatus,
+        source_set_scope: AgentRelationshipCoverageStatus,
+        index_freshness: AgentRelationshipCoverageStatus,
+        backend: AgentRelationshipCoverageStatus,
+        requested_family: AgentRelationshipCoverageStatus,
+        limitations: Vec<AgentRelationshipSearchLimitation>,
+    },
+}
+
+impl AgentRelationshipCoverageInput {
+    fn is_valid(&self) -> bool {
+        match self {
+            Self::Complete {
+                identity,
+                project_scope,
+                source_set_scope,
+                index_freshness,
+                backend,
+                requested_family,
+                limitations,
+            } => {
+                [
+                    identity,
+                    project_scope,
+                    source_set_scope,
+                    index_freshness,
+                    backend,
+                    requested_family,
+                ]
+                .into_iter()
+                .all(|status| *status == AgentRelationshipCoverageStatus::Complete)
+                    && limitations.is_empty()
+            }
+            Self::Resumable {
+                identity,
+                project_scope,
+                source_set_scope,
+                index_freshness,
+                backend,
+                requested_family,
+                limitations,
+            } => {
+                [
+                    identity,
+                    project_scope,
+                    source_set_scope,
+                    index_freshness,
+                    backend,
+                ]
+                .into_iter()
+                .all(|status| *status == AgentRelationshipCoverageStatus::Complete)
+                    && *requested_family == AgentRelationshipCoverageStatus::InProgress
+                    && limitations
+                        == &[AgentRelationshipSearchLimitation::FamilySearchInProgress]
+            }
+            Self::Limited {
+                identity,
+                project_scope,
+                source_set_scope,
+                index_freshness,
+                backend,
+                requested_family,
+                limitations,
+            } => {
+                let canonical = !limitations.is_empty()
+                    && limitations.windows(2).all(|pair| pair[0] < pair[1]);
+                canonical
+                    && *identity
+                        == status_for_identity_limitations(limitations)
+                    && *project_scope
+                        == status_for_project_limitations(limitations)
+                    && *source_set_scope
+                        == status_for_source_set_limitations(limitations)
+                    && *index_freshness
+                        == status_for_index_limitations(limitations)
+                    && *backend == status_for_backend_limitations(limitations)
+                    && *requested_family == status_for_family_limitations(limitations)
+            }
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        matches!(self, Self::Complete { .. }) && self.is_valid()
+    }
+
+    fn is_resumable(&self) -> bool {
+        matches!(self, Self::Resumable { .. }) && self.is_valid()
+    }
+
+    fn is_limited(&self) -> bool {
+        matches!(self, Self::Limited { .. }) && self.is_valid()
+    }
+
+    fn limitations(&self) -> &[AgentRelationshipSearchLimitation] {
+        match self {
+            Self::Complete { limitations, .. }
+            | Self::Resumable { limitations, .. }
+            | Self::Limited { limitations, .. } => limitations,
+        }
+    }
+}
+
+fn status_for_identity_limitations(
+    limitations: &[AgentRelationshipSearchLimitation],
+) -> AgentRelationshipCoverageStatus {
+    if limitations.contains(&AgentRelationshipSearchLimitation::IdentityUnproven) {
+        AgentRelationshipCoverageStatus::Unavailable
+    } else {
+        AgentRelationshipCoverageStatus::Complete
+    }
+}
+
+fn status_for_project_limitations(
+    limitations: &[AgentRelationshipSearchLimitation],
+) -> AgentRelationshipCoverageStatus {
+    if limitations.contains(&AgentRelationshipSearchLimitation::ProjectScopeIncomplete) {
+        AgentRelationshipCoverageStatus::Partial
+    } else {
+        AgentRelationshipCoverageStatus::Complete
+    }
+}
+
+fn status_for_source_set_limitations(
+    limitations: &[AgentRelationshipSearchLimitation],
+) -> AgentRelationshipCoverageStatus {
+    if limitations.contains(&AgentRelationshipSearchLimitation::SourceSetExcluded) {
+        AgentRelationshipCoverageStatus::Excluded
+    } else if limitations.contains(&AgentRelationshipSearchLimitation::SourceSetScopeIncomplete) {
+        AgentRelationshipCoverageStatus::Partial
+    } else {
+        AgentRelationshipCoverageStatus::Complete
+    }
+}
+
+fn status_for_index_limitations(
+    limitations: &[AgentRelationshipSearchLimitation],
+) -> AgentRelationshipCoverageStatus {
+    if limitations.contains(&AgentRelationshipSearchLimitation::IndexStale)
+        || limitations.contains(&AgentRelationshipSearchLimitation::GenerationChanged)
+    {
+        AgentRelationshipCoverageStatus::Stale
+    } else if limitations.contains(&AgentRelationshipSearchLimitation::IndexNotReady) {
+        AgentRelationshipCoverageStatus::InProgress
+    } else {
+        AgentRelationshipCoverageStatus::Complete
+    }
+}
+
+fn status_for_backend_limitations(
+    limitations: &[AgentRelationshipSearchLimitation],
+) -> AgentRelationshipCoverageStatus {
+    if limitations.contains(&AgentRelationshipSearchLimitation::Cancelled) {
+        AgentRelationshipCoverageStatus::Cancelled
+    } else if limitations.iter().any(|limitation| {
+        matches!(
+            limitation,
+            AgentRelationshipSearchLimitation::BackendUnavailable
+                | AgentRelationshipSearchLimitation::TraversalStateBudgetReached
+                | AgentRelationshipSearchLimitation::ContinuationExpired
+                | AgentRelationshipSearchLimitation::ContinuationInvalid
+        )
+    }) {
+        AgentRelationshipCoverageStatus::Unavailable
+    } else if limitations.contains(&AgentRelationshipSearchLimitation::BackendIncomplete) {
+        AgentRelationshipCoverageStatus::Partial
+    } else {
+        AgentRelationshipCoverageStatus::Complete
+    }
+}
+
+fn status_for_family_limitations(
+    limitations: &[AgentRelationshipSearchLimitation],
+) -> AgentRelationshipCoverageStatus {
+    if limitations.contains(&AgentRelationshipSearchLimitation::TimedOut) {
+        AgentRelationshipCoverageStatus::TimedOut
+    } else if limitations.contains(&AgentRelationshipSearchLimitation::Cancelled) {
+        AgentRelationshipCoverageStatus::Cancelled
+    } else if limitations.contains(&AgentRelationshipSearchLimitation::FamilySearchInProgress) {
+        AgentRelationshipCoverageStatus::InProgress
+    } else if limitations.iter().any(|limitation| {
+        matches!(
+            limitation,
+            AgentRelationshipSearchLimitation::IndexNotReady
+                | AgentRelationshipSearchLimitation::BackendUnavailable
+                | AgentRelationshipSearchLimitation::ContinuationExpired
+                | AgentRelationshipSearchLimitation::ContinuationInvalid
+        )
+    }) {
+        AgentRelationshipCoverageStatus::Unavailable
+    } else {
+        AgentRelationshipCoverageStatus::Partial
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(
+    tag = "type",
+    rename_all = "SCREAMING_SNAKE_CASE",
+    rename_all_fields = "camelCase"
+)]
+enum AgentKnownMinimumCardinality {
+    KnownMinimum { known_minimum_count: usize },
+}
+
+impl AgentKnownMinimumCardinality {
+    fn known_minimum(self) -> usize {
+        match self {
+            Self::KnownMinimum {
+                known_minimum_count,
+            } => known_minimum_count,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all_fields = "camelCase")]
+enum AgentRelationshipResultEvidenceInput {
+    #[serde(rename = "COMPLETE")]
+    Complete {
+        cardinality: AgentExactCardinality,
+        coverage: AgentRelationshipCoverageInput,
+    },
+    #[serde(rename = "RESUMABLE")]
+    Resumable {
+        cardinality: AgentKnownMinimumCardinality,
+        coverage: AgentRelationshipCoverageInput,
+    },
+    #[serde(rename = "LIMITED")]
+    Limited {
+        cardinality: AgentKnownMinimumCardinality,
+        coverage: AgentRelationshipCoverageInput,
+    },
+}
+
+impl AgentRelationshipResultEvidenceInput {
+    fn is_valid_available(&self) -> bool {
+        match self {
+            Self::Complete { coverage, .. } => coverage.is_complete(),
+            Self::Resumable { coverage, .. } => coverage.is_resumable(),
+            Self::Limited { .. } => false,
+        }
+    }
+
+    fn is_valid_complete(&self) -> bool {
+        matches!(self, Self::Complete { coverage, .. } if coverage.is_complete())
+    }
+
+    fn is_valid_resumable(&self) -> bool {
+        matches!(self, Self::Resumable { coverage, .. } if coverage.is_resumable())
+    }
+
+    fn is_valid_limited(&self) -> bool {
+        matches!(self, Self::Limited { coverage, .. } if coverage.is_limited())
+    }
+
+    fn cardinality(&self) -> AgentResultCardinality {
+        match self {
+            Self::Complete { cardinality, .. } => AgentResultCardinality::Exact {
+                total_count: cardinality.total_count(),
+            },
+            Self::Resumable { cardinality, .. } | Self::Limited { cardinality, .. } => {
+                AgentResultCardinality::KnownMinimum {
+                    known_minimum_count: cardinality.known_minimum(),
+                }
+            }
+        }
+    }
+
+    fn coverage(&self) -> &AgentRelationshipCoverageInput {
+        match self {
+            Self::Complete { coverage, .. }
+            | Self::Resumable { coverage, .. }
+            | Self::Limited { coverage, .. } => coverage,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -55,7 +411,7 @@ enum AgentReferencesResponseInput {
     Available {
         subject: AgentRelationIdentityProjection,
         references: Vec<AgentReferenceOccurrenceInput>,
-        cardinality: AgentResultCardinality,
+        evidence: AgentRelationshipResultEvidenceInput,
         #[serde(default)]
         page: Option<AgentReferencePageInput>,
     },
@@ -78,16 +434,19 @@ enum AgentReferencesResponseInput {
         selector: AgentRelationSelectorProjection,
         subject: AgentRelationIdentityProjection,
         reason: AgentReferencesDegradedReason,
+        evidence: AgentRelationshipResultEvidenceInput,
     },
     #[serde(rename = "CURSOR_STALE")]
     CursorStale {
         selector: AgentRelationSelectorProjection,
         reason: AgentRelationCursorStaleReason,
+        evidence: AgentRelationshipResultEvidenceInput,
     },
     #[serde(rename = "CURSOR_INVALID")]
     CursorInvalid {
         selector: AgentRelationSelectorProjection,
         reason: AgentRelationCursorInvalidReason,
+        evidence: AgentRelationshipResultEvidenceInput,
     },
     #[serde(rename = "SELECTOR_HANDLE_REJECTED")]
     SelectorHandleRejected {
@@ -103,6 +462,8 @@ enum AgentReferencesDegradedReason {
     IndexIdentityUnavailable,
     BoundSourceUnavailable,
     CandidateBudgetReached,
+    Timeout,
+    Cancelled,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
@@ -234,7 +595,9 @@ struct AgentReferencesAvailableProjection {
     #[serde(skip_serializing_if = "Option::is_none")]
     page: Option<AgentRelationPageProjection>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    limitations: Option<Vec<String>>,
+    coverage: Option<AgentRelationshipCoverageInput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    limitations: Option<Vec<AgentRelationshipSearchLimitation>>,
     schema_version: u32,
 }
 
@@ -247,6 +610,10 @@ fn project_references_envelope(
         return compact_error_envelope(envelope);
     }
     let method = envelope.method.clone();
+    let provenance = match reference_request_provenance(&envelope) {
+        Ok(provenance) => provenance,
+        Err(message) => return invalid_projection_envelope(method, message),
+    };
     let Some(result) = envelope.result.clone() else {
         return invalid_projection_envelope(method, "References returned no result.");
     };
@@ -263,7 +630,7 @@ fn project_references_envelope(
         AgentReferencesResponseInput::Available {
             subject,
             references,
-            cardinality,
+            evidence,
             page,
         } => project_available_references(
             method,
@@ -271,10 +638,92 @@ fn project_references_envelope(
             result_limit,
             subject,
             references,
-            cardinality,
+            evidence,
             page,
+            &provenance,
         ),
-        other => project_expected_reference_outcome(method, other),
+        other => project_expected_reference_outcome(method, other, &provenance),
+    }
+}
+
+#[derive(Debug, Clone)]
+enum AgentReferenceRequestProvenance {
+    Explicit(AgentExpectedRelationshipSelector),
+    Handle,
+}
+
+impl AgentReferenceRequestProvenance {
+    fn matches_subject(&self, subject: &mut AgentRelationIdentityProjection) -> bool {
+        subject.is_valid()
+            && match self {
+                Self::Explicit(expected) => expected.matches(subject),
+                Self::Handle => true,
+            }
+    }
+
+    fn matches_selector(&self, selector: &AgentRelationSelectorProjection) -> bool {
+        selector.is_valid()
+            && match self {
+                Self::Explicit(expected) => expected.matches_selector(selector),
+                Self::Handle => true,
+            }
+    }
+
+    fn matches_selector_and_subject(
+        &self,
+        selector: &AgentRelationSelectorProjection,
+        subject: &mut AgentRelationIdentityProjection,
+    ) -> bool {
+        self.matches_selector(selector)
+            && self.matches_subject(subject)
+            && selector.matches_identity(subject)
+    }
+
+    fn is_handle(&self) -> bool {
+        matches!(self, Self::Handle)
+    }
+}
+
+fn reference_request_provenance(
+    envelope: &AgentEnvelope,
+) -> std::result::Result<AgentReferenceRequestProvenance, String> {
+    let params = envelope
+        .request
+        .as_ref()
+        .and_then(|request| request.get("params"))
+        .and_then(Value::as_object)
+        .ok_or_else(|| "References omitted normalized request provenance.".to_string())?;
+    let selector = params.get("selector").filter(|value| !value.is_null());
+    let selector_handle = params
+        .get("selectorHandle")
+        .filter(|value| !value.is_null());
+    match (selector, selector_handle) {
+        (Some(selector), None) => {
+            let selector = serde_json::from_value::<AgentRelationSelectorProjection>(
+                selector.clone(),
+            )
+            .map_err(|error| format!("References explicit selector provenance was invalid: {error}"))?;
+            if !selector.is_valid() {
+                return Err("References explicit selector provenance was invalid.".to_string());
+            }
+            Ok(AgentReferenceRequestProvenance::Explicit(
+                AgentExpectedRelationshipSelector {
+                    workspace_root: String::new(),
+                    fq_name: selector.fq_name,
+                    declaration_file: selector.declaration_file,
+                    declaration_start_offset: selector.declaration_start_offset,
+                    kind: selector.kind,
+                    containing_type: selector.containing_type,
+                },
+            ))
+        }
+        (None, Some(Value::String(handle))) if !handle.trim().is_empty() => {
+            Ok(AgentReferenceRequestProvenance::Handle)
+        }
+        _ => Err(
+            "References request provenance did not contain exactly one explicit selector or selector handle."
+                .to_string(),
+        ),
     }
 }
 
@@ -283,12 +732,14 @@ fn project_available_references(
     method: String,
     view: AgentResultView<AgentRelationField>,
     result_limit: usize,
-    subject: AgentRelationIdentityProjection,
+    mut subject: AgentRelationIdentityProjection,
     references: Vec<AgentReferenceOccurrenceInput>,
-    cardinality: AgentResultCardinality,
+    evidence: AgentRelationshipResultEvidenceInput,
     page: Option<AgentReferencePageInput>,
+    provenance: &AgentReferenceRequestProvenance,
 ) -> AgentEnvelope {
-    if !subject.is_valid()
+    if !evidence.is_valid_available()
+        || !provenance.matches_subject(&mut subject)
         || references.len() > result_limit
         || references.iter().any(|reference| {
             reference.location.file_path.trim().is_empty()
@@ -304,8 +755,9 @@ fn project_available_references(
     let returned_count = references.len();
     let truncated = page.as_ref().is_some_and(|page| page.truncated);
     let next_page_token = page.and_then(|page| page.next_page_token);
-    if cardinality.known_minimum() < returned_count
-        || (truncated && cardinality.known_minimum() < returned_count.saturating_add(1))
+    let cardinality = evidence.cardinality();
+    if evidence.is_valid_resumable() != truncated
+        || cardinality.known_minimum() < returned_count
         || truncated != next_page_token.is_some()
     {
         return invalid_projection_envelope(method, "References contained inconsistent page evidence.");
@@ -329,6 +781,8 @@ fn project_available_references(
         truncated,
         next_page_token,
     };
+    let coverage = evidence.coverage().clone();
+    let limitations = evidence.coverage().limitations().to_vec();
     projected_agent_envelope(
         method,
         true,
@@ -343,7 +797,8 @@ fn project_available_references(
             records: selected(AgentRelationField::Records).then_some(records),
             page: (selected(AgentRelationField::Page) || matches!(view, AgentResultView::Count))
                 .then_some(page),
-            limitations: selected(AgentRelationField::Limitations).then_some(Vec::new()),
+            coverage: Some(coverage),
+            limitations: Some(limitations),
             schema_version: SCHEMA_VERSION,
         },
         None,
@@ -353,20 +808,37 @@ fn project_available_references(
 fn project_expected_reference_outcome(
     method: String,
     outcome: AgentReferencesResponseInput,
+    provenance: &AgentReferenceRequestProvenance,
 ) -> AgentEnvelope {
     let evidence_is_valid = match &outcome {
-        AgentReferencesResponseInput::SubjectNotFound { selector }
-        | AgentReferencesResponseInput::CursorStale { selector, .. }
-        | AgentReferencesResponseInput::CursorInvalid { selector, .. } => selector.is_valid(),
-        AgentReferencesResponseInput::SubjectIdentityMismatch { selector, actual } => {
-            selector.is_valid() && actual.is_valid()
+        AgentReferencesResponseInput::SubjectNotFound { selector } => {
+            provenance.matches_selector(selector)
         }
-        AgentReferencesResponseInput::UnsupportedSubjectKind { selector, subject }
-        | AgentReferencesResponseInput::Degraded {
-            selector, subject, ..
-        } => selector.is_valid() && subject.is_valid(),
+        AgentReferencesResponseInput::CursorStale {
+            selector, evidence, ..
+        }
+        | AgentReferencesResponseInput::CursorInvalid {
+            selector, evidence, ..
+        } => provenance.matches_selector(selector) && evidence.is_valid_limited(),
+        AgentReferencesResponseInput::SubjectIdentityMismatch { selector, actual } => {
+            provenance.matches_selector(selector) && actual.is_valid()
+        }
+        AgentReferencesResponseInput::UnsupportedSubjectKind { selector, subject } => {
+            let mut subject = subject.clone();
+            provenance.matches_selector_and_subject(selector, &mut subject)
+        }
+        AgentReferencesResponseInput::Degraded {
+            selector,
+            subject,
+            evidence,
+            ..
+        } => {
+            let mut subject = subject.clone();
+            provenance.matches_selector_and_subject(selector, &mut subject)
+                && evidence.is_valid_limited()
+        }
         AgentReferencesResponseInput::SelectorHandleRejected { reason, recovery } => {
-            reason.recovery() == *recovery
+            provenance.is_handle() && reason.recovery() == *recovery
         }
         AgentReferencesResponseInput::Available { .. } => false,
     };
@@ -400,29 +872,51 @@ fn project_expected_reference_outcome(
             "subject": subject,
             "schemaVersion": SCHEMA_VERSION,
         }),
-        AgentReferencesResponseInput::Degraded { selector, subject, reason } => json!({
+        AgentReferencesResponseInput::Degraded {
+            selector,
+            subject,
+            reason,
+            evidence,
+        } => json!({
             "type": "KAST_AGENT_REFERENCES_RESULT",
             "ok": true,
             "outcome": "DEGRADED",
             "selector": selector,
             "subject": subject,
             "reason": reason,
+            "cardinality": evidence.cardinality(),
+            "coverage": evidence.coverage(),
+            "limitations": evidence.coverage().limitations(),
             "schemaVersion": SCHEMA_VERSION,
         }),
-        AgentReferencesResponseInput::CursorStale { selector, reason } => json!({
+        AgentReferencesResponseInput::CursorStale {
+            selector,
+            reason,
+            evidence,
+        } => json!({
             "type": "KAST_AGENT_REFERENCES_RESULT",
             "ok": true,
             "outcome": "CURSOR_STALE",
             "selector": selector,
             "reason": reason,
+            "cardinality": evidence.cardinality(),
+            "coverage": evidence.coverage(),
+            "limitations": evidence.coverage().limitations(),
             "schemaVersion": SCHEMA_VERSION,
         }),
-        AgentReferencesResponseInput::CursorInvalid { selector, reason } => json!({
+        AgentReferencesResponseInput::CursorInvalid {
+            selector,
+            reason,
+            evidence,
+        } => json!({
             "type": "KAST_AGENT_REFERENCES_RESULT",
             "ok": true,
             "outcome": "CURSOR_INVALID",
             "selector": selector,
             "reason": reason,
+            "cardinality": evidence.cardinality(),
+            "coverage": evidence.coverage(),
+            "limitations": evidence.coverage().limitations(),
             "schemaVersion": SCHEMA_VERSION,
         }),
         AgentReferencesResponseInput::SelectorHandleRejected { reason, recovery } => json!({
@@ -452,10 +946,8 @@ struct AgentExpectedRelationshipSelector {
 
 impl AgentExpectedRelationshipSelector {
     fn matches(&self, actual: &mut AgentRelationIdentityProjection) -> bool {
-        let declaration_file_matches = self.declaration_file == actual.declaration_file
-            || std::fs::canonicalize(&actual.declaration_file)
-                .ok()
-                .is_some_and(|path| path.to_string_lossy() == self.declaration_file);
+        let declaration_file_matches =
+            declaration_files_match(&self.declaration_file, &actual.declaration_file);
         if declaration_file_matches {
             actual.declaration_file.clone_from(&self.declaration_file);
         }
@@ -472,406 +964,22 @@ impl AgentExpectedRelationshipSelector {
     }
 
     fn matches_selector(&self, selector: &AgentRelationSelectorProjection) -> bool {
+        let declaration_file_matches =
+            declaration_files_match(&self.declaration_file, &selector.declaration_file);
         self.fq_name == selector.fq_name
-            && self.declaration_file == selector.declaration_file
+            && declaration_file_matches
             && self.declaration_start_offset == selector.declaration_start_offset
             && self.kind == selector.kind
             && self.containing_type == selector.containing_type
     }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentRawRelationshipSymbolInput {
-    fq_name: String,
-    kind: String,
-    location: AgentLocationInput,
-    #[serde(default)]
-    containing_type: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentRawCallNodeInput {
-    symbol: AgentRawRelationshipSymbolInput,
-    #[serde(default)]
-    call_site: Option<AgentLocationInput>,
-    #[serde(default)]
-    children: Vec<AgentRawCallNodeInput>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentRawCallStatsInput {
-    total_edges: usize,
-    max_depth_reached: usize,
-    #[serde(default)]
-    truncated_nodes: usize,
-    #[serde(default)]
-    timeout_reached: bool,
-    #[serde(default)]
-    max_total_calls_reached: bool,
-    #[serde(default)]
-    max_children_per_node_reached: bool,
-}
-
-impl AgentRawCallStatsInput {
-    fn is_exhaustive(&self) -> bool {
-        self.truncated_nodes == 0
-            && !self.timeout_reached
-            && !self.max_total_calls_reached
-            && !self.max_children_per_node_reached
-    }
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentRawCallHierarchyInput {
-    root: AgentRawCallNodeInput,
-    stats: AgentRawCallStatsInput,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentRawImplementationsInput {
-    declaration: AgentRawRelationshipSymbolInput,
-    implementations: Vec<AgentRawRelationshipSymbolInput>,
-    exhaustive: bool,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentRawHierarchyNodeInput {
-    symbol: AgentRawRelationshipSymbolInput,
-    #[serde(default)]
-    children: Vec<AgentRawHierarchyNodeInput>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentRawHierarchyStatsInput {
-    total_nodes: usize,
-    max_depth_reached: usize,
-    truncated: bool,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentRawHierarchyInput {
-    root: AgentRawHierarchyNodeInput,
-    stats: AgentRawHierarchyStatsInput,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentCallRelationshipRecordProjection {
-    relation: &'static str,
-    related_symbol: AgentRelationIdentityProjection,
-    call_site: AgentLocationInput,
-    depth: usize,
-    containing_symbol: AgentContainingSymbolInput,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentImplementationRecordProjection {
-    relation: &'static str,
-    implementation: AgentRelationIdentityProjection,
-    declaration_location: AgentLocationInput,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct AgentHierarchyRecordProjection {
-    relation: &'static str,
-    related_symbol: AgentRelationIdentityProjection,
-    declaration_location: AgentLocationInput,
-    depth: usize,
-}
-
-#[allow(clippy::too_many_arguments)]
-fn project_raw_call_relationship_envelope(
-    method: String,
-    envelope: AgentEnvelope,
-    expected: AgentExpectedRelationshipSelector,
-    relation: &'static str,
-    record_relation: &'static str,
-    direction: &'static str,
-    result_limit: usize,
-    max_depth: usize,
-    view: AgentResultView<AgentRelationField>,
-) -> AgentEnvelope {
-    if !envelope.ok {
-        return compact_relationship_error(method, envelope);
-    }
-    let Some(result) = envelope.result else {
-        return invalid_projection_envelope(method, "Call hierarchy returned no result.");
-    };
-    let input = match serde_json::from_value::<AgentRawCallHierarchyInput>(result) {
-        Ok(input) => input,
-        Err(error) => {
-            return invalid_projection_envelope(
-                method,
-                format!("Call hierarchy violated its closed response contract: {error}"),
-            );
-        }
-    };
-    let AgentRawCallHierarchyInput { root, stats } = input;
-    if !stats.is_exhaustive() {
-        return invalid_projection_envelope(
-            method,
-            "Call hierarchy was incomplete without resumable traversal state.",
-        );
-    }
-    let AgentRawCallNodeInput {
-        symbol,
-        call_site: _,
-        children,
-    } = root;
-    let (mut subject, _) = match project_raw_relationship_symbol(symbol) {
-        Ok(subject) => subject,
-        Err(message) => return invalid_projection_envelope(method, message),
-    };
-    if !expected.matches(&mut subject) {
-        return invalid_projection_envelope(
-            method,
-            "Call hierarchy subject did not match the selected declaration anchor.",
-        );
-    }
-    let mut records = Vec::new();
-    let mut observed_max_depth = 0_usize;
-    let mut frontier = std::collections::VecDeque::new();
-    for child in children {
-        frontier.push_back((child, 1_usize, subject.clone()));
-    }
-    while let Some((node, depth, parent)) = frontier.pop_front() {
-        if records.len() == result_limit || depth > max_depth {
-            return invalid_projection_envelope(
-                method,
-                "Call hierarchy exceeded the requested result or depth bound.",
-            );
-        }
-        observed_max_depth = observed_max_depth.max(depth);
-        let AgentRawCallNodeInput {
-            symbol,
-            call_site,
-            children,
-        } = node;
-        let (related_symbol, _) = match project_raw_relationship_symbol(symbol) {
-            Ok(symbol) => symbol,
-            Err(message) => return invalid_projection_envelope(method, message),
-        };
-        let Some(call_site) = call_site.filter(valid_relationship_location) else {
-            return invalid_projection_envelope(
-                method,
-                "Call hierarchy record omitted its valid call-site location.",
-            );
-        };
-        let containing_identity = if direction == "INCOMING" {
-            related_symbol.clone()
-        } else {
-            parent
-        };
-        for child in children {
-            frontier.push_back((child, depth + 1, related_symbol.clone()));
-        }
-        records.push(AgentCallRelationshipRecordProjection {
-            relation: record_relation,
-            related_symbol,
-            call_site: call_site.compact_relationship(),
-            depth,
-            containing_symbol: AgentContainingSymbolInput::Known {
-                symbol: containing_identity,
-            },
-        });
-    }
-    if stats.total_edges != records.len() || stats.max_depth_reached != observed_max_depth {
-        return invalid_projection_envelope(
-            method,
-            "Call hierarchy statistics did not match its complete bounded evidence.",
-        );
-    }
-    project_available_relationship(
-        method,
-        "KAST_AGENT_CALL_RELATIONSHIP_RESULT",
-        subject,
-        relation,
-        records,
-        view,
-    )
-}
-
-fn project_raw_implementations_envelope(
-    method: String,
-    envelope: AgentEnvelope,
-    expected: AgentExpectedRelationshipSelector,
-    result_limit: usize,
-    view: AgentResultView<AgentRelationField>,
-) -> AgentEnvelope {
-    if !envelope.ok {
-        return compact_relationship_error(method, envelope);
-    }
-    let Some(result) = envelope.result else {
-        return invalid_projection_envelope(method, "Implementations returned no result.");
-    };
-    let input = match serde_json::from_value::<AgentRawImplementationsInput>(result) {
-        Ok(input) => input,
-        Err(error) => {
-            return invalid_projection_envelope(
-                method,
-                format!("Implementations violated its closed response contract: {error}"),
-            );
-        }
-    };
-    if !input.exhaustive || input.implementations.len() > result_limit {
-        return invalid_projection_envelope(
-            method,
-            "Implementations were incomplete or exceeded the requested result bound.",
-        );
-    }
-    let (mut subject, _) = match project_raw_relationship_symbol(input.declaration) {
-        Ok(subject) => subject,
-        Err(message) => return invalid_projection_envelope(method, message),
-    };
-    if !expected.matches(&mut subject) {
-        return invalid_projection_envelope(
-            method,
-            "Implementation subject did not match the selected declaration anchor.",
-        );
-    }
-    let mut records = Vec::with_capacity(input.implementations.len());
-    for implementation in input.implementations {
-        let (implementation, declaration_location) =
-            match project_raw_relationship_symbol(implementation) {
-                Ok(value) => value,
-                Err(message) => return invalid_projection_envelope(method, message),
-            };
-        records.push(AgentImplementationRecordProjection {
-            relation: "IMPLEMENTATION",
-            implementation,
-            declaration_location,
-        });
-    }
-    project_available_relationship(
-        method,
-        "KAST_AGENT_IMPLEMENTATIONS_RESULT",
-        subject,
-        "implementations",
-        records,
-        view,
-    )
-}
-
-fn project_raw_hierarchy_envelope(
-    method: String,
-    envelope: AgentEnvelope,
-    expected: AgentExpectedRelationshipSelector,
-    record_relation: &'static str,
-    result_limit: usize,
-    max_depth: usize,
-    view: AgentResultView<AgentRelationField>,
-) -> AgentEnvelope {
-    if !envelope.ok {
-        return compact_relationship_error(method, envelope);
-    }
-    let Some(result) = envelope.result else {
-        return invalid_projection_envelope(method, "Type hierarchy returned no result.");
-    };
-    let input = match serde_json::from_value::<AgentRawHierarchyInput>(result) {
-        Ok(input) => input,
-        Err(error) => {
-            return invalid_projection_envelope(
-                method,
-                format!("Type hierarchy violated its closed response contract: {error}"),
-            );
-        }
-    };
-    if input.stats.truncated {
-        return invalid_projection_envelope(
-            method,
-            "Type hierarchy was incomplete without resumable traversal state.",
-        );
-    }
-    let AgentRawHierarchyNodeInput { symbol, children } = input.root;
-    let (mut subject, _) = match project_raw_relationship_symbol(symbol) {
-        Ok(subject) => subject,
-        Err(message) => return invalid_projection_envelope(method, message),
-    };
-    if !expected.matches(&mut subject) {
-        return invalid_projection_envelope(
-            method,
-            "Type hierarchy subject did not match the selected declaration anchor.",
-        );
-    }
-    let mut records = Vec::new();
-    let mut observed_max_depth = 0_usize;
-    let mut frontier = std::collections::VecDeque::new();
-    for child in children {
-        frontier.push_back((child, 1_usize));
-    }
-    while let Some((node, depth)) = frontier.pop_front() {
-        if records.len() == result_limit || depth > max_depth {
-            return invalid_projection_envelope(
-                method,
-                "Type hierarchy exceeded the requested result or depth bound.",
-            );
-        }
-        observed_max_depth = observed_max_depth.max(depth);
-        let AgentRawHierarchyNodeInput { symbol, children } = node;
-        let (related_symbol, declaration_location) =
-            match project_raw_relationship_symbol(symbol) {
-                Ok(value) => value,
-                Err(message) => return invalid_projection_envelope(method, message),
-            };
-        records.push(AgentHierarchyRecordProjection {
-            relation: record_relation,
-            related_symbol,
-            declaration_location,
-            depth,
-        });
-        for child in children {
-            frontier.push_back((child, depth + 1));
-        }
-    }
-    if input.stats.total_nodes != records.len().saturating_add(1)
-        || input.stats.max_depth_reached != observed_max_depth
-    {
-        return invalid_projection_envelope(
-            method,
-            "Type hierarchy statistics did not match its complete bounded evidence.",
-        );
-    }
-    project_available_relationship(
-        method,
-        "KAST_AGENT_HIERARCHY_RESULT",
-        subject,
-        "hierarchy",
-        records,
-        view,
-    )
-}
-
-fn project_raw_relationship_symbol(
-    symbol: AgentRawRelationshipSymbolInput,
-) -> std::result::Result<(AgentRelationIdentityProjection, AgentLocationInput), &'static str> {
-    if !valid_relationship_location(&symbol.location) {
-        return Err("Relationship symbol omitted its valid declaration location.");
-    }
-    let declaration_start_offset = symbol
-        .location
-        .start_offset
-        .ok_or("Relationship symbol omitted its declaration offset.")?;
-    let identity = AgentRelationIdentityProjection {
-        fq_name: symbol.fq_name,
-        kind: symbol.kind,
-        declaration_file: symbol.location.file_path.clone(),
-        declaration_start_offset,
-        containing_type: symbol.containing_type,
-    };
-    if !identity.is_valid() {
-        return Err("Relationship symbol contained an invalid identity.");
-    }
-    Ok((identity, symbol.location.compact_relationship()))
+fn declaration_files_match(left: &str, right: &str) -> bool {
+    left == right
+        || std::fs::canonicalize(left)
+            .ok()
+            .zip(std::fs::canonicalize(right).ok())
+            .is_some_and(|(left, right)| left == right)
 }
 
 fn valid_relationship_location(location: &AgentLocationInput) -> bool {
@@ -885,60 +993,6 @@ fn valid_relationship_location(location: &AgentLocationInput) -> bool {
 fn compact_relationship_error(method: String, mut envelope: AgentEnvelope) -> AgentEnvelope {
     envelope.method = method;
     compact_error_envelope(envelope)
-}
-
-fn project_available_relationship<Record: Serialize>(
-    method: String,
-    result_type: &'static str,
-    subject: AgentRelationIdentityProjection,
-    relation: &'static str,
-    records: Vec<Record>,
-    view: AgentResultView<AgentRelationField>,
-) -> AgentEnvelope {
-    let returned_count = records.len();
-    let selected = |field| match &view {
-        AgentResultView::Fields(fields) => fields.contains(&field),
-        AgentResultView::Count => false,
-        AgentResultView::Compact | AgentResultView::Verbose | AgentResultView::Explain => true,
-    };
-    let mut result = serde_json::Map::from_iter([
-        ("type".to_string(), Value::String(result_type.to_string())),
-        ("ok".to_string(), Value::Bool(true)),
-        ("outcome".to_string(), Value::String("AVAILABLE".to_string())),
-        ("schemaVersion".to_string(), Value::from(SCHEMA_VERSION)),
-    ]);
-    if selected(AgentRelationField::Subject) {
-        result.insert(
-            "subject".to_string(),
-            serde_json::to_value(subject).unwrap_or(Value::Null),
-        );
-    }
-    if selected(AgentRelationField::Relation) || matches!(view, AgentResultView::Count) {
-        result.insert("relation".to_string(), Value::String(relation.to_string()));
-    }
-    if selected(AgentRelationField::Records) {
-        result.insert(
-            "records".to_string(),
-            serde_json::to_value(records).unwrap_or(Value::Null),
-        );
-    }
-    if selected(AgentRelationField::Page) || matches!(view, AgentResultView::Count) {
-        result.insert(
-            "page".to_string(),
-            json!({
-                "cardinality": {
-                    "type": "EXACT",
-                    "totalCount": returned_count,
-                },
-                "returnedCount": returned_count,
-                "truncated": false,
-            }),
-        );
-    }
-    if selected(AgentRelationField::Limitations) {
-        result.insert("limitations".to_string(), Value::Array(Vec::new()));
-    }
-    projected_agent_envelope(method, true, Value::Object(result), None)
 }
 
 #[derive(Debug, Deserialize)]
@@ -969,16 +1023,19 @@ enum AgentTypedTraversalResponseInput<Record, Reason> {
         selector: AgentRelationSelectorProjection,
         subject: AgentRelationIdentityProjection,
         reason: Reason,
+        evidence: AgentRelationshipResultEvidenceInput,
     },
     #[serde(rename = "CURSOR_STALE")]
     CursorStale {
         selector: AgentRelationSelectorProjection,
         reason: AgentRelationCursorStaleReason,
+        evidence: AgentRelationshipResultEvidenceInput,
     },
     #[serde(rename = "CURSOR_INVALID")]
     CursorInvalid {
         selector: AgentRelationSelectorProjection,
         reason: AgentRelationCursorInvalidReason,
+        evidence: AgentRelationshipResultEvidenceInput,
     },
     #[serde(rename = "SELECTOR_HANDLE_REJECTED")]
     SelectorHandleRejected {
@@ -990,7 +1047,7 @@ enum AgentTypedTraversalResponseInput<Record, Reason> {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct AgentTypedTraversalPageInput {
-    cardinality: AgentResultCardinality,
+    evidence: AgentRelationshipResultEvidenceInput,
     returned_count: usize,
     visited_candidate_count: usize,
     truncated: bool,
@@ -1000,14 +1057,27 @@ struct AgentTypedTraversalPageInput {
 
 impl AgentTypedTraversalPageInput {
     fn is_valid(&self, record_count: usize, result_limit: usize) -> bool {
-        self.returned_count == record_count
+        let cardinality = self.evidence.cardinality();
+        self.evidence.is_valid_complete()
+            && self.returned_count == record_count
             && record_count <= result_limit
             && self.visited_candidate_count >= record_count
             && self.visited_candidate_count <= 16_384
             && self.truncated == self.next_page_token.is_some()
-            && self.cardinality.known_minimum() >= record_count
-            && (!self.truncated || self.cardinality.known_minimum() > record_count)
+            && cardinality.known_minimum() >= record_count
+            && (!self.truncated || cardinality.known_minimum() > record_count)
     }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentTypedTraversalPageProjection {
+    cardinality: AgentResultCardinality,
+    returned_count: usize,
+    visited_candidate_count: usize,
+    truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_page_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1044,6 +1114,7 @@ enum AgentCallDegradedReason {
     CandidateBudgetReached,
     TraversalStateBudgetReached,
     Timeout,
+    Cancelled,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
@@ -1053,6 +1124,7 @@ enum AgentImplementationsDegradedReason {
     CandidateBudgetReached,
     TraversalStateBudgetReached,
     Timeout,
+    Cancelled,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
@@ -1062,6 +1134,7 @@ enum AgentHierarchyDegradedReason {
     CandidateBudgetReached,
     TraversalStateBudgetReached,
     Timeout,
+    Cancelled,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1247,6 +1320,23 @@ fn project_typed_available_relationship<Record: Serialize>(
     page: AgentTypedTraversalPageInput,
     view: AgentResultView<AgentRelationField>,
 ) -> AgentEnvelope {
+    let AgentTypedTraversalPageInput {
+        evidence,
+        returned_count,
+        visited_candidate_count,
+        truncated,
+        next_page_token,
+    } = page;
+    let cardinality = evidence.cardinality();
+    let coverage = evidence.coverage().clone();
+    let limitations = evidence.coverage().limitations().to_vec();
+    let page = AgentTypedTraversalPageProjection {
+        cardinality,
+        returned_count,
+        visited_candidate_count,
+        truncated,
+        next_page_token,
+    };
     let selected = |field| match &view {
         AgentResultView::Fields(fields) => fields.contains(&field),
         AgentResultView::Count => false,
@@ -1279,9 +1369,14 @@ fn project_typed_available_relationship<Record: Serialize>(
             serde_json::to_value(page).unwrap_or(Value::Null),
         );
     }
-    if selected(AgentRelationField::Limitations) {
-        result.insert("limitations".to_string(), Value::Array(Vec::new()));
-    }
+    result.insert(
+        "coverage".to_string(),
+        serde_json::to_value(coverage).unwrap_or(Value::Null),
+    );
+    result.insert(
+        "limitations".to_string(),
+        serde_json::to_value(limitations).unwrap_or(Value::Null),
+    );
     projected_agent_envelope(method, true, Value::Object(result), None)
 }
 
@@ -1317,6 +1412,97 @@ where
             return invalid_projection_envelope(
                 method,
                 "Selector handle rejection did not match a handle request and its required recovery.",
+            );
+        }
+        AgentTypedTraversalResponseInput::Degraded {
+            selector,
+            mut subject,
+            reason,
+            evidence,
+        } if expected.is_none() => {
+            if !selector.is_valid()
+                || !subject.is_valid()
+                || !selector.matches_identity(&mut subject)
+                || !admitted_kind(&subject.kind)
+                || !evidence.is_valid_limited()
+            {
+                return invalid_projection_envelope(
+                    method,
+                    "Handle-backed degraded relationship contained inconsistent subject or limitation evidence.",
+                );
+            }
+            return projected_agent_envelope(
+                method,
+                true,
+                json!({
+                    "type": result_type,
+                    "ok": true,
+                    "outcome": "DEGRADED",
+                    "selector": selector,
+                    "subject": subject,
+                    "reason": reason,
+                    "cardinality": evidence.cardinality(),
+                    "coverage": evidence.coverage(),
+                    "limitations": evidence.coverage().limitations(),
+                    "schemaVersion": SCHEMA_VERSION,
+                }),
+                None,
+            );
+        }
+        AgentTypedTraversalResponseInput::CursorStale {
+            selector,
+            reason,
+            evidence,
+        } if expected.is_none() => {
+            if !selector.is_valid() || !evidence.is_valid_limited() {
+                return invalid_projection_envelope(
+                    method,
+                    "Handle-backed stale relationship contained invalid selector or limitation evidence.",
+                );
+            }
+            return projected_agent_envelope(
+                method,
+                true,
+                json!({
+                    "type": result_type,
+                    "ok": true,
+                    "outcome": "CURSOR_STALE",
+                    "selector": selector,
+                    "reason": reason,
+                    "cardinality": evidence.cardinality(),
+                    "coverage": evidence.coverage(),
+                    "limitations": evidence.coverage().limitations(),
+                    "schemaVersion": SCHEMA_VERSION,
+                }),
+                None,
+            );
+        }
+        AgentTypedTraversalResponseInput::CursorInvalid {
+            selector,
+            reason,
+            evidence,
+        } if expected.is_none() => {
+            if !selector.is_valid() || !evidence.is_valid_limited() {
+                return invalid_projection_envelope(
+                    method,
+                    "Handle-backed invalid relationship contained invalid selector or limitation evidence.",
+                );
+            }
+            return projected_agent_envelope(
+                method,
+                true,
+                json!({
+                    "type": result_type,
+                    "ok": true,
+                    "outcome": "CURSOR_INVALID",
+                    "selector": selector,
+                    "reason": reason,
+                    "cardinality": evidence.cardinality(),
+                    "coverage": evidence.coverage(),
+                    "limitations": evidence.coverage().limitations(),
+                    "schemaVersion": SCHEMA_VERSION,
+                }),
+                None,
             );
         }
         other => other,
@@ -1390,12 +1576,14 @@ where
             selector,
             mut subject,
             reason,
+            evidence,
         } => {
             if !selector.is_valid()
                 || !expected.matches_selector(&selector)
                 || !subject.is_valid()
                 || !expected.matches(&mut subject)
                 || !admitted_kind(&subject.kind)
+                || !evidence.is_valid_limited()
             {
                 return invalid_projection_envelope(
                     method,
@@ -1409,11 +1597,20 @@ where
                 "selector": selector,
                 "subject": subject,
                 "reason": reason,
+                "cardinality": evidence.cardinality(),
+                "coverage": evidence.coverage(),
+                "limitations": evidence.coverage().limitations(),
                 "schemaVersion": SCHEMA_VERSION,
             })
         }
-        AgentTypedTraversalResponseInput::CursorStale { selector, reason }
-            if selector.is_valid() && expected.matches_selector(&selector) =>
+        AgentTypedTraversalResponseInput::CursorStale {
+            selector,
+            reason,
+            evidence,
+        }
+            if selector.is_valid()
+                && expected.matches_selector(&selector)
+                && evidence.is_valid_limited() =>
         {
             json!({
                 "type": result_type,
@@ -1421,11 +1618,20 @@ where
                 "outcome": "CURSOR_STALE",
                 "selector": selector,
                 "reason": reason,
+                "cardinality": evidence.cardinality(),
+                "coverage": evidence.coverage(),
+                "limitations": evidence.coverage().limitations(),
                 "schemaVersion": SCHEMA_VERSION,
             })
         }
-        AgentTypedTraversalResponseInput::CursorInvalid { selector, reason }
-            if selector.is_valid() && expected.matches_selector(&selector) =>
+        AgentTypedTraversalResponseInput::CursorInvalid {
+            selector,
+            reason,
+            evidence,
+        }
+            if selector.is_valid()
+                && expected.matches_selector(&selector)
+                && evidence.is_valid_limited() =>
         {
             json!({
                 "type": result_type,
@@ -1433,6 +1639,9 @@ where
                 "outcome": "CURSOR_INVALID",
                 "selector": selector,
                 "reason": reason,
+                "cardinality": evidence.cardinality(),
+                "coverage": evidence.coverage(),
+                "limitations": evidence.coverage().limitations(),
                 "schemaVersion": SCHEMA_VERSION,
             })
         }

--- a/cli-rs/src/cli/agent.rs
+++ b/cli-rs/src/cli/agent.rs
@@ -1624,7 +1624,7 @@ pub struct AgentRelationViewArgs {
     /// Return only selected relationship result fields.
     #[arg(long, value_enum, value_delimiter = ',', num_args = 1..)]
     pub fields: Vec<AgentRelationField>,
-    /// Return relationship cardinality and page evidence only.
+    /// Return relationship cardinality, coverage, limitations, and page evidence only.
     #[arg(long)]
     pub count: bool,
 }
@@ -1635,6 +1635,7 @@ pub enum AgentRelationField {
     Relation,
     Records,
     Page,
+    Coverage,
     Limitations,
 }
 

--- a/cli-rs/tests/agent_relationship_navigation_smoke.rs
+++ b/cli-rs/tests/agent_relationship_navigation_smoke.rs
@@ -44,10 +44,100 @@ fn relation_location(file: &std::path::Path, start_offset: u64) -> serde_json::V
 
 fn exact_relation_page(total_count: usize) -> serde_json::Value {
     serde_json::json!({
+        "evidence": complete_relationship_evidence(total_count),
+        "returnedCount": total_count,
+        "visitedCandidateCount": total_count,
+        "truncated": false
+    })
+}
+
+fn proofless_exact_relation_page(total_count: usize) -> serde_json::Value {
+    serde_json::json!({
         "cardinality": {"type": "EXACT", "totalCount": total_count},
         "returnedCount": total_count,
         "visitedCandidateCount": total_count,
         "truncated": false
+    })
+}
+
+fn complete_relationship_coverage() -> serde_json::Value {
+    serde_json::json!({
+        "type": "COMPLETE",
+        "identity": "COMPLETE",
+        "projectScope": "COMPLETE",
+        "sourceSetScope": "COMPLETE",
+        "indexFreshness": "COMPLETE",
+        "backend": "COMPLETE",
+        "requestedFamily": "COMPLETE",
+        "limitations": []
+    })
+}
+
+fn complete_relationship_evidence(total_count: usize) -> serde_json::Value {
+    serde_json::json!({
+        "type": "COMPLETE",
+        "cardinality": {"type": "EXACT", "totalCount": total_count},
+        "coverage": complete_relationship_coverage()
+    })
+}
+
+fn resumable_relationship_evidence(known_minimum_count: usize) -> serde_json::Value {
+    serde_json::json!({
+        "type": "RESUMABLE",
+        "cardinality": {
+            "type": "KNOWN_MINIMUM",
+            "knownMinimumCount": known_minimum_count
+        },
+        "coverage": {
+            "type": "RESUMABLE",
+            "identity": "COMPLETE",
+            "projectScope": "COMPLETE",
+            "sourceSetScope": "COMPLETE",
+            "indexFreshness": "COMPLETE",
+            "backend": "COMPLETE",
+            "requestedFamily": "IN_PROGRESS",
+            "limitations": ["FAMILY_SEARCH_IN_PROGRESS"]
+        }
+    })
+}
+
+fn excluded_source_set_evidence(known_minimum_count: usize) -> serde_json::Value {
+    serde_json::json!({
+        "type": "LIMITED",
+        "cardinality": {
+            "type": "KNOWN_MINIMUM",
+            "knownMinimumCount": known_minimum_count
+        },
+        "coverage": {
+            "type": "LIMITED",
+            "identity": "COMPLETE",
+            "projectScope": "COMPLETE",
+            "sourceSetScope": "EXCLUDED",
+            "indexFreshness": "COMPLETE",
+            "backend": "COMPLETE",
+            "requestedFamily": "PARTIAL",
+            "limitations": ["SOURCE_SET_EXCLUDED", "FAMILY_SEARCH_INCOMPLETE"]
+        }
+    })
+}
+
+fn generation_changed_evidence(known_minimum_count: usize) -> serde_json::Value {
+    serde_json::json!({
+        "type": "LIMITED",
+        "cardinality": {
+            "type": "KNOWN_MINIMUM",
+            "knownMinimumCount": known_minimum_count
+        },
+        "coverage": {
+            "type": "LIMITED",
+            "identity": "COMPLETE",
+            "projectScope": "COMPLETE",
+            "sourceSetScope": "COMPLETE",
+            "indexFreshness": "STALE",
+            "backend": "COMPLETE",
+            "requestedFamily": "PARTIAL",
+            "limitations": ["GENERATION_CHANGED"]
+        }
     })
 }
 
@@ -191,6 +281,469 @@ fn relationship_types_reject_invalid_values_before_runtime_io() {
             String::from_utf8_lossy(&output.stderr),
         );
     }
+}
+
+#[test]
+fn exact_zero_relationships_require_complete_coverage_proof() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let declaration_file = workspace.join("Service.kt");
+    let selector_handle = "ksh1.proofless-exact-zero";
+    let function = relation_identity("sample.Service.run", "FUNCTION", &declaration_file, 42);
+    let interface = relation_identity("sample.Service", "INTERFACE", &declaration_file, 10);
+    let cases = vec![
+        (
+            "references",
+            "symbol/references",
+            Vec::<&str>::new(),
+            serde_json::json!({
+                "type": "AVAILABLE",
+                "subject": function,
+                "references": [],
+                "cardinality": {"type": "EXACT", "totalCount": 0},
+                "schemaVersion": 3
+            }),
+        ),
+        (
+            "callers",
+            "symbol/callers",
+            Vec::<&str>::new(),
+            serde_json::json!({
+                "type": "AVAILABLE",
+                "subject": function,
+                "records": [],
+                "page": proofless_exact_relation_page(0),
+                "schemaVersion": 3
+            }),
+        ),
+        (
+            "callees",
+            "symbol/callers",
+            Vec::<&str>::new(),
+            serde_json::json!({
+                "type": "AVAILABLE",
+                "subject": function,
+                "records": [],
+                "page": proofless_exact_relation_page(0),
+                "schemaVersion": 3
+            }),
+        ),
+        (
+            "implementations",
+            "symbol/implementations",
+            Vec::<&str>::new(),
+            serde_json::json!({
+                "type": "AVAILABLE",
+                "subject": interface,
+                "records": [],
+                "page": proofless_exact_relation_page(0),
+                "schemaVersion": 3
+            }),
+        ),
+        (
+            "hierarchy",
+            "symbol/hierarchy",
+            vec!["--direction", "both"],
+            serde_json::json!({
+                "type": "AVAILABLE",
+                "subject": interface,
+                "records": [],
+                "page": proofless_exact_relation_page(0),
+                "schemaVersion": 3
+            }),
+        ),
+    ];
+
+    for (index, (command_name, method, extra_args, response)) in cases.into_iter().enumerate() {
+        let backend = spawn_scripted_idea_backend(
+            &home,
+            &config,
+            &workspace,
+            &temp.path().join(format!("proofless-zero-{index}.sock")),
+            vec![(method, response)],
+        );
+        let mut command = kast(&home, &config);
+        command.args([
+            "--output",
+            "json",
+            "agent",
+            command_name,
+            "--selector-handle",
+            selector_handle,
+        ]);
+        command.args(extra_args);
+        command.args(["--workspace-root", workspace.to_str().expect("workspace")]);
+
+        let output = command.output().expect("proofless relationship");
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "command={command_name} stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let stdout: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("invalid relationship json");
+        assert_eq!(
+            stdout["error"]["code"], "AGENT_RESULT_INVALID",
+            "command={command_name} output={stdout}",
+        );
+        backend.join().expect("scripted backend");
+    }
+}
+
+#[test]
+fn relationship_evidence_variants_reject_inconsistent_coverage_facts() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let declaration_file = workspace.join("Service.kt");
+    let selector_handle = "ksh1.inconsistent-relationship-evidence";
+    let subject = relation_identity("sample.Service.run", "FUNCTION", &declaration_file, 42);
+    let cases = [
+        serde_json::json!({
+            "type": "COMPLETE",
+            "cardinality": {"type": "EXACT", "totalCount": 0},
+            "coverage": {
+                "type": "COMPLETE",
+                "identity": "COMPLETE",
+                "projectScope": "COMPLETE",
+                "sourceSetScope": "EXCLUDED",
+                "indexFreshness": "COMPLETE",
+                "backend": "COMPLETE",
+                "requestedFamily": "COMPLETE",
+                "limitations": []
+            }
+        }),
+        serde_json::json!({
+            "type": "RESUMABLE",
+            "cardinality": {"type": "KNOWN_MINIMUM", "knownMinimumCount": 1},
+            "coverage": {
+                "type": "RESUMABLE",
+                "identity": "COMPLETE",
+                "projectScope": "COMPLETE",
+                "sourceSetScope": "COMPLETE",
+                "indexFreshness": "COMPLETE",
+                "backend": "COMPLETE",
+                "requestedFamily": "IN_PROGRESS",
+                "limitations": []
+            }
+        }),
+        serde_json::json!({
+            "type": "LIMITED",
+            "cardinality": {"type": "KNOWN_MINIMUM", "knownMinimumCount": 0},
+            "coverage": {
+                "type": "LIMITED",
+                "identity": "COMPLETE",
+                "projectScope": "COMPLETE",
+                "sourceSetScope": "COMPLETE",
+                "indexFreshness": "COMPLETE",
+                "backend": "COMPLETE",
+                "requestedFamily": "PARTIAL",
+                "limitations": []
+            }
+        }),
+    ];
+
+    for (index, evidence) in cases.into_iter().enumerate() {
+        let backend = spawn_scripted_idea_backend(
+            &home,
+            &config,
+            &workspace,
+            &temp.path().join(format!("invalid-evidence-{index}.sock")),
+            vec![(
+                "symbol/references",
+                serde_json::json!({
+                    "type": "AVAILABLE",
+                    "subject": subject,
+                    "references": [],
+                    "evidence": evidence,
+                    "schemaVersion": 3
+                }),
+            )],
+        );
+        let output = kast(&home, &config)
+            .args([
+                "--output",
+                "json",
+                "agent",
+                "references",
+                "--selector-handle",
+                selector_handle,
+                "--workspace-root",
+                workspace.to_str().expect("workspace"),
+            ])
+            .output()
+            .expect("inconsistent relationship evidence");
+
+        assert_eq!(output.status.code(), Some(1));
+        let stdout: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("invalid evidence output");
+        assert_eq!(stdout["error"]["code"], "AGENT_RESULT_INVALID");
+        backend.join().expect("scripted backend");
+    }
+}
+
+#[test]
+fn genuine_exact_zero_preserves_complete_coverage_in_compact_and_count_views() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let declaration_file = workspace.join("Service.kt");
+    let selector_handle = "ksh1.complete-exact-zero";
+    let response = || {
+        serde_json::json!({
+            "type": "AVAILABLE",
+            "subject": relation_identity(
+                "sample.Service.run",
+                "FUNCTION",
+                &declaration_file,
+                42,
+            ),
+            "references": [],
+            "evidence": complete_relationship_evidence(0),
+            "schemaVersion": 3
+        })
+    };
+
+    let compact_backend = spawn_scripted_idea_backend(
+        &home,
+        &config,
+        &workspace,
+        &temp.path().join("complete-zero-compact.sock"),
+        vec![("symbol/references", response())],
+    );
+    let compact = kast(&home, &config)
+        .args([
+            "agent",
+            "references",
+            "--selector-handle",
+            selector_handle,
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("compact complete zero");
+    assert!(
+        compact.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&compact.stdout),
+        String::from_utf8_lossy(&compact.stderr),
+    );
+    let compact_stdout = String::from_utf8_lossy(&compact.stdout);
+    assert!(compact_stdout.contains("coverage"), "{compact_stdout}");
+    assert!(compact_stdout.contains("COMPLETE"), "{compact_stdout}");
+    assert!(compact_stdout.contains("limitations"), "{compact_stdout}");
+    compact_backend.join().expect("compact backend");
+
+    let count_backend = spawn_scripted_idea_backend(
+        &home,
+        &config,
+        &workspace,
+        &temp.path().join("complete-zero-count.sock"),
+        vec![("symbol/references", response())],
+    );
+    let count = kast(&home, &config)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "references",
+            "--selector-handle",
+            selector_handle,
+            "--count",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("count complete zero");
+    assert!(
+        count.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&count.stdout),
+        String::from_utf8_lossy(&count.stderr),
+    );
+    let count: serde_json::Value =
+        serde_json::from_slice(&count.stdout).expect("count complete zero json");
+    assert_eq!(count["result"]["page"]["cardinality"]["type"], "EXACT");
+    assert_eq!(count["result"]["page"]["cardinality"]["totalCount"], 0);
+    assert_eq!(count["result"]["coverage"]["type"], "COMPLETE");
+    assert_eq!(count["result"]["limitations"], serde_json::json!([]));
+    count_backend.join().expect("count backend");
+
+    let selected_backend = spawn_scripted_idea_backend(
+        &home,
+        &config,
+        &workspace,
+        &temp.path().join("complete-zero-selected.sock"),
+        vec![("symbol/references", response())],
+    );
+    let selected = kast(&home, &config)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "references",
+            "--selector-handle",
+            selector_handle,
+            "--fields",
+            "subject",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("selected complete zero");
+    assert!(
+        selected.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&selected.stdout),
+        String::from_utf8_lossy(&selected.stderr),
+    );
+    let selected: serde_json::Value =
+        serde_json::from_slice(&selected.stdout).expect("selected complete zero json");
+    assert!(selected["result"].get("page").is_none());
+    assert_eq!(selected["result"]["coverage"]["type"], "COMPLETE");
+    assert_eq!(selected["result"]["limitations"], serde_json::json!([]));
+    selected_backend.join().expect("selected backend");
+}
+
+#[test]
+fn handle_backed_degraded_relationship_preserves_known_minimum_and_limitations() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let declaration_file = workspace.join("Service.kt");
+    let selector_handle = "ksh1.degraded-relationship";
+    let selector = serde_json::json!({
+        "fqName": "sample.Service.run",
+        "declarationFile": declaration_file,
+        "declarationStartOffset": 42,
+        "kind": "FUNCTION"
+    });
+    let subject = relation_identity("sample.Service.run", "FUNCTION", &declaration_file, 42);
+    let backend = spawn_scripted_idea_backend(
+        &home,
+        &config,
+        &workspace,
+        &temp.path().join("degraded-evidence.sock"),
+        vec![(
+            "symbol/callers",
+            serde_json::json!({
+                "type": "DEGRADED",
+                "selector": selector,
+                "subject": subject,
+                "reason": "CALL_HIERARCHY_UNAVAILABLE",
+                "evidence": excluded_source_set_evidence(3),
+                "schemaVersion": 3
+            }),
+        )],
+    );
+
+    let output = kast(&home, &config)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "callers",
+            "--selector-handle",
+            selector_handle,
+            "--count",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("degraded relationship evidence");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("degraded relationship json");
+    assert_eq!(stdout["result"]["outcome"], "DEGRADED");
+    assert_eq!(
+        stdout["result"]["cardinality"],
+        serde_json::json!({"type": "KNOWN_MINIMUM", "knownMinimumCount": 3})
+    );
+    assert_eq!(stdout["result"]["coverage"]["type"], "LIMITED");
+    assert_eq!(
+        stdout["result"]["limitations"],
+        serde_json::json!(["SOURCE_SET_EXCLUDED", "FAMILY_SEARCH_INCOMPLETE"])
+    );
+    backend.join().expect("degraded backend");
+}
+
+#[test]
+fn handle_backed_stale_relationship_preserves_known_minimum_and_limitations() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let declaration_file = workspace.join("Service.kt");
+    let selector_handle = "ksh1.stale-relationship";
+    let backend = spawn_scripted_idea_backend(
+        &home,
+        &config,
+        &workspace,
+        &temp.path().join("stale-evidence.sock"),
+        vec![(
+            "symbol/callers",
+            serde_json::json!({
+                "type": "CURSOR_STALE",
+                "selector": {
+                    "fqName": "sample.Service.run",
+                    "declarationFile": declaration_file,
+                    "declarationStartOffset": 42,
+                    "kind": "FUNCTION"
+                },
+                "reason": "GENERATION_CHANGED",
+                "evidence": generation_changed_evidence(2),
+                "schemaVersion": 3
+            }),
+        )],
+    );
+
+    let output = kast(&home, &config)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "callers",
+            "--selector-handle",
+            selector_handle,
+            "--count",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("stale relationship evidence");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stale relationship json");
+    assert_eq!(stdout["result"]["outcome"], "CURSOR_STALE");
+    assert_eq!(
+        stdout["result"]["cardinality"],
+        serde_json::json!({"type": "KNOWN_MINIMUM", "knownMinimumCount": 2})
+    );
+    assert_eq!(stdout["result"]["coverage"]["indexFreshness"], "STALE");
+    assert_eq!(
+        stdout["result"]["limitations"],
+        serde_json::json!(["GENERATION_CHANGED"])
+    );
+    backend.join().expect("stale backend");
 }
 
 #[test]
@@ -806,7 +1359,7 @@ fn selector_handle_resolves_once_and_reuses_identity_for_references() {
                 "type": "AVAILABLE",
                 "subject": selector,
                 "references": [],
-                "cardinality": {"type": "EXACT", "totalCount": 0},
+                "evidence": complete_relationship_evidence(0),
                 "schemaVersion": 3
             }),
         )],
@@ -1118,7 +1671,7 @@ fn exact_identity_drives_references_callers_continuation_and_impact_without_redi
                     "location": relation_location(&workspace.join("app/A.kt"), 30),
                     "containingSymbol": {"type": "TOP_LEVEL"}
                 }],
-                "cardinality": {"type": "KNOWN_MINIMUM", "knownMinimumCount": 2},
+                "evidence": resumable_relationship_evidence(2),
                 "page": {
                     "truncated": true,
                     "nextPageToken": reference_handle
@@ -1173,7 +1726,7 @@ fn exact_identity_drives_references_callers_continuation_and_impact_without_redi
                 "type": "AVAILABLE",
                 "subject": selector,
                 "references": [],
-                "cardinality": {"type": "EXACT", "totalCount": 1},
+                "evidence": complete_relationship_evidence(1),
                 "schemaVersion": 3
             }),
         )],
@@ -1451,10 +2004,7 @@ fn references_send_the_exact_anchor_and_project_occurrence_evidence() {
                         }
                     }
                 }],
-                "cardinality": {
-                    "type": "KNOWN_MINIMUM",
-                    "knownMinimumCount": 2
-                },
+                "evidence": resumable_relationship_evidence(2),
                 "page": {
                     "truncated": true,
                     "nextPageToken": backend_token
@@ -1539,7 +2089,7 @@ fn references_send_the_exact_anchor_and_project_occurrence_evidence() {
                     "declarationStartOffset": 15
                 },
                 "references": [],
-                "cardinality": {"type": "EXACT", "totalCount": 1},
+                "evidence": complete_relationship_evidence(1),
                 "schemaVersion": 3
             }),
         )],
@@ -1605,6 +2155,80 @@ fn references_send_the_exact_anchor_and_project_occurrence_evidence() {
 }
 
 #[test]
+fn references_preserve_a_zero_known_minimum_while_search_remains_resumable() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let declaration_file = workspace.join("Service.kt");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(&declaration_file, "package sample\nclass Service\n").expect("source");
+    let backend_token = "00000000-0000-4000-8000-000000000337";
+    let backend = spawn_scripted_idea_backend(
+        &home,
+        &config,
+        &workspace,
+        &temp.path().join("idea.sock"),
+        vec![(
+            "symbol/references",
+            serde_json::json!({
+                "type": "AVAILABLE",
+                "subject": {
+                    "fqName": "sample.Service",
+                    "kind": "CLASS",
+                    "declarationFile": declaration_file,
+                    "declarationStartOffset": 15
+                },
+                "references": [],
+                "evidence": resumable_relationship_evidence(0),
+                "page": {
+                    "truncated": true,
+                    "nextPageToken": backend_token
+                },
+                "schemaVersion": 3
+            }),
+        )],
+    );
+
+    let output = kast(&home, &config)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "references",
+            "--symbol",
+            "sample.Service",
+            "--declaration-file",
+            declaration_file.to_str().expect("declaration file"),
+            "--declaration-start-offset",
+            "15",
+            "--kind",
+            "class",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("resumable empty reference page");
+
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("resumable reference json");
+    assert_eq!(stdout["result"]["page"]["returnedCount"], 0);
+    assert_eq!(
+        stdout["result"]["page"]["cardinality"],
+        serde_json::json!({"type": "KNOWN_MINIMUM", "knownMinimumCount": 0}),
+    );
+    assert_eq!(stdout["result"]["coverage"]["type"], "RESUMABLE");
+    assert!(stdout["result"]["page"]["truncated"].as_bool().unwrap());
+    backend.join().expect("scripted backend");
+}
+
+#[test]
 fn references_project_every_closed_non_available_outcome() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -1652,7 +2276,8 @@ fn references_project_every_closed_non_available_outcome() {
                 "type": "DEGRADED",
                 "selector": selector,
                 "subject": subject,
-                "reason": "REFERENCES_UNAVAILABLE"
+                "reason": "REFERENCES_UNAVAILABLE",
+                "evidence": excluded_source_set_evidence(0)
             }),
         ),
         (
@@ -1660,7 +2285,8 @@ fn references_project_every_closed_non_available_outcome() {
             serde_json::json!({
                 "type": "CURSOR_STALE",
                 "selector": selector,
-                "reason": "GENERATION_CHANGED"
+                "reason": "GENERATION_CHANGED",
+                "evidence": excluded_source_set_evidence(0)
             }),
         ),
         (
@@ -1668,7 +2294,8 @@ fn references_project_every_closed_non_available_outcome() {
             serde_json::json!({
                 "type": "CURSOR_INVALID",
                 "selector": selector,
-                "reason": "UNKNOWN_HANDLE"
+                "reason": "UNKNOWN_HANDLE",
+                "evidence": excluded_source_set_evidence(0)
             }),
         ),
     ];
@@ -1757,6 +2384,108 @@ fn references_fail_closed_on_an_unknown_response_variant() {
         serde_json::from_slice(&output.stdout).expect("invalid references json");
     assert_eq!(stdout["error"]["code"], "AGENT_RESULT_INVALID");
     backend.join().expect("scripted backend");
+}
+
+#[test]
+fn explicit_references_fail_closed_on_response_provenance_mismatch() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    let declaration_file = workspace.join("Service.kt");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(&declaration_file, "package sample\nclass Service\n").expect("source");
+    let requested_selector = serde_json::json!({
+        "fqName": "sample.Service",
+        "declarationFile": declaration_file,
+        "declarationStartOffset": 15,
+        "kind": "CLASS"
+    });
+    let other_selector = serde_json::json!({
+        "fqName": "sample.Other",
+        "declarationFile": declaration_file,
+        "declarationStartOffset": 15,
+        "kind": "CLASS"
+    });
+    let other_subject = serde_json::json!({
+        "fqName": "sample.Other",
+        "kind": "CLASS",
+        "declarationFile": declaration_file,
+        "declarationStartOffset": 15
+    });
+    let cases = [
+        serde_json::json!({
+            "type": "AVAILABLE",
+            "subject": other_subject,
+            "references": [],
+            "evidence": complete_relationship_evidence(0),
+            "schemaVersion": 3
+        }),
+        serde_json::json!({
+            "type": "DEGRADED",
+            "selector": requested_selector,
+            "subject": other_subject,
+            "reason": "REFERENCES_UNAVAILABLE",
+            "evidence": excluded_source_set_evidence(0),
+            "schemaVersion": 3
+        }),
+        serde_json::json!({
+            "type": "CURSOR_STALE",
+            "selector": other_selector,
+            "reason": "GENERATION_CHANGED",
+            "evidence": excluded_source_set_evidence(0),
+            "schemaVersion": 3
+        }),
+        serde_json::json!({
+            "type": "SELECTOR_HANDLE_REJECTED",
+            "reason": "STALE",
+            "recovery": "RESOLVE_AGAIN",
+            "schemaVersion": 3
+        }),
+    ];
+
+    for (index, response) in cases.into_iter().enumerate() {
+        let backend = spawn_scripted_idea_backend(
+            &home,
+            &config,
+            &workspace,
+            &temp
+                .path()
+                .join(format!("reference-provenance-{index}.sock")),
+            vec![("symbol/references", response)],
+        );
+        let output = kast(&home, &config)
+            .args([
+                "--output",
+                "json",
+                "agent",
+                "references",
+                "--symbol",
+                "sample.Service",
+                "--declaration-file",
+                declaration_file.to_str().expect("declaration file"),
+                "--declaration-start-offset",
+                "15",
+                "--kind",
+                "class",
+                "--workspace-root",
+                workspace.to_str().expect("workspace"),
+            ])
+            .output()
+            .expect("mismatched reference provenance");
+
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "case={index} stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let result: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("provenance failure JSON");
+        assert_eq!(result["error"]["code"], "AGENT_RESULT_INVALID");
+        backend.join().expect("provenance backend");
+    }
 }
 
 #[test]
@@ -1883,10 +2612,7 @@ fn compact_references_bound_high_cardinality_output() {
                     "declarationStartOffset": 15
                 },
                 "references": references,
-                "cardinality": {
-                    "type": "KNOWN_MINIMUM",
-                    "knownMinimumCount": TOTAL_REFERENCES
-                },
+                "evidence": resumable_relationship_evidence(TOTAL_REFERENCES),
                 "page": {"truncated": true, "nextPageToken": backend_token},
                 "schemaVersion": 3
             }),
@@ -2222,7 +2948,7 @@ fn call_relationship_page_tokens_round_trip_only_the_backend_handle() {
                 ),
                 "records": first_records,
                 "page": {
-                    "cardinality": {"type": "KNOWN_MINIMUM", "knownMinimumCount": 5},
+                    "evidence": complete_relationship_evidence(5),
                     "returnedCount": 4,
                     "visitedCandidateCount": 5,
                     "truncated": true,
@@ -2292,7 +3018,7 @@ fn call_relationship_page_tokens_round_trip_only_the_backend_handle() {
                 ),
                 "records": [second_record],
                 "page": {
-                    "cardinality": {"type": "EXACT", "totalCount": 5},
+                    "evidence": complete_relationship_evidence(5),
                     "returnedCount": 1,
                     "visitedCandidateCount": 1,
                     "truncated": false
@@ -2392,7 +3118,8 @@ fn typed_relationship_commands_project_closed_non_available_outcomes() {
                     &canonical_file,
                     15,
                 ),
-                "reason": "CALL_HIERARCHY_UNAVAILABLE"
+                "reason": "CALL_HIERARCHY_UNAVAILABLE",
+                "evidence": excluded_source_set_evidence(0)
             }),
         ),
         (
@@ -2435,7 +3162,8 @@ fn typed_relationship_commands_project_closed_non_available_outcomes() {
                     &canonical_file,
                     15,
                 ),
-                "reason": "TYPE_HIERARCHY_UNAVAILABLE"
+                "reason": "TYPE_HIERARCHY_UNAVAILABLE",
+                "evidence": excluded_source_set_evidence(0)
             }),
         ),
     ]

--- a/cli-rs/tests/selector_handle_installed_workflow.rs
+++ b/cli-rs/tests/selector_handle_installed_workflow.rs
@@ -39,6 +39,23 @@ fn installed_cli_version(binary: &std::path::Path) -> String {
         .to_string()
 }
 
+fn complete_relationship_evidence(total_count: usize) -> serde_json::Value {
+    serde_json::json!({
+        "type": "COMPLETE",
+        "cardinality": {"type": "EXACT", "totalCount": total_count},
+        "coverage": {
+            "type": "COMPLETE",
+            "identity": "COMPLETE",
+            "projectScope": "COMPLETE",
+            "sourceSetScope": "COMPLETE",
+            "indexFreshness": "COMPLETE",
+            "backend": "COMPLETE",
+            "requestedFamily": "COMPLETE",
+            "limitations": []
+        }
+    })
+}
+
 #[test]
 fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations() {
     let Some(installed_binary) = std::env::var_os(INSTALLED_BINARY_ENV) else {
@@ -107,7 +124,7 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
                     "type": "AVAILABLE",
                     "subject": identity,
                     "references": [],
-                    "cardinality": {"type": "EXACT", "totalCount": 0},
+                    "evidence": complete_relationship_evidence(0),
                     "schemaVersion": 3
                 }),
             ),
@@ -118,7 +135,7 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
                     "subject": identity,
                     "records": [],
                     "page": {
-                        "cardinality": {"type": "EXACT", "totalCount": 0},
+                        "evidence": complete_relationship_evidence(0),
                         "returnedCount": 0,
                         "visitedCandidateCount": 0,
                         "truncated": false
@@ -177,6 +194,8 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
     let (references_toon, references) = decode_default_toon("references", references);
     assert_eq!(references["result"]["outcome"], "AVAILABLE");
     assert_eq!(references["result"]["subject"], identity);
+    assert_eq!(references["result"]["coverage"]["type"], "COMPLETE");
+    assert_eq!(references["result"]["limitations"], serde_json::json!([]));
 
     let callers = kast_at(&installed_binary, &home, &config_home)
         .args([
@@ -192,6 +211,8 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
     let (callers_toon, callers) = decode_default_toon("callers", callers);
     assert_eq!(callers["result"]["outcome"], "AVAILABLE");
     assert_eq!(callers["result"]["subject"], identity);
+    assert_eq!(callers["result"]["coverage"]["type"], "COMPLETE");
+    assert_eq!(callers["result"]["limitations"], serde_json::json!([]));
 
     let toon_bytes = resolved_toon.len() + references_toon.len() + callers_toon.len();
     let pretty_json_bytes = [&resolved, &references, &callers]


### PR DESCRIPTION
Closes #393 
## Risks / uncertainty
- Relationship queries now expose explicit coverage and continuation state; consumers must handle degraded or incomplete results.

## Summary
- Add proof-carrying relationship coverage, evidence, limitations, and continuation contracts.
- Propagate fail-closed semantics through API, server, IDEA backend, CLI projections, and protocol docs.
- Strengthen end-to-end and contract coverage for relationship navigation and installed workflows.

## Testing
- Added and updated Kotlin contract, backend, dispatcher, and relationship-model tests.
- Added Rust relationship-navigation and installed-workflow smoke tests.