### PR TITLE
fix: resolve macOS golden pathway review findings

### DIFF
--- a/cli-rs/src/install/idea_plugin.rs
+++ b/cli-rs/src/install/idea_plugin.rs
@@ -52,14 +52,13 @@ fn setup_idea_plugin(
             )
             .is_ok()
         {
-            let legacy_backup = archive_legacy_installations(&targets)?;
             if let Some(config_defaults) = &config_defaults {
                 fs::write(
                     targets.current_link.join("config/config.toml"),
                     config_defaults,
                 )?;
             }
-            install_user_command(&targets)?;
+            let legacy_backup = install_current_idea_user_command(&targets)?;
             return Ok(idea_setup_result(
                 &targets,
                 (SetupStatus::Current, legacy_backup.as_deref()),
@@ -133,6 +132,30 @@ fn setup_idea_plugin(
             &installed_plugin,
         ))
     })
+}
+
+fn install_current_idea_user_command(targets: &ActivationTargetPaths) -> Result<Option<PathBuf>> {
+    let user_command = manifest::home_dir().join(".local/bin/kast");
+    let is_managed = fs::read_link(&user_command)
+        .is_ok_and(|target| target.starts_with(&targets.current_link));
+    if is_managed || fs::symlink_metadata(&user_command).is_err() {
+        install_user_command(targets)?;
+        return Ok(None);
+    }
+
+    let backup = targets
+        .resolved
+        .install_root
+        .join("backups/legacy-local-bin-kast");
+    fs::create_dir_all(backup.parent().expect("backup parent"))?;
+    manifest::remove_path(&backup)?;
+    fs::rename(&user_command, &backup)?;
+    if let Err(error) = install_user_command(targets) {
+        manifest::remove_path(&user_command)?;
+        fs::rename(&backup, &user_command)?;
+        return Err(error);
+    }
+    Ok(Some(backup))
 }
 
 fn idea_activation_target_paths(

--- a/cli-rs/src/install/idea_plugin.rs
+++ b/cli-rs/src/install/idea_plugin.rs
@@ -52,6 +52,7 @@ fn setup_idea_plugin(
             )
             .is_ok()
         {
+            let legacy_backup = archive_legacy_installations(&targets)?;
             if let Some(config_defaults) = &config_defaults {
                 fs::write(
                     targets.current_link.join("config/config.toml"),
@@ -61,7 +62,7 @@ fn setup_idea_plugin(
             install_user_command(&targets)?;
             return Ok(idea_setup_result(
                 &targets,
-                (SetupStatus::Current, None),
+                (SetupStatus::Current, legacy_backup.as_deref()),
                 &release_digest,
                 &cli_sha256,
                 &extracted_plugin_digest,

--- a/cli-rs/tests/setup_smoke.rs
+++ b/cli-rs/tests/setup_smoke.rs
@@ -98,6 +98,57 @@ fn setup_installs_native_cli_and_idea_plugin() {
 }
 
 #[test]
+fn current_idea_setup_archives_a_restored_unmanaged_user_command() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let kast_home = home.join(".local/share/kast");
+    let plugins = home.join("Library/Application Support/JetBrains/IntelliJIdea2026.2/plugins");
+    let plugin = write_idea_plugin_zip(temp.path(), "kast-idea.zip", b"plugin");
+    std::fs::create_dir_all(&plugins).expect("IDEA profile");
+    let run = || {
+        kast(&home, &kast_home.join("unused-config"))
+            .env_remove("KAST_CONFIG_HOME")
+            .env("KAST_HOME", &kast_home)
+            .env("KAST_MACHINE_IDE_STATE", "closed")
+            .args([
+                "--output",
+                "json",
+                "setup",
+                "--idea-plugin",
+                plugin.to_str().expect("plugin path"),
+            ])
+            .output()
+            .expect("kast setup")
+    };
+
+    assert!(run().status.success(), "initial setup should succeed");
+    let user_command = home.join(".local/bin/kast");
+    std::fs::remove_file(&user_command).expect("managed user command");
+    std::fs::write(&user_command, "unmanaged").expect("unmanaged user command");
+
+    let current = run();
+
+    assert!(
+        current.status.success(),
+        "current setup should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&current.stdout),
+        String::from_utf8_lossy(&current.stderr),
+    );
+    let result: serde_json::Value = serde_json::from_slice(&current.stdout).expect("setup result");
+    let backup = kast_home.join("backups/legacy-local-bin-kast");
+    assert_eq!(result["status"], "CURRENT");
+    assert_eq!(result["backup"], backup.display().to_string());
+    assert_eq!(
+        std::fs::read_to_string(backup).expect("archived unmanaged command"),
+        "unmanaged",
+    );
+    assert_eq!(
+        std::fs::read_link(user_command).expect("restored managed user command"),
+        kast_home.join("current/bin/kast"),
+    );
+}
+
+#[test]
 fn setup_rejects_multiple_supported_plugin_profiles_without_selection() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/cli-rs/tests/setup_smoke.rs
+++ b/cli-rs/tests/setup_smoke.rs
@@ -149,6 +149,49 @@ fn current_idea_setup_archives_a_restored_unmanaged_user_command() {
 }
 
 #[test]
+fn failed_current_idea_setup_preserves_unrelated_legacy_state() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let kast_home = home.join(".local/share/kast");
+    let plugins = home.join("Library/Application Support/JetBrains/IntelliJIdea2026.2/plugins");
+    let plugin = write_idea_plugin_zip(temp.path(), "kast-idea.zip", b"plugin");
+    std::fs::create_dir_all(&plugins).expect("IDEA profile");
+    let run = || {
+        kast(&home, &kast_home.join("unused-config"))
+            .env_remove("KAST_CONFIG_HOME")
+            .env("KAST_HOME", &kast_home)
+            .env("KAST_MACHINE_IDE_STATE", "closed")
+            .args([
+                "--output",
+                "json",
+                "setup",
+                "--idea-plugin",
+                plugin.to_str().expect("plugin path"),
+            ])
+            .output()
+            .expect("kast setup")
+    };
+
+    assert!(run().status.success(), "initial setup should succeed");
+    let local_bin = home.join(".local/bin");
+    std::fs::remove_file(local_bin.join("kast")).expect("managed user command");
+    std::fs::remove_dir(&local_bin).expect("empty command directory");
+    std::fs::write(&local_bin, "blocks command projection").expect("blocking command path");
+    let legacy_config = home.join(".config/kast/config.toml");
+    std::fs::create_dir_all(legacy_config.parent().expect("legacy config parent"))
+        .expect("legacy config directory");
+    std::fs::write(&legacy_config, "legacy").expect("legacy config");
+
+    let failed = run();
+
+    assert!(!failed.status.success(), "command projection should fail");
+    assert_eq!(
+        std::fs::read_to_string(legacy_config).expect("preserved legacy config"),
+        "legacy",
+    );
+}
+
+#[test]
 fn setup_rejects_multiple_supported_plugin_profiles_without_selection() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/docs/tutorials/first-compiler-backed-task.md
+++ b/docs/tutorials/first-compiler-backed-task.md
@@ -34,17 +34,17 @@ If you still need Kast, follow [Install or update Kast](../how-to/install-or-upd
 From the repository root, run:
 
 ```console
-kast ready --for kotlin
+kast developer runtime up --backend idea --accept-indexing
 ```
 
-A ready result means Kast found a compatible compiler-backed runtime for this
+A `READY` result means Kast found a compatible compiler-backed runtime for this
 exact root. If the project was closed, Kast background-opens it in the sole
 supported host. A new worktree is opened the same way and receives
 plugin-created metadata.
 
 If the result is `INDEXING`, the exact runtime is already reachable. Wait for
 Gradle import, IDEA/Kotlin indexing, and the Kast reference index, then rerun
-the check. If it reports a typed blocker, use the action it reports before
+the command. If it reports a typed blocker, use the action it reports before
 continuing.
 
 ## 2. Ask for a semantic explanation


### PR DESCRIPTION
## What
- Preserve and report a restored unmanaged user command during idempotent IDEA setup.
- Use the real IDEA runtime bootstrap command in the first compiler-backed task tutorial.

## Why
These are the two delayed Codex review findings from #443, which merged before that review was resolved.

## Validation
- `cargo test --manifest-path cli-rs/Cargo.toml --test setup_smoke`
- `cargo test --manifest-path cli-rs/Cargo.toml --test agent_command_surface_smoke`
- Task contract green proof

## Risk
- The setup change only affects a verified-current install when an unmanaged `~/.local/bin/kast` is present.