### PR TITLE
fix: install native macOS CLI and IDEA plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ complete headless release:
 
 The bootstrap delegates to `kast setup`. A successful invocation activates the
 platform release and receipt under `KAST_HOME` (default
-`~/.local/share/kast`). A failed invocation leaves the prior active release
-usable.
+`~/.local/share/kast`). A failed invocation leaves the prior active release usable.
 
 For a local bundle:
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@ IDEA, Android Studio, or the packaged headless backend.
 
 ## Install or update
 
-One command installs, replaces, repairs, upgrades, or downgrades the complete
-release on macOS and Linux:
+One command installs, replaces, repairs, upgrades, or downgrades Kast. On macOS
+it installs the native CLI and matching IDEA plugin; on Linux it installs the
+complete headless release:
 
 ```console
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/amichne/kast/main/install.sh)"
 ```
 
-The bootstrap delegates to `kast setup`. A successful invocation atomically
-activates one checksum-verified CLI, backend, IDEA plugin, skill, guidance set,
-config, and receipt under `KAST_HOME` (default `~/.local/share/kast`). A failed
-invocation leaves the prior active release usable.
+The bootstrap delegates to `kast setup`. A successful invocation activates the
+platform release and receipt under `KAST_HOME` (default
+`~/.local/share/kast`). A failed invocation leaves the prior active release
+usable.
 
 For a local bundle:
 

--- a/cli-rs/src/cli/root.rs
+++ b/cli-rs/src/cli/root.rs
@@ -57,8 +57,18 @@ pub enum Command {
 #[derive(Debug, Args, Clone)]
 pub struct SetupArgs {
     /// Extracted bundle directory or bundle .tar.gz archive.
-    #[arg(long)]
-    pub source: PathBuf,
+    #[arg(
+        long,
+        required_unless_present = "idea_plugin",
+        conflicts_with = "idea_plugin"
+    )]
+    pub source: Option<PathBuf>,
+    /// IDEA plugin ZIP to install with the running native CLI.
+    #[arg(long, required_unless_present = "source", conflicts_with = "source")]
+    pub idea_plugin: Option<PathBuf>,
+    /// IntelliJ IDEA or Android Studio plugins directory.
+    #[arg(long, requires = "idea_plugin")]
+    pub idea_plugins_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/cli-rs/src/install.rs
+++ b/cli-rs/src/install.rs
@@ -14,6 +14,7 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use std::env;
 use std::fs;
+use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command as ProcessCommand, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -24,6 +25,7 @@ include!("install/bundle_source.rs");
 include!("install/bundle_validation.rs");
 include!("install/bundle_install.rs");
 include!("install/bundle_helpers.rs");
+include!("install/idea_plugin.rs");
 
 fn command_error(code: &'static str, message: &str, args: &[String], output: &Output) -> CliError {
     let mut error = CliError::new(

--- a/cli-rs/src/install/bundle_entrypoint.rs
+++ b/cli-rs/src/install/bundle_entrypoint.rs
@@ -1,7 +1,18 @@
 pub fn setup(args: SetupArgs) -> Result<SetupResult> {
+    match (args.source, args.idea_plugin) {
+        (Some(source), None) => setup_bundle(source),
+        (None, Some(idea_plugin)) => setup_idea_plugin(idea_plugin, args.idea_plugins_dir),
+        _ => Err(CliError::new(
+            "CLI_USAGE",
+            "Pass exactly one of --source or --idea-plugin.",
+        )),
+    }
+}
+
+fn setup_bundle(source: PathBuf) -> Result<SetupResult> {
     let kast_home = env_path("KAST_HOME")
         .unwrap_or_else(|| manifest::home_dir().join(".local/share/kast"));
-    let source = config::normalize(args.source);
+    let source = config::normalize(source);
     let scratch = ScratchDir::new("kast-setup")?;
     let bundle_root = bundle_source_root(&source, scratch.path())?;
     let bundle = validate_bundle(&bundle_root)?;

--- a/cli-rs/src/install/idea_plugin.rs
+++ b/cli-rs/src/install/idea_plugin.rs
@@ -360,25 +360,37 @@ fn extract_idea_plugin_zip(source: &Path, target: &Path) -> Result<()> {
 }
 
 fn default_idea_plugins_dir() -> Result<PathBuf> {
-    let profiles = manifest::home_dir().join("Library/Application Support/JetBrains");
-    let mut candidates = fs::read_dir(&profiles)
-        .map_err(|error| {
-            CliError::new(
-                "IDE_PROFILE_NOT_FOUND",
-                format!("Cannot inspect {}: {error}", profiles.display()),
-            )
-        })?
-        .filter_map(std::result::Result::ok)
-        .filter(|entry| {
-            entry.file_type().is_ok_and(|kind| kind.is_dir())
-                && entry.file_name().to_str().is_some_and(|name| {
-                    ["IntelliJIdea", "IdeaIC", "AndroidStudio"]
-                        .iter()
-                        .any(|prefix| name.starts_with(prefix))
+    let application_support = manifest::home_dir().join("Library/Application Support");
+    let mut candidates = Vec::new();
+    for (root, prefixes) in [
+        (
+            application_support.join("JetBrains"),
+            &["IntelliJIdea", "IdeaIC"][..],
+        ),
+        (application_support.join("Google"), &["AndroidStudio"][..]),
+    ] {
+        let entries = match fs::read_dir(&root) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(CliError::new(
+                    "IDE_PROFILE_NOT_FOUND",
+                    format!("Cannot inspect {}: {error}", root.display()),
+                ));
+            }
+        };
+        candidates.extend(
+            entries
+                .filter_map(std::result::Result::ok)
+                .filter(|entry| {
+                    entry.file_type().is_ok_and(|kind| kind.is_dir())
+                        && entry.file_name().to_str().is_some_and(|name| {
+                            prefixes.iter().any(|prefix| name.starts_with(prefix))
+                        })
                 })
-        })
-        .map(|entry| entry.path().join("plugins"))
-        .collect::<Vec<_>>();
+                .map(|entry| entry.path().join("plugins")),
+        );
+    }
     candidates.sort();
     candidates.pop().ok_or_else(|| {
         CliError::new(

--- a/cli-rs/src/install/idea_plugin.rs
+++ b/cli-rs/src/install/idea_plugin.rs
@@ -1,0 +1,446 @@
+fn setup_idea_plugin(
+    idea_plugin: PathBuf,
+    idea_plugins_dir: Option<PathBuf>,
+) -> Result<SetupResult> {
+    let idea_plugin = config::normalize(idea_plugin);
+    require_regular_file(&idea_plugin, "Kast IDEA plugin ZIP")?;
+    require_jetbrains_ides_closed()?;
+
+    let current_exe = env::current_exe()?;
+    require_executable(&current_exe, "running Kast CLI")?;
+    let cli_sha256 = manifest::sha256_file(&current_exe)?;
+    let plugin_sha256 = manifest::sha256_file(&idea_plugin)?;
+    let release_digest =
+        manifest::sha256_bytes(format!("{cli_sha256}\n{plugin_sha256}\n").as_bytes());
+    let resolved = manifest::default_resolved_paths();
+    let targets = idea_activation_target_paths(resolved, &release_digest);
+    let plugins_dir = idea_plugins_dir
+        .map(config::normalize)
+        .map(Ok)
+        .unwrap_or_else(default_idea_plugins_dir)?;
+    let scratch = ScratchDir::new("kast-idea-setup")?;
+    let extracted_plugin = scratch.path().join("plugin");
+    extract_idea_plugin_zip(&idea_plugin, &extracted_plugin)?;
+    let extracted_plugin_digest = directory_sha256(&extracted_plugin)?;
+
+    manifest::with_install_lock(&targets.resolved, || {
+        if current_release_matches(&targets)
+            && verify_idea_plugin_setup(
+                &targets,
+                &plugins_dir.join("kast"),
+                &cli_sha256,
+                &extracted_plugin_digest,
+            )
+            .is_ok()
+        {
+            return Ok(idea_setup_result(
+                &targets,
+                SetupStatus::Current,
+                &release_digest,
+                &cli_sha256,
+                &extracted_plugin_digest,
+                &plugins_dir.join("kast"),
+                None,
+            ));
+        }
+
+        let legacy_backup = archive_legacy_installations(&targets)?;
+        let (previous, release_backup) = install_idea_release(
+            &targets,
+            &current_exe,
+            &idea_plugin,
+            &release_digest,
+            &cli_sha256,
+            &plugin_sha256,
+        )?;
+        let installed_plugin = plugins_dir.join("kast");
+        let plugin_backup = match install_idea_plugin(&extracted_plugin, &installed_plugin) {
+            Ok(backup) => backup,
+            Err(error) => {
+                rollback_activated_bundle(&targets, previous.as_deref())?;
+                return Err(error);
+            }
+        };
+        if let Err(error) = verify_idea_plugin_setup(
+            &targets,
+            &installed_plugin,
+            &cli_sha256,
+            &extracted_plugin_digest,
+        ) {
+            rollback_idea_plugin(&installed_plugin, plugin_backup.as_deref())?;
+            rollback_activated_bundle(&targets, previous.as_deref())?;
+            return Err(error);
+        }
+
+        Ok(idea_setup_result(
+            &targets,
+            SetupStatus::Activated,
+            &release_digest,
+            &cli_sha256,
+            &extracted_plugin_digest,
+            &installed_plugin,
+            release_backup.as_deref().or(legacy_backup.as_deref()),
+        ))
+    })
+}
+
+fn idea_activation_target_paths(
+    resolved: manifest::ResolvedKastPaths,
+    release_digest: &str,
+) -> ActivationTargetPaths {
+    let version_dir = resolved.install_root.join("releases").join(release_digest);
+    ActivationTargetPaths {
+        current_link: resolved.install_root.join("current"),
+        previous_link: resolved.install_root.join("previous"),
+        headless_current_dir: version_dir.join("lib/backends/headless/current"),
+        version_dir,
+        resolved,
+    }
+}
+
+fn install_idea_release(
+    targets: &ActivationTargetPaths,
+    current_exe: &Path,
+    idea_plugin: &Path,
+    release_digest: &str,
+    cli_sha256: &str,
+    plugin_sha256: &str,
+) -> Result<(Option<PathBuf>, Option<PathBuf>)> {
+    let staging_root = targets.resolved.install_root.join("staging");
+    manifest::remove_path(&staging_root)?;
+    fs::create_dir_all(&staging_root)?;
+    fs::create_dir_all(targets.resolved.install_root.join("releases"))?;
+    fs::create_dir_all(targets.resolved.install_root.join("backups"))?;
+    let staged = staging_root.join(format!("{release_digest}-{}", std::process::id()));
+    fs::create_dir_all(staged.join("bin"))?;
+    fs::create_dir_all(staged.join("idea"))?;
+    fs::create_dir_all(staged.join("config"))?;
+    fs::copy(current_exe, staged.join("bin/kast"))?;
+    manifest::make_executable(&staged.join("bin/kast"))?;
+    fs::copy(idea_plugin, staged.join("idea/kast.zip"))?;
+    fs::write(
+        staged.join("config/config.toml"),
+        "[runtime]\ndefaultBackend = \"idea\"\n\n[backends.headless]\nenabled = false\n\n[backends.idea]\nenabled = true\n",
+    )?;
+    manifest::write_manifest_atomic(
+        &staged.join(manifest::INSTALL_MANIFEST_FILE),
+        &idea_install_manifest(targets, release_digest, cli_sha256, plugin_sha256),
+    )?;
+
+    let (previous, backup) = archive_current_activation(targets)?;
+    manifest::remove_path(&targets.version_dir)?;
+    fs::rename(&staged, &targets.version_dir)?;
+    if let Some(previous) = &previous {
+        manifest::replace_symlink_or_copy(previous, &targets.previous_link)?;
+    }
+    manifest::replace_symlink_or_copy(&targets.version_dir, &targets.current_link)?;
+    Ok((previous, backup))
+}
+
+fn idea_install_manifest(
+    targets: &ActivationTargetPaths,
+    release_digest: &str,
+    cli_sha256: &str,
+    plugin_sha256: &str,
+) -> manifest::KastInstallManifest {
+    let now = manifest::current_timestamp();
+    let version = crate::cli::version().to_string();
+    manifest::KastInstallManifest {
+        tool: "kast".to_string(),
+        install_id: format!("kast-macos-idea-{version}"),
+        release_digest: release_digest.to_string(),
+        manifest_digest: manifest::sha256_bytes(
+            format!("{cli_sha256}\n{plugin_sha256}\n").as_bytes(),
+        ),
+        profile: "macos-idea".to_string(),
+        active_version: version.clone(),
+        previous_version: None,
+        created_at: now.clone(),
+        updated_at: now,
+        roots: manifest::ManifestRoots {
+            install: targets.resolved.install_root.display().to_string(),
+            bin: targets.resolved.bin_dir.display().to_string(),
+            config: targets.resolved.config_root.display().to_string(),
+            data: targets.resolved.data_dir.display().to_string(),
+            cache: targets.resolved.cache_dir.display().to_string(),
+            runtime: targets.resolved.runtime_dir.display().to_string(),
+            logs: targets.resolved.logs_dir.display().to_string(),
+            locks: targets.resolved.locks_dir.display().to_string(),
+        },
+        entrypoints: manifest::ManifestEntrypoints {
+            shim: targets.resolved.shim_path.display().to_string(),
+            active_binary: targets.resolved.active_binary.display().to_string(),
+        },
+        schemas: manifest::ManifestSchemas::default(),
+        version: version.clone(),
+        backend_version: String::new(),
+        installed_at: format!("macos-idea:{version}"),
+        platform: macos_platform_id(),
+        components: vec!["cli".to_string(), "idea-plugin".to_string()],
+        backends: vec![],
+        managed_paths: vec!["bin/kast".to_string(), "idea/kast.zip".to_string()],
+        owned_paths: manifest::owned_paths(&targets.resolved),
+        shell_rc_patches: vec![],
+        repos: vec![],
+        schema_version: crate::SCHEMA_VERSION,
+    }
+}
+
+fn install_idea_plugin(source: &Path, target: &Path) -> Result<Option<PathBuf>> {
+    let parent = target
+        .parent()
+        .ok_or_else(|| CliError::new("IDE_PROFILE_INVALID", "IDE plugin target has no parent."))?;
+    fs::create_dir_all(parent)?;
+    let staging = parent.join(format!(".kast-staging-{}", std::process::id()));
+    manifest::remove_path(&staging)?;
+    copy_bundle_tree(source, &staging)?;
+    let backup = if fs::symlink_metadata(target).is_ok() {
+        let backup = parent.join(format!(".kast-backup-{}", std::process::id()));
+        manifest::remove_path(&backup)?;
+        fs::rename(target, &backup)?;
+        Some(backup)
+    } else {
+        None
+    };
+    if let Err(error) = fs::rename(&staging, target) {
+        if let Some(backup) = &backup {
+            let _ = fs::rename(backup, target);
+        }
+        return Err(error.into());
+    }
+    Ok(backup)
+}
+
+fn rollback_idea_plugin(target: &Path, backup: Option<&Path>) -> Result<()> {
+    manifest::remove_path(target)?;
+    if let Some(backup) = backup {
+        fs::rename(backup, target)?;
+    }
+    Ok(())
+}
+
+fn verify_idea_plugin_setup(
+    targets: &ActivationTargetPaths,
+    installed_plugin: &Path,
+    cli_sha256: &str,
+    plugin_digest: &str,
+) -> Result<()> {
+    let active_cli = targets.current_link.join("bin/kast");
+    require_executable(&active_cli, "installed Kast CLI")?;
+    require_file(
+        &targets.current_link.join(manifest::INSTALL_MANIFEST_FILE),
+        "install receipt",
+    )?;
+    if manifest::sha256_file(&active_cli)? != cli_sha256 {
+        return Err(CliError::new(
+            "SETUP_VERIFY_FAILED",
+            "Installed Kast CLI does not match the setup source.",
+        ));
+    }
+    if directory_sha256(installed_plugin)? != plugin_digest {
+        return Err(CliError::new(
+            "SETUP_VERIFY_FAILED",
+            "Installed IDEA plugin does not match the setup source.",
+        ));
+    }
+    Ok(())
+}
+
+fn idea_setup_result(
+    targets: &ActivationTargetPaths,
+    status: SetupStatus,
+    release_digest: &str,
+    cli_sha256: &str,
+    plugin_digest: &str,
+    installed_plugin: &Path,
+    backup: Option<&Path>,
+) -> SetupResult {
+    SetupResult {
+        result_type: "KAST_SETUP",
+        status,
+        release_digest: release_digest.to_string(),
+        manifest_digest: release_digest.to_string(),
+        kast_home: targets.resolved.install_root.display().to_string(),
+        current: targets.current_link.display().to_string(),
+        active_binary: targets.resolved.active_binary.display().to_string(),
+        backup: backup.map(|path| path.display().to_string()),
+        artifacts: vec![
+            SetupArtifact {
+                role: "cli".to_string(),
+                path: targets.resolved.active_binary.display().to_string(),
+                sha256: cli_sha256.to_string(),
+                verified: true,
+            },
+            SetupArtifact {
+                role: "idea-plugin".to_string(),
+                path: installed_plugin.display().to_string(),
+                sha256: plugin_digest.to_string(),
+                verified: true,
+            },
+        ],
+        verified: true,
+        schema_version: crate::SCHEMA_VERSION,
+    }
+}
+
+fn macos_platform_id() -> String {
+    match env::consts::ARCH {
+        "aarch64" => "macos-arm64".to_string(),
+        "x86_64" => "macos-x64".to_string(),
+        arch => format!("macos-{arch}"),
+    }
+}
+
+fn extract_idea_plugin_zip(source: &Path, target: &Path) -> Result<()> {
+    let file = fs::File::open(source)?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|error| {
+        CliError::new(
+            "IDE_PLUGIN_ARCHIVE_INVALID",
+            format!("Cannot read IDEA plugin ZIP {}: {error}", source.display()),
+        )
+    })?;
+    let mut root_name = None;
+    let mut file_count = 0usize;
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|error| CliError::new("IDE_PLUGIN_ARCHIVE_INVALID", error.to_string()))?;
+        let enclosed = entry.enclosed_name().ok_or_else(|| {
+            CliError::new(
+                "IDE_PLUGIN_ARCHIVE_UNSAFE",
+                format!("IDEA plugin ZIP contains an unsafe path: {}", entry.name()),
+            )
+        })?;
+        if entry
+            .unix_mode()
+            .is_some_and(|mode| mode & 0o170000 == 0o120000)
+        {
+            return Err(CliError::new(
+                "IDE_PLUGIN_ARCHIVE_UNSAFE",
+                format!("IDEA plugin ZIP contains a symlink: {}", entry.name()),
+            ));
+        }
+        let mut components = enclosed.components();
+        let Some(Component::Normal(first)) = components.next() else {
+            continue;
+        };
+        match &root_name {
+            Some(expected) if expected != first => {
+                return Err(CliError::new(
+                    "IDE_PLUGIN_ARCHIVE_INVALID",
+                    "IDEA plugin ZIP must contain exactly one top-level directory.",
+                ));
+            }
+            None => root_name = Some(first.to_os_string()),
+            _ => {}
+        }
+        let relative = components.collect::<PathBuf>();
+        if relative.as_os_str().is_empty() {
+            continue;
+        }
+        let output = target.join(relative);
+        if entry.is_dir() {
+            fs::create_dir_all(&output)?;
+        } else {
+            if let Some(parent) = output.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let mut file = fs::File::create(&output)?;
+            io::copy(&mut entry, &mut file)?;
+            file_count += 1;
+        }
+    }
+    if root_name.is_none() || file_count == 0 {
+        return Err(CliError::new(
+            "IDE_PLUGIN_ARCHIVE_INVALID",
+            "IDEA plugin ZIP must contain one nonempty top-level plugin directory.",
+        ));
+    }
+    Ok(())
+}
+
+fn default_idea_plugins_dir() -> Result<PathBuf> {
+    let profiles = manifest::home_dir().join("Library/Application Support/JetBrains");
+    let mut candidates = fs::read_dir(&profiles)
+        .map_err(|error| {
+            CliError::new(
+                "IDE_PROFILE_NOT_FOUND",
+                format!("Cannot inspect {}: {error}", profiles.display()),
+            )
+        })?
+        .filter_map(std::result::Result::ok)
+        .filter(|entry| {
+            entry.file_type().is_ok_and(|kind| kind.is_dir())
+                && entry.file_name().to_str().is_some_and(|name| {
+                    ["IntelliJIdea", "IdeaIC", "AndroidStudio"]
+                        .iter()
+                        .any(|prefix| name.starts_with(prefix))
+                })
+        })
+        .map(|entry| entry.path().join("plugins"))
+        .collect::<Vec<_>>();
+    candidates.sort();
+    candidates.pop().ok_or_else(|| {
+        CliError::new(
+            "IDE_PROFILE_NOT_FOUND",
+            "No IntelliJ IDEA or Android Studio profile was found; pass --idea-plugins-dir.",
+        )
+    })
+}
+
+fn require_jetbrains_ides_closed() -> Result<()> {
+    if let Ok(state) = env::var("KAST_MACHINE_IDE_STATE") {
+        return match state.as_str() {
+            "closed" => Ok(()),
+            "open" => Err(CliError::new(
+                "IDE_RESTART_REQUIRED",
+                "Close IntelliJ IDEA or Android Studio, then rerun `kast setup`.",
+            )),
+            _ => Err(CliError::new(
+                "IDE_STATE_INVALID",
+                "KAST_MACHINE_IDE_STATE must be `open` or `closed` when set.",
+            )),
+        };
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let output = ProcessCommand::new("pgrep")
+            .args([
+                "-f",
+                "/(IntelliJ IDEA|Android Studio)[^/]*\\.app/Contents/MacOS/",
+            ])
+            .output()?;
+        match output.status.code() {
+            Some(1) => Ok(()),
+            Some(0) => Err(CliError::new(
+                "IDE_RESTART_REQUIRED",
+                "Close IntelliJ IDEA or Android Studio, then rerun `kast setup`.",
+            )),
+            status => Err(CliError::new(
+                "IDE_STATE_UNAVAILABLE",
+                format!("Could not determine IDE process state: {status:?}."),
+            )),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(())
+    }
+}
+
+fn require_regular_file(path: &Path, label: &str) -> Result<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        CliError::new(
+            "SETUP_COMPONENT_MISSING",
+            format!("Cannot read {label} at {}: {error}", path.display()),
+        )
+    })?;
+    if metadata.is_file() && !metadata.file_type().is_symlink() {
+        Ok(())
+    } else {
+        Err(CliError::new(
+            "SETUP_COMPONENT_INVALID",
+            format!("{label} must be a regular file: {}", path.display()),
+        ))
+    }
+}

--- a/cli-rs/tests/setup_smoke.rs
+++ b/cli-rs/tests/setup_smoke.rs
@@ -1,7 +1,22 @@
 mod support;
 
+use std::io::Write;
 use std::process::Stdio;
 use support::*;
+
+fn write_idea_plugin_zip(root: &Path) -> PathBuf {
+    let archive = root.join("kast-idea.zip");
+    let file = std::fs::File::create(&archive).expect("plugin archive");
+    let mut zip = zip::ZipWriter::new(file);
+    zip.start_file(
+        "kast/lib/plugin.jar",
+        zip::write::SimpleFileOptions::default(),
+    )
+    .expect("plugin entry");
+    zip.write_all(b"plugin").expect("plugin contents");
+    zip.finish().expect("plugin archive");
+    archive
+}
 
 fn setup_command(home: &Path, kast_home: &Path, source: &Path) -> Command {
     let mut command = kast(home, &kast_home.join("unused-config"));
@@ -24,6 +39,55 @@ fn setup(home: &Path, kast_home: &Path, source: &Path) -> std::process::Output {
     setup_command(home, kast_home, source)
         .output()
         .expect("kast setup")
+}
+
+#[test]
+fn setup_installs_native_cli_and_idea_plugin() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let kast_home = home.join(".local/share/kast");
+    let plugins = temp.path().join("plugins");
+    let plugin = write_idea_plugin_zip(temp.path());
+    std::fs::create_dir_all(&home).expect("home");
+
+    let output = kast(&home, &kast_home.join("unused-config"))
+        .env_remove("KAST_CONFIG_HOME")
+        .env("KAST_HOME", &kast_home)
+        .env("KAST_MACHINE_IDE_STATE", "closed")
+        .args([
+            "--output",
+            "json",
+            "setup",
+            "--idea-plugin",
+            plugin.to_str().expect("plugin path"),
+            "--idea-plugins-dir",
+            plugins.to_str().expect("plugins path"),
+        ])
+        .output()
+        .expect("kast setup");
+
+    assert!(
+        output.status.success(),
+        "setup should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(kast_home.join("current/bin/kast").is_file());
+    assert!(plugins.join("kast/lib/plugin.jar").is_file());
+    let receipt: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(kast_home.join("current/receipt.json")).expect("setup receipt"),
+    )
+    .expect("setup receipt JSON");
+    assert_eq!(
+        receipt["components"],
+        serde_json::json!(["cli", "idea-plugin"])
+    );
+    let platform = match std::env::consts::ARCH {
+        "aarch64" => "macos-arm64".to_string(),
+        "x86_64" => "macos-x64".to_string(),
+        arch => format!("macos-{arch}"),
+    };
+    assert_eq!(receipt["platform"], platform);
 }
 
 #[test]

--- a/cli-rs/tests/setup_smoke.rs
+++ b/cli-rs/tests/setup_smoke.rs
@@ -46,9 +46,9 @@ fn setup_installs_native_cli_and_idea_plugin() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let kast_home = home.join(".local/share/kast");
-    let plugins = temp.path().join("plugins");
+    let plugins = home.join("Library/Application Support/Google/AndroidStudio2026.1/plugins");
     let plugin = write_idea_plugin_zip(temp.path());
-    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&plugins).expect("Android Studio profile");
 
     let output = kast(&home, &kast_home.join("unused-config"))
         .env_remove("KAST_CONFIG_HOME")
@@ -60,8 +60,6 @@ fn setup_installs_native_cli_and_idea_plugin() {
             "setup",
             "--idea-plugin",
             plugin.to_str().expect("plugin path"),
-            "--idea-plugins-dir",
-            plugins.to_str().expect("plugins path"),
         ])
         .output()
         .expect("kast setup");

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,37 @@ Environment:
 USAGE
 }
 
+supports_color() {
+  if [[ "${CLICOLOR_FORCE:-}" == "1" ]]; then return 0; fi
+  if [[ -n "${NO_COLOR:-}" ]]; then return 1; fi
+  if [[ ! -t 2 ]]; then return 1; fi
+  [[ "${TERM:-}" != "dumb" ]]
+}
+
+colorize() {
+  local code="$1"
+  shift
+  if supports_color; then
+    printf '\033[%sm%s\033[0m' "$code" "$*"
+    return
+  fi
+  printf '%s' "$*"
+}
+
+print_banner() {
+  printf '\n' >&2
+  printf '  %s\n' "$(colorize '1;36' '  ██╗  ██╗ █████╗ ███████╗████████╗')" >&2
+  printf '  %s\n' "$(colorize '1;36' '  ██║ ██╔╝██╔══██╗██╔════╝╚══██╔══╝')" >&2
+  printf '  %s\n' "$(colorize '1;36' '  █████╔╝ ███████║███████╗   ██║   ')" >&2
+  printf '  %s\n' "$(colorize '1;36' '  ██╔═██╗ ██╔══██║╚════██║   ██║   ')" >&2
+  printf '  %s\n' "$(colorize '1;36' '  ██║  ██║██║  ██║███████║   ██║   ')" >&2
+  printf '  %s\n' "$(colorize '1;36' '  ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝   ╚═╝  ')" >&2
+  printf '\n' >&2
+  printf '  %s\n' "Kotlin semantic analysis — from your terminal" >&2
+  printf '  %s\n' "$(colorize '2' 'https://github.com/amichne/kast')" >&2
+  printf '\n' >&2
+}
+
 die() {
   printf 'kast setup: %s\n' "$*" >&2
   exit 1
@@ -56,7 +87,8 @@ latest_version() {
 }
 
 main() {
-  local source="" version="" bundle_root="" bundle_archive=""
+  local source="" version="" bundle_root="" bundle_archive="" platform_id=""
+  local cli_archive="" cli_url="" plugin_archive="" plugin_url=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --source) [[ $# -ge 2 ]] || die '--source requires a value'; source="$2"; shift 2 ;;
@@ -66,14 +98,36 @@ main() {
     esac
   done
 
+  print_banner
   setup_scratch="$(mktemp -d "${TMPDIR:-/tmp}/kast-setup.XXXXXX")"
 
   if [[ -z "$source" ]]; then
     require curl
     version="${version:-$(latest_version)}"
+    platform_id="$(platform)"
+    if [[ "$platform_id" == macos-* ]]; then
+      require unzip
+      cli_archive="${setup_scratch}/kast-${version}-${platform_id}.zip"
+      plugin_archive="${setup_scratch}/kast-idea-${version}.zip"
+      cli_url="${RELEASES_URL}/download/${version}/kast-${version}-${platform_id}.zip"
+      plugin_url="${RELEASES_URL}/download/${version}/kast-idea-${version}.zip"
+      printf 'Downloading %s...\n' "${cli_url##*/}" >&2
+      curl -fL --progress-bar --output "$cli_archive" "$cli_url"
+      printf 'Downloading %s...\n' "${plugin_url##*/}" >&2
+      curl -fL --progress-bar --output "$plugin_archive" "$plugin_url"
+      mkdir -p "${setup_scratch}/cli"
+      unzip -q "$cli_archive" -d "${setup_scratch}/cli"
+      [[ -f "${setup_scratch}/cli/kast" ]] || die "native CLI bundle is missing kast"
+      chmod 755 "${setup_scratch}/cli/kast"
+      printf 'Installing Kast and the IDEA plugin...\n' >&2
+      "${setup_scratch}/cli/kast" setup --idea-plugin "$plugin_archive"
+      printf 'Kast is ready at %s/current/bin/kast\n' "${KAST_HOME:-${HOME}/.local/share/kast}"
+      return 0
+    fi
     bundle_archive="${setup_scratch}/kast-bundle.tar.gz"
-    source="${RELEASES_URL}/download/${version}/kast-$(platform)-${version}.tar.gz"
-    curl -fsSL --output "$bundle_archive" "$source"
+    source="${RELEASES_URL}/download/${version}/kast-${platform_id}-${version}.tar.gz"
+    printf 'Downloading %s...\n' "${source##*/}" >&2
+    curl -fL --progress-bar --output "$bundle_archive" "$source"
     source="$bundle_archive"
   fi
 
@@ -82,6 +136,7 @@ main() {
   else
     require tar
     [[ -f "$source" ]] || die "bundle source does not exist: $source"
+    printf 'Extracting Kast bundle...\n' >&2
     mkdir -p "${setup_scratch}/bundle"
     tar -xzf "$source" -C "${setup_scratch}/bundle"
     bundle_root="$(find "${setup_scratch}/bundle" -mindepth 1 -maxdepth 1 -type d -print -quit)"
@@ -89,6 +144,7 @@ main() {
   fi
 
   [[ -x "${bundle_root}/bin/kast" ]] || die "bundle CLI is missing: ${bundle_root}/bin/kast"
+  printf 'Installing Kast...\n' >&2
   "${bundle_root}/bin/kast" setup --source "$bundle_root"
   printf 'Kast is ready at %s/current/bin/kast\n' "${KAST_HOME:-${HOME}/.local/share/kast}"
 }

--- a/tests/install_macos_test.sh
+++ b/tests/install_macos_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/kast-install-test.XXXXXX")"
+cleanup() {
+  status=$?
+  trap - EXIT
+  if [[ $status -ne 0 && -f "$scratch/stderr" ]]; then
+    sed -n '1,160p' "$scratch/stderr" >&2
+  fi
+  find "$scratch" -depth -delete
+  exit "$status"
+}
+trap cleanup EXIT
+
+mkdir -p "$scratch/bin" "$scratch/home"
+printf '%s\n' '#!/bin/sh' 'if [ "$1" = "-s" ]; then printf "%s\\n" "${KAST_TEST_OS:-Darwin}"; else printf "%s\\n" "${KAST_TEST_ARCH:-arm64}"; fi' > "$scratch/bin/uname"
+printf '%s\n' '#!/bin/sh' 'output=""' 'url=""' 'while [ "$#" -gt 0 ]; do case "$1" in --output) output="$2"; shift 2 ;; *) url="$1"; shift ;; esac; done' 'printf "%s\\n" "$url" >> "$KAST_TEST_CURL_LOG"' ': > "$output"' > "$scratch/bin/curl"
+printf '%s\n' '#!/bin/sh' 'destination=""' 'while [ "$#" -gt 0 ]; do case "$1" in -d) destination="$2"; shift 2 ;; *) shift ;; esac; done' 'mkdir -p "$destination"' 'printf "%s\n" "#!/bin/sh" "printf \"%s\\n\" \"\$*\" > \"\$KAST_TEST_SETUP_ARGS\"" > "$destination/kast"' 'chmod 755 "$destination/kast"' > "$scratch/bin/unzip"
+printf '%s\n' '#!/bin/sh' 'destination=""' 'while [ "$#" -gt 0 ]; do case "$1" in -C) destination="$2"; shift 2 ;; *) shift ;; esac; done' 'mkdir -p "$destination/bundle/bin"' 'printf "%s\n" "#!/bin/sh" "printf \"%s\\n\" \"\$*\" > \"\$KAST_TEST_SETUP_ARGS\"" > "$destination/bundle/bin/kast"' 'chmod 755 "$destination/bundle/bin/kast"' > "$scratch/bin/tar"
+chmod 755 "$scratch/bin/uname" "$scratch/bin/curl" "$scratch/bin/unzip" "$scratch/bin/tar"
+
+export PATH="$scratch/bin:$PATH"
+export HOME="$scratch/home"
+export KAST_RELEASES_URL="https://releases.test"
+export KAST_TEST_CURL_LOG="$scratch/curl.log"
+export KAST_TEST_SETUP_ARGS="$scratch/setup.args"
+export CLICOLOR_FORCE=1
+
+bash "$repo_root/install.sh" --version v1.2.3 >"$scratch/stdout" 2>"$scratch/stderr"
+
+grep -Fqx 'https://releases.test/download/v1.2.3/kast-v1.2.3-macos-arm64.zip' "$scratch/curl.log"
+grep -Fqx 'https://releases.test/download/v1.2.3/kast-idea-v1.2.3.zip' "$scratch/curl.log"
+grep -Eq '^setup --idea-plugin .*/kast-idea-v1\.2\.3\.zip$' "$scratch/setup.args"
+grep -Fq $'\033[1;36m  ██╗  ██╗ █████╗ ███████╗████████╗\033[0m' "$scratch/stderr"
+if grep -Fq 'kast-macos-arm64-v1.2.3.tar.gz' "$scratch/curl.log"; then
+  printf '%s\n' 'macOS installer selected the headless bundle' >&2
+  exit 1
+fi
+
+: > "$scratch/curl.log"
+KAST_TEST_OS=Linux KAST_TEST_ARCH=x86_64 bash "$repo_root/install.sh" --version v1.2.3 >"$scratch/stdout" 2>"$scratch/stderr"
+grep -Fqx 'https://releases.test/download/v1.2.3/kast-linux-x64-v1.2.3.tar.gz' "$scratch/curl.log"


### PR DESCRIPTION
## Summary
- make the macOS bootstrap download the native Kast CLI and matching IDEA plugin
- add kast setup support for installing that plugin alongside the running CLI
- restore the large blue Kast banner while retaining the Linux headless path

## Verification
- .github/scripts/test-setup-contract.sh
- bash tests/install_macos_test.sh
- cargo clippy --manifest-path cli-rs/Cargo.toml --locked --test setup_smoke -- -D warnings
- targeted rustfmt check