### PR TITLE
perf: parallelize phase-two reference indexing

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/indexing/IdeaProjectIndexer.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/indexing/IdeaProjectIndexer.kt
@@ -42,7 +42,12 @@ internal class IdeaProjectIndexer(
                 dependentModuleGraph = buildIdeaDependencyGraph(moduleSpecs),
                 depth = config.indexing.phase2PriorityDepth.value,
             )
-            indexReferences(currentFilePaths, modulePriorityOrder, config.indexing.referenceBatchSize.value)
+            indexReferences(
+                currentFilePaths = currentFilePaths,
+                moduleOrder = modulePriorityOrder,
+                batchSize = config.indexing.phase2BatchSize.value,
+                parallelism = config.indexing.phase2Parallelism.value,
+            )
         }
     }
 
@@ -73,7 +78,8 @@ internal class IdeaProjectIndexer(
     private fun indexReferences(
         currentFilePaths: Collection<String>,
         moduleOrder: List<String>,
-        referenceBatchSize: Int,
+        batchSize: Int,
+        parallelism: Int,
     ) {
         if (currentFilePaths.isEmpty()) return
         val fileModuleByPath = currentFilePaths
@@ -112,7 +118,7 @@ internal class IdeaProjectIndexer(
                 environment.findPsiFile(path)?.let(::moduleNameForFile)
             },
         )
-        ReferenceIndexer(store, batchSize = referenceBatchSize).indexReferences(
+        ReferenceIndexer(store, batchSize = batchSize, parallelism = parallelism).indexReferences(
             filePaths = orderedFilePaths,
             referenceScanner = scanner::scanFileReferences,
             declarationScanner = scanner::scanFileDeclarations,

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/indexing/ReferenceIndexer.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/indexing/ReferenceIndexer.kt
@@ -5,6 +5,7 @@ import io.github.amichne.kast.indexstore.api.reference.SymbolReferenceRow
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import java.util.concurrent.Callable
 import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
@@ -38,22 +39,27 @@ class ReferenceIndexer(
         isCancelled: () -> Boolean = { Thread.currentThread().isInterrupted },
         onFilesIndexed: (Collection<String>) -> Unit = {},
     ) {
-        for (batch in filePaths.toList().chunked(batchSize)) {
-            if (isCancelled()) break
-            val referenceResults = scanBatch(batch, referenceScanner, isCancelled)
-            if (isCancelled()) break
+        val executor = createExecutor()
+        try {
+            for (batch in filePaths.asSequence().chunked(batchSize)) {
+                if (isCancelled()) break
+                val referenceResults = scanBatch(batch, referenceScanner, isCancelled, executor)
+                if (isCancelled()) break
 
-            val declarationResults = declarationScanner?.let { scanner ->
-                scanBatch(batch, scanner, isCancelled)
-            }
-            if (isCancelled()) break
+                val declarationResults = declarationScanner?.let { scanner ->
+                    scanBatch(batch, scanner, isCancelled, executor)
+                }
+                if (isCancelled()) break
 
-            store.replaceReferencesFromFiles(referenceResults)
-            if (declarationResults != null) {
-                store.replaceDeclarationsFromFiles(declarationResults)
+                store.replaceReferencesFromFiles(referenceResults)
+                if (declarationResults != null) {
+                    store.replaceDeclarationsFromFiles(declarationResults)
+                }
+                if (isCancelled()) break
+                onFilesIndexed(batch)
             }
-            if (isCancelled()) break
-            onFilesIndexed(batch)
+        } finally {
+            executor?.shutdownNow()
         }
     }
 
@@ -85,9 +91,10 @@ class ReferenceIndexer(
         batch: List<String>,
         scanner: (String) -> T,
         isCancelled: () -> Boolean,
+        executor: ExecutorService?,
     ): List<Pair<String, T>> =
-        if (parallelism > 1) {
-            scanBatchParallel(batch, scanner, isCancelled)
+        if (executor != null) {
+            scanBatchParallel(batch, scanner, isCancelled, executor)
         } else {
             batch.mapNotNull { filePath ->
                 if (isCancelled()) return@mapNotNull null
@@ -111,41 +118,43 @@ class ReferenceIndexer(
         batch: List<String>,
         scanner: (String) -> T,
         isCancelled: () -> Boolean,
+        executor: ExecutorService,
     ): List<Pair<String, T>> {
+        val futures = batch.map { filePath ->
+            executor.submit(
+                Callable<Pair<String, T>?> {
+                    if (isCancelled()) return@Callable null
+                    try {
+                        filePath to scanner(filePath)
+                    } catch (error: Exception) {
+                        if (error.isCancellation()) throw error
+                        null
+                    }
+                },
+            )
+        }
+        return futures.mapNotNull { future ->
+            try {
+                future.get()
+            } catch (e: ExecutionException) {
+                val cause = e.cause ?: return@mapNotNull null
+                if (cause.isCancellation()) throw cause
+                if (cause !is Exception) throw cause
+                null
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw InterruptedException("Interrupted while awaiting parallel scan result")
+            }
+        }
+    }
+
+    private fun createExecutor(): ExecutorService? {
+        if (parallelism == 1) return null
         val threadCounter = AtomicInteger(0)
-        val executor = Executors.newFixedThreadPool(parallelism) { runnable ->
+        return Executors.newFixedThreadPool(parallelism) { runnable ->
             Thread(runnable, "kast-ref-indexer-${threadCounter.incrementAndGet()}").apply {
                 isDaemon = true
             }
-        }
-        return try {
-            val futures = batch.map { filePath ->
-                executor.submit(
-                    Callable<Pair<String, T>?> {
-                        if (isCancelled()) return@Callable null
-                        try {
-                            filePath to scanner(filePath)
-                        } catch (error: Exception) {
-                            if (error.isCancellation()) throw error
-                            null
-                        }
-                    },
-                )
-            }
-            futures.mapNotNull { future ->
-                try {
-                    future.get()
-                } catch (e: ExecutionException) {
-                    val cause = e.cause ?: return@mapNotNull null
-                    if (cause.isCancellation()) throw cause
-                    null
-                } catch (e: InterruptedException) {
-                    Thread.currentThread().interrupt()
-                    throw InterruptedException("Interrupted while awaiting parallel scan result")
-                }
-            }
-        } finally {
-            executor.shutdownNow()
         }
     }
 

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/codec/PathInterningCodec.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/codec/PathInterningCodec.kt
@@ -63,6 +63,8 @@ internal class PathInterningCodec(
 
     fun loadPrefixes(conn: Connection) = interning.loadAll(conn)
 
+    fun reloadPrefixes(conn: Connection) = interning.reloadAll(conn)
+
     fun resolvePrefix(prefixId: Int): String =
         interning.resolve(prefixId)
 

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/codec/StringInterningCodec.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/codec/StringInterningCodec.kt
@@ -8,28 +8,52 @@ internal class StringInterningCodec(
     private val idColumn: String,
     private val valueColumn: String,
 ) {
-    private val valueToId = ConcurrentHashMap<String, Int>()
-    private val idToValue = ConcurrentHashMap<Int, String>()
+    @Volatile
+    private var valueToId = ConcurrentHashMap<String, Int>()
+
+    @Volatile
+    private var idToValue = ConcurrentHashMap<Int, String>()
 
     @Volatile
     private var loaded = false
 
+    /**
+     * Hydrates the cache once for the current connection lifecycle.
+     */
     fun loadAll(conn: Connection) {
-        val loadedValues = mutableMapOf<String, Int>()
-        val loadedIds = mutableMapOf<Int, String>()
-        conn.createStatement().use { stmt ->
-            val rs = stmt.executeQuery("SELECT $idColumn, $valueColumn FROM $tableName")
-            while (rs.next()) {
-                val id = rs.getInt(1)
-                val value = rs.getString(2)
-                loadedValues[value] = id
-                loadedIds[id] = value
+        if (loaded) return
+        synchronized(this) {
+            if (!loaded) reloadAllLocked(conn)
+        }
+    }
+
+    fun reloadAll(conn: Connection) {
+        synchronized(this) {
+            loaded = false
+            reloadAllLocked(conn)
+        }
+    }
+
+    private fun reloadAllLocked(conn: Connection) {
+        val rowCount = conn.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT COUNT(*) FROM $tableName").use { rs ->
+                if (rs.next()) rs.getInt(1) else 0
             }
         }
-        valueToId.clear()
-        valueToId.putAll(loadedValues)
-        idToValue.clear()
-        idToValue.putAll(loadedIds)
+        val loadedValues = ConcurrentHashMap<String, Int>(rowCount)
+        val loadedIds = ConcurrentHashMap<Int, String>(rowCount)
+        conn.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT $idColumn, $valueColumn FROM $tableName").use { rs ->
+                while (rs.next()) {
+                    val id = rs.getInt(1)
+                    val value = rs.getString(2)
+                    loadedValues[value] = id
+                    loadedIds[id] = value
+                }
+            }
+        }
+        valueToId = loadedValues
+        idToValue = loadedIds
         loaded = true
     }
 
@@ -54,7 +78,8 @@ internal class StringInterningCodec(
         values: Set<String>,
     ) {
         ensureLoaded(conn)
-        val missingValues = values.filterNot { valueToId.containsKey(it) }
+        val missingValues = ArrayList<String>(values.size)
+        values.filterTo(missingValues) { !valueToId.containsKey(it) }
         if (missingValues.isEmpty()) return
         conn.prepareStatement("INSERT OR IGNORE INTO $tableName ($valueColumn) VALUES (?)").use { stmt ->
             for (value in missingValues) {
@@ -63,7 +88,7 @@ internal class StringInterningCodec(
             }
             stmt.executeBatch()
         }
-        loadAll(conn)
+        loadValues(conn, missingValues)
     }
 
     fun resolve(id: Int): String =
@@ -75,6 +100,33 @@ internal class StringInterningCodec(
 
     private fun ensureLoaded(conn: Connection) {
         if (!loaded) loadAll(conn)
+    }
+
+    private fun loadValues(
+        conn: Connection,
+        values: List<String>,
+    ) {
+        var start = 0
+        while (start < values.size) {
+            val end = minOf(start + SQLITE_QUERY_BATCH_SIZE, values.size)
+            val batch = values.subList(start, end)
+            val placeholders = batch.joinToString(",") { "?" }
+            conn.prepareStatement(
+                "SELECT $idColumn, $valueColumn FROM $tableName WHERE $valueColumn IN ($placeholders)",
+            ).use { stmt ->
+                batch.forEachIndexed { index, value -> stmt.setString(index + 1, value) }
+                stmt.executeQuery().use { rs ->
+                    while (rs.next()) {
+                        val id = rs.getInt(1)
+                        val value = rs.getString(2)
+                        valueToId[value] = id
+                        idToValue[id] = value
+                    }
+                }
+            }
+            start = end
+        }
+        check(values.all(valueToId::containsKey)) { "Failed to load newly interned values from $tableName" }
     }
 
     private fun selectId(
@@ -90,4 +142,8 @@ internal class StringInterningCodec(
                 throw IllegalStateException("Failed to intern value in $tableName: $value")
             }
         }
+
+    private companion object {
+        const val SQLITE_QUERY_BATCH_SIZE = 900
+    }
 }

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/sqlite/lifecycle/SqliteSourceIndexStoreState.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/sqlite/lifecycle/SqliteSourceIndexStoreState.kt
@@ -43,6 +43,9 @@ internal class SqliteSourceIndexStoreState(
     @Volatile
     private var validatedSchemaConnection: Connection? = null
 
+    @Volatile
+    private var loadedInterningDataVersion: Long? = null
+
     internal fun dbExists(): Boolean = Files.isRegularFile(dbPath)
 
     internal fun connection(requireCurrentSchema: Boolean = true): Connection {
@@ -66,6 +69,7 @@ internal class SqliteSourceIndexStoreState(
                 runCatching { conn.close() }
                 cachedConnection = null
                 validatedSchemaConnection = null
+                loadedInterningDataVersion = null
             }
             Files.createDirectories(dbPath.parent)
             SqliteJdbcDriverBootstrap.ensureRegistered()
@@ -91,7 +95,7 @@ internal class SqliteSourceIndexStoreState(
                 if (requireCurrentSchema) {
                     schema.validateCurrentSchema(conn)
                     initializeRepositoryOverlay(conn)
-                    loadInterningTables(conn)
+                    reloadInterningTables(conn)
                 }
                 cachedConnection = conn
                 validatedSchemaConnection = conn.takeIf { requireCurrentSchema }
@@ -166,12 +170,15 @@ internal class SqliteSourceIndexStoreState(
         validatedSchemaConnection = conn
     }
 
+    internal fun isSchemaValidated(conn: Connection): Boolean = validatedSchemaConnection === conn
+
     override fun close() {
         synchronized(connectionLock) {
             cachedConnection?.let { conn ->
                 runCatching { conn.close() }
                 cachedConnection = null
                 validatedSchemaConnection = null
+                loadedInterningDataVersion = null
             }
         }
     }
@@ -205,13 +212,30 @@ internal class SqliteSourceIndexStoreState(
     }
 
     internal fun loadInterningTables(conn: Connection) {
-        pathCodec.loadPrefixes(conn)
-        fqCodec.loadAll(conn)
+        val dataVersion = readDataVersion(conn)
+        if (loadedInterningDataVersion != dataVersion) {
+            reloadInterningTables(conn, dataVersion)
+        }
+    }
+
+    internal fun reloadInterningTables(conn: Connection) {
+        loadedInterningDataVersion = null
+        reloadInterningTables(conn, readDataVersion(conn))
+    }
+
+    private fun reloadInterningTables(conn: Connection, dataVersion: Long) {
+        loadedInterningDataVersion = null
+        try {
+            pathCodec.reloadPrefixes(conn)
+        } finally {
+            fqCodec.reloadAll(conn)
+        }
+        loadedInterningDataVersion = dataVersion
     }
 
     internal fun rollbackAndReloadPrefixes(conn: Connection) {
         conn.rollback()
-        runCatching { loadInterningTables(conn) }
+        runCatching { reloadInterningTables(conn) }
     }
 
     internal fun decodeNullablePath(
@@ -225,6 +249,14 @@ internal class SqliteSourceIndexStoreState(
         }
         return pathCodec.decode(prefixId, filename)
     }
+
+    private fun readDataVersion(conn: Connection): Long =
+        conn.createStatement().use { stmt ->
+            stmt.executeQuery("PRAGMA main.data_version").use { rs ->
+                check(rs.next()) { "SQLite did not return main.data_version" }
+                rs.getLong(1)
+            }
+        }
 
     internal fun removeIneligibleSourceIndexRows(conn: Connection) {
         conn.createStatement().use { stmt ->

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/sqlite/schema/SqliteSourceIndexSchema.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/sqlite/schema/SqliteSourceIndexSchema.kt
@@ -12,10 +12,15 @@ internal class SqliteSourceIndexSchema(
             val conn = state.connection(requireCurrentSchema = false)
             val version = readSchemaVersion(conn)
             if (version == SOURCE_INDEX_SCHEMA_VERSION) {
+                val interningTablesNeedReload = !state.isSchemaValidated(conn)
                 validateCurrentSchema(conn)
                 state.initializeRepositoryOverlay(conn)
+                if (interningTablesNeedReload) {
+                    state.reloadInterningTables(conn)
+                } else {
+                    state.loadInterningTables(conn)
+                }
                 state.markSchemaValidated(conn)
-                state.loadInterningTables(conn)
                 return true
             }
             val previousGeneration = state.readGenerationOrNullInTransaction(conn) ?: SourceIndexGeneration(0)
@@ -33,8 +38,8 @@ internal class SqliteSourceIndexSchema(
             }
             validateCurrentSchema(conn)
             state.initializeRepositoryOverlay(conn)
+            state.reloadInterningTables(conn)
             state.markSchemaValidated(conn)
-            state.loadInterningTables(conn)
             return false
         }
     }

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/ParallelReferenceIndexerTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/ParallelReferenceIndexerTest.kt
@@ -4,6 +4,7 @@ import io.github.amichne.kast.indexstore.api.reference.SymbolReferenceRow
 import io.github.amichne.kast.indexstore.indexing.ReferenceIndexer
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -107,6 +108,40 @@ class ParallelReferenceIndexerTest {
         assertEquals(resultsSerial, resultsParallel)
     }
 
+    @Test
+    fun `indexes first batch before consuming remaining paths`() {
+        val fileCount = 20
+        val yieldedPaths = AtomicInteger(0)
+        val firstScanYieldCount = AtomicInteger(0)
+        val filePaths = object : AbstractCollection<String>() {
+            override val size: Int = fileCount
+
+            override fun iterator(): Iterator<String> = object : Iterator<String> {
+                private var index = 0
+
+                override fun hasNext(): Boolean = index < fileCount
+
+                override fun next(): String = "/src/File${index++}.kt".also {
+                    yieldedPaths.incrementAndGet()
+                }
+            }
+        }
+
+        storeWithManifest(*filePaths.toTypedArray()).use { store ->
+            yieldedPaths.set(0)
+
+            ReferenceIndexer(store, batchSize = 4).indexReferences(
+                filePaths = filePaths,
+                referenceScanner = {
+                    firstScanYieldCount.compareAndSet(0, yieldedPaths.get())
+                    emptyList()
+                },
+            )
+        }
+
+        assertEquals(4, firstScanYieldCount.get(), "Only the active batch should be retained before scanning starts")
+    }
+
     /**
      * When cancellation is requested before writing a batch, the database must remain empty
      * even when parallel workers have already completed their scans. Verifies that the
@@ -184,6 +219,20 @@ class ParallelReferenceIndexerTest {
                 refs.none { it.sourcePath == failingPath },
                 "Failing file $failingPath should not appear in results",
             )
+        }
+    }
+
+    @Test
+    fun `parallel indexing propagates fatal scanner errors`() {
+        val filePath = "/src/Fatal.kt"
+
+        storeWithManifest(filePath).use { store ->
+            assertThrows(AssertionError::class.java) {
+                ReferenceIndexer(store, batchSize = 1, parallelism = 2).indexReferences(
+                    filePaths = listOf(filePath),
+                    referenceScanner = { throw AssertionError("fatal") },
+                )
+            }
         }
     }
 

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/store/codec/StringInterningCodecTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/store/codec/StringInterningCodecTest.kt
@@ -1,0 +1,135 @@
+package io.github.amichne.kast.indexstore.store.codec
+
+import io.github.amichne.kast.api.client.WorkspaceIdentity
+import io.github.amichne.kast.indexstore.store.SourceIndexPageReadObserver
+import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStoreState
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.lang.reflect.Proxy
+import java.nio.file.Path
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.sql.Statement
+import java.util.concurrent.atomic.AtomicInteger
+
+class StringInterningCodecTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `incremental inserts do not reload the full table`() {
+        Class.forName("org.sqlite.JDBC")
+        DriverManager.getConnection("jdbc:sqlite::memory:").use { delegate ->
+            delegate.createStatement().use { statement ->
+                statement.execute("CREATE TABLE strings (id INTEGER PRIMARY KEY, value TEXT NOT NULL UNIQUE)")
+                statement.execute("INSERT INTO strings(value) VALUES ('alpha')")
+            }
+            val fullLoads = AtomicInteger(0)
+            val connection = interceptedConnection(delegate) { query ->
+                if (query == "SELECT id, value FROM strings") fullLoads.incrementAndGet()
+            }
+            val codec = StringInterningCodec("strings", "id", "value")
+
+            codec.loadAll(connection)
+            codec.batchEnsure(connection, setOf("beta"))
+            codec.batchEnsure(connection, setOf("gamma"))
+
+            assertEquals(1, fullLoads.get(), "The table should be fully hydrated only once")
+            assertNotNull(codec.idFor("alpha"))
+            assertNotNull(codec.idFor("beta"))
+            assertNotNull(codec.idFor("gamma"))
+        }
+    }
+
+    @Test
+    fun `failed reload remains retryable after rollback`() {
+        Class.forName("org.sqlite.JDBC")
+        DriverManager.getConnection("jdbc:sqlite::memory:").use { delegate ->
+            delegate.createStatement().use { statement ->
+                statement.execute("CREATE TABLE strings (id INTEGER PRIMARY KEY, value TEXT NOT NULL UNIQUE)")
+                statement.execute("INSERT INTO strings(value) VALUES ('alpha')")
+            }
+            val codec = StringInterningCodec("strings", "id", "value")
+            codec.loadAll(delegate)
+
+            delegate.autoCommit = false
+            codec.batchEnsure(delegate, setOf("beta"))
+            delegate.rollback()
+
+            val failingConnection = interceptedConnection(delegate) { query ->
+                if (query == "SELECT id, value FROM strings") {
+                    throw SQLException("simulated reload failure")
+                }
+            }
+            assertThrows(SQLException::class.java) {
+                codec.reloadAll(failingConnection)
+            }
+
+            codec.loadAll(delegate)
+            assertNotNull(codec.idFor("alpha"))
+            assertNull(codec.idFor("beta"))
+        }
+    }
+
+    @Test
+    fun `failed state reload invalidates the data version marker`() {
+        val state = SqliteSourceIndexStoreState(
+            workspaceIdentity = WorkspaceIdentity.fromWorkspaceRoot(workspaceRoot.toAbsolutePath().normalize()),
+            pageReadObserver = SourceIndexPageReadObserver {},
+        )
+        state.use {
+            val connection = state.connection()
+            val stalePath = workspaceRoot.resolve("stale/File.kt").toString()
+            connection.autoCommit = false
+            state.pathCodec.encodeOrCreate(connection, stalePath)
+            connection.rollback()
+            connection.autoCommit = true
+
+            val failingConnection = interceptedConnection(connection) { query ->
+                if (query == "PRAGMA main.data_version") {
+                    throw SQLException("simulated data-version failure")
+                }
+            }
+            assertThrows(SQLException::class.java) {
+                state.reloadInterningTables(failingConnection)
+            }
+
+            state.loadInterningTables(connection)
+            assertNull(state.pathCodec.encodeIfInterned(stalePath))
+        }
+    }
+
+    private fun interceptedConnection(
+        delegate: Connection,
+        onQuery: (String) -> Unit,
+    ): Connection =
+        Proxy.newProxyInstance(
+            Connection::class.java.classLoader,
+            arrayOf(Connection::class.java),
+        ) { _, method, arguments ->
+            if (method.name == "createStatement" && arguments.isNullOrEmpty()) {
+                interceptedStatement(method.invoke(delegate) as Statement, onQuery)
+            } else {
+                method.invoke(delegate, *(arguments ?: emptyArray()))
+            }
+        } as Connection
+
+    private fun interceptedStatement(
+        delegate: Statement,
+        onQuery: (String) -> Unit,
+    ): Statement =
+        Proxy.newProxyInstance(
+            Statement::class.java.classLoader,
+            arrayOf(Statement::class.java),
+        ) { _, method, arguments ->
+            if (method.name == "executeQuery") {
+                (arguments?.singleOrNull() as? String)?.let(onQuery)
+            }
+            method.invoke(delegate, *(arguments ?: emptyArray()))
+        } as Statement
+}

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/store/source/SqliteSourceIndexSchemaTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/store/source/SqliteSourceIndexSchemaTest.kt
@@ -108,6 +108,92 @@ class SqliteSourceIndexSchemaTest {
     }
 
     @Test
+    fun `ensureSchema reloads interning tables after database replacement`() {
+        val normalized = workspaceRoot.toAbsolutePath().normalize()
+        val dbPath = sourceIndexDatabasePath(normalized)
+        val oldPackage = IndexedPackageEvidence.CanonicalName.parse("old.pkg")
+        val freshPackage = IndexedPackageEvidence.CanonicalName.parse("fresh.pkg")
+
+        SqliteSourceIndexStore(normalized).use { store ->
+            store.ensureSchema()
+            store.saveFileIndex(
+                fileUpdate(normalized.resolve("old/Before.kt").toString(), "Before").copy(
+                    packageName = oldPackage.value,
+                    packageEvidence = IndexedPackageEvidence.ProvenNamed(oldPackage),
+                ),
+            )
+
+            assertTrue(Files.deleteIfExists(dbPath))
+            assertTrue(store.ensureSchema())
+            store.saveFileIndex(
+                fileUpdate(normalized.resolve("fresh/Fresh.kt").toString(), "Fresh").copy(
+                    packageName = freshPackage.value,
+                    packageEvidence = IndexedPackageEvidence.ProvenNamed(freshPackage),
+                ),
+            )
+
+            val afterPath = normalized.resolve("old/After.kt").toString()
+            store.saveFileIndex(
+                fileUpdate(afterPath, "After").copy(
+                    packageName = oldPackage.value,
+                    packageEvidence = IndexedPackageEvidence.ProvenNamed(oldPackage),
+                ),
+            )
+
+            assertEquals(
+                IndexedPackageEvidence.ProvenNamed(oldPackage),
+                store.packageEvidenceForFile(afterPath),
+            )
+        }
+    }
+
+    @Test
+    fun `interning caches refresh after another store commits`() {
+        val normalized = workspaceRoot.toAbsolutePath().normalize()
+        val beforePath = normalized.resolve("before/Before.kt").toString()
+        val afterPath = normalized.resolve("after/After.kt").toString()
+        val targetPath = normalized.resolve("target/Target.kt").toString()
+        val afterTargetPath = normalized.resolve("after-target/Target.kt").toString()
+        val pendingPath = normalized.resolve("pending/Removed.kt").toString()
+
+        SqliteSourceIndexStore(normalized).use { reader ->
+            reader.ensureSchema()
+            reader.upsertSymbolReference(
+                sourcePath = beforePath,
+                sourceOffset = 1,
+                targetFqName = "demo.Target",
+                targetPath = targetPath,
+                targetOffset = 1,
+                sourceFqName = "demo.Before",
+            )
+            assertEquals(listOf(beforePath), reader.referencesToSymbol("demo.Target").map { it.sourcePath })
+
+            SqliteSourceIndexStore(normalized).use { writer ->
+                writer.ensureSchema()
+                writer.upsertSymbolReference(
+                    sourcePath = afterPath,
+                    sourceOffset = 2,
+                    targetFqName = "demo.AfterTarget",
+                    targetPath = afterTargetPath,
+                    targetOffset = 1,
+                    sourceFqName = "demo.After",
+                )
+
+                val reference = reader.referencesToSymbol("demo.AfterTarget").single()
+                assertEquals(afterPath, reference.sourcePath)
+                assertEquals("demo.After", reference.sourceFqName)
+                assertEquals("demo.AfterTarget", reference.targetFqName)
+                assertEquals(afterTargetPath, reference.targetPath)
+
+                val generationBeforePendingUpdate = writer.readGeneration()
+                writer.appendPendingUpdate("remove_file", pendingPath, payload = null)
+                assertEquals(generationBeforePendingUpdate, writer.readGeneration())
+                assertEquals(1, reader.reconcilePendingUpdates())
+            }
+        }
+    }
+
+    @Test
     fun `head commit round-trips through schema version table`() {
         val normalized = workspaceRoot.toAbsolutePath().normalize()
         SqliteSourceIndexStore(normalized).use { store ->


### PR DESCRIPTION
## Summary

- run phase-two reference and declaration scans with the configured bounded worker pool and lazy batches
- avoid full interning-table hydration after incremental inserts
- refresh interning caches after external-connection commits while preserving incremental same-connection writes
- preserve the behavior in the v0.17.2 split-store owners with focused regressions

## Risk

- The real-repository JFR profiles were captured before the v0.17.2 store split. The unchanged owners are byte-equivalent, the lifecycle changes were mapped into the split state/schema owners, and current-main Gradle/plugin verification is green.
- Exact-root Kast diagnostics were unavailable in the clean worktree because opening a second IDEA root is prohibited; compiler, focused test, module, packaging, and plugin-verifier proof ran instead.

## Why

The latest profile showed phase two serialized on the coordinator while full interning-table reload and map rebuilds remained allocation hot paths. This change makes phase two parallelizable without retaining the full corpus or rebuilding complete interning maps for every insert.

## Validation

- `./gradlew :index-store:check --no-daemon`
- focused `KastProjectOpenAutoIndexingTest` and `IdeaReferenceIndexEnvironmentTest`
- IDEA plugin build and verifier against IntelliJ IDEA 2026.2 and Android Studio 2026.1.2
- cross-store cache freshness and failed-invalidation retry regressions
- six-repository profile: 7,032 files and 209,798 references; warm four-worker rebuild completed in 53.94s with zero `StringInterningCodec.loadAll` allocation samples
- independent concurrency, SQLite lifecycle, and current-main port reviews: no actionable findings