### PR TITLE
fix: align IDEA runtime paths with setup

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/fields/ConfigurationDefaults.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/fields/ConfigurationDefaults.kt
@@ -15,7 +15,7 @@ internal fun defaultConfigBinDir(): Path = userHome.resolve(".local/bin")
 internal fun defaultConfigLibDir(installRoot: String = defaultConfigInstallRoot().toString()): Path = Path.of(installRoot).resolve("current/lib")
 internal fun defaultConfigCacheDir(): Path = userHome.resolve(".cache/kast")
 internal fun defaultConfigLogsDir(): Path = userHome.resolve(".local/state/kast/logs")
-internal fun defaultConfigRuntimeDir(installRoot: String = defaultConfigInstallRoot().toString()): Path = Path.of(installRoot).resolve("runtime")
+internal fun defaultConfigRuntimeDir(installRoot: String = defaultConfigInstallRoot().toString()): Path = Path.of(installRoot).resolve("state/runtime")
 internal fun defaultConfigDescriptorDir(runtimeDir: String = defaultConfigRuntimeDir().toString()): Path = Path.of(runtimeDir).resolve("daemons")
 internal fun defaultConfigSocketDir(runtimeDir: String = defaultConfigRuntimeDir().toString()): String = runtimeDir
 internal fun defaultConfigCliBinaryPath(binDir: String = defaultConfigBinDir().toString()): Path = Path.of(binDir).resolve("kast")

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastConfigTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastConfigTest.kt
@@ -116,7 +116,7 @@ class KastConfigTest {
         val libDir = installRoot.resolve("current/lib")
         val cacheDir = Path.of(System.getProperty("user.home")).resolve(".cache/kast")
         val logsDir = Path.of(System.getProperty("user.home")).resolve(".local/state/kast/logs")
-        val runtimeDir = installRoot.resolve("runtime")
+        val runtimeDir = installRoot.resolve("state/runtime")
         val descriptorDir = runtimeDir.resolve("daemons")
         val socketDir = runtimeDir
         val binaryPath = binDir.resolve("kast")

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspacePathsTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspacePathsTest.kt
@@ -50,7 +50,7 @@ class WorkspacePathsTest {
         val binDir = Path.of(System.getProperty("user.home")).resolve(".local/bin").toAbsolutePath().normalize()
         val cacheDir = Path.of(System.getProperty("user.home")).resolve(".cache/kast").toAbsolutePath().normalize()
         val logsDir = Path.of(System.getProperty("user.home")).resolve(".local/state/kast/logs").toAbsolutePath().normalize()
-        val runtimeDir = installRoot.resolve("runtime")
+        val runtimeDir = installRoot.resolve("state/runtime")
         val defaults = KastConfig.defaults()
 
         assertEquals(runtimeDir.resolve("daemons"), defaultDescriptorDirectory())
@@ -197,7 +197,7 @@ class WorkspacePathsTest {
         fun `resolves to descriptor directory from config defaults`() {
             val result = defaultDescriptorDirectory()
             assertEquals(
-                defaultInstallRootPath().resolve("runtime/daemons"),
+                defaultInstallRootPath().resolve("state/runtime/daemons"),
                 result,
             )
         }


### PR DESCRIPTION
Risk: already-running IDEA backends keep their current socket until the IDE restarts; explicit runtime path overrides are unchanged.

## What

Move the JVM default runtime root from `KAST_HOME/runtime` to the setup-owned `KAST_HOME/state/runtime`, covering both sockets and descriptor registration.

## Why

The native CLI resolves runtime state from the setup receipt under `state/runtime`. The plugin’s legacy default made healthy IDEA backends invisible without manual symlinks.

## Validation

- `./gradlew :analysis-api:test --tests io.github.amichne.kast.api.client.WorkspacePathsTest --no-daemon`
- `./gradlew :analysis-api:test --no-daemon`