### PR TITLE
fix: select Kast binary in Codex release job

### DIFF
--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -539,7 +539,7 @@ require_contains "$idea_plugin_update_feed" 'id="io.github.amichne.kast"' "IDEA 
 require_contains "$idea_plugin_update_feed" 'version="#version#"' "IDEA update feed must bind the release version"
 require_contains "$idea_plugin_update_feed" "releases/download/#tag#/kast-idea-#tag#.zip" "IDEA update feed must resolve the exact release ZIP"
 require_block_contains "$release_workflow" "  build-codex-plugin:" "  build-idea-plugin:" "KAST_VERSION=" "Codex plugin generation must use the release-coupled Kast binary"
-require_block_contains "$release_workflow" "  build-codex-plugin:" "  build-idea-plugin:" "developer codex generate" "Release must generate the Codex plugin from the typed Rust contract"
+require_block_contains "$release_workflow" "  build-codex-plugin:" "  build-idea-plugin:" "cargo run --locked --bin kast -- developer codex generate --check" "Release must check committed Codex plugin generation with the exact Kast binary"
 require_block_contains "$release_workflow" "  build-codex-plugin:" "  build-idea-plugin:" "--release" "Release must request release-mode Codex metadata"
 # shellcheck disable=SC2016 # Release shell expressions must remain literal contract strings.
 require_block_contains "$release_workflow" "  build-codex-plugin:" "  build-idea-plugin:" 'asset_name="kast-codex-plugin-${tag}.zip"' "Release must publish the versioned Codex plugin ZIP"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -629,7 +629,7 @@ jobs:
       - name: Verify committed Codex plugin generation
         working-directory: cli-rs
         shell: bash
-        run: cargo run --locked -- developer codex generate --check
+        run: cargo run --locked --bin kast -- developer codex generate --check
 
       - name: Build release-coupled Kast generator
         working-directory: cli-rs


### PR DESCRIPTION
Fixes the deterministic `Build Codex plugin` failure in [release run 29655790999](https://github.com/amichne/kast/actions/runs/29655790999/job/88109832710).

The crate now exposes both `kast` and `kast-metrics-bench`, so release generation must select `--bin kast`, matching the existing CI command. The release workflow contract now preserves that invariant.

Validation:
- `.github/scripts/test-release-workflow-contract.sh`
- `cargo run --locked --bin kast -- developer codex generate --check`

Risk: one release command selector only; generated output and release packaging are unchanged.