### PR TITLE
fix: harden semantic index readiness

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphExtraction.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphExtraction.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.symbols.KaConstructorSymbol
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructor
@@ -230,6 +231,7 @@ internal fun KastPluginBackend.extractSemanticGraphFile(
     }
 
     PsiTreeUtil.findChildrenOfType(file, KtCallExpression::class.java)
+        .filterNot { call -> call.parent is KtCallableReferenceExpression && call.valueArgumentList == null }
         .sortedBy { it.textRange.startOffset }
         .forEach { call ->
             val target = analyze(call) {

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastPluginService.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastPluginService.kt
@@ -16,13 +16,15 @@ import io.github.amichne.kast.server.RuntimeLifecycleController
 import java.nio.file.Path
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 @Service(Service.Level.PROJECT)
 internal class KastPluginService(
     private val project: Project,
-    private val coroutineScope: CoroutineScope,
 ) : Disposable {
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val backendLifecycle = KastPluginBackendLifecycle(
         startBackend = ::createBackend,
         onStopping = ::recordBackendStopping,
@@ -51,6 +53,7 @@ internal class KastPluginService(
     }
 
     override fun dispose() {
+        coroutineScope.cancel()
         backendLifecycle.dispose()
     }
 
@@ -64,7 +67,7 @@ internal class KastPluginService(
     fun failIndexing(error: Throwable) = backendLifecycle.markIndexFailed(error)
 
     fun reloadConfigAsync() {
-        coroutineScope.launch(Dispatchers.IO) {
+        coroutineScope.launch {
             reloadConfig()
         }
     }

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/backend/NativeSemanticGraphBackendTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/backend/NativeSemanticGraphBackendTest.kt
@@ -99,6 +99,21 @@ class NativeSemanticGraphBackendTest {
             typealias Resolver = (workspaceRoot: String) -> String
         """
 
+        private const val genericCallableReferenceSource = """
+            package demo
+
+            data class Entry<Query, State>(val state: State)
+            data class List<Element>(val size: Int) {
+                fun isNotEmpty(): Boolean = size > 0
+            }
+            data class Pair<First, Second>(val first: First)
+
+            fun <Query, State> stateReference(): (Entry<Query, State>) -> State = Entry<Query, State>::state
+            fun sizeReference(): (List<String>) -> Int = List<String>::size
+            fun nonEmptyReference(): (List<String>) -> Boolean = List<String>::isNotEmpty
+            fun firstReference(): (Pair<String, String?>) -> String = Pair<String, String?>::first
+        """
+
         private const val enumSource = """
             package demo
 
@@ -122,6 +137,8 @@ class NativeSemanticGraphBackendTest {
     private val localPropertyFixture = sourceRootFixture.psiFileFixture("LocalProperty.kt", localPropertySource)
     private val functionTypeParameterFixture =
         sourceRootFixture.psiFileFixture("FunctionTypeParameter.kt", functionTypeParameterSource)
+    private val genericCallableReferenceFixture =
+        sourceRootFixture.psiFileFixture("GenericCallableReference.kt", genericCallableReferenceSource)
     private val enumFixture = sourceRootFixture.psiFileFixture("Mode.kt", enumSource)
     private val unresolvedCallFixture = sourceRootFixture.psiFileFixture("UnresolvedCall.kt", unresolvedCallSource)
     private val unresolvedSupertypeFixture =
@@ -276,6 +293,36 @@ class NativeSemanticGraphBackendTest {
                     ).parsed(),
                 )
                 assertTrue(result.symbolCount.value > 0)
+            }
+        }
+    }
+
+    @Test
+    fun `generic callable references do not abort semantic graph extraction`() = runBlocking {
+        val project = projectFixture.get()
+        val sourceFile = genericCallableReferenceFixture.get()
+        waitUntilIndexesAreReady(project)
+        val workspaceRoot = Path.of(sourceFile.virtualFile.path).toRealPath().parent
+
+        SqliteSourceIndexStore(storeRoot).use { store ->
+            store.ensureSchema()
+            KastPluginBackend(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                limits = limits(),
+                semanticGraphStore = store,
+                psiGeneration = { 1L },
+            ).use { backend ->
+                val result = backend.semanticGraph(
+                    SemanticGraphQuery(
+                        filePaths = listOf(SemanticGraphPath.parse(sourceFile.virtualFile.path)),
+                    ).parsed(),
+                )
+                assertTrue(result.symbolCount.value > 0)
+                assertEquals(
+                    listOf(SemanticGraphSourcePath.parse(sourceFile.name)),
+                    result.coverage.files.map { coverage -> coverage.path },
+                )
             }
         }
     }

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/config/KastPluginXmlSurfaceTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/config/KastPluginXmlSurfaceTest.kt
@@ -2,6 +2,9 @@ package io.github.amichne.kast.idea
 
 import io.github.amichne.kast.idea.diagnostics.*
 
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -25,5 +28,17 @@ class KastPluginXmlSurfaceTest {
         assertFalse(pluginXml.contains("Install Kast Skill"))
         assertFalse(pluginXml.contains("Install Copilot Extension"))
         assertFalse(pluginXml.contains("Uninstall Copilot Extension"))
+    }
+
+    @Test
+    fun `project service uses a supported disposable constructor`() {
+        val pluginXml = Files.readString(Path.of("src/main/resources/META-INF/plugin.xml"))
+
+        assertTrue(pluginXml.contains("""<projectService serviceImplementation="io.github.amichne.kast.idea.KastPluginService"/>"""))
+        assertEquals(
+            listOf(Project::class.java),
+            KastPluginService::class.java.declaredConstructors.single().parameterTypes.toList(),
+        )
+        assertTrue(Disposable::class.java.isAssignableFrom(KastPluginService::class.java))
     }
 }

--- a/cli-rs/src/agent/core/dispatch/steps.rs
+++ b/cli-rs/src/agent/core/dispatch/steps.rs
@@ -122,6 +122,24 @@ fn execute_agent_steps(
             "method": "runtime/status",
         }));
     }
+    let semantic_graph = if issues.is_empty() {
+        workspace_admission.as_ref().and_then(|admission| {
+            verification_semantic_graph_readiness(method, admission, &step_results)
+        })
+    } else {
+        None
+    };
+    let semantic_graph_failure = semantic_graph
+        .as_ref()
+        .and_then(semantic_graph_verification_failure);
+    if let (Some((code, _)), Some(readiness)) =
+        (semantic_graph_failure, semantic_graph.as_ref())
+    {
+        issues.push(json!({
+            "code": code,
+            "state": readiness.state,
+        }));
+    }
     let ok = issues.is_empty();
     let mut result = json!({
         "type": "KAST_AGENT_COMMAND",
@@ -136,13 +154,30 @@ fn execute_agent_steps(
     if let (Some(semantic_workspace), Some(result)) = (semantic_workspace, result.as_object_mut()) {
         result.insert("semanticWorkspace".to_string(), json!(semantic_workspace));
     }
-    let error = (!ok).then(|| {
-        let mut error = agent_error("AGENT_COMMAND_FAILED", "Agent command failed.");
-        error
-            .details
-            .insert("issues".to_string(), result["issues"].clone());
-        error
-    });
+    if let (Some(semantic_graph), Some(result)) = (semantic_graph, result.as_object_mut()) {
+        result.insert("semanticGraph".to_string(), json!(semantic_graph));
+    }
+    let error = semantic_graph_failure.map_or_else(
+        || {
+            (!ok).then(|| {
+                let mut error = agent_error("AGENT_COMMAND_FAILED", "Agent command failed.");
+                error
+                    .details
+                    .insert("issues".to_string(), result["issues"].clone());
+                error
+            })
+        },
+        |(code, message)| {
+            let mut error = agent_error(code, message);
+            error
+                .details
+                .insert("issues".to_string(), result["issues"].clone());
+            error
+                .details
+                .insert("semanticGraph".to_string(), result["semanticGraph"].clone());
+            Some(error)
+        },
+    );
     AgentEnvelope {
         ok,
         method: method.to_string(),
@@ -153,6 +188,49 @@ fn execute_agent_steps(
         error,
         schema_version: SCHEMA_VERSION,
     }
+}
+
+fn semantic_graph_verification_failure(
+    readiness: &crate::repository_intelligence::SemanticGraphReadiness,
+) -> Option<(&'static str, &'static str)> {
+    use crate::repository_intelligence::SemanticGraphReadinessState;
+
+    match readiness.state {
+        SemanticGraphReadinessState::Ready => None,
+        SemanticGraphReadinessState::Incomplete => Some((
+            "SEMANTIC_GRAPH_COVERAGE_INCOMPLETE",
+            "Persisted semantic graph coverage is incomplete; refresh each affected file with `kast agent graph --operation refresh --file-path <path-to-kotlin-file>`, then retry verification.",
+        )),
+        SemanticGraphReadinessState::Unavailable => Some((
+            "SEMANTIC_GRAPH_COVERAGE_UNAVAILABLE",
+            "Persisted semantic graph coverage is unavailable; refresh a selected file with `kast agent graph --operation refresh --file-path <path-to-kotlin-file>`, then retry verification.",
+        )),
+    }
+}
+
+fn verification_semantic_graph_readiness(
+    method: &str,
+    admission: &runtime::SemanticWorkspaceAdmission,
+    step_results: &[Value],
+) -> Option<crate::repository_intelligence::SemanticGraphReadiness> {
+    if method != "agent/verify" {
+        return None;
+    }
+    let capabilities = step_results
+        .iter()
+        .find(|step| step.get("name").and_then(Value::as_str) == Some("capabilities"))?
+        .get("result")?;
+    let advertised = capabilities
+        .get("readCapabilities")
+        .and_then(Value::as_array)
+        .is_some_and(|capabilities| {
+            capabilities
+                .iter()
+                .any(|capability| capability.as_str() == Some("SEMANTIC_GRAPH"))
+        });
+    advertised.then(|| {
+        crate::repository_intelligence::semantic_graph_readiness(&admission.workspace_root)
+    })
 }
 
 fn verification_workspace_evidence(

--- a/cli-rs/src/agent/projection/verify.rs
+++ b/cli-rs/src/agent/projection/verify.rs
@@ -81,6 +81,8 @@ struct AgentVerifyCompactResult {
     capabilities: AgentCapabilitiesProjection,
     #[serde(skip_serializing_if = "Option::is_none")]
     semantic_workspace: Option<AgentSemanticWorkspaceProjection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    semantic_graph: Option<crate::repository_intelligence::SemanticGraphReadiness>,
     schema_version: u32,
 }
 
@@ -98,6 +100,8 @@ struct AgentVerifySelectedResult {
     capabilities: Option<AgentCapabilitiesProjection>,
     #[serde(skip_serializing_if = "Option::is_none")]
     semantic_workspace: Option<AgentSemanticWorkspaceProjection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    semantic_graph: Option<crate::repository_intelligence::SemanticGraphReadiness>,
     schema_version: u32,
 }
 
@@ -115,6 +119,8 @@ struct AgentVerifyCountResult {
     public_read_capability_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     semantic_workspace: Option<AgentSemanticWorkspaceProjection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    semantic_graph: Option<crate::repository_intelligence::SemanticGraphReadiness>,
     schema_version: u32,
 }
 
@@ -137,7 +143,14 @@ fn project_verify_envelope(
             );
         }
     };
-    if !envelope.ok {
+    let retain_semantic_graph_evidence = command.semantic_graph.is_some()
+        && envelope.error.as_ref().is_some_and(|error| {
+            matches!(
+                error.code.as_str(),
+                "SEMANTIC_GRAPH_COVERAGE_INCOMPLETE" | "SEMANTIC_GRAPH_COVERAGE_UNAVAILABLE"
+            )
+        });
+    if !envelope.ok && !retain_semantic_graph_evidence {
         return compact_command_error_envelope(envelope, &command);
     }
     let Some(health_step) = command.step("health") else {
@@ -185,8 +198,13 @@ fn project_verify_envelope(
         ok: health_step.ok,
         status: health_input.and_then(|input| input.status),
     };
-    let check_count = command.steps.len();
-    let passed_count = command.steps.iter().filter(|step| step.ok).count();
+    let semantic_graph = command.semantic_graph;
+    let semantic_graph_check_count = usize::from(semantic_graph.is_some());
+    let semantic_graph_passed_count =
+        usize::from(semantic_graph.as_ref().is_some_and(|graph| graph.is_ready()));
+    let check_count = command.steps.len() + semantic_graph_check_count;
+    let passed_count =
+        command.steps.iter().filter(|step| step.ok).count() + semantic_graph_passed_count;
     let failed_count = check_count.saturating_sub(passed_count);
     let semantic_workspace = command.semantic_workspace;
     let ok = envelope.ok;
@@ -203,6 +221,7 @@ fn project_verify_envelope(
                 runtime,
                 capabilities,
                 semantic_workspace,
+                semantic_graph,
                 schema_version: SCHEMA_VERSION,
             },
             error,
@@ -220,6 +239,7 @@ fn project_verify_envelope(
                     capabilities: selected(AgentVerifyField::Capabilities)
                         .then_some(capabilities),
                     semantic_workspace,
+                    semantic_graph,
                     schema_version: SCHEMA_VERSION,
                 },
                 error,
@@ -238,6 +258,7 @@ fn project_verify_envelope(
                 mutation_capability_count: capabilities.mutation_count,
                 public_read_capability_count: capabilities.public_read_count,
                 semantic_workspace,
+                semantic_graph,
                 schema_version: SCHEMA_VERSION,
             },
             error,

--- a/cli-rs/src/agent/projection/view.rs
+++ b/cli-rs/src/agent/projection/view.rs
@@ -161,6 +161,8 @@ struct AgentStepCommandProjectionInput {
     file_paths: Vec<String>,
     #[serde(default)]
     semantic_workspace: Option<AgentSemanticWorkspaceProjection>,
+    #[serde(default)]
+    semantic_graph: Option<crate::repository_intelligence::SemanticGraphReadiness>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/cli-rs/src/execution/runtime/backend/workspace.rs
+++ b/cli-rs/src/execution/runtime/backend/workspace.rs
@@ -14,14 +14,34 @@ pub fn workspace_status(args: RuntimeArgs) -> Result<WorkspaceStatusResult> {
         preference,
         StaleDescriptorPolicy::Preserve,
     )?;
+    let semantic_graph = inspection
+        .selected
+        .as_ref()
+        .filter(|candidate| candidate.ready)
+        .filter(|candidate| candidate_advertises_semantic_graph(candidate))
+        .map(|_| crate::repository_intelligence::semantic_graph_readiness(&workspace_root));
     Ok(WorkspaceStatusResult {
         workspace_root: workspace_root.display().to_string(),
         descriptor_directory: inspection.descriptor_directory.display().to_string(),
         path_resolution,
         selected: inspection.selected,
+        semantic_graph,
         candidates: inspection.candidates,
         schema_version: SCHEMA_VERSION,
     })
+}
+
+fn candidate_advertises_semantic_graph(candidate: &RuntimeCandidateStatus) -> bool {
+    candidate
+        .capabilities
+        .as_ref()
+        .and_then(|capabilities| capabilities.get("readCapabilities"))
+        .and_then(Value::as_array)
+        .is_some_and(|capabilities| {
+            capabilities
+                .iter()
+                .any(|capability| capability.as_str() == Some("SEMANTIC_GRAPH"))
+        })
 }
 
 pub fn workspace_ensure(args: RuntimeArgs) -> Result<WorkspaceEnsureResult> {

--- a/cli-rs/src/execution/runtime/types.rs
+++ b/cli-rs/src/execution/runtime/types.rs
@@ -85,6 +85,8 @@ pub struct WorkspaceStatusResult {
     pub path_resolution: PathResolutionReport,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selected: Option<RuntimeCandidateStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub semantic_graph: Option<crate::repository_intelligence::SemanticGraphReadiness>,
     pub candidates: Vec<RuntimeCandidateStatus>,
     pub schema_version: u32,
 }

--- a/cli-rs/src/interface/output/package_runtime.rs
+++ b/cli-rs/src/interface/output/package_runtime.rs
@@ -44,6 +44,27 @@ pub fn print_workspace_status(result: &WorkspaceStatusResult) -> Result<()> {
             "- Install or replace the complete release with `kast setup --source <bundle>`."
         );
     }
+    if let Some(semantic_graph) = &result.semantic_graph {
+        mdln!(document);
+        mdln!(document, "## Semantic graph");
+        mdln!(document);
+        mdln!(document, "- State: `{:?}`", semantic_graph.state);
+        mdln!(
+            document,
+            "- Files: {} indexed, {} excluded, {} failed, {} stale, {} total",
+            semantic_graph.indexed,
+            semantic_graph.excluded,
+            semantic_graph.failed,
+            semantic_graph.stale,
+            semantic_graph.total
+        );
+        for limitation in &semantic_graph.limitations {
+            mdln!(document, "- Limitation: `{limitation}`");
+        }
+        if let Some(error) = &semantic_graph.error {
+            mdln!(document, "- Error: `{}` — {}", error.code, error.message);
+        }
+    }
     if result.selected.is_some() && result.candidates.len() > 1 {
         mdln!(document);
         mdln!(document, "## Other candidates");

--- a/cli-rs/src/semantics/repository_intelligence/coverage/model.rs
+++ b/cli-rs/src/semantics/repository_intelligence/coverage/model.rs
@@ -1,3 +1,41 @@
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SemanticGraphReadinessState {
+    Ready,
+    Incomplete,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SemanticGraphReadinessError {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SemanticGraphReadiness {
+    pub state: SemanticGraphReadinessState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation: Option<u64>,
+    pub total: usize,
+    pub indexed: usize,
+    pub excluded: usize,
+    pub failed: usize,
+    pub stale: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub limitations: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<SemanticGraphReadinessError>,
+}
+
+impl SemanticGraphReadiness {
+    pub fn is_ready(&self) -> bool {
+        self.state == SemanticGraphReadinessState::Ready
+    }
+}
+
 #[derive(Debug, Clone)]
 struct SemanticFileRow {
     content_hash: Option<String>,

--- a/cli-rs/src/semantics/repository_intelligence/coverage/read.rs
+++ b/cli-rs/src/semantics/repository_intelligence/coverage/read.rs
@@ -1,3 +1,46 @@
+pub fn semantic_graph_readiness(workspace_root: &Path) -> SemanticGraphReadiness {
+    match read_coverage(
+        workspace_root,
+        RepositoryScope {
+            language: Some("kotlin".to_string()),
+            ..RepositoryScope::default()
+        },
+    ) {
+        Ok(snapshot) => {
+            let coverage = snapshot.coverage;
+            SemanticGraphReadiness {
+                state: if coverage.complete {
+                    SemanticGraphReadinessState::Ready
+                } else {
+                    SemanticGraphReadinessState::Incomplete
+                },
+                generation: Some(snapshot.generation),
+                total: coverage.counts.total,
+                indexed: coverage.counts.indexed,
+                excluded: coverage.counts.excluded,
+                failed: coverage.counts.failed,
+                stale: coverage.counts.stale,
+                limitations: coverage.limitations,
+                error: None,
+            }
+        }
+        Err(error) => SemanticGraphReadiness {
+            state: SemanticGraphReadinessState::Unavailable,
+            generation: None,
+            total: 0,
+            indexed: 0,
+            excluded: 0,
+            failed: 0,
+            stale: 0,
+            limitations: vec![error.code.to_string()],
+            error: Some(SemanticGraphReadinessError {
+                code: error.code.to_string(),
+                message: error.message,
+            }),
+        },
+    }
+}
+
 fn validate_scope(scope: &RepositoryScope) -> Result<()> {
     if scope
         .language

--- a/cli-rs/tests/repository_intelligence_smoke.rs
+++ b/cli-rs/tests/repository_intelligence_smoke.rs
@@ -22,6 +22,7 @@ include!("repository_intelligence_smoke/agent_views/remaining.rs");
 include!("repository_intelligence_smoke/agent_views/contract.rs");
 include!("repository_intelligence_smoke/coverage/rpc.rs");
 include!("repository_intelligence_smoke/coverage/continuation.rs");
+include!("repository_intelligence_smoke/coverage/readiness.rs");
 include!("repository_intelligence_smoke/authority/root.rs");
 include!("repository_intelligence_smoke/authority/scope.rs");
 include!("repository_intelligence_smoke/validation/intent_fields.rs");

--- a/cli-rs/tests/repository_intelligence_smoke/coverage/readiness.rs
+++ b/cli-rs/tests/repository_intelligence_smoke/coverage/readiness.rs
@@ -1,0 +1,283 @@
+fn ready_runtime(workspace: &std::path::Path) -> serde_json::Value {
+    serde_json::json!({
+        "state": "READY",
+        "healthy": true,
+        "active": true,
+        "indexing": false,
+        "backendName": "idea",
+        "backendVersion": "scripted-test",
+        "workspaceRoot": workspace.display().to_string(),
+        "sourceModuleNames": ["app"],
+        "referenceIndexReady": true,
+        "schemaVersion": 5
+    })
+}
+
+fn semantic_graph_capabilities(workspace: &std::path::Path) -> serde_json::Value {
+    serde_json::json!({
+        "backendName": "idea",
+        "backendVersion": "scripted-test",
+        "workspaceRoot": workspace.display().to_string(),
+        "readCapabilities": ["SEMANTIC_GRAPH"],
+        "mutationCapabilities": [],
+        "limits": {
+            "requestTimeoutMillis": 60000,
+            "maxResults": 1000,
+            "maxConcurrentRequests": 4
+        },
+        "schemaVersion": 5
+    })
+}
+
+fn remove_semantic_graph_coverage(fixture: &WorkspaceIndexFixture) {
+    fixture
+        .connection()
+        .execute("DELETE FROM semantic_files", [])
+        .expect("remove semantic graph coverage");
+}
+
+#[test]
+fn status_separates_runtime_readiness_from_incomplete_semantic_graph_coverage() {
+    let (_temp, home, config_home, workspace, fixture) = coverage_fixture();
+    remove_semantic_graph_coverage(&fixture);
+    let socket_path = workspace.join("status.sock");
+    let backend = spawn_sequenced_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        vec![
+            ("runtime/status", ready_runtime(&workspace)),
+            ("capabilities", semantic_graph_capabilities(&workspace)),
+        ],
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "status",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("status");
+    backend.join().expect("status backend");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("status JSON");
+
+    assert_eq!(result["selected"]["ready"], true, "{result}");
+    assert_eq!(
+        result["selected"]["runtimeStatus"]["state"],
+        "READY",
+        "{result}"
+    );
+    assert_eq!(
+        result["selected"]["runtimeStatus"]["healthy"],
+        true,
+        "{result}"
+    );
+    assert_eq!(result["semanticGraph"]["state"], "INCOMPLETE", "{result}");
+    assert_eq!(result["semanticGraph"]["total"], 1, "{result}");
+    assert_eq!(result["semanticGraph"]["failed"], 1, "{result}");
+    assert_eq!(result["semanticGraph"]["stale"], 0, "{result}");
+}
+
+#[test]
+fn status_omits_semantic_graph_coverage_while_runtime_is_indexing() {
+    let (_temp, home, config_home, workspace, fixture) = coverage_fixture();
+    std::fs::remove_file(fixture.database_path()).expect("remove graph database");
+    let socket_path = workspace.join("status-indexing.sock");
+    let backend = spawn_sequenced_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        vec![
+            (
+                "runtime/status",
+                serde_json::json!({
+                    "state": "INDEXING",
+                    "healthy": true,
+                    "active": true,
+                    "indexing": true,
+                    "backendName": "idea",
+                    "backendVersion": "scripted-test",
+                    "workspaceRoot": workspace.display().to_string(),
+                    "sourceModuleNames": ["app"],
+                    "referenceIndexReady": false,
+                    "schemaVersion": 5
+                }),
+            ),
+            ("capabilities", semantic_graph_capabilities(&workspace)),
+        ],
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "status",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("indexing status");
+    backend.join().expect("indexing status backend");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("indexing status JSON");
+
+    assert_eq!(result["selected"]["ready"], false, "{result}");
+    assert_eq!(
+        result["selected"]["runtimeStatus"]["state"],
+        "INDEXING",
+        "{result}"
+    );
+    assert!(
+        result.get("semanticGraph").is_none(),
+        "indexing status must not scan graph coverage: {result}"
+    );
+}
+
+#[test]
+fn verify_fails_incomplete_semantic_graph_coverage_without_discarding_runtime_evidence() {
+    let (_temp, home, config_home, workspace, fixture) = coverage_fixture();
+    remove_semantic_graph_coverage(&fixture);
+    let socket_path = workspace.join("verify.sock");
+    let runtime = ready_runtime(&workspace);
+    let capabilities = semantic_graph_capabilities(&workspace);
+    let backend = spawn_sequenced_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        vec![
+            ("runtime/status", runtime.clone()),
+            ("capabilities", capabilities.clone()),
+            ("health", serde_json::json!({"ok": true, "status": "READY"})),
+            ("runtime/status", runtime),
+            ("capabilities", capabilities),
+        ],
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "verify",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+        ])
+        .output()
+        .expect("verify");
+    backend.join().expect("verify backend");
+    assert!(
+        !output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("verify JSON");
+
+    assert_eq!(result["ok"], false, "{result}");
+    assert_eq!(result["result"]["runtime"]["state"], "READY", "{result}");
+    assert_eq!(
+        result["result"]["runtime"]["healthy"],
+        true,
+        "{result}"
+    );
+    assert_eq!(
+        result["result"]["semanticGraph"]["state"],
+        "INCOMPLETE",
+        "{result}"
+    );
+    assert_eq!(result["result"]["semanticGraph"]["failed"], 1, "{result}");
+    assert_eq!(
+        result["error"]["code"],
+        "SEMANTIC_GRAPH_COVERAGE_INCOMPLETE",
+        "{result}"
+    );
+    assert!(
+        result["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("--file-path <path-to-kotlin-file>")),
+        "{result}"
+    );
+}
+
+#[test]
+fn verify_verbose_reports_execution_level_semantic_graph_issue() {
+    let (_temp, home, config_home, workspace, fixture) = coverage_fixture();
+    remove_semantic_graph_coverage(&fixture);
+    let socket_path = workspace.join("verify-verbose.sock");
+    let runtime = ready_runtime(&workspace);
+    let capabilities = semantic_graph_capabilities(&workspace);
+    let backend = spawn_sequenced_idea_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket_path,
+        vec![
+            ("runtime/status", runtime.clone()),
+            ("capabilities", capabilities.clone()),
+            ("health", serde_json::json!({"ok": true, "status": "READY"})),
+            ("runtime/status", runtime),
+            ("capabilities", capabilities),
+        ],
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "verify",
+            "--workspace-root",
+            workspace.to_str().expect("workspace"),
+            "--verbose",
+        ])
+        .output()
+        .expect("verbose verify");
+    backend.join().expect("verbose verify backend");
+    assert!(
+        !output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("verbose verify JSON");
+
+    assert_eq!(result["ok"], false, "{result}");
+    assert_eq!(result["result"]["ok"], false, "{result}");
+    assert_eq!(
+        result["result"]["issues"][0]["code"],
+        "SEMANTIC_GRAPH_COVERAGE_INCOMPLETE",
+        "{result}"
+    );
+    assert_eq!(
+        result["result"]["semanticGraph"]["state"],
+        "INCOMPLETE",
+        "{result}"
+    );
+    assert_eq!(
+        result["error"]["code"],
+        "SEMANTIC_GRAPH_COVERAGE_INCOMPLETE",
+        "{result}"
+    );
+    assert_eq!(
+        result["error"]["details"]["issues"][0]["code"],
+        "SEMANTIC_GRAPH_COVERAGE_INCOMPLETE",
+        "{result}"
+    );
+}

--- a/scripts/benchmark-native-graph.py
+++ b/scripts/benchmark-native-graph.py
@@ -365,17 +365,21 @@ def latest_logged_database(idea_log, workspace):
 
 
 def database_candidates(receipt, workspace):
-    install_root = Path(receipt["roots"]["install"])
-    state_root = install_root / "state" / "workspaces"
-    name_prefix = f"{workspace.name}--"
-    return sorted(
-        path
-        for path in state_root.glob("**/cache/source-index.db")
-        if path.parent.parent.name.startswith(name_prefix)
-    )
+    state_root = Path(receipt["roots"]["data"]) / "workspaces"
+    workspace = workspace.resolve()
+    candidates = []
+    for database in state_root.glob("**/cache/source-index.db"):
+        metadata = database.parent.parent / "workspace.json"
+        try:
+            prepared_root = Path(load_json(metadata, "WORKSPACE_METADATA_INVALID")["workspaceRoot"])
+        except (BenchmarkError, KeyError, TypeError):
+            continue
+        if prepared_root.is_absolute() and prepared_root.resolve() == workspace:
+            candidates.append(database)
+    return sorted(candidates)
 
 
-def discover_database(explicit, receipt, idea_log, workspace):
+def discover_database(explicit, receipt, idea_log, workspace, source_path=None):
     if explicit:
         database = Path(explicit).expanduser().resolve()
         if not database.is_file():
@@ -383,6 +387,16 @@ def discover_database(explicit, receipt, idea_log, workspace):
                 "DATABASE_MISSING", f"source-index.db does not exist: {database}"
             )
         return database
+    if source_path:
+        data_root = (Path(receipt["roots"]["data"]) / "workspaces").resolve()
+        database = Path(source_path).expanduser().resolve().parent / "cache" / "source-index.db"
+        try:
+            database.relative_to(data_root)
+        except ValueError:
+            pass
+        else:
+            if database.is_file():
+                return database
     logged = latest_logged_database(idea_log, workspace)
     if logged:
         return logged
@@ -825,7 +839,13 @@ def run_benchmark(args):
 
     idea_log = newest_idea_log(args.idea_log)
     log_start = log_offsets.get(idea_log, 0)
-    database = discover_database(args.database, receipt, idea_log, workspace)
+    database = discover_database(
+        args.database,
+        receipt,
+        idea_log,
+        workspace,
+        source_path=backend.get("sourcePath"),
+    )
     files = tracked_kotlin_files(workspace, args.source_root, args.limit)
     write_json(
         run_dir / "preflight.json",
@@ -1010,7 +1030,71 @@ def self_test():
         thread.join()
         assert response["result"]["generation"] == 7
 
-    emit_result("selfTest", {"ok": True, "checks": 5})
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        database = (
+            root
+            / "data"
+            / "workspaces"
+            / "git"
+            / "local"
+            / "repo--abc"
+            / "cache"
+            / "source-index.db"
+        )
+        database.parent.mkdir(parents=True)
+        database.touch()
+        receipt = {
+            "roots": {
+                "install": str(root / "install"),
+                "data": str(root / "data"),
+            }
+        }
+        metadata = database.parent.parent / "workspace.json"
+        metadata.write_text(json.dumps({"workspaceRoot": str(workspace)}))
+        assert database_candidates(receipt, workspace) == [database]
+        other_database = (
+            root
+            / "data"
+            / "workspaces"
+            / "git"
+            / "local"
+            / "repo--def"
+            / "cache"
+            / "source-index.db"
+        )
+        other_database.parent.mkdir(parents=True)
+        other_database.touch()
+        (other_database.parent.parent / "workspace.json").write_text(
+            json.dumps({"workspaceRoot": "/other/repo"})
+        )
+        assert database_candidates(receipt, workspace) == [database]
+        assert discover_database(
+            None,
+            receipt,
+            root / "idea.log",
+            workspace,
+            source_path=metadata,
+        ) == database.resolve()
+        spaced_workspace = root / "my repo"
+        spaced_database = (
+            root
+            / "data"
+            / "workspaces"
+            / "git"
+            / "local"
+            / "my-repo--ghi"
+            / "cache"
+            / "source-index.db"
+        )
+        spaced_database.parent.mkdir(parents=True)
+        spaced_database.touch()
+        (spaced_database.parent.parent / "workspace.json").write_text(
+            json.dumps({"workspaceRoot": str(spaced_workspace)})
+        )
+        assert database_candidates(receipt, spaced_workspace) == [spaced_database]
+
+    emit_result("selfTest", {"ok": True, "checks": 8})
     return 0
 
 


### PR DESCRIPTION
## Risk

- IntelliJ 2026.2 passes Plugin Verifier and live restart checks. The local Android Studio 2026.1.2 verifier image could not resolve its bundled Gradle plugins, so that target remains CI-owned evidence.

## What

- Restore lifecycle-safe project-service startup and preserve valid generic callable references during graph extraction.
- Report persisted semantic graph readiness in status and verification, failing closed when coverage is incomplete or unavailable.
- Discover the exact global workspace database for benchmarks, including sanitized and same-name worktree paths.

## Why

A restarted runtime could be compiler-ready while its graph was incomplete, yet verification still reported success. The benchmark also searched the retired project-local state layout, and valid callable references could abort graph refresh.

## Evidence

- Gradle analysis and IDEA backend tests pass.
- Full locked Rust tests, formatting, and clippy pass.
- Live IDEA restart: 727/727 requested files refreshed, zero failures; final coverage READY with 729 indexed, 511 excluded, 0 failed, 0 stale.
- Five-sample graph refresh p50 18.427 ms / p95 86.916 ms; neighbor traversals p50 10.388-76.749 ms.
- Project-local .kast is absent; metadata, cache, socket, and database resolve under the global Kast home.