### PR TITLE
ci: remove duplicate proof execution

### DIFF
--- a/.agents/adr/0024-revision-coherent-local-development-authority.md
+++ b/.agents/adr/0024-revision-coherent-local-development-authority.md
@@ -236,6 +236,23 @@ The local authority is not complete until executable checks prove:
   diagnostics, and a backend-produced nonzero plan-only mutation preview
   through the refreshed headless generation.
 
+Validation is layered by authored owner. Source and ownership contracts may
+assert that a focused owner exists and is wired, but they do not invoke that
+owner again. Rust unit and integration tests execute in the Rust job, Kotlin
+and IDEA tests execute in their Gradle jobs, documentation renders in the
+documentation workflow, and installer, runtime-compatibility, release,
+provenance, and asset contracts execute once in their named owners. The
+selector-handle integration test binds directly to Cargo's exact built binary,
+so the Rust owner cannot report success by silently skipping it.
+
+The pre-existing `installDevelopmentLocal` compatibility task is not the
+revision-coherent local authority defined by this ADR. Its profile-writing
+contract remains executable on integrated `main` pushes, but it is quarantined
+from the universal pull-request gate. This changes validation frequency, not
+the documented compatibility surface; removing the task or its supported
+profile behavior requires a separate product decision. Pull requests retain
+the source/task-graph assertions and the release-free local-authority proof.
+
 The focused source gate is:
 
 ```console

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -34,12 +34,23 @@ generation activation, rollback/removal, local readiness, or installed
 skill/guidance routing changes. Its Gradle graph must remain headless and must
 not include user JetBrains profile or release-configuration mutation.
 The legacy developer install remains covered separately by
-`.github/scripts/test-development-cli-install-contract.sh` in the same job.
-Keep its real IDEA plugin task execution wired in CI so explicit-directory,
-configured-profile, running-profile, newest-profile, missing-profile, and
-configuration-cache behavior cannot regress behind dry-run task-graph
-coverage. Installed CLI workflow proofs also belong in that build-backed job,
-not in the static fanout gate.
+`.github/scripts/test-development-cli-install-contract.sh`. It is not the
+revision-coherent local authority and must not run for every pull request.
+Keep its real IDEA plugin task execution on integrated `main` pushes so
+explicit-directory, configured-profile, running-profile, newest-profile,
+missing-profile, and configuration-cache behavior cannot regress behind
+dry-run task-graph coverage. Removing that documented compatibility surface
+requires an explicit ADR decision.
+
+Umbrella source contracts must not rerun focused owners. The CLI/plugin
+cutover contract owns source presence, absence, and authority assertions only;
+the runtime compatibility contract owns deterministic source and manifest
+rendering only. Rust unit and integration tests run in `rust-cli`, Kotlin and
+IDEA tests run in their Gradle owners, documentation rendering runs in the
+documentation workflow, and installer, release, provenance, and asset
+contracts run once in their named jobs. A focused Rust integration test must
+not return success by skipping when an outer installer environment variable is
+absent.
 
 The `workflow-contracts` job is the static CI fanout gate. It must not install
 Java, initialize Gradle, install Rust, or execute an installed-development

--- a/.github/ci/issue-401-workflow-model.json
+++ b/.github/ci/issue-401-workflow-model.json
@@ -2,7 +2,7 @@
   "$schema": "./workflow-graph-model.schema.json",
   "schemaVersion": 1,
   "provenance": {
-    "description": "Issue 401 fanout split. The first four baseline static-gate samples predate the installed-selector contract and are normalized by its observed three-second warm execution; the fifth baseline and candidate are exact proof-shape observations. Candidate timing remains provisional until five comparable final-shape runs exist.",
+    "description": "Issue 401 fanout split with current focused proof ownership. The first four baseline static-gate samples predate the selector-handle contract and are normalized by its observed three-second warm execution; the fifth baseline and candidate timing samples describe the split before duplicate-owner removal. The integrated candidate proof set is exact, including the main-only legacy profile-install canary, while timing remains provisional until five comparable final-shape runs exist.",
     "observedAt": "2026-07-17",
     "source": "https://github.com/amichne/kast/pull/407",
     "baselineRunIds": [
@@ -321,7 +321,6 @@
         "outputs": [
           "local-development-refresh-contract",
           "development-cli-install-contract",
-          "installed-selector-handle-workflow",
           "cli-plugin-authority-cutover-contract"
         ],
         "durationSamplesSeconds": [
@@ -366,7 +365,7 @@
         "durationSamplesSeconds": [
           566
         ],
-        "executionClass": "toolchain"
+        "executionClass": "static"
       },
       {
         "id": "maven-publication-contract",
@@ -391,6 +390,7 @@
           "rust-format",
           "rust-clippy",
           "rust-tests",
+          "installed-selector-handle-workflow",
           "rust-release-build",
           "lsp-config-smoke",
           "lsp-pivot-gates",

--- a/.github/scripts/test-cli-plugin-authority-cutover-contract.sh
+++ b/.github/scripts/test-cli-plugin-authority-cutover-contract.sh
@@ -123,31 +123,5 @@ require_not_contains "cli-rs/resources/kast-skill/SKILL.md" "developer machine p
 
 bash -n install.sh
 bash -n .github/scripts/test-cli-plugin-authority-cutover-contract.sh
-.github/scripts/test-macos-installer-contract.sh
-python3 packaging/homebrew/scripts/test-formulas.py
-
-cargo test \
-  --manifest-path cli-rs/Cargo.toml \
-  --locked \
-  --test cli_plugin_authority_cutover_smoke \
-  --test runtime_compatibility_metadata_smoke \
-  --test ready_repair_smoke
-
-./scripts/ci-gradle-retry.sh ./gradlew \
-  :analysis-api:test \
-  --tests '*RuntimeCompatibilityMatrixTest*' \
-  --tests '*RuntimeCompatibilitySourceContractTest*' \
-  :backend-idea:test \
-  --tests '*MacosHomebrewInstallReceiptTest*' \
-  --tests '*KastProjectOpenProfileAutoInitTest*' \
-  --no-daemon
-
-.github/scripts/test-runtime-compatibility-contract.sh
-.github/scripts/test-release-workflow-contract.sh
-.github/scripts/test-release-asset-verifier.sh
-cargo run --manifest-path cli-rs/Cargo.toml --bin kast -- developer release generate contract --check
-.github/scripts/test-docs-content-contract.sh
-.github/scripts/test-docs-navigation-contract.sh
-zensical build --clean
 
 printf 'cli/plugin authority cutover contract: ok\n'

--- a/.github/scripts/test-local-development-refresh-contract.sh
+++ b/.github/scripts/test-local-development-refresh-contract.sh
@@ -242,15 +242,4 @@ legacy_install_reuse="$("${repo_root}/gradlew" "${profile_free_install_args[@]}"
 grep -Fq 'Configuration cache entry reused.' <<<"$legacy_install_reuse" \
   || die 'profile-free legacy install planning must reuse configuration cache state'
 
-cargo test \
-  --quiet \
-  --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
-  --locked \
-  local_development::
-cargo test \
-  --quiet \
-  --manifest-path "${repo_root}/cli-rs/Cargo.toml" \
-  --locked \
-  --test local_development_refresh_smoke
-
 printf '%s\n' 'Local development refresh contract passed'

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -26,6 +26,13 @@ require_not_contains() {
   ! grep -Fq -- "$unexpected" "$file_path" || die "${description}: found '${unexpected}' in ${file_path}"
 }
 
+require_not_matches() {
+  local file_path="$1"
+  local unexpected_pattern="$2"
+  local description="$3"
+  ! grep -Eq -- "$unexpected_pattern" "$file_path" || die "${description}: matched '${unexpected_pattern}' in ${file_path}"
+}
+
 require_order() {
   local file_path="$1"
   local earlier="$2"
@@ -101,6 +108,24 @@ require_block_not_contains() {
   ! grep -Fq -- "$unexpected" <<< "$block" || die "${description}: found '${unexpected}' in '${block_start}' block"
 }
 
+require_block_not_matches() {
+  local file_path="$1"
+  local block_start="$2"
+  local block_end="$3"
+  local unexpected_pattern="$4"
+  local description="$5"
+  local block
+  block="$(
+    awk -v block_start="$block_start" -v block_end="$block_end" '
+      index($0, block_start) { in_block = 1 }
+      in_block && index($0, block_end) && !index($0, block_start) { exit }
+      in_block { print }
+    ' "$file_path"
+  )"
+  [[ -n "$block" ]] || die "${description}: missing block '${block_start}' in ${file_path}"
+  ! grep -Eq -- "$unexpected_pattern" <<< "$block" || die "${description}: matched '${unexpected_pattern}' in '${block_start}' block"
+}
+
 repo_root="$(resolve_repo_root)"
 ci_workflow="${repo_root}/.github/workflows/ci.yml"
 ci_build_and_test_workflow="${repo_root}/.github/workflows/ci-build-and-test.yml"
@@ -126,6 +151,9 @@ idea_plugin_repository_contract="${repo_root}/.github/scripts/test-jetbrains-plu
 idea_plugin_repository_source="${repo_root}/packaging/jetbrains/plugin-repository.json"
 idea_plugin_repository_renderer="${repo_root}/.github/scripts/render-jetbrains-plugin-repository.py"
 runtime_compatibility_contract="${repo_root}/.github/scripts/test-runtime-compatibility-contract.sh"
+cli_plugin_authority_cutover_contract="${repo_root}/.github/scripts/test-cli-plugin-authority-cutover-contract.sh"
+local_development_refresh_contract="${repo_root}/.github/scripts/test-local-development-refresh-contract.sh"
+selector_handle_workflow_test="${repo_root}/cli-rs/tests/selector_handle_installed_workflow.rs"
 runtime_compatibility_source="${repo_root}/packaging/jetbrains/runtime-compatibility.json"
 runtime_compatibility_renderer="${repo_root}/.github/scripts/render-runtime-compatibility.py"
 release_state_verifier="${repo_root}/scripts/verify-release-state.sh"
@@ -239,7 +267,7 @@ require_block_not_contains "$ci_workflow" "  workflow-contracts:" "  local-autho
 require_block_contains "$ci_workflow" "  workflow-contracts:" "  local-authority-contracts:" "Test CI workflow graph model" "CI static fanout contracts must execute the deterministic graph model"
 require_block_contains "$ci_workflow" "  workflow-contracts:" "  local-authority-contracts:" "test-ci-workflow-model.sh" "CI static fanout contracts must own proof-output equivalence validation"
 require_block_not_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "    needs:" "CI local-authority contracts must remain an independent required root"
-require_block_not_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "    if:" "CI local-authority contracts must run for every CI trigger"
+require_block_not_matches "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" '^    if:' "CI local-authority contracts must run for every CI trigger"
 require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "uses: gradle/actions/setup-gradle@v5" "CI local-authority contracts must restore persisted Gradle build state"
 require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "cache-cleanup: always" "CI local-authority contracts must keep Gradle cache cleanup bounded"
 require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32" "CI local-authority contracts must restore pruned Rust dependency builds from the pinned cache action"
@@ -249,8 +277,30 @@ require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-de
 require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" 'save-if: ${{ github.ref == '\''refs/heads/main'\'' }}' "CI local-authority contracts must persist Rust caches only from trusted main pushes"
 require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "test-local-development-refresh-contract.sh" "CI local-authority contracts must execute the local refresh contract"
 require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "test-development-cli-install-contract.sh" "CI local-authority contracts must execute the legacy development install contract"
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" "CI must quarantine the legacy development install proof to integrated main pushes"
 require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "test-cli-plugin-authority-cutover-contract.sh" "CI local-authority contracts must execute the CLI and plugin cutover contract"
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "test-selector-handle-installed-workflow.sh" "CI local-authority contracts must execute the installed selector handle workflow"
+require_block_not_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "test-selector-handle-installed-workflow.sh" "CI local-authority contracts must not reinstall the CLI to rerun a Rust integration test"
+require_block_not_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "actions/setup-python" "CI local-authority contracts must not initialize the documentation toolchain"
+require_not_matches "$cli_plugin_authority_cutover_contract" '^[[:space:]]*\.github/scripts/test-macos-installer-contract\.sh[[:space:]]*$' "CLI/plugin cutover must not rerun the installer owner"
+require_not_matches "$cli_plugin_authority_cutover_contract" '^[[:space:]]*python3 packaging/homebrew/scripts/test-formulas\.py[[:space:]]*$' "CLI/plugin cutover must not rerun the Homebrew owner"
+require_not_contains "$cli_plugin_authority_cutover_contract" "cargo test" "CLI/plugin cutover must not rerun Rust tests"
+require_not_contains "$cli_plugin_authority_cutover_contract" "./gradlew" "CLI/plugin cutover must not rerun Kotlin or IDEA tests"
+require_not_contains "$cli_plugin_authority_cutover_contract" ".github/scripts/test-runtime-compatibility-contract.sh" "CLI/plugin cutover must not rerun the runtime compatibility owner"
+require_not_contains "$cli_plugin_authority_cutover_contract" ".github/scripts/test-release-workflow-contract.sh" "CLI/plugin cutover must not rerun the release workflow owner"
+require_not_contains "$cli_plugin_authority_cutover_contract" ".github/scripts/test-release-asset-verifier.sh" "CLI/plugin cutover must not rerun the release asset owner"
+require_not_contains "$cli_plugin_authority_cutover_contract" ".github/scripts/test-docs-content-contract.sh" "CLI/plugin cutover must not rerun the documentation owner"
+require_not_contains "$cli_plugin_authority_cutover_contract" ".github/scripts/test-docs-navigation-contract.sh" "CLI/plugin cutover must not rerun the documentation navigation owner"
+require_not_contains "$cli_plugin_authority_cutover_contract" "zensical build" "CLI/plugin cutover must not rerun the documentation renderer"
+require_not_contains "$cli_plugin_authority_cutover_contract" "cargo run" "CLI/plugin cutover must not rebuild the CLI for a generation contract"
+require_not_contains "$runtime_compatibility_contract" "./gradlew" "Runtime compatibility source contract must not rerun Kotlin or IDEA tests"
+require_not_contains "$runtime_compatibility_contract" "cargo test" "Runtime compatibility source contract must not rerun Rust tests"
+require_not_contains "$runtime_compatibility_contract" ".github/scripts/test-release-provenance-assembler.sh" "Runtime compatibility source contract must not rerun release provenance tests"
+require_not_contains "$runtime_compatibility_contract" ".github/scripts/test-release-asset-verifier.sh" "Runtime compatibility source contract must not rerun release asset tests"
+require_not_contains "$runtime_compatibility_contract" ".github/scripts/test-release-workflow-contract.sh" "Runtime compatibility source contract must not rerun release workflow tests"
+require_not_contains "$local_development_refresh_contract" "cargo test" "Local refresh source contract must not rerun Rust tests"
+require_not_contains "$selector_handle_workflow_test" "skipped:" "Selector handle integration proof must not silently skip in the Rust owner"
+require_contains "$selector_handle_workflow_test" "env!(\"CARGO_BIN_EXE_kast\")" "Selector handle integration proof must execute Cargo's exact built CLI"
+require_block_contains "$ci_workflow" "  rust-cli:" "  build-and-test:" "cli-rs/target/release/kast developer release generate contract --check" "The Rust owner must reuse its release binary for generation contract validation"
 require_block_contains "$ci_workflow" "  runtime-contracts:" "  maven-publication-contract:" "    needs: workflow-contracts" "CI runtime contracts must wait for the static workflow preflight"
 require_block_contains "$ci_workflow" "  runtime-contracts:" "  maven-publication-contract:" "      - name: Test terminal command contract" "CI runtime contracts must own the terminal command contract"
 require_block_contains "$ci_workflow" "  runtime-contracts:" "  maven-publication-contract:" "      - name: Test Kast Copilot plugin package" "CI runtime contracts must reuse the terminal build for the Copilot package contract"

--- a/.github/scripts/test-runtime-compatibility-contract.sh
+++ b/.github/scripts/test-runtime-compatibility-contract.sh
@@ -140,27 +140,4 @@ for invalid_source in "$scratch_dir"/invalid-*.json; do
   fi
 done
 
-./scripts/ci-gradle-retry.sh ./gradlew \
-  :analysis-api:test \
-  --tests '*RuntimeCompatibilityMatrixTest*' \
-  --tests '*RuntimeCompatibilitySourceContractTest*' \
-  --tests '*AnalysisOpenApiDocumentTest*' \
-  --tests '*DocFieldCoverageTest*' \
-  --no-daemon
-
-./scripts/ci-gradle-retry.sh ./gradlew \
-  :backend-idea:test \
-  --tests '*KastProjectOpenProfileAutoInitTest*' \
-  --no-daemon
-
-cargo test \
-  --manifest-path cli-rs/Cargo.toml \
-  --locked \
-  --test runtime_compatibility_metadata_smoke
-
-.github/scripts/test-jetbrains-plugin-repository-contract.sh
-.github/scripts/test-release-provenance-assembler.sh
-.github/scripts/test-release-asset-verifier.sh
-.github/scripts/test-release-workflow-contract.sh
-
 echo "runtime compatibility contract: ok"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,21 +118,9 @@ jobs:
         run: ./.github/scripts/test-local-development-refresh-contract.sh
 
       - name: Test development CLI and IDEA profile install contract
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
         run: ./.github/scripts/test-development-cli-install-contract.sh
-
-      - name: Test installed selector handle workflow
-        shell: bash
-        run: ./.github/scripts/test-selector-handle-installed-workflow.sh
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: requirements-docs.txt
-
-      - name: Install docs dependencies for authority gate
-        run: pip install -r requirements-docs.txt
 
       - name: Test CLI and plugin authority cutover contract
         shell: bash
@@ -180,22 +168,10 @@ jobs:
 
   runtime-compatibility-contract:
     name: Runtime compatibility matrix
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: workflow-contracts
     steps:
       - uses: actions/checkout@v5
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "21"
-
-      - uses: gradle/actions/setup-gradle@v5
-        with:
-          cache-cleanup: always
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
 
       - name: Test runtime compatibility contract
         shell: bash
@@ -282,6 +258,9 @@ jobs:
       - name: Build Rust CLI
         working-directory: cli-rs
         run: KAST_VERSION=0.0.0-ci cargo build --release --locked
+
+      - name: Validate generated CLI contracts
+        run: cli-rs/target/release/kast developer release generate contract --check
 
       - name: Test LSP config smoke
         shell: bash

--- a/cli-rs/tests/selector_handle_installed_workflow.rs
+++ b/cli-rs/tests/selector_handle_installed_workflow.rs
@@ -3,8 +3,6 @@ mod support;
 use support::metrics::seed_source_index;
 use support::{ScriptedCliAuthority, kast_at, spawn_scripted_idea_backend_for_invocations};
 
-const INSTALLED_BINARY_ENV: &str = "KAST_INSTALLED_SELECTOR_WORKFLOW_BINARY";
-
 fn decode_default_toon(
     operation: &str,
     output: std::process::Output,
@@ -15,7 +13,7 @@ fn decode_default_toon(
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
-    let rendered = String::from_utf8(output.stdout).expect("installed CLI output is UTF-8");
+    let rendered = String::from_utf8(output.stdout).expect("CLI output is UTF-8");
     assert!(
         !rendered.trim_start().starts_with('{'),
         "{operation} must use default TOON instead of JSON",
@@ -25,35 +23,29 @@ fn decode_default_toon(
     (rendered, decoded)
 }
 
-fn installed_cli_version(binary: &std::path::Path) -> String {
+fn cli_version(binary: &std::path::Path) -> String {
     let output = std::process::Command::new(binary)
         .arg("--version")
         .output()
-        .expect("read installed CLI version");
-    assert!(output.status.success(), "installed CLI version command");
+        .expect("read CLI version");
+    assert!(output.status.success(), "CLI version command");
     String::from_utf8(output.stdout)
-        .expect("installed CLI version is UTF-8")
+        .expect("CLI version is UTF-8")
         .trim()
         .strip_prefix("kast ")
-        .expect("installed CLI version prefix")
+        .expect("CLI version prefix")
         .to_string()
 }
 
 #[test]
-fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations() {
-    let Some(installed_binary) = std::env::var_os(INSTALLED_BINARY_ENV) else {
-        eprintln!(
-            "skipped: run .github/scripts/test-selector-handle-installed-workflow.sh for installed proof"
-        );
-        return;
-    };
-    let installed_binary = std::path::PathBuf::from(installed_binary);
+fn cargo_built_cli_resolves_once_and_reuses_handle_across_default_toon_operations() {
+    let cli_binary = std::path::PathBuf::from(env!("CARGO_BIN_EXE_kast"));
     assert!(
-        installed_binary.is_file(),
-        "installed CLI does not exist: {}",
-        installed_binary.display(),
+        cli_binary.is_file(),
+        "Cargo-built CLI does not exist: {}",
+        cli_binary.display(),
     );
-    let installed_version = installed_cli_version(&installed_binary);
+    let cli_version = cli_version(&cli_binary);
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let config_home = temp.path().join("config");
@@ -80,7 +72,7 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
         &config_home,
         &workspace,
         &temp.path().join("idea.sock"),
-        ScriptedCliAuthority::new(&installed_binary, &installed_version),
+        ScriptedCliAuthority::new(&cli_binary, &cli_version),
         3,
         vec![
             (
@@ -130,7 +122,7 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
     );
 
     let workspace_root = workspace.to_str().expect("workspace path");
-    let resolved = kast_at(&installed_binary, &home, &config_home)
+    let resolved = kast_at(&cli_binary, &home, &config_home)
         .args([
             "agent",
             "symbol",
@@ -140,7 +132,7 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
             workspace_root,
         ])
         .output()
-        .expect("run installed selector resolve");
+        .expect("run selector resolve");
     let (resolved_toon, resolved) = decode_default_toon("resolve", resolved);
     assert_eq!(
         resolved["result"]["identity"], identity,
@@ -163,7 +155,7 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
         );
     }
 
-    let references = kast_at(&installed_binary, &home, &config_home)
+    let references = kast_at(&cli_binary, &home, &config_home)
         .args([
             "agent",
             "references",
@@ -173,12 +165,12 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
             workspace_root,
         ])
         .output()
-        .expect("run installed references");
+        .expect("run references");
     let (references_toon, references) = decode_default_toon("references", references);
     assert_eq!(references["result"]["outcome"], "AVAILABLE");
     assert_eq!(references["result"]["subject"], identity);
 
-    let callers = kast_at(&installed_binary, &home, &config_home)
+    let callers = kast_at(&cli_binary, &home, &config_home)
         .args([
             "agent",
             "callers",
@@ -188,7 +180,7 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
             workspace_root,
         ])
         .output()
-        .expect("run installed callers");
+        .expect("run callers");
     let (callers_toon, callers) = decode_default_toon("callers", callers);
     assert_eq!(callers["result"]["outcome"], "AVAILABLE");
     assert_eq!(callers["result"]["subject"], identity);
@@ -218,7 +210,7 @@ fn installed_cli_resolves_once_and_reuses_handle_across_default_toon_operations(
             .filter_map(|request| request["method"].as_str())
             .collect::<Vec<_>>(),
         vec!["symbol/resolve", "symbol/references", "symbol/callers"],
-        "installed workflow must resolve once and never rediscover by name",
+        "selector handle workflow must resolve once and never rediscover by name",
     );
     assert_eq!(
         semantic_requests


### PR DESCRIPTION
## What

- make each focused CI owner execute its proof once
- keep the legacy development-profile install contract on integrated main pushes instead of every pull request
- bind the selector-handle integration test to Cargo's exact built CLI so it cannot silently skip
- reuse the Rust job's release binary for generated-contract validation
- keep deterministic ownership and proof-equivalence assertions in the static workflow contract

## Why

The current umbrella contracts recursively rerun Rust, Gradle, installer, documentation, runtime-compatibility, and release checks. This preserves the proof set while removing redundant execution and toolchain setup from ordinary pull requests. It advances the revised validation premise in #399: focused proof at the owning boundary, then one full installed canary for integrated source generations.

## Verification

- `.github/scripts/test-release-workflow-contract.sh`
- `.github/scripts/test-cli-plugin-authority-cutover-contract.sh`
- `.github/scripts/test-runtime-compatibility-contract.sh`
- `.github/scripts/test-local-development-refresh-contract.sh`
- `.github/scripts/test-ci-workflow-model.sh`
- `.github/scripts/test-docs-content-contract.sh`
- `.github/scripts/test-docs-navigation-contract.sh`
- `bash -n` for every changed shell contract
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- focused `selector_handle_installed_workflow` integration test: 1 passed, 0 skipped
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- release build plus `cli-rs/target/release/kast developer release generate contract --check`: 152 contracts checked

## Risk

The legacy `installDevelopmentLocal` compatibility task is still exercised on integrated main pushes, but no longer blocks ordinary pull requests. Removing that compatibility surface remains a separate product decision. Full Kast-on-Kast canary relocation is intentionally the next slice.
