### PR TITLE
feat: add CI auxiliary job controls

### DIFF
--- a/.github/scripts/ci/test-ci-auxiliary-controls.sh
+++ b/.github/scripts/ci/test-ci-auxiliary-controls.sh
@@ -17,6 +17,25 @@ require() {
   grep -Fq -- "$needle" "$file" || die "$description"
 }
 
+reject() {
+  local file="$1"
+  local needle="$2"
+  local description="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    die "$description"
+  fi
+}
+
+require_count() {
+  local file="$1"
+  local needle="$2"
+  local expected="$3"
+  local description="$4"
+  local actual
+  actual="$(awk -v needle="$needle" 'index($0, needle) { count++ } END { print count + 0 }' "$file")"
+  [[ "$actual" -eq "$expected" ]] || die "${description}: expected ${expected}, found ${actual}"
+}
+
 [[ -f "$controls" ]] || die "missing CI auxiliary-control workflow"
 
 flags=(
@@ -28,17 +47,26 @@ flags=(
   CI_AUX_IDEA_PERFORMANCE
 )
 
+criticality_owners=(1 1 1 7 1 1)
+
 require "$controls" "set-one" "workflow must expose the set-one operation"
 require "$controls" "apply-profile" "workflow must expose the apply-profile operation"
-require "$controls" "lean) values=(false false false false false false)" "lean profile must disable every auxiliary flag"
-require "$controls" "standard) values=(true true false false true false)" "standard profile must keep contract smokes only"
-require "$controls" "full) values=(true true true true true true)" "full profile must enable every auxiliary flag"
+require "$controls" "lean) values=(optional optional optional optional optional optional)" "lean profile must make every auxiliary flag optional"
+require "$controls" "standard) values=(required required optional optional required optional)" "standard profile must require contract smokes only"
+require "$controls" "full) values=(required required required required required required)" "full profile must require every auxiliary flag"
 require "$controls" 'gh variable set "$FLAG" --body "$VALUE" --repo "$GITHUB_REPOSITORY"' "set-one job must write the selected flag"
 require "$controls" 'gh variable set "${flags[$index]}" --body "${values[$index]}" --repo "$GITHUB_REPOSITORY"' "profile job must write every flag"
+reject "$controls" '- "true"' "set-one must not expose the old enabled value"
+reject "$controls" '- "false"' "set-one must not expose the old disabled value"
 
-for flag in "${flags[@]}"; do
+for index in "${!flags[@]}"; do
+  flag="${flags[$index]}"
   require "$controls" "- ${flag}" "workflow must offer ${flag}"
-  require "$ci" "vars.${flag} != 'false'" "CI must gate an auxiliary surface with ${flag} while defaulting to enabled"
+  require_count "$ci" \
+    "continue-on-error: vars.${flag} == 'optional'" \
+    "${criticality_owners[$index]}" \
+    "CI must apply ${flag} criticality to every owning job or step"
+  reject "$ci" "if: vars.${flag}" "CI must not skip work with ${flag}"
 done
 
 printf '%s\n' 'CI auxiliary controls contract passed'

--- a/.github/scripts/ci/test-ci-auxiliary-controls.sh
+++ b/.github/scripts/ci/test-ci-auxiliary-controls.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'CI auxiliary controls contract: %s\n' "$*" >&2
+  exit 1
+}
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ci="${repo_root}/.github/workflows/ci.yml"
+controls="${repo_root}/.github/workflows/ci-auxiliary-controls.yml"
+
+require() {
+  local file="$1"
+  local needle="$2"
+  local description="$3"
+  grep -Fq -- "$needle" "$file" || die "$description"
+}
+
+[[ -f "$controls" ]] || die "missing CI auxiliary-control workflow"
+
+flags=(
+  CI_AUX_LOCAL_AUTHORITY
+  CI_AUX_RUNTIME_CONTRACTS
+  CI_AUX_MAVEN_PUBLICATION
+  CI_AUX_DISTRIBUTION
+  CI_AUX_ANALYSIS_TRANSPORT
+  CI_AUX_IDEA_PERFORMANCE
+)
+
+require "$controls" "set-one" "workflow must expose the set-one operation"
+require "$controls" "apply-profile" "workflow must expose the apply-profile operation"
+require "$controls" "lean) values=(false false false false false false)" "lean profile must disable every auxiliary flag"
+require "$controls" "standard) values=(true true false false true false)" "standard profile must keep contract smokes only"
+require "$controls" "full) values=(true true true true true true)" "full profile must enable every auxiliary flag"
+require "$controls" 'gh variable set "$FLAG" --body "$VALUE" --repo "$GITHUB_REPOSITORY"' "set-one job must write the selected flag"
+require "$controls" 'gh variable set "${flags[$index]}" --body "${values[$index]}" --repo "$GITHUB_REPOSITORY"' "profile job must write every flag"
+
+for flag in "${flags[@]}"; do
+  require "$controls" "- ${flag}" "workflow must offer ${flag}"
+  require "$ci" "vars.${flag} != 'false'" "CI must gate an auxiliary surface with ${flag} while defaulting to enabled"
+done
+
+printf '%s\n' 'CI auxiliary controls contract passed'

--- a/.github/scripts/ci/test-ci-auxiliary-controls.sh
+++ b/.github/scripts/ci/test-ci-auxiliary-controls.sh
@@ -61,9 +61,10 @@ reject "$controls" '- "false"' "set-one must not expose the old disabled value"
 
 for index in "${!flags[@]}"; do
   flag="${flags[$index]}"
+  criticality="continue-on-error: \${{ vars.${flag} == 'optional' }}"
   require "$controls" "- ${flag}" "workflow must offer ${flag}"
   require_count "$ci" \
-    "continue-on-error: vars.${flag} == 'optional'" \
+    "$criticality" \
     "${criticality_owners[$index]}" \
     "CI must apply ${flag} criticality to every owning job or step"
   reject "$ci" "if: vars.${flag}" "CI must not skip work with ${flag}"

--- a/.github/workflows/ci-auxiliary-controls.yml
+++ b/.github/workflows/ci-auxiliary-controls.yml
@@ -22,12 +22,12 @@ on:
           - CI_AUX_IDEA_PERFORMANCE
         default: CI_AUX_DISTRIBUTION
       value:
-        description: Value used by set-one
+        description: Criticality used by set-one
         type: choice
         options:
-          - "true"
-          - "false"
-        default: "true"
+          - required
+          - optional
+        default: required
       profile:
         description: Profile used by apply-profile
         type: choice
@@ -72,9 +72,9 @@ jobs:
             CI_AUX_IDEA_PERFORMANCE
           )
           case "$PROFILE" in
-            lean) values=(false false false false false false) ;;
-            standard) values=(true true false false true false) ;;
-            full) values=(true true true true true true) ;;
+            lean) values=(optional optional optional optional optional optional) ;;
+            standard) values=(required required optional optional required optional) ;;
+            full) values=(required required required required required required) ;;
           esac
           for index in "${!flags[@]}"; do
             gh variable set "${flags[$index]}" --body "${values[$index]}" --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/ci-auxiliary-controls.yml
+++ b/.github/workflows/ci-auxiliary-controls.yml
@@ -1,0 +1,81 @@
+name: Configure CI auxiliary jobs
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Update one flag or apply a profile
+        type: choice
+        options:
+          - set-one
+          - apply-profile
+        default: set-one
+      flag:
+        description: Flag used by set-one
+        type: choice
+        options:
+          - CI_AUX_LOCAL_AUTHORITY
+          - CI_AUX_RUNTIME_CONTRACTS
+          - CI_AUX_MAVEN_PUBLICATION
+          - CI_AUX_DISTRIBUTION
+          - CI_AUX_ANALYSIS_TRANSPORT
+          - CI_AUX_IDEA_PERFORMANCE
+        default: CI_AUX_DISTRIBUTION
+      value:
+        description: Value used by set-one
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
+      profile:
+        description: Profile used by apply-profile
+        type: choice
+        options:
+          - lean
+          - standard
+          - full
+        default: full
+
+permissions:
+  contents: read
+
+jobs:
+  set-flag:
+    if: inputs.operation == 'set-one'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set repository variable
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          FLAG: ${{ inputs.flag }}
+          VALUE: ${{ inputs.value }}
+        run: gh variable set "$FLAG" --body "$VALUE" --repo "$GITHUB_REPOSITORY"
+
+  apply-profile:
+    if: inputs.operation == 'apply-profile'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply repository variable profile
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          PROFILE: ${{ inputs.profile }}
+        run: |
+          set -euo pipefail
+          flags=(
+            CI_AUX_LOCAL_AUTHORITY
+            CI_AUX_RUNTIME_CONTRACTS
+            CI_AUX_MAVEN_PUBLICATION
+            CI_AUX_DISTRIBUTION
+            CI_AUX_ANALYSIS_TRANSPORT
+            CI_AUX_IDEA_PERFORMANCE
+          )
+          case "$PROFILE" in
+            lean) values=(false false false false false false) ;;
+            standard) values=(true true false false true false) ;;
+            full) values=(true true true true true true) ;;
+          esac
+          for index in "${!flags[@]}"; do
+            gh variable set "${flags[$index]}" --body "${values[$index]}" --repo "$GITHUB_REPOSITORY"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         run: ./.github/scripts/ci/test-ci-gradle-retry.sh
 
   local-authority-contracts:
-    if: vars.CI_AUX_LOCAL_AUTHORITY != 'false'
+    continue-on-error: ${{ vars.CI_AUX_LOCAL_AUTHORITY == 'optional' }}
     name: Local development authority contracts
     runs-on: ubuntu-latest
     steps:
@@ -152,7 +152,7 @@ jobs:
         run: ./.github/scripts/install/test-local-development-refresh-contract.sh
 
   runtime-contracts:
-    if: vars.CI_AUX_RUNTIME_CONTRACTS != 'false'
+    continue-on-error: ${{ vars.CI_AUX_RUNTIME_CONTRACTS == 'optional' }}
     name: Runtime command and bundle contracts
     runs-on: ubuntu-latest
     needs: workflow-contracts
@@ -182,7 +182,7 @@ jobs:
         run: ./.github/scripts/runtime/test-runtime-compatibility-contract.sh
 
   maven-publication-contract:
-    if: vars.CI_AUX_MAVEN_PUBLICATION != 'false'
+    continue-on-error: ${{ vars.CI_AUX_MAVEN_PUBLICATION == 'optional' }}
     name: Maven publication metadata
     runs-on: ubuntu-latest
     needs: workflow-contracts
@@ -268,7 +268,7 @@ jobs:
         run: cargo test --locked --all-targets --all-features
 
   source-bound-cli:
-    if: vars.CI_AUX_DISTRIBUTION != 'false'
+    continue-on-error: ${{ vars.CI_AUX_DISTRIBUTION == 'optional' }}
     name: Source-bound release CLI
     runs-on: ubuntu-22.04
     needs: workflow-contracts
@@ -361,6 +361,7 @@ jobs:
     uses: ./.github/workflows/ci-build-and-test.yml
 
   prepared-generation:
+    continue-on-error: ${{ vars.CI_AUX_DISTRIBUTION == 'optional' }}
     name: Prepared source-attested generation
     runs-on: ubuntu-24.04
     needs:
@@ -487,6 +488,7 @@ jobs:
           retention-days: 3
 
   prepared-ubuntu-debian-bundle:
+    continue-on-error: ${{ vars.CI_AUX_DISTRIBUTION == 'optional' }}
     name: Prepared Ubuntu and Debian bundle
     runs-on: ubuntu-24.04
     needs:
@@ -605,7 +607,7 @@ jobs:
           retention-days: 3
 
   source-bound-headless-backend:
-    if: vars.CI_AUX_DISTRIBUTION != 'false'
+    continue-on-error: ${{ vars.CI_AUX_DISTRIBUTION == 'optional' }}
     name: Source-bound headless backend
     runs-on: ubuntu-24.04
     needs:
@@ -699,6 +701,7 @@ jobs:
           retention-days: 3
 
   install-ubuntu-debian-container:
+    continue-on-error: ${{ vars.CI_AUX_DISTRIBUTION == 'optional' }}
     name: Ubuntu/Debian install container (${{ matrix.container-image }}, Java ${{ matrix.java-version }})
     runs-on: ubuntu-24.04
     needs:
@@ -743,6 +746,7 @@ jobs:
         run: ./scripts/verify-setup-bundle.sh "$KAST_UBUNTU_DEBIAN_BUNDLE"
 
   kast-action-runtime-contract:
+    continue-on-error: ${{ vars.CI_AUX_DISTRIBUTION == 'optional' }}
     name: kast-action runtime contract
     runs-on: ubuntu-latest
     needs:
@@ -890,7 +894,7 @@ jobs:
             --gradle-root "$GITHUB_WORKSPACE"
 
   analysis-server-transport:
-    if: vars.CI_AUX_ANALYSIS_TRANSPORT != 'false'
+    continue-on-error: ${{ vars.CI_AUX_ANALYSIS_TRANSPORT == 'optional' }}
     name: Analysis server transport
     runs-on: ubuntu-latest
     needs: workflow-contracts
@@ -914,7 +918,7 @@ jobs:
           --tests io.github.amichne.kast.server.AnalysisServerSocketTest
 
   build-idea-plugin:
-    if: vars.CI_AUX_DISTRIBUTION != 'false'
+    continue-on-error: ${{ vars.CI_AUX_DISTRIBUTION == 'optional' }}
     name: Build IDEA plugin
     runs-on: ubuntu-latest
     needs: workflow-contracts
@@ -1043,5 +1047,5 @@ jobs:
           -PexcludeTags=performance
 
       - name: Run IDEA plugin performance baselines
-        if: vars.CI_AUX_IDEA_PERFORMANCE != 'false'
+        continue-on-error: ${{ vars.CI_AUX_IDEA_PERFORMANCE == 'optional' }}
         run: ./scripts/ci-gradle-retry.sh ./gradlew :backend-idea:test -PincludeTags=performance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
         run: ./.github/scripts/ci/test-ci-gradle-retry.sh
 
   local-authority-contracts:
+    if: vars.CI_AUX_LOCAL_AUTHORITY != 'false'
     name: Local development authority contracts
     runs-on: ubuntu-latest
     steps:
@@ -151,6 +152,7 @@ jobs:
         run: ./.github/scripts/install/test-local-development-refresh-contract.sh
 
   runtime-contracts:
+    if: vars.CI_AUX_RUNTIME_CONTRACTS != 'false'
     name: Runtime command and bundle contracts
     runs-on: ubuntu-latest
     needs: workflow-contracts
@@ -180,6 +182,7 @@ jobs:
         run: ./.github/scripts/runtime/test-runtime-compatibility-contract.sh
 
   maven-publication-contract:
+    if: vars.CI_AUX_MAVEN_PUBLICATION != 'false'
     name: Maven publication metadata
     runs-on: ubuntu-latest
     needs: workflow-contracts
@@ -265,6 +268,7 @@ jobs:
         run: cargo test --locked --all-targets --all-features
 
   source-bound-cli:
+    if: vars.CI_AUX_DISTRIBUTION != 'false'
     name: Source-bound release CLI
     runs-on: ubuntu-22.04
     needs: workflow-contracts
@@ -601,6 +605,7 @@ jobs:
           retention-days: 3
 
   source-bound-headless-backend:
+    if: vars.CI_AUX_DISTRIBUTION != 'false'
     name: Source-bound headless backend
     runs-on: ubuntu-24.04
     needs:
@@ -885,6 +890,7 @@ jobs:
             --gradle-root "$GITHUB_WORKSPACE"
 
   analysis-server-transport:
+    if: vars.CI_AUX_ANALYSIS_TRANSPORT != 'false'
     name: Analysis server transport
     runs-on: ubuntu-latest
     needs: workflow-contracts
@@ -908,6 +914,7 @@ jobs:
           --tests io.github.amichne.kast.server.AnalysisServerSocketTest
 
   build-idea-plugin:
+    if: vars.CI_AUX_DISTRIBUTION != 'false'
     name: Build IDEA plugin
     runs-on: ubuntu-latest
     needs: workflow-contracts
@@ -1036,4 +1043,5 @@ jobs:
           -PexcludeTags=performance
 
       - name: Run IDEA plugin performance baselines
+        if: vars.CI_AUX_IDEA_PERFORMANCE != 'false'
         run: ./scripts/ci-gradle-retry.sh ./gradlew :backend-idea:test -PincludeTags=performance


### PR DESCRIPTION
## What
- add repository-variable criticality controls for six heavy auxiliary CI surfaces
- keep every existing job and dependency running on the unchanged CI graph
- let `required` failures block while `optional` failures remain visible without blocking
- provide lean, standard, and full criticality profiles plus one-flag updates

## Why
Maintainers keep consistent auxiliary feedback while choosing which proofs sit on the required execution path.

## Validation
- `.github/scripts/ci/test-ci-auxiliary-controls.sh`
- `.github/scripts/ci/test-ci-workflow-model.sh`
- exact 16-job and `needs` comparison against `origin/main`
- repository shape contract and checker
- YAML parse, Bash syntax, and diff checks

## Risk
The dispatch workflow uses the existing `RELEASE_GITHUB_TOKEN`; its repository-variable write access can only be exercised after this workflow reaches the default branch.