### PR TITLE
fix(ci): require live timing provenance

### DIFF
--- a/.github/scripts/ci/ci_workflow_model.py
+++ b/.github/scripts/ci/ci_workflow_model.py
@@ -78,6 +78,8 @@ class Expectations:
 class Model:
     baseline: Plan
     candidate: Plan
+    baseline_run_count: int
+    candidate_run_count: int
     retired_proof_output_replacements: Mapping[str, str]
     expectations: Expectations
 
@@ -388,7 +390,7 @@ def parse_expectations(value: Any) -> Expectations:
     )
 
 
-def validate_provenance(value: Any) -> None:
+def validate_provenance(value: Any) -> tuple[int, int]:
     path = "provenance"
     item = require_mapping(value, path)
     required = {"description", "observedAt", "source", "baselineRunIds", "candidateRunIds"}
@@ -398,6 +400,7 @@ def validate_provenance(value: Any) -> None:
     if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", observed_at):
         raise ModelError(f"{path}.observedAt must use YYYY-MM-DD")
     require_string(item["source"], f"{path}.source")
+    run_counts: dict[str, int] = {}
     for key in ("baselineRunIds", "candidateRunIds"):
         raw_ids = require_list(item[key], f"{path}.{key}")
         parsed_ids = [
@@ -406,6 +409,8 @@ def validate_provenance(value: Any) -> None:
         ]
         if len(set(parsed_ids)) != len(parsed_ids):
             raise ModelError(f"{path}.{key} must not contain duplicates")
+        run_counts[key] = len(parsed_ids)
+    return run_counts["baselineRunIds"], run_counts["candidateRunIds"]
 
 
 def parse_proof_output_replacements(
@@ -470,13 +475,14 @@ def parse_model(value: Any) -> Model:
         )
     if "$schema" in item:
         require_string(item["$schema"], "model.$schema")
-    if "provenance" in item:
-        validate_provenance(item["provenance"])
+    run_counts = validate_provenance(item["provenance"]) if "provenance" in item else (0, 0)
     baseline = parse_plan(item["baseline"], "baseline")
     candidate = parse_plan(item["candidate"], "candidate")
     return Model(
         baseline=baseline,
         candidate=candidate,
+        baseline_run_count=run_counts[0],
+        candidate_run_count=run_counts[1],
         retired_proof_output_replacements=parse_proof_output_replacements(
             item["retiredProofOutputReplacements"], baseline, candidate
         ),
@@ -519,7 +525,7 @@ def maximum_parallel_tasks(starts: Mapping[str, float], finishes: Mapping[str, f
     return maximum
 
 
-def analyze_plan(plan: Plan) -> PlanAnalysis:
+def analyze_plan(plan: Plan, successful_run_count: int) -> PlanAnalysis:
     canary_task_ids = set(plan.canary_task_ids)
     order = tuple(
         task_id
@@ -575,7 +581,7 @@ def analyze_plan(plan: Plan) -> PlanAnalysis:
             sorted(
                 task_id
                 for task_id, stats in task_durations.items()
-                if stats.count < RECOMMENDED_SAMPLE_FLOOR
+                if min(stats.count, successful_run_count) < RECOMMENDED_SAMPLE_FLOOR
             )
         ),
     )
@@ -618,8 +624,8 @@ def analysis_document(analysis: PlanAnalysis) -> dict[str, Any]:
 
 
 def compare(model: Model) -> dict[str, Any]:
-    baseline = analyze_plan(model.baseline)
-    candidate = analyze_plan(model.candidate)
+    baseline = analyze_plan(model.baseline, model.baseline_run_count)
+    candidate = analyze_plan(model.candidate, model.candidate_run_count)
     expectations = model.expectations
     baseline_outputs = set(baseline.output_ids)
     candidate_outputs = set(candidate.output_ids)
@@ -673,15 +679,16 @@ def compare(model: Model) -> dict[str, Any]:
             f"{expectations.maximum_candidate_task_count_increase}"
         )
 
-    for name, plan, analysis in (
-        ("baseline", model.baseline, baseline),
-        ("candidate", model.candidate, candidate),
+    for name, plan, analysis, successful_run_count in (
+        ("baseline", model.baseline, baseline, model.baseline_run_count),
+        ("candidate", model.candidate, candidate, model.candidate_run_count),
     ):
         undersampled = sorted(
             task_id
             for task_id, task in plan.tasks.items()
             if task_id not in plan.canary_task_ids
-            and len(task.duration_samples_seconds) < expectations.minimum_task_samples
+            and min(len(task.duration_samples_seconds), successful_run_count)
+            < expectations.minimum_task_samples
         )
         if undersampled:
             undersampled_finding = (
@@ -693,7 +700,10 @@ def compare(model: Model) -> dict[str, Any]:
             else:
                 timing_findings.append(undersampled_finding)
         if (
-            len(plan.observed_workflow_duration_samples_seconds)
+            min(
+                len(plan.observed_workflow_duration_samples_seconds),
+                successful_run_count,
+            )
             < expectations.minimum_workflow_samples
         ):
             timing_findings.append(f"{name} workflow is below minimumWorkflowSamples")
@@ -708,7 +718,10 @@ def compare(model: Model) -> dict[str, Any]:
                 f"{name} task timing is provisional below {RECOMMENDED_SAMPLE_FLOOR} samples: "
                 + ", ".join(analysis.provisional_task_ids)
             )
-        if analysis.observed_workflow_duration.count < RECOMMENDED_SAMPLE_FLOOR:
+        if (
+            min(analysis.observed_workflow_duration.count, successful_run_count)
+            < RECOMMENDED_SAMPLE_FLOOR
+        ):
             warnings.append(
                 f"{name} workflow timing is provisional below "
                 f"{RECOMMENDED_SAMPLE_FLOOR} samples"

--- a/.github/scripts/ci/test-ci-workflow-model.sh
+++ b/.github/scripts/ci/test-ci-workflow-model.sh
@@ -51,6 +51,10 @@ if "test-idea-plugin" in report["candidate"]["criticalPathTaskIds"]:
     raise SystemExit("independent IDEA tests must not delay the artifact consumer path")
 
 candidate_tasks = {task["id"]: task for task in model["candidate"]["tasks"]}
+if report["candidate"]["provisionalTaskIds"] != sorted(candidate_tasks):
+    raise SystemExit(
+        "candidate projected timings must remain provisional without declared runs"
+    )
 if set(candidate_tasks["prepared-ubuntu-debian-bundle"]["needs"]) != {
     "prepared-generation",
     "build-idea-plugin",
@@ -121,21 +125,20 @@ set +e
 python3 "$checker" "$blocking_required_task_model" >"$blocking_required_task_report"
 blocking_required_task_status=$?
 set -e
-if [[ "$blocking_required_task_status" -ne 0 ]]; then
-  cat "$blocking_required_task_report" >&2
-  die "blocking required-task timing model failed with exit ${blocking_required_task_status}"
-fi
+[[ "$blocking_required_task_status" -eq 1 ]] \
+  || die "projected candidate timing must fail blocking evidence with exit 1"
 python3 - "$blocking_required_task_report" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-if report["status"] != "pass":
-    raise SystemExit(
-        "blocking PR timing must not require five samples from an off-PR canary: "
-        + "; ".join(report["failures"])
-    )
+if report["status"] != "fail":
+    raise SystemExit("projected candidate timing must not satisfy blocking evidence")
+if not any("candidate required tasks below minimumTaskSamples" in finding for finding in report["failures"]):
+    raise SystemExit("blocking evidence must reject candidate tasks without declared runs")
+if "candidate workflow is below minimumWorkflowSamples" not in report["failures"]:
+    raise SystemExit("blocking evidence must reject candidate workflow timing without declared runs")
 PY
 
 lost_output_model="${scratch_dir}/lost-output.json"


### PR DESCRIPTION
## Summary

- Cap task and workflow timing evidence by the number of declared successful run IDs.
- Keep projected candidate durations usable for modeling while reporting them provisional when no live candidate runs are declared.
- Make blocking timing mode reject five projected values when candidateRunIds is empty.

## Proof

- Red: CI workflow model contract failed with candidate projected timings must remain provisional without declared runs.
- Green: ./.github/scripts/ci/test-ci-workflow-model.sh
- Python AST parsing, Bash syntax validation, and git diff checks pass.

Follow-up to the P1 review finding on merged PR #459.