### PR TITLE
feat: reuse repository source index snapshots

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspaceDirectoryResolver.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspaceDirectoryResolver.kt
@@ -44,6 +44,12 @@ class WorkspaceDirectoryResolver(
         }.toAbsolutePath().normalize()
     }
 
+    fun repositoryDataDirectory(workspaceRoot: Path): Path? {
+        val normalizedRoot = workspaceRoot.toAbsolutePath().normalize()
+        val workspace = gitWorkspaceResolver(normalizedRoot) ?: return null
+        return gitRepositoryDataDirectory(workspace, workspace.remote ?: gitRemoteResolver(normalizedRoot))
+    }
+
     fun workspaceCacheDirectory(workspaceRoot: Path): Path = workspaceDataDirectory(workspaceRoot).resolve("cache")
 
     fun workspaceDatabasePath(workspaceRoot: Path): Path = workspaceCacheDirectory(workspaceRoot).resolve("source-index.db")
@@ -65,7 +71,15 @@ class WorkspaceDirectoryResolver(
     private fun workspacesRoot(): Path = dataRoot().resolve("workspaces").toAbsolutePath().normalize()
 
     private fun gitWorkspaceDataDirectory(workspace: GitWorkspace, remote: GitRemote?): Path {
-        val repoRoot = if (remote != null) {
+        return gitRepositoryDataDirectory(workspace, remote)
+            .resolve("worktrees")
+            .resolve("${workspaceSlug(workspace.toplevel)}--${gitWorktreeHash(workspace.toplevel, workspace.gitDir)}")
+            .toAbsolutePath()
+            .normalize()
+    }
+
+    private fun gitRepositoryDataDirectory(workspace: GitWorkspace, remote: GitRemote?): Path =
+        if (remote != null) {
             workspacesRoot()
                 .resolve("git")
                 .resolve(remote.host)
@@ -77,12 +91,6 @@ class WorkspaceDirectoryResolver(
                 .resolve("local")
                 .resolve(gitCommonDirHash(workspace.commonDir))
         }
-        return repoRoot
-            .resolve("worktrees")
-            .resolve("${workspaceSlug(workspace.toplevel)}--${gitWorktreeHash(workspace.toplevel, workspace.gitDir)}")
-            .toAbsolutePath()
-            .normalize()
-    }
 
     private fun localWorkspaceId(workspaceRoot: Path): String {
         val registryPath = workspacesRoot().resolve("local-workspaces.json").toAbsolutePath().normalize()

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspaceIdentity.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspaceIdentity.kt
@@ -27,6 +27,7 @@ data class WorkspaceIdentity(
     val canonicalWorkspaceRoot: NormalizedPath,
     val workspaceId: WorkspaceId,
     val canonicalWorkspaceId: WorkspaceId,
+    val repositoryDataDirectory: NormalizedPath?,
     val workspaceDataDirectory: NormalizedPath,
     val workspaceCacheDirectory: NormalizedPath,
     val sourceIndexDatabasePath: NormalizedPath,
@@ -42,6 +43,9 @@ data class WorkspaceIdentity(
 
     val workspaceDataDirectoryPath: Path
         get() = workspaceDataDirectory.toJavaPath()
+
+    val repositoryDataDirectoryPath: Path?
+        get() = repositoryDataDirectory?.toJavaPath()
 
     val workspaceCacheDirectoryPath: Path
         get() = workspaceCacheDirectory.toJavaPath()
@@ -78,6 +82,7 @@ data class WorkspaceIdentity(
         "canonicalWorkspaceId" to canonicalWorkspaceId.value,
         "workspaceRoot" to workspaceRoot.value,
         "canonicalWorkspaceRoot" to canonicalWorkspaceRoot.value,
+        "repositoryDataDirectory" to repositoryDataDirectory?.value,
         "workspaceDataDirectory" to workspaceDataDirectory.value,
         "workspaceCacheDirectory" to workspaceCacheDirectory.value,
         "sourceIndexDatabasePath" to sourceIndexDatabasePath.value,
@@ -105,6 +110,8 @@ data class WorkspaceIdentity(
                 canonicalWorkspaceRoot = canonicalWorkspaceRoot,
                 workspaceId = workspaceId,
                 canonicalWorkspaceId = canonicalWorkspaceId,
+                repositoryDataDirectory = resolver.repositoryDataDirectory(normalizedWorkspaceRoot.toJavaPath())
+                    ?.let(NormalizedPath::ofAbsolute),
                 workspaceDataDirectory = NormalizedPath.ofAbsolute(workspaceDataDirectory),
                 workspaceCacheDirectory = NormalizedPath.ofAbsolute(workspaceCacheDirectory),
                 sourceIndexDatabasePath = NormalizedPath.ofAbsolute(resolver.workspaceDatabasePath(normalizedWorkspaceRoot.toJavaPath())),

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspacePathsTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspacePathsTest.kt
@@ -2,6 +2,7 @@ package io.github.amichne.kast.api.client
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -141,12 +142,28 @@ class WorkspacePathsTest {
 
         val first = resolver.workspaceDataDirectory(firstRoot)
         val second = resolver.workspaceDataDirectory(secondRoot)
+        val repository = installRoot.resolve("state/workspaces/git/github.com/amichne/kast")
 
-        assertTrue(first.startsWith(installRoot.resolve("state/workspaces/git/github.com/amichne/kast/worktrees")))
-        assertTrue(second.startsWith(installRoot.resolve("state/workspaces/git/github.com/amichne/kast/worktrees")))
+        assertEquals(repository, resolver.repositoryDataDirectory(firstRoot))
+        assertEquals(repository, resolver.repositoryDataDirectory(secondRoot))
+        assertTrue(first.startsWith(repository.resolve("worktrees")))
+        assertTrue(second.startsWith(repository.resolve("worktrees")))
         assertTrue(first != second, "sibling worktrees should not share workspace data: first=$first second=$second")
         assertEquals(first, resolver.workspaceCacheDirectory(firstRoot).parent)
         assertEquals(second.resolve("cache/source-index.db"), resolver.workspaceDatabasePath(secondRoot))
+    }
+
+    @Test
+    fun `non git workspace has no repository snapshot directory`() {
+        val workspaceRoot = tempDir.resolve("workspace")
+        val resolver = WorkspaceDirectoryResolver(
+            dataRoot = { tempDir.resolve("data") },
+            gitWorkspaceResolver = { null },
+            gitRemoteResolver = { null },
+        )
+
+        assertNull(resolver.repositoryDataDirectory(workspaceRoot))
+        assertNull(resolver.workspaceIdentity(workspaceRoot).repositoryDataDirectory)
     }
 
     @Test

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastIdeaBackendRuntime.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/KastIdeaBackendRuntime.kt
@@ -2,6 +2,8 @@ package io.github.amichne.kast.idea
 
 import io.github.amichne.kast.idea.backend.KastPluginBackend
 import io.github.amichne.kast.idea.diagnostics.*
+import io.github.amichne.kast.idea.snapshot.BuildClasspathFingerprintResolver
+import io.github.amichne.kast.idea.snapshot.RepositorySnapshotCoordinator
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
@@ -12,6 +14,7 @@ import io.github.amichne.kast.api.client.defaultSocketPath
 import io.github.amichne.kast.api.contract.CloseableAnalysisBackend
 import io.github.amichne.kast.api.contract.AnalysisTransport
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
+import io.github.amichne.kast.indexstore.snapshot.ProducerVersion
 import io.github.amichne.kast.server.AnalysisServer
 import io.github.amichne.kast.server.RuntimeLifecycleController
 import io.github.amichne.kast.server.RunningAnalysisServer
@@ -98,7 +101,26 @@ object KastIdeaBackendRuntime {
         )
         val diagnostics = KastDiagnosticsService.getInstance(project)
         val limits = ideaServerLimits(config)
+        val snapshotCoordinator = workspaceIdentity.workspaceIdentity.repositoryDataDirectoryPath?.let { repositoryDirectory ->
+            RepositorySnapshotCoordinator(
+                workspaceRoot = workspaceIdentity.workspaceRootPath,
+                repositoryDirectory = repositoryDirectory,
+                buildClasspathFingerprint = BuildClasspathFingerprintResolver.resolve(
+                    project,
+                    workspaceIdentity.workspaceIdentity,
+                ),
+                producerVersion = ProducerVersion.parse(KastPluginBackend.BACKEND_VERSION),
+            )
+        }
+        val preparedOverlay = snapshotCoordinator?.prepareWorktreeDatabase(
+            workspaceIdentity.workspaceIdentity.sourceIndexDatabaseFile,
+        )
         val sourceIndexStore = SqliteSourceIndexStore(workspaceIdentity.workspaceIdentity)
+        preparedOverlay?.let { overlay ->
+            (overlay.tombstones + overlay.shards.keys).forEach { relativePath ->
+                sourceIndexStore.removeFile(workspaceIdentity.workspaceRootPath.resolve(relativePath).toString())
+            }
+        }
         val semanticAdmission = IdeaIndexSemanticAdmission(project)
         var pluginBackend: KastPluginBackend? = null
         val backend = try {
@@ -166,6 +188,7 @@ object KastIdeaBackendRuntime {
                 diagnostics = diagnostics,
                 indexStore = sourceIndexStore,
                 semanticAdmission = semanticAdmission,
+                snapshotCoordinator = snapshotCoordinator,
             ).also { it.start() }
             projectIndexing = startedProjectIndexing
             return RunningKastIdeaBackend(
@@ -198,6 +221,7 @@ internal class KastIdeaProjectIndexing(
     private val diagnostics: KastDiagnosticsService = KastDiagnosticsService.getInstance(project),
     private val indexStore: SqliteSourceIndexStore = SqliteSourceIndexStore(workspaceIdentity.workspaceIdentity),
     private val semanticAdmission: IdeaIndexSemanticAdmission = IdeaIndexSemanticAdmission(project),
+    private val snapshotCoordinator: RepositorySnapshotCoordinator? = null,
 ) {
     constructor(
         project: Project,
@@ -278,6 +302,13 @@ internal class KastIdeaProjectIndexing(
                     indexStore.loadKastSourceIndexSummary()
                 }.onSuccess { summary ->
                     if (!cancelled.get()) {
+                        snapshotCoordinator?.let { coordinator ->
+                            runCatching {
+                                coordinator.publishCompletedIndex(indexStore)
+                            }.onFailure { error ->
+                                LOG.warn("Kast repository snapshot publication failed", error)
+                            }
+                        }
                         KastStructuredTrace.event(
                             eventName = "idea.index.completed",
                             project = project,

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/BuildClasspathFingerprintResolver.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/BuildClasspathFingerprintResolver.kt
@@ -13,11 +13,23 @@ object BuildClasspathFingerprintResolver {
                 add("settings:${gradleRoot.settingsFileHash.value}")
             }
             OrderEnumerator.orderEntries(project).recursively().classes().roots
-                .mapTo(this) { root -> "classpath:${root.url}" }
+                .mapTo(this) { root -> "classpath:${stableClasspathRootUrl(root.url, workspaceIdentity.workspaceRootPath)}" }
         }.sorted()
         val digest = MessageDigest.getInstance("SHA-256")
             .digest(entries.joinToString("\n").toByteArray())
             .joinToString("") { byte -> "%02x".format(byte) }
         return BuildClasspathFingerprint.parse(digest)
+    }
+}
+
+internal fun stableClasspathRootUrl(url: String, workspaceRoot: java.nio.file.Path): String {
+    val workspacePath = workspaceRoot.toAbsolutePath().normalize().toString().replace('\\', '/').trimEnd('/')
+    if (workspacePath.isEmpty()) return url
+    val start = url.indexOf("://").takeIf { it >= 0 }?.plus(3) ?: return url
+    val end = start + workspacePath.length
+    return if (url.startsWith(workspacePath, start) && (end == url.length || url[end] == '/' || url[end] == '!')) {
+        url.replaceRange(start, end, "\$WORKSPACE")
+    } else {
+        url
     }
 }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/BuildClasspathFingerprintResolver.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/BuildClasspathFingerprintResolver.kt
@@ -1,0 +1,23 @@
+package io.github.amichne.kast.idea.snapshot
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.OrderEnumerator
+import io.github.amichne.kast.api.client.WorkspaceIdentity
+import io.github.amichne.kast.indexstore.snapshot.BuildClasspathFingerprint
+import java.security.MessageDigest
+
+object BuildClasspathFingerprintResolver {
+    fun resolve(project: Project, workspaceIdentity: WorkspaceIdentity): BuildClasspathFingerprint {
+        val entries = buildList {
+            workspaceIdentity.gradleRoot?.let { gradleRoot ->
+                add("settings:${gradleRoot.settingsFileHash.value}")
+            }
+            OrderEnumerator.orderEntries(project).recursively().classes().roots
+                .mapTo(this) { root -> "classpath:${root.url}" }
+        }.sorted()
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(entries.joinToString("\n").toByteArray())
+            .joinToString("") { byte -> "%02x".format(byte) }
+        return BuildClasspathFingerprint.parse(digest)
+    }
+}

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/BuildClasspathFingerprintResolver.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/BuildClasspathFingerprintResolver.kt
@@ -9,6 +9,7 @@ import java.security.MessageDigest
 object BuildClasspathFingerprintResolver {
     fun resolve(project: Project, workspaceIdentity: WorkspaceIdentity): BuildClasspathFingerprint {
         val entries = buildList {
+            add("workspace:${gitWorkspaceScope(workspaceIdentity.workspaceRootPath)}")
             workspaceIdentity.gradleRoot?.let { gradleRoot ->
                 add("settings:${gradleRoot.settingsFileHash.value}")
             }
@@ -21,6 +22,17 @@ object BuildClasspathFingerprintResolver {
         return BuildClasspathFingerprint.parse(digest)
     }
 }
+
+internal fun gitWorkspaceScope(workspaceRoot: java.nio.file.Path): String = runCatching {
+    val process = ProcessBuilder("git", "rev-parse", "--show-prefix")
+        .directory(workspaceRoot.toFile())
+        .redirectError(ProcessBuilder.Redirect.DISCARD)
+        .start()
+    val output = process.inputStream.use { it.readAllBytes() }.toString(Charsets.UTF_8)
+        .removeSuffix("\n")
+        .removeSuffix("\r")
+    output.takeIf { process.waitFor() == 0 } ?: ""
+}.getOrDefault("")
 
 internal fun stableClasspathRootUrl(url: String, workspaceRoot: java.nio.file.Path): String {
     val workspacePath = workspaceRoot.toAbsolutePath().normalize().toString().replace('\\', '/').trimEnd('/')

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/CommittedGitTreeResolver.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/CommittedGitTreeResolver.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.idea.snapshot
 
+import io.github.amichne.kast.indexstore.api.index.SourceIndexFilePolicy
 import io.github.amichne.kast.indexstore.snapshot.GitObjectId
 import java.nio.file.Path
 
@@ -11,6 +12,12 @@ data class CommittedGitTree(
 object CommittedGitTreeResolver {
     fun resolve(workspaceRoot: Path): CommittedGitTree? {
         if (git(workspaceRoot, "status", "--porcelain", "--untracked-files=normal")?.isNotEmpty() != false) return null
+        if (
+            gitBytes(workspaceRoot, "ls-files", "--others", "--ignored", "--exclude-standard", "-z", "--", "*.kt")
+                ?.isNotEmpty() != false
+        ) {
+            return null
+        }
         val workspacePrefix = gitBytes(workspaceRoot, "rev-parse", "--show-prefix")
             ?.toString(Charsets.UTF_8)
             ?.removeSuffix("\n")
@@ -29,6 +36,7 @@ object CommittedGitTreeResolver {
                 require(fields.size == 3 && fields[1] == "blob") { "Git tree contains an unsupported entry" }
                 path to GitObjectId.parse(fields[2])
             }
+            .filterKeys(SourceIndexFilePolicy::isEligible)
             .toSortedMap()
         return CommittedGitTree(treeOid, files)
     }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/CommittedGitTreeResolver.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/CommittedGitTreeResolver.kt
@@ -1,0 +1,41 @@
+package io.github.amichne.kast.idea.snapshot
+
+import io.github.amichne.kast.indexstore.snapshot.GitObjectId
+import java.nio.file.Path
+
+data class CommittedGitTree(
+    val treeOid: GitObjectId,
+    val files: Map<String, GitObjectId>,
+)
+
+object CommittedGitTreeResolver {
+    fun resolve(workspaceRoot: Path): CommittedGitTree? {
+        if (git(workspaceRoot, "status", "--porcelain", "--untracked-files=normal")?.isNotEmpty() != false) return null
+        val treeOid = git(workspaceRoot, "rev-parse", "HEAD^{tree}")?.let(GitObjectId::parse) ?: return null
+        val rawManifest = gitBytes(workspaceRoot, "ls-tree", "-r", "-z", "HEAD") ?: return null
+        val files = rawManifest.toString(Charsets.UTF_8)
+            .split('\u0000')
+            .asSequence()
+            .filter(String::isNotEmpty)
+            .associate { record ->
+                val (metadata, path) = record.split('\t', limit = 2)
+                val fields = metadata.split(' ')
+                require(fields.size == 3 && fields[1] == "blob") { "Git tree contains an unsupported entry" }
+                path to GitObjectId.parse(fields[2])
+            }
+            .toSortedMap()
+        return CommittedGitTree(treeOid, files)
+    }
+
+    private fun git(workspaceRoot: Path, vararg arguments: String): String? =
+        gitBytes(workspaceRoot, *arguments)?.toString(Charsets.UTF_8)?.trim()
+
+    private fun gitBytes(workspaceRoot: Path, vararg arguments: String): ByteArray? = runCatching {
+        val process = ProcessBuilder("git", *arguments)
+            .directory(workspaceRoot.toFile())
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+        val output = process.inputStream.use { it.readAllBytes() }
+        output.takeIf { process.waitFor() == 0 }
+    }.getOrNull()
+}

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/CommittedGitTreeResolver.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/CommittedGitTreeResolver.kt
@@ -11,8 +11,14 @@ data class CommittedGitTree(
 object CommittedGitTreeResolver {
     fun resolve(workspaceRoot: Path): CommittedGitTree? {
         if (git(workspaceRoot, "status", "--porcelain", "--untracked-files=normal")?.isNotEmpty() != false) return null
-        val treeOid = git(workspaceRoot, "rev-parse", "HEAD^{tree}")?.let(GitObjectId::parse) ?: return null
-        val rawManifest = gitBytes(workspaceRoot, "ls-tree", "-r", "-z", "HEAD") ?: return null
+        val workspacePrefix = gitBytes(workspaceRoot, "rev-parse", "--show-prefix")
+            ?.toString(Charsets.UTF_8)
+            ?.removeSuffix("\n")
+            ?.removeSuffix("\r")
+            ?: return null
+        val tree = workspacePrefix.removeSuffix("/").takeIf(String::isNotEmpty)?.let { "HEAD:$it" } ?: "HEAD^{tree}"
+        val treeOid = git(workspaceRoot, "rev-parse", tree)?.let(GitObjectId::parse) ?: return null
+        val rawManifest = gitBytes(workspaceRoot, "ls-tree", "--full-tree", "-r", "-z", treeOid.value) ?: return null
         val files = rawManifest.toString(Charsets.UTF_8)
             .split('\u0000')
             .asSequence()

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/RepositorySnapshotCoordinator.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/RepositorySnapshotCoordinator.kt
@@ -22,9 +22,15 @@ class RepositorySnapshotCoordinator(
     private val buildClasspathFingerprint: BuildClasspathFingerprint,
     private val producerVersion: ProducerVersion,
 ) {
+    private var preparedFromSnapshot = false
+
     fun prepareWorktreeDatabase(databasePath: Path): OverlayManifest? {
-        if (Files.exists(databasePath)) return null
         val overlayPath = databasePath.resolveSibling("repository-overlay.json")
+        if (Files.exists(databasePath)) {
+            preparedFromSnapshot = Files.isRegularFile(overlayPath)
+            return null
+        }
+        var stagedDatabase: Path? = null
         return runCatching {
             val committedTree = CommittedGitTreeResolver.resolve(workspaceRoot) ?: return null
             val target = SnapshotManifest(
@@ -44,17 +50,23 @@ class RepositorySnapshotCoordinator(
                 gitBlob(shard.blobOid)?.let { content -> snapshotStore.putContentShard(shard, content) }
             }
             Files.createDirectories(databasePath.parent)
-            Files.copy(snapshotStore.snapshotDatabase(base.key), databasePath)
+            val staged = Files.createTempFile(databasePath.parent, ".source-index-", ".preparing")
+            stagedDatabase = staged
+            Files.copy(snapshotStore.snapshotDatabase(base.key), staged, StandardCopyOption.REPLACE_EXISTING)
             Files.writeString(overlayPath, Json { prettyPrint = true }.encodeToString(overlay))
-            overlay
+            Files.move(staged, databasePath, StandardCopyOption.ATOMIC_MOVE)
+            stagedDatabase = null
+            overlay.also { preparedFromSnapshot = true }
         }.getOrElse {
-            runCatching { Files.deleteIfExists(databasePath) }
+            stagedDatabase?.let { staged -> runCatching { Files.deleteIfExists(staged) } }
             runCatching { Files.deleteIfExists(overlayPath) }
             null
         }
     }
 
     fun publishCompletedIndex(store: SqliteSourceIndexStore): SnapshotPublicationResult? {
+        // ponytail: copied progress has no run identity; compact after publication evidence gains one.
+        if (preparedFromSnapshot) return null
         if (currentBranch() != "main") return null
         val committedTree = CommittedGitTreeResolver.resolve(workspaceRoot) ?: return null
         val key = SnapshotKey(

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/RepositorySnapshotCoordinator.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/RepositorySnapshotCoordinator.kt
@@ -1,0 +1,92 @@
+package io.github.amichne.kast.idea.snapshot
+
+import io.github.amichne.kast.indexstore.snapshot.BuildClasspathFingerprint
+import io.github.amichne.kast.indexstore.snapshot.ProducerVersion
+import io.github.amichne.kast.indexstore.snapshot.RepositorySnapshotStore
+import io.github.amichne.kast.indexstore.snapshot.RepositorySnapshotSelector
+import io.github.amichne.kast.indexstore.snapshot.OverlayManifest
+import io.github.amichne.kast.indexstore.snapshot.SnapshotKey
+import io.github.amichne.kast.indexstore.snapshot.SnapshotManifest
+import io.github.amichne.kast.indexstore.snapshot.SnapshotPublicationResult
+import io.github.amichne.kast.indexstore.store.SOURCE_INDEX_SCHEMA_VERSION
+import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class RepositorySnapshotCoordinator(
+    private val workspaceRoot: Path,
+    private val repositoryDirectory: Path,
+    private val buildClasspathFingerprint: BuildClasspathFingerprint,
+    private val producerVersion: ProducerVersion,
+) {
+    fun prepareWorktreeDatabase(databasePath: Path): OverlayManifest? {
+        if (Files.exists(databasePath)) return null
+        val committedTree = CommittedGitTreeResolver.resolve(workspaceRoot) ?: return null
+        val target = SnapshotManifest(
+            key = SnapshotKey(
+                committedTree.treeOid,
+                buildClasspathFingerprint,
+                SOURCE_INDEX_SCHEMA_VERSION,
+                producerVersion,
+            ),
+            files = committedTree.files,
+            createdAtEpochMillis = System.currentTimeMillis(),
+        )
+        val snapshotStore = RepositorySnapshotStore(repositoryDirectory)
+        val base = RepositorySnapshotSelector.choose(target, snapshotStore.retainedManifests()) ?: return null
+        val overlay = OverlayManifest.between(base, target)
+        overlay.shards.values.toSet().forEach { shard ->
+            gitBlob(shard.blobOid)?.let { content -> snapshotStore.putContentShard(shard, content) }
+        }
+        Files.createDirectories(databasePath.parent)
+        Files.copy(snapshotStore.snapshotDatabase(base.key), databasePath)
+        Files.writeString(
+            databasePath.resolveSibling("repository-overlay.json"),
+            Json { prettyPrint = true }.encodeToString(overlay),
+        )
+        return overlay
+    }
+
+    fun publishCompletedIndex(store: SqliteSourceIndexStore): SnapshotPublicationResult? {
+        if (currentBranch() != "main") return null
+        val committedTree = CommittedGitTreeResolver.resolve(workspaceRoot) ?: return null
+        val key = SnapshotKey(
+            treeOid = committedTree.treeOid,
+            buildClasspathFingerprint = buildClasspathFingerprint,
+            indexSchema = SOURCE_INDEX_SCHEMA_VERSION,
+            producerVersion = producerVersion,
+        )
+        val exportedDatabase = Files.createTempFile(repositoryDirectory.parent, ".kast-snapshot-", ".db")
+        Files.delete(exportedDatabase)
+        return try {
+            val evidence = store.exportSnapshotDatabase(exportedDatabase, committedTree.treeOid, producerVersion)
+            if (CommittedGitTreeResolver.resolve(workspaceRoot) != committedTree) return null
+            RepositorySnapshotStore(repositoryDirectory).publishMain(
+                manifest = SnapshotManifest(key, committedTree.files, System.currentTimeMillis()),
+                sourceDatabase = exportedDatabase,
+                evidence = evidence,
+            )
+        } finally {
+            Files.deleteIfExists(exportedDatabase)
+        }
+    }
+
+    private fun currentBranch(): String? = runCatching {
+        val process = ProcessBuilder("git", "symbolic-ref", "--quiet", "--short", "HEAD")
+            .directory(workspaceRoot.toFile())
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+        process.inputStream.bufferedReader().use { it.readText() }.trim().takeIf { process.waitFor() == 0 }
+    }.getOrNull()
+
+    private fun gitBlob(oid: io.github.amichne.kast.indexstore.snapshot.GitObjectId): ByteArray? = runCatching {
+        val process = ProcessBuilder("git", "cat-file", "blob", oid.value)
+            .directory(workspaceRoot.toFile())
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+        process.inputStream.use { it.readAllBytes() }.takeIf { process.waitFor() == 0 }
+    }.getOrNull()
+}

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/RepositorySnapshotCoordinator.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/RepositorySnapshotCoordinator.kt
@@ -24,30 +24,34 @@ class RepositorySnapshotCoordinator(
 ) {
     fun prepareWorktreeDatabase(databasePath: Path): OverlayManifest? {
         if (Files.exists(databasePath)) return null
-        val committedTree = CommittedGitTreeResolver.resolve(workspaceRoot) ?: return null
-        val target = SnapshotManifest(
-            key = SnapshotKey(
-                committedTree.treeOid,
-                buildClasspathFingerprint,
-                SOURCE_INDEX_SCHEMA_VERSION,
-                producerVersion,
-            ),
-            files = committedTree.files,
-            createdAtEpochMillis = System.currentTimeMillis(),
-        )
-        val snapshotStore = RepositorySnapshotStore(repositoryDirectory)
-        val base = RepositorySnapshotSelector.choose(target, snapshotStore.retainedManifests()) ?: return null
-        val overlay = OverlayManifest.between(base, target)
-        overlay.shards.values.toSet().forEach { shard ->
-            gitBlob(shard.blobOid)?.let { content -> snapshotStore.putContentShard(shard, content) }
+        val overlayPath = databasePath.resolveSibling("repository-overlay.json")
+        return runCatching {
+            val committedTree = CommittedGitTreeResolver.resolve(workspaceRoot) ?: return null
+            val target = SnapshotManifest(
+                key = SnapshotKey(
+                    committedTree.treeOid,
+                    buildClasspathFingerprint,
+                    SOURCE_INDEX_SCHEMA_VERSION,
+                    producerVersion,
+                ),
+                files = committedTree.files,
+                createdAtEpochMillis = System.currentTimeMillis(),
+            )
+            val snapshotStore = RepositorySnapshotStore(repositoryDirectory)
+            val base = RepositorySnapshotSelector.choose(target, snapshotStore.retainedManifests()) ?: return null
+            val overlay = OverlayManifest.between(base, target)
+            overlay.shards.values.toSet().forEach { shard ->
+                gitBlob(shard.blobOid)?.let { content -> snapshotStore.putContentShard(shard, content) }
+            }
+            Files.createDirectories(databasePath.parent)
+            Files.copy(snapshotStore.snapshotDatabase(base.key), databasePath)
+            Files.writeString(overlayPath, Json { prettyPrint = true }.encodeToString(overlay))
+            overlay
+        }.getOrElse {
+            runCatching { Files.deleteIfExists(databasePath) }
+            runCatching { Files.deleteIfExists(overlayPath) }
+            null
         }
-        Files.createDirectories(databasePath.parent)
-        Files.copy(snapshotStore.snapshotDatabase(base.key), databasePath)
-        Files.writeString(
-            databasePath.resolveSibling("repository-overlay.json"),
-            Json { prettyPrint = true }.encodeToString(overlay),
-        )
-        return overlay
     }
 
     fun publishCompletedIndex(store: SqliteSourceIndexStore): SnapshotPublicationResult? {

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/RepositorySnapshotCoordinator.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/snapshot/RepositorySnapshotCoordinator.kt
@@ -53,6 +53,7 @@ class RepositorySnapshotCoordinator(
             val staged = Files.createTempFile(databasePath.parent, ".source-index-", ".preparing")
             stagedDatabase = staged
             Files.copy(snapshotStore.snapshotDatabase(base.key), staged, StandardCopyOption.REPLACE_EXISTING)
+            check(staged.toFile().setWritable(true, true)) { "Snapshot database could not be made writable" }
             Files.writeString(overlayPath, Json { prettyPrint = true }.encodeToString(overlay))
             Files.move(staged, databasePath, StandardCopyOption.ATOMIC_MOVE)
             stagedDatabase = null

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RepositorySnapshotIntegrationTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RepositorySnapshotIntegrationTest.kt
@@ -2,6 +2,7 @@ package io.github.amichne.kast.idea
 
 import io.github.amichne.kast.idea.snapshot.CommittedGitTreeResolver
 import io.github.amichne.kast.idea.snapshot.RepositorySnapshotCoordinator
+import io.github.amichne.kast.idea.snapshot.stableClasspathRootUrl
 import io.github.amichne.kast.indexstore.snapshot.BuildClasspathFingerprint
 import io.github.amichne.kast.indexstore.snapshot.ProducerVersion
 import io.github.amichne.kast.indexstore.snapshot.RepositorySnapshotStore
@@ -11,6 +12,8 @@ import io.github.amichne.kast.indexstore.snapshot.SnapshotManifest
 import io.github.amichne.kast.indexstore.store.SOURCE_INDEX_SCHEMA_VERSION
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -41,6 +44,38 @@ class RepositorySnapshotIntegrationTest {
         git("checkout", "--", "A.kt")
         Files.writeString(workspace.resolve("untracked.kt"), "class Untracked")
         assertNull(CommittedGitTreeResolver.resolve(workspace))
+    }
+
+    @Test
+    fun `subdirectory tree identity matches its scoped manifest`() {
+        git("init", "-b", "main")
+        git("config", "user.email", "kast@example.invalid")
+        git("config", "user.name", "Kast Test")
+        val projectDirectory = workspace.resolve(" app ")
+        Files.createDirectories(projectDirectory)
+        Files.writeString(projectDirectory.resolve("A.kt"), "class A")
+        Files.writeString(workspace.resolve("Root.kt"), "class Root")
+        git("add", ".")
+        git("commit", "-m", "initial")
+
+        val repositoryTree = requireNotNull(CommittedGitTreeResolver.resolve(workspace))
+        val subdirectoryTree = requireNotNull(CommittedGitTreeResolver.resolve(projectDirectory))
+
+        assertEquals(setOf("A.kt"), subdirectoryTree.files.keys)
+        assertNotEquals(repositoryTree.treeOid, subdirectoryTree.treeOid)
+    }
+
+    @Test
+    fun `workspace-local classpath roots have worktree-stable identity`() {
+        val firstWorktree = workspace.resolveSibling("worktree-a").toAbsolutePath()
+        val secondWorktree = workspace.resolveSibling("worktree-b").toAbsolutePath()
+
+        assertEquals(
+            stableClasspathRootUrl("file://$firstWorktree/build/classes/kotlin/main", firstWorktree),
+            stableClasspathRootUrl("file://$secondWorktree/build/classes/kotlin/main", secondWorktree),
+        )
+        val externalRoot = "file:///external$firstWorktree/build/classes/kotlin/main"
+        assertEquals(externalRoot, stableClasspathRootUrl(externalRoot, firstWorktree))
     }
 
     @Test
@@ -109,6 +144,37 @@ class RepositorySnapshotIntegrationTest {
         overlay?.shards?.values?.forEach { shard ->
             assertTrue(RepositorySnapshotStore(repositoryDirectory).contentShard(shard)?.let(Files::isRegularFile) == true)
         }
+    }
+
+    @Test
+    fun `missing retained database is a cache miss`() {
+        git("init", "-b", "main")
+        git("config", "user.email", "kast@example.invalid")
+        git("config", "user.name", "Kast Test")
+        Files.writeString(workspace.resolve("A.kt"), "class A")
+        git("add", ".")
+        git("commit", "-m", "base")
+        val tree = requireNotNull(CommittedGitTreeResolver.resolve(workspace))
+        val fingerprint = BuildClasspathFingerprint.parse("8".repeat(64))
+        val producer = ProducerVersion.parse("test-producer")
+        val key = SnapshotKey(tree.treeOid, fingerprint, SOURCE_INDEX_SCHEMA_VERSION, producer)
+        val repositoryDirectory = workspace.resolveSibling("${workspace.fileName}-repository-state")
+        val source = repositoryDirectory.resolveSibling("${workspace.fileName}-base.db")
+        Files.writeString(source, "immutable base")
+        val snapshotStore = RepositorySnapshotStore(repositoryDirectory)
+        snapshotStore.publishMain(
+            SnapshotManifest(key, tree.files, 1),
+            source,
+            PublicationEvidence(1, 1, 1, 0, 0, key.treeOid, key.indexSchema, key.producerVersion),
+        )
+        Files.delete(snapshotStore.snapshotDatabase(key))
+        val targetDatabase = repositoryDirectory.resolveSibling("${workspace.fileName}-worktree/source-index.db")
+
+        val overlay = RepositorySnapshotCoordinator(workspace, repositoryDirectory, fingerprint, producer)
+            .prepareWorktreeDatabase(targetDatabase)
+
+        assertNull(overlay)
+        assertFalse(Files.exists(targetDatabase))
     }
 
     private fun git(vararg arguments: String) {

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RepositorySnapshotIntegrationTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RepositorySnapshotIntegrationTest.kt
@@ -1,0 +1,118 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.idea.snapshot.CommittedGitTreeResolver
+import io.github.amichne.kast.idea.snapshot.RepositorySnapshotCoordinator
+import io.github.amichne.kast.indexstore.snapshot.BuildClasspathFingerprint
+import io.github.amichne.kast.indexstore.snapshot.ProducerVersion
+import io.github.amichne.kast.indexstore.snapshot.RepositorySnapshotStore
+import io.github.amichne.kast.indexstore.snapshot.PublicationEvidence
+import io.github.amichne.kast.indexstore.snapshot.SnapshotKey
+import io.github.amichne.kast.indexstore.snapshot.SnapshotManifest
+import io.github.amichne.kast.indexstore.store.SOURCE_INDEX_SCHEMA_VERSION
+import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class RepositorySnapshotIntegrationTest {
+    @TempDir
+    lateinit var workspace: Path
+
+    @Test
+    fun `committed tree is reusable only while the worktree is clean`() {
+        git("init", "-b", "main")
+        git("config", "user.email", "kast@example.invalid")
+        git("config", "user.name", "Kast Test")
+        Files.writeString(workspace.resolve("A.kt"), "class A")
+        git("add", "A.kt")
+        git("commit", "-m", "initial")
+
+        val committed = CommittedGitTreeResolver.resolve(workspace)
+        assertEquals(40, committed?.treeOid?.value?.length)
+        assertEquals(setOf("A.kt"), committed?.files?.keys)
+
+        Files.writeString(workspace.resolve("A.kt"), "class Changed")
+        assertNull(CommittedGitTreeResolver.resolve(workspace))
+
+        git("checkout", "--", "A.kt")
+        Files.writeString(workspace.resolve("untracked.kt"), "class Untracked")
+        assertNull(CommittedGitTreeResolver.resolve(workspace))
+    }
+
+    @Test
+    fun `completed clean index publishes repository latest good`() {
+        git("init", "-b", "main")
+        git("config", "user.email", "kast@example.invalid")
+        git("config", "user.name", "Kast Test")
+        Files.writeString(workspace.resolve("A.kt"), "class A")
+        git("add", "A.kt")
+        git("commit", "-m", "initial")
+        val repositoryDirectory = workspace.resolveSibling("${workspace.fileName}-repository-state")
+
+        SqliteSourceIndexStore(workspace).use { store ->
+            store.ensureSchema()
+            store.initializeModuleProgress(mapOf("main" to 1))
+            store.markModuleComplete("main", 1)
+            val result = RepositorySnapshotCoordinator(
+                workspaceRoot = workspace,
+                repositoryDirectory = repositoryDirectory,
+                buildClasspathFingerprint = BuildClasspathFingerprint.parse("8".repeat(64)),
+                producerVersion = ProducerVersion.parse("test-producer"),
+            ).publishCompletedIndex(store)
+
+            assertTrue(result != null)
+            assertEquals(
+                CommittedGitTreeResolver.resolve(workspace)?.treeOid,
+                RepositorySnapshotStore(repositoryDirectory).latestGood()?.key?.treeOid,
+            )
+        }
+    }
+
+    @Test
+    fun `clean target bootstraps from cheapest snapshot with one direct overlay and blob shards`() {
+        git("init", "-b", "main")
+        git("config", "user.email", "kast@example.invalid")
+        git("config", "user.name", "Kast Test")
+        Files.writeString(workspace.resolve("A.kt"), "class A")
+        Files.writeString(workspace.resolve("B.kt"), "class B")
+        git("add", ".")
+        git("commit", "-m", "base")
+        val baseTree = requireNotNull(CommittedGitTreeResolver.resolve(workspace))
+        val fingerprint = BuildClasspathFingerprint.parse("8".repeat(64))
+        val producer = ProducerVersion.parse("test-producer")
+        val key = SnapshotKey(baseTree.treeOid, fingerprint, SOURCE_INDEX_SCHEMA_VERSION, producer)
+        val repositoryDirectory = workspace.resolveSibling("${workspace.fileName}-repository-state")
+        val source = repositoryDirectory.resolveSibling("${workspace.fileName}-base.db")
+        Files.writeString(source, "immutable base")
+        RepositorySnapshotStore(repositoryDirectory).publishMain(
+            SnapshotManifest(key, baseTree.files, 1),
+            source,
+            PublicationEvidence(1, 1, 1, 0, 0, key.treeOid, key.indexSchema, key.producerVersion),
+        )
+
+        Files.writeString(workspace.resolve("A.kt"), "class A2")
+        Files.delete(workspace.resolve("B.kt"))
+        Files.writeString(workspace.resolve("C.kt"), "class C")
+        git("add", "-A")
+        git("commit", "-m", "target")
+        val targetDatabase = repositoryDirectory.resolveSibling("${workspace.fileName}-worktree/source-index.db")
+        val overlay = RepositorySnapshotCoordinator(workspace, repositoryDirectory, fingerprint, producer)
+            .prepareWorktreeDatabase(targetDatabase)
+
+        assertEquals(setOf("B.kt"), overlay?.tombstones)
+        assertEquals(setOf("A.kt", "C.kt"), overlay?.shards?.keys)
+        assertEquals("immutable base", Files.readString(targetDatabase))
+        overlay?.shards?.values?.forEach { shard ->
+            assertTrue(RepositorySnapshotStore(repositoryDirectory).contentShard(shard)?.let(Files::isRegularFile) == true)
+        }
+    }
+
+    private fun git(vararg arguments: String) {
+        val process = ProcessBuilder("git", *arguments).directory(workspace.toFile()).start()
+        assertTrue(process.waitFor() == 0, process.errorStream.bufferedReader().readText())
+    }
+}

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RepositorySnapshotIntegrationTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RepositorySnapshotIntegrationTest.kt
@@ -154,6 +154,7 @@ class RepositorySnapshotIntegrationTest {
         assertEquals(setOf("B.kt"), overlay?.tombstones)
         assertEquals(setOf("A.kt", "C.kt"), overlay?.shards?.keys)
         assertEquals("immutable base", Files.readString(targetDatabase))
+        assertTrue(Files.isWritable(targetDatabase))
         overlay?.shards?.values?.forEach { shard ->
             assertTrue(RepositorySnapshotStore(repositoryDirectory).contentShard(shard)?.let(Files::isRegularFile) == true)
         }

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RepositorySnapshotIntegrationTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RepositorySnapshotIntegrationTest.kt
@@ -2,6 +2,7 @@ package io.github.amichne.kast.idea
 
 import io.github.amichne.kast.idea.snapshot.CommittedGitTreeResolver
 import io.github.amichne.kast.idea.snapshot.RepositorySnapshotCoordinator
+import io.github.amichne.kast.idea.snapshot.gitWorkspaceScope
 import io.github.amichne.kast.idea.snapshot.stableClasspathRootUrl
 import io.github.amichne.kast.indexstore.snapshot.BuildClasspathFingerprint
 import io.github.amichne.kast.indexstore.snapshot.ProducerVersion
@@ -63,6 +64,8 @@ class RepositorySnapshotIntegrationTest {
 
         assertEquals(setOf("A.kt"), subdirectoryTree.files.keys)
         assertNotEquals(repositoryTree.treeOid, subdirectoryTree.treeOid)
+        assertEquals("", gitWorkspaceScope(workspace))
+        assertEquals(" app /", gitWorkspaceScope(projectDirectory))
     }
 
     @Test
@@ -135,14 +138,19 @@ class RepositorySnapshotIntegrationTest {
         git("add", "-A")
         git("commit", "-m", "target")
         val targetDatabase = repositoryDirectory.resolveSibling("${workspace.fileName}-worktree/source-index.db")
-        val overlay = RepositorySnapshotCoordinator(workspace, repositoryDirectory, fingerprint, producer)
-            .prepareWorktreeDatabase(targetDatabase)
+        val coordinator = RepositorySnapshotCoordinator(workspace, repositoryDirectory, fingerprint, producer)
+        val overlay = coordinator.prepareWorktreeDatabase(targetDatabase)
 
         assertEquals(setOf("B.kt"), overlay?.tombstones)
         assertEquals(setOf("A.kt", "C.kt"), overlay?.shards?.keys)
         assertEquals("immutable base", Files.readString(targetDatabase))
         overlay?.shards?.values?.forEach { shard ->
             assertTrue(RepositorySnapshotStore(repositoryDirectory).contentShard(shard)?.let(Files::isRegularFile) == true)
+        }
+        val restartedCoordinator = RepositorySnapshotCoordinator(workspace, repositoryDirectory, fingerprint, producer)
+        assertNull(restartedCoordinator.prepareWorktreeDatabase(targetDatabase))
+        SqliteSourceIndexStore(workspace).use { store ->
+            assertNull(restartedCoordinator.publishCompletedIndex(store))
         }
     }
 

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RepositorySnapshotIntegrationTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/RepositorySnapshotIntegrationTest.kt
@@ -32,7 +32,8 @@ class RepositorySnapshotIntegrationTest {
         git("config", "user.email", "kast@example.invalid")
         git("config", "user.name", "Kast Test")
         Files.writeString(workspace.resolve("A.kt"), "class A")
-        git("add", "A.kt")
+        Files.writeString(workspace.resolve("Notes.txt"), "not indexed")
+        git("add", "A.kt", "Notes.txt")
         git("commit", "-m", "initial")
 
         val committed = CommittedGitTreeResolver.resolve(workspace)
@@ -44,6 +45,13 @@ class RepositorySnapshotIntegrationTest {
 
         git("checkout", "--", "A.kt")
         Files.writeString(workspace.resolve("untracked.kt"), "class Untracked")
+        assertNull(CommittedGitTreeResolver.resolve(workspace))
+
+        Files.delete(workspace.resolve("untracked.kt"))
+        Files.writeString(workspace.resolve(".gitignore"), "ignored.kt\n")
+        git("add", ".gitignore")
+        git("commit", "-m", "ignore local source")
+        Files.writeString(workspace.resolve("ignored.kt"), "class Ignored")
         assertNull(CommittedGitTreeResolver.resolve(workspace))
     }
 
@@ -117,6 +125,7 @@ class RepositorySnapshotIntegrationTest {
         git("config", "user.name", "Kast Test")
         Files.writeString(workspace.resolve("A.kt"), "class A")
         Files.writeString(workspace.resolve("B.kt"), "class B")
+        Files.writeString(workspace.resolve("asset.bin"), "base asset")
         git("add", ".")
         git("commit", "-m", "base")
         val baseTree = requireNotNull(CommittedGitTreeResolver.resolve(workspace))
@@ -135,6 +144,7 @@ class RepositorySnapshotIntegrationTest {
         Files.writeString(workspace.resolve("A.kt"), "class A2")
         Files.delete(workspace.resolve("B.kt"))
         Files.writeString(workspace.resolve("C.kt"), "class C")
+        Files.writeString(workspace.resolve("asset.bin"), "changed asset")
         git("add", "-A")
         git("commit", "-m", "target")
         val targetDatabase = repositoryDirectory.resolveSibling("${workspace.fileName}-worktree/source-index.db")

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotStore.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotStore.kt
@@ -1,0 +1,238 @@
+package io.github.amichne.kast.indexstore.snapshot
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.PosixFilePermission
+import java.util.UUID
+
+private const val MAIN_HISTORY_RETENTION = 8
+private const val MERGE_BASE_LEASE_MILLIS = 30L * 24 * 60 * 60 * 1_000
+private const val DEFAULT_DISK_BUDGET_BYTES = 10L * 1024 * 1024 * 1024
+
+data class SnapshotRetentionPins(
+    val activeWorktreeTargets: Set<SnapshotKey> = emptySet(),
+    val mergeBaseLeases: Map<SnapshotKey, Long> = emptyMap(),
+    val nowEpochMillis: Long = System.currentTimeMillis(),
+    val diskBudgetBytes: Long = DEFAULT_DISK_BUDGET_BYTES,
+) {
+    init {
+        require(nowEpochMillis >= 0)
+        require(diskBudgetBytes >= 0)
+    }
+}
+
+data class PublicationEvidence(
+    val generationBefore: Long,
+    val generationAfter: Long,
+    val moduleProgressCount: Int,
+    val incompleteModuleCount: Int,
+    val pendingCount: Int,
+    val treeOid: GitObjectId,
+    val indexSchema: Int,
+    val producerVersion: ProducerVersion,
+) {
+    fun proves(key: SnapshotKey): Boolean = generationBefore >= 0 &&
+        generationBefore == generationAfter &&
+        moduleProgressCount > 0 &&
+        incompleteModuleCount == 0 &&
+        pendingCount == 0 &&
+        treeOid == key.treeOid &&
+        indexSchema == key.indexSchema &&
+        producerVersion == key.producerVersion
+}
+
+sealed interface SnapshotPublicationResult {
+    data class Published(val manifest: SnapshotManifest) : SnapshotPublicationResult
+    data class Reused(val manifest: SnapshotManifest) : SnapshotPublicationResult
+    data class Rejected(val reason: String) : SnapshotPublicationResult
+}
+
+class RepositorySnapshotStore(private val repositoryDirectory: Path) {
+    private val snapshotsDirectory = repositoryDirectory.resolve("snapshots")
+    private val latestGoodPath = repositoryDirectory.resolve("main/latest-good.json")
+    private val mainHistoryPath = repositoryDirectory.resolve("main/history.json")
+    private val shardsDirectory = repositoryDirectory.resolve("shards")
+
+    fun publishMain(
+        manifest: SnapshotManifest,
+        sourceDatabase: Path,
+        evidence: PublicationEvidence,
+    ): SnapshotPublicationResult {
+        if (!evidence.proves(manifest.key)) {
+            return SnapshotPublicationResult.Rejected("Source index evidence is not complete and stable for the target tree")
+        }
+        if (!Files.isRegularFile(sourceDatabase)) {
+            return SnapshotPublicationResult.Rejected("Source index database is unavailable")
+        }
+        val destination = snapshotDirectory(manifest.key)
+        if (Files.isDirectory(destination)) {
+            recordMainSnapshot(manifest.key)
+            publishLatestGood(manifest.key)
+            return SnapshotPublicationResult.Reused(readManifest(destination))
+        }
+        Files.createDirectories(snapshotsDirectory)
+        val temporary = snapshotsDirectory.resolve(".${manifest.key.directoryName}.${UUID.randomUUID()}.tmp")
+        try {
+            Files.createDirectory(temporary)
+            val database = temporary.resolve(DATABASE_FILE)
+            Files.copy(sourceDatabase, database, StandardCopyOption.COPY_ATTRIBUTES)
+            writeJson(temporary.resolve(MANIFEST_FILE), manifest.copy(files = manifest.files.toSortedMap()))
+            sync(database)
+            sync(temporary.resolve(MANIFEST_FILE))
+            Files.move(temporary, destination, StandardCopyOption.ATOMIC_MOVE)
+            makeImmutable(destination.resolve(DATABASE_FILE))
+            makeImmutable(destination.resolve(MANIFEST_FILE))
+            recordMainSnapshot(manifest.key)
+            publishLatestGood(manifest.key)
+            return SnapshotPublicationResult.Published(manifest)
+        } catch (failure: Throwable) {
+            temporary.toFile().deleteRecursively()
+            throw failure
+        }
+    }
+
+    fun latestGood(): SnapshotManifest? {
+        if (!Files.isRegularFile(latestGoodPath)) return null
+        val pointer = Json.decodeFromString<LatestGood>(Files.readString(latestGoodPath))
+        val manifest = readManifest(snapshotDirectory(pointer.key))
+        return manifest.takeIf { it.key == pointer.key }
+    }
+
+    fun snapshotDatabase(key: SnapshotKey): Path = snapshotDirectory(key).resolve(DATABASE_FILE)
+
+    fun putContentShard(key: ExtractionShardKey, content: ByteArray): Path {
+        Files.createDirectories(shardsDirectory)
+        val destination = shardsDirectory.resolve(key.directoryName)
+        if (Files.isRegularFile(destination)) return destination
+        val temporary = shardsDirectory.resolve(".${key.directoryName}.${UUID.randomUUID()}.tmp")
+        Files.write(temporary, content)
+        sync(temporary)
+        runCatching { Files.move(temporary, destination, StandardCopyOption.ATOMIC_MOVE) }
+            .getOrElse {
+                Files.deleteIfExists(temporary)
+                if (!Files.isRegularFile(destination)) throw it
+            }
+        makeImmutable(destination)
+        return destination
+    }
+
+    fun contentShard(key: ExtractionShardKey): Path? =
+        shardsDirectory.resolve(key.directoryName).takeIf(Files::isRegularFile)
+
+    fun retainedManifests(): List<SnapshotManifest> {
+        if (!Files.isDirectory(snapshotsDirectory)) return emptyList()
+        return Files.list(snapshotsDirectory).use { paths ->
+            paths.toList().filter(Files::isDirectory)
+                .mapNotNull { directory -> runCatching { readManifest(directory) }.getOrNull() }
+                .sortedBy(SnapshotManifest::createdAtEpochMillis)
+        }
+    }
+
+    fun garbageCollect(pins: SnapshotRetentionPins) {
+        deleteChildren(repositoryDirectory.resolve("overlays"))
+        val history = readMainHistory()
+        val pinned = buildSet {
+            latestGood()?.key?.let(::add)
+            addAll(history.takeLast(MAIN_HISTORY_RETENTION))
+            addAll(pins.activeWorktreeTargets)
+            pins.mergeBaseLeases.forEach { (key, acquiredAt) ->
+                if (pins.nowEpochMillis - acquiredAt <= MERGE_BASE_LEASE_MILLIS) add(key)
+            }
+        }
+        retainedManifests()
+            .filterNot { it.key in pinned }
+            .forEach { snapshotDirectory(it.key).toFile().deleteRecursively() }
+        if (directorySize(repositoryDirectory) > pins.diskBudgetBytes) {
+            retainedManifests()
+                .filterNot { it.key in pinned }
+                .takeWhile { directorySize(repositoryDirectory) > pins.diskBudgetBytes }
+                .forEach { snapshotDirectory(it.key).toFile().deleteRecursively() }
+        }
+        deleteChildren(repositoryDirectory.resolve("shards"))
+    }
+
+    private fun snapshotDirectory(key: SnapshotKey): Path = snapshotsDirectory.resolve(key.directoryName)
+
+    private fun readManifest(directory: Path): SnapshotManifest =
+        Json.decodeFromString(Files.readString(directory.resolve(MANIFEST_FILE)))
+
+    private fun publishLatestGood(key: SnapshotKey) {
+        Files.createDirectories(latestGoodPath.parent)
+        val temporary = latestGoodPath.resolveSibling(".${latestGoodPath.fileName}.${UUID.randomUUID()}.tmp")
+        writeJson(temporary, LatestGood(key))
+        sync(temporary)
+        Files.move(
+            temporary,
+            latestGoodPath,
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING,
+        )
+    }
+
+    private fun recordMainSnapshot(key: SnapshotKey) {
+        val history = (readMainHistory() + key).distinct()
+        Files.createDirectories(mainHistoryPath.parent)
+        val temporary = mainHistoryPath.resolveSibling(".${mainHistoryPath.fileName}.${UUID.randomUUID()}.tmp")
+        Files.writeString(temporary, JSON.encodeToString(MainHistory(history)))
+        sync(temporary)
+        Files.move(temporary, mainHistoryPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+    }
+
+    private fun readMainHistory(): List<SnapshotKey> = if (Files.isRegularFile(mainHistoryPath)) {
+        runCatching { JSON.decodeFromString<MainHistory>(Files.readString(mainHistoryPath)).snapshots }.getOrDefault(emptyList())
+    } else {
+        emptyList()
+    }
+
+    private fun deleteChildren(directory: Path) {
+        if (!Files.isDirectory(directory)) return
+        Files.list(directory).use { paths -> paths.forEach { it.toFile().deleteRecursively() } }
+    }
+
+    private fun directorySize(directory: Path): Long {
+        if (!Files.exists(directory)) return 0
+        return Files.walk(directory).use { paths ->
+            paths.filter(Files::isRegularFile).mapToLong(Files::size).sum()
+        }
+    }
+
+    private fun writeJson(path: Path, value: SnapshotManifest) {
+        Files.writeString(path, JSON.encodeToString(value))
+    }
+
+    private fun writeJson(path: Path, value: LatestGood) {
+        Files.writeString(path, JSON.encodeToString(value))
+    }
+
+    private fun sync(path: Path) {
+        FileChannel.open(path, StandardOpenOption.WRITE).use { channel -> channel.force(true) }
+    }
+
+    private fun makeImmutable(path: Path) {
+        runCatching {
+            Files.setPosixFilePermissions(
+                path,
+                setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.GROUP_READ, PosixFilePermission.OTHERS_READ),
+            )
+        }.getOrElse { path.toFile().setWritable(false, false) }
+    }
+
+    @Serializable
+    private data class LatestGood(val key: SnapshotKey)
+
+    @Serializable
+    private data class MainHistory(val snapshots: List<SnapshotKey>)
+
+    private companion object {
+        const val DATABASE_FILE = "source-index.db"
+        const val MANIFEST_FILE = "manifest.json"
+        val JSON = Json { prettyPrint = true }
+    }
+}

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/SnapshotIdentity.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/SnapshotIdentity.kt
@@ -1,0 +1,86 @@
+package io.github.amichne.kast.indexstore.snapshot
+
+import kotlinx.serialization.Serializable
+import java.security.MessageDigest
+
+@Serializable
+@JvmInline
+value class GitObjectId private constructor(val value: String) {
+    companion object {
+        fun parse(value: String): GitObjectId {
+            require(value.length == 40 || value.length == 64) { "Git object ID must contain 40 or 64 hexadecimal characters" }
+            require(value.all { it in '0'..'9' || it in 'a'..'f' }) { "Git object ID must be lowercase hexadecimal" }
+            return GitObjectId(value)
+        }
+    }
+}
+
+@Serializable
+@JvmInline
+value class BuildClasspathFingerprint private constructor(val value: String) {
+    companion object {
+        fun parse(value: String): BuildClasspathFingerprint {
+            require(value.length == 64 && value.all { it in '0'..'9' || it in 'a'..'f' }) {
+                "Build/classpath fingerprint must be a lowercase SHA-256 digest"
+            }
+            return BuildClasspathFingerprint(value)
+        }
+    }
+}
+
+@Serializable
+@JvmInline
+value class ProducerVersion private constructor(val value: String) {
+    companion object {
+        fun parse(value: String): ProducerVersion {
+            require(value.isNotBlank() && value.trim() == value && !value.any { Character.isISOControl(it.code) }) {
+                "Producer version must be one non-blank canonical value"
+            }
+            return ProducerVersion(value)
+        }
+    }
+}
+
+@Serializable
+data class SnapshotCompatibility(
+    val buildClasspathFingerprint: BuildClasspathFingerprint,
+    val indexSchema: Int,
+    val producerVersion: ProducerVersion,
+) {
+    init {
+        require(indexSchema > 0) { "Index schema must be positive" }
+    }
+}
+
+@Serializable
+data class SnapshotKey(
+    val treeOid: GitObjectId,
+    val buildClasspathFingerprint: BuildClasspathFingerprint,
+    val indexSchema: Int,
+    val producerVersion: ProducerVersion,
+) {
+    val compatibility: SnapshotCompatibility = SnapshotCompatibility(
+        buildClasspathFingerprint,
+        indexSchema,
+        producerVersion,
+    )
+
+    val directoryName: String
+        get() = sha256("${treeOid.value}\n${buildClasspathFingerprint.value}\n$indexSchema\n${producerVersion.value}")
+}
+
+@Serializable
+data class ExtractionShardKey(
+    val compatibility: SnapshotCompatibility,
+    val blobOid: GitObjectId,
+) {
+    val directoryName: String
+        get() = sha256(
+            "${compatibility.buildClasspathFingerprint.value}\n${compatibility.indexSchema}\n" +
+                "${compatibility.producerVersion.value}\n${blobOid.value}",
+        )
+}
+
+private fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")
+    .digest(value.toByteArray())
+    .joinToString("") { byte -> "%02x".format(byte) }

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/SnapshotManifest.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/SnapshotManifest.kt
@@ -1,0 +1,56 @@
+package io.github.amichne.kast.indexstore.snapshot
+
+import kotlinx.serialization.Serializable
+import java.nio.file.Path
+
+@Serializable
+data class SnapshotManifest(
+    val key: SnapshotKey,
+    val files: Map<String, GitObjectId>,
+    val createdAtEpochMillis: Long,
+) {
+    init {
+        require(createdAtEpochMillis >= 0) { "Snapshot creation time must be non-negative" }
+        require(files.keys.all(::isCanonicalRelativePath)) { "Snapshot paths must be canonical repository-relative paths" }
+    }
+}
+
+@Serializable
+data class OverlayManifest(
+    val base: SnapshotKey,
+    val target: SnapshotKey,
+    val tombstones: Set<String>,
+    val shards: Map<String, ExtractionShardKey>,
+) {
+    companion object {
+        fun between(base: SnapshotManifest, target: SnapshotManifest): OverlayManifest {
+            require(base.key.compatibility == target.key.compatibility) { "Snapshot overlay requires exact compatibility" }
+            val tombstones = base.files.keys.minus(target.files.keys).toSortedSet()
+            val shards = target.files
+                .filter { (path, oid) -> base.files[path] != oid }
+                .toSortedMap()
+                .mapValues { (_, oid) -> ExtractionShardKey(target.key.compatibility, oid) }
+            return OverlayManifest(base.key, target.key, tombstones, shards)
+        }
+    }
+}
+
+object RepositorySnapshotSelector {
+    fun choose(target: SnapshotManifest, retained: Collection<SnapshotManifest>): SnapshotManifest? = retained
+        .asSequence()
+        .filter { candidate -> candidate.key.compatibility == target.key.compatibility }
+        .minWithOrNull(
+            compareBy<SnapshotManifest> { candidate -> differenceCost(candidate, target) }
+                .thenByDescending(SnapshotManifest::createdAtEpochMillis)
+                .thenBy { candidate -> candidate.key.directoryName },
+        )
+
+    private fun differenceCost(base: SnapshotManifest, target: SnapshotManifest): Int =
+        (base.files.keys + target.files.keys).count { path -> base.files[path] != target.files[path] }
+}
+
+private fun isCanonicalRelativePath(raw: String): Boolean {
+    if (raw.isBlank() || '\\' in raw) return false
+    val path = runCatching { Path.of(raw) }.getOrNull() ?: return false
+    return !path.isAbsolute && path.normalize().toString() == raw && path.none { it.toString() == ".." }
+}

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.kt
@@ -40,6 +40,9 @@ import io.github.amichne.kast.indexstore.api.reference.ExactReferenceTarget
 import io.github.amichne.kast.indexstore.api.reference.SourceIndexGeneration
 import io.github.amichne.kast.indexstore.api.reference.SymbolReferenceRow
 import io.github.amichne.kast.indexstore.api.reference.SymbolReferencePage
+import io.github.amichne.kast.indexstore.snapshot.GitObjectId
+import io.github.amichne.kast.indexstore.snapshot.ProducerVersion
+import io.github.amichne.kast.indexstore.snapshot.PublicationEvidence
 import io.github.amichne.kast.indexstore.store.cache.defaultCacheJson
 import io.github.amichne.kast.indexstore.store.codec.PathInterningCodec
 import io.github.amichne.kast.indexstore.store.codec.StringInterningCodec
@@ -1973,6 +1976,45 @@ class SqliteSourceIndexStore private constructor(
                 SourceIndexGeneration(0)
             }
         }
+    }
+
+    fun exportSnapshotDatabase(
+        target: Path,
+        treeOid: GitObjectId,
+        producerVersion: ProducerVersion,
+    ): PublicationEvidence = synchronized(writeLock) {
+        require(!Files.exists(target)) { "Snapshot export target already exists: $target" }
+        Files.createDirectories(target.toAbsolutePath().normalize().parent)
+        val conn = connection()
+        val generationBefore = readGenerationInTransaction(conn).value
+        val (moduleProgressCount, incompleteModuleCount) = conn.createStatement().use { statement ->
+            val result = statement.executeQuery(
+                """SELECT COUNT(*) AS total,
+                          SUM(CASE WHEN phase2_status != 'COMPLETE' OR indexed_file_count != total_file_count
+                                   THEN 1 ELSE 0 END) AS incomplete
+                   FROM module_index_progress""",
+            )
+            check(result.next())
+            result.getInt("total") to result.getInt("incomplete")
+        }
+        val pendingCount = conn.createStatement().use { statement ->
+            val result = statement.executeQuery("SELECT COUNT(*) FROM pending_updates WHERE applied = 0")
+            check(result.next())
+            result.getInt(1)
+        }
+        val escapedTarget = target.toAbsolutePath().normalize().toString().replace("'", "''")
+        conn.createStatement().use { statement -> statement.execute("VACUUM INTO '$escapedTarget'") }
+        val generationAfter = readGenerationInTransaction(conn).value
+        PublicationEvidence(
+            generationBefore = generationBefore,
+            generationAfter = generationAfter,
+            moduleProgressCount = moduleProgressCount,
+            incompleteModuleCount = incompleteModuleCount,
+            pendingCount = pendingCount,
+            treeOid = treeOid,
+            indexSchema = SOURCE_INDEX_SCHEMA_VERSION,
+            producerVersion = producerVersion,
+        )
     }
 
     private fun readGenerationInTransaction(conn: Connection): SourceIndexGeneration =

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/RepositorySnapshotStoreTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/RepositorySnapshotStoreTest.kt
@@ -1,0 +1,142 @@
+package io.github.amichne.kast.indexstore
+
+import io.github.amichne.kast.indexstore.snapshot.BuildClasspathFingerprint
+import io.github.amichne.kast.indexstore.snapshot.ExtractionShardKey
+import io.github.amichne.kast.indexstore.snapshot.GitObjectId
+import io.github.amichne.kast.indexstore.snapshot.OverlayManifest
+import io.github.amichne.kast.indexstore.snapshot.ProducerVersion
+import io.github.amichne.kast.indexstore.snapshot.PublicationEvidence
+import io.github.amichne.kast.indexstore.snapshot.RepositorySnapshotSelector
+import io.github.amichne.kast.indexstore.snapshot.RepositorySnapshotStore
+import io.github.amichne.kast.indexstore.snapshot.SnapshotKey
+import io.github.amichne.kast.indexstore.snapshot.SnapshotManifest
+import io.github.amichne.kast.indexstore.snapshot.SnapshotPublicationResult
+import io.github.amichne.kast.indexstore.snapshot.SnapshotRetentionPins
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class RepositorySnapshotStoreTest {
+    @TempDir
+    lateinit var root: Path
+
+    @Test
+    fun `publishes only complete stable evidence and never rewrites a retained snapshot`() {
+        val source = root.resolve("source-index.db")
+        Files.writeString(source, "generation-one")
+        val store = RepositorySnapshotStore(root.resolve("repository"))
+        val first = manifest(tree = 'a', files = mapOf("src/A.kt" to oid('1')))
+
+        val published = store.publishMain(first, source, exactEvidence(first.key))
+        assertTrue(published is SnapshotPublicationResult.Published)
+        assertEquals(first.key, store.latestGood()?.key)
+
+        Files.writeString(source, "generation-two")
+        val rejected = store.publishMain(
+            manifest(tree = 'b', files = mapOf("src/B.kt" to oid('2'))),
+            source,
+            exactEvidence(first.key).copy(pendingCount = 1),
+        )
+
+        assertTrue(rejected is SnapshotPublicationResult.Rejected)
+        assertEquals(first.key, store.latestGood()?.key)
+        assertEquals("generation-one", Files.readString(store.snapshotDatabase(first.key)))
+        assertFalse(Files.isWritable(store.snapshotDatabase(first.key)))
+    }
+
+    @Test
+    fun `chooses the compatible retained tree with the cheapest direct manifest difference`() {
+        val target = manifest(
+            tree = 'f',
+            files = mapOf("A.kt" to oid('1'), "B.kt" to oid('2'), "C.kt" to oid('3')),
+        )
+        val expensive = manifest(tree = 'a', files = mapOf("A.kt" to oid('9')))
+        val cheapest = manifest(tree = 'b', files = mapOf("A.kt" to oid('1'), "B.kt" to oid('2')))
+        val incompatible = manifest(
+            tree = 'c',
+            files = target.files,
+            fingerprint = BuildClasspathFingerprint.parse("9".repeat(64)),
+        )
+
+        assertEquals(cheapest, RepositorySnapshotSelector.choose(target, listOf(expensive, incompatible, cheapest)))
+    }
+
+    @Test
+    fun `overlay is the direct retained tree to target tree delta`() {
+        val retained = manifest(
+            tree = 'a',
+            files = mapOf("gone.kt" to oid('1'), "same.kt" to oid('2'), "changed.kt" to oid('3')),
+        )
+        val target = manifest(
+            tree = 'b',
+            files = mapOf("same.kt" to oid('2'), "changed.kt" to oid('4'), "added.kt" to oid('5')),
+        )
+
+        val overlay = OverlayManifest.between(retained, target)
+
+        assertEquals(setOf("gone.kt"), overlay.tombstones)
+        assertEquals(setOf("added.kt", "changed.kt"), overlay.shards.keys)
+        assertEquals(
+            ExtractionShardKey(target.key.compatibility, oid('4')),
+            overlay.shards.getValue("changed.kt"),
+        )
+    }
+
+    @Test
+    fun `retention keeps latest eight main snapshots active targets and fresh merge bases`() {
+        val repository = root.resolve("repository")
+        val store = RepositorySnapshotStore(repository)
+        val source = root.resolve("source-index.db")
+        Files.writeString(source, "snapshot")
+        val snapshots = (('0'..'9') + 'a').mapIndexed { index, tree ->
+            manifest(tree, mapOf("$tree.kt" to oid('1'))).copy(createdAtEpochMillis = index.toLong())
+                .also { store.publishMain(it, source, exactEvidence(it.key)) }
+        }
+
+        store.garbageCollect(
+            SnapshotRetentionPins(
+                activeWorktreeTargets = setOf(snapshots[0].key),
+                mergeBaseLeases = mapOf(snapshots[1].key to 100L),
+                nowEpochMillis = 100L,
+                diskBudgetBytes = Long.MAX_VALUE,
+            ),
+        )
+
+        assertEquals(
+            snapshots.filterIndexed { index, _ -> index != 2 }.map { it.key }.toSet(),
+            store.retainedManifests().map { it.key }.toSet(),
+        )
+    }
+
+    private fun manifest(
+        tree: Char,
+        files: Map<String, GitObjectId>,
+        fingerprint: BuildClasspathFingerprint = BuildClasspathFingerprint.parse("8".repeat(64)),
+    ) = SnapshotManifest(
+        key = SnapshotKey(
+            treeOid = oid(tree),
+            buildClasspathFingerprint = fingerprint,
+            indexSchema = 8,
+            producerVersion = ProducerVersion.parse("0.13.9"),
+        ),
+        files = files,
+        createdAtEpochMillis = 1,
+    )
+
+    private fun exactEvidence(key: SnapshotKey) = PublicationEvidence(
+        generationBefore = 7,
+        generationAfter = 7,
+        moduleProgressCount = 2,
+        incompleteModuleCount = 0,
+        pendingCount = 0,
+        treeOid = key.treeOid,
+        indexSchema = key.indexSchema,
+        producerVersion = key.producerVersion,
+    )
+
+    private fun oid(character: Char) = GitObjectId.parse(character.toString().repeat(40))
+}

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SqliteSourceIndexStoreTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SqliteSourceIndexStoreTest.kt
@@ -17,6 +17,8 @@ import io.github.amichne.kast.indexstore.store.SourceIndexPageReadObserver
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import io.github.amichne.kast.indexstore.store.cache.kastCacheDirectory
 import io.github.amichne.kast.indexstore.store.cache.sourceIndexDatabasePath
+import io.github.amichne.kast.indexstore.snapshot.GitObjectId
+import io.github.amichne.kast.indexstore.snapshot.ProducerVersion
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -38,6 +40,25 @@ import kotlin.concurrent.thread
 class SqliteSourceIndexStoreTest {
     @TempDir
     lateinit var workspaceRoot: Path
+
+    @Test
+    fun `snapshot export carries complete stable progress and pending evidence`() {
+        val tree = GitObjectId.parse("a".repeat(40))
+        val producer = ProducerVersion.parse("test-producer")
+        SqliteSourceIndexStore(workspaceRoot).use { store ->
+            store.ensureSchema()
+            store.initializeModuleProgress(mapOf("main" to 1))
+            store.markModuleComplete("main", 1)
+
+            val exact = store.exportSnapshotDatabase(workspaceRoot.resolve("exact.db"), tree, producer)
+            assertTrue(exact.proves(key(tree, producer)))
+
+            store.appendPendingUpdate("remove_file", workspaceRoot.resolve("A.kt").toString(), null)
+            val pending = store.exportSnapshotDatabase(workspaceRoot.resolve("pending.db"), tree, producer)
+            assertFalse(pending.proves(key(tree, producer)))
+            assertEquals(1, pending.pendingCount)
+        }
+    }
 
     @Test
     fun `typed Gradle and package provenance round-trips and advances generation on every transition`() {
@@ -1283,6 +1304,16 @@ class SqliteSourceIndexStoreTest {
             packageEvidence = IndexedPackageEvidence.ProvenNamed(
                 IndexedPackageEvidence.CanonicalName.parse("demo"),
             ),
+        )
+
+    private fun key(tree: GitObjectId, producer: ProducerVersion) =
+        io.github.amichne.kast.indexstore.snapshot.SnapshotKey(
+            treeOid = tree,
+            buildClasspathFingerprint = io.github.amichne.kast.indexstore.snapshot.BuildClasspathFingerprint.parse(
+                "8".repeat(64),
+            ),
+            indexSchema = SOURCE_INDEX_SCHEMA_VERSION,
+            producerVersion = producer,
         )
 
     private fun gradleProject(


### PR DESCRIPTION
## Summary

- share immutable source-index snapshots across Git worktrees by repository identity
- bootstrap clean worktrees from the compatible retained snapshot with the cheapest direct manifest delta
- publish `main/latest-good` atomically only from complete, stable SQLite evidence
- retain recent main snapshots, active targets, and leased merge bases under a disk budget

## Validation

```shell
./gradlew :analysis-api:test --tests '*WorkspacePathsTest*' :index-store:test --tests '*RepositorySnapshotStoreTest*' :backend-idea:test --tests '*RepositorySnapshotIntegrationTest*' --no-daemon
```

Kast completed semantic analysis. Its IDE model retained one stale cross-module unresolved-reference diagnostic for the new SQLite export method; Gradle compilation and the focused tests pass.
