### PR TITLE
fix: close macOS development install transaction

### DIFF
--- a/.github/scripts/test-local-development-refresh-contract.sh
+++ b/.github/scripts/test-local-development-refresh-contract.sh
@@ -12,19 +12,23 @@ grep -Fq 'Replaces the active installation through the sole setup transaction.' 
 dry_run="$($repo_root/gradlew -m refreshDevelopmentMachine --no-daemon)"
 for task in \
   ':buildDevelopmentCli' \
-  ':packageDevelopmentCli' \
-  ':backend-headless:portableDistZip' \
   ':backend-idea:buildPlugin' \
-  ':packageDevelopmentSetupBundle' \
   ':refreshDevelopmentMachine'; do
   grep -Fq "$task" <<<"$dry_run" || { printf 'error: missing development setup task %s\n' "$task" >&2; exit 1; }
 done
 
-for retired in ':activateDevelopmentMachine' ':reconcileDevelopmentMachine'; do
-  ! grep -Fq "$retired" <<<"$dry_run" || { printf 'error: retired task remains: %s\n' "$retired" >&2; exit 1; }
+for unwanted in \
+  ':packageDevelopmentCli' \
+  ':backend-headless:portableDistZip' \
+  ':packageDevelopmentSetupBundle' \
+  ':activateDevelopmentMachine' \
+  ':reconcileDevelopmentMachine'; do
+  ! grep -Fq "$unwanted" <<<"$dry_run" || { printf 'error: unwanted development setup task remains: %s\n' "$unwanted" >&2; exit 1; }
 done
 
-grep -Fq '"setup",' "$repo_root/build.gradle.kts"
-grep -Fq '"--source",' "$repo_root/build.gradle.kts"
+refresh_task="$(sed -n '/tasks.register<Exec>("refreshDevelopmentMachine")/,/^}/p' "$repo_root/build.gradle.kts")"
+grep -Fq '"setup",' <<<"$refresh_task"
+grep -Fq '"--idea-plugin",' <<<"$refresh_task"
+! grep -Fq '"--source",' <<<"$refresh_task"
 
 printf '%s\n' 'local setup refresh contract passed'

--- a/.github/scripts/test-release-workflow-contract.sh
+++ b/.github/scripts/test-release-workflow-contract.sh
@@ -29,7 +29,7 @@ require "$ci" '.github/scripts/test-setup-contract.sh' 'CI must execute the sole
 require "$ci" '--plugin-archive "$plugin_asset"' 'CI setup bundles must include the verified IDEA plugin'
 require "$ci" 'scripts/verify-setup-bundle.sh' 'hosted-agent CI must enter through kast setup'
 require "$build" '"setup",' 'local development refresh must invoke kast setup'
-require "$build" '"--source",' 'local development refresh must pass one setup bundle'
+require "$build" '"--idea-plugin",' 'local development refresh must pass the IDEA plugin'
 
 require "$release" 'for platform in linux-x64 linux-arm64 macos-x64 macos-arm64' 'release must package every supported setup platform'
 for platform in linux-x64 linux-arm64 macos-x64 macos-arm64; do

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,10 +91,6 @@ val resolvedCargoExecutable = resolveCargoExecutable()
 val developmentIdeaPluginArchive: RegularFile = layout.projectDirectory.file(
     "backend-idea/build/distributions/backend-idea-${version}.zip",
 )
-val developmentCliArchive = layout.buildDirectory.file("setup/kast-cli.zip")
-val developmentBundle = layout.buildDirectory.file(
-    "setup/kast-ubuntu-debian-headless-x86_64-${version}.tar.gz",
-)
 
 val buildDevelopmentCli: TaskProvider<Exec> by tasks.registering(Exec::class) {
     group = "build"
@@ -109,44 +105,16 @@ val buildDevelopmentCli: TaskProvider<Exec> by tasks.registering(Exec::class) {
     )
 }
 
-val packageDevelopmentCli: TaskProvider<Zip> by tasks.registering(Zip::class) {
-    group = "distribution"
-    description = "Packages the development CLI for the setup bundle."
-    dependsOn(buildDevelopmentCli)
-    from(cliDevelopmentBinary)
-    archiveFileName.set("kast-cli.zip")
-    destinationDirectory.set(layout.buildDirectory.dir("setup"))
-}
-
-val packageDevelopmentSetupBundle: TaskProvider<Exec> by tasks.registering(Exec::class) {
-    group = "distribution"
-    description = "Builds one complete development setup bundle."
-    dependsOn(packageDevelopmentCli, ":backend-headless:portableDistZip", ":backend-idea:buildPlugin")
-    val backendArchive = project(":backend-headless").tasks.named<Zip>("portableDistZip")
-        .flatMap { task -> task.archiveFile }
-    commandLine(
-        cliDevelopmentBinary.asFile.absolutePath,
-        "developer", "release", "package", "ubuntu-debian-bundle",
-        "--repo-root", layout.projectDirectory.asFile.absolutePath,
-        "--cli-archive", developmentCliArchive.get().asFile.absolutePath,
-        "--backend-archive", backendArchive.get().asFile.absolutePath,
-        "--plugin-archive",
-        developmentIdeaPluginArchive.asFile.absolutePath,
-        "--version", project.version.toString(),
-        "--bundle-output", developmentBundle.get().asFile.absolutePath,
-    )
-}
-
 tasks.register<Exec>("refreshDevelopmentMachine") {
     group = "distribution"
     description = "Replaces the active installation through the sole setup transaction."
-    dependsOn(packageDevelopmentSetupBundle)
+    dependsOn(buildDevelopmentCli, ":backend-idea:buildPlugin")
     commandLine(
         cliDevelopmentBinary.asFile.absolutePath,
         "--output",
         "json",
         "setup",
-        "--source",
-        developmentBundle.get().asFile.absolutePath,
+        "--idea-plugin",
+        developmentIdeaPluginArchive.asFile.absolutePath,
     )
 }

--- a/cli-rs/src/install/idea_plugin.rs
+++ b/cli-rs/src/install/idea_plugin.rs
@@ -72,9 +72,7 @@ fn setup_idea_plugin(
 
         let plugin_is_current = directory_sha256(&installed_plugin).ok().as_deref()
             == Some(extracted_plugin_digest.as_str());
-        if !plugin_is_current {
-            require_jetbrains_ides_closed()?;
-        }
+        require_jetbrains_ides_closed()?;
         let config_defaults = idea_config_defaults(&targets, config_defaults.as_deref())?;
         let legacy_backup = archive_legacy_installations(&targets)?;
         let (previous, release_backup) = install_idea_release(
@@ -225,6 +223,14 @@ fn idea_config_defaults(
     if !previous.is_file() {
         return Ok(DEFAULT_IDEA_CONFIG.to_string());
     }
+    let previous_receipt = targets
+        .current_link
+        .join(manifest::INSTALL_MANIFEST_FILE);
+    if !manifest_from_file(&previous_receipt)
+        .is_ok_and(|receipt| receipt.profile == "macos-idea")
+    {
+        return Ok(DEFAULT_IDEA_CONFIG.to_string());
+    }
     let contents = fs::read_to_string(previous)?;
     config::validate_toml(&contents)?;
     migrate_missing_idea_launch_choice(contents)
@@ -232,6 +238,15 @@ fn idea_config_defaults(
 
 fn migrate_missing_idea_launch_choice(mut contents: String) -> Result<String> {
     let mut value: toml::Value = toml::from_str(&contents)?;
+    if value
+        .get("runtime")
+        .and_then(toml::Value::as_table)
+        .and_then(|runtime| runtime.get("defaultBackend"))
+        .and_then(toml::Value::as_str)
+        == Some("headless")
+    {
+        return Ok(DEFAULT_IDEA_CONFIG.to_string());
+    }
     if let Some(launch) = value
         .get_mut("runtime")
         .and_then(toml::Value::as_table_mut)
@@ -302,12 +317,18 @@ fn install_idea_plugin(source: &Path, target: &Path) -> Result<Option<PathBuf>> 
     let parent = target
         .parent()
         .ok_or_else(|| CliError::new("IDE_PROFILE_INVALID", "IDE plugin target has no parent."))?;
+    let profile = parent.parent().ok_or_else(|| {
+        CliError::new(
+            "IDE_PROFILE_INVALID",
+            "IDE plugin directory has no profile root.",
+        )
+    })?;
     fs::create_dir_all(parent)?;
     let staging = parent.join(format!(".kast-staging-{}", std::process::id()));
     manifest::remove_path(&staging)?;
     copy_bundle_tree(source, &staging)?;
     let backup = if fs::symlink_metadata(target).is_ok() {
-        let backup = parent.join(format!(".kast-backup-{}", std::process::id()));
+        let backup = profile.join(".kast-plugin-backup");
         manifest::remove_path(&backup)?;
         fs::rename(target, &backup)?;
         Some(backup)

--- a/cli-rs/tests/setup_smoke.rs
+++ b/cli-rs/tests/setup_smoke.rs
@@ -222,9 +222,7 @@ fn setup_rejects_multiple_supported_plugin_profiles_without_selection() {
 }
 
 #[test]
-fn matching_plugin_is_not_replaced_while_idea_runs() {
-    use std::os::unix::fs::MetadataExt;
-
+fn changed_cli_requires_a_running_ide_to_close() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let kast_home = home.join(".local/share/kast");
@@ -251,23 +249,15 @@ fn matching_plugin_is_not_replaced_while_idea_runs() {
         command("closed").status.success(),
         "initial setup should succeed",
     );
-    let installed_plugin = plugins.join("kast/lib/plugin.jar");
-    let plugin_inode = std::fs::metadata(&installed_plugin)
-        .expect("installed plugin")
-        .ino();
     std::fs::write(kast_home.join("current/bin/kast"), "drifted CLI").expect("drift active CLI");
-    let current = command("open");
+    let blocked = command("open");
 
-    assert!(
-        current.status.success(),
-        "CLI repair should preserve the matching plugin while IDEA runs: {}",
-        String::from_utf8_lossy(&current.stdout),
-    );
+    assert!(!blocked.status.success());
+    let result: serde_json::Value = serde_json::from_slice(&blocked.stdout).expect("setup failure");
+    assert_eq!(result["code"], "IDE_RESTART_REQUIRED");
     assert_eq!(
-        std::fs::metadata(installed_plugin)
-            .expect("preserved plugin")
-            .ino(),
-        plugin_inode,
+        std::fs::read(plugins.join("kast/lib/plugin.jar")).expect("installed plugin"),
+        b"plugin",
     );
 }
 
@@ -305,6 +295,108 @@ fn changed_plugin_requires_a_running_ide_to_close() {
     assert_eq!(
         std::fs::read(plugins.join("kast/lib/plugin.jar")).expect("installed plugin"),
         b"plugin",
+    );
+}
+
+#[test]
+fn macos_idea_setup_closes_plugin_and_config_authority() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let kast_home = home.join(".local/share/kast");
+    let headless = write_install_bundle_source(temp.path(), "v9.8.7");
+    let headless_setup = setup(&home, &kast_home, &headless);
+    assert!(
+        headless_setup.status.success(),
+        "headless setup should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&headless_setup.stdout),
+        String::from_utf8_lossy(&headless_setup.stderr),
+    );
+    let plugins = home.join("Library/Application Support/JetBrains/IntelliJIdea2026.2/plugins");
+    std::fs::create_dir_all(plugins.join("kast/lib")).expect("existing IDEA plugin");
+    std::fs::write(plugins.join("kast/lib/plugin.jar"), b"old plugin")
+        .expect("existing plugin contents");
+    let plugin = write_idea_plugin_zip(temp.path(), "kast-idea.zip", b"new plugin");
+
+    let output = kast(&home, &kast_home.join("unused-config"))
+        .env_remove("KAST_CONFIG_HOME")
+        .env("KAST_HOME", &kast_home)
+        .env("KAST_MACHINE_IDE_STATE", "closed")
+        .args([
+            "setup",
+            "--idea-plugin",
+            plugin.to_str().expect("plugin path"),
+            "--idea-plugins-dir",
+            plugins.to_str().expect("plugins path"),
+        ])
+        .output()
+        .expect("kast setup");
+
+    assert!(
+        output.status.success(),
+        "IDEA setup should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let mut plugin_backups = std::fs::read_dir(&plugins)
+        .expect("plugins directory")
+        .filter_map(std::result::Result::ok)
+        .map(|entry| entry.file_name())
+        .filter(|name| name.to_string_lossy().starts_with(".kast-backup-"))
+        .collect::<Vec<_>>();
+    plugin_backups.sort();
+    let config = std::fs::read_to_string(kast_home.join("current/config/config.toml"))
+        .expect("IDEA defaults");
+    assert_eq!(
+        (plugin_backups, config),
+        (
+            vec![],
+            "[runtime]\ndefaultBackend = \"idea\"\n\n[runtime.ideaLaunch]\nenabled = true\n\n[backends.headless]\nenabled = false\n\n[backends.idea]\nenabled = true\n"
+                .to_string(),
+        ),
+    );
+}
+
+#[test]
+fn macos_idea_setup_repairs_headless_defaults_from_prior_broken_setup() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let kast_home = home.join(".local/share/kast");
+    let plugins = home.join("Library/Application Support/JetBrains/IntelliJIdea2026.2/plugins");
+    std::fs::create_dir_all(&plugins).expect("IDEA profile");
+    let plugin = write_idea_plugin_zip(temp.path(), "kast-idea.zip", b"plugin revision 1");
+    let run = || {
+        kast(&home, &kast_home.join("unused-config"))
+            .env_remove("KAST_CONFIG_HOME")
+            .env("KAST_HOME", &kast_home)
+            .env("KAST_MACHINE_IDE_STATE", "closed")
+            .args([
+                "setup",
+                "--idea-plugin",
+                plugin.to_str().expect("plugin path"),
+            ])
+            .output()
+            .expect("kast setup")
+    };
+    assert!(run().status.success(), "initial setup should succeed");
+    std::fs::write(
+        kast_home.join("current/config/config.toml"),
+        "[runtime]\ndefaultBackend = \"headless\"\n\n[backends.headless]\nenabled = true\n",
+    )
+    .expect("broken headless defaults");
+    write_idea_plugin_zip(temp.path(), "kast-idea.zip", b"plugin revision 2");
+
+    let output = run();
+
+    assert!(
+        output.status.success(),
+        "repair setup should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        std::fs::read_to_string(kast_home.join("current/config/config.toml"))
+            .expect("repaired IDEA defaults"),
+        "[runtime]\ndefaultBackend = \"idea\"\n\n[runtime.ideaLaunch]\nenabled = true\n\n[backends.headless]\nenabled = false\n\n[backends.idea]\nenabled = true\n",
     );
 }
 


### PR DESCRIPTION
## Summary

- Route `refreshDevelopmentMachine` through the macOS IDEA setup transaction instead of packaging a Linux/headless bundle.
- Keep plugin rollback state outside JetBrains plugin scanning and normalize invalid preserved headless configuration to IDEA defaults.
- Require the supported IDEA close/reopen handoff for every non-current generation so CLI, plugin, and exact-root workspace metadata cannot split.

## Root cause

Development refresh combined a macOS IDEA plugin with an Ubuntu/headless setup bundle. The installer could also leave rollback plugins inside JetBrains scanning, preserve headless defaults, and advance a changed CLI while the open IDE still referenced the prior generation.

## Validation

Branch-local:

- `.github/scripts/test-local-development-refresh-contract.sh`
- `cargo test --manifest-path cli-rs/Cargo.toml --test setup_smoke` — 22 passed
- `git diff --check`

Live machine with the identical patch:

- `./gradlew refreshDevelopmentMachine --console=plain` converged to one release digest and returned `CURRENT` on repeat
- `kast developer runtime up --workspace-root "$PWD" --backend idea --accept-indexing` reached `READY`
- `kast ready --workspace-root "$PWD" --for agent --output toon` reported zero issues and warnings
- The active receipt, config, CLI, plugin, backend, and workspace metadata agreed on one revision; JetBrains scanned only `plugins/kast`

## Operational change

A non-current development generation now returns typed `IDE_RESTART_REQUIRED` until IDEA is closed. An already-current generation remains an open-IDE no-op.