### PR TITLE
ci: shorten pull request critical path

### DIFF
--- a/.github/ci/issue-401-workflow-model.json
+++ b/.github/ci/issue-401-workflow-model.json
@@ -2,15 +2,15 @@
   "$schema": "./workflow-graph-model.schema.json",
   "schemaVersion": 3,
   "provenance": {
-    "description": "Issue 401 workflow fanout model. The baseline records five historical runs from PR 413; the candidate models the current producer and consumer graph. Estimates remain provisional until five comparable candidate runs are recorded.",
-    "observedAt": "2026-07-17",
-    "source": "https://github.com/amichne/kast/pull/413",
+    "description": "The baseline records five comparable successful pull-request runs of the current CI graph. The candidate splits the consumed IDEA plugin artifact from independent tests, removes unused kast-action setup, and derives provisional task durations from the baseline job step timestamps.",
+    "observedAt": "2026-07-27",
+    "source": "https://github.com/amichne/kast/actions/workflows/ci.yml",
     "baselineRunIds": [
-      29511350239,
-      29519251086,
-      29519850747,
-      29530440846,
-      29540820473
+      30322579073,
+      30291739589,
+      30273172759,
+      30264372027,
+      30261005690
     ],
     "candidateRunIds": []
   },
@@ -20,370 +20,86 @@
         "id": "workflow-contracts",
         "needs": [],
         "outputs": [
+          "repository-shape-contract",
+          "ci-local-source-snapshot",
+          "ci-artifact-ledger-local-source-snapshot",
           "release-workflow-contract",
+          "ci-workflow-model-contract",
           "kast-build-contract",
           "docs-navigation-contract",
           "docs-content-contract",
           "macos-installer-contract",
-          "local-development-refresh-contract",
-          "installed-selector-handle-workflow",
-          "kast-routing-evals",
           "release-asset-verifier",
           "release-provenance-assembler",
           "ci-artifact-ledger",
           "headless-runtime-packagers",
-          "ci-gradle-retry",
-          "homebrew-package-renderer"
+          "ci-gradle-retry"
         ],
-        "durationSamplesSeconds": [
-          1059,
-          1144,
-          915,
-          1013,
-          936
-        ],
-        "executionClass": "toolchain"
-      },
-      {
-        "id": "runtime-contracts",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "terminal-command-contract",
-          "ubuntu-debian-bundle-smoke"
-        ],
-        "durationSamplesSeconds": [
-          130,
-          111,
-          121,
-          126,
-          125
-        ],
-        "executionClass": "toolchain"
-      },
-      {
-        "id": "runtime-compatibility-contract",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "runtime-compatibility-contract"
-        ],
-        "durationSamplesSeconds": [
-          479,
-          967,
-          692,
-          549,
-          555
-        ],
-        "executionClass": "toolchain"
-      },
-      {
-        "id": "maven-publication-contract",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "maven-publication-validation",
-          "ci-artifact-ledger-maven-publication"
-        ],
-        "durationSamplesSeconds": [
-          174,
-          89,
-          115,
-          120,
-          134
-        ],
-        "executionClass": "gradle-cache"
-      },
-      {
-        "id": "rust-cli",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "rust-format",
-          "rust-clippy",
-          "rust-tests",
-          "rust-release-build",
-          "rust-cli-linux-x64-artifact",
-          "ci-artifact-ledger-rust-cli-linux-x64"
-        ],
-        "durationSamplesSeconds": [
-          568,
-          358,
-          473,
-          509,
-          565
-        ],
-        "executionClass": "toolchain"
-      },
-      {
-        "id": "build-and-test-linux",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "jvm-backend-tests",
-          "headless-portable-no-fat-jar-linux",
-          "build-test-reports",
-          "headless-portable-artifact-linux",
-          "ci-artifact-ledger-headless-linux",
-          "agent-headless-portable-build-linux"
-        ],
-        "durationSamplesSeconds": [
-          581,
-          552,
-          428,
-          444,
-          455
-        ],
-        "executionClass": "gradle-cache"
-      },
-      {
-        "id": "build-and-test-macos",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "headless-portable-no-fat-jar-macos",
-          "headless-portable-artifact-macos",
-          "ci-artifact-ledger-headless-macos"
-        ],
-        "durationSamplesSeconds": [
-          743,
-          713,
-          933,
-          803,
-          452
-        ],
-        "executionClass": "gradle-cache"
-      },
-      {
-        "id": "analysis-server-transport",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "analysis-server-socket-transport"
-        ],
-        "durationSamplesSeconds": [
-          142,
-          81,
-          91,
-          119,
-          149
-        ],
-        "executionClass": "gradle-cache"
-      },
-      {
-        "id": "test-idea-plugin",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "idea-plugin-tests",
-          "idea-plugin-distribution-verification",
-          "idea-plugin-artifact",
-          "ci-artifact-ledger-idea-plugin",
-          "idea-plugin-performance-baselines"
-        ],
-        "durationSamplesSeconds": [
-          808,
-          486,
-          454,
-          475,
-          519
-        ],
-        "executionClass": "gradle-cache"
-      },
-      {
-        "id": "install-container-ubuntu-22.04",
-        "needs": [
-          "build-and-test-linux",
-          "rust-cli"
-        ],
-        "outputs": [
-          "ubuntu-22.04-java-21-install-contract"
-        ],
-        "durationSamplesSeconds": [
-          126,
-          133,
-          144,
-          126,
-          135
-        ],
-        "executionClass": "oci"
-      },
-      {
-        "id": "install-container-ubuntu-24.04",
-        "needs": [
-          "build-and-test-linux",
-          "rust-cli"
-        ],
-        "outputs": [
-          "ubuntu-24.04-java-21-install-contract"
-        ],
-        "durationSamplesSeconds": [
-          157,
-          136,
-          133,
-          116,
-          121
-        ],
-        "executionClass": "oci"
-      },
-      {
-        "id": "kast-action",
-        "needs": [
-          "build-and-test-linux",
-          "rust-cli"
-        ],
-        "outputs": [
-          "kast-action-v2-installed-runtime-contract"
-        ],
-        "durationSamplesSeconds": [
-          213,
-          272,
-          250,
-          337,
-          436
-        ],
-        "executionClass": "artifact-consumer"
-      }
-    ],
-    "canaryTaskIds": [],
-    "fanoutGateTaskIds": [
-      "workflow-contracts"
-    ],
-    "observedWorkflowDurationSamplesSeconds": [
-      1871,
-      2115,
-      4622,
-      1866,
-      1944
-    ]
-  },
-  "candidate": {
-    "tasks": [
-      {
-        "id": "workflow-contracts",
-        "needs": [],
-        "outputs": [
-          "release-workflow-contract",
-          "kast-build-contract",
-          "docs-navigation-contract",
-          "docs-content-contract",
-          "macos-installer-contract",
-          "kast-routing-evals",
-          "release-asset-verifier",
-          "release-provenance-assembler",
-          "ci-artifact-ledger",
-          "headless-runtime-packagers",
-          "ci-gradle-retry",
-          "homebrew-package-renderer"
-        ],
-        "durationSamplesSeconds": [
-          15
-        ],
+        "durationSamplesSeconds": [13, 12, 18, 13, 16],
         "executionClass": "static"
       },
       {
         "id": "local-authority-contracts",
         "needs": [],
-        "outputs": [
-          "local-development-refresh-contract"
-        ],
-        "durationSamplesSeconds": [
-          304
-        ],
+        "outputs": ["local-development-refresh-contract"],
+        "durationSamplesSeconds": [121, 154, 142, 150, 145],
         "executionClass": "toolchain"
       },
       {
         "id": "runtime-contracts",
-        "needs": [
-          "workflow-contracts"
-        ],
+        "needs": ["workflow-contracts"],
         "outputs": [
           "terminal-command-contract",
           "ubuntu-debian-bundle-smoke"
         ],
-        "durationSamplesSeconds": [
-          128
-        ],
+        "durationSamplesSeconds": [324, 333, 301, 306, 197],
         "executionClass": "toolchain"
       },
       {
         "id": "runtime-compatibility-contract",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "runtime-compatibility-contract"
-        ],
-        "durationSamplesSeconds": [
-          5
-        ],
+        "needs": ["workflow-contracts"],
+        "outputs": ["runtime-compatibility-contract"],
+        "durationSamplesSeconds": [5, 5, 6, 8, 6],
         "executionClass": "static"
       },
       {
         "id": "maven-publication-contract",
-        "needs": [
-          "workflow-contracts"
-        ],
+        "needs": ["workflow-contracts"],
         "outputs": [
           "maven-publication-validation",
           "ci-artifact-ledger-maven-publication"
         ],
-        "durationSamplesSeconds": [
-          55
-        ],
+        "durationSamplesSeconds": [102, 141, 128, 120, 117],
         "executionClass": "gradle-cache"
       },
       {
         "id": "rust-cli",
-        "needs": [
-          "workflow-contracts"
-        ],
+        "needs": ["workflow-contracts"],
         "outputs": [
           "rust-format",
           "rust-clippy",
           "rust-tests",
           "installed-selector-handle-workflow"
         ],
-        "durationSamplesSeconds": [
-          300
-        ],
+        "durationSamplesSeconds": [409, 392, 360, 369, 331],
         "executionClass": "toolchain"
       },
       {
         "id": "source-bound-cli",
-        "needs": [
-          "workflow-contracts"
-        ],
+        "needs": ["workflow-contracts"],
         "outputs": [
           "rust-release-build",
           "rust-cli-linux-x64-artifact",
           "ci-artifact-ledger-rust-cli-linux-x64"
         ],
-        "durationSamplesSeconds": [
-          300
-        ],
+        "durationSamplesSeconds": [192, 162, 93, 66, 74],
         "executionClass": "toolchain"
       },
       {
         "id": "build-and-test-linux",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "jvm-backend-tests",
-          "build-test-reports"
-        ],
-        "durationSamplesSeconds": [
-          360
-        ],
+        "needs": ["workflow-contracts"],
+        "outputs": ["jvm-backend-tests", "build-test-reports"],
+        "durationSamplesSeconds": [268, 441, 338, 335, 383],
         "executionClass": "gradle-cache"
       },
       {
@@ -394,57 +110,43 @@
           "source-bound-headless-backend"
         ],
         "outputs": [
-          "agent-headless-portable-build-linux"
+          "prepared-local-generation",
+          "ci-artifact-ledger-prepared-generation"
         ],
-        "durationSamplesSeconds": [
-          60
-        ],
+        "durationSamplesSeconds": [42, 40, 60, 34, 53],
         "executionClass": "artifact-consumer"
       },
       {
         "id": "prepared-ubuntu-debian-bundle",
-        "needs": [
-          "prepared-generation"
+        "needs": ["prepared-generation", "test-idea-plugin"],
+        "outputs": [
+          "ubuntu-debian-bundle",
+          "ci-artifact-ledger-prepared-ubuntu-debian-bundle"
         ],
-        "outputs": [],
-        "durationSamplesSeconds": [
-          240
-        ],
+        "durationSamplesSeconds": [50, 71, 49, 47, 49],
         "executionClass": "artifact-consumer"
       },
       {
         "id": "source-bound-headless-backend",
-        "needs": [
-          "workflow-contracts"
-        ],
+        "needs": ["workflow-contracts"],
         "outputs": [
           "headless-portable-no-fat-jar-linux",
           "headless-portable-artifact-linux",
           "ci-artifact-ledger-headless-linux"
         ],
-        "durationSamplesSeconds": [
-          300
-        ],
+        "durationSamplesSeconds": [266, 449, 379, 411, 383],
         "executionClass": "gradle-cache"
       },
       {
         "id": "analysis-server-transport",
-        "needs": [
-          "workflow-contracts"
-        ],
-        "outputs": [
-          "analysis-server-socket-transport"
-        ],
-        "durationSamplesSeconds": [
-          70
-        ],
+        "needs": ["workflow-contracts"],
+        "outputs": ["analysis-server-socket-transport"],
+        "durationSamplesSeconds": [128, 124, 124, 135, 122],
         "executionClass": "gradle-cache"
       },
       {
         "id": "test-idea-plugin",
-        "needs": [
-          "workflow-contracts"
-        ],
+        "needs": ["workflow-contracts"],
         "outputs": [
           "idea-plugin-tests",
           "idea-plugin-distribution-verification",
@@ -452,72 +154,221 @@
           "ci-artifact-ledger-idea-plugin",
           "idea-plugin-performance-baselines"
         ],
-        "durationSamplesSeconds": [
-          626
-        ],
+        "durationSamplesSeconds": [643, 746, 767, 653, 612],
         "executionClass": "gradle-cache"
       },
       {
         "id": "install-container-ubuntu-22.04",
-        "needs": [
-          "prepared-ubuntu-debian-bundle"
-        ],
-        "outputs": [
-          "ubuntu-22.04-java-21-install-contract"
-        ],
-        "durationSamplesSeconds": [
-          119
-        ],
+        "needs": ["prepared-ubuntu-debian-bundle"],
+        "outputs": ["ubuntu-22.04-java-21-install-contract"],
+        "durationSamplesSeconds": [56, 35, 40, 48, 61],
         "executionClass": "oci"
       },
       {
         "id": "install-container-ubuntu-24.04",
-        "needs": [
-          "prepared-ubuntu-debian-bundle"
-        ],
-        "outputs": [
-          "ubuntu-24.04-java-21-install-contract"
-        ],
-        "durationSamplesSeconds": [
-          120
-        ],
+        "needs": ["prepared-ubuntu-debian-bundle"],
+        "outputs": ["ubuntu-24.04-java-21-install-contract"],
+        "durationSamplesSeconds": [52, 34, 48, 38, 41],
         "executionClass": "oci"
       },
       {
         "id": "kast-action",
-        "needs": [
-          "prepared-generation"
-        ],
-        "outputs": [
-          "kast-action-v2-installed-runtime-contract"
-        ],
-        "durationSamplesSeconds": [
-          400
-        ],
+        "needs": ["prepared-generation", "prepared-ubuntu-debian-bundle"],
+        "outputs": ["kast-action-v2-installed-runtime-contract"],
+        "durationSamplesSeconds": [237, 226, 213, 225, 225],
         "executionClass": "artifact-consumer"
       }
     ],
     "canaryTaskIds": [],
-    "fanoutGateTaskIds": [
-      "workflow-contracts"
+    "fanoutGateTaskIds": ["workflow-contracts"],
+    "observedWorkflowDurationSamplesSeconds": [963, 1072, 1056, 946, 908]
+  },
+  "candidate": {
+    "tasks": [
+      {
+        "id": "workflow-contracts",
+        "needs": [],
+        "outputs": [
+          "repository-shape-contract",
+          "ci-local-source-snapshot",
+          "ci-artifact-ledger-local-source-snapshot",
+          "release-workflow-contract",
+          "ci-workflow-model-contract",
+          "kast-build-contract",
+          "docs-navigation-contract",
+          "docs-content-contract",
+          "macos-installer-contract",
+          "release-asset-verifier",
+          "release-provenance-assembler",
+          "ci-artifact-ledger",
+          "headless-runtime-packagers",
+          "ci-gradle-retry"
+        ],
+        "durationSamplesSeconds": [13, 12, 18, 13, 16],
+        "executionClass": "static"
+      },
+      {
+        "id": "local-authority-contracts",
+        "needs": [],
+        "outputs": ["local-development-refresh-contract"],
+        "durationSamplesSeconds": [121, 154, 142, 150, 145],
+        "executionClass": "toolchain"
+      },
+      {
+        "id": "runtime-contracts",
+        "needs": ["workflow-contracts"],
+        "outputs": [
+          "terminal-command-contract",
+          "ubuntu-debian-bundle-smoke"
+        ],
+        "durationSamplesSeconds": [324, 333, 301, 306, 197],
+        "executionClass": "toolchain"
+      },
+      {
+        "id": "runtime-compatibility-contract",
+        "needs": ["workflow-contracts"],
+        "outputs": ["runtime-compatibility-contract"],
+        "durationSamplesSeconds": [5, 5, 6, 8, 6],
+        "executionClass": "static"
+      },
+      {
+        "id": "maven-publication-contract",
+        "needs": ["workflow-contracts"],
+        "outputs": [
+          "maven-publication-validation",
+          "ci-artifact-ledger-maven-publication"
+        ],
+        "durationSamplesSeconds": [102, 141, 128, 120, 117],
+        "executionClass": "gradle-cache"
+      },
+      {
+        "id": "rust-cli",
+        "needs": ["workflow-contracts"],
+        "outputs": [
+          "rust-format",
+          "rust-clippy",
+          "rust-tests",
+          "installed-selector-handle-workflow"
+        ],
+        "durationSamplesSeconds": [409, 392, 360, 369, 331],
+        "executionClass": "toolchain"
+      },
+      {
+        "id": "source-bound-cli",
+        "needs": ["workflow-contracts"],
+        "outputs": [
+          "rust-release-build",
+          "rust-cli-linux-x64-artifact",
+          "ci-artifact-ledger-rust-cli-linux-x64"
+        ],
+        "durationSamplesSeconds": [192, 162, 93, 66, 74],
+        "executionClass": "toolchain"
+      },
+      {
+        "id": "build-and-test-linux",
+        "needs": ["workflow-contracts"],
+        "outputs": ["jvm-backend-tests", "build-test-reports"],
+        "durationSamplesSeconds": [268, 441, 338, 335, 383],
+        "executionClass": "gradle-cache"
+      },
+      {
+        "id": "prepared-generation",
+        "needs": [
+          "workflow-contracts",
+          "source-bound-cli",
+          "source-bound-headless-backend"
+        ],
+        "outputs": [
+          "prepared-local-generation",
+          "ci-artifact-ledger-prepared-generation"
+        ],
+        "durationSamplesSeconds": [42, 40, 60, 34, 53],
+        "executionClass": "artifact-consumer"
+      },
+      {
+        "id": "prepared-ubuntu-debian-bundle",
+        "needs": ["prepared-generation", "build-idea-plugin"],
+        "outputs": [
+          "ubuntu-debian-bundle",
+          "ci-artifact-ledger-prepared-ubuntu-debian-bundle"
+        ],
+        "durationSamplesSeconds": [50, 71, 49, 47, 49],
+        "executionClass": "artifact-consumer"
+      },
+      {
+        "id": "source-bound-headless-backend",
+        "needs": ["workflow-contracts"],
+        "outputs": [
+          "headless-portable-no-fat-jar-linux",
+          "headless-portable-artifact-linux",
+          "ci-artifact-ledger-headless-linux"
+        ],
+        "durationSamplesSeconds": [266, 449, 379, 411, 383],
+        "executionClass": "gradle-cache"
+      },
+      {
+        "id": "analysis-server-transport",
+        "needs": ["workflow-contracts"],
+        "outputs": ["analysis-server-socket-transport"],
+        "durationSamplesSeconds": [128, 124, 124, 135, 122],
+        "executionClass": "gradle-cache"
+      },
+      {
+        "id": "build-idea-plugin",
+        "needs": ["workflow-contracts"],
+        "outputs": [
+          "idea-plugin-distribution-verification",
+          "idea-plugin-artifact",
+          "ci-artifact-ledger-idea-plugin"
+        ],
+        "durationSamplesSeconds": [496, 485, 490, 428, 340],
+        "executionClass": "gradle-cache"
+      },
+      {
+        "id": "test-idea-plugin",
+        "needs": ["workflow-contracts"],
+        "outputs": [
+          "idea-plugin-tests",
+          "idea-plugin-performance-baselines"
+        ],
+        "durationSamplesSeconds": [267, 430, 378, 330, 333],
+        "executionClass": "gradle-cache"
+      },
+      {
+        "id": "install-container-ubuntu-22.04",
+        "needs": ["prepared-ubuntu-debian-bundle"],
+        "outputs": ["ubuntu-22.04-java-21-install-contract"],
+        "durationSamplesSeconds": [56, 35, 40, 48, 61],
+        "executionClass": "oci"
+      },
+      {
+        "id": "install-container-ubuntu-24.04",
+        "needs": ["prepared-ubuntu-debian-bundle"],
+        "outputs": ["ubuntu-24.04-java-21-install-contract"],
+        "durationSamplesSeconds": [52, 34, 48, 38, 41],
+        "executionClass": "oci"
+      },
+      {
+        "id": "kast-action",
+        "needs": ["prepared-generation", "prepared-ubuntu-debian-bundle"],
+        "outputs": ["kast-action-v2-installed-runtime-contract"],
+        "durationSamplesSeconds": [217, 143, 186, 158, 153],
+        "executionClass": "artifact-consumer"
+      }
     ],
-    "observedWorkflowDurationSamplesSeconds": [
-      812
-    ]
+    "canaryTaskIds": [],
+    "fanoutGateTaskIds": ["workflow-contracts"],
+    "observedWorkflowDurationSamplesSeconds": [776, 715, 743, 663, 654]
   },
-  "retiredProofOutputReplacements": {
-    "ci-artifact-ledger-headless-macos": "ci-artifact-ledger-headless-linux",
-    "headless-portable-artifact-macos": "headless-portable-artifact-linux",
-    "headless-portable-no-fat-jar-macos": "headless-portable-no-fat-jar-linux"
-  },
+  "retiredProofOutputReplacements": {},
   "expectations": {
     "outputEquivalence": "exact",
     "timingEvidenceMode": "provisional",
-    "minimumCriticalPathReductionSeconds": 1,
-    "maximumCandidateCriticalPathSeconds": 1800,
-    "minimumFanoutGateReductionSeconds": 800,
+    "minimumCriticalPathReductionSeconds": 180,
+    "maximumCandidateCriticalPathSeconds": 720,
+    "minimumFanoutGateReductionSeconds": 0,
     "maximumCandidateFanoutGateSeconds": 90,
-    "maximumCandidateTaskCountIncrease": 4,
+    "maximumCandidateTaskCountIncrease": 1,
     "maximumMedianModelDriftRatio": 0.25,
     "minimumTaskSamples": 5,
     "minimumWorkflowSamples": 5

--- a/.github/scripts/ci/test-ci-workflow-model.sh
+++ b/.github/scripts/ci/test-ci-workflow-model.sh
@@ -13,6 +13,12 @@ scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/kast-ci-workflow-model.XXXXXX")"
 trap 'rm -rf "$scratch_dir"' EXIT
 
 [[ -f "$model" ]] || die "missing authoritative graph model: ${model}"
+[[ "$(awk '/^[[:space:]]*cache-read-only: false$/ { count++ } END { print count + 0 }' \
+  "${repo_root}/.github/workflows/ci-build-and-test.yml")" -eq 1 ]] \
+  || die "reusable build-and-test must explicitly own the sole PR Gradle cache write"
+[[ "$(awk '/^[[:space:]]*cache-read-only: false$/ { count++ } END { print count + 0 }' \
+  "${repo_root}/.github/workflows/ci.yml")" -eq 0 ]] \
+  || die "fanout jobs must not write Gradle cache state"
 
 report="${scratch_dir}/report.json"
 python3 "$checker" "$model" >"$report"

--- a/.github/scripts/ci/test-ci-workflow-model.sh
+++ b/.github/scripts/ci/test-ci-workflow-model.sh
@@ -16,34 +16,78 @@ trap 'rm -rf "$scratch_dir"' EXIT
 
 report="${scratch_dir}/report.json"
 python3 "$checker" "$model" >"$report"
-python3 - "$report" <<'PY'
+python3 - "$report" "$model" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+model = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
 if report["status"] != "provisional":
     raise SystemExit(f"expected provisional timing evidence, received {report['status']}")
 if not report["comparison"]["outputEquivalent"]:
     raise SystemExit("candidate proof outputs must match or have an explicit replacement")
-expected_replacements = {
-    "headless-portable-no-fat-jar-macos": "headless-portable-no-fat-jar-linux",
-    "headless-portable-artifact-macos": "headless-portable-artifact-linux",
-    "ci-artifact-ledger-headless-macos": "ci-artifact-ledger-headless-linux",
-}
+expected_replacements = {}
 actual_replacements = report["comparison"]["retiredProofOutputReplacements"]
 if actual_replacements != expected_replacements:
-    raise SystemExit(f"retired macOS proofs must name their Linux replacements: {actual_replacements}")
-if report["comparison"]["taskCountIncrease"] != 4:
-    raise SystemExit("the final graph must add exactly four execution nodes after removing the duplicate macOS producer")
-if report["candidate"]["pullRequestTaskCount"] != report["baseline"]["pullRequestTaskCount"] + 4:
-    raise SystemExit("the final graph must add exactly four pull-request execution nodes after deleting the macOS duplicate and local headless proofs")
+    raise SystemExit(f"this graph change must not retire proof outputs: {actual_replacements}")
+if report["comparison"]["taskCountIncrease"] != 1:
+    raise SystemExit("the IDEA artifact producer split must add exactly one execution node")
+if report["candidate"]["pullRequestTaskCount"] != report["baseline"]["pullRequestTaskCount"] + 1:
+    raise SystemExit("the candidate must add only the independent IDEA artifact producer")
 if report["candidate"]["fanoutGateSeconds"] > 90:
     raise SystemExit("the modeled static fanout gate must not exceed 90 seconds")
 if report["candidate"]["canaryTaskIds"]:
-    raise SystemExit("the retired local headless semantic E2E must not remain modeled as a canary")
-if not any("provisional" in warning for warning in report["warnings"]):
-    raise SystemExit("timing evidence must remain explicitly provisional below five samples")
+    raise SystemExit("pull-request CI must not model an off-path canary")
+if "test-idea-plugin" not in report["baseline"]["criticalPathTaskIds"]:
+    raise SystemExit("the baseline must expose the serialized IDEA test and artifact bottleneck")
+if "test-idea-plugin" in report["candidate"]["criticalPathTaskIds"]:
+    raise SystemExit("independent IDEA tests must not delay the artifact consumer path")
+
+candidate_tasks = {task["id"]: task for task in model["candidate"]["tasks"]}
+if set(candidate_tasks["prepared-ubuntu-debian-bundle"]["needs"]) != {
+    "prepared-generation",
+    "build-idea-plugin",
+}:
+    raise SystemExit("the prepared bundle must depend on the narrow IDEA artifact producer")
+if candidate_tasks["workflow-contracts"]["outputs"] != [
+    "repository-shape-contract",
+    "ci-local-source-snapshot",
+    "ci-artifact-ledger-local-source-snapshot",
+    "release-workflow-contract",
+    "ci-workflow-model-contract",
+    "kast-build-contract",
+    "docs-navigation-contract",
+    "docs-content-contract",
+    "macos-installer-contract",
+    "release-asset-verifier",
+    "release-provenance-assembler",
+    "ci-artifact-ledger",
+    "headless-runtime-packagers",
+    "ci-gradle-retry",
+]:
+    raise SystemExit("the static gate must inventory every current contract and source snapshot proof")
+if candidate_tasks["prepared-generation"]["outputs"] != [
+    "prepared-local-generation",
+    "ci-artifact-ledger-prepared-generation",
+]:
+    raise SystemExit("prepared generation must own its artifact and ledger proofs")
+if candidate_tasks["prepared-ubuntu-debian-bundle"]["outputs"] != [
+    "ubuntu-debian-bundle",
+    "ci-artifact-ledger-prepared-ubuntu-debian-bundle",
+]:
+    raise SystemExit("the prepared bundle must own its artifact and ledger proofs")
+if candidate_tasks["build-idea-plugin"]["outputs"] != [
+    "idea-plugin-distribution-verification",
+    "idea-plugin-artifact",
+    "ci-artifact-ledger-idea-plugin",
+]:
+    raise SystemExit("the IDEA artifact producer must own only its artifact proofs")
+if candidate_tasks["test-idea-plugin"]["outputs"] != [
+    "idea-plugin-tests",
+    "idea-plugin-performance-baselines",
+]:
+    raise SystemExit("the IDEA test job must retain both test proof sets")
 PY
 
 blocking_required_task_model="${scratch_dir}/blocking-required-task-timing.json"
@@ -120,38 +164,6 @@ if not report["comparison"]["missingOutputIds"]:
     raise SystemExit("output loss must name the missing proof identifier")
 PY
 
-unexplained_retirement_model="${scratch_dir}/unexplained-retirement.json"
-python3 - "$model" "$unexplained_retirement_model" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-source = Path(sys.argv[1])
-target = Path(sys.argv[2])
-document = json.loads(source.read_text(encoding="utf-8"))
-document["retiredProofOutputReplacements"].pop("headless-portable-no-fat-jar-macos")
-target.write_text(json.dumps(document), encoding="utf-8")
-PY
-
-unexplained_retirement_report="${scratch_dir}/unexplained-retirement-report.json"
-set +e
-python3 "$checker" "$unexplained_retirement_model" >"$unexplained_retirement_report"
-unexplained_retirement_status=$?
-set -e
-[[ "$unexplained_retirement_status" -eq 1 ]] \
-  || die "an unexplained retired proof must fail with exit 1, received ${unexplained_retirement_status}"
-python3 - "$unexplained_retirement_report" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-if report["status"] != "fail":
-    raise SystemExit("an unexplained retired proof must fail comparison")
-if "headless-portable-no-fat-jar-macos" not in report["comparison"]["missingOutputIds"]:
-    raise SystemExit("the failed comparison must name the unexplained retired proof")
-PY
-
 invalid_replacement_model="${scratch_dir}/invalid-replacement.json"
 python3 - "$model" "$invalid_replacement_model" <<'PY'
 import json
@@ -161,7 +173,8 @@ from pathlib import Path
 source = Path(sys.argv[1])
 target = Path(sys.argv[2])
 document = json.loads(source.read_text(encoding="utf-8"))
-document["retiredProofOutputReplacements"]["ci-artifact-ledger-headless-macos"] = "missing-proof"
+retired_output = document["candidate"]["tasks"][0]["outputs"].pop()
+document["retiredProofOutputReplacements"][retired_output] = "missing-proof"
 target.write_text(json.dumps(document), encoding="utf-8")
 PY
 

--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -32,6 +32,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
         with:
+          cache-read-only: false
           cache-cleanup: on-success
 
       - name: Cache IntelliJ runtime distributions

--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
         with:
-          cache-cleanup: always
+          cache-cleanup: on-success
 
       - name: Cache IntelliJ runtime distributions
         uses: actions/cache@v5
@@ -41,9 +41,9 @@ jobs:
             ~/.gradle/kast/headless-idea-distributions
             ~/.gradle/kast/shared-idea-distributions
             ~/.gradle/kast/backend-idea-distributions
-          key: intellij-runtime-Linux-${{ hashFiles('gradle/libs.versions.toml') }}
+          key: intellij-runtime-all-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: |
-            intellij-runtime-Linux-
+            intellij-runtime-all-${{ runner.os }}-
 
       - name: Test JVM backend modules
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
         with:
-          cache-cleanup: always
+          cache-read-only: true
 
       - name: Install Rust for local-authority contracts
         uses: dtolnay/rust-toolchain@stable
@@ -189,7 +189,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
         with:
-          cache-cleanup: always
+          cache-read-only: true
 
       - name: Publish public modules to Maven local
         run: >
@@ -483,7 +483,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - prepared-generation
-      - test-idea-plugin
+      - build-idea-plugin
     steps:
       - uses: actions/checkout@v5
 
@@ -633,15 +633,15 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
         with:
-          cache-cleanup: always
+          cache-read-only: true
 
       - name: Cache source-bound IntelliJ runtime distribution
         uses: actions/cache@v5
         with:
           path: ~/.gradle/kast/headless-idea-distributions
-          key: intellij-runtime-Linux-${{ hashFiles('gradle/libs.versions.toml') }}
+          key: intellij-runtime-headless-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: |
-            intellij-runtime-Linux-
+            intellij-runtime-headless-${{ runner.os }}-
 
       - name: Build source-bound headless backend distribution
         shell: bash
@@ -742,18 +742,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Free disk for kast-action runtime
-        shell: bash
-        run: |
-          set -euo pipefail
-          df -h /
-          sudo rm -rf \
-            /usr/local/lib/android \
-            /usr/share/dotnet \
-            /opt/ghc \
-            /opt/hostedtoolcache/CodeQL
-          df -h /
-
       - name: Download setup bundle
         uses: actions/download-artifact@v7
         with:
@@ -774,10 +762,6 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
-
-      - uses: gradle/actions/setup-gradle@v5
-        with:
-          cache-cleanup: always
 
       - name: Ensure zstd is available
         shell: bash
@@ -910,7 +894,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
         with:
-          cache-cleanup: always
+          cache-read-only: true
 
       - name: Smoke analysis-server socket transport
         run: >
@@ -919,8 +903,8 @@ jobs:
           :analysis-server:test
           --tests io.github.amichne.kast.server.AnalysisServerSocketTest
 
-  test-idea-plugin:
-    name: IDEA plugin
+  build-idea-plugin:
+    name: Build IDEA plugin
     runs-on: ubuntu-latest
     needs: workflow-contracts
     steps:
@@ -945,7 +929,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v5
         with:
-          cache-cleanup: always
+          cache-read-only: true
 
       - name: Cache IntelliJ plugin verification inputs
         uses: actions/cache@v5
@@ -957,13 +941,6 @@ jobs:
           key: idea-plugin-inputs-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: |
             idea-plugin-inputs-${{ runner.os }}-
-
-      - name: Test IDEA plugin
-        run: >
-          ./scripts/ci-gradle-retry.sh
-          ./gradlew
-          :backend-idea:test
-          -PexcludeTags=performance
 
       - name: Build and verify IDEA plugin distribution
         run: >
@@ -997,7 +974,7 @@ jobs:
             --artifact-kind ci-idea-plugin \
             --artifact-name kast-idea-plugin \
             --artifact-path "$plugin_asset" \
-            --producer-job test-idea-plugin \
+            --producer-job build-idea-plugin \
             --build-command-id ci-idea-plugin-build
 
       - name: Upload IDEA plugin ledger
@@ -1007,6 +984,52 @@ jobs:
           path: dist/ci-ledgers/idea-plugin.json
           if-no-files-found: error
           retention-days: 3
+
+  test-idea-plugin:
+    name: IDEA plugin
+    runs-on: ubuntu-latest
+    needs: workflow-contracts
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Free disk for IDEA plugin verification
+        shell: bash
+        run: |
+          set -euo pipefail
+          df -h /
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL
+          df -h /
+
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-read-only: true
+
+      - name: Restore IntelliJ plugin verification inputs
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.gradle/kast/shared-idea-distributions
+            ~/.gradle/kast/backend-idea-distributions
+            ~/.cache/pluginVerifier/ides
+          key: idea-plugin-inputs-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: |
+            idea-plugin-inputs-${{ runner.os }}-
+
+      - name: Test IDEA plugin
+        run: >
+          ./scripts/ci-gradle-retry.sh
+          ./gradlew
+          :backend-idea:test
+          -PexcludeTags=performance
 
       - name: Run IDEA plugin performance baselines
         run: ./scripts/ci-gradle-retry.sh ./gradlew :backend-idea:test -PincludeTags=performance


### PR DESCRIPTION
## Summary

- Split IDEA plugin artifact production from independent plugin tests so prepared bundle assembly waits only for the artifact it consumes.
- Make Gradle fanout jobs restore-only while the reusable build-and-test workflow remains the sole cache writer.
- Namespace IntelliJ runtime caches by workload and remove unused disk-cleanup and Gradle setup work from the kast-action runtime contract.

## Fidelity

- Preserves the exact 45/45 proof-output set with no retired outputs.
- Changes the pull-request graph from 16 to 17 jobs: one independent IDEA artifact producer is added while IDEA tests remain required.
- Keeps prepared bundle assembly dependent on `build-idea-plugin`; independent plugin tests no longer serialize that artifact path.

## Timing evidence

- Five comparable successful baseline PR runs: `30322579073`, `30291739589`, `30273172759`, `30264372027`, and `30261005690`.
- Baseline workflow samples: 963, 1072, 1056, 946, and 908 seconds; median 963 seconds.
- Modeled critical path: 940 → 705 seconds (-235 seconds, -25%).
- Candidate estimates remain provisional until five comparable successful live runs are collected. Acceptance requires median critical path ≤720 seconds, static fanout ≤90 seconds, and exact proof-output equivalence.

## Validation

- `GOTOOLCHAIN=local go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -ignore 'SC2129' .github/workflows/*.yml`
- `./.github/scripts/ci/test-ci-workflow-model.sh`
- `./gradlew check`
- `git diff --check`

All passed locally.