### PR TITLE
fix: require explicit IntelliJ binary for macOS indexing

### DIFF
--- a/cli-rs/src/runtime/idea_launch.rs
+++ b/cli-rs/src/runtime/idea_launch.rs
@@ -12,10 +12,13 @@ trait IdeaBackendLaunchOps {
 struct SystemIdeaBackendLaunchOps;
 
 impl IdeaBackendLaunchOps for SystemIdeaBackendLaunchOps {
-    fn launch(&self, command: &Path, workspace_root: &Path) -> Result<()> {
-        if command == Path::new("idea") && launch_default_jetbrains_app(workspace_root) {
-            return Ok(());
-        }
+    fn launch(&self, _command: &Path, workspace_root: &Path) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        let selected_command = macos_intellij_bin()?;
+        #[cfg(target_os = "macos")]
+        let command = selected_command.as_path();
+        #[cfg(not(target_os = "macos"))]
+        let command = _command;
         let launch_error = match Command::new(command).arg(workspace_root).spawn() {
             Ok(_) => return Ok(()),
             Err(error) => error,
@@ -55,19 +58,33 @@ impl IdeaBackendLaunchOps for SystemIdeaBackendLaunchOps {
 }
 
 #[cfg(target_os = "macos")]
-fn launch_default_jetbrains_app(workspace_root: &Path) -> bool {
-    ["IntelliJ IDEA", "Android Studio"].into_iter().any(|app_name| {
-        Command::new("open")
-            .args(["-g", "-n", "-a", app_name])
-            .arg(workspace_root)
-            .output()
-            .is_ok_and(|output| output.status.success())
-    })
-}
+fn macos_intellij_bin() -> Result<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
 
-#[cfg(not(target_os = "macos"))]
-fn launch_default_jetbrains_app(_workspace_root: &Path) -> bool {
-    false
+    let Some(value) =
+        std::env::var_os("KAST_INTELLIJ_BIN").filter(|value| !value.is_empty())
+    else {
+        return Err(CliError::new(
+            "KAST_INTELLIJ_BIN_REQUIRED",
+            "macOS IDEA autolaunch requires KAST_INTELLIJ_BIN. Set it to the exact IntelliJ executable, for example `/Applications/IntelliJ IDEA.app/Contents/MacOS/idea`.",
+        ));
+    };
+    let path = PathBuf::from(value);
+    let valid = path.is_absolute()
+        && fs::metadata(&path).is_ok_and(|metadata| {
+            metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+        });
+    if !valid {
+        let mut error = CliError::new(
+            "KAST_INTELLIJ_BIN_INVALID",
+            "KAST_INTELLIJ_BIN must be an absolute path to an executable IntelliJ binary.",
+        );
+        error
+            .details
+            .insert("KAST_INTELLIJ_BIN".to_string(), path.display().to_string());
+        return Err(error);
+    }
+    Ok(path)
 }
 
 fn maybe_launch_idea_backend(
@@ -81,7 +98,7 @@ fn maybe_launch_idea_backend(
         return Ok(None);
     }
     let launch_config = &config.runtime.idea_launch;
-    if !launch_config.enabled {
+    if !launch_config.enabled && !cfg!(target_os = "macos") {
         return Ok(None);
     }
     if !config.backends.idea.enabled {

--- a/cli-rs/src/runtime/tests.rs
+++ b/cli-rs/src/runtime/tests.rs
@@ -226,6 +226,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn idea_launch_is_skipped_unless_enabled_and_idea_is_selected() {
         let workspace = PathBuf::from("/work/kast");
@@ -243,6 +244,26 @@ mod tests {
 
         assert!(selected.is_none());
         assert!(ops.launches.borrow().is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn idea_launch_is_required_for_macos_idea_workspaces() {
+        let workspace = PathBuf::from("/work/kast");
+        let config = KastConfig::defaults();
+        let ops = FakeIdeaLaunchOps::ready();
+
+        let selected = maybe_launch_idea_backend(
+            &workspace,
+            &config,
+            RuntimeBackendPreference::Fixed(BackendName::Idea),
+            false,
+            &ops,
+        )
+        .unwrap();
+
+        assert!(selected.is_some());
+        assert_eq!(ops.launches.borrow().len(), 1);
     }
 
     #[test]

--- a/cli-rs/src/runtime/workspace.rs
+++ b/cli-rs/src/runtime/workspace.rs
@@ -33,7 +33,18 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
         config::PathResolutionMode::Cli,
     )?;
     let preference = runtime_backend_preference(&config, args.backend_name);
-    validate_macos_workspace_for_preference(&workspace_root, preference)?;
+    #[cfg(target_os = "macos")]
+    if preference.fixed_backend() == Some(BackendName::Idea)
+        && !is_gradle_workspace(&workspace_root)
+    {
+        return Err(CliError::new(
+            "SEMANTIC_WORKSPACE_UNSUPPORTED",
+            format!(
+                "{} is not a supported Kotlin Gradle workspace. Select a workspace containing settings.gradle(.kts) or build.gradle(.kts).",
+                workspace_root.display()
+            ),
+        ));
+    }
     let stale_descriptor_policy = if args.no_auto_start.unwrap_or(false) {
         StaleDescriptorPolicy::Preserve
     } else {
@@ -55,6 +66,7 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
         preference.backend_filter(),
         args.accept_indexing.unwrap_or(false),
     ) {
+        validate_macos_workspace_for_preference(&workspace_root, preference)?;
         return Ok(WorkspaceEnsureResult {
             workspace_root: workspace_root.display().to_string(),
             descriptor_directory: inspection.descriptor_directory.display().to_string(),
@@ -68,6 +80,7 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
     }
 
     if args.no_auto_start.unwrap_or(false) {
+        validate_macos_workspace_for_preference(&workspace_root, preference)?;
         return Err(no_backend_error(
             &workspace_root,
             preference.backend_filter(),
@@ -82,6 +95,7 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
         args.accept_indexing.unwrap_or(false),
         &idea_launch_ops,
     )? {
+        validate_macos_workspace_for_preference(&workspace_root, preference)?;
         return Ok(WorkspaceEnsureResult {
             workspace_root: workspace_root.display().to_string(),
             descriptor_directory: inspection.descriptor_directory.display().to_string(),
@@ -94,6 +108,7 @@ pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {
         });
     }
 
+    validate_macos_workspace_for_preference(&workspace_root, preference)?;
     let Some(launch_backend) = fallback_launch_backend(preference) else {
         return Err(CliError::new(
             "IDEA_NOT_RUNNING",

--- a/cli-rs/tests/semantic_workspace_admission_smoke.rs
+++ b/cli-rs/tests/semantic_workspace_admission_smoke.rs
@@ -557,6 +557,119 @@ fn agent_verify_never_runs_configured_idea_launch_command() {
     );
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_runtime_up_requires_and_uses_only_kast_intellij_bin() {
+    let fixture = tempfile::tempdir().expect("launch fixture");
+    let workspace = fixture.path().join("workspace");
+    let home = fixture.path().join("home");
+    let kast_home = fixture.path().join("kast-home");
+    let config_home = kast_home.join("current/config");
+    let configured_marker = fixture.path().join("configured-command-launched");
+    let configured_command = fixture.path().join("configured-command");
+    let selected_marker = fixture.path().join("selected-command-launched");
+    let selected_command = fixture.path().join("selected-command");
+    write_gradle_workspace(&workspace);
+    let workspace = std::fs::canonicalize(workspace).expect("canonical workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&config_home).expect("config home");
+    std::fs::write(
+        &configured_command,
+        format!("#!/bin/sh\ntouch '{}'\n", configured_marker.display()),
+    )
+    .expect("configured command");
+    let mut permissions = std::fs::metadata(&configured_command)
+        .expect("configured command metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&configured_command, permissions)
+        .expect("configured command executable");
+    std::fs::write(
+        &selected_command,
+        format!("#!/bin/sh\ntouch '{}'\n", selected_marker.display()),
+    )
+    .expect("selected command");
+    let mut permissions = std::fs::metadata(&selected_command)
+        .expect("selected command metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&selected_command, permissions).expect("selected command executable");
+    std::fs::write(
+        config_home.join("config.toml"),
+        format!(
+            "[runtime]\ndefaultBackend = \"headless\"\n\n[runtime.ideaLaunch]\nenabled = false\ncommand = \"{}\"\nwaitTimeoutMillis = 100\n",
+            configured_command.display()
+        ),
+    )
+    .expect("config");
+
+    let missing = kast(&home, &config_home)
+        .env("KAST_HOME", &kast_home)
+        .env_remove("KAST_INTELLIJ_BIN")
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "runtime",
+            "up",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+            "--backend=idea",
+        ])
+        .output()
+        .expect("runtime up without KAST_INTELLIJ_BIN");
+    let missing: serde_json::Value =
+        serde_json::from_slice(&missing.stdout).expect("missing variable JSON");
+    assert_eq!(missing["code"], "KAST_INTELLIJ_BIN_REQUIRED", "{missing:#}");
+
+    let invalid = kast(&home, &config_home)
+        .env("KAST_HOME", &kast_home)
+        .env("KAST_INTELLIJ_BIN", fixture.path().join("missing-idea"))
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "runtime",
+            "up",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+            "--backend=idea",
+        ])
+        .output()
+        .expect("runtime up with invalid KAST_INTELLIJ_BIN");
+    let invalid: serde_json::Value =
+        serde_json::from_slice(&invalid.stdout).expect("invalid variable JSON");
+    assert_eq!(invalid["code"], "KAST_INTELLIJ_BIN_INVALID", "{invalid:#}");
+
+    let selected = kast(&home, &config_home)
+        .env("KAST_HOME", &kast_home)
+        .env("KAST_INTELLIJ_BIN", &selected_command)
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "runtime",
+            "up",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+            "--backend=idea",
+        ])
+        .output()
+        .expect("runtime up with selected IntelliJ");
+    let selected: serde_json::Value =
+        serde_json::from_slice(&selected.stdout).expect("selected runtime JSON");
+
+    assert!(
+        selected_marker.exists(),
+        "runtime up must execute KAST_INTELLIJ_BIN before requiring plugin metadata: {selected:#}"
+    );
+    assert!(
+        !configured_marker.exists(),
+        "macOS runtime must not execute runtime.ideaLaunch.command"
+    );
+    assert_eq!(selected["code"], "RUNTIME_TIMEOUT", "{selected:#}");
+}
+
 #[test]
 fn reuse_only_verify_preserves_dead_descriptor_bytes_without_launching() {
     let fixture = tempfile::tempdir().expect("stale descriptor fixture");

--- a/install.sh
+++ b/install.sh
@@ -31,9 +31,10 @@ Options:
   -h, --help              Show this help.
 
 Environment:
-  KAST_HOME          Active install root. Defaults to ~/.local/share/kast.
-  KAST_RELEASES_URL  Release base URL. Defaults to the Kast GitHub releases.
-  NONINTERACTIVE=1   Never close a detected JetBrains IDE.
+  KAST_HOME           Active install root. Defaults to ~/.local/share/kast.
+  KAST_INTELLIJ_BIN   Exact IntelliJ executable required for macOS autolaunch.
+  KAST_RELEASES_URL   Release base URL. Defaults to the Kast GitHub releases.
+  NONINTERACTIVE=1    Never close a detected JetBrains IDE.
 USAGE
 }
 
@@ -170,6 +171,7 @@ reconcile_codex() {
 JETBRAINS_PROCESS_PIDS=()
 JETBRAINS_PROCESS_PRODUCTS=()
 JETBRAINS_PROCESS_EXECUTABLES=()
+DETECTED_INTELLIJ_BIN=""
 
 detect_running_jetbrains_ides() {
   local process_table pid executable product
@@ -191,9 +193,23 @@ detect_running_jetbrains_ides() {
   done <<<"$process_table"
 }
 
+remember_running_intellij_bin() {
+  local index executable
+  for ((index = 0; index < ${#JETBRAINS_PROCESS_EXECUTABLES[@]}; index += 1)); do
+    [[ "${JETBRAINS_PROCESS_PRODUCTS[$index]}" == "IntelliJ IDEA" ]] || continue
+    executable="${JETBRAINS_PROCESS_EXECUTABLES[$index]}"
+    if [[ -n "$DETECTED_INTELLIJ_BIN" && "$DETECTED_INTELLIJ_BIN" != "$executable" ]]; then
+      DETECTED_INTELLIJ_BIN=""
+      return
+    fi
+    DETECTED_INTELLIJ_BIN="$executable"
+  done
+}
+
 require_jetbrains_ides_closed() {
   local index reply="" deadline
   detect_running_jetbrains_ides
+  remember_running_intellij_bin
   ((${#JETBRAINS_PROCESS_PIDS[@]} > 0)) || return 0
   ui_warning "A JetBrains IDE must close before its plugin is updated"
   for ((index = 0; index < ${#JETBRAINS_PROCESS_PIDS[@]}; index += 1)); do
@@ -216,6 +232,48 @@ require_jetbrains_ides_closed() {
     sleep 1
   done
   die "timed out waiting for the detected JetBrains IDE to stop"
+}
+
+detect_installed_intellij_bin() {
+  local candidate found=""
+  if [[ -n "${KAST_INTELLIJ_BIN:-}" ]]; then
+    if [[ "$KAST_INTELLIJ_BIN" == /* && -f "$KAST_INTELLIJ_BIN" && -x "$KAST_INTELLIJ_BIN" ]]; then
+      DETECTED_INTELLIJ_BIN="$KAST_INTELLIJ_BIN"
+    else
+      DETECTED_INTELLIJ_BIN=""
+      ui_warning "KAST_INTELLIJ_BIN is not an absolute executable file"
+    fi
+    return 0
+  fi
+  [[ -z "$DETECTED_INTELLIJ_BIN" ]] || return 0
+  while IFS= read -r candidate; do
+    [[ -f "$candidate" && -x "$candidate" ]] || continue
+    if [[ -n "$found" && "$found" != "$candidate" ]]; then
+      ui_warning "Multiple IntelliJ executables detected; set KAST_INTELLIJ_BIN explicitly"
+      return
+    fi
+    found="$candidate"
+  done < <(
+    find \
+      "$HOME/Applications" \
+      /Applications \
+      "$HOME/Library/Application Support/JetBrains/Toolbox/apps" \
+      -path '*/IntelliJ IDEA*.app/Contents/MacOS/idea' \
+      -print 2>/dev/null
+  )
+  DETECTED_INTELLIJ_BIN="$found"
+}
+
+report_intellij_bin() {
+  local quoted
+  detect_installed_intellij_bin
+  if [[ -z "$DETECTED_INTELLIJ_BIN" ]]; then
+    ui_warning "IntelliJ was not detected; set KAST_INTELLIJ_BIN before using macOS autolaunch"
+    return
+  fi
+  printf -v quoted '%q' "$DETECTED_INTELLIJ_BIN"
+  ui_success "IntelliJ executable detected"
+  ui_detail "export KAST_INTELLIJ_BIN=${quoted}"
 }
 
 prompt_boolean() {
@@ -455,6 +513,7 @@ main() {
       ui_success "Installer prepared"
       require ps
       require_jetbrains_ides_closed
+      report_intellij_bin
       if ((configure == 1)); then
         config_defaults="${setup_scratch}/config.toml"
         configure_idea_defaults "$config_defaults"

--- a/tests/install_macos_test.sh
+++ b/tests/install_macos_test.sh
@@ -14,7 +14,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$scratch/bin" "$scratch/home"
+idea_bin="$scratch/home/Applications/IntelliJ IDEA.app/Contents/MacOS/idea"
+mkdir -p "$scratch/bin" "$scratch/home" "$(dirname "$idea_bin")"
+printf '%s\n' '#!/bin/sh' > "$idea_bin"
+chmod 755 "$idea_bin"
 printf '%s\n' '#!/bin/sh' 'if [ "$1" = "-s" ]; then printf "%s\\n" "${KAST_TEST_OS:-Darwin}"; else printf "%s\\n" "${KAST_TEST_ARCH:-arm64}"; fi' > "$scratch/bin/uname"
 printf '%s\n' '#!/bin/sh' 'output=""' 'url=""' 'while [ "$#" -gt 0 ]; do case "$1" in --output) output="$2"; shift 2 ;; *) url="$1"; shift ;; esac; done' 'printf "%s\\n" "$url" >> "$KAST_TEST_CURL_LOG"' ': > "$output"' > "$scratch/bin/curl"
 printf '%s\n' '#!/bin/sh' 'destination=""' 'while [ "$#" -gt 0 ]; do case "$1" in -d) destination="$2"; shift 2 ;; *) shift ;; esac; done' 'mkdir -p "$destination"' 'printf "%s\n" "#!/bin/sh" "printf \"%s\\n\" \"\$*\" > \"\$KAST_TEST_SETUP_ARGS\"" "while [ \"\$#\" -gt 0 ]; do case \"\$1\" in --config-defaults) cp \"\$2\" \"\$KAST_TEST_CONFIG_DEFAULTS\"; shift 2 ;; *) shift ;; esac; done" "printf \"%s\\n\" \"type: KAST_SETUP\" \"status: CURRENT\"" > "$destination/kast"' 'chmod 755 "$destination/kast"' > "$scratch/bin/unzip"
@@ -52,6 +55,8 @@ grep -Fq $'\033[36m◆\033[0m Downloading Kast CLI' "$scratch/stderr"
 grep -Fq $'\033[32m✓\033[0m Kast is ready' "$scratch/stderr"
 grep -Fq "$HOME/.local/bin is not on PATH" "$scratch/stderr"
 grep -Fq 'export PATH="$HOME/.local/bin:$PATH"' "$scratch/stderr"
+printf -v expected_idea_export 'export KAST_INTELLIJ_BIN=%q' "$idea_bin"
+grep -Fq "$expected_idea_export" "$scratch/stderr"
 if [[ -s "$scratch/stdout" ]]; then
   printf '%s\n' 'successful installer leaked the setup payload to stdout' >&2
   exit 1


### PR DESCRIPTION
## Summary

- launch Kast-viable Gradle workspaces in IDEA before requiring plugin metadata
- require an absolute executable `KAST_INTELLIJ_BIN` on macOS and remove the `open -n -a` application-name fallback
- best-effort detect IntelliJ during macOS installation and print a shell-safe environment assignment

## Validation

- `cargo test --manifest-path cli-rs/Cargo.toml --test semantic_workspace_admission_smoke macos_runtime_up_ -- --nocapture`
- `bash tests/install_macos_test.sh`