### PR TITLE
Scope Codex hooks to applicable Gradle workspaces

### DIFF
--- a/cli-rs/src/configuration/config/filesystem.rs
+++ b/cli-rs/src/configuration/config/filesystem.rs
@@ -37,31 +37,33 @@ pub fn resolve_workspace_root(value: Option<PathBuf>) -> Result<PathBuf> {
 }
 
 pub(crate) fn resolve_workspace_root_from(start: &Path) -> PathBuf {
-    find_workspace_marker_root(start)
+    find_workspace_root_from(start)
         .map(normalize)
         .unwrap_or_else(|| normalize(start.to_path_buf()))
 }
 
-fn find_workspace_marker_root(start: &Path) -> Option<PathBuf> {
-    let mut current = Some(start);
-    while let Some(path) = current {
-        if WORKSPACE_MARKERS
+pub(crate) fn find_workspace_root_from(start: &Path) -> Option<PathBuf> {
+    let mut build_root = None;
+    for path in start.ancestors() {
+        if SETTINGS_MARKERS
             .iter()
-            .any(|marker| path.join(marker).exists())
+            .any(|marker| path.join(marker).is_file())
         {
             return Some(path.to_path_buf());
         }
-        current = path.parent();
+        if build_root.is_none()
+            && BUILD_MARKERS
+                .iter()
+                .any(|marker| path.join(marker).is_file())
+        {
+            build_root = Some(path.to_path_buf());
+        }
     }
-    None
+    build_root
 }
 
-const WORKSPACE_MARKERS: &[&str] = &[
-    "settings.gradle.kts",
-    "settings.gradle",
-    "build.gradle.kts",
-    "build.gradle",
-];
+const SETTINGS_MARKERS: &[&str] = &["settings.gradle.kts", "settings.gradle"];
+const BUILD_MARKERS: &[&str] = &["build.gradle.kts", "build.gradle"];
 const MAX_UNIX_SOCKET_PATH_BYTES: usize = 100;
 
 pub fn workspace_data_directory(workspace_root: &Path) -> Result<PathBuf> {

--- a/cli-rs/src/interface/codex/hook/runtime.rs
+++ b/cli-rs/src/interface/codex/hook/runtime.rs
@@ -37,11 +37,21 @@ fn evaluate(event: CodexHookEvent) -> Result<Value> {
         return Ok(json!({}));
     }
     let input = read_input()?;
-    let cwd = input.cwd.clone().unwrap_or(std::env::current_dir()?);
-    let workspace = crate::config::resolve_workspace_root_from(&cwd);
+    evaluate_with_runner(event, input, run_kast)
+}
+
+fn evaluate_with_runner(
+    event: CodexHookEvent,
+    input: HookInput,
+    runner: impl Fn(&[OsString]) -> Result<String>,
+) -> Result<Value> {
+    let cwd = crate::config::normalize(input.cwd.clone().unwrap_or(std::env::current_dir()?));
+    let Some(workspace) = crate::config::find_workspace_root_from(&cwd) else {
+        return Ok(json!({}));
+    };
     Ok(match event {
-        CodexHookEvent::SessionStart => session_start(&workspace),
-        CodexHookEvent::PostToolUse => post_tool_use(&input, &workspace, &cwd),
+        CodexHookEvent::SessionStart => session_start_with_runner(&workspace, runner),
+        CodexHookEvent::PostToolUse => post_tool_use_with_runner(&input, &workspace, &cwd, runner),
     })
 }
 
@@ -64,10 +74,6 @@ fn read_input() -> Result<HookInput> {
     })
 }
 
-fn session_start(workspace: &Path) -> Value {
-    session_start_with_runner(workspace, run_kast)
-}
-
 fn session_start_with_runner(
     workspace: &Path,
     runner: impl FnOnce(&[OsString]) -> Result<String>,
@@ -84,13 +90,21 @@ fn session_start_with_runner(
         OsString::from("idea"),
         OsString::from("--accept-indexing"),
     ];
-    additional_context(
-        CodexHookEvent::SessionStart,
-        advisory_result("Kast session launch", runner(&args)),
-    )
+    match runner(&args) {
+        Ok(_) => json!({}),
+        Err(error) => additional_context(
+            CodexHookEvent::SessionStart,
+            advisory_result("Kast session launch", Err(error)),
+        ),
+    }
 }
 
-fn post_tool_use(input: &HookInput, workspace: &Path, cwd: &Path) -> Value {
+fn post_tool_use_with_runner(
+    input: &HookInput,
+    workspace: &Path,
+    cwd: &Path,
+    runner: impl Fn(&[OsString]) -> Result<String>,
+) -> Value {
     let paths = qualifying_kotlin_paths(input, workspace, cwd);
     if paths.is_empty() {
         return json!({});
@@ -104,38 +118,20 @@ fn post_tool_use(input: &HookInput, workspace: &Path, cwd: &Path) -> Value {
         OsString::from("--backend"),
         OsString::from("idea"),
     ];
-    let status = match run_kast(&status_args) {
-        Ok(status) if status_is_healthy(&status, workspace) => status,
-        Ok(status) => {
-            return additional_context(
-                CodexHookEvent::PostToolUse,
-                format!("Kast status is unhealthy; diagnostics skipped.\n{status}"),
-            );
-        }
-        Err(error) => {
-            return additional_context(
-                CodexHookEvent::PostToolUse,
-                format!(
-                    "Kast status is unhealthy; diagnostics skipped.\n{}: {}",
-                    error.code, error.message
-                ),
-            );
-        }
-    };
+    if !matches!(runner(&status_args), Ok(status) if status_is_healthy(&status, workspace)) {
+        return json!({});
+    }
     let diagnostics = paths
         .iter()
         .map(|path| {
             advisory_result(
                 "Kast diagnostics",
-                run_kast(&diagnostics_args(workspace, path)),
+                runner(&diagnostics_args(workspace, path)),
             )
         })
         .collect::<Vec<_>>()
         .join("\n");
-    additional_context(
-        CodexHookEvent::PostToolUse,
-        format!("Kast status is healthy.\n{status}\n{diagnostics}"),
-    )
+    additional_context(CodexHookEvent::PostToolUse, diagnostics)
 }
 
 fn diagnostics_args(workspace: &Path, path: &str) -> [OsString; 10] {

--- a/cli-rs/src/interface/codex/hook/tests.rs
+++ b/cli-rs/src/interface/codex/hook/tests.rs
@@ -95,6 +95,30 @@ mod tests {
     }
 
     #[test]
+    fn settings_file_wins_over_nested_build_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let module = workspace.join("module");
+        let nested = module.join("src");
+        std::fs::create_dir_all(&nested).expect("nested module");
+        std::fs::write(workspace.join("settings.gradle.kts"), "").expect("settings file");
+        std::fs::write(module.join("build.gradle.kts"), "").expect("build file");
+
+        assert_eq!(
+            crate::config::find_workspace_root_from(&nested),
+            Some(workspace)
+        );
+    }
+
+    #[test]
+    fn marker_directory_is_not_a_hook_workspace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(temp.path().join("build.gradle.kts")).expect("marker directory");
+
+        assert_eq!(crate::config::find_workspace_root_from(temp.path()), None);
+    }
+
+    #[test]
     fn status_requires_a_healthy_exact_root() {
         let healthy = json!({
             "workspaceRoot": "/workspace",
@@ -147,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    fn session_start_invokes_kast_once_and_accepts_indexing() {
+    fn successful_session_start_is_quiet() {
         let calls = std::cell::RefCell::new(Vec::new());
 
         let output = session_start_with_runner(Path::new("/workspace"), |args| {
@@ -157,9 +181,125 @@ mod tests {
 
         assert_eq!(calls.borrow().len(), 1);
         assert!(calls.borrow()[0].contains(&OsString::from("--accept-indexing")));
+        assert_eq!(output, json!({}));
+    }
+
+    #[test]
+    fn relative_hook_cwd_resolves_to_an_absolute_workspace() {
+        let current = std::env::current_dir().expect("current dir");
+        let temp = tempfile::tempdir_in(&current).expect("tempdir");
+        let nested = temp.path().join("module");
+        std::fs::create_dir(&nested).expect("nested workspace");
+        std::fs::write(temp.path().join("settings.gradle.kts"), "").expect("settings file");
+        let relative = nested.strip_prefix(&current).expect("relative cwd");
+        let input = HookInput {
+            cwd: Some(relative.to_path_buf()),
+            tool_name: None,
+            tool_input: Value::Null,
+            tool_response: Value::Null,
+        };
+        let workspace_argument = std::cell::RefCell::new(None);
+
+        evaluate_with_runner(CodexHookEvent::SessionStart, input, |args| {
+            workspace_argument.replace(args.get(6).cloned());
+            Ok(String::new())
+        })
+        .expect("hook evaluation");
+
         assert_eq!(
-            output.pointer("/hookSpecificOutput/hookEventName"),
-            Some(&json!("SessionStart"))
+            workspace_argument.into_inner(),
+            Some(temp.path().as_os_str().to_os_string())
+        );
+    }
+
+    #[test]
+    fn unsupported_root_does_not_reach_the_hook_runner() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let calls = std::cell::Cell::new(0);
+        let input = HookInput {
+            cwd: Some(temp.path().to_path_buf()),
+            tool_name: None,
+            tool_input: Value::Null,
+            tool_response: Value::Null,
+        };
+
+        let output = evaluate_with_runner(CodexHookEvent::SessionStart, input, |_| {
+            calls.set(calls.get() + 1);
+            Ok(String::new())
+        })
+        .expect("hook evaluation");
+
+        assert_eq!((calls.get(), output), (0, json!({})));
+    }
+
+    #[test]
+    fn unavailable_status_is_quiet_and_skips_diagnostics() {
+        let calls = std::cell::RefCell::new(Vec::new());
+        let input = input(
+            "Write",
+            json!({"file_path": "src/A.kt"}),
+            json!({"success": true}),
+        );
+
+        let output = post_tool_use_with_runner(
+            &input,
+            Path::new("/workspace"),
+            Path::new("/workspace"),
+            |args| {
+                calls.borrow_mut().push(args.to_vec());
+                Err(CliError::new(
+                    "CODEX_HOOK_COMMAND_FAILED",
+                    "Kast is unavailable",
+                ))
+            },
+        );
+
+        assert_eq!(calls.borrow().len(), 1);
+        assert_eq!(output, json!({}));
+    }
+
+    #[test]
+    fn healthy_status_runs_diagnostics() {
+        let calls = std::cell::RefCell::new(Vec::new());
+        let input = input(
+            "Write",
+            json!({"file_path": "src/A.kt"}),
+            json!({"success": true}),
+        );
+        let healthy = json!({
+            "workspaceRoot": "/workspace",
+            "selected": {
+                "ready": true,
+                "descriptor": {"workspaceRoot": "/workspace"},
+                "runtimeStatus": {"healthy": true}
+            }
+        })
+        .to_string();
+
+        let output = post_tool_use_with_runner(
+            &input,
+            Path::new("/workspace"),
+            Path::new("/workspace"),
+            |args| {
+                let call_count = {
+                    let mut calls = calls.borrow_mut();
+                    calls.push(args.to_vec());
+                    calls.len()
+                };
+                Ok(if call_count == 1 {
+                    healthy.clone()
+                } else {
+                    "{\"diagnostics\":[]}".to_string()
+                })
+            },
+        );
+
+        assert_eq!(calls.borrow().len(), 2);
+        assert!(
+            output
+                .pointer("/hookSpecificOutput/additionalContext")
+                .and_then(Value::as_str)
+                .is_some_and(|context| context.contains("Kast diagnostics: completed"))
         );
     }
 }


### PR DESCRIPTION
## Summary
- skip Kast hooks outside Kotlin/Gradle workspaces
- prefer canonical settings roots over nested build files
- keep successful startup and unavailable status quiet
- preserve diagnostics when exact-root status is healthy

## Proof
- `cargo test --manifest-path cli-rs/Cargo.toml codex::hook::tests -- --nocapture` (14 passed)
- changed Rust files pass `rustfmt --edition 2024 --check`
- `git diff --check`