### PR TITLE
Use standalone Ktor release probe

### DIFF
--- a/.github/scripts/test-release-indexing-benchmark-contract.sh
+++ b/.github/scripts/test-release-indexing-benchmark-contract.sh
@@ -29,11 +29,12 @@ reject() {
 
 require "$release" 'real-repository-indexing:' 'release workflow must own the real-repository indexing gate'
 require "$release" 'fail-fast: false' 'repository matrix failures must not cancel remaining repositories'
-require "$release" 'ktorio/ktor.git' 'release gate must include Ktor'
+require "$release" 'ktorio/ktor-samples.git' 'release gate must include a self-contained official Ktor sample'
+reject "$release" 'ktorio/ktor.git' 'release gate must not use the Ktor included-build probe'
 require "$release" 'AleksK1NG/Kotlin-Clean-Architecture-CQRS.git' 'release gate must include a Java 21 Kotlin Spring project'
 reject "$release" 'spring-projects/spring-boot.git' 'release gate must not import the full Spring Boot monorepo'
 require "$release" 'square/okhttp.git' 'release gate must include a Kotlin Multiplatform integration repository'
-require "$release" 'graph_file: ktor-test-server/src/main/kotlin/test/server/ServerUtils.kt' 'Ktor must use a pinned compiler graph probe'
+require "$release" 'graph_file: httpbin/src/main/kotlin/io/ktor/samples/httpbin/Server.kt' 'Ktor must use a pinned compiler graph probe'
 require "$release" 'graph_file: src/main/kotlin/com/alexander/bryksin/kotlinspringcleanarchitecture/KotlinSpringCleanArchitectureApplication.kt' 'Spring must use a pinned compiler graph probe'
 require "$release" 'graph_file: okcurl/src/main/kotlin/okhttp3/curl/Main.kt' 'OkHttp must use a pinned compiler graph probe'
 
@@ -54,6 +55,12 @@ relationship_setting() {
 [[ "$(relationship_setting okhttp)" == true ]] || { printf 'error: OkHttp must retain full relationship indexing\n' >&2; exit 1; }
 # shellcheck disable=SC2016 # GitHub expression is intentionally matched literally.
 require "$release" 'linux-headless-tarball-${{ github.run_id }}' 'release gate must test the built release runtime'
+require "$release" 'Set up Gradle Java 17 toolchain' 'release gate must install the Ktor sample toolchain'
+require "$release" 'set-default: false' 'Gradle toolchain setup must not replace the Java 21 Kast runtime'
+# shellcheck disable=SC2016 # GitHub expression is intentionally matched literally.
+require "$release" 'GRADLE_JAVA_HOME: ${{ steps.gradle-java.outputs.path }}' 'release gate must bind the installed Gradle toolchain'
+# shellcheck disable=SC2016 # Workflow shell variables are intentionally matched literally.
+require "$release" 'export GRADLE_OPTS="-Dorg.gradle.java.installations.paths=${GRADLE_JAVA_HOME},${JAVA_HOME}"' 'Gradle must see both its Java 17 toolchain and the Java 21 runtime'
 require "$release" "--graph-file \"\${{ matrix.graph_file }}\"" 'release gate must pass the pinned compiler graph probe'
 require "$release" "--relationships-enabled \"\${{ matrix.relationships_enabled }}\"" 'release gate must pass the relationship indexing plan'
 require "$release" 'needs.real-repository-indexing.result == '\''success'\''' 'release publication must require the repository gate'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1110,9 +1110,9 @@ jobs:
       matrix:
         include:
           - name: ktor
-            repository: https://github.com/ktorio/ktor.git
-            revision: 3ccad96fbb891469cdb5ff92b51a96bb6d6374c9
-            graph_file: ktor-test-server/src/main/kotlin/test/server/ServerUtils.kt
+            repository: https://github.com/ktorio/ktor-samples.git
+            revision: c89f051e1183455eda8b26146555a1b5ed23d18c
+            graph_file: httpbin/src/main/kotlin/io/ktor/samples/httpbin/Server.kt
             relationships_enabled: false
           - name: spring-boot
             repository: https://github.com/AleksK1NG/Kotlin-Clean-Architecture-CQRS.git
@@ -1128,6 +1128,14 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Set up Gradle Java 17 toolchain
+        id: gradle-java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          set-default: false
 
       - uses: actions/setup-java@v5
         with:
@@ -1148,8 +1156,11 @@ jobs:
 
       - name: Index pinned repository
         shell: bash
+        env:
+          GRADLE_JAVA_HOME: ${{ steps.gradle-java.outputs.path }}
         run: |
           set -euo pipefail
+          export GRADLE_OPTS="-Dorg.gradle.java.installations.paths=${GRADLE_JAVA_HOME},${JAVA_HOME}"
           bundle="$(find release-bundle -maxdepth 1 -name 'kast-ubuntu-debian-headless-x86_64-*.tar.gz' -print -quit)"
           [[ -n "$bundle" ]] || { echo "Linux setup bundle not found" >&2; exit 1; }
           scripts/release/benchmark-real-repositories.sh \


### PR DESCRIPTION
## Summary
- replace the Ktor monorepo included-build probe that reached READY but returned KNOWN_MINIMUM workspace cardinality
- pin the official Ktor 3.5.0 httpbin sample as a self-contained Gradle root
- install its Java 17 Gradle toolchain without replacing the Java 21 Kast runtime

## Evidence
- v0.17.6 run 30385016379: Ktor reached READY, then exact workspace proof failed with KNOWN_MINIMUM 32
- upstream identical httpbin sample build succeeds
- bash .github/scripts/test-release-indexing-benchmark-contract.sh
- shellcheck .github/scripts/test-release-indexing-benchmark-contract.sh
- PyYAML parse of .github/workflows/release.yml
- git diff --check
- independent review: no findings