### PR TITLE
Make release repository probes executable

### DIFF
--- a/.github/scripts/test-release-indexing-benchmark-contract.sh
+++ b/.github/scripts/test-release-indexing-benchmark-contract.sh
@@ -32,12 +32,70 @@ require "$release" 'fail-fast: false' 'repository matrix failures must not cance
 require "$release" 'ktorio/ktor.git' 'release gate must include Ktor'
 require "$release" 'spring-projects/spring-boot.git' 'release gate must include Spring Boot'
 require "$release" 'square/okhttp.git' 'release gate must include a Kotlin Multiplatform integration repository'
+require "$release" 'graph_file: ktor-test-server/src/main/kotlin/test/server/ServerUtils.kt' 'Ktor must use a pinned compiler graph probe'
+require "$release" 'graph_file: core/spring-boot/src/main/kotlin/org/springframework/boot/SpringApplicationExtensions.kt' 'Spring Boot must use a pinned compiler graph probe'
+require "$release" 'graph_file: okcurl/src/main/kotlin/okhttp3/curl/Main.kt' 'OkHttp must use a pinned compiler graph probe'
+
+relationship_setting() {
+  local name="$1"
+  awk -v name="$name" '
+    $1 == "-" && $2 == "name:" {
+      if (selected) exit
+      selected = ($3 == name)
+      next
+    }
+    selected && $1 == "relationships_enabled:" { print $2; exit }
+  ' "$release"
+}
+
+[[ "$(relationship_setting ktor)" == false ]] || { printf 'error: Ktor relationship indexing must stay bounded\n' >&2; exit 1; }
+[[ "$(relationship_setting spring-boot)" == false ]] || { printf 'error: Spring Boot relationship indexing must stay bounded\n' >&2; exit 1; }
+[[ "$(relationship_setting okhttp)" == true ]] || { printf 'error: OkHttp must retain full relationship indexing\n' >&2; exit 1; }
 # shellcheck disable=SC2016 # GitHub expression is intentionally matched literally.
 require "$release" 'linux-headless-tarball-${{ github.run_id }}' 'release gate must test the built release runtime'
+require "$release" "--graph-file \"\${{ matrix.graph_file }}\"" 'release gate must pass the pinned compiler graph probe'
+require "$release" "--relationships-enabled \"\${{ matrix.relationships_enabled }}\"" 'release gate must pass the relationship indexing plan'
 require "$release" 'needs.real-repository-indexing.result == '\''success'\''' 'release publication must require the repository gate'
+require "$runner" 'wait_timeout_ms=2700000' 'real repositories must have bounded Gradle import headroom'
 require "$runner" 'kast config list' 'benchmark must capture effective workspace configuration'
+require "$runner" "kast config set indexing.relationships.enabled \"\$relationships_enabled\"" 'benchmark must apply the declared relationship indexing plan'
+require "$runner" "if [[ \"\$relationships_enabled\" == true ]]" 'relationship tuning must apply only when relationship indexing is enabled'
 require "$runner" 'kast config set indexing.relationships.parallelism 2' 'benchmark must exercise relationship indexing configuration'
+require "$runner" "cat \"\$scratch/runtime.json\" >&2" 'runtime readiness failures must preserve their typed evidence'
+require "$runner" '--operation refresh' 'benchmark must populate the native graph through the compiler backend'
+require "$runner" "--file-path \"\$graph_file\"" 'benchmark must refresh the pinned Kotlin source'
+require "$runner" '--exclusive' 'benchmark graph evidence must stay within the pinned probe scope'
+require "$runner" 'Semantic graph refresh was incomplete' 'benchmark must verify compiler graph coverage'
 reject "$runner" '--accept-indexing' 'benchmark must wait for the runtime to become ready'
+
+reject_graph_file() {
+  local candidate="$1" output
+  if output="$(
+    "$runner" \
+      --name validation \
+      --repository https://github.com/example/repository.git \
+      --revision 0000000000000000000000000000000000000000 \
+      --graph-file "$candidate" \
+      --relationships-enabled false \
+      --bundle /missing \
+      --cache-root /unused 2>&1
+  )"; then
+    printf 'error: graph file was accepted: %s\n' "$candidate" >&2
+    exit 1
+  fi
+  [[ "$output" == *'graph file must be a relative Kotlin path'* ]] || {
+    printf 'error: graph file failed at the wrong boundary: %s: %s\n' "$candidate" "$output" >&2
+    exit 1
+  }
+}
+
+reject_graph_file ''
+reject_graph_file /tmp/Probe.kt
+reject_graph_file ./Probe.kt
+reject_graph_file src//Probe.kt
+reject_graph_file src/./Probe.kt
+reject_graph_file src/../Probe.kt
+reject_graph_file src/Probe.kts
 
 require "$cli_root" 'Config(ConfigArgs)' 'CLI must expose the config command family'
 require "$cli_config" 'List(ConfigWorkspaceArgs)' 'config must list effective workspace state'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1112,12 +1112,18 @@ jobs:
           - name: ktor
             repository: https://github.com/ktorio/ktor.git
             revision: 3ccad96fbb891469cdb5ff92b51a96bb6d6374c9
+            graph_file: ktor-test-server/src/main/kotlin/test/server/ServerUtils.kt
+            relationships_enabled: false
           - name: spring-boot
             repository: https://github.com/spring-projects/spring-boot.git
             revision: 8821ad2cd381bb4b9615a61479e1de7305a8ba39
+            graph_file: core/spring-boot/src/main/kotlin/org/springframework/boot/SpringApplicationExtensions.kt
+            relationships_enabled: false
           - name: okhttp
             repository: https://github.com/square/okhttp.git
             revision: 0960b47ec28a02e893499d2a7e53bf462a62875e
+            graph_file: okcurl/src/main/kotlin/okhttp3/curl/Main.kt
+            relationships_enabled: true
     steps:
       - uses: actions/checkout@v5
         with:
@@ -1150,6 +1156,8 @@ jobs:
             --name "${{ matrix.name }}" \
             --repository "${{ matrix.repository }}" \
             --revision "${{ matrix.revision }}" \
+            --graph-file "${{ matrix.graph_file }}" \
+            --relationships-enabled "${{ matrix.relationships_enabled }}" \
             --bundle "$bundle" \
             --cache-root "${{ runner.temp }}/kast-real-repository-cache"
 

--- a/scripts/release/benchmark-real-repositories.sh
+++ b/scripts/release/benchmark-real-repositories.sh
@@ -7,22 +7,38 @@ Usage: benchmark-real-repositories.sh \
   --name <slug> \
   --repository <https://github.com/owner/repo.git> \
   --revision <40-hex commit> \
+  --graph-file <relative Kotlin path> \
+  --relationships-enabled <true|false> \
   --bundle <linux setup tarball> \
   --cache-root <directory>
 EOF
 }
 
+valid_graph_file() {
+  local path="$1" component
+  local -a components
+  [[ -n "$path" && "$path" != /* && "$path" == *.kt ]] || return 1
+  IFS=/ read -r -a components <<<"$path"
+  for component in "${components[@]}"; do
+    [[ "$component" =~ ^[A-Za-z0-9._-]+$ && "$component" != . && "$component" != .. ]] || return 1
+  done
+}
+
 name=
 repository=
 revision=
+graph_file=
+relationships_enabled=
 bundle=
 cache_root=
-wait_timeout_ms=1200000
+wait_timeout_ms=2700000
 while (($#)); do
   case "$1" in
     --name) name="${2:-}"; shift 2 ;;
     --repository) repository="${2:-}"; shift 2 ;;
     --revision) revision="${2:-}"; shift 2 ;;
+    --graph-file) graph_file="${2:-}"; shift 2 ;;
+    --relationships-enabled) relationships_enabled="${2:-}"; shift 2 ;;
     --bundle) bundle="${2:-}"; shift 2 ;;
     --cache-root) cache_root="${2:-}"; shift 2 ;;
     --wait-timeout-ms) wait_timeout_ms="${2:-}"; shift 2 ;;
@@ -35,6 +51,10 @@ done
 [[ "$repository" =~ ^https://github\.com/[^/]+/[^/]+\.git$ ]] \
   || { printf 'error: benchmark repository must be a GitHub HTTPS clone URL\n' >&2; exit 2; }
 [[ "$revision" =~ ^[0-9a-f]{40}$ ]] || { printf 'error: revision must be a full commit SHA\n' >&2; exit 2; }
+valid_graph_file "$graph_file" \
+  || { printf 'error: graph file must be a relative Kotlin path\n' >&2; exit 2; }
+[[ "$relationships_enabled" == true || "$relationships_enabled" == false ]] \
+  || { printf 'error: relationships enabled must be true or false\n' >&2; exit 2; }
 [[ -f "$bundle" ]] || { printf 'error: bundle not found: %s\n' "$bundle" >&2; exit 2; }
 [[ -n "$cache_root" ]] || { printf 'error: --cache-root is required\n' >&2; exit 2; }
 [[ "$wait_timeout_ms" =~ ^[1-9][0-9]*$ ]] || { printf 'error: wait timeout must be positive\n' >&2; exit 2; }
@@ -67,6 +87,8 @@ cleanup() {
 trap cleanup EXIT
 
 git -C "$repository_cache" worktree add --detach "$workspace" "$revision"
+[[ -f "$workspace/$graph_file" ]] \
+  || { printf 'error: graph file not found: %s\n' "$graph_file" >&2; exit 1; }
 tar -xzf "$bundle" -C "$bundle_dir"
 bundle_bin="$(find "$bundle_dir" -maxdepth 3 -type f -path '*/bin/kast' -print -quit)"
 [[ -n "$bundle_bin" ]] || { printf 'error: bundle does not contain bin/kast\n' >&2; exit 1; }
@@ -91,13 +113,19 @@ kast() {
     "$kast_bin" "$@"
 }
 
-kast config set indexing.relationships.parallelism 2 --workspace-root "$workspace" >/dev/null
+kast config set indexing.relationships.enabled "$relationships_enabled" --workspace-root "$workspace" >/dev/null
+if [[ "$relationships_enabled" == true ]]; then
+  kast config set indexing.relationships.parallelism 2 --workspace-root "$workspace" >/dev/null
+fi
 kast config set gradle.toolingApiTimeoutMillis "$wait_timeout_ms" --workspace-root "$workspace" >/dev/null
 kast config list --workspace-root "$workspace" >"$scratch/effective-config.toon"
-kast --output json developer runtime up \
-  --backend headless \
-  --workspace-root "$workspace" \
-  --wait-timeout-ms "$wait_timeout_ms" >"$scratch/runtime.json"
+if ! kast --output json developer runtime up \
+    --backend headless \
+    --workspace-root "$workspace" \
+    --wait-timeout-ms "$wait_timeout_ms" >"$scratch/runtime.json"; then
+  cat "$scratch/runtime.json" >&2
+  exit 1
+fi
 kast --output json agent workspace-files \
   --backend headless \
   --workspace-root "$workspace" \
@@ -105,9 +133,15 @@ kast --output json agent workspace-files \
 kast --output json agent graph \
   --backend headless \
   --workspace-root "$workspace" \
+  --operation refresh \
+  --file-path "$graph_file" \
+  --exclusive >"$scratch/graph-refresh.json"
+kast --output json agent graph \
+  --backend headless \
+  --workspace-root "$workspace" \
   --operation summary >"$scratch/graph.json"
 
-python3 - "$scratch/workspace-files.json" "$scratch/graph.json" <<'PY'
+python3 - "$scratch/workspace-files.json" "$scratch/graph-refresh.json" "$scratch/graph.json" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -117,7 +151,17 @@ cardinality = workspace_files["result"]["cardinality"]
 if cardinality.get("type") != "EXACT" or cardinality.get("totalCount", 0) <= 0:
     raise SystemExit(f"workspace indexing was not complete: {cardinality}")
 
-graph = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+refresh = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+coverage = refresh.get("result", {}).get("coverage", {}).get("files", [])
+if (
+    not refresh.get("ok")
+    or refresh.get("result", {}).get("symbolCount", 0) <= 0
+    or len(coverage) != 1
+    or coverage[0].get("status") != "REFRESHED"
+):
+    raise SystemExit(f"Semantic graph refresh was incomplete: {refresh}")
+
+graph = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
 if not graph.get("ok") or graph.get("result", {}).get("nodeCount", 0) <= 0:
     raise SystemExit("native graph summary was unavailable")
 PY


### PR DESCRIPTION
## Summary
- keep strict READY and exact inventory proof for every real repository
- retain full relationship indexing on OkHttp while bounding Ktor and Spring Boot
- explicitly refresh and verify one pinned compiler graph per repository
- preserve typed runtime failure output

## Root cause
Ktor and Spring Boot exhausted the old 20-minute relationship-index wait. OkHttp reached READY but queried an unpopulated native graph.

## Proof
- release indexing benchmark contract
- release workflow contract
- bash syntax and ShellCheck
- repository shape check
- git diff check