### PR TITLE
ci: relocate full semantic e2e to canary

### DIFF
--- a/.agents/adr/0024-revision-coherent-local-development-authority.md
+++ b/.agents/adr/0024-revision-coherent-local-development-authority.md
@@ -204,7 +204,7 @@ into or inferred by the local prefix.
 | Generation staging, validation, activation, rollback, removal | `cli-rs/src/local_development/` | failure-injection and idempotence tests |
 | Checkout build orchestration | root `build.gradle.kts` and typed tasks under `build-logic/` | `.github/scripts/test-local-development-refresh-contract.sh` |
 | Headless development backend | `backend-headless/` portable distribution | layout verification plus semantic probes |
-| Installed semantic boundary | `.github/scripts/test-local-development-semantic-e2e.sh` | refresh/reuse, readiness, exact semantic reads, plan-only mutation, stop, and removal |
+| Installed semantic boundary | `.github/scripts/test-local-development-semantic-e2e.sh` | integrated main/nightly/manual/release canary for refresh/reuse, readiness, exact semantic reads, plan-only mutation, stop, and removal |
 | Skill source | `cli-rs/resources/kast-skill/SKILL.md` | command/help lockstep contract |
 | Managed local guidance renderer | `cli-rs/src/local_development/` | receipt, command-lockstep, and workspace-preservation tests |
 | Machine-readable readiness | `cli-rs/src/self_mgmt.rs` and `cli-rs/src/output/ready.rs` | local authority smoke tests |
@@ -253,10 +253,23 @@ the documented compatibility surface; removing the task or its supported
 profile behavior requires a separate product decision. Pull requests retain
 the source/task-graph assertions and the release-free local-authority proof.
 
-The focused source gate is:
+The complete Kast-on-Kast installed semantic boundary is an integration
+canary, not an ordinary pull-request root. One reusable workflow runs it on
+integrated `main`, nightly, manually, and against the exact prepared release
+tag. A failed canary is a failed release prerequisite, is never
+`continue-on-error`, and retains runtime logs for diagnosis. The deterministic
+workflow model keeps this canary's proof output in the exact integrated output
+inventory while excluding its duration from the pull-request critical path.
+
+The focused pull-request source gate is:
 
 ```console
 .github/scripts/test-local-development-refresh-contract.sh
+```
+
+The integrated installed canary is:
+
+```console
 .github/scripts/test-local-development-semantic-e2e.sh
 ```
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -57,15 +57,21 @@ Java, initialize Gradle, install Rust, or execute an installed-development
 workflow. `.github/ci/issue-401-workflow-model.json` records the expanded DAG,
 stable proof-output ownership, and timing samples. Keep output equivalence
 blocking, keep timing provisional until five comparable successful candidate
-runs exist, and run `.github/scripts/test-ci-workflow-model.sh` whenever jobs,
-`needs` edges, proof owners, or timing evidence change.
-The separate `.github/scripts/test-local-development-semantic-e2e.sh` gate
+runs exist, and list integrated non-PR proofs explicitly in `canaryTaskIds` so
+they remain in the output inventory without inflating the required
+pull-request critical path. Run `.github/scripts/test-ci-workflow-model.sh`
+whenever jobs, `needs` edges, proof owners, canary classification, or timing
+evidence change.
+The separate `.github/scripts/test-local-development-semantic-e2e.sh` canary
 must exercise the receipt-owned installed entrypoint, not checkout build
 outputs. It owns refresh idempotence plus compiler-backed readiness, exact
 symbol resolution, a known exhaustive nonzero reference, complete clean-file
 diagnostics, plan-only mutation, explicit runtime shutdown, and receipt-owned
-removal. Keep it in its own CI job so the cold IDEA import does not serialize
-unrelated workflow contracts.
+removal. Keep its authoritative job in
+`.github/workflows/local-development-canary.yml`, outside ordinary pull-request
+CI. The reusable workflow must run on integrated `main`, nightly, manually,
+and from release preparation; release publication must fail closed when it
+fails and preserve actionable runtime logs.
 
 The signed JetBrains repository source lives at
 `packaging/jetbrains/plugin-repository.json`. Runtime pair and IDEA build-range

--- a/.github/ci/issue-401-workflow-model.json
+++ b/.github/ci/issue-401-workflow-model.json
@@ -2,9 +2,9 @@
   "$schema": "./workflow-graph-model.schema.json",
   "schemaVersion": 2,
   "provenance": {
-    "description": "Issue 401 fanout split with current focused proof ownership. The first four baseline static-gate samples predate the selector-handle contract and are normalized by its observed three-second warm execution; the fifth baseline and current candidate timing samples predate duplicate-owner removal and full-E2E relocation. The integrated candidate proof set remains exact: the legacy profile install runs on main and the full Kast-on-Kast E2E is an explicit canary outside the pull-request critical path. Timing remains provisional until five comparable final-shape runs exist.",
+    "description": "Issue 401 fanout split with current focused proof ownership. The first four baseline static-gate samples predate the selector-handle contract and are normalized by its observed three-second warm execution; the fifth baseline predates duplicate-owner removal and full-E2E relocation. Candidate pull-request timing is the first comparable final-shape run after relocating the full Kast-on-Kast E2E to an explicit canary; that canary retains its latest observed duration so exact integrated proof remains represented outside the pull-request critical path. Timing remains provisional until five comparable final-shape runs exist.",
     "observedAt": "2026-07-17",
-    "source": "https://github.com/amichne/kast/pull/407",
+    "source": "https://github.com/amichne/kast/pull/409",
     "baselineRunIds": [
       29511350239,
       29519251086,
@@ -13,7 +13,7 @@
       29540820473
     ],
     "candidateRunIds": [
-      29558675350
+      29565328465
     ]
   },
   "baseline": {
@@ -312,7 +312,7 @@
           "homebrew-package-renderer"
         ],
         "durationSamplesSeconds": [
-          18
+          15
         ],
         "executionClass": "static"
       },
@@ -325,7 +325,7 @@
           "cli-plugin-authority-cutover-contract"
         ],
         "durationSamplesSeconds": [
-          855
+          304
         ],
         "executionClass": "toolchain"
       },
@@ -351,7 +351,7 @@
           "ubuntu-debian-bundle-smoke"
         ],
         "durationSamplesSeconds": [
-          140
+          128
         ],
         "executionClass": "toolchain"
       },
@@ -364,7 +364,7 @@
           "runtime-compatibility-contract"
         ],
         "durationSamplesSeconds": [
-          566
+          5
         ],
         "executionClass": "static"
       },
@@ -378,7 +378,7 @@
           "ci-artifact-ledger-maven-publication"
         ],
         "durationSamplesSeconds": [
-          58
+          55
         ],
         "executionClass": "gradle-cache"
       },
@@ -399,7 +399,7 @@
           "ci-artifact-ledger-rust-cli-linux-x64"
         ],
         "durationSamplesSeconds": [
-          459
+          434
         ],
         "executionClass": "toolchain"
       },
@@ -417,7 +417,7 @@
           "agent-headless-portable-build-linux"
         ],
         "durationSamplesSeconds": [
-          548
+          520
         ],
         "executionClass": "gradle-cache"
       },
@@ -434,7 +434,7 @@
           "ci-artifact-ledger-headless-macos"
         ],
         "durationSamplesSeconds": [
-          933
+          552
         ],
         "executionClass": "gradle-cache"
       },
@@ -447,7 +447,7 @@
           "analysis-server-socket-transport"
         ],
         "durationSamplesSeconds": [
-          53
+          70
         ],
         "executionClass": "gradle-cache"
       },
@@ -465,7 +465,7 @@
           "idea-plugin-performance-baselines"
         ],
         "durationSamplesSeconds": [
-          423
+          626
         ],
         "executionClass": "gradle-cache"
       },
@@ -479,7 +479,7 @@
           "ubuntu-22.04-java-21-install-contract"
         ],
         "durationSamplesSeconds": [
-          118
+          119
         ],
         "executionClass": "oci"
       },
@@ -493,7 +493,7 @@
           "ubuntu-24.04-java-21-install-contract"
         ],
         "durationSamplesSeconds": [
-          117
+          120
         ],
         "executionClass": "oci"
       },
@@ -507,7 +507,7 @@
           "kast-action-v2-installed-runtime-contract"
         ],
         "durationSamplesSeconds": [
-          328
+          267
         ],
         "executionClass": "artifact-consumer"
       }
@@ -519,7 +519,7 @@
       "workflow-contracts"
     ],
     "observedWorkflowDurationSamplesSeconds": [
-      1224
+      812
     ]
   },
   "expectations": {

--- a/.github/ci/issue-401-workflow-model.json
+++ b/.github/ci/issue-401-workflow-model.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./workflow-graph-model.schema.json",
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "provenance": {
-    "description": "Issue 401 fanout split with current focused proof ownership. The first four baseline static-gate samples predate the selector-handle contract and are normalized by its observed three-second warm execution; the fifth baseline and candidate timing samples describe the split before duplicate-owner removal. The integrated candidate proof set is exact, including the main-only legacy profile-install canary, while timing remains provisional until five comparable final-shape runs exist.",
+    "description": "Issue 401 fanout split with current focused proof ownership. The first four baseline static-gate samples predate the selector-handle contract and are normalized by its observed three-second warm execution; the fifth baseline and current candidate timing samples predate duplicate-owner removal and full-E2E relocation. The integrated candidate proof set remains exact: the legacy profile install runs on main and the full Kast-on-Kast E2E is an explicit canary outside the pull-request critical path. Timing remains provisional until five comparable final-shape runs exist.",
     "observedAt": "2026-07-17",
     "source": "https://github.com/amichne/kast/pull/407",
     "baselineRunIds": [
@@ -279,6 +279,7 @@
         "executionClass": "artifact-consumer"
       }
     ],
+    "canaryTaskIds": [],
     "fanoutGateTaskIds": [
       "workflow-contracts"
     ],
@@ -337,7 +338,7 @@
         "durationSamplesSeconds": [
           1223
         ],
-        "executionClass": "toolchain"
+        "executionClass": "release"
       },
       {
         "id": "runtime-contracts",
@@ -510,6 +511,9 @@
         ],
         "executionClass": "artifact-consumer"
       }
+    ],
+    "canaryTaskIds": [
+      "local-development-semantic-e2e"
     ],
     "fanoutGateTaskIds": [
       "workflow-contracts"

--- a/.github/ci/workflow-graph-model.schema.json
+++ b/.github/ci/workflow-graph-model.schema.json
@@ -16,7 +16,7 @@
       "minLength": 1
     },
     "schemaVersion": {
-      "const": 1
+      "const": 2
     },
     "provenance": {
       "$ref": "#/$defs/provenance"
@@ -90,6 +90,7 @@
       "additionalProperties": false,
       "required": [
         "tasks",
+        "canaryTaskIds",
         "fanoutGateTaskIds",
         "observedWorkflowDurationSamplesSeconds"
       ],
@@ -100,6 +101,13 @@
           "items": {
             "$ref": "#/$defs/task"
           }
+        },
+        "canaryTaskIds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/identifier"
+          },
+          "uniqueItems": true
         },
         "fanoutGateTaskIds": {
           "type": "array",

--- a/.github/scripts/ci_workflow_model.py
+++ b/.github/scripts/ci_workflow_model.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 RECOMMENDED_SAMPLE_FLOOR = 5
 IDENTIFIER = re.compile(r"^[a-z0-9][a-z0-9._:/-]*$")
 EXECUTION_CLASSES = {
@@ -55,6 +55,7 @@ class Task:
 @dataclass(frozen=True)
 class Plan:
     tasks: Mapping[str, Task]
+    canary_task_ids: tuple[str, ...]
     fanout_gate_task_ids: tuple[str, ...]
     observed_workflow_duration_samples_seconds: tuple[float, ...]
 
@@ -85,6 +86,7 @@ class PlanAnalysis:
     task_count: int
     edge_count: int
     output_ids: tuple[str, ...]
+    canary_task_ids: tuple[str, ...]
     critical_path_task_ids: tuple[str, ...]
     critical_path_seconds: float
     fanout_gate_seconds: float
@@ -229,7 +231,12 @@ def parse_plan(value: Any, path: str) -> Plan:
     validate_keys(
         item,
         path=path,
-        required={"tasks", "fanoutGateTaskIds", "observedWorkflowDurationSamplesSeconds"},
+        required={
+            "tasks",
+            "canaryTaskIds",
+            "fanoutGateTaskIds",
+            "observedWorkflowDurationSamplesSeconds",
+        },
     )
     raw_tasks = require_list(item["tasks"], f"{path}.tasks")
     if not raw_tasks:
@@ -262,6 +269,26 @@ def parse_plan(value: Any, path: str) -> Plan:
                 )
             output_owners[output] = task.id
 
+    canary_tasks = parse_identifier_list(
+        item["canaryTaskIds"],
+        f"{path}.canaryTaskIds",
+    )
+    missing_canaries = sorted(set(canary_tasks) - tasks.keys())
+    if missing_canaries:
+        raise ModelError(
+            f"{path}.canaryTaskIds references missing tasks: {', '.join(missing_canaries)}"
+        )
+    required_tasks = set(tasks) - set(canary_tasks)
+    if not required_tasks:
+        raise ModelError(f"{path} must contain at least one pull-request task")
+    for task_id in sorted(required_tasks):
+        canary_needs = sorted(set(tasks[task_id].needs) & set(canary_tasks))
+        if canary_needs:
+            raise ModelError(
+                f"{path}.tasks[{task_id}] pull-request task depends on canary tasks: "
+                + ", ".join(canary_needs)
+            )
+
     fanout_gates = parse_identifier_list(
         item["fanoutGateTaskIds"],
         f"{path}.fanoutGateTaskIds",
@@ -272,9 +299,15 @@ def parse_plan(value: Any, path: str) -> Plan:
         raise ModelError(
             f"{path}.fanoutGateTaskIds references missing tasks: {', '.join(missing_gates)}"
         )
+    canary_gates = sorted(set(fanout_gates) & set(canary_tasks))
+    if canary_gates:
+        raise ModelError(
+            f"{path}.fanoutGateTaskIds must not include canary tasks: {', '.join(canary_gates)}"
+        )
 
     plan = Plan(
         tasks=tasks,
+        canary_task_ids=canary_tasks,
         fanout_gate_task_ids=fanout_gates,
         observed_workflow_duration_samples_seconds=parse_duration_samples(
             item["observedWorkflowDurationSamplesSeconds"],
@@ -434,7 +467,12 @@ def maximum_parallel_tasks(starts: Mapping[str, float], finishes: Mapping[str, f
 
 
 def analyze_plan(plan: Plan) -> PlanAnalysis:
-    order = topological_order(plan)
+    canary_task_ids = set(plan.canary_task_ids)
+    order = tuple(
+        task_id
+        for task_id in topological_order(plan)
+        if task_id not in canary_task_ids
+    )
     starts: dict[str, float] = {}
     finishes: dict[str, float] = {}
     predecessor: dict[str, str | None] = {}
@@ -471,6 +509,7 @@ def analyze_plan(plan: Plan) -> PlanAnalysis:
         task_count=len(plan.tasks),
         edge_count=sum(len(task.needs) for task in plan.tasks.values()),
         output_ids=output_ids,
+        canary_task_ids=tuple(sorted(canary_task_ids)),
         critical_path_task_ids=tuple(critical_path),
         critical_path_seconds=modeled,
         fanout_gate_seconds=max(finishes[task_id] for task_id in plan.fanout_gate_task_ids),
@@ -506,8 +545,10 @@ def stats_document(stats: DurationStats) -> dict[str, int | float]:
 def analysis_document(analysis: PlanAnalysis) -> dict[str, Any]:
     return {
         "taskCount": analysis.task_count,
+        "pullRequestTaskCount": analysis.task_count - len(analysis.canary_task_ids),
         "edgeCount": analysis.edge_count,
         "outputCount": len(analysis.output_ids),
+        "canaryTaskIds": list(analysis.canary_task_ids),
         "criticalPathTaskIds": list(analysis.critical_path_task_ids),
         "criticalPathSeconds": rounded(analysis.critical_path_seconds),
         "fanoutGateSeconds": rounded(analysis.fanout_gate_seconds),

--- a/.github/scripts/test-ci-workflow-model.sh
+++ b/.github/scripts/test-ci-workflow-model.sh
@@ -28,10 +28,44 @@ if not report["comparison"]["outputEquivalent"]:
     raise SystemExit("candidate proof outputs must exactly match the baseline")
 if report["comparison"]["taskCountIncrease"] != 1:
     raise SystemExit("the fanout split must add exactly one execution node")
+if report["candidate"]["pullRequestTaskCount"] != report["baseline"]["pullRequestTaskCount"]:
+    raise SystemExit("canary relocation must not add a pull-request execution node")
 if report["candidate"]["fanoutGateSeconds"] > 90:
     raise SystemExit("the modeled static fanout gate must not exceed 90 seconds")
+if report["candidate"]["canaryTaskIds"] != ["local-development-semantic-e2e"]:
+    raise SystemExit("the full installed semantic E2E must remain modeled as a canary")
+if "local-development-semantic-e2e" in report["candidate"]["criticalPathTaskIds"]:
+    raise SystemExit("the full installed semantic E2E must not remain on the pull-request critical path")
 if not any("provisional" in warning for warning in report["warnings"]):
     raise SystemExit("timing evidence must remain explicitly provisional below five samples")
+PY
+
+required_canary_model="${scratch_dir}/required-canary.json"
+python3 - "$model" "$required_canary_model" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+document = json.loads(source.read_text(encoding="utf-8"))
+document["candidate"]["canaryTaskIds"] = []
+target.write_text(json.dumps(document), encoding="utf-8")
+PY
+
+required_canary_report="${scratch_dir}/required-canary-report.json"
+python3 "$checker" "$required_canary_model" >"$required_canary_report"
+python3 - "$report" "$required_canary_report" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+canary = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+required = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+if "local-development-semantic-e2e" not in required["candidate"]["criticalPathTaskIds"]:
+    raise SystemExit("clearing canaryTaskIds must restore the E2E to the required critical path")
+if required["candidate"]["criticalPathSeconds"] <= canary["candidate"]["criticalPathSeconds"]:
+    raise SystemExit("a required full E2E must lengthen the modeled pull-request critical path")
 PY
 
 lost_output_model="${scratch_dir}/lost-output.json"

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -129,6 +129,7 @@ require_block_not_matches() {
 repo_root="$(resolve_repo_root)"
 ci_workflow="${repo_root}/.github/workflows/ci.yml"
 ci_build_and_test_workflow="${repo_root}/.github/workflows/ci-build-and-test.yml"
+local_development_canary_workflow="${repo_root}/.github/workflows/local-development-canary.yml"
 release_workflow="${repo_root}/.github/workflows/release.yml"
 snapshot_workflow="${repo_root}/.github/workflows/snapshot.yml"
 docs_workflow="${repo_root}/.github/workflows/docs.yml"
@@ -168,10 +169,12 @@ headless_packager_test="${repo_root}/.github/scripts/test-headless-runtime-packa
 ci_artifact_ledger_test="${repo_root}/.github/scripts/test-ci-artifact-ledger.sh"
 runtime_artifact_contract="${repo_root}/docs/distribute/runtime-artifact-contract.md"
 release_and_mirror_doc="${repo_root}/docs/distribute/release-and-mirror.md"
+local_development_doc="${repo_root}/docs/distribute/local-development-refresh.md"
 kast_script="${repo_root}/kast.sh"
 
 for path in \
   "$ci_workflow" \
+  "$local_development_canary_workflow" \
   "$release_workflow" \
   "$snapshot_workflow" \
   "$docs_workflow" \
@@ -208,6 +211,7 @@ for path in \
   "$ci_artifact_ledger_test" \
   "$runtime_artifact_contract" \
   "$release_and_mirror_doc" \
+  "$local_development_doc" \
   "$kast_script"
 do
   [[ -f "$path" || -x "$path" ]] || die "Required release file is missing: $path"
@@ -219,7 +223,7 @@ done
 [[ ! -e "${repo_root}/.github/workflows/claude.yml" ]] || die "Provider-specific assistant trigger workflows are outside the V1 GitHub surface"
 [[ ! -e "${repo_root}/docs/distribute/setup-kast-action.md" ]] || die "Detailed action docs must live in the kast-action repository"
 
-for workflow in "$ci_workflow" "$ci_build_and_test_workflow" "$release_workflow" "$snapshot_workflow" "$docs_workflow" "$seed_gradle_ro_cache_workflow"; do
+for workflow in "$ci_workflow" "$ci_build_and_test_workflow" "$local_development_canary_workflow" "$release_workflow" "$snapshot_workflow" "$docs_workflow" "$seed_gradle_ro_cache_workflow"; do
   require_not_contains "$workflow" "actions/cache@v4" "Workflow actions must not use the Node 20 cache action"
   require_not_contains "$workflow" "actions/upload-artifact@v4" "Workflow actions must not use the Node 20 upload-artifact action"
   require_not_contains "$workflow" "actions/download-artifact@v4" "Workflow actions must not use the Node 20 download-artifact action"
@@ -266,21 +270,41 @@ require_block_not_contains "$ci_workflow" "  workflow-contracts:" "  local-autho
 require_block_not_contains "$ci_workflow" "  workflow-contracts:" "  local-authority-contracts:" "test-selector-handle-installed-workflow.sh" "CI static fanout contracts must not execute an installed CLI workflow"
 require_block_contains "$ci_workflow" "  workflow-contracts:" "  local-authority-contracts:" "Test CI workflow graph model" "CI static fanout contracts must execute the deterministic graph model"
 require_block_contains "$ci_workflow" "  workflow-contracts:" "  local-authority-contracts:" "test-ci-workflow-model.sh" "CI static fanout contracts must own proof-output equivalence validation"
-require_block_not_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "    needs:" "CI local-authority contracts must remain an independent required root"
-require_block_not_matches "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" '^    if:' "CI local-authority contracts must run for every CI trigger"
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "uses: gradle/actions/setup-gradle@v5" "CI local-authority contracts must restore persisted Gradle build state"
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "cache-cleanup: always" "CI local-authority contracts must keep Gradle cache cleanup bounded"
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32" "CI local-authority contracts must restore pruned Rust dependency builds from the pinned cache action"
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "workspaces: cli-rs -> target" "CI local-authority contracts must cache the actual Rust workspace"
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" 'cache-bin: "false"' "CI local-authority contracts must not persist runner toolchain binaries"
+require_not_contains "$ci_workflow" "local-development-semantic-e2e:" "Ordinary pull-request CI must not own the full installed semantic E2E"
+require_not_contains "$ci_workflow" "test-local-development-semantic-e2e.sh" "Ordinary pull-request CI must not invoke the full installed semantic E2E"
+require_contains "$local_development_canary_workflow" "workflow_call:" "The installed semantic canary must be reusable from release"
+require_contains "$local_development_canary_workflow" "workflow_dispatch:" "The installed semantic canary must support manual execution"
+require_contains "$local_development_canary_workflow" "schedule:" "The installed semantic canary must run nightly"
+require_contains "$local_development_canary_workflow" "branches:" "The installed semantic canary must select main pushes"
+require_contains "$local_development_canary_workflow" "- main" "The installed semantic canary must run on integrated main"
+require_contains "$local_development_canary_workflow" "test-local-development-semantic-e2e.sh" "The canary must execute the full Kast-on-Kast installed semantic proof"
+require_not_contains "$local_development_canary_workflow" "continue-on-error" "The installed semantic canary must fail closed"
+require_contains "$local_development_canary_workflow" "if: failure()" "A failed installed semantic canary must preserve diagnostics"
+require_contains "$local_development_canary_workflow" ".kast/local-development/state/**/*.log" "Canary diagnostics must include receipt-owned runtime logs"
+require_contains "$release_workflow" "installed-semantic-canary:" "Release must invoke the installed semantic canary"
+require_contains "$release_workflow" "uses: ./.github/workflows/local-development-canary.yml" "Release must reuse the authoritative canary workflow"
 # shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" 'save-if: ${{ github.ref == '\''refs/heads/main'\'' }}' "CI local-authority contracts must persist Rust caches only from trusted main pushes"
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "test-local-development-refresh-contract.sh" "CI local-authority contracts must execute the local refresh contract"
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "test-development-cli-install-contract.sh" "CI local-authority contracts must execute the legacy development install contract"
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" "CI must quarantine the legacy development install proof to integrated main pushes"
-require_block_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "test-cli-plugin-authority-cutover-contract.sh" "CI local-authority contracts must execute the CLI and plugin cutover contract"
-require_block_not_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "test-selector-handle-installed-workflow.sh" "CI local-authority contracts must not reinstall the CLI to rerun a Rust integration test"
-require_block_not_contains "$ci_workflow" "  local-authority-contracts:" "  local-development-semantic-e2e:" "actions/setup-python" "CI local-authority contracts must not initialize the documentation toolchain"
+require_contains "$release_workflow" 'source_ref: ${{ needs.prepare-release.outputs.release_tag }}' "Release canary must exercise the exact prepared tag"
+require_block_contains "$release_workflow" "  publish-maven-central:" "  build-cli:" "installed-semantic-canary" "Maven publication must depend on the installed semantic canary"
+require_block_contains "$release_workflow" "  publish-maven-central:" "  build-cli:" "needs.installed-semantic-canary.result == 'success'" "Maven publication must require a successful installed semantic canary"
+require_block_contains "$release_workflow" "  publish-release:" "  build-jetbrains-plugin-repository-pages:" "installed-semantic-canary" "GitHub release publication must depend on the installed semantic canary"
+require_block_contains "$release_workflow" "  publish-release:" "  build-jetbrains-plugin-repository-pages:" "needs.installed-semantic-canary.result == 'success'" "GitHub release publication must require a successful installed semantic canary"
+require_contains "$local_development_doc" "main, nightly, manual, and release" "Local-development docs must explain full canary ownership"
+require_block_not_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "    needs:" "CI local-authority contracts must remain an independent required root"
+require_block_not_matches "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" '^    if:' "CI local-authority contracts must run for every CI trigger"
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "uses: gradle/actions/setup-gradle@v5" "CI local-authority contracts must restore persisted Gradle build state"
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "cache-cleanup: always" "CI local-authority contracts must keep Gradle cache cleanup bounded"
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32" "CI local-authority contracts must restore pruned Rust dependency builds from the pinned cache action"
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "workspaces: cli-rs -> target" "CI local-authority contracts must cache the actual Rust workspace"
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" 'cache-bin: "false"' "CI local-authority contracts must not persist runner toolchain binaries"
+# shellcheck disable=SC2016 # GitHub expressions must remain literal contract strings.
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" 'save-if: ${{ github.ref == '\''refs/heads/main'\'' }}' "CI local-authority contracts must persist Rust caches only from trusted main pushes"
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "test-local-development-refresh-contract.sh" "CI local-authority contracts must execute the local refresh contract"
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "test-development-cli-install-contract.sh" "CI local-authority contracts must execute the legacy development install contract"
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" "CI must quarantine the legacy development install proof to integrated main pushes"
+require_block_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "test-cli-plugin-authority-cutover-contract.sh" "CI local-authority contracts must execute the CLI and plugin cutover contract"
+require_block_not_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "test-selector-handle-installed-workflow.sh" "CI local-authority contracts must not reinstall the CLI to rerun a Rust integration test"
+require_block_not_contains "$ci_workflow" "  local-authority-contracts:" "  runtime-contracts:" "actions/setup-python" "CI local-authority contracts must not initialize the documentation toolchain"
 require_not_matches "$cli_plugin_authority_cutover_contract" '^[[:space:]]*\.github/scripts/test-macos-installer-contract\.sh[[:space:]]*$' "CLI/plugin cutover must not rerun the installer owner"
 require_not_matches "$cli_plugin_authority_cutover_contract" '^[[:space:]]*python3 packaging/homebrew/scripts/test-formulas\.py[[:space:]]*$' "CLI/plugin cutover must not rerun the Homebrew owner"
 require_not_contains "$cli_plugin_authority_cutover_contract" "cargo test" "CLI/plugin cutover must not rerun Rust tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,24 +126,6 @@ jobs:
         shell: bash
         run: ./.github/scripts/test-cli-plugin-authority-cutover-contract.sh
 
-  local-development-semantic-e2e:
-    name: Local development installed semantic E2E
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "21"
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Exercise refreshed installed semantics
-        shell: bash
-        run: ./.github/scripts/test-local-development-semantic-e2e.sh
-
   runtime-contracts:
     name: Runtime command and bundle contracts
     runs-on: ubuntu-latest

--- a/.github/workflows/local-development-canary.yml
+++ b/.github/workflows/local-development-canary.yml
@@ -1,0 +1,68 @@
+name: Full installed semantic canary
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Exact source ref whose installed generation must be exercised.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: installed-semantic-canary-${{ github.workflow }}-${{ inputs.source_ref || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  installed-semantic-canary:
+    name: Full Kast-on-Kast installed semantic canary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_ref || github.sha }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-cleanup: always
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache canary Rust builds
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          workspaces: cli-rs -> target
+          cache-bin: "false"
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Exercise full refreshed installed semantics
+        shell: bash
+        run: ./.github/scripts/test-local-development-semantic-e2e.sh
+
+      - name: Upload failed canary diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: installed-semantic-canary-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            .kast/local-development/state/**/*.log
+            **/build/reports/problems/problems-report.html
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,14 @@ jobs:
               --generate-notes
           fi
 
+  installed-semantic-canary:
+    name: Full installed semantic canary
+    needs: [prepare-release]
+    if: always() && needs.prepare-release.result == 'success'
+    uses: ./.github/workflows/local-development-canary.yml
+    with:
+      source_ref: ${{ needs.prepare-release.outputs.release_tag }}
+
   validate-jvm:
     name: Validate JVM and Maven publications
     needs: [prepare-release]
@@ -469,7 +477,8 @@ jobs:
     needs:
       - prepare-release
       - validate-jvm
-    if: always() && needs.prepare-release.result == 'success' && needs.validate-jvm.result == 'success'
+      - installed-semantic-canary
+    if: always() && needs.prepare-release.result == 'success' && needs.validate-jvm.result == 'success' && needs.installed-semantic-canary.result == 'success'
     runs-on: ubuntu-latest
     outputs:
       state: ${{ steps.maven-state.outputs.state }}
@@ -1320,7 +1329,8 @@ jobs:
       - build-idea-plugin
       - build-headless-backend
       - build-linux-headless-tarball
-    if: always() && needs.prepare-release.result == 'success' && needs.validate-jvm.result == 'success' && needs.build-openapi-spec.result == 'success' && needs.build-runtime-compatibility-manifest.result == 'success' && needs.build-cli.result == 'success' && needs.build-idea-plugin.result == 'success' && needs.build-headless-backend.result == 'success' && needs.build-linux-headless-tarball.result == 'success'
+      - installed-semantic-canary
+    if: always() && needs.prepare-release.result == 'success' && needs.validate-jvm.result == 'success' && needs.build-openapi-spec.result == 'success' && needs.build-runtime-compatibility-manifest.result == 'success' && needs.build-cli.result == 'success' && needs.build-idea-plugin.result == 'success' && needs.build-headless-backend.result == 'success' && needs.build-linux-headless-tarball.result == 'success' && needs.installed-semantic-canary.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/distribute/local-development-refresh.md
+++ b/docs/distribute/local-development-refresh.md
@@ -42,6 +42,16 @@ names and hashes every repo-built runtime JAR in the portable distribution.
 Refresh rejects an ordinary Cargo binary, a relabeled backend, a stale sibling
 JAR, an incomplete component set, or bytes changed after attestation.
 
+## Understand Repository Validation
+
+Pull requests run focused proof at the boundary that owns each change. The
+complete Kast-on-Kast installed semantic scenario runs on
+main, nightly, manual, and release paths so a cold import does not delay
+ordinary pull-request feedback. The same fail-closed canary definition
+exercises the receipt-owned CLI and headless backend in every path; release
+publication cannot proceed after a failed canary. A failure preserves the
+workflow log and uploads available runtime logs for diagnosis.
+
 ## Verify What Agents Will Use
 
 Ask the receipt-owned launcher for machine-readable readiness before relying on


### PR DESCRIPTION
## What

- remove the full Kast-on-Kast installed semantic E2E from ordinary pull-request CI
- add one fail-closed reusable canary for main pushes, nightly schedule, manual dispatch, and release preparation
- require a successful exact-tag canary before Maven Central or GitHub release publication
- preserve failed-canary runtime logs as workflow artifacts
- evolve the deterministic workflow model so integrated canary outputs remain exact while PR critical-path analysis excludes them
- update ADR 0024, scoped workflow guidance, and contributor documentation

## Why

The unchanged self-hosting E2E passed on #408 but took 20m22s and was the sole long pull-request root after focused-owner cleanup. It remains valuable integrated proof; it is not useful as universal change feedback. This moves that proof to the source-generation and release boundary without retiring any output.

## Verification

- `kast agent verify --workspace-root "$PWD" --backend=idea`: compiler-backed, 23 source modules
- `.github/scripts/test-ci-workflow-model.sh`
- `.github/scripts/test-release-workflow-contract.sh`
- `.github/scripts/test-docs-content-contract.sh`
- `.github/scripts/test-docs-navigation-contract.sh`
- `.github/scripts/test-local-development-refresh-contract.sh`
- `.github/scripts/test-development-cli-install-contract.sh`
- `.github/scripts/test-selector-handle-installed-workflow.sh`: 1 passed, 0 skipped
- `.github/scripts/test-local-development-semantic-e2e.sh`
- Python compile plus JSON parsing for the graph checker/model/schema
- YAML parse for CI, canary, and release workflows
- `zensical build --clean`

## Risk

Release publication now has an additional hard prerequisite. A canary defect intentionally blocks publication; the canary job prints typed failure context and uploads receipt-owned runtime logs. The first integrated-main execution will be babysat after merge to prove the new trigger and reusable definition in GitHub Actions.

Advances #399.
