### PR TITLE
fix: stabilize index and graph rebuilds

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspacePaths.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspacePaths.kt
@@ -1,6 +1,10 @@
 package io.github.amichne.kast.api.client
 
 import io.github.amichne.kast.api.client.fields.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.Path
 
@@ -25,11 +29,14 @@ fun kastDataRoot(): Path = kastDataRoot(System::getenv, kastInstallRoot())
 fun kastDataRoot(
     envLookup: (String) -> String?,
     installRoot: Path,
-): Path = envLookup("KAST_DATA_HOME")
-    ?.trim()
-    ?.takeIf(String::isNotEmpty)
-    ?.let { Path(it).toAbsolutePath().normalize() }
-    ?: installRoot.resolve("state").toAbsolutePath().normalize()
+): Path {
+    val cliInstallRoot = envLookup("KAST_HOME")
+        ?.takeIf(String::isNotEmpty)
+        ?.let { Path(it).toAbsolutePath().normalize() }
+        ?: installRoot.toAbsolutePath().normalize()
+    return activeCliDataRoot(cliInstallRoot)
+        ?: cliInstallRoot.resolve("state/data").toAbsolutePath().normalize()
+}
 
 fun defaultDescriptorDirectory(): Path =
     configPath(KastConfig.defaults().paths.descriptorDir.value)
@@ -38,3 +45,15 @@ fun defaultSocketPath(workspaceRoot: Path): Path =
     WorkspaceIdentity.fromWorkspaceRoot(workspaceRoot).defaultSocketFile
 
 private fun configPath(value: String): Path = Path(value).toAbsolutePath().normalize()
+
+private fun activeCliDataRoot(installRoot: Path): Path? {
+    val receiptPath = installRoot.resolve("current/receipt.json")
+    if (!Files.isRegularFile(receiptPath)) return null
+    return runCatching {
+        val receipt = Json.parseToJsonElement(Files.readString(receiptPath)).jsonObject
+        require(receipt.getValue("tool").jsonPrimitive.content == "kast")
+        Path(receipt.getValue("roots").jsonObject.getValue("data").jsonPrimitive.content)
+            .toAbsolutePath()
+            .normalize()
+    }.getOrNull()
+}

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastConfigTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/KastConfigTest.kt
@@ -266,7 +266,7 @@ class KastConfigTest {
         val dataDirectory = resolver.workspaceDataDirectory(workspaceRoot)
 
         assertEquals(
-            installRoot.resolve("state/workspaces/git/github.com/amichne/kast/worktrees/workspace--${gitWorktreeHash(workspaceRoot, gitDir)}"),
+            installRoot.resolve("state/data/workspaces/git/github.com/amichne/kast/worktrees/workspace--${gitWorktreeHash(workspaceRoot, gitDir)}"),
             dataDirectory,
         )
         assertEquals(dataDirectory.resolve("cache"), resolver.workspaceCacheDirectory(workspaceRoot))
@@ -286,9 +286,9 @@ class KastConfigTest {
         val second = resolver.workspaceDataDirectory(workspaceRoot)
 
         assertEquals(first, second)
-        assertTrue(first.startsWith(installRoot.resolve("state/workspaces/local")))
+        assertTrue(first.startsWith(installRoot.resolve("state/data/workspaces/local")))
         assertTrue(
-            installRoot.resolve("state/workspaces/local-workspaces.json")
+            installRoot.resolve("state/data/workspaces/local-workspaces.json")
                 .readText()
                 .contains(workspaceRoot.toAbsolutePath().normalize().toString())
         )

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspacePathsTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/WorkspacePathsTest.kt
@@ -21,23 +21,34 @@ class WorkspacePathsTest {
     }
 
     @Test
-    fun `kast data root follows explicit environment authority`() {
-        val installRoot = tempDir.resolve("install-root")
-        val dataRoot = tempDir.resolve("generation-data")
-        val env = mapOf(kastDataHomeEnv to dataRoot.toString())
+    fun `kast data root follows active CLI receipt authority`() {
+        val configuredInstallRoot = tempDir.resolve("configured-install-root")
+        val cliInstallRoot = tempDir.resolve("cli-install-root")
+        val cliDataRoot = tempDir.resolve("cli-data-root")
+        val ignoredDataRoot = tempDir.resolve("ignored-data-root")
+        val receipt = cliInstallRoot.resolve("current/receipt.json")
+        Files.createDirectories(receipt.parent)
+        Files.writeString(
+            receipt,
+            """{"tool":"kast","roots":{"data":"$cliDataRoot"}}""",
+        )
+        val env = mapOf(
+            kastHomeEnv to cliInstallRoot.toString(),
+            kastDataHomeEnv to ignoredDataRoot.toString(),
+        )
 
         assertEquals(
-            dataRoot.toAbsolutePath().normalize(),
-            kastDataRoot(env::get, installRoot),
+            cliDataRoot.toAbsolutePath().normalize(),
+            kastDataRoot(env::get, configuredInstallRoot),
         )
     }
 
     @Test
-    fun `kast data root falls back to install state`() {
+    fun `kast data root falls back to CLI install state data`() {
         val installRoot = tempDir.resolve("install-root")
 
         assertEquals(
-            installRoot.resolve("state").toAbsolutePath().normalize(),
+            installRoot.resolve("state/data").toAbsolutePath().normalize(),
             kastDataRoot(emptyMap<String, String>()::get, installRoot),
         )
     }
@@ -84,7 +95,7 @@ class WorkspacePathsTest {
         val worktreeHash = gitWorktreeHash(workspaceRoot, gitDir)
 
         assertEquals(
-            installRoot.resolve("state/workspaces/git/github.com/amichne/kast/worktrees/workspace--$worktreeHash"),
+            installRoot.resolve("state/data/workspaces/git/github.com/amichne/kast/worktrees/workspace--$worktreeHash"),
             resolver.workspaceDataDirectory(workspaceRoot),
         )
     }
@@ -142,7 +153,7 @@ class WorkspacePathsTest {
 
         val first = resolver.workspaceDataDirectory(firstRoot)
         val second = resolver.workspaceDataDirectory(secondRoot)
-        val repository = installRoot.resolve("state/workspaces/git/github.com/amichne/kast")
+        val repository = installRoot.resolve("state/data/workspaces/git/github.com/amichne/kast")
 
         assertEquals(repository, resolver.repositoryDataDirectory(firstRoot))
         assertEquals(repository, resolver.repositoryDataDirectory(secondRoot))
@@ -185,7 +196,7 @@ class WorkspacePathsTest {
         )
 
         assertEquals(
-            installRoot.resolve("state/workspaces/git/local/${gitCommonDirHash(commonDir)}/worktrees/workspace--${gitWorktreeHash(workspaceRoot, gitDir)}"),
+            installRoot.resolve("state/data/workspaces/git/local/${gitCommonDirHash(commonDir)}/worktrees/workspace--${gitWorktreeHash(workspaceRoot, gitDir)}"),
             resolver.workspaceDataDirectory(workspaceRoot),
         )
     }
@@ -309,6 +320,7 @@ class WorkspacePathsTest {
     private companion object {
         val kastConfigHomeEnv: String = env("KAST", "CONFIG", "HOME")
         val kastDataHomeEnv: String = env("KAST", "DATA", "HOME")
+        val kastHomeEnv: String = env("KAST", "HOME")
 
         fun env(vararg parts: String): String = parts.joinToString("_")
     }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphOperations.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphOperations.kt
@@ -540,6 +540,7 @@ private fun KtNamedDeclaration.semanticModality(): SemanticGraphModality? = when
 
 private fun semanticTypeFacts(file: KtFile): List<SemanticGraphTypeFact> =
     PsiTreeUtil.findChildrenOfType(file, KtTypeReference::class.java)
+        .filter { reference -> reference.text.isNotBlank() }
         .map(::semanticTypeFact)
         .distinctBy(SemanticGraphTypeFact::stableKey)
         .sortedBy { type -> type.stableKey.value }
@@ -755,7 +756,7 @@ private fun projectableKind(declaration: KtNamedDeclaration): SemanticGraphSymbo
         SemanticGraphSymbolKind.FUNCTION
     }
     is KtProperty -> SemanticGraphSymbolKind.PROPERTY
-    is KtParameter -> SemanticGraphSymbolKind.VALUE_PARAMETER
+    is KtParameter -> if (declaration.parent?.parent is KtFunctionType) null else SemanticGraphSymbolKind.VALUE_PARAMETER
     is KtTypeParameter -> SemanticGraphSymbolKind.TYPE_PARAMETER
     is KtTypeAlias -> SemanticGraphSymbolKind.TYPE_ALIAS
     else -> null

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/NativeSemanticGraphBackendTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/NativeSemanticGraphBackendTest.kt
@@ -103,6 +103,20 @@ class NativeSemanticGraphBackendTest {
                 return localValue
             }
         """
+
+        private const val functionTypeParameterSource = """
+            package demo
+
+            typealias Resolver = (workspaceRoot: String) -> String
+        """
+
+        private const val enumSource = """
+            package demo
+
+            enum class Mode(val value: Int) {
+                VALUE(1),
+            }
+        """
     }
 
     private val moduleFixture = projectFixture.moduleFixture("main")
@@ -115,6 +129,9 @@ class NativeSemanticGraphBackendTest {
     private val leftTypeConsumerFixture = sourceRootFixture.psiFileFixture("LeftTypeConsumer.kt", leftTypeConsumer)
     private val rightTypeConsumerFixture = sourceRootFixture.psiFileFixture("RightTypeConsumer.kt", rightTypeConsumer)
     private val localPropertyFixture = sourceRootFixture.psiFileFixture("LocalProperty.kt", localPropertySource)
+    private val functionTypeParameterFixture =
+        sourceRootFixture.psiFileFixture("FunctionTypeParameter.kt", functionTypeParameterSource)
+    private val enumFixture = sourceRootFixture.psiFileFixture("Mode.kt", enumSource)
 
     @TempDir
     lateinit var storeRoot: Path
@@ -269,6 +286,58 @@ class NativeSemanticGraphBackendTest {
                 SemanticGraphVisibility.LOCAL,
                 snapshot.symbols.single { symbol -> symbol.name.value == "localValue" }.visibility,
             )
+        }
+    }
+
+    @Test
+    fun `function type parameters do not abort semantic graph extraction`() = runBlocking {
+        val project = projectFixture.get()
+        val sourceFile = functionTypeParameterFixture.get()
+        waitUntilIndexesAreReady(project)
+        val workspaceRoot = Path.of(sourceFile.virtualFile.path).toRealPath().parent
+
+        SqliteSourceIndexStore(storeRoot).use { store ->
+            store.ensureSchema()
+            KastPluginBackend(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                limits = limits(),
+                semanticGraphStore = store,
+                psiGeneration = { 1L },
+            ).use { backend ->
+                val result = backend.semanticGraph(
+                    SemanticGraphQuery(
+                        filePaths = listOf(SemanticGraphPath.parse(sourceFile.virtualFile.path)),
+                    ).parsed(),
+                )
+                assertTrue(result.symbolCount.value > 0)
+            }
+        }
+    }
+
+    @Test
+    fun `unnamed declarations do not break semantic graph extraction`() = runBlocking {
+        val project = projectFixture.get()
+        val sourceFile = enumFixture.get()
+        waitUntilIndexesAreReady(project)
+        val workspaceRoot = Path.of(sourceFile.virtualFile.path).toRealPath().parent
+
+        SqliteSourceIndexStore(storeRoot).use { store ->
+            store.ensureSchema()
+            KastPluginBackend(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                limits = limits(),
+                semanticGraphStore = store,
+                psiGeneration = { 1L },
+            ).use { backend ->
+                val result = backend.semanticGraph(
+                    SemanticGraphQuery(
+                        filePaths = listOf(SemanticGraphPath.parse(sourceFile.virtualFile.path)),
+                    ).parsed(),
+                )
+                assertTrue(result.symbolCount.value > 0)
+            }
         }
     }
 


### PR DESCRIPTION
## What
- Resolve plugin workspace databases from the active CLI receipt data root.
- Skip function-type parameters and blank compiler type references that cannot form graph facts.
- Add regressions for all three failures.

## Why
The CLI and IDEA plugin selected different source-index databases, while valid Kotlin declarations could abort graph extraction. Keeping these fixes together restores the index-to-graph rebuild path.

## Verification
- `./gradlew :analysis-api:test --no-daemon`
- `./gradlew :backend-idea:test --tests "io.github.amichne.kast.idea.NativeSemanticGraphBackendTest.function type parameters do not abort semantic graph extraction" --tests "io.github.amichne.kast.idea.NativeSemanticGraphBackendTest.unnamed declarations do not break semantic graph extraction" --no-daemon`