### PR TITLE
fix(release): complete indexing for exact cardinality

### DIFF
--- a/.github/scripts/test-release-indexing-benchmark-contract.sh
+++ b/.github/scripts/test-release-indexing-benchmark-contract.sh
@@ -50,9 +50,12 @@ relationship_setting() {
   ' "$release"
 }
 
-[[ "$(relationship_setting ktor)" == false ]] || { printf 'error: Ktor relationship indexing must stay bounded\n' >&2; exit 1; }
-[[ "$(relationship_setting spring-boot)" == false ]] || { printf 'error: Spring Boot relationship indexing must stay bounded\n' >&2; exit 1; }
-[[ "$(relationship_setting okhttp)" == true ]] || { printf 'error: OkHttp must retain full relationship indexing\n' >&2; exit 1; }
+for repository in ktor spring-boot okhttp; do
+  [[ "$(relationship_setting "$repository")" == true ]] || {
+    printf 'error: %s must complete relationship indexing for exact workspace cardinality\n' "$repository" >&2
+    exit 1
+  }
+done
 # shellcheck disable=SC2016 # GitHub expression is intentionally matched literally.
 require "$release" 'linux-headless-tarball-${{ github.run_id }}' 'release gate must test the built release runtime'
 require "$release" 'Set up Gradle Java 17 toolchain' 'release gate must install the Ktor sample toolchain'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1113,12 +1113,12 @@ jobs:
             repository: https://github.com/ktorio/ktor-samples.git
             revision: c89f051e1183455eda8b26146555a1b5ed23d18c
             graph_file: httpbin/src/main/kotlin/io/ktor/samples/httpbin/Server.kt
-            relationships_enabled: false
+            relationships_enabled: true
           - name: spring-boot
             repository: https://github.com/AleksK1NG/Kotlin-Clean-Architecture-CQRS.git
             revision: d523770246f2ddb586868e4a9e55cafce7e0d6f8
             graph_file: src/main/kotlin/com/alexander/bryksin/kotlinspringcleanarchitecture/KotlinSpringCleanArchitectureApplication.kt
-            relationships_enabled: false
+            relationships_enabled: true
           - name: okhttp
             repository: https://github.com/square/okhttp.git
             revision: 0960b47ec28a02e893499d2a7e53bf462a62875e


### PR DESCRIPTION
## Summary
- enable relationship indexing for Ktor and Spring release probes
- require every exact-cardinality probe to complete relationship indexing

## Root cause
Exact workspace cardinality requires a complete source-index candidate inventory. Kast only completes module index progress while relationship indexing is enabled, so the prior Ktor and Spring configuration could never satisfy the exact-cardinality contract.

## Proof
- red: contract rejected Ktor with `must complete relationship indexing for exact workspace cardinality`
- green: `bash .github/scripts/test-release-indexing-benchmark-contract.sh`
- `actionlint .github/workflows/release.yml`
- `git diff --check`