### PR TITLE
Scope release repository indexing probes

### DIFF
--- a/.github/scripts/test-release-indexing-benchmark-contract.sh
+++ b/.github/scripts/test-release-indexing-benchmark-contract.sh
@@ -30,10 +30,11 @@ reject() {
 require "$release" 'real-repository-indexing:' 'release workflow must own the real-repository indexing gate'
 require "$release" 'fail-fast: false' 'repository matrix failures must not cancel remaining repositories'
 require "$release" 'ktorio/ktor.git' 'release gate must include Ktor'
-require "$release" 'spring-projects/spring-boot.git' 'release gate must include Spring Boot'
+require "$release" 'AleksK1NG/Kotlin-Clean-Architecture-CQRS.git' 'release gate must include a Java 21 Kotlin Spring project'
+reject "$release" 'spring-projects/spring-boot.git' 'release gate must not import the full Spring Boot monorepo'
 require "$release" 'square/okhttp.git' 'release gate must include a Kotlin Multiplatform integration repository'
 require "$release" 'graph_file: ktor-test-server/src/main/kotlin/test/server/ServerUtils.kt' 'Ktor must use a pinned compiler graph probe'
-require "$release" 'graph_file: core/spring-boot/src/main/kotlin/org/springframework/boot/SpringApplicationExtensions.kt' 'Spring Boot must use a pinned compiler graph probe'
+require "$release" 'graph_file: src/main/kotlin/com/alexander/bryksin/kotlinspringcleanarchitecture/KotlinSpringCleanArchitectureApplication.kt' 'Spring must use a pinned compiler graph probe'
 require "$release" 'graph_file: okcurl/src/main/kotlin/okhttp3/curl/Main.kt' 'OkHttp must use a pinned compiler graph probe'
 
 relationship_setting() {
@@ -62,8 +63,12 @@ require "$runner" "kast config set indexing.relationships.enabled \"\$relationsh
 require "$runner" "if [[ \"\$relationships_enabled\" == true ]]" 'relationship tuning must apply only when relationship indexing is enabled'
 require "$runner" 'kast config set indexing.relationships.parallelism 2' 'benchmark must exercise relationship indexing configuration'
 require "$runner" "cat \"\$scratch/runtime.json\" >&2" 'runtime readiness failures must preserve their typed evidence'
+require "$runner" 'settings.gradle.kts' 'benchmark must recognize Kotlin Gradle build roots'
+require "$runner" 'settings.gradle' 'benchmark must recognize Groovy Gradle build roots'
+# shellcheck disable=SC2016 # Runner variables are intentionally matched literally.
+require "$runner" 'scoped_graph_file="${graph_path#"$workspace"/}"' 'benchmark must make the probe relative to the selected Gradle root'
 require "$runner" '--operation refresh' 'benchmark must populate the native graph through the compiler backend'
-require "$runner" "--file-path \"\$graph_file\"" 'benchmark must refresh the pinned Kotlin source'
+require "$runner" "--file-path \"\$scoped_graph_file\"" 'benchmark must refresh the pinned Kotlin source within the selected Gradle root'
 require "$runner" '--exclusive' 'benchmark graph evidence must stay within the pinned probe scope'
 require "$runner" 'Semantic graph refresh was incomplete' 'benchmark must verify compiler graph coverage'
 reject "$runner" '--accept-indexing' 'benchmark must wait for the runtime to become ready'
@@ -96,6 +101,29 @@ reject_graph_file src//Probe.kt
 reject_graph_file src/./Probe.kt
 reject_graph_file src/../Probe.kt
 reject_graph_file src/Probe.kts
+
+# shellcheck disable=SC1090,SC1091 # The checked runner path is resolved above.
+source "$runner"
+scope_fixture="$(mktemp -d "${TMPDIR:-/tmp}/kast-release-scope.XXXXXX")"
+trap 'rm -rf -- "$scope_fixture"' EXIT
+repository_fixture="$scope_fixture/repository"
+ktor_fixture="$repository_fixture/ktor-test-server"
+mkdir -p "$ktor_fixture/src/main/kotlin/test/server" "$repository_fixture/okcurl/src/main/kotlin"
+touch \
+  "$repository_fixture/settings.gradle.kts" \
+  "$ktor_fixture/settings.gradle.kts" \
+  "$ktor_fixture/src/main/kotlin/test/server/ServerUtils.kt" \
+  "$repository_fixture/okcurl/src/main/kotlin/Main.kt"
+[[ "$(gradle_workspace_for "$ktor_fixture/src/main/kotlin/test/server/ServerUtils.kt" "$repository_fixture")" == "$ktor_fixture" ]] \
+  || { printf 'error: nested Ktor build was not selected\n' >&2; exit 1; }
+[[ "$(gradle_workspace_for "$repository_fixture/okcurl/src/main/kotlin/Main.kt" "$repository_fixture")" == "$repository_fixture" ]] \
+  || { printf 'error: repository Gradle root was not selected\n' >&2; exit 1; }
+mkdir -p "$scope_fixture/no-settings/src"
+touch "$scope_fixture/no-settings/src/Probe.kt"
+if gradle_workspace_for "$scope_fixture/no-settings/src/Probe.kt" "$scope_fixture/no-settings" >/dev/null; then
+  printf 'error: probe outside a Gradle build was accepted\n' >&2
+  exit 1
+fi
 
 require "$cli_root" 'Config(ConfigArgs)' 'CLI must expose the config command family'
 require "$cli_config" 'List(ConfigWorkspaceArgs)' 'config must list effective workspace state'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1115,9 +1115,9 @@ jobs:
             graph_file: ktor-test-server/src/main/kotlin/test/server/ServerUtils.kt
             relationships_enabled: false
           - name: spring-boot
-            repository: https://github.com/spring-projects/spring-boot.git
-            revision: 8821ad2cd381bb4b9615a61479e1de7305a8ba39
-            graph_file: core/spring-boot/src/main/kotlin/org/springframework/boot/SpringApplicationExtensions.kt
+            repository: https://github.com/AleksK1NG/Kotlin-Clean-Architecture-CQRS.git
+            revision: d523770246f2ddb586868e4a9e55cafce7e0d6f8
+            graph_file: src/main/kotlin/com/alexander/bryksin/kotlinspringcleanarchitecture/KotlinSpringCleanArchitectureApplication.kt
             relationships_enabled: false
           - name: okhttp
             repository: https://github.com/square/okhttp.git

--- a/scripts/release/benchmark-real-repositories.sh
+++ b/scripts/release/benchmark-real-repositories.sh
@@ -24,6 +24,20 @@ valid_graph_file() {
   done
 }
 
+gradle_workspace_for() {
+  local graph_path="$1" repository_root="$2" workspace
+  workspace="$(dirname "$graph_path")"
+  while [[ "$workspace" != "$repository_root" \
+      && ! -f "$workspace/settings.gradle" \
+      && ! -f "$workspace/settings.gradle.kts" ]]; do
+    workspace="$(dirname "$workspace")"
+  done
+  [[ -f "$workspace/settings.gradle" || -f "$workspace/settings.gradle.kts" ]] || return 1
+  printf '%s\n' "$workspace"
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] || return 0
+
 name=
 repository=
 revision=
@@ -69,7 +83,8 @@ git -C "$repository_cache" fetch --force --depth=1 origin "$revision"
 git -C "$repository_cache" cat-file -e "${revision}^{commit}"
 
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/kast-real-repository.XXXXXX")"
-workspace="$scratch/workspace"
+repository_worktree="$scratch/repository"
+workspace=
 bundle_dir="$scratch/bundle"
 benchmark_user_dir="$scratch/user"
 kast_home_dir="$scratch/kast-home"
@@ -78,17 +93,21 @@ gradle_user_dir="$scratch/gradle"
 mkdir -p "$bundle_dir" "$benchmark_user_dir" "$kast_home_dir" "$kast_cache_dir" "$gradle_user_dir"
 
 cleanup() {
-  if [[ -n "${kast_bin:-}" && -x "${kast_bin:-}" && -d "$workspace" ]]; then
+  if [[ -n "${kast_bin:-}" && -x "${kast_bin:-}" && -n "$workspace" && -d "$workspace" ]]; then
     kast developer runtime stop --backend headless --workspace-root "$workspace" >/dev/null 2>&1 || true
   fi
-  git -C "$repository_cache" worktree remove --force "$workspace" >/dev/null 2>&1 || true
+  git -C "$repository_cache" worktree remove --force "$repository_worktree" >/dev/null 2>&1 || true
   rm -rf "$scratch"
 }
 trap cleanup EXIT
 
-git -C "$repository_cache" worktree add --detach "$workspace" "$revision"
-[[ -f "$workspace/$graph_file" ]] \
+git -C "$repository_cache" worktree add --detach "$repository_worktree" "$revision"
+graph_path="$repository_worktree/$graph_file"
+[[ -f "$graph_path" ]] \
   || { printf 'error: graph file not found: %s\n' "$graph_file" >&2; exit 1; }
+workspace="$(gradle_workspace_for "$graph_path" "$repository_worktree")" \
+  || { printf 'error: graph file is not inside a Gradle build: %s\n' "$graph_file" >&2; exit 1; }
+scoped_graph_file="${graph_path#"$workspace"/}"
 tar -xzf "$bundle" -C "$bundle_dir"
 bundle_bin="$(find "$bundle_dir" -maxdepth 3 -type f -path '*/bin/kast' -print -quit)"
 [[ -n "$bundle_bin" ]] || { printf 'error: bundle does not contain bin/kast\n' >&2; exit 1; }
@@ -134,7 +153,7 @@ kast --output json agent graph \
   --backend headless \
   --workspace-root "$workspace" \
   --operation refresh \
-  --file-path "$graph_file" \
+  --file-path "$scoped_graph_file" \
   --exclusive >"$scratch/graph-refresh.json"
 kast --output json agent graph \
   --backend headless \


### PR DESCRIPTION
## Summary
- select the nearest checked-in Gradle build around each pinned Kotlin graph probe
- scope Ktor to its standalone ktor-test-server build
- replace the unbounded Spring Boot monorepo import with a pinned small Kotlin/Spring Boot project that runs natively on Java 21
- execute the scope resolver against nested, root, and invalid fixtures

## Proof
- bash .github/scripts/test-release-indexing-benchmark-contract.sh
- bash -n scripts/release/benchmark-real-repositories.sh .github/scripts/test-release-indexing-benchmark-contract.sh
- shellcheck scripts/release/benchmark-real-repositories.sh .github/scripts/test-release-indexing-benchmark-contract.sh
- PyYAML parse of .github/workflows/release.yml
- git diff --check