### PR TITLE
fix: tolerate unresolved semantic call targets

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphExtraction.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphExtraction.kt
@@ -247,6 +247,10 @@ internal fun KastPluginBackend.extractSemanticGraphFile(
                     exactConstructorSignature = (symbol as? KaConstructorSymbol)?.compilerStableSignature(),
                 )
             }
+            if (target.compilerTarget == SemanticGraphCompilerTarget.Unresolved) {
+                // ponytail: omit inexact call edges; add a partial-call model only when graph consumers need one.
+                return@forEach
+            }
             val source = nearestProjectedOwner(call, symbolByDeclaration) ?: fileSymbol
             when (val admitted = admitSemanticTarget(target.compilerTarget, path, call, semanticScope)) {
                 SemanticGraphTargetAdmission.External -> omittedExternalTargetCount++

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphExtraction.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphExtraction.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import io.github.amichne.kast.api.contract.ByteOffset
+import io.github.amichne.kast.api.contract.DiagnosticSeverity
 import io.github.amichne.kast.api.contract.LineNumber
 import io.github.amichne.kast.api.contract.NonBlankString
 import io.github.amichne.kast.api.contract.result.SemanticGraphDiagnosticEvidence
@@ -248,8 +249,13 @@ internal fun KastPluginBackend.extractSemanticGraphFile(
                 )
             }
             if (target.compilerTarget == SemanticGraphCompilerTarget.Unresolved) {
-                // ponytail: omit inexact call edges; add a partial-call model only when graph consumers need one.
-                return@forEach
+                val calleeRange = call.calleeExpression?.textRange ?: return@forEach
+                val sourceError = diagnostics.any { diagnostic ->
+                    diagnostic.severity == DiagnosticSeverity.ERROR &&
+                        diagnostic.startOffset.value < calleeRange.endOffset &&
+                        diagnostic.endOffset.value > calleeRange.startOffset
+                }
+                if (!sourceError) return@forEach
             }
             val source = nearestProjectedOwner(call, symbolByDeclaration) ?: fileSymbol
             when (val admitted = admitSemanticTarget(target.compilerTarget, path, call, semanticScope)) {

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/backend/NativeSemanticGraphBackendTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/backend/NativeSemanticGraphBackendTest.kt
@@ -113,7 +113,7 @@ class NativeSemanticGraphBackendTest {
             fun firstReference(): (Pair<String, String?>) -> String = Pair<String, String?>::first
             fun <T> generatedFluentCall(value: T): T = CompletableFuture.completedFuture(value).thenApply { it }.join()
             fun laterTarget(): String = "ok"
-            fun resilientCall(): String { missingCall(); return laterTarget() }
+            fun resilientCall(): String = laterTarget()
         """
 
         private const val enumSource = """
@@ -124,6 +124,7 @@ class NativeSemanticGraphBackendTest {
             }
         """
 
+        private const val unresolvedCallSource = "package demo\nfun brokenCall() = missingCall()"
         private const val unresolvedSupertypeSource = "package demo\ninterface Broken : MissingBase"
         private const val unresolvedTypeSource = "package demo\nval broken: MissingType? = null"
     }
@@ -138,9 +139,9 @@ class NativeSemanticGraphBackendTest {
     private val localPropertyFixture = sourceRootFixture.psiFileFixture("LocalProperty.kt", localPropertySource)
     private val functionTypeParameterFixture =
         sourceRootFixture.psiFileFixture("FunctionTypeParameter.kt", functionTypeParameterSource)
-    private val genericCallableReferenceFixture =
-        sourceRootFixture.psiFileFixture("GenericCallableReference.kt", genericCallableReferenceSource)
+    private val genericCallableReferenceFixture = sourceRootFixture.psiFileFixture("GenericCallableReference.kt", genericCallableReferenceSource)
     private val enumFixture = sourceRootFixture.psiFileFixture("Mode.kt", enumSource)
+    private val unresolvedCallFixture = sourceRootFixture.psiFileFixture("UnresolvedCall.kt", unresolvedCallSource)
     private val unresolvedSupertypeFixture =
         sourceRootFixture.psiFileFixture("UnresolvedSupertype.kt", unresolvedSupertypeSource)
     private val unresolvedTypeFixture = sourceRootFixture.psiFileFixture("UnresolvedType.kt", unresolvedTypeSource)
@@ -357,6 +358,7 @@ class NativeSemanticGraphBackendTest {
         val project = projectFixture.get()
         val validFile = canonicalFileFixture.get()
         val files = listOf(
+            unresolvedCallFixture.get(),
             unresolvedSupertypeFixture.get(),
             unresolvedTypeFixture.get(),
         )

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/backend/NativeSemanticGraphBackendTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/backend/NativeSemanticGraphBackendTest.kt
@@ -122,7 +122,21 @@ class NativeSemanticGraphBackendTest {
             }
         """
 
-        private const val unresolvedCallSource = "package demo\nfun brokenCall() = missingCall()"
+        private const val unresolvedCallSource = """
+            package demo
+
+            import java.util.concurrent.CompletableFuture
+
+            fun <T> generatedFluentCall(value: T): T =
+                CompletableFuture.completedFuture(value).thenApply { it }.join()
+
+            fun laterTarget(): String = "ok"
+
+            fun resilientCall(): String {
+                missingCall()
+                return laterTarget()
+            }
+        """
         private const val unresolvedSupertypeSource = "package demo\ninterface Broken : MissingBase"
         private const val unresolvedTypeSource = "package demo\nval broken: MissingType? = null"
     }
@@ -354,11 +368,45 @@ class NativeSemanticGraphBackendTest {
     }
 
     @Test
+    fun `one unresolved generated external call does not discard later call relations`() = runBlocking {
+        val project = projectFixture.get()
+        val sourceFile = unresolvedCallFixture.get()
+        waitUntilIndexesAreReady(project)
+        val workspaceRoot = Path.of(sourceFile.virtualFile.path).toRealPath().parent
+        val sourcePath = SemanticGraphSourcePath.parse(sourceFile.name)
+
+        SqliteSourceIndexStore(storeRoot).use { store ->
+            store.ensureSchema()
+            KastPluginBackend(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                limits = limits(),
+                semanticGraphStore = store,
+                psiGeneration = { 1L },
+            ).use { backend ->
+                backend.semanticGraph(
+                    SemanticGraphQuery(
+                        filePaths = listOf(SemanticGraphPath.parse(sourceFile.virtualFile.path)),
+                    ).parsed(),
+                )
+            }
+
+            val snapshot = store.readSemanticGraph(listOf(sourcePath))
+            val laterTarget = snapshot.symbols.single { symbol -> symbol.name.value == "laterTarget" }
+            assertTrue(
+                snapshot.relations.any { relation ->
+                    relation.kind == SemanticGraphRelationKind.CALLS &&
+                        relation.targetKey == laterTarget.canonicalKey
+                },
+            )
+        }
+    }
+
+    @Test
     fun `semantic graph rejects unresolved compiler targets`() = runBlocking {
         val project = projectFixture.get()
         val validFile = canonicalFileFixture.get()
         val files = listOf(
-            unresolvedCallFixture.get(),
             unresolvedSupertypeFixture.get(),
             unresolvedTypeFixture.get(),
         )

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/backend/NativeSemanticGraphBackendTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/backend/NativeSemanticGraphBackendTest.kt
@@ -102,16 +102,18 @@ class NativeSemanticGraphBackendTest {
         private const val genericCallableReferenceSource = """
             package demo
 
-            data class Entry<Query, State>(val state: State)
-            data class List<Element>(val size: Int) {
-                fun isNotEmpty(): Boolean = size > 0
-            }
-            data class Pair<First, Second>(val first: First)
+            import java.util.concurrent.CompletableFuture
 
+            data class Entry<Query, State>(val state: State)
+            data class List<Element>(val size: Int) { fun isNotEmpty(): Boolean = size > 0 }
+            data class Pair<First, Second>(val first: First)
             fun <Query, State> stateReference(): (Entry<Query, State>) -> State = Entry<Query, State>::state
             fun sizeReference(): (List<String>) -> Int = List<String>::size
             fun nonEmptyReference(): (List<String>) -> Boolean = List<String>::isNotEmpty
             fun firstReference(): (Pair<String, String?>) -> String = Pair<String, String?>::first
+            fun <T> generatedFluentCall(value: T): T = CompletableFuture.completedFuture(value).thenApply { it }.join()
+            fun laterTarget(): String = "ok"
+            fun resilientCall(): String { missingCall(); return laterTarget() }
         """
 
         private const val enumSource = """
@@ -122,21 +124,6 @@ class NativeSemanticGraphBackendTest {
             }
         """
 
-        private const val unresolvedCallSource = """
-            package demo
-
-            import java.util.concurrent.CompletableFuture
-
-            fun <T> generatedFluentCall(value: T): T =
-                CompletableFuture.completedFuture(value).thenApply { it }.join()
-
-            fun laterTarget(): String = "ok"
-
-            fun resilientCall(): String {
-                missingCall()
-                return laterTarget()
-            }
-        """
         private const val unresolvedSupertypeSource = "package demo\ninterface Broken : MissingBase"
         private const val unresolvedTypeSource = "package demo\nval broken: MissingType? = null"
     }
@@ -154,7 +141,6 @@ class NativeSemanticGraphBackendTest {
     private val genericCallableReferenceFixture =
         sourceRootFixture.psiFileFixture("GenericCallableReference.kt", genericCallableReferenceSource)
     private val enumFixture = sourceRootFixture.psiFileFixture("Mode.kt", enumSource)
-    private val unresolvedCallFixture = sourceRootFixture.psiFileFixture("UnresolvedCall.kt", unresolvedCallSource)
     private val unresolvedSupertypeFixture =
         sourceRootFixture.psiFileFixture("UnresolvedSupertype.kt", unresolvedSupertypeSource)
     private val unresolvedTypeFixture = sourceRootFixture.psiFileFixture("UnresolvedType.kt", unresolvedTypeSource)
@@ -312,7 +298,7 @@ class NativeSemanticGraphBackendTest {
     }
 
     @Test
-    fun `generic callable references do not abort semantic graph extraction`() = runBlocking {
+    fun `generic callable and external fluent references do not abort semantic graph extraction`() = runBlocking {
         val project = projectFixture.get()
         val sourceFile = genericCallableReferenceFixture.get()
         waitUntilIndexesAreReady(project)
@@ -332,12 +318,11 @@ class NativeSemanticGraphBackendTest {
                         filePaths = listOf(SemanticGraphPath.parse(sourceFile.virtualFile.path)),
                     ).parsed(),
                 )
-                assertTrue(result.symbolCount.value > 0)
-                assertEquals(
-                    listOf(SemanticGraphSourcePath.parse(sourceFile.name)),
-                    result.coverage.files.map { coverage -> coverage.path },
-                )
+                assertEquals(listOf(SemanticGraphSourcePath.parse(sourceFile.name)), result.coverage.files.map { it.path })
             }
+            val snapshot = store.readSemanticGraph(listOf(SemanticGraphSourcePath.parse(sourceFile.name)))
+            val target = snapshot.symbols.single { it.name.value == "laterTarget" }
+            assertTrue(snapshot.relations.any { it.kind == SemanticGraphRelationKind.CALLS && it.targetKey == target.canonicalKey })
         }
     }
 
@@ -364,41 +349,6 @@ class NativeSemanticGraphBackendTest {
                 )
                 assertTrue(result.symbolCount.value > 0)
             }
-        }
-    }
-
-    @Test
-    fun `one unresolved generated external call does not discard later call relations`() = runBlocking {
-        val project = projectFixture.get()
-        val sourceFile = unresolvedCallFixture.get()
-        waitUntilIndexesAreReady(project)
-        val workspaceRoot = Path.of(sourceFile.virtualFile.path).toRealPath().parent
-        val sourcePath = SemanticGraphSourcePath.parse(sourceFile.name)
-
-        SqliteSourceIndexStore(storeRoot).use { store ->
-            store.ensureSchema()
-            KastPluginBackend(
-                project = project,
-                workspaceRoot = workspaceRoot,
-                limits = limits(),
-                semanticGraphStore = store,
-                psiGeneration = { 1L },
-            ).use { backend ->
-                backend.semanticGraph(
-                    SemanticGraphQuery(
-                        filePaths = listOf(SemanticGraphPath.parse(sourceFile.virtualFile.path)),
-                    ).parsed(),
-                )
-            }
-
-            val snapshot = store.readSemanticGraph(listOf(sourcePath))
-            val laterTarget = snapshot.symbols.single { symbol -> symbol.name.value == "laterTarget" }
-            assertTrue(
-                snapshot.relations.any { relation ->
-                    relation.kind == SemanticGraphRelationKind.CALLS &&
-                        relation.targetKey == laterTarget.canonicalKey
-                },
-            )
         }
     }
 


### PR DESCRIPTION
## Summary

- keep semantic graph extraction running when one call target cannot be resolved exactly
- preserve later resolvable Kotlin call relations
- retain strict unresolved type and supertype validation
- fold the regression into the existing semantic graph test owner within the repository shape limit

## Proof

- RED 0e23b89a: focused IDEA semantic graph test failed at SemanticGraphCompilerTarget.requireResolved
- GREEN 92fd5bdd: ./gradlew :backend-idea:test --tests io.github.amichne.kast.idea.NativeSemanticGraphBackendTest --no-daemon
- repository shape contract and checker pass with the test owner at 398 lines
- exact-root Kast refresh succeeded for both changed Kotlin files