### PR TITLE
fix: overwrite incompatible Kast installs

### DIFF
--- a/cli-rs/src/install/bundle_install.rs
+++ b/cli-rs/src/install/bundle_install.rs
@@ -12,7 +12,7 @@ fn install_validated_bundle(
             ),
         ));
     }
-    let install_manifest = project_install_manifest(bundle, targets)?;
+    let install_manifest = project_install_manifest(bundle, targets);
     for directory in [
         targets.resolved.install_root.join("releases"),
         targets.resolved.install_root.join("backups"),
@@ -96,29 +96,19 @@ fn rollback_activated_bundle(
 fn project_install_manifest(
     bundle: &ValidatedBundle,
     targets: &ActivationTargetPaths,
-) -> Result<manifest::KastInstallManifest> {
-    let active_receipt = targets.current_link.join(manifest::INSTALL_MANIFEST_FILE);
-    let previous = if active_receipt.is_file() {
-        let manifest = manifest_from_file(&active_receipt)?;
-        BundleVersion::parse(&manifest.active_version)
-            .ok()
-            .filter(|version| version.as_str() != bundle.version.as_str())
-            .map(BundleVersion::into_string)
-    } else {
-        None
-    };
+) -> manifest::KastInstallManifest {
     let now = manifest::current_timestamp();
     let normalized_version = bundle.version.normalized();
     let headless_root = targets.headless_current_dir.clone();
     let install_id = format!("kast-{}-{}", bundle.manifest.platform, normalized_version);
-    Ok(manifest::KastInstallManifest {
+    manifest::KastInstallManifest {
         tool: "kast".to_string(),
         install_id,
         release_digest: bundle.release_digest.clone(),
         manifest_digest: bundle.manifest_digest.clone(),
         profile: bundle.manifest.profile.clone(),
         active_version: bundle.version.as_str().to_string(),
-        previous_version: previous,
+        previous_version: None,
         created_at: now.clone(),
         updated_at: now,
         roots: manifest::ManifestRoots {
@@ -162,7 +152,7 @@ fn project_install_manifest(
         shell_rc_patches: vec![],
         repos: vec![],
         schema_version: SCHEMA_VERSION,
-    })
+    }
 }
 
 fn verify_activated_bundle(

--- a/cli-rs/src/install/idea_plugin.rs
+++ b/cli-rs/src/install/idea_plugin.rs
@@ -21,6 +21,14 @@ fn setup_idea_plugin(
     let plugin_sha256 = manifest::sha256_file(&idea_plugin)?;
     let release_digest =
         manifest::sha256_bytes(format!("{cli_sha256}\n{plugin_sha256}\n").as_bytes());
+    let mut bundle_manifest = serde_json::to_vec_pretty(&serde_json::json!({
+        "artifacts": [
+            {"role": "cli", "path": "bin/kast", "sha256": cli_sha256},
+            {"role": "idea-plugin", "path": "idea/kast.zip", "sha256": plugin_sha256}
+        ]
+    }))?;
+    bundle_manifest.push(b'\n');
+    let manifest_digest = manifest::sha256_bytes(&bundle_manifest);
     let resolved = manifest::default_resolved_paths();
     let targets = idea_activation_target_paths(resolved, &release_digest);
     let plugins_dir = idea_plugins_dir
@@ -39,6 +47,8 @@ fn setup_idea_plugin(
                 &plugins_dir.join("kast"),
                 &cli_sha256,
                 &extracted_plugin_digest,
+                &release_digest,
+                &manifest_digest,
             )
             .is_ok()
         {
@@ -54,6 +64,7 @@ fn setup_idea_plugin(
                 &release_digest,
                 &cli_sha256,
                 &extracted_plugin_digest,
+                &manifest_digest,
                 &plugins_dir.join("kast"),
                 None,
             ));
@@ -65,9 +76,9 @@ fn setup_idea_plugin(
             &current_exe,
             &idea_plugin,
             &release_digest,
-            &cli_sha256,
-            &plugin_sha256,
             config_defaults.as_deref().unwrap_or(DEFAULT_IDEA_CONFIG),
+            &bundle_manifest,
+            &manifest_digest,
         )?;
         let installed_plugin = plugins_dir.join("kast");
         let plugin_backup = match install_idea_plugin(&extracted_plugin, &installed_plugin) {
@@ -82,6 +93,8 @@ fn setup_idea_plugin(
             &installed_plugin,
             &cli_sha256,
             &extracted_plugin_digest,
+            &release_digest,
+            &manifest_digest,
         ) {
             rollback_idea_plugin(&installed_plugin, plugin_backup.as_deref())?;
             rollback_activated_bundle(&targets, previous.as_deref())?;
@@ -94,6 +107,7 @@ fn setup_idea_plugin(
             &release_digest,
             &cli_sha256,
             &extracted_plugin_digest,
+            &manifest_digest,
             &installed_plugin,
             release_backup.as_deref().or(legacy_backup.as_deref()),
         ))
@@ -119,9 +133,9 @@ fn install_idea_release(
     current_exe: &Path,
     idea_plugin: &Path,
     release_digest: &str,
-    cli_sha256: &str,
-    plugin_sha256: &str,
     config_defaults: &str,
+    bundle_manifest: &[u8],
+    manifest_digest: &str,
 ) -> Result<(Option<PathBuf>, Option<PathBuf>)> {
     let staging_root = targets.resolved.install_root.join("staging");
     manifest::remove_path(&staging_root)?;
@@ -136,9 +150,14 @@ fn install_idea_release(
     manifest::make_executable(&staged.join("bin/kast"))?;
     fs::copy(idea_plugin, staged.join("idea/kast.zip"))?;
     fs::write(staged.join("config/config.toml"), config_defaults)?;
+    fs::write(staged.join(BUNDLE_MANIFEST_FILE), bundle_manifest)?;
     manifest::write_manifest_atomic(
         &staged.join(manifest::INSTALL_MANIFEST_FILE),
-        &idea_install_manifest(targets, release_digest, cli_sha256, plugin_sha256),
+        &idea_install_manifest(
+            targets,
+            release_digest,
+            manifest_digest,
+        ),
     )?;
 
     let (previous, backup) = archive_current_activation(targets)?;
@@ -156,8 +175,7 @@ const DEFAULT_IDEA_CONFIG: &str = "[runtime]\ndefaultBackend = \"idea\"\n\n[back
 fn idea_install_manifest(
     targets: &ActivationTargetPaths,
     release_digest: &str,
-    cli_sha256: &str,
-    plugin_sha256: &str,
+    manifest_digest: &str,
 ) -> manifest::KastInstallManifest {
     let now = manifest::current_timestamp();
     let version = crate::cli::version().to_string();
@@ -165,9 +183,7 @@ fn idea_install_manifest(
         tool: "kast".to_string(),
         install_id: format!("kast-macos-idea-{version}"),
         release_digest: release_digest.to_string(),
-        manifest_digest: manifest::sha256_bytes(
-            format!("{cli_sha256}\n{plugin_sha256}\n").as_bytes(),
-        ),
+        manifest_digest: manifest_digest.to_string(),
         profile: "macos-idea".to_string(),
         active_version: version.clone(),
         previous_version: None,
@@ -240,13 +256,25 @@ fn verify_idea_plugin_setup(
     installed_plugin: &Path,
     cli_sha256: &str,
     plugin_digest: &str,
+    release_digest: &str,
+    manifest_digest: &str,
 ) -> Result<()> {
     let active_cli = targets.current_link.join("bin/kast");
     require_executable(&active_cli, "installed Kast CLI")?;
-    require_file(
-        &targets.current_link.join(manifest::INSTALL_MANIFEST_FILE),
-        "install receipt",
-    )?;
+    let receipt_path = targets.current_link.join(manifest::INSTALL_MANIFEST_FILE);
+    require_file(&receipt_path, "install receipt")?;
+    let receipt = manifest_from_file(&receipt_path)?;
+    let bundle_manifest = targets.current_link.join(BUNDLE_MANIFEST_FILE);
+    require_file(&bundle_manifest, "bundle manifest")?;
+    if receipt.release_digest != release_digest
+        || receipt.manifest_digest != manifest_digest
+        || manifest::sha256_file(&bundle_manifest)? != manifest_digest
+    {
+        return Err(CliError::new(
+            "SETUP_VERIFY_FAILED",
+            "Installed Kast manifest does not match the setup source.",
+        ));
+    }
     if manifest::sha256_file(&active_cli)? != cli_sha256 {
         return Err(CliError::new(
             "SETUP_VERIFY_FAILED",
@@ -268,6 +296,7 @@ fn idea_setup_result(
     release_digest: &str,
     cli_sha256: &str,
     plugin_digest: &str,
+    manifest_digest: &str,
     installed_plugin: &Path,
     backup: Option<&Path>,
 ) -> SetupResult {
@@ -275,7 +304,7 @@ fn idea_setup_result(
         result_type: "KAST_SETUP",
         status,
         release_digest: release_digest.to_string(),
-        manifest_digest: release_digest.to_string(),
+        manifest_digest: manifest_digest.to_string(),
         kast_home: targets.resolved.install_root.display().to_string(),
         current: targets.current_link.display().to_string(),
         active_binary: targets.resolved.active_binary.display().to_string(),

--- a/cli-rs/src/install/idea_plugin.rs
+++ b/cli-rs/src/install/idea_plugin.rs
@@ -60,13 +60,12 @@ fn setup_idea_plugin(
             }
             return Ok(idea_setup_result(
                 &targets,
-                SetupStatus::Current,
+                (SetupStatus::Current, None),
                 &release_digest,
                 &cli_sha256,
                 &extracted_plugin_digest,
                 &manifest_digest,
                 &plugins_dir.join("kast"),
-                None,
             ));
         }
 
@@ -103,13 +102,15 @@ fn setup_idea_plugin(
 
         Ok(idea_setup_result(
             &targets,
-            SetupStatus::Activated,
+            (
+                SetupStatus::Activated,
+                release_backup.as_deref().or(legacy_backup.as_deref()),
+            ),
             &release_digest,
             &cli_sha256,
             &extracted_plugin_digest,
             &manifest_digest,
             &installed_plugin,
-            release_backup.as_deref().or(legacy_backup.as_deref()),
         ))
     })
 }
@@ -292,14 +293,14 @@ fn verify_idea_plugin_setup(
 
 fn idea_setup_result(
     targets: &ActivationTargetPaths,
-    status: SetupStatus,
+    activation: (SetupStatus, Option<&Path>),
     release_digest: &str,
     cli_sha256: &str,
     plugin_digest: &str,
     manifest_digest: &str,
     installed_plugin: &Path,
-    backup: Option<&Path>,
 ) -> SetupResult {
+    let (status, backup) = activation;
     SetupResult {
         result_type: "KAST_SETUP",
         status,

--- a/cli-rs/tests/setup_smoke.rs
+++ b/cli-rs/tests/setup_smoke.rs
@@ -180,6 +180,91 @@ fn setup_replaces_defaults_when_release_is_current() {
 }
 
 #[test]
+fn setup_replaces_incompatible_legacy_bundle_activation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let kast_home = home.join(".local/share/kast");
+    let source = write_install_bundle_source(temp.path(), "v9.8.7");
+    std::fs::create_dir_all(kast_home.join("current")).expect("legacy current");
+    std::fs::write(kast_home.join("current/receipt.json"), "legacy").expect("legacy receipt");
+
+    let output = setup(&home, &kast_home, &source);
+
+    assert!(
+        output.status.success(),
+        "setup should replace the legacy activation: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).expect("setup JSON");
+    assert_eq!(result["status"], "ACTIVATED");
+    assert!(kast_home.join("current/manifest.json").is_file());
+    let receipt: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(kast_home.join("current/receipt.json")).expect("replacement receipt"),
+    )
+    .expect("replacement receipt JSON");
+    assert_eq!(receipt["activeVersion"], "v9.8.7");
+}
+
+#[test]
+fn setup_replaces_incompatible_legacy_idea_activation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let kast_home = home.join(".local/share/kast");
+    let plugins = home.join("Library/Application Support/Google/AndroidStudio2026.1/plugins");
+    let plugin = write_idea_plugin_zip(temp.path());
+    std::fs::create_dir_all(&plugins).expect("Android Studio profile");
+    let run_setup = || {
+        kast(&home, &kast_home.join("unused-config"))
+            .env_remove("KAST_CONFIG_HOME")
+            .env("KAST_HOME", &kast_home)
+            .env("KAST_MACHINE_IDE_STATE", "closed")
+            .args([
+                "--output",
+                "json",
+                "setup",
+                "--idea-plugin",
+                plugin.to_str().expect("plugin path"),
+            ])
+            .output()
+            .expect("kast setup")
+    };
+    let first = run_setup();
+    assert!(first.status.success(), "initial setup should succeed");
+    let manifest_path = kast_home.join("current/manifest.json");
+    let _ = std::fs::remove_file(&manifest_path);
+
+    let replacement = run_setup();
+
+    assert!(
+        replacement.status.success(),
+        "setup should replace the incompatible activation: stdout={}, stderr={}",
+        String::from_utf8_lossy(&replacement.stdout),
+        String::from_utf8_lossy(&replacement.stderr),
+    );
+    let result: serde_json::Value =
+        serde_json::from_slice(&replacement.stdout).expect("setup JSON");
+    assert_eq!(result["status"], "ACTIVATED");
+    assert!(manifest_path.is_file());
+    let receipt: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(kast_home.join("current/receipt.json")).expect("replacement receipt"),
+    )
+    .expect("replacement receipt JSON");
+    assert_eq!(
+        receipt["manifestDigest"],
+        test_path_sha256(&manifest_path)
+    );
+    let manifest: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&manifest_path).expect("replacement manifest"),
+    )
+    .expect("replacement manifest JSON");
+    assert_eq!(
+        manifest["artifacts"][0]["sha256"],
+        test_path_sha256(&kast_home.join("current/bin/kast"))
+    );
+}
+
+#[test]
 fn setup_activates_one_validated_release_and_converges_on_rerun() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/cli-rs/tests/setup_smoke.rs
+++ b/cli-rs/tests/setup_smoke.rs
@@ -250,14 +250,10 @@ fn setup_replaces_incompatible_legacy_idea_activation() {
         &std::fs::read(kast_home.join("current/receipt.json")).expect("replacement receipt"),
     )
     .expect("replacement receipt JSON");
-    assert_eq!(
-        receipt["manifestDigest"],
-        test_path_sha256(&manifest_path)
-    );
-    let manifest: serde_json::Value = serde_json::from_slice(
-        &std::fs::read(&manifest_path).expect("replacement manifest"),
-    )
-    .expect("replacement manifest JSON");
+    assert_eq!(receipt["manifestDigest"], test_path_sha256(&manifest_path));
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest_path).expect("replacement manifest"))
+            .expect("replacement manifest JSON");
     assert_eq!(
         manifest["artifacts"][0]["sha256"],
         test_path_sha256(&kast_home.join("current/bin/kast"))


### PR DESCRIPTION
Risk: setup trust detection changes for both bundle and macOS IDEA activations; focused replacement tests cover both paths.

## What

Make setup replace incompatible older activations and ensure macOS IDEA installations carry matching receipt, manifest, and CLI artifact digests.

## Why

Older or incomplete receipts could block bundle upgrades, while a same-release IDEA install could be reported current despite missing the manifest required during project open.

## Validation

- cargo test --manifest-path cli-rs/Cargo.toml --locked --test setup_smoke setup_replaces_incompatible_legacy -- --nocapture