### PR TITLE
fix(release): expose Gradle toolchains to tooling API

### DIFF
--- a/.github/scripts/test-release-indexing-benchmark-contract.sh
+++ b/.github/scripts/test-release-indexing-benchmark-contract.sh
@@ -59,8 +59,7 @@ require "$release" 'Set up Gradle Java 17 toolchain' 'release gate must install 
 require "$release" 'set-default: false' 'Gradle toolchain setup must not replace the Java 21 Kast runtime'
 # shellcheck disable=SC2016 # GitHub expression is intentionally matched literally.
 require "$release" 'GRADLE_JAVA_HOME: ${{ steps.gradle-java.outputs.path }}' 'release gate must bind the installed Gradle toolchain'
-# shellcheck disable=SC2016 # Workflow shell variables are intentionally matched literally.
-require "$release" 'export GRADLE_OPTS="-Dorg.gradle.java.installations.paths=${GRADLE_JAVA_HOME},${JAVA_HOME}"' 'Gradle must see both its Java 17 toolchain and the Java 21 runtime'
+reject "$release" 'GRADLE_OPTS=' 'Gradle toolchain paths must not depend on a gradlew-only launcher variable'
 require "$release" "--graph-file \"\${{ matrix.graph_file }}\"" 'release gate must pass the pinned compiler graph probe'
 require "$release" "--relationships-enabled \"\${{ matrix.relationships_enabled }}\"" 'release gate must pass the relationship indexing plan'
 require "$release" 'needs.real-repository-indexing.result == '\''success'\''' 'release publication must require the repository gate'
@@ -129,6 +128,18 @@ mkdir -p "$scope_fixture/no-settings/src"
 touch "$scope_fixture/no-settings/src/Probe.kt"
 if gradle_workspace_for "$scope_fixture/no-settings/src/Probe.kt" "$scope_fixture/no-settings" >/dev/null; then
   printf 'error: probe outside a Gradle build was accepted\n' >&2
+  exit 1
+fi
+gradle_user_fixture="$scope_fixture/gradle-user"
+gradle_java_fixture="$scope_fixture/java-17"
+runtime_java_fixture="$scope_fixture/java-21"
+mkdir -p "$gradle_user_fixture" "$gradle_java_fixture" "$runtime_java_fixture"
+configure_gradle_java_paths "$gradle_user_fixture" "$gradle_java_fixture" "$runtime_java_fixture"
+[[ "$(cat "$gradle_user_fixture/gradle.properties")" == \
+    "org.gradle.java.installations.paths=$gradle_java_fixture,$runtime_java_fixture" ]] \
+  || { printf 'error: Gradle Tooling API paths were not configured\n' >&2; exit 1; }
+if configure_gradle_java_paths "$gradle_user_fixture" "$scope_fixture/missing-java" "$runtime_java_fixture" 2>/dev/null; then
+  printf 'error: missing Gradle Java home was accepted\n' >&2
   exit 1
 fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1160,7 +1160,6 @@ jobs:
           GRADLE_JAVA_HOME: ${{ steps.gradle-java.outputs.path }}
         run: |
           set -euo pipefail
-          export GRADLE_OPTS="-Dorg.gradle.java.installations.paths=${GRADLE_JAVA_HOME},${JAVA_HOME}"
           bundle="$(find release-bundle -maxdepth 1 -name 'kast-ubuntu-debian-headless-x86_64-*.tar.gz' -print -quit)"
           [[ -n "$bundle" ]] || { echo "Linux setup bundle not found" >&2; exit 1; }
           scripts/release/benchmark-real-repositories.sh \

--- a/scripts/release/benchmark-real-repositories.sh
+++ b/scripts/release/benchmark-real-repositories.sh
@@ -36,6 +36,15 @@ gradle_workspace_for() {
   printf '%s\n' "$workspace"
 }
 
+configure_gradle_java_paths() {
+  local gradle_user_dir="$1" gradle_java_home="${2:-}" java_home="${3:-}"
+  [[ -n "$gradle_java_home" ]] || return 0
+  [[ -d "$gradle_java_home" ]] || { printf 'error: Gradle Java home not found: %s\n' "$gradle_java_home" >&2; return 1; }
+  [[ -d "$java_home" ]] || { printf 'error: Java home not found: %s\n' "$java_home" >&2; return 1; }
+  printf 'org.gradle.java.installations.paths=%s,%s\n' "$gradle_java_home" "$java_home" \
+    >"$gradle_user_dir/gradle.properties"
+}
+
 [[ "${BASH_SOURCE[0]}" == "$0" ]] || return 0
 
 name=
@@ -91,6 +100,7 @@ kast_home_dir="$scratch/kast-home"
 kast_cache_dir="$scratch/kast-cache"
 gradle_user_dir="$scratch/gradle"
 mkdir -p "$bundle_dir" "$benchmark_user_dir" "$kast_home_dir" "$kast_cache_dir" "$gradle_user_dir"
+configure_gradle_java_paths "$gradle_user_dir" "${GRADLE_JAVA_HOME:-}" "${JAVA_HOME:-}"
 
 cleanup() {
   if [[ -n "${kast_bin:-}" && -x "${kast_bin:-}" && -n "$workspace" && -d "$workspace" ]]; then


### PR DESCRIPTION
## Summary
- write setup-java JDK paths to the benchmark's isolated Gradle user properties
- remove launcher-only `GRADLE_OPTS` propagation
- execute the toolchain property contract and reject missing JDK paths

## Proof
- `bash .github/scripts/test-release-indexing-benchmark-contract.sh`
- `shellcheck scripts/release/benchmark-real-repositories.sh .github/scripts/test-release-indexing-benchmark-contract.sh`
- `git diff --check`