### PR TITLE
feat: expose agent lifecycle commands

### DIFF
--- a/cli-rs/src/cli/root.rs
+++ b/cli-rs/src/cli/root.rs
@@ -41,8 +41,12 @@ pub enum Command {
     Setup(SetupArgs),
     /// Verify that Kast is ready for a task.
     Ready(ReadyArgs),
+    /// Start or resume the workspace backend and indexing.
+    Start(RuntimeArgs),
     /// Check the current workspace status.
     Status(RuntimeArgs),
+    /// Stop indexing and the workspace backend.
+    Stop(RuntimeArgs),
     /// Explore a guided semantic story from this Kotlin repository.
     Demo(PublicDemoArgs),
     /// Developer and release-engineering commands.

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -226,7 +226,9 @@ fn run(cli: Cli, output_format: OutputFormat) -> Result<i32> {
         Command::Context(args) => run_context(args, output_format),
         Command::Setup(args) => run_setup(args, output_format),
         Command::Ready(args) => run_ready(args, output_format),
+        Command::Start(args) => run_runtime(cli::RuntimeCommand::Up(args), output_format),
         Command::Status(args) => run_runtime(cli::RuntimeCommand::Status(args), output_format),
+        Command::Stop(args) => run_runtime(cli::RuntimeCommand::Stop(args), output_format),
         Command::Demo(args) => demo::run_public(args, output_format),
         Command::Developer(args) => run_developer(args.command, output_format),
         Command::Doctor(args) => run_ready(args.into(), output_format),
@@ -282,8 +284,16 @@ fn run_context(args: cli::RuntimeArgs, output_format: OutputFormat) -> Result<i3
 fn context_command_hints() -> Vec<ContextCommandHint> {
     vec![
         ContextCommandHint {
-            command: "kast setup --source <bundle>".to_string(),
-            purpose: "Install or replace the complete verified Kast release.".to_string(),
+            command: "kast start --workspace-root <repo>".to_string(),
+            purpose: "Start or resume the workspace backend and indexing.".to_string(),
+        },
+        ContextCommandHint {
+            command: "kast status --workspace-root <repo>".to_string(),
+            purpose: "Inspect backend and indexing state.".to_string(),
+        },
+        ContextCommandHint {
+            command: "kast stop --workspace-root <repo>".to_string(),
+            purpose: "Stop indexing and the workspace backend.".to_string(),
         },
         ContextCommandHint {
             command: "kast agent verify --workspace-root <repo>".to_string(),

--- a/cli-rs/tests/cli_core_smoke.rs
+++ b/cli-rs/tests/cli_core_smoke.rs
@@ -9,6 +9,47 @@ fn help_lists_command(stdout: &str, command: &str) -> bool {
 }
 
 #[test]
+fn public_cli_exposes_start_status_and_stop() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let help = kast(&home, &config_home)
+        .arg("--help")
+        .output()
+        .expect("help");
+    assert!(help.status.success());
+    let stdout = String::from_utf8_lossy(&help.stdout);
+    for command in ["start", "status", "stop"] {
+        assert!(
+            help_lists_command(&stdout, command),
+            "missing {command}: {stdout}"
+        );
+    }
+
+    let context = kast(&home, &config_home)
+        .args([
+            "context",
+            "--workspace-root",
+            workspace.to_str().expect("workspace path"),
+        ])
+        .output()
+        .expect("context");
+    assert!(context.status.success());
+    let stdout = String::from_utf8_lossy(&context.stdout);
+    for command in [
+        "kast start --workspace-root <repo>",
+        "kast status --workspace-root <repo>",
+        "kast stop --workspace-root <repo>",
+    ] {
+        assert!(stdout.contains(command), "missing {command}: {stdout}");
+    }
+}
+
+#[test]
 fn public_cli_exposes_setup_and_no_retired_install_mutators() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");


### PR DESCRIPTION
## Summary

- expose root kast start, kast status, and kast stop lifecycle commands
- reuse the existing backend lifecycle operations, including indexing cancellation during stop
- advertise the lifecycle loop in the default agent context

## Verification

- cargo test --manifest-path cli-rs/Cargo.toml --locked --test cli_core_smoke public_cli_exposes_start_status_and_stop -- --exact
- git diff --cached --check