### PR TITLE
fix: make Graphify extraction bounded and composable

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/SemanticGraphResult.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract/result/SemanticGraphResult.kt
@@ -232,6 +232,8 @@ data class SemanticGraphResult(
     val coverage: SemanticGraphCoverage,
     @DocField(description = "Semantic symbol records included in this page.")
     val symbols: List<SemanticGraphSymbol>,
+    @DocField(description = "Referenced workspace symbols outside the selected file scope, returned without expansion.")
+    val boundarySymbols: List<SemanticGraphSymbol> = emptyList(),
     @DocField(description = "Semantic relation records included in this page.")
     val relations: List<SemanticGraphRelation>,
     @DocField(description = "Opaque token for the next page, or null when complete.")

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphOperations.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphOperations.kt
@@ -81,6 +81,7 @@ internal data class SemanticGraphSnapshot(
     val scopeFingerprint: SemanticGraphSha256,
     val coverage: SemanticGraphCoverage,
     val symbols: List<SemanticGraphSymbol>,
+    val boundarySymbols: List<SemanticGraphSymbol>,
     val relations: List<SemanticGraphRelation>,
 )
 
@@ -104,12 +105,19 @@ internal data class SemanticGraphContinuationProjection(
 
 private sealed interface SemanticGraphRecord {
     data class Symbol(val value: SemanticGraphSymbol) : SemanticGraphRecord
+    data class BoundarySymbol(val value: SemanticGraphSymbol) : SemanticGraphRecord
     data class Relation(val value: SemanticGraphRelation) : SemanticGraphRecord
 }
 
 private data class ExtractedSemanticGraphFile(
     val update: SemanticGraphFileIndexUpdate,
+    val boundarySymbols: List<SemanticGraphSymbol>,
     val omittedExternalTargetCount: Int,
+)
+
+private data class ResolvedSemanticTarget(
+    val key: SemanticGraphSymbolKey,
+    val boundarySymbol: SemanticGraphSymbol?,
 )
 
 private data class ResolvedSemanticCallTarget(
@@ -185,6 +193,7 @@ private fun KastPluginBackend.buildSemanticGraphSnapshot(query: ParsedSemanticGr
     val removedPaths = query.removedFilePaths.map(::toRelativeSemanticGraphPath)
     val updates = mutableListOf<SemanticGraphFileIndexUpdate>()
     val coverage = mutableListOf<SemanticGraphFileCoverage>()
+    val extractedBoundarySymbols = mutableMapOf<SemanticGraphSymbolKey, SemanticGraphSymbol>()
     var omittedExternalTargetCount = 0
 
     query.filePaths.zip(selectedPaths).forEach { (absolutePath, relativePath) ->
@@ -207,6 +216,9 @@ private fun KastPluginBackend.buildSemanticGraphSnapshot(query: ParsedSemanticGr
         }
         val extracted = extractSemanticGraphFile(file, relativePath, contentHash, evidence)
         updates += extracted.update
+        extracted.boundarySymbols.forEach { symbol ->
+            extractedBoundarySymbols[symbol.canonicalKey] = symbol
+        }
         coverage += SemanticGraphFileCoverage(
             path = relativePath,
             contentHash = contentHash,
@@ -226,12 +238,18 @@ private fun KastPluginBackend.buildSemanticGraphSnapshot(query: ParsedSemanticGr
         SemanticGraphFileCoverage(path, null, SemanticGraphFileStatus.REMOVED)
     }
     val persisted = store.readSemanticGraph(selectedPaths)
-    val symbolKeys = store.readSemanticGraph(currentWorkspaceSemanticGraphPaths()).symbols
-        .mapTo(mutableSetOf(), SemanticGraphSymbol::canonicalKey)
-    val missingTargets = persisted.relations.map(SemanticGraphRelation::targetKey).filterNot(symbolKeys::contains).distinct()
+    val selectedSymbolKeys = persisted.symbols.mapTo(mutableSetOf(), SemanticGraphSymbol::canonicalKey)
+    val boundarySymbols = extractedBoundarySymbols.values
+        .filterNot { symbol -> symbol.canonicalKey in selectedSymbolKeys }
+        .sortedBy(SemanticGraphSymbol::canonicalKey)
+    val availableTargetKeys = selectedSymbolKeys + boundarySymbols.map(SemanticGraphSymbol::canonicalKey)
+    val missingTargets = persisted.relations
+        .map(SemanticGraphRelation::targetKey)
+        .filterNot(availableTargetKeys::contains)
+        .distinct()
     if (missingTargets.isNotEmpty()) {
-        throw ValidationException(
-            "Semantic graph contains internal targets outside the current workspace snapshot: " +
+        error(
+            "Semantic graph extraction produced relations without selected or boundary targets: " +
                 missingTargets.joinToString { it.value },
         )
     }
@@ -243,6 +261,7 @@ private fun KastPluginBackend.buildSemanticGraphSnapshot(query: ParsedSemanticGr
             omittedExternalTargetCount = NonNegativeInt(omittedExternalTargetCount),
         ),
         symbols = persisted.symbols.sortedBy(SemanticGraphSymbol::canonicalKey),
+        boundarySymbols = boundarySymbols,
         relations = persisted.relations.sortedWith(semanticGraphRelationOrder),
     )
 }
@@ -267,6 +286,7 @@ private fun KastPluginBackend.extractSemanticGraphFile(
         line = LineNumber(1),
     )
     val symbols = listOf(fileSymbol) + symbolByDeclaration.values
+    val boundarySymbols = mutableMapOf<SemanticGraphSymbolKey, SemanticGraphSymbol>()
     val relations = mutableListOf<SemanticGraphRelation>()
     declarations.forEach { declaration ->
         val symbol = symbolByDeclaration.getValue(declaration)
@@ -300,15 +320,18 @@ private fun KastPluginBackend.extractSemanticGraphFile(
                 )
             }
             val source = nearestProjectedOwner(call, symbolByDeclaration) ?: fileSymbol
-            val targetKey = target.element?.let { semanticTargetKey(it, path) }
-            if (targetKey != null) {
+            val semanticTarget = target.element?.let { semanticTarget(it, path) }
+            if (semanticTarget != null) {
+                semanticTarget.boundarySymbol?.let { symbol ->
+                    boundarySymbols[symbol.canonicalKey] = symbol
+                }
                 val resolvedTargetKey = target.exactConstructorSignature?.let { signature ->
                     val targetPath = relativePathOr(requireNotNull(target.element), path)
                     SemanticGraphSymbolKey.parse("constructor:${targetPath.value}:$signature")
                 }
                 relations += relation(
                     source,
-                    targetKey,
+                    semanticTarget.key,
                     SemanticGraphRelationKind.CALLS,
                     SemanticGraphRelationContext.CALL,
                     call,
@@ -329,14 +352,17 @@ private fun KastPluginBackend.extractSemanticGraphFile(
         .forEach { entry ->
             val source = nearestProjectedOwner(entry, symbolByDeclaration) ?: return@forEach
             val target = entry.typeReference?.resolveTypeTarget()
-            val targetKey = target?.let { semanticTargetKey(it, path) }
-            if (targetKey != null) {
+            val semanticTarget = target?.let { semanticTarget(it, path) }
+            if (semanticTarget != null) {
+                semanticTarget.boundarySymbol?.let { symbol ->
+                    boundarySymbols[symbol.canonicalKey] = symbol
+                }
                 val kind = if ((target as? KtClass)?.isInterface() == true) {
                     SemanticGraphRelationKind.IMPLEMENTS
                 } else {
                     SemanticGraphRelationKind.INHERITS
                 }
-                relations += relation(source, targetKey, kind, SemanticGraphRelationContext.NONE, entry, path)
+                relations += relation(source, semanticTarget.key, kind, SemanticGraphRelationContext.NONE, entry, path)
             } else if (target == null || target.containingFile !is KtFile || !isWorkspaceFile(target.containingFile.virtualFile.path)) {
                 omittedExternalTargetCount++
             }
@@ -350,9 +376,12 @@ private fun KastPluginBackend.extractSemanticGraphFile(
                 .sortedBy { it.textRange.startOffset }
                 .forEach { userType ->
                     val target = userType.resolveTarget()
-                    val targetKey = target?.let { semanticTargetKey(it, path) }
+                    val semanticTarget = target?.let { semanticTarget(it, path) }
                     val source = nearestProjectedOwner(reference, symbolByDeclaration) ?: fileSymbol
-                    if (targetKey != null) {
+                    if (semanticTarget != null) {
+                        semanticTarget.boundarySymbol?.let { symbol ->
+                            boundarySymbols[symbol.canonicalKey] = symbol
+                        }
                         val context = if (PsiTreeUtil.getParentOfType(userType, KtTypeProjection::class.java, false) != null) {
                             SemanticGraphRelationContext.GENERIC_ARG
                         } else {
@@ -360,7 +389,7 @@ private fun KastPluginBackend.extractSemanticGraphFile(
                         }
                         relations += relation(
                             source,
-                            targetKey,
+                            semanticTarget.key,
                             SemanticGraphRelationKind.REFERENCES,
                             context,
                             userType,
@@ -381,6 +410,7 @@ private fun KastPluginBackend.extractSemanticGraphFile(
             symbols = symbols,
             relations = relations.distinct().sortedWith(semanticGraphRelationOrder),
         ),
+        boundarySymbols = boundarySymbols.values.sortedBy(SemanticGraphSymbol::canonicalKey),
         omittedExternalTargetCount = omittedExternalTargetCount,
     )
 }
@@ -425,18 +455,23 @@ private fun KtNamedDeclaration.semanticKey(path: SemanticGraphSourcePath): Seman
     else -> localKey(path, this, requireNotNull(projectableKind(this)))
 }
 
-private fun KastPluginBackend.semanticTargetKey(
+private fun KastPluginBackend.semanticTarget(
     target: PsiElement,
     sourcePath: SemanticGraphSourcePath,
-): SemanticGraphSymbolKey? {
+): ResolvedSemanticTarget? {
     val targetFile = target.containingFile as? KtFile ?: return null
     if (!isWorkspaceFile(targetFile.virtualFile.path)) return null
-    return when (target) {
-        is KtNamedFunction -> target.semanticKey(relativePathOr(target, sourcePath))
-        is KtClassOrObject -> target.semanticKey(relativePathOr(target, sourcePath))
+    val declaration = when (target) {
+        is KtNamedFunction -> target
+        is KtClassOrObject -> target
         else -> PsiTreeUtil.getParentOfType(target, KtClassOrObject::class.java, false)
-            ?.semanticKey(relativePathOr(target, sourcePath))
-    }
+    } ?: return null
+    val targetPath = relativePathOr(declaration, sourcePath)
+    val symbol = semanticGraphSymbol(declaration, targetPath)
+    return ResolvedSemanticTarget(
+        key = symbol.canonicalKey,
+        boundarySymbol = symbol.takeUnless { targetPath == sourcePath },
+    )
 }
 
 private fun KastPluginBackend.relativePathOr(
@@ -560,11 +595,6 @@ private fun KastPluginBackend.toRelativeSemanticGraphPath(path: SemanticGraphPat
     return SemanticGraphSourcePath.parse(workspaceRoot.relativize(absolute).toString())
 }
 
-private fun KastPluginBackend.currentWorkspaceSemanticGraphPaths(): List<SemanticGraphSourcePath> =
-    kotlinCandidateFiles(com.intellij.psi.search.GlobalSearchScope.projectScope(project)).map { file ->
-        toRelativeSemanticGraphPath(SemanticGraphPath.parse(file.path))
-    }
-
 private fun sha256(value: String): SemanticGraphSha256 = SemanticGraphSha256.parse(
     MessageDigest.getInstance("SHA-256")
         .digest(value.toByteArray(StandardCharsets.UTF_8))
@@ -591,7 +621,10 @@ private val semanticGraphRelationOrder = compareBy<SemanticGraphRelation>(
 )
 
 private fun semanticGraphRecordCount(snapshot: SemanticGraphSnapshot): Int =
-    Math.addExact(snapshot.symbols.size, snapshot.relations.size)
+    Math.addExact(
+        Math.addExact(snapshot.symbols.size, snapshot.boundarySymbols.size),
+        snapshot.relations.size,
+    )
 
 private fun semanticGraphNextOffset(
     snapshot: SemanticGraphSnapshot,
@@ -612,6 +645,7 @@ private fun semanticGraphPage(
 ): SemanticGraphResult {
     val snapshot = projection.snapshot
     val records = snapshot.symbols.map(SemanticGraphRecord::Symbol) +
+        snapshot.boundarySymbols.map(SemanticGraphRecord::BoundarySymbol) +
         snapshot.relations.map(SemanticGraphRecord::Relation)
     val page = records.drop(projection.pageOffset).take(pageSize)
     return SemanticGraphResult(
@@ -619,6 +653,8 @@ private fun semanticGraphPage(
         scopeFingerprint = snapshot.scopeFingerprint,
         coverage = snapshot.coverage,
         symbols = page.filterIsInstance<SemanticGraphRecord.Symbol>().map(SemanticGraphRecord.Symbol::value),
+        boundarySymbols = page.filterIsInstance<SemanticGraphRecord.BoundarySymbol>()
+            .map(SemanticGraphRecord.BoundarySymbol::value),
         relations = page.filterIsInstance<SemanticGraphRecord.Relation>().map(SemanticGraphRecord.Relation::value),
         nextPageToken = nextToken,
     )

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/SemanticGraphBackendTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/SemanticGraphBackendTest.kt
@@ -62,18 +62,81 @@ class SemanticGraphBackendTest {
 
             class Box<T>
         """
+
+        private const val boundarySource = """
+            package demo
+
+            fun reachBoundary(): BoundaryTarget = BoundaryTarget()
+        """
+
+        private const val boundaryTarget = """
+            package demo
+
+            class BoundaryTarget
+        """
     }
 
     private val moduleFixture = projectFixture.moduleFixture("main")
     private val sourceRootFixture = moduleFixture.sourceRootFixture()
     private val sourceFileFixture = sourceRootFixture.psiFileFixture("SemanticGraph.kt", source)
     private val brokenSourceFileFixture = sourceRootFixture.psiFileFixture("Broken.kt", brokenSource)
+    private val boundarySourceFileFixture = sourceRootFixture.psiFileFixture("BoundarySource.kt", boundarySource)
+    private val boundaryTargetFileFixture = sourceRootFixture.psiFileFixture("BoundaryTarget.kt", boundaryTarget)
     private val duplicateModuleFixture = projectFixture.moduleFixture("duplicate")
     private val duplicateSourceRootFixture = duplicateModuleFixture.sourceRootFixture()
     private val duplicateSourceFileFixture = duplicateSourceRootFixture.psiFileFixture("Duplicate.kt", duplicateSource)
 
     @TempDir
     lateinit var storeRoot: Path
+
+    @Test
+    fun `scoped graph returns unexpanded cross file targets`() = runBlocking {
+        val project = projectFixture.get()
+        val sourceFile = boundarySourceFileFixture.get()
+        val targetFile = boundaryTargetFileFixture.get()
+        waitUntilIndexesAreReady(project)
+        val workspaceRoot = Path.of(sourceFile.virtualFile.path).toRealPath().parent
+
+        SqliteSourceIndexStore(storeRoot).use { store ->
+            store.ensureSchema()
+            KastPluginBackend(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                limits = ServerLimits(maxResults = 500, requestTimeoutMillis = 30_000, maxConcurrentRequests = 4),
+                semanticGraphStore = store,
+                psiGeneration = { 1L },
+            ).use { backend ->
+                val scoped = backend.semanticGraph(
+                    SemanticGraphQuery(
+                        filePaths = listOf(SemanticGraphPath.parse(sourceFile.virtualFile.path)),
+                    ).parsed(),
+                )
+                val boundary = scoped.boundarySymbols.single { symbol -> symbol.name.value == "BoundaryTarget" }
+
+                assertEquals("BoundaryTarget.kt", boundary.path.value)
+                assertTrue(scoped.symbols.none { symbol -> symbol.canonicalKey == boundary.canonicalKey })
+                assertTrue(scoped.relations.any { relation -> relation.targetKey == boundary.canonicalKey })
+                assertTrue(
+                    scoped.relations.all { relation ->
+                        relation.targetKey in scoped.symbols.map { it.canonicalKey }.toSet() ||
+                            relation.targetKey in scoped.boundarySymbols.map { it.canonicalKey }.toSet()
+                    },
+                )
+
+                val expanded = backend.semanticGraph(
+                    SemanticGraphQuery(
+                        filePaths = listOf(
+                            SemanticGraphPath.parse(sourceFile.virtualFile.path),
+                            SemanticGraphPath.parse(targetFile.virtualFile.path),
+                        ),
+                    ).parsed(),
+                )
+
+                assertTrue(expanded.symbols.any { symbol -> symbol.canonicalKey == boundary.canonicalKey })
+                assertTrue(expanded.boundarySymbols.none { symbol -> symbol.canonicalKey == boundary.canonicalKey })
+            }
+        }
+    }
 
     @Test
     fun `returns compiler diagnostics without aborting graph extraction`() = runBlocking {

--- a/cli-rs/Cargo.lock
+++ b/cli-rs/Cargo.lock
@@ -1134,6 +1134,8 @@ dependencies = [
  "tiktoken-rs",
  "toml 1.1.2+spec-1.1.0",
  "toon-format",
+ "unicode-casefold",
+ "unicode-normalization",
  "uuid",
  "zip",
 ]
@@ -2348,6 +2350,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-casefold"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f66b1c8f8caa2ab31dc6d3f35386f16efdab89668f93411e565ac368908e8f"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,6 +2522,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/cli-rs/Cargo.toml
+++ b/cli-rs/Cargo.toml
@@ -24,6 +24,8 @@ tar = "0.4"
 thiserror = "2.0"
 toon-format = { version = "0.5.0", default-features = false }
 toml = "1.1"
+unicode-casefold = "0.2.0"
+unicode-normalization = "0.1.25"
 uuid = { version = "1.18", features = ["serde", "v4"] }
 zip = { version = "6.0", default-features = false, features = ["deflate"] }
 jsonschema = { version = "0.46.5", default-features = false }

--- a/cli-rs/protocol/api-reference.md
+++ b/cli-rs/protocol/api-reference.md
@@ -1327,6 +1327,7 @@ daemon, including input/output schemas, examples, and behavioral notes.
             | `#!kotlin scopeFingerprint: SemanticGraphSha256` | SHA-256 fingerprint of the selected and removed path scope. |
             | `#!kotlin coverage: SemanticGraphCoverage` | Refresh, diagnostic, and omission evidence for the scope. |
             | `#!kotlin symbols: List<SemanticGraphSymbol>` | Semantic symbol records included in this page. |
+            | `#!kotlin boundarySymbols: List<SemanticGraphSymbol>?` | Referenced workspace symbols outside the selected file scope, returned without expansion. |
             | `#!kotlin relations: List<SemanticGraphRelation>` | Semantic relation records included in this page. |
             | `#!kotlin nextPageToken: SemanticGraphPageToken?` | Opaque token for the next page, or null when complete. |
         === "Internal protocol"
@@ -1380,6 +1381,7 @@ daemon, including input/output schemas, examples, and behavioral notes.
                             "line": 1
                         }
                     ],
+                    "boundarySymbols": [],
                     "relations": []
                 },
                 "id": 1,

--- a/cli-rs/protocol/api-specification.md
+++ b/cli-rs/protocol/api-specification.md
@@ -44,7 +44,7 @@ so the page exposes the internal JSON-RPC catalog used by typed
 families, flow-oriented building blocks, and request fields that
 callers compose into larger automation flows.
 
-Catalog version: `dev`. Methods: `41`.
+Catalog version: `dev`. Methods: `42`.
 
 #### Method families
 
@@ -55,7 +55,7 @@ The families below are internal JSON-RPC namespaces, not public CLI commands.
 | `system` | Runtime readiness, backend state, and capability discovery. | backend | `health`<br>`runtime/status`<br>`runtime/shutdown`<br>`runtime/restart`<br>`capabilities` |
 | `mutation` | Cataloged JSON-RPC methods. | backend | `mutation/submit` |
 | `symbol` | Name-based orchestration for agent and script workflows. | backend, sqlite | `symbol/scaffold`<br>`symbol/discover`<br>`symbol/query`<br>`symbol/resolve`<br>`selector/identity`<br>`symbol/references`<br>`symbol/callers`<br>`symbol/implementations`<br>`symbol/hierarchy`<br>`symbol/rename`<br>`symbol/write-and-validate`<br>`symbol/add-file`<br>`symbol/add-declaration`<br>`symbol/add-implementation`<br>`symbol/add-statement`<br>`symbol/replace-declaration` |
-| `raw` | Position- and file-based backend primitives. | backend | `raw/resolve`<br>`raw/references`<br>`raw/call-hierarchy`<br>`raw/type-hierarchy`<br>`raw/semantic-insertion-point`<br>`raw/diagnostics`<br>`raw/rename`<br>`raw/optimize-imports`<br>`raw/apply-edits`<br>`raw/workspace-refresh`<br>`raw/file-outline`<br>`raw/workspace-symbol`<br>`raw/workspace-search`<br>`raw/workspace-files`<br>`raw/workspace-files-continuation`<br>`raw/implementations`<br>`raw/code-actions`<br>`raw/completions` |
+| `raw` | Position- and file-based backend primitives. | backend | `raw/resolve`<br>`raw/references`<br>`raw/call-hierarchy`<br>`raw/type-hierarchy`<br>`raw/semantic-insertion-point`<br>`raw/diagnostics`<br>`raw/rename`<br>`raw/optimize-imports`<br>`raw/apply-edits`<br>`raw/workspace-refresh`<br>`raw/file-outline`<br>`raw/workspace-symbol`<br>`raw/workspace-search`<br>`raw/workspace-files`<br>`raw/semantic-graph`<br>`raw/workspace-files-continuation`<br>`raw/implementations`<br>`raw/code-actions`<br>`raw/completions` |
 | `database` | Source-index queries for metrics and impact views. | sqlite | `database/metrics` |
 
 #### Composition building blocks
@@ -117,6 +117,7 @@ uses a discriminated response envelope.
 | `raw/workspace-symbol` | `raw` | backend | Search the workspace for symbols by name pattern | `pattern` | `kind`<br>`maxResults`<br>`regex`<br>`includeDeclarationScope` | `WorkspaceSymbolResult` | single result |
 | `raw/workspace-search` | `raw` | backend | Search workspace file contents by text or regex | `pattern` | `regex`<br>`maxResults`<br>`fileGlob`<br>`caseSensitive` | `WorkspaceSearchResult` | single result |
 | `raw/workspace-files` | `raw` | backend | List generation-bound workspace modules and Kotlin file pages | none | `kindDomain`<br>`moduleName`<br>`includeFiles`<br>`maxFilesPerModule`<br>`snapshotToken`<br>`pageToken` | `WorkspaceFilesResult` | single result |
+| `raw/semantic-graph` | `raw` | backend | Project compiler-backed Kotlin symbols and relations | none | `filePaths`<br>`removedFilePaths`<br>`pageSize`<br>`continuation` | `SemanticGraphResult` | single result |
 | `raw/workspace-files-continuation` | `raw` | backend | Issue or consume server-held public workspace-file continuation state | `action`<br>`ISSUE`: `identity`, `state`<br>`CONSUME`: `identity`, `pageToken` | none | `WorkspaceFilesContinuationResult` | `ISSUED`<br>`CONSUMED` |
 | `raw/implementations` | `raw` | backend | Find concrete implementations and subclasses for a declaration | `position` | `maxResults` | `ImplementationsResult` | single result |
 | `raw/code-actions` | `raw` | backend | Return available code actions at a file position | `position` | `diagnosticCode` | `CodeActionsResult` | single result |
@@ -178,7 +179,6 @@ Response type: `BackendCapabilities`.
 | Field | Type | Required | Nullable | Values |
 | --- | --- | --- | --- | --- |
 | `type` | `string` | yes | no | `RENAME`<br>`ADD_FILE`<br>`ADD_DECLARATION`<br>`ADD_IMPLEMENTATION`<br>`ADD_STATEMENT`<br>`REPLACE_DECLARATION` |
-
 
 Request variants:
 
@@ -718,6 +718,26 @@ Notes:
 - File pages echo kindDomain and snapshotToken, require one exact moduleName and a positive server-bounded maxFilesPerModule, and pass the preceding nextPageToken as pageToken.
 - Each module page reports returnedFileCount equal to files.size; nextPageToken is non-null exactly when filesTruncated is true and another page remains.
 - Unknown, replayed, mismatched, evicted, or stale snapshot and page handles fail instead of restarting enumeration.
+
+</details>
+
+<details markdown="1">
+<summary><code>raw/semantic-graph</code> - Project compiler-backed Kotlin symbols and relations</summary>
+
+| Field | Type | Required | Nullable | Values |
+| --- | --- | --- | --- | --- |
+| `filePaths` | `array of string` | no | no |  |
+| `removedFilePaths` | `array of string` | no | no |  |
+| `pageSize` | `integer` | no | no |  |
+| `continuation` | `string` | no | yes |  |
+
+Response type: `SemanticGraphResult`.
+
+Notes:
+
+- The scope must contain at least one selected or removed Kotlin path.
+- Continuation is an opaque single-use token bound to the selected and removed path scope.
+- Direct workspace targets outside the selected file scope are returned in boundarySymbols; every relation target is present in symbols or boundarySymbols.
 
 </details>
 

--- a/cli-rs/protocol/capabilities.md
+++ b/cli-rs/protocol/capabilities.md
@@ -341,6 +341,7 @@ category. Expand any operation to see its input and output schemas.
             | `#!kotlin scopeFingerprint: SemanticGraphSha256` | SHA-256 fingerprint of the selected and removed path scope. |
             | `#!kotlin coverage: SemanticGraphCoverage` | Refresh, diagnostic, and omission evidence for the scope. |
             | `#!kotlin symbols: List<SemanticGraphSymbol>` | Semantic symbol records included in this page. |
+            | `#!kotlin boundarySymbols: List<SemanticGraphSymbol>?` | Referenced workspace symbols outside the selected file scope, returned without expansion. |
             | `#!kotlin relations: List<SemanticGraphRelation>` | Semantic relation records included in this page. |
             | `#!kotlin nextPageToken: SemanticGraphPageToken?` | Opaque token for the next page, or null when complete. |
 

--- a/cli-rs/protocol/examples/semanticGraph-response.json
+++ b/cli-rs/protocol/examples/semanticGraph-response.json
@@ -24,6 +24,7 @@
                 "line": 1
             }
         ],
+        "boundarySymbols": [],
         "relations": []
     },
     "id": 1,

--- a/cli-rs/protocol/openapi.yaml
+++ b/cli-rs/protocol/openapi.yaml
@@ -2397,6 +2397,10 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/SemanticGraphSymbol"
+        boundarySymbols:
+          type: array
+          items:
+            "$ref": "#/components/schemas/SemanticGraphSymbol"
         relations:
           type: array
           items:

--- a/cli-rs/protocol/source/commands.json
+++ b/cli-rs/protocol/source/commands.json
@@ -2370,7 +2370,8 @@
       "responseType": "SemanticGraphResult",
       "notes": [
         "The scope must contain at least one selected or removed Kotlin path.",
-        "Continuation is an opaque single-use token bound to the selected and removed path scope."
+        "Continuation is an opaque single-use token bound to the selected and removed path scope.",
+        "Direct workspace targets outside the selected file scope are returned in boundarySymbols; every relation target is present in symbols or boundarySymbols."
       ]
     },
     "raw/workspace-files-continuation": {

--- a/cli-rs/protocol/source/commands.yaml
+++ b/cli-rs/protocol/source/commands.yaml
@@ -552,6 +552,7 @@ commands:
     notes:
     - The scope must contain at least one selected or removed Kotlin path.
     - Continuation is an opaque single-use token bound to the selected and removed path scope.
+    - Direct workspace targets outside the selected file scope are returned in boundarySymbols; every relation target is present in symbols or boundarySymbols.
     request:
       fields:
         continuation:

--- a/cli-rs/src/agent/graphify.rs
+++ b/cli-rs/src/agent/graphify.rs
@@ -37,7 +37,7 @@ fn execute_agent_graphify(mut args: AgentGraphifyArgs) -> AgentEnvelope {
             None,
             agent_error(
                 "FULL_REBUILD_REQUIRED",
-                "Incremental Kotlin extraction requires --base-graph with Kast-v1 identities.",
+                "Incremental Kotlin extraction requires --base-graph with Kast Graphify-v2 identities.",
             ),
         );
     }
@@ -53,9 +53,9 @@ fn execute_agent_graphify(mut args: AgentGraphifyArgs) -> AgentEnvelope {
     }
 
     let semantic = if scope.selected.is_empty() {
-        json!({"symbols": [], "relations": [], "coverage": {"files": [], "omittedExternalTargetCount": 0}})
+        json!({"symbols": [], "boundarySymbols": [], "relations": [], "coverage": {"files": [], "omittedExternalTargetCount": 0}})
     } else {
-        match graphify_semantic_pages(&args.runtime, &scope) {
+        match graphify_semantic_pages(&args.runtime, &scope, usize::from(args.batch_size)) {
             Ok(result) => result,
             Err(envelope) => return *envelope,
         }
@@ -87,6 +87,7 @@ fn execute_agent_graphify(mut args: AgentGraphifyArgs) -> AgentEnvelope {
             "nodeCount": fragment["nodes"].as_array().map_or(0, Vec::len),
             "edgeCount": fragment["edges"].as_array().map_or(0, Vec::len),
             "incremental": scope.incremental,
+            "batchSize": args.batch_size,
             "coverage": semantic["coverage"],
         }),
     )
@@ -227,6 +228,7 @@ fn graphify_lexically_normalize(path: &Path) -> std::result::Result<PathBuf, Age
 fn graphify_semantic_pages(
     runtime: &AgentRuntimeArgs,
     scope: &GraphifyManifestScope,
+    batch_size: usize,
 ) -> std::result::Result<Value, Box<AgentEnvelope>> {
     let capabilities = execute_request(AgentRequest {
         method: "capabilities".to_string(),
@@ -251,14 +253,131 @@ fn graphify_semantic_pages(
             error,
         ))
     })?;
+    let workspace_root = runtime
+        .workspace_root
+        .as_deref()
+        .expect("Graphify workspace root was validated before semantic extraction");
+    let expected_hashes = graphify_capture_file_hashes(&scope.selected, workspace_root).map_err(|error| {
+        Box::new(error_envelope(
+            "agent/graphify".to_string(),
+            None,
+            error,
+        ))
+    })?;
+    let batch_count = scope.selected.len().div_ceil(batch_size);
+    let mut symbols = BTreeMap::new();
+    let mut boundary_symbols = BTreeMap::new();
+    let mut relations = BTreeMap::new();
+    let mut coverage_files = BTreeMap::new();
+    let mut omitted_external_target_count = 0_u64;
+    for (batch_index, batch) in scope.selected.chunks(batch_size).enumerate() {
+        let result = graphify_semantic_batch(runtime, batch, page_size, batch_index, batch_count)?;
+        graphify_validate_batch_coverage(&result["coverage"], batch, workspace_root, &expected_hashes)
+            .map_err(|error| {
+                Box::new(error_envelope(
+                    "agent/graphify".to_string(),
+                    None,
+                    error,
+                ))
+            })?;
+        graphify_verify_current_file_hashes(batch, workspace_root, &expected_hashes).map_err(
+            |error| {
+                Box::new(error_envelope(
+                    "agent/graphify".to_string(),
+                    None,
+                    error,
+                ))
+            },
+        )?;
+        for symbol in result["symbols"].as_array().into_iter().flatten() {
+            let key = graphify_required_str(symbol, "canonicalKey").map_err(|error| {
+                Box::new(error_envelope(
+                    "agent/graphify".to_string(),
+                    None,
+                    error,
+                ))
+            })?;
+            symbols.insert(key.to_string(), symbol.clone());
+        }
+        for symbol in result["boundarySymbols"].as_array().into_iter().flatten() {
+            let key = graphify_required_str(symbol, "canonicalKey").map_err(|error| {
+                Box::new(error_envelope(
+                    "agent/graphify".to_string(),
+                    None,
+                    error,
+                ))
+            })?;
+            boundary_symbols.insert(key.to_string(), symbol.clone());
+        }
+        for relation in result["relations"].as_array().into_iter().flatten() {
+            relations.insert(relation.to_string(), relation.clone());
+        }
+        for file in result["coverage"]["files"].as_array().into_iter().flatten() {
+            let path = graphify_required_str(file, "path").map_err(|error| {
+                Box::new(error_envelope(
+                    "agent/graphify".to_string(),
+                    None,
+                    error,
+                ))
+            })?;
+            coverage_files.insert(path.to_string(), file.clone());
+        }
+        let omitted = result["coverage"]["omittedExternalTargetCount"]
+            .as_u64()
+            .ok_or_else(|| {
+                Box::new(error_envelope(
+                    "agent/graphify".to_string(),
+                    None,
+                    agent_error(
+                        "SEMANTIC_GRAPH_INVALID",
+                        "Semantic graph coverage omitted omittedExternalTargetCount.",
+                    ),
+                ))
+            })?;
+        omitted_external_target_count = omitted_external_target_count.checked_add(omitted).ok_or_else(|| {
+            Box::new(error_envelope(
+                "agent/graphify".to_string(),
+                None,
+                agent_error("SEMANTIC_GRAPH_INVALID", "Semantic graph omission count overflowed."),
+            ))
+        })?;
+    }
+    graphify_verify_current_file_hashes(&scope.selected, workspace_root, &expected_hashes).map_err(
+        |error| {
+            Box::new(error_envelope(
+                "agent/graphify".to_string(),
+                None,
+                error,
+            ))
+        },
+    )?;
+    boundary_symbols.retain(|key, _| !symbols.contains_key(key));
+    Ok(json!({
+        "symbols": symbols.into_values().collect::<Vec<_>>(),
+        "boundarySymbols": boundary_symbols.into_values().collect::<Vec<_>>(),
+        "relations": relations.into_values().collect::<Vec<_>>(),
+        "coverage": {
+            "files": coverage_files.into_values().collect::<Vec<_>>(),
+            "omittedExternalTargetCount": omitted_external_target_count,
+        },
+    }))
+}
+
+fn graphify_semantic_batch(
+    runtime: &AgentRuntimeArgs,
+    batch: &[PathBuf],
+    page_size: u64,
+    batch_index: usize,
+    batch_count: usize,
+) -> std::result::Result<Value, Box<AgentEnvelope>> {
     let mut symbols = Vec::new();
+    let mut boundary_symbols = Vec::new();
     let mut relations = Vec::new();
-    let coverage: Value;
     let mut continuation: Option<String> = None;
-    loop {
+    let coverage = loop {
         let params = drop_nulls(json!({
-            "filePaths": scope.selected,
-            "removedFilePaths": scope.removed,
+            "filePaths": batch,
+            "removedFilePaths": [],
             "pageSize": page_size,
             "continuation": continuation,
         }));
@@ -270,19 +389,155 @@ fn graphify_semantic_pages(
             operation: AgentOperation::ReadOnly,
         });
         if !envelope.ok {
-            return Err(Box::new(envelope));
+            return Err(graphify_batch_failure(envelope, batch_index, batch_count, batch.len()));
         }
         let result = envelope.result.as_ref().expect("successful RPC has a result");
         symbols.extend(result["symbols"].as_array().cloned().unwrap_or_default());
+        boundary_symbols.extend(
+            result["boundarySymbols"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default(),
+        );
         relations.extend(result["relations"].as_array().cloned().unwrap_or_default());
         let next = result["nextPageToken"].as_str().map(str::to_string);
         if next.is_none() {
-            coverage = result["coverage"].clone();
-            break;
+            break result["coverage"].clone();
         }
         continuation = next;
+    };
+    Ok(json!({
+        "symbols": symbols,
+        "boundarySymbols": boundary_symbols,
+        "relations": relations,
+        "coverage": coverage,
+    }))
+}
+
+fn graphify_batch_failure(
+    mut envelope: AgentEnvelope,
+    batch_index: usize,
+    batch_count: usize,
+    batch_size: usize,
+) -> Box<AgentEnvelope> {
+    if let Some(error) = envelope.error.as_mut() {
+        error.message = format!(
+            "Semantic graph batch {}/{} ({} Kotlin files) failed: {}",
+            batch_index + 1,
+            batch_count,
+            batch_size,
+            error.message,
+        );
+        error.details.insert("batchIndex".to_string(), json!(batch_index + 1));
+        error.details.insert("batchCount".to_string(), json!(batch_count));
+        error.details.insert("batchSize".to_string(), json!(batch_size));
     }
-    Ok(json!({"symbols": symbols, "relations": relations, "coverage": coverage}))
+    Box::new(envelope)
+}
+
+fn graphify_capture_file_hashes(
+    selected: &[PathBuf],
+    workspace_root: &Path,
+) -> std::result::Result<BTreeMap<String, String>, AgentError> {
+    selected
+        .iter()
+        .map(|path| {
+            Ok((
+                graphify_relative_source_path(path, workspace_root)?,
+                graphify_file_hash(path)?,
+            ))
+        })
+        .collect()
+}
+
+fn graphify_validate_batch_coverage(
+    coverage: &Value,
+    batch: &[PathBuf],
+    workspace_root: &Path,
+    expected_hashes: &BTreeMap<String, String>,
+) -> std::result::Result<(), AgentError> {
+    let files = coverage["files"].as_array().ok_or_else(|| {
+        agent_error(
+            "SEMANTIC_GRAPH_INVALID",
+            "Semantic graph coverage omitted its files array.",
+        )
+    })?;
+    let covered = files
+        .iter()
+        .map(|file| {
+            let path = graphify_required_str(file, "path")?;
+            let actual_hash = graphify_required_str(file, "contentHash")?;
+            let expected_hash = expected_hashes.get(path).ok_or_else(|| {
+                agent_error(
+                    "SEMANTIC_GRAPH_INVALID",
+                    format!("Semantic graph coverage returned an unrequested file: {path}"),
+                )
+            })?;
+            if actual_hash != expected_hash {
+                return Err(agent_error(
+                    "WORKSPACE_CHANGED",
+                    format!("Kotlin file changed while semantic extraction was running: {path}"),
+                ));
+            }
+            Ok(path.to_string())
+        })
+        .collect::<std::result::Result<BTreeSet<_>, _>>()?;
+    for path in batch {
+        let relative = graphify_relative_source_path(path, workspace_root)?;
+        if !covered.contains(&relative) {
+            return Err(agent_error(
+                "SEMANTIC_GRAPH_INVALID",
+                format!("Semantic graph coverage omitted requested file: {relative}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn graphify_verify_current_file_hashes(
+    selected: &[PathBuf],
+    workspace_root: &Path,
+    expected_hashes: &BTreeMap<String, String>,
+) -> std::result::Result<(), AgentError> {
+    for path in selected {
+        let relative = graphify_relative_source_path(path, workspace_root)?;
+        let expected = expected_hashes
+            .get(&relative)
+            .expect("captured Graphify file has an expected hash");
+        if graphify_file_hash(path)? != *expected {
+            return Err(agent_error(
+                "WORKSPACE_CHANGED",
+                format!("Kotlin file changed while semantic extraction was running: {relative}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn graphify_relative_source_path(
+    path: &Path,
+    workspace_root: &Path,
+) -> std::result::Result<String, AgentError> {
+    path.strip_prefix(workspace_root)
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        .map_err(|_| {
+            agent_error(
+                "AGENT_USAGE",
+                format!("Graphify Kotlin path is outside the workspace: {}", path.display()),
+            )
+        })
+}
+
+fn graphify_file_hash(path: &Path) -> std::result::Result<String, AgentError> {
+    use sha2::{Digest, Sha256};
+
+    let bytes = std::fs::read(path).map_err(|error| {
+        agent_error(
+            "WORKSPACE_CHANGED",
+            format!("Cannot read Kotlin file {} during extraction: {error}", path.display()),
+        )
+    })?;
+    Ok(hex::encode(Sha256::digest(bytes)))
 }
 
 fn graphify_page_size_from_capabilities(
@@ -300,42 +555,145 @@ fn graphify_page_size_from_capabilities(
     Ok(advertised.min(500))
 }
 
+#[derive(Debug, Clone)]
+struct GraphifyCanonicalIdentity {
+    fq_name: Option<String>,
+    signature: Option<String>,
+    kind: String,
+    source_file: String,
+    start_offset: u64,
+    end_offset: u64,
+    line: u64,
+}
+
+#[derive(Debug)]
+struct GraphifyNodeGroup {
+    label: String,
+    source_file: String,
+    line: u64,
+    expanded: bool,
+    identities: BTreeMap<String, GraphifyCanonicalIdentity>,
+}
+
 fn project_graphify_fragment(semantic: &Value) -> std::result::Result<Value, AgentError> {
     let symbols = semantic["symbols"].as_array().ok_or_else(|| {
         agent_error("SEMANTIC_GRAPH_INVALID", "Semantic graph response omitted symbols.")
     })?;
-    let mut ids = BTreeMap::new();
-    let mut nodes = Vec::new();
-    for symbol in symbols {
-        if symbol["kind"] == "CONSTRUCTOR" {
-            continue;
-        }
-        let canonical_key = graphify_required_str(symbol, "canonicalKey")?;
-        let id = graphify_public_id(canonical_key);
-        ids.insert(canonical_key.to_string(), id.clone());
-        nodes.push(json!({
-            "id": id,
-            "label": graphify_required_str(symbol, "name")?,
-            "file_type": "code",
-            "source_file": graphify_required_str(symbol, "path")?,
-            "source_location": format!("L{}", symbol["line"].as_u64().unwrap_or(1)),
-            "_origin": "ast",
-            "metadata": {
-                "canonical_key": canonical_key,
-                "fq_name": symbol.get("fqName").cloned().unwrap_or(Value::Null),
-                "signature": symbol.get("signature").cloned().unwrap_or(Value::Null),
-                "kotlin_kind": graphify_required_str(symbol, "kind")?,
-                "provider": "kast-k2",
-                "id_schema_version": "kast:kotlin:v1",
-                "exact_range": {
-                    "start_offset": symbol["startOffset"],
-                    "end_offset": symbol["endOffset"],
-                    "line": symbol["line"],
-                }
+    let boundary_symbols = semantic["boundarySymbols"].as_array().ok_or_else(|| {
+        agent_error(
+            "SEMANTIC_GRAPH_INVALID",
+            "Semantic graph response omitted boundarySymbols.",
+        )
+    })?;
+    let mut symbol_records = BTreeMap::new();
+    for (records, expanded) in [(boundary_symbols, false), (symbols, true)] {
+        for symbol in records {
+            if symbol["kind"] == "CONSTRUCTOR" {
+                continue;
             }
-        }));
+            let canonical_key = graphify_required_str(symbol, "canonicalKey")?;
+            symbol_records.insert(canonical_key.to_string(), (symbol.clone(), expanded));
+        }
     }
-    nodes.sort_by(|left, right| left["id"].as_str().cmp(&right["id"].as_str()));
+    let mut ids = BTreeMap::new();
+    for (canonical_key, (symbol, _)) in &symbol_records {
+        ids.insert(
+            canonical_key.clone(),
+            graphify_native_symbol_id(symbol, &symbol_records)?,
+        );
+    }
+    let mut groups: BTreeMap<String, GraphifyNodeGroup> = BTreeMap::new();
+    for (canonical_key, (symbol, expanded)) in &symbol_records {
+        let id = ids
+            .get(canonical_key)
+            .expect("every Graphify symbol has a projected id")
+            .clone();
+        let label = graphify_required_str(symbol, "name")?.to_string();
+        let source_file = graphify_required_str(symbol, "path")?.to_string();
+        let line = graphify_required_u64(symbol, "line")?;
+        let group = groups.entry(id).or_insert_with(|| GraphifyNodeGroup {
+            label: label.clone(),
+            source_file: source_file.clone(),
+            line,
+            expanded: false,
+            identities: BTreeMap::new(),
+        });
+        if (line, source_file.as_str(), canonical_key.as_str()) <
+            (group.line, group.source_file.as_str(), group.identities.keys().next().map_or("", String::as_str))
+        {
+            group.label = label;
+            group.source_file.clone_from(&source_file);
+            group.line = line;
+        }
+        group.expanded |= *expanded;
+        group.identities.insert(
+            canonical_key.clone(),
+            GraphifyCanonicalIdentity {
+                fq_name: symbol["fqName"].as_str().map(str::to_string),
+                signature: symbol["signature"].as_str().map(str::to_string),
+                kind: graphify_required_str(symbol, "kind")?.to_string(),
+                source_file,
+                start_offset: graphify_required_u64(symbol, "startOffset")?,
+                end_offset: graphify_required_u64(symbol, "endOffset")?,
+                line,
+            },
+        );
+    }
+    let nodes = groups
+        .into_iter()
+        .map(|(id, group)| {
+            let canonical_keys = group.identities.keys().cloned().collect::<Vec<_>>();
+            let fq_names = group
+                .identities
+                .values()
+                .filter_map(|identity| identity.fq_name.clone())
+                .collect::<BTreeSet<_>>();
+            let signatures = group
+                .identities
+                .values()
+                .filter_map(|identity| identity.signature.clone())
+                .collect::<BTreeSet<_>>();
+            let kotlin_kinds = group
+                .identities
+                .values()
+                .map(|identity| identity.kind.clone())
+                .collect::<BTreeSet<_>>();
+            let exact_ranges = group
+                .identities
+                .iter()
+                .map(|(canonical_key, identity)| {
+                    json!({
+                        "canonical_key": canonical_key,
+                        "source_file": identity.source_file,
+                        "start_offset": identity.start_offset,
+                        "end_offset": identity.end_offset,
+                        "line": identity.line,
+                    })
+                })
+                .collect::<Vec<_>>();
+            let mut metadata = json!({
+                "canonical_keys": canonical_keys,
+                "fq_names": fq_names,
+                "signatures": signatures,
+                "kotlin_kinds": kotlin_kinds,
+                "provider": "kast-k2",
+                "id_schema_version": "kast:graphify:v2",
+                "exact_ranges": exact_ranges,
+            });
+            if !group.expanded {
+                metadata["boundary"] = Value::String("unexpanded".to_string());
+            }
+            json!({
+                "id": id,
+                "label": group.label,
+                "file_type": "code",
+                "source_file": group.source_file,
+                "source_location": format!("L{}", group.line),
+                "_origin": "ast",
+                "metadata": metadata,
+            })
+        })
+        .collect::<Vec<_>>();
 
     let relations = semantic["relations"].as_array().ok_or_else(|| {
         agent_error("SEMANTIC_GRAPH_INVALID", "Semantic graph response omitted relations.")
@@ -344,13 +702,21 @@ fn project_graphify_fragment(semantic: &Value) -> std::result::Result<Value, Age
     for relation in relations {
         let source_key = graphify_required_str(relation, "sourceKey")?;
         let target_key = graphify_required_str(relation, "targetKey")?;
-        let Some(source) = ids.get(source_key).cloned() else {
-            continue;
-        };
+        let source = ids.get(source_key).cloned().ok_or_else(|| {
+            agent_error(
+                "SEMANTIC_GRAPH_INVALID",
+                format!("Semantic graph relation source has no projected node: {source_key}"),
+            )
+        })?;
         let target = ids
             .get(target_key)
             .cloned()
-            .unwrap_or_else(|| graphify_public_id(target_key));
+            .ok_or_else(|| {
+                agent_error(
+                    "SEMANTIC_GRAPH_INVALID",
+                    format!("Semantic graph relation target has no selected or boundary node: {target_key}"),
+                )
+            })?;
         let relation_name = graphify_required_str(relation, "kind")?.to_ascii_lowercase();
         let context = relation["context"]
             .as_str()
@@ -440,12 +806,94 @@ fn graphify_required_str<'a>(value: &'a Value, field: &str) -> std::result::Resu
     })
 }
 
-fn graphify_public_id(canonical_key: &str) -> String {
-    use sha2::{Digest, Sha256};
-    format!(
-        "kast:kotlin:v1:{}",
-        hex::encode(Sha256::digest(canonical_key.as_bytes()))
-    )
+fn graphify_required_u64(value: &Value, field: &str) -> std::result::Result<u64, AgentError> {
+    value[field].as_u64().ok_or_else(|| {
+        agent_error(
+            "SEMANTIC_GRAPH_INVALID",
+            format!("Semantic graph record omitted unsigned integer field {field}."),
+        )
+    })
+}
+
+fn graphify_native_symbol_id(
+    symbol: &Value,
+    symbols: &BTreeMap<String, (Value, bool)>,
+) -> std::result::Result<String, AgentError> {
+    let kind = graphify_required_str(symbol, "kind")?;
+    let path = graphify_required_str(symbol, "path")?;
+    let name = graphify_required_str(symbol, "name")?;
+    let stem = graphify_file_stem(path);
+    match kind {
+        "FILE" => Ok(graphify_make_id(&[stem.as_str()])),
+        "CLASS" | "INTERFACE" | "OBJECT" | "ENUM_CLASS" => {
+            Ok(graphify_make_id(&[stem.as_str(), name]))
+        }
+        "FUNCTION" => Ok(graphify_make_id(&[stem.as_str(), name])),
+        "MEMBER_FUNCTION" | "ENUM_ENTRY" => {
+            let owner_id = symbol["ownerKey"]
+                .as_str()
+                .and_then(|owner_key| symbols.get(owner_key))
+                .map(|(owner, _)| {
+                    let owner_path = graphify_required_str(owner, "path")?;
+                    let owner_name = graphify_required_str(owner, "name")?;
+                    let owner_stem = graphify_file_stem(owner_path);
+                    Ok(graphify_make_id(&[owner_stem.as_str(), owner_name]))
+                })
+                .transpose()?
+                .or_else(|| {
+                    symbol["fqName"].as_str().and_then(|fq_name| {
+                        fq_name
+                            .rsplit_once('.')
+                            .and_then(|(owner, _)| owner.rsplit('.').next())
+                            .map(|owner_name| graphify_make_id(&[stem.as_str(), owner_name]))
+                    })
+                })
+                .ok_or_else(|| {
+                    agent_error(
+                        "SEMANTIC_GRAPH_INVALID",
+                        format!("Semantic graph member has no projectable owner: {name}"),
+                    )
+                })?;
+            Ok(graphify_make_id(&[owner_id.as_str(), name]))
+        }
+        other => Err(agent_error(
+            "SEMANTIC_GRAPH_INVALID",
+            format!("Semantic graph symbol kind cannot be projected to Graphify: {other}"),
+        )),
+    }
+}
+
+fn graphify_file_stem(path: &str) -> String {
+    Path::new(path)
+        .with_extension("")
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn graphify_make_id(parts: &[&str]) -> String {
+    use unicode_casefold::UnicodeCaseFold;
+    use unicode_normalization::UnicodeNormalization;
+
+    let joined = parts
+        .iter()
+        .filter(|part| !part.is_empty())
+        .map(|part| part.trim_matches(|character| character == '_' || character == '.'))
+        .collect::<Vec<_>>()
+        .join("_");
+    let mut normalized = String::new();
+    let mut separator_pending = false;
+    for character in joined.nfkc() {
+        if character.is_alphanumeric() {
+            if separator_pending && !normalized.is_empty() {
+                normalized.push('_');
+            }
+            normalized.push(character);
+            separator_pending = false;
+        } else {
+            separator_pending = true;
+        }
+    }
+    normalized.as_str().case_fold().collect()
 }
 
 fn validate_graphify_incremental_base(
@@ -469,21 +917,33 @@ fn validate_graphify_incremental_base(
         let source_file = node["source_file"].as_str().unwrap_or_default();
         if graphify_is_kotlin_path(Path::new(source_file)) {
             let id = node["id"].as_str().unwrap_or_default();
-            if !id.starts_with("kast:kotlin:v1:") {
+            if node["metadata"]["id_schema_version"] != "kast:graphify:v2" {
                 return Err(agent_error(
                     "FULL_REBUILD_REQUIRED",
                     "Base graph mixes Kotlin identity schemas; run one full Kast rebuild.",
                 ));
             }
             base_ids.insert(id.to_string());
-            if selected_relative.contains(source_file) {
-                let key = node["metadata"]["canonical_key"].as_str().ok_or_else(|| {
+            for range in node["metadata"]["exact_ranges"]
+                .as_array()
+                .into_iter()
+                .flatten()
+            {
+                let range_source = range["source_file"].as_str().ok_or_else(|| {
                     agent_error(
                         "FULL_REBUILD_REQUIRED",
-                        "A selected Kotlin base node has no Kast canonical key.",
+                        "A Kotlin base identity has no source file.",
                     )
                 })?;
-                base_keys.insert(key.to_string());
+                if selected_relative.contains(range_source) {
+                    let key = range["canonical_key"].as_str().ok_or_else(|| {
+                        agent_error(
+                            "FULL_REBUILD_REQUIRED",
+                            "A selected Kotlin base identity has no Kast canonical key.",
+                        )
+                    })?;
+                    base_keys.insert(key.to_string());
+                }
             }
         }
     }
@@ -491,7 +951,18 @@ fn validate_graphify_incremental_base(
         .as_array()
         .into_iter()
         .flatten()
-        .filter_map(|node| node["metadata"]["canonical_key"].as_str())
+        .flat_map(|node| {
+            node["metadata"]["exact_ranges"]
+                .as_array()
+                .into_iter()
+                .flatten()
+        })
+        .filter(|range| {
+            range["source_file"]
+                .as_str()
+                .is_some_and(|source_file| selected_relative.contains(source_file))
+        })
+        .filter_map(|range| range["canonical_key"].as_str())
         .map(str::to_string)
         .collect::<BTreeSet<_>>();
     if base_keys != new_keys {
@@ -510,7 +981,7 @@ fn validate_graphify_incremental_base(
         if !target_is_current && !base_ids.contains(target) {
             return Err(agent_error(
                 "FULL_REBUILD_REQUIRED",
-                "A scoped Kotlin relation targets a node missing from the validated Kast-v1 base graph.",
+                "A scoped Kotlin relation targets a node missing from the validated Kast Graphify-v2 base graph.",
             ));
         }
     }
@@ -554,11 +1025,97 @@ fn write_graphify_fragment_atomically(
 #[cfg(test)]
 mod graphify_projection_tests {
     use super::*;
+    use clap::Parser;
+
+    fn parsed_graphify_batch_size(extra: &[&str]) -> u16 {
+        let mut arguments = vec![
+            "kast",
+            "agent",
+            "graphify",
+            "--workspace-root",
+            "/workspace",
+            "--manifest",
+            "/workspace/manifest.json",
+            "--output-file",
+            "/workspace/fragment.json",
+        ];
+        arguments.extend_from_slice(extra);
+        let cli = crate::cli::Cli::try_parse_from(arguments).expect("Graphify arguments");
+        let Some(crate::cli::Command::Agent(crate::cli::AgentArgs {
+            command: Some(AgentCommand::Graphify(args)),
+        })) = cli.command
+        else {
+            panic!("expected Graphify command");
+        };
+        args.batch_size
+    }
 
     #[test]
-    fn graphify_ids_are_deterministic_and_namespaced() {
-        assert_eq!(graphify_public_id("class:CLASS:demo.Box"), graphify_public_id("class:CLASS:demo.Box"));
-        assert!(graphify_public_id("class:CLASS:demo.Box").starts_with("kast:kotlin:v1:"));
+    fn graphify_batch_size_is_bounded_and_defaults_to_twenty_five() {
+        assert_eq!(parsed_graphify_batch_size(&[]), 25);
+        assert_eq!(parsed_graphify_batch_size(&["--batch-size", "500"]), 500);
+        assert!(crate::cli::Cli::try_parse_from([
+            "kast",
+            "agent",
+            "graphify",
+            "--workspace-root",
+            "/workspace",
+            "--manifest",
+            "/workspace/manifest.json",
+            "--output-file",
+            "/workspace/fragment.json",
+            "--batch-size",
+            "501",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn graphify_projection_uses_native_ids_and_aggregates_overloads_and_boundaries() {
+        let semantic = json!({
+            "symbols": [
+                {"canonicalKey":"file:src/demo/Sample.kt","kind":"FILE","name":"Sample.kt","path":"src/demo/Sample.kt","startOffset":0,"endOffset":100,"line":1},
+                {"canonicalKey":"class:CLASS:src/demo/Sample.kt:10:demo.Box","kind":"CLASS","name":"Box","fqName":"demo.Box","path":"src/demo/Sample.kt","startOffset":10,"endOffset":90,"line":3},
+                {"canonicalKey":"callable:src/demo/Sample.kt:20:demo.Box.pick|string","kind":"MEMBER_FUNCTION","name":"pick","fqName":"demo.Box.pick","signature":"demo.Box.pick|string","ownerKey":"class:CLASS:src/demo/Sample.kt:10:demo.Box","path":"src/demo/Sample.kt","startOffset":20,"endOffset":40,"line":4},
+                {"canonicalKey":"callable:src/demo/Sample.kt:50:demo.Box.pick|int","kind":"MEMBER_FUNCTION","name":"pick","fqName":"demo.Box.pick","signature":"demo.Box.pick|int","ownerKey":"class:CLASS:src/demo/Sample.kt:10:demo.Box","path":"src/demo/Sample.kt","startOffset":50,"endOffset":70,"line":5}
+            ],
+            "boundarySymbols": [
+                {"canonicalKey":"class:CLASS:src/shared/Target.kt:0:demo.Target","kind":"CLASS","name":"Target","fqName":"demo.Target","path":"src/shared/Target.kt","startOffset":0,"endOffset":20,"line":1}
+            ],
+            "relations": [
+                {"sourceKey":"callable:src/demo/Sample.kt:20:demo.Box.pick|string","targetKey":"class:CLASS:src/shared/Target.kt:0:demo.Target","kind":"REFERENCES","context":"RETURN_TYPE","sourcePath":"src/demo/Sample.kt","startOffset":20,"endOffset":40,"line":4}
+            ]
+        });
+
+        let fragment = project_graphify_fragment(&semantic).expect("projection");
+        let ids = fragment["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|node| node["id"].as_str())
+            .collect::<BTreeSet<_>>();
+
+        assert!(ids.contains("src_demo_sample"));
+        assert!(ids.contains("src_demo_sample_box"));
+        assert!(ids.contains("src_demo_sample_box_pick"));
+        assert!(ids.contains("src_shared_target_target"));
+        let overload = fragment["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|node| node["id"] == "src_demo_sample_box_pick")
+            .unwrap();
+        assert_eq!(overload["metadata"]["canonical_keys"].as_array().unwrap().len(), 2);
+        let boundary = fragment["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|node| node["id"] == "src_shared_target_target")
+            .unwrap();
+        assert_eq!(boundary["metadata"]["boundary"], "unexpanded");
+        assert!(fragment["edges"].as_array().unwrap().iter().all(|edge| {
+            ids.contains(edge["source"].as_str().unwrap()) && ids.contains(edge["target"].as_str().unwrap())
+        }));
     }
 
     #[test]
@@ -568,6 +1125,7 @@ mod graphify_projection_tests {
                 {"canonicalKey":"file:A.kt","kind":"FILE","name":"A.kt","path":"A.kt","startOffset":0,"endOffset":10,"line":1},
                 {"canonicalKey":"class:CLASS:demo.A","kind":"CLASS","name":"A","path":"A.kt","startOffset":0,"endOffset":10,"line":1}
             ],
+            "boundarySymbols": [],
             "relations": [
                 {"sourceKey":"file:A.kt","targetKey":"class:CLASS:demo.A","resolvedTargetKey":"constructor:demo.A.<init>|-||kotlin.String|0","kind":"CONTAINS","context":"NONE","sourcePath":"A.kt","startOffset":0,"endOffset":1,"line":1},
                 {"sourceKey":"file:A.kt","targetKey":"class:CLASS:demo.A","kind":"REFERENCES","context":"FIELD","sourcePath":"A.kt","startOffset":2,"endOffset":3,"line":2}
@@ -623,6 +1181,36 @@ mod graphify_projection_tests {
         let capabilities = json!({"limits": {"maxResults": 17}});
 
         assert_eq!(graphify_page_size_from_capabilities(&capabilities).unwrap(), 17);
+    }
+
+    #[test]
+    fn graphify_id_normalization_matches_unicode_native_scheme() {
+        assert_eq!(
+            graphify_make_id(&["src/Ｆoo", "Straße.pick"]),
+            "src_foo_strasse_pick",
+        );
+    }
+
+    #[test]
+    fn graphify_file_snapshot_rejects_a_changed_source() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let source = workspace.path().join("Sample.kt");
+        std::fs::write(&source, "class Before").expect("source fixture");
+        let expected = graphify_capture_file_hashes(
+            std::slice::from_ref(&source),
+            workspace.path(),
+        )
+        .expect("initial snapshot");
+        std::fs::write(&source, "class After").expect("changed source fixture");
+
+        let error = graphify_verify_current_file_hashes(
+            std::slice::from_ref(&source),
+            workspace.path(),
+            &expected,
+        )
+        .expect_err("changed input must abort extraction");
+
+        assert_eq!(error.code, "WORKSPACE_CHANGED");
     }
 
     #[test]

--- a/cli-rs/src/cli/agent.rs
+++ b/cli-rs/src/cli/agent.rs
@@ -154,9 +154,12 @@ pub struct AgentGraphifyArgs {
     /// Atomic destination for the Kotlin Graphify extraction fragment.
     #[arg(long)]
     pub output_file: PathBuf,
-    /// Existing Kast-v1 graph required for incremental extraction.
+    /// Existing Kast Graphify-v2 graph required for incremental extraction.
     #[arg(long)]
     pub base_graph: Option<PathBuf>,
+    /// Maximum Kotlin files analyzed by one semantic-graph RPC.
+    #[arg(long, default_value_t = 25, value_parser = clap::value_parser!(u16).range(1..=500))]
+    pub batch_size: u16,
 }
 
 #[derive(Debug, Args, Clone)]


### PR DESCRIPTION
## Summary
- return direct cross-file workspace targets as typed boundary symbols
- process Graphify manifests in configurable bounded batches with source-change detection and atomic publication
- emit Graphify-native v2 node IDs while retaining every Kast canonical identity in metadata

## Validation
- ./gradlew :analysis-api:test :analysis-server:test :backend-idea:test --no-daemon
- cargo test --manifest-path cli-rs/Cargo.toml --locked
- cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings
- ./gradlew test buildIdeaPlugin --no-daemon
- generated contract, documentation, runtime compatibility, and LSP gates

## Residual evidence
- Live installed Kast diagnostics were unavailable because the local CLI/plugin pair reports UnsupportedReleasePair; compiler-backed backend tests passed.