### PR TITLE
feat: add IntelliJ semantic explorer

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastIdeaBackendRuntime.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastIdeaBackendRuntime.kt
@@ -25,8 +25,7 @@ import kotlin.concurrent.thread
 
 class RunningKastIdeaBackend internal constructor(
     val backend: CloseableAnalysisBackend,
-    val server: RunningAnalysisServer,
-    private val workspaceRoot: Path,
+    val server: RunningAnalysisServer, private val workspaceRoot: Path,
     private val projectIndexing: KastIdeaProjectIndexing,
     private val sourceIndexStore: SqliteSourceIndexStore,
 ) : AutoCloseable, KastIdeaBackendHandle {
@@ -85,11 +84,8 @@ class RunningKastIdeaBackend internal constructor(
     override fun startIndexing() {
         projectIndexing.start()
     }
-    override fun failIndexing(error: Throwable) {
-        projectIndexing.fail(error)
-    }
-    override fun explore(request: KastExplorerRequest): KastExplorerResult =
-        sourceIndexStore.explore(workspaceRoot, request)
+    override fun failIndexing(error: Throwable) { projectIndexing.fail(error) }
+    override fun explore(request: KastExplorerRequest): KastExplorerResult = sourceIndexStore.explore(workspaceRoot, request)
 
     private companion object {
         val LOG: Logger = Logger.getInstance(RunningKastIdeaBackend::class.java)
@@ -293,8 +289,7 @@ object KastIdeaBackendRuntime {
             }
             return RunningKastIdeaBackend(
                 backend = backend,
-                server = server,
-                workspaceRoot = workspaceIdentity.workspaceRootPath,
+                server = server, workspaceRoot = workspaceIdentity.workspaceRootPath,
                 projectIndexing = startedProjectIndexing,
                 sourceIndexStore = sourceIndexStore,
             )

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastIdeaBackendRuntime.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastIdeaBackendRuntime.kt
@@ -26,6 +26,7 @@ import kotlin.concurrent.thread
 class RunningKastIdeaBackend internal constructor(
     val backend: CloseableAnalysisBackend,
     val server: RunningAnalysisServer,
+    private val workspaceRoot: Path,
     private val projectIndexing: KastIdeaProjectIndexing,
     private val sourceIndexStore: SqliteSourceIndexStore,
 ) : AutoCloseable, KastIdeaBackendHandle {
@@ -87,6 +88,8 @@ class RunningKastIdeaBackend internal constructor(
     override fun failIndexing(error: Throwable) {
         projectIndexing.fail(error)
     }
+    override fun explore(request: KastExplorerRequest): KastExplorerResult =
+        sourceIndexStore.explore(workspaceRoot, request)
 
     private companion object {
         val LOG: Logger = Logger.getInstance(RunningKastIdeaBackend::class.java)
@@ -291,6 +294,7 @@ object KastIdeaBackendRuntime {
             return RunningKastIdeaBackend(
                 backend = backend,
                 server = server,
+                workspaceRoot = workspaceIdentity.workspaceRootPath,
                 projectIndexing = startedProjectIndexing,
                 sourceIndexStore = sourceIndexStore,
             )

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastPluginBackendLifecycle.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastPluginBackendLifecycle.kt
@@ -31,6 +31,9 @@ internal interface KastIdeaBackendHandle {
 
     fun failIndexing(error: Throwable)
 
+    fun explore(request: KastExplorerRequest): KastExplorerResult =
+        KastExplorerResult.Problem(io.github.amichne.kast.api.contract.NonBlankString("Kast explorer is unavailable"))
+
     fun closeAsync(): CompletableFuture<Unit>
 }
 
@@ -109,6 +112,13 @@ internal class KastPluginBackendLifecycle(
     fun markIndexFailed(error: Throwable) = lock.withLock {
         admission = KastGradleIndexAdmission.Failed(error)
         (state as? State.Running)?.backend?.failIndexing(error)
+    }
+
+    fun explore(request: KastExplorerRequest): KastExplorerResult = lock.withLock {
+        (state as? State.Running)?.backend?.explore(request)
+            ?: KastExplorerResult.Problem(
+                io.github.amichne.kast.api.contract.NonBlankString("Kast backend is not ready"),
+            )
     }
 
     internal fun status(): KastPluginBackendLifecycleStatus = lock.withLock {

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastPluginService.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastPluginService.kt
@@ -3,6 +3,7 @@ package io.github.amichne.kast.idea
 import io.github.amichne.kast.idea.diagnostics.*
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
@@ -65,6 +66,29 @@ internal class KastPluginService(
     fun startIndexing() = backendLifecycle.markIndexReady()
 
     fun failIndexing(error: Throwable) = backendLifecycle.markIndexFailed(error)
+
+    fun exploreAsync(
+        request: KastExplorerRequest,
+        deliver: (KastExplorerResult) -> Unit,
+    ) {
+        coroutineScope.launch {
+            val result = runCatching { backendLifecycle.explore(request) }
+                .getOrElse { error ->
+                    KastExplorerResult.Problem(
+                        io.github.amichne.kast.api.contract.NonBlankString(
+                            error.message?.takeIf(String::isNotBlank)
+                                ?: error::class.simpleName
+                                ?: "Kast explorer query failed",
+                        ),
+                    )
+                }
+            if (!project.isDisposed) {
+                ApplicationManager.getApplication().invokeLater {
+                    if (!project.isDisposed) deliver(result)
+                }
+            }
+        }
+    }
 
     fun reloadConfigAsync() {
         coroutineScope.launch {

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerData.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerData.kt
@@ -96,7 +96,7 @@ private fun SqliteSourceIndexStore.semanticGraphRelations(
         .asSequence()
         .filter { symbol ->
             symbol.fqName?.value == item.declaration.fqName &&
-                symbol.startOffset.value == declarationOffset
+                declarationOffset in symbol.startOffset.value until symbol.endOffset.value
         }
         .map { symbol -> symbol.canonicalKey }
         .toSet()
@@ -105,7 +105,9 @@ private fun SqliteSourceIndexStore.semanticGraphRelations(
         .filter { relation -> relation.sourceKey in selectedKeys }
         .take(MAX_RELATIONS_PER_LAYER)
         .mapNotNull { relation ->
-            val target = allSymbols[relation.resolvedTargetKey ?: relation.targetKey] ?: return@mapNotNull null
+            val target = relation.resolvedTargetKey?.let(allSymbols::get)
+                ?: allSymbols[relation.targetKey]
+                ?: return@mapNotNull null
             KastExplorerRelation(
                 layer = KastExplorerEvidenceLayer.SEMANTIC_GRAPH,
                 title = NonBlankString(target.fqName?.value ?: target.name.value),

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerData.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerData.kt
@@ -1,0 +1,126 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.api.contract.NonBlankString
+import io.github.amichne.kast.api.contract.NonNegativeInt
+import io.github.amichne.kast.api.contract.result.SemanticGraphSourcePath
+import io.github.amichne.kast.indexstore.api.reference.SymbolReferenceRow
+import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
+import java.nio.file.Path
+
+internal fun SqliteSourceIndexStore.explore(
+    workspaceRoot: Path,
+    request: KastExplorerRequest,
+): KastExplorerResult = when (request) {
+    KastExplorerRequest.Overview -> semanticGraphScopeSnapshot().let { snapshot ->
+        KastExplorerResult.Overview(
+            KastExplorerOverview(
+                graphGeneration = snapshot.generation,
+                graphFileCount = NonNegativeInt(snapshot.sourcePaths.size),
+            ),
+        )
+    }
+    is KastExplorerRequest.Search -> KastExplorerResult.SearchResults(
+        searchDeclarations(request.pattern, request.maxResults).map(::KastExplorerSearchItem),
+    )
+    is KastExplorerRequest.Inspect -> inspect(workspaceRoot, request.item)
+}
+
+private fun SqliteSourceIndexStore.inspect(
+    workspaceRoot: Path,
+    item: KastExplorerSearchItem,
+): KastExplorerResult.Inspection {
+    val declaration = item.declaration
+    val incoming = referencesToSymbol(declaration.fqName)
+        .asSequence()
+        .take(MAX_RELATIONS_PER_LAYER)
+        .map(::incomingRelation)
+    val outgoing = referencesFromFile(declaration.filePath)
+        .asSequence()
+        .filter { reference -> reference.sourceFqName == declaration.fqName }
+        .take(MAX_RELATIONS_PER_LAYER)
+        .map(::outgoingRelation)
+    val graph = semanticGraphRelations(workspaceRoot, item)
+    return KastExplorerResult.Inspection(
+        KastExplorerInspection(
+            selected = item,
+            relations = (incoming + outgoing + graph)
+                .distinctBy { relation ->
+                    Triple(relation.layer, relation.title, relation.navigationTarget)
+                }
+                .toList(),
+        ),
+    )
+}
+
+private fun incomingRelation(reference: SymbolReferenceRow): KastExplorerRelation =
+    KastExplorerRelation(
+        layer = KastExplorerEvidenceLayer.INCOMING,
+        title = NonBlankString(
+            reference.sourceFqName?.takeIf(String::isNotBlank)
+                ?: Path.of(reference.sourcePath).fileName.toString(),
+        ),
+        detail = NonBlankString(reference.edgeKind.displayName()),
+        navigationTarget = sourceTarget(reference.sourcePath, reference.sourceOffset),
+    )
+
+private fun outgoingRelation(reference: SymbolReferenceRow): KastExplorerRelation =
+    KastExplorerRelation(
+        layer = KastExplorerEvidenceLayer.OUTGOING,
+        title = NonBlankString(reference.targetFqName),
+        detail = NonBlankString(reference.edgeKind.displayName()),
+        navigationTarget = reference.targetPath?.let { path ->
+            reference.targetOffset?.let { offset -> sourceTarget(path, offset) }
+        },
+    )
+
+private fun SqliteSourceIndexStore.semanticGraphRelations(
+    workspaceRoot: Path,
+    item: KastExplorerSearchItem,
+): Sequence<KastExplorerRelation> {
+    val declarationPath = Path.of(item.declaration.filePath).toAbsolutePath().normalize()
+    if (!declarationPath.startsWith(workspaceRoot)) return emptySequence()
+    val relativePath = SemanticGraphSourcePath.parse(
+        workspaceRoot.relativize(declarationPath).toString(),
+    )
+    val snapshot = readSemanticGraph(listOf(relativePath))
+    val allSymbols = (snapshot.symbols + snapshot.boundarySymbols)
+        .associateBy { symbol -> symbol.canonicalKey }
+    val selectedKeys = snapshot.symbols
+        .asSequence()
+        .filter { symbol -> symbol.fqName?.value == item.declaration.fqName }
+        .map { symbol -> symbol.canonicalKey }
+        .toSet()
+    return snapshot.relations
+        .asSequence()
+        .filter { relation -> relation.sourceKey in selectedKeys }
+        .take(MAX_RELATIONS_PER_LAYER)
+        .mapNotNull { relation ->
+            val target = allSymbols[relation.resolvedTargetKey ?: relation.targetKey] ?: return@mapNotNull null
+            KastExplorerRelation(
+                layer = KastExplorerEvidenceLayer.SEMANTIC_GRAPH,
+                title = NonBlankString(target.fqName?.value ?: target.name.value),
+                detail = NonBlankString(
+                    listOf(relation.kind.name, relation.context.name)
+                        .filterNot { value -> value == "NONE" }
+                        .joinToString(" · ") { value -> value.replace('_', ' ').lowercase() },
+                ),
+                navigationTarget = sourceTarget(
+                    workspaceRoot.resolve(target.path.value).toString(),
+                    target.startOffset.value,
+                ),
+            )
+        }
+}
+
+private fun sourceTarget(
+    path: String,
+    offset: Int,
+): KastSourceTarget = KastSourceTarget(
+    Path.of(path).toAbsolutePath().normalize(),
+    offset,
+)
+
+private fun Enum<*>.displayName(): String = name.replace('_', ' ').lowercase()
+
+// ponytail: keep one screenful per evidence layer; add continuation-backed paging if users hit this ceiling.
+private const val MAX_RELATIONS_PER_LAYER = 250

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerData.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerData.kt
@@ -2,7 +2,11 @@ package io.github.amichne.kast.idea
 
 import io.github.amichne.kast.api.contract.NonBlankString
 import io.github.amichne.kast.api.contract.NonNegativeInt
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.api.contract.PositiveInt
 import io.github.amichne.kast.api.contract.result.SemanticGraphSourcePath
+import io.github.amichne.kast.indexstore.api.reference.DeclarationRow
+import io.github.amichne.kast.indexstore.api.reference.ExactReferenceTarget
 import io.github.amichne.kast.indexstore.api.reference.SymbolReferenceRow
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import java.nio.file.Path
@@ -30,26 +34,38 @@ private fun SqliteSourceIndexStore.inspect(
     item: KastExplorerSearchItem,
 ): KastExplorerResult.Inspection {
     val declaration = item.declaration
-    val incoming = referencesToSymbol(declaration.fqName)
-        .asSequence()
-        .take(MAX_RELATIONS_PER_LAYER)
-        .map(::incomingRelation)
-    val outgoing = referencesFromFile(declaration.filePath)
-        .asSequence()
-        .filter { reference -> reference.sourceFqName == declaration.fqName }
-        .take(MAX_RELATIONS_PER_LAYER)
-        .map(::outgoingRelation)
+    val incoming = exactIncomingRelations(declaration)
     val graph = semanticGraphRelations(workspaceRoot, item)
     return KastExplorerResult.Inspection(
         KastExplorerInspection(
             selected = item,
-            relations = (incoming + outgoing + graph)
+            relations = (incoming + graph)
                 .distinctBy { relation ->
                     Triple(relation.layer, relation.title, relation.navigationTarget)
                 }
                 .toList(),
         ),
     )
+}
+
+private fun SqliteSourceIndexStore.exactIncomingRelations(
+    declaration: DeclarationRow,
+): Sequence<KastExplorerRelation> {
+    val declarationOffset = declaration.declarationOffset ?: return emptySequence()
+    val page = generatedReferencePageToExactSymbol(
+        target = ExactReferenceTarget(
+            fqName = declaration.fqName,
+            declarationFile = NormalizedPath.parse(declaration.filePath),
+            declarationStartOffset = NonNegativeInt(declarationOffset),
+        ),
+        offset = NonNegativeInt(0),
+        maxResults = PositiveInt(MAX_RELATIONS_PER_LAYER),
+    )
+    return if (page.exactIdentityAvailable) {
+        page.page.references.asSequence().map(::incomingRelation)
+    } else {
+        emptySequence()
+    }
 }
 
 private fun incomingRelation(reference: SymbolReferenceRow): KastExplorerRelation =
@@ -63,16 +79,6 @@ private fun incomingRelation(reference: SymbolReferenceRow): KastExplorerRelatio
         navigationTarget = sourceTarget(reference.sourcePath, reference.sourceOffset),
     )
 
-private fun outgoingRelation(reference: SymbolReferenceRow): KastExplorerRelation =
-    KastExplorerRelation(
-        layer = KastExplorerEvidenceLayer.OUTGOING,
-        title = NonBlankString(reference.targetFqName),
-        detail = NonBlankString(reference.edgeKind.displayName()),
-        navigationTarget = reference.targetPath?.let { path ->
-            reference.targetOffset?.let { offset -> sourceTarget(path, offset) }
-        },
-    )
-
 private fun SqliteSourceIndexStore.semanticGraphRelations(
     workspaceRoot: Path,
     item: KastExplorerSearchItem,
@@ -83,11 +89,15 @@ private fun SqliteSourceIndexStore.semanticGraphRelations(
         workspaceRoot.relativize(declarationPath).toString(),
     )
     val snapshot = readSemanticGraph(listOf(relativePath))
+    val declarationOffset = item.declaration.declarationOffset ?: return emptySequence()
     val allSymbols = (snapshot.symbols + snapshot.boundarySymbols)
         .associateBy { symbol -> symbol.canonicalKey }
     val selectedKeys = snapshot.symbols
         .asSequence()
-        .filter { symbol -> symbol.fqName?.value == item.declaration.fqName }
+        .filter { symbol ->
+            symbol.fqName?.value == item.declaration.fqName &&
+                symbol.startOffset.value == declarationOffset
+        }
         .map { symbol -> symbol.canonicalKey }
         .toSet()
     return snapshot.relations

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
@@ -62,6 +62,15 @@ internal fun preferExactCurrentSymbol(
     }
 }
 
+internal fun explorerSelectionIndex(
+    items: List<KastExplorerSearchItem>,
+    current: KastCurrentSymbol?,
+): Int? = if (current == null) {
+    items.indices.firstOrNull()
+} else {
+    items.indexOfFirst { item -> item.navigationTarget == current.navigationTarget }.takeIf { it >= 0 }
+}
+
 enum class KastExplorerEvidenceLayer(
     val title: String,
 ) {

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
@@ -38,7 +38,6 @@ enum class KastExplorerEvidenceLayer(
     val title: String,
 ) {
     INCOMING("Incoming references"),
-    OUTGOING("Outgoing references"),
     SEMANTIC_GRAPH("Semantic graph"),
 }
 
@@ -129,3 +128,9 @@ internal class KastExplorerModel {
         }
     }
 }
+
+internal fun shouldAcceptExplorerResult(
+    result: KastExplorerResult,
+    resultSequence: Long,
+    currentSequence: Long,
+): Boolean = result is KastExplorerResult.Overview || resultSequence == currentSequence

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
@@ -3,6 +3,7 @@ package io.github.amichne.kast.idea
 import io.github.amichne.kast.api.contract.NonBlankString
 import io.github.amichne.kast.api.contract.NonNegativeInt
 import io.github.amichne.kast.api.contract.PositiveInt
+import io.github.amichne.kast.idea.diagnostics.KastBackendUiState
 import io.github.amichne.kast.indexstore.api.reference.DeclarationRow
 import io.github.amichne.kast.indexstore.api.reference.SourceIndexGeneration
 import java.nio.file.Path
@@ -134,3 +135,13 @@ internal fun shouldAcceptExplorerResult(
     resultSequence: Long,
     currentSequence: Long,
 ): Boolean = request is KastExplorerRequest.Overview || resultSequence == currentSequence
+
+internal fun shouldRefreshExplorerOverview(
+    previousState: KastBackendUiState,
+    currentState: KastBackendUiState,
+): Boolean = previousState != KastBackendUiState.READY && currentState == KastBackendUiState.READY
+
+internal fun nextExplorerRequestSequence(
+    request: KastExplorerRequest,
+    currentSequence: Long,
+): Long = if (request is KastExplorerRequest.Overview) currentSequence else currentSequence + 1

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.idea
 
+import io.github.amichne.kast.api.contract.FqName
 import io.github.amichne.kast.api.contract.NonBlankString
 import io.github.amichne.kast.api.contract.NonNegativeInt
 import io.github.amichne.kast.api.contract.PositiveInt
@@ -32,6 +33,32 @@ data class KastExplorerSearchItem(
     val ownerName: String = declaration.fqName.substringBeforeLast('.', "")
     val navigationTarget: KastSourceTarget? = declaration.declarationOffset?.let { offset ->
         KastSourceTarget(Path.of(declaration.filePath).toAbsolutePath().normalize(), offset)
+    }
+}
+
+internal data class KastCurrentSymbol(
+    val fqName: FqName,
+    val navigationTarget: KastSourceTarget,
+)
+
+internal fun preferExactCurrentSymbol(
+    items: List<KastExplorerSearchItem>,
+    current: KastCurrentSymbol?,
+): List<KastExplorerSearchItem> {
+    current ?: return items
+    return items.map { item ->
+        if (item.declaration.fqName == current.fqName.value &&
+            Path.of(item.declaration.filePath).toAbsolutePath().normalize() == current.navigationTarget.filePath
+        ) {
+            item.copy(
+                declaration = item.declaration.copy(
+                    filePath = current.navigationTarget.filePath.toString(),
+                    declarationOffset = current.navigationTarget.offset,
+                ),
+            )
+        } else {
+            item
+        }
     }
 }
 

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
@@ -130,7 +130,7 @@ internal class KastExplorerModel {
 }
 
 internal fun shouldAcceptExplorerResult(
-    result: KastExplorerResult,
+    request: KastExplorerRequest,
     resultSequence: Long,
     currentSequence: Long,
-): Boolean = result is KastExplorerResult.Overview || resultSequence == currentSequence
+): Boolean = request is KastExplorerRequest.Overview || resultSequence == currentSequence

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModel.kt
@@ -1,0 +1,131 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.api.contract.NonBlankString
+import io.github.amichne.kast.api.contract.NonNegativeInt
+import io.github.amichne.kast.api.contract.PositiveInt
+import io.github.amichne.kast.indexstore.api.reference.DeclarationRow
+import io.github.amichne.kast.indexstore.api.reference.SourceIndexGeneration
+import java.nio.file.Path
+
+internal enum class KastToolWindowContent(
+    val title: String,
+) {
+    EXPLORE("Explore"),
+    ACTIVITY("Activity"),
+}
+
+data class KastSourceTarget(
+    val filePath: Path,
+    val offset: Int,
+) {
+    init {
+        require(filePath.isAbsolute) { "Kast source targets must be absolute" }
+        require(offset >= 0) { "Kast source target offsets must be non-negative" }
+    }
+}
+
+data class KastExplorerSearchItem(
+    val declaration: DeclarationRow,
+) {
+    val displayName: String = declaration.fqName.substringAfterLast('.')
+    val ownerName: String = declaration.fqName.substringBeforeLast('.', "")
+    val navigationTarget: KastSourceTarget? = declaration.declarationOffset?.let { offset ->
+        KastSourceTarget(Path.of(declaration.filePath).toAbsolutePath().normalize(), offset)
+    }
+}
+
+enum class KastExplorerEvidenceLayer(
+    val title: String,
+) {
+    INCOMING("Incoming references"),
+    OUTGOING("Outgoing references"),
+    SEMANTIC_GRAPH("Semantic graph"),
+}
+
+data class KastExplorerRelation(
+    val layer: KastExplorerEvidenceLayer,
+    val title: NonBlankString,
+    val detail: NonBlankString?,
+    val navigationTarget: KastSourceTarget?,
+)
+
+data class KastExplorerSection(
+    val layer: KastExplorerEvidenceLayer,
+    val relations: List<KastExplorerRelation>,
+)
+
+data class KastExplorerInspection(
+    val selected: KastExplorerSearchItem,
+    val relations: List<KastExplorerRelation>,
+) {
+    val sections: List<KastExplorerSection> = KastExplorerEvidenceLayer.entries.map { layer ->
+        KastExplorerSection(layer, relations.filter { relation -> relation.layer == layer })
+    }
+}
+
+data class KastExplorerOverview(
+    val graphGeneration: SourceIndexGeneration,
+    val graphFileCount: NonNegativeInt,
+)
+
+sealed interface KastExplorerRequest {
+    data object Overview : KastExplorerRequest
+
+    data class Search(
+        val pattern: NonBlankString,
+        val maxResults: PositiveInt = PositiveInt(DEFAULT_SEARCH_LIMIT),
+    ) : KastExplorerRequest {
+        companion object {
+            const val DEFAULT_SEARCH_LIMIT: Int = 75
+
+            fun parse(rawPattern: String): Search? =
+                rawPattern.trim().takeIf(String::isNotEmpty)?.let(::NonBlankString)?.let(::Search)
+        }
+    }
+
+    data class Inspect(
+        val item: KastExplorerSearchItem,
+    ) : KastExplorerRequest
+}
+
+sealed interface KastExplorerResult {
+    data class Overview(
+        val value: KastExplorerOverview,
+    ) : KastExplorerResult
+
+    data class SearchResults(
+        val items: List<KastExplorerSearchItem>,
+    ) : KastExplorerResult
+
+    data class Inspection(
+        val value: KastExplorerInspection,
+    ) : KastExplorerResult
+
+    data class Problem(
+        val message: NonBlankString,
+    ) : KastExplorerResult
+}
+
+internal class KastExplorerModel {
+    var overview: KastExplorerOverview? = null
+        private set
+    var searchItems: List<KastExplorerSearchItem> = emptyList()
+        private set
+    var inspection: KastExplorerInspection? = null
+        private set
+    var problem: NonBlankString? = null
+        private set
+
+    fun accept(result: KastExplorerResult) {
+        problem = null
+        when (result) {
+            is KastExplorerResult.Overview -> overview = result.value
+            is KastExplorerResult.SearchResults -> {
+                searchItems = result.items
+                inspection = null
+            }
+            is KastExplorerResult.Inspection -> inspection = result.value
+            is KastExplorerResult.Problem -> problem = result.message
+        }
+    }
+}

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
@@ -21,6 +21,7 @@ import com.intellij.ui.components.JBPanel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.treeStructure.Tree
 import com.intellij.util.ui.JBUI
+import io.github.amichne.kast.api.contract.FqName
 import io.github.amichne.kast.idea.diagnostics.KastDiagnosticsService
 import io.github.amichne.kast.idea.diagnostics.KastDiagnosticsSnapshot
 import io.github.amichne.kast.idea.diagnostics.KastBackendUiState
@@ -65,7 +66,7 @@ internal class KastExplorerPanel(
     private val openSourceButton = JButton("Open Source")
     private var requestSequence = 0L
     private var lastBackendState = KastBackendUiState.STOPPED
-    private var preferredFqName: String? = null
+    private var preferredCurrentSymbol: KastCurrentSymbol? = null
     private var disposed = false
 
     init {
@@ -236,18 +237,24 @@ internal class KastExplorerPanel(
     }
 
     private fun searchCurrentSymbol() {
-        val fqName = ApplicationManager.getApplication().runReadAction<String?> {
+        val current = ApplicationManager.getApplication().runReadAction<KastCurrentSymbol?> {
             val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@runReadAction null
             val file = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return@runReadAction null
             val element = file.findElementAt(editor.caretModel.offset) ?: return@runReadAction null
-            PsiTreeUtil.getParentOfType(element, KtNamedDeclaration::class.java, false)?.fqName?.asString()
+            val declaration =
+                PsiTreeUtil.getParentOfType(element, KtNamedDeclaration::class.java, false)
+                    ?: return@runReadAction null
+            val fqName = declaration.fqName?.asString() ?: return@runReadAction null
+            val path = file.virtualFile?.path ?: return@runReadAction null
+            val offset = declaration.nameIdentifier?.textRange?.startOffset ?: declaration.textRange.startOffset
+            KastCurrentSymbol(FqName(fqName), KastSourceTarget(Path.of(path), offset))
         }
-        if (fqName == null) {
+        if (current == null) {
             detailHint.text = "Place the caret inside a named Kotlin declaration."
             return
         }
-        preferredFqName = fqName
-        searchField.text = fqName
+        preferredCurrentSymbol = current
+        searchField.text = current.fqName.value
         search()
     }
 
@@ -280,14 +287,31 @@ internal class KastExplorerPanel(
     }
 
     private fun renderSearchResults(items: List<KastExplorerSearchItem>) {
+        val current = preferredCurrentSymbol
+        preferredCurrentSymbol = null
+        val exactItems = preferExactCurrentSymbol(items, current)
         searchButton.isEnabled = true
         resultModel.clear()
-        items.forEach(resultModel::addElement)
+        exactItems.forEach(resultModel::addElement)
         results.emptyText.text = "No indexed declarations match"
-        val preferred = preferredFqName
-        preferredFqName = null
-        val selectedIndex = items.indexOfFirst { item -> item.declaration.fqName == preferred }.takeIf { it >= 0 } ?: 0
-        if (items.isNotEmpty()) results.selectedIndex = selectedIndex
+        if (exactItems.isEmpty()) {
+            clearInspection()
+            return
+        }
+        val selectedIndex = current
+            ?.let { preferred -> exactItems.indexOfFirst { item -> item.navigationTarget == preferred.navigationTarget } }
+            ?.takeIf { index -> index >= 0 }
+            ?: 0
+        results.selectedIndex = selectedIndex
+    }
+
+    private fun clearInspection() {
+        relationRoot.removeAllChildren()
+        relationModel.reload()
+        detailTitle.text = "No matching declarations"
+        detailMeta.text = ""
+        detailHint.text = "Try another symbol name or use Current Symbol."
+        openSourceButton.isEnabled = false
     }
 
     private fun renderSelection(selected: KastExplorerSearchItem) {

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
@@ -23,6 +23,7 @@ import com.intellij.ui.treeStructure.Tree
 import com.intellij.util.ui.JBUI
 import io.github.amichne.kast.idea.diagnostics.KastDiagnosticsService
 import io.github.amichne.kast.idea.diagnostics.KastDiagnosticsSnapshot
+import io.github.amichne.kast.idea.diagnostics.KastBackendUiState
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import java.awt.BorderLayout
 import java.awt.Component
@@ -63,6 +64,7 @@ internal class KastExplorerPanel(
     private val detailHint = JBLabel("Search indexed Kotlin symbols or inspect the declaration under the caret.")
     private val openSourceButton = JButton("Open Source")
     private var requestSequence = 0L
+    private var lastBackendState = KastBackendUiState.STOPPED
     private var preferredFqName: String? = null
     private var disposed = false
 
@@ -70,7 +72,6 @@ internal class KastExplorerPanel(
         setContent(buildContent())
         configureInteractions()
         diagnostics.addListener(this, ::renderDiagnostics)
-        request(KastExplorerRequest.Overview)
     }
 
     override fun dispose() {
@@ -251,7 +252,8 @@ internal class KastExplorerPanel(
     }
 
     private fun request(request: KastExplorerRequest) {
-        val sequence = ++requestSequence
+        val sequence = nextExplorerRequestSequence(request, requestSequence)
+        requestSequence = sequence
         service.exploreAsync(request) { result ->
             if (disposed || !shouldAcceptExplorerResult(request, sequence, requestSequence)) return@exploreAsync
             if (request is KastExplorerRequest.Overview && result is KastExplorerResult.Problem) {
@@ -317,9 +319,14 @@ internal class KastExplorerPanel(
     }
 
     private fun renderDiagnostics(snapshot: KastDiagnosticsSnapshot) {
+        val previousBackendState = lastBackendState
+        lastBackendState = snapshot.backendState
         compilerValue.text = "${snapshot.backendState.displayName} · K2 / PSI / AA"
         indexValue.text = snapshot.indexSummary.displayText()
         workspaceValue.text = snapshot.workspaceRoot?.let { Path.of(it).fileName.toString() } ?: "No workspace"
+        if (shouldRefreshExplorerOverview(previousBackendState, snapshot.backendState)) {
+            request(KastExplorerRequest.Overview)
+        }
     }
 
     private fun navigate(target: KastSourceTarget) {

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
@@ -225,12 +225,13 @@ internal class KastExplorerPanel(
         })
     }
 
-    private fun search() {
+    private fun search(current: KastCurrentSymbol? = null) {
         val request = KastExplorerRequest.Search.parse(searchField.text)
         if (request == null) {
             results.emptyText.text = "Enter a symbol name"
             return
         }
+        preferredCurrentSymbol = current
         results.emptyText.text = "Searching persistent FTS…"
         searchButton.isEnabled = false
         request(request)
@@ -253,9 +254,8 @@ internal class KastExplorerPanel(
             detailHint.text = "Place the caret inside a named Kotlin declaration."
             return
         }
-        preferredCurrentSymbol = current
         searchField.text = current.fqName.value
-        search()
+        search(current)
     }
 
     private fun request(request: KastExplorerRequest) {
@@ -298,10 +298,12 @@ internal class KastExplorerPanel(
             clearInspection()
             return
         }
-        val selectedIndex = current
-            ?.let { preferred -> exactItems.indexOfFirst { item -> item.navigationTarget == preferred.navigationTarget } }
-            ?.takeIf { index -> index >= 0 }
-            ?: 0
+        val selectedIndex = explorerSelectionIndex(exactItems, current)
+        if (selectedIndex == null) {
+            clearInspection()
+            detailHint.text = "The current declaration is not available in the persistent index."
+            return
+        }
         results.selectedIndex = selectedIndex
     }
 

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
@@ -1,0 +1,353 @@
+@file:Suppress("UnstableApiUsage")
+
+package io.github.amichne.kast.idea
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.ui.ColoredListCellRenderer
+import com.intellij.ui.OnePixelSplitter
+import com.intellij.ui.SearchTextField
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBPanel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.ui.JBUI
+import io.github.amichne.kast.idea.diagnostics.KastDiagnosticsService
+import io.github.amichne.kast.idea.diagnostics.KastDiagnosticsSnapshot
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.FlowLayout
+import java.awt.GridLayout
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.nio.file.Path
+import javax.swing.DefaultListModel
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JList
+import javax.swing.ListSelectionModel
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.DefaultTreeCellRenderer
+import javax.swing.tree.DefaultTreeModel
+
+internal class KastExplorerPanel(
+    private val project: Project,
+) : SimpleToolWindowPanel(true, true), Disposable {
+    private val diagnostics = KastDiagnosticsService.getInstance(project)
+    private val service = KastPluginService.getInstance(project)
+    private val model = KastExplorerModel()
+    private val searchField = SearchTextField(false)
+    private val searchButton = JButton("Search")
+    private val currentSymbolButton = JButton("Current Symbol")
+    private val resultModel = DefaultListModel<KastExplorerSearchItem>()
+    private val results = JBList(resultModel)
+    private val relationRoot = DefaultMutableTreeNode("Neighborhood")
+    private val relationModel = DefaultTreeModel(relationRoot)
+    private val relations = Tree(relationModel)
+    private val compilerValue = JBLabel()
+    private val indexValue = JBLabel()
+    private val graphValue = JBLabel("Loading…")
+    private val workspaceValue = JBLabel()
+    private val detailTitle = JBLabel("Explore the workspace")
+    private val detailMeta = JBLabel("Live K2 / PSI / Analysis API  →  SQLite FTS  →  references  →  semantic graph")
+    private val detailHint = JBLabel("Search indexed Kotlin symbols or inspect the declaration under the caret.")
+    private val openSourceButton = JButton("Open Source")
+    private var requestSequence = 0L
+    private var preferredFqName: String? = null
+    private var disposed = false
+
+    init {
+        setContent(buildContent())
+        configureInteractions()
+        diagnostics.addListener(this, ::renderDiagnostics)
+        request(KastExplorerRequest.Overview)
+    }
+
+    override fun dispose() {
+        disposed = true
+    }
+
+    private fun buildContent(): JComponent {
+        val content = JBPanel<JBPanel<*>>(BorderLayout())
+        content.border = JBUI.Borders.empty(10)
+        content.add(buildHeader(), BorderLayout.NORTH)
+
+        val splitter = OnePixelSplitter(false, 0.42f)
+        splitter.firstComponent = buildResults()
+        splitter.secondComponent = buildDetail()
+        content.add(splitter, BorderLayout.CENTER)
+        return content
+    }
+
+    private fun buildHeader(): JComponent {
+        val header = JBPanel<JBPanel<*>>(BorderLayout(0, 8))
+        val heading = JBLabel("<html><b>Kast Atlas</b> &nbsp; Explore compiler and persisted workspace evidence</html>")
+        heading.border = JBUI.Borders.emptyBottom(2)
+        header.add(heading, BorderLayout.NORTH)
+
+        val body = JBPanel<JBPanel<*>>(BorderLayout(0, 8))
+        body.add(buildSearchRow(), BorderLayout.NORTH)
+        body.add(buildEvidenceRibbon(), BorderLayout.CENTER)
+        header.add(body, BorderLayout.CENTER)
+        header.border = JBUI.Borders.emptyBottom(10)
+        return header
+    }
+
+    private fun buildSearchRow(): JComponent {
+        searchField.textEditor.emptyText.text = "Search indexed Kotlin symbols…"
+        searchField.accessibleContext.accessibleName = "Kast symbol search"
+        searchButton.toolTipText = "Search the persistent FTS declaration index"
+        currentSymbolButton.toolTipText = "Use the Kotlin declaration under the editor caret"
+        val actions = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.RIGHT, 6, 0))
+        actions.add(currentSymbolButton)
+        actions.add(searchButton)
+        return JBPanel<JBPanel<*>>(BorderLayout(8, 0)).apply {
+            add(searchField, BorderLayout.CENTER)
+            add(actions, BorderLayout.EAST)
+        }
+    }
+
+    private fun buildEvidenceRibbon(): JComponent =
+        JBPanel<JBPanel<*>>(GridLayout(1, 4, 8, 0)).apply {
+            add(metric("LIVE MODEL", compilerValue))
+            add(metric("PERSISTENT INDEX", indexValue))
+            add(metric("SEMANTIC GRAPH", graphValue))
+            add(metric("WORKSPACE", workspaceValue))
+        }
+
+    private fun metric(
+        title: String,
+        value: JBLabel,
+    ): JComponent = JBPanel<JBPanel<*>>(BorderLayout()).apply {
+        border = JBUI.Borders.compound(
+            JBUI.Borders.customLine(JBUI.CurrentTheme.CustomFrameDecorations.separatorForeground(), 1),
+            JBUI.Borders.empty(6, 8),
+        )
+        add(JBLabel(title), BorderLayout.NORTH)
+        value.border = JBUI.Borders.emptyTop(3)
+        add(value, BorderLayout.CENTER)
+    }
+
+    private fun buildResults(): JComponent {
+        results.selectionMode = ListSelectionModel.SINGLE_SELECTION
+        results.emptyText.text = "Search to discover indexed declarations"
+        results.cellRenderer = object : ColoredListCellRenderer<KastExplorerSearchItem>() {
+            override fun customizeCellRenderer(
+                list: JList<out KastExplorerSearchItem>,
+                value: KastExplorerSearchItem?,
+                index: Int,
+                selected: Boolean,
+                hasFocus: Boolean,
+            ) {
+                value ?: return
+                append(value.displayName, SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                append("  ${value.declaration.kind.name.lowercase()}", SimpleTextAttributes.GRAYED_ATTRIBUTES)
+                append("  —  ${value.ownerName}", SimpleTextAttributes.GRAYED_SMALL_ATTRIBUTES)
+                value.declaration.modulePath?.let { module ->
+                    append("  $module", SimpleTextAttributes.GRAYED_SMALL_ATTRIBUTES)
+                }
+            }
+        }
+        return titledPanel("Symbols", JBScrollPane(results))
+    }
+
+    private fun buildDetail(): JComponent {
+        relations.isRootVisible = false
+        relations.showsRootHandles = true
+        relations.emptyText.text = "Select a symbol to inspect its neighborhood"
+        relations.cellRenderer = RelationRenderer()
+
+        val summary = JBPanel<JBPanel<*>>(BorderLayout(0, 4))
+        summary.border = JBUI.Borders.empty(2, 4, 8, 4)
+        summary.add(detailTitle, BorderLayout.NORTH)
+        summary.add(detailMeta, BorderLayout.CENTER)
+        summary.add(detailHint, BorderLayout.SOUTH)
+
+        openSourceButton.isEnabled = false
+        val footer = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.RIGHT, 0, 4))
+        footer.add(openSourceButton)
+
+        return titledPanel(
+            "Neighborhood",
+            JBPanel<JBPanel<*>>(BorderLayout()).apply {
+                add(summary, BorderLayout.NORTH)
+                add(JBScrollPane(relations), BorderLayout.CENTER)
+                add(footer, BorderLayout.SOUTH)
+            },
+        )
+    }
+
+    private fun titledPanel(
+        title: String,
+        body: JComponent,
+    ): JComponent = JBPanel<JBPanel<*>>(BorderLayout(0, 6)).apply {
+        border = JBUI.Borders.empty(0, 4)
+        add(JBLabel("<html><b>$title</b></html>"), BorderLayout.NORTH)
+        add(body, BorderLayout.CENTER)
+    }
+
+    private fun configureInteractions() {
+        searchField.textEditor.addActionListener { search() }
+        searchButton.addActionListener { search() }
+        currentSymbolButton.addActionListener { searchCurrentSymbol() }
+        openSourceButton.addActionListener { model.inspection?.selected?.navigationTarget?.let(::navigate) }
+        results.addListSelectionListener { event ->
+            if (!event.valueIsAdjusting) {
+                results.selectedValue?.let { selected ->
+                    renderSelection(selected)
+                    request(KastExplorerRequest.Inspect(selected))
+                }
+            }
+        }
+        results.addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(event: MouseEvent) {
+                if (event.clickCount == 2) results.selectedValue?.navigationTarget?.let(::navigate)
+            }
+        })
+        relations.addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(event: MouseEvent) {
+                if (event.clickCount != 2) return
+                val node = relations.getPathForLocation(event.x, event.y)?.lastPathComponent as? DefaultMutableTreeNode
+                (node?.userObject as? KastExplorerRelation)?.navigationTarget?.let(::navigate)
+            }
+        })
+    }
+
+    private fun search() {
+        val request = KastExplorerRequest.Search.parse(searchField.text)
+        if (request == null) {
+            results.emptyText.text = "Enter a symbol name"
+            return
+        }
+        results.emptyText.text = "Searching persistent FTS…"
+        searchButton.isEnabled = false
+        request(request)
+    }
+
+    private fun searchCurrentSymbol() {
+        val fqName = ReadAction.compute<String?, RuntimeException> {
+            val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@compute null
+            val file = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return@compute null
+            val element = file.findElementAt(editor.caretModel.offset) ?: return@compute null
+            PsiTreeUtil.getParentOfType(element, KtNamedDeclaration::class.java, false)?.fqName?.asString()
+        }
+        if (fqName == null) {
+            detailHint.text = "Place the caret inside a named Kotlin declaration."
+            return
+        }
+        preferredFqName = fqName
+        searchField.text = fqName
+        search()
+    }
+
+    private fun request(request: KastExplorerRequest) {
+        val sequence = ++requestSequence
+        service.exploreAsync(request) { result ->
+            if (disposed || sequence != requestSequence) return@exploreAsync
+            model.accept(result)
+            render(result)
+        }
+    }
+
+    private fun render(result: KastExplorerResult) {
+        when (result) {
+            is KastExplorerResult.Overview -> {
+                graphValue.text = "${result.value.graphFileCount.value} files · generation ${result.value.graphGeneration.value}"
+            }
+            is KastExplorerResult.SearchResults -> renderSearchResults(result.items)
+            is KastExplorerResult.Inspection -> renderInspection(result.value)
+            is KastExplorerResult.Problem -> {
+                searchButton.isEnabled = true
+                detailHint.text = result.message.value
+            }
+        }
+    }
+
+    private fun renderSearchResults(items: List<KastExplorerSearchItem>) {
+        searchButton.isEnabled = true
+        resultModel.clear()
+        items.forEach(resultModel::addElement)
+        results.emptyText.text = "No indexed declarations match"
+        val preferred = preferredFqName
+        preferredFqName = null
+        val selectedIndex = items.indexOfFirst { item -> item.declaration.fqName == preferred }.takeIf { it >= 0 } ?: 0
+        if (items.isNotEmpty()) results.selectedIndex = selectedIndex
+    }
+
+    private fun renderSelection(selected: KastExplorerSearchItem) {
+        detailTitle.text = selected.declaration.fqName
+        detailMeta.text = listOfNotNull(
+            selected.declaration.kind.name.lowercase(),
+            selected.declaration.visibility.name.lowercase(),
+            selected.declaration.modulePath,
+            selected.declaration.sourceSet,
+        ).joinToString("  ·  ")
+        detailHint.text = "Loading indexed and semantic relationships…"
+        openSourceButton.isEnabled = selected.navigationTarget != null
+    }
+
+    private fun renderInspection(inspection: KastExplorerInspection) {
+        relationRoot.removeAllChildren()
+        inspection.sections.forEach { section ->
+            val group = DefaultMutableTreeNode("${section.layer.title} (${section.relations.size})")
+            section.relations.forEach { relation -> group.add(DefaultMutableTreeNode(relation, false)) }
+            relationRoot.add(group)
+        }
+        relationModel.reload()
+        repeat(relations.rowCount) { row -> relations.expandRow(row) }
+        detailHint.text = if (inspection.relations.isEmpty()) {
+            "No persisted neighborhood is available for this symbol."
+        } else {
+            "Double-click a relationship to open its source."
+        }
+    }
+
+    private fun renderDiagnostics(snapshot: KastDiagnosticsSnapshot) {
+        compilerValue.text = "${snapshot.backendState.displayName} · K2 / PSI / AA"
+        indexValue.text = snapshot.indexSummary.displayText()
+        workspaceValue.text = snapshot.workspaceRoot?.let { Path.of(it).fileName.toString() } ?: "No workspace"
+    }
+
+    private fun navigate(target: KastSourceTarget) {
+        val file = LocalFileSystem.getInstance().findFileByNioFile(target.filePath)
+        if (file == null) {
+            detailHint.text = "Source file is no longer available: ${target.filePath}"
+            return
+        }
+        OpenFileDescriptor(project, file, target.offset).navigate(true)
+    }
+
+    private class RelationRenderer : DefaultTreeCellRenderer() {
+        override fun getTreeCellRendererComponent(
+            tree: javax.swing.JTree,
+            value: Any,
+            selected: Boolean,
+            expanded: Boolean,
+            leaf: Boolean,
+            row: Int,
+            hasFocus: Boolean,
+        ): Component {
+            val component = super.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, hasFocus)
+            val node = value as? DefaultMutableTreeNode
+            val relation = node?.userObject as? KastExplorerRelation
+            if (relation != null) {
+                text = buildString {
+                    append(relation.title.value)
+                    relation.detail?.let { append("  ·  ").append(it.value) }
+                }
+                toolTipText = relation.navigationTarget?.filePath?.toString()
+            }
+            return component
+        }
+    }
+}

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
@@ -253,7 +253,11 @@ internal class KastExplorerPanel(
     private fun request(request: KastExplorerRequest) {
         val sequence = ++requestSequence
         service.exploreAsync(request) { result ->
-            if (disposed || !shouldAcceptExplorerResult(result, sequence, requestSequence)) return@exploreAsync
+            if (disposed || !shouldAcceptExplorerResult(request, sequence, requestSequence)) return@exploreAsync
+            if (request is KastExplorerRequest.Overview && result is KastExplorerResult.Problem) {
+                graphValue.text = result.message.value
+                return@exploreAsync
+            }
             model.accept(result)
             render(result)
         }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
@@ -3,7 +3,7 @@
 package io.github.amichne.kast.idea
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
@@ -235,10 +235,10 @@ internal class KastExplorerPanel(
     }
 
     private fun searchCurrentSymbol() {
-        val fqName = ReadAction.compute<String?, RuntimeException> {
-            val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@compute null
-            val file = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return@compute null
-            val element = file.findElementAt(editor.caretModel.offset) ?: return@compute null
+        val fqName = ApplicationManager.getApplication().runReadAction<String?> {
+            val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@runReadAction null
+            val file = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return@runReadAction null
+            val element = file.findElementAt(editor.caretModel.offset) ?: return@runReadAction null
             PsiTreeUtil.getParentOfType(element, KtNamedDeclaration::class.java, false)?.fqName?.asString()
         }
         if (fqName == null) {

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerPanel.kt
@@ -253,7 +253,7 @@ internal class KastExplorerPanel(
     private fun request(request: KastExplorerRequest) {
         val sequence = ++requestSequence
         service.exploreAsync(request) { result ->
-            if (disposed || sequence != requestSequence) return@exploreAsync
+            if (disposed || !shouldAcceptExplorerResult(result, sequence, requestSequence)) return@exploreAsync
             model.accept(result)
             render(result)
         }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastToolWindowFactory.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastToolWindowFactory.kt
@@ -26,10 +26,17 @@ import javax.swing.table.AbstractTableModel
 internal class KastToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         val contentManager = toolWindow.contentManager
+        val explorerPanel = KastExplorerPanel(project)
         val activityPanel = KastActivityPanel(project)
 
         contentManager.addContent(
-            contentManager.factory.createContent(activityPanel, "Activity", false).apply {
+            contentManager.factory.createContent(explorerPanel, KastToolWindowContent.EXPLORE.title, false).apply {
+                setPreferredFocusableComponent(explorerPanel)
+                setDisposer(explorerPanel)
+            },
+        )
+        contentManager.addContent(
+            contentManager.factory.createContent(activityPanel, KastToolWindowContent.ACTIVITY.title, false).apply {
                 setPreferredFocusableComponent(activityPanel)
                 setDisposer(activityPanel)
             },

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
@@ -73,6 +73,19 @@ class KastExplorerModelTest {
     }
 
     @Test
+    fun `current symbol does not fall back to a declaration in another file`() {
+        val persisted = KastExplorerSearchItem(
+            declaration("io.demo.overloaded", "Other.kt", 10),
+        )
+        val current = KastCurrentSymbol(
+            fqName = FqName("io.demo.overloaded"),
+            navigationTarget = KastSourceTarget(tempDir.resolve("Overloads.kt"), 40),
+        )
+
+        assertNull(explorerSelectionIndex(listOf(persisted), current))
+    }
+
+    @Test
     fun `inspection separates indexed and semantic graph evidence`() {
         val model = KastExplorerModel()
         val selected = KastExplorerSearchItem(declaration("io.demo.GraphExplorer", "GraphExplorer.kt", 42))

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
@@ -4,12 +4,19 @@ import io.github.amichne.kast.api.contract.NonBlankString
 import io.github.amichne.kast.indexstore.api.reference.DeclarationKind
 import io.github.amichne.kast.indexstore.api.reference.DeclarationRow
 import io.github.amichne.kast.indexstore.api.reference.DeclarationVisibility
+import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
 class KastExplorerModelTest {
+    @TempDir
+    lateinit var tempDir: Path
+
     @Test
     fun `tool window prioritizes exploration while retaining activity`() {
         assertEquals(
@@ -42,7 +49,6 @@ class KastExplorerModelTest {
         val model = KastExplorerModel()
         val selected = KastExplorerSearchItem(declaration("io.demo.GraphExplorer", "GraphExplorer.kt", 42))
         val caller = KastSourceTarget(tempDir.resolve("Caller.kt"), 17)
-        val callee = KastSourceTarget(tempDir.resolve("Callee.kt"), 23)
         val type = KastSourceTarget(tempDir.resolve("GraphNode.kt"), 11)
 
         model.accept(
@@ -55,12 +61,6 @@ class KastExplorerModelTest {
                             title = NonBlankString("io.demo.Caller"),
                             detail = NonBlankString("CALL"),
                             navigationTarget = caller,
-                        ),
-                        KastExplorerRelation(
-                            layer = KastExplorerEvidenceLayer.OUTGOING,
-                            title = NonBlankString("io.demo.Callee"),
-                            detail = NonBlankString("CALL"),
-                            navigationTarget = callee,
                         ),
                         KastExplorerRelation(
                             layer = KastExplorerEvidenceLayer.SEMANTIC_GRAPH,
@@ -76,7 +76,6 @@ class KastExplorerModelTest {
         assertEquals(
             listOf(
                 KastExplorerEvidenceLayer.INCOMING,
-                KastExplorerEvidenceLayer.OUTGOING,
                 KastExplorerEvidenceLayer.SEMANTIC_GRAPH,
             ),
             model.inspection?.sections?.map(KastExplorerSection::layer),
@@ -84,7 +83,61 @@ class KastExplorerModelTest {
         assertEquals(type, model.inspection?.sections?.last()?.relations?.single()?.navigationTarget)
     }
 
-    private val tempDir: Path = Path.of("/tmp/kast-explorer-model-test").toAbsolutePath().normalize()
+    @Test
+    fun `inspection isolates declarations that share an fq name`() {
+        SqliteSourceIndexStore(tempDir).use { store ->
+            store.ensureSchema()
+            val first = declaration("io.demo.overloaded", "First.kt", 10)
+            val second = declaration("io.demo.overloaded", "Second.kt", 40)
+            store.replaceDeclarationsFromFiles(
+                listOf(first.filePath to listOf(first), second.filePath to listOf(second)),
+            )
+            store.upsertSymbolReference(
+                sourcePath = tempDir.resolve("FirstCaller.kt").toString(),
+                sourceOffset = 1,
+                targetFqName = first.fqName,
+                targetPath = first.filePath,
+                targetOffset = first.declarationOffset,
+            )
+            store.upsertSymbolReference(
+                sourcePath = tempDir.resolve("SecondCaller.kt").toString(),
+                sourceOffset = 2,
+                targetFqName = second.fqName,
+                targetPath = second.filePath,
+                targetOffset = second.declarationOffset,
+            )
+
+            val inspection = store.explore(
+                tempDir,
+                KastExplorerRequest.Inspect(KastExplorerSearchItem(second)),
+            ) as KastExplorerResult.Inspection
+
+            assertEquals(
+                listOf(tempDir.resolve("SecondCaller.kt")),
+                inspection.value.relations.mapNotNull(KastExplorerRelation::navigationTarget)
+                    .map(KastSourceTarget::filePath),
+            )
+        }
+    }
+
+    @Test
+    fun `overview results are independent from interactive request ordering`() {
+        val overview = KastExplorerResult.Overview(
+            KastExplorerOverview(
+                graphGeneration = io.github.amichne.kast.indexstore.api.reference.SourceIndexGeneration(1),
+                graphFileCount = io.github.amichne.kast.api.contract.NonNegativeInt(2),
+            ),
+        )
+
+        assertTrue(shouldAcceptExplorerResult(overview, resultSequence = 1, currentSequence = 2))
+        assertFalse(
+            shouldAcceptExplorerResult(
+                KastExplorerResult.SearchResults(emptyList()),
+                resultSequence = 1,
+                currentSequence = 2,
+            ),
+        )
+    }
 
     private fun declaration(
         fqName: String,

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
@@ -1,0 +1,102 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.api.contract.NonBlankString
+import io.github.amichne.kast.indexstore.api.reference.DeclarationKind
+import io.github.amichne.kast.indexstore.api.reference.DeclarationRow
+import io.github.amichne.kast.indexstore.api.reference.DeclarationVisibility
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+class KastExplorerModelTest {
+    @Test
+    fun `tool window prioritizes exploration while retaining activity`() {
+        assertEquals(
+            listOf("Explore", "Activity"),
+            KastToolWindowContent.entries.map(KastToolWindowContent::title),
+        )
+    }
+
+    @Test
+    fun `search results retain exact source navigation evidence`() {
+        val model = KastExplorerModel()
+        val declaration = declaration("io.demo.GraphExplorer", "GraphExplorer.kt", 42)
+
+        model.accept(
+            KastExplorerResult.SearchResults(
+                listOf(KastExplorerSearchItem(declaration)),
+            ),
+        )
+
+        assertEquals("GraphExplorer", model.searchItems.single().displayName)
+        assertEquals(
+            KastSourceTarget(Path.of(declaration.filePath), 42),
+            model.searchItems.single().navigationTarget,
+        )
+        assertNull(model.inspection)
+    }
+
+    @Test
+    fun `inspection separates indexed and semantic graph evidence`() {
+        val model = KastExplorerModel()
+        val selected = KastExplorerSearchItem(declaration("io.demo.GraphExplorer", "GraphExplorer.kt", 42))
+        val caller = KastSourceTarget(tempDir.resolve("Caller.kt"), 17)
+        val callee = KastSourceTarget(tempDir.resolve("Callee.kt"), 23)
+        val type = KastSourceTarget(tempDir.resolve("GraphNode.kt"), 11)
+
+        model.accept(
+            KastExplorerResult.Inspection(
+                KastExplorerInspection(
+                    selected = selected,
+                    relations = listOf(
+                        KastExplorerRelation(
+                            layer = KastExplorerEvidenceLayer.INCOMING,
+                            title = NonBlankString("io.demo.Caller"),
+                            detail = NonBlankString("CALL"),
+                            navigationTarget = caller,
+                        ),
+                        KastExplorerRelation(
+                            layer = KastExplorerEvidenceLayer.OUTGOING,
+                            title = NonBlankString("io.demo.Callee"),
+                            detail = NonBlankString("CALL"),
+                            navigationTarget = callee,
+                        ),
+                        KastExplorerRelation(
+                            layer = KastExplorerEvidenceLayer.SEMANTIC_GRAPH,
+                            title = NonBlankString("io.demo.GraphNode"),
+                            detail = NonBlankString("IMPLEMENTS"),
+                            navigationTarget = type,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                KastExplorerEvidenceLayer.INCOMING,
+                KastExplorerEvidenceLayer.OUTGOING,
+                KastExplorerEvidenceLayer.SEMANTIC_GRAPH,
+            ),
+            model.inspection?.sections?.map(KastExplorerSection::layer),
+        )
+        assertEquals(type, model.inspection?.sections?.last()?.relations?.single()?.navigationTarget)
+    }
+
+    private val tempDir: Path = Path.of("/tmp/kast-explorer-model-test").toAbsolutePath().normalize()
+
+    private fun declaration(
+        fqName: String,
+        fileName: String,
+        offset: Int,
+    ): DeclarationRow = DeclarationRow(
+        fqName = fqName,
+        kind = DeclarationKind.CLASS,
+        visibility = DeclarationVisibility.INTERNAL,
+        filePath = tempDir.resolve(fileName).toString(),
+        declarationOffset = offset,
+        modulePath = ":demo",
+        sourceSet = "main",
+    )
+}

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
@@ -122,12 +122,9 @@ class KastExplorerModelTest {
 
     @Test
     fun `overview results are independent from interactive request ordering`() {
-        val overviewFailure = KastExplorerResult.Problem(NonBlankString("Graph evidence unavailable"))
-
         assertTrue(
             shouldAcceptExplorerResult(
                 KastExplorerRequest.Overview,
-                overviewFailure,
                 resultSequence = 1,
                 currentSequence = 2,
             ),
@@ -135,7 +132,6 @@ class KastExplorerModelTest {
         assertFalse(
             shouldAcceptExplorerResult(
                 KastExplorerRequest.Search(NonBlankString("GraphExplorer")),
-                KastExplorerResult.SearchResults(emptyList()),
                 resultSequence = 1,
                 currentSequence = 2,
             ),

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
@@ -1,6 +1,7 @@
 package io.github.amichne.kast.idea
 
 import io.github.amichne.kast.api.contract.NonBlankString
+import io.github.amichne.kast.idea.diagnostics.KastBackendUiState
 import io.github.amichne.kast.indexstore.api.reference.DeclarationKind
 import io.github.amichne.kast.indexstore.api.reference.DeclarationRow
 import io.github.amichne.kast.indexstore.api.reference.DeclarationVisibility

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
@@ -138,6 +138,20 @@ class KastExplorerModelTest {
         )
     }
 
+    @Test
+    fun `overview refreshes once on ready without invalidating interactive requests`() {
+        assertTrue(shouldRefreshExplorerOverview(KastBackendUiState.INDEXING, KastBackendUiState.READY))
+        assertFalse(shouldRefreshExplorerOverview(KastBackendUiState.READY, KastBackendUiState.READY))
+        assertEquals(4, nextExplorerRequestSequence(KastExplorerRequest.Overview, 4))
+        assertEquals(
+            5,
+            nextExplorerRequestSequence(
+                KastExplorerRequest.Search(NonBlankString("GraphExplorer")),
+                4,
+            ),
+        )
+    }
+
     private fun declaration(
         fqName: String,
         fileName: String,

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
@@ -122,16 +122,19 @@ class KastExplorerModelTest {
 
     @Test
     fun `overview results are independent from interactive request ordering`() {
-        val overview = KastExplorerResult.Overview(
-            KastExplorerOverview(
-                graphGeneration = io.github.amichne.kast.indexstore.api.reference.SourceIndexGeneration(1),
-                graphFileCount = io.github.amichne.kast.api.contract.NonNegativeInt(2),
+        val overviewFailure = KastExplorerResult.Problem(NonBlankString("Graph evidence unavailable"))
+
+        assertTrue(
+            shouldAcceptExplorerResult(
+                KastExplorerRequest.Overview,
+                overviewFailure,
+                resultSequence = 1,
+                currentSequence = 2,
             ),
         )
-
-        assertTrue(shouldAcceptExplorerResult(overview, resultSequence = 1, currentSequence = 2))
         assertFalse(
             shouldAcceptExplorerResult(
+                KastExplorerRequest.Search(NonBlankString("GraphExplorer")),
                 KastExplorerResult.SearchResults(emptyList()),
                 resultSequence = 1,
                 currentSequence = 2,

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
@@ -58,6 +58,21 @@ class KastExplorerModelTest {
     }
 
     @Test
+    fun `current symbol preserves the exact caret declaration offset`() {
+        val persisted = KastExplorerSearchItem(
+            declaration("io.demo.overloaded", "Overloads.kt", 10),
+        )
+        val current = KastCurrentSymbol(
+            fqName = FqName("io.demo.overloaded"),
+            navigationTarget = KastSourceTarget(tempDir.resolve("Overloads.kt"), 40),
+        )
+
+        val selected = preferExactCurrentSymbol(listOf(persisted), current).single()
+
+        assertEquals(current.navigationTarget, selected.navigationTarget)
+    }
+
+    @Test
     fun `inspection separates indexed and semantic graph evidence`() {
         val model = KastExplorerModel()
         val selected = KastExplorerSearchItem(declaration("io.demo.GraphExplorer", "GraphExplorer.kt", 42))
@@ -94,6 +109,22 @@ class KastExplorerModelTest {
             model.inspection?.sections?.map(KastExplorerSection::layer),
         )
         assertEquals(type, model.inspection?.sections?.last()?.relations?.single()?.navigationTarget)
+    }
+
+    @Test
+    fun `empty search clears the previous inspection`() {
+        val model = KastExplorerModel()
+        val selected = KastExplorerSearchItem(declaration("io.demo.GraphExplorer", "GraphExplorer.kt", 42))
+        model.accept(
+            KastExplorerResult.Inspection(
+                KastExplorerInspection(selected, emptyList()),
+            ),
+        )
+
+        model.accept(KastExplorerResult.SearchResults(emptyList()))
+
+        assertTrue(model.searchItems.isEmpty())
+        assertNull(model.inspection)
     }
 
     @Test

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/ui/KastExplorerModelTest.kt
@@ -1,7 +1,19 @@
 package io.github.amichne.kast.idea
 
+import io.github.amichne.kast.api.contract.ByteOffset
+import io.github.amichne.kast.api.contract.FqName
+import io.github.amichne.kast.api.contract.LineNumber
 import io.github.amichne.kast.api.contract.NonBlankString
+import io.github.amichne.kast.api.contract.result.SemanticGraphFileStatus
+import io.github.amichne.kast.api.contract.result.SemanticGraphRelation
+import io.github.amichne.kast.api.contract.result.SemanticGraphRelationKind
+import io.github.amichne.kast.api.contract.result.SemanticGraphSha256
+import io.github.amichne.kast.api.contract.result.SemanticGraphSourcePath
+import io.github.amichne.kast.api.contract.result.SemanticGraphSymbol
+import io.github.amichne.kast.api.contract.result.SemanticGraphSymbolKey
+import io.github.amichne.kast.api.contract.result.SemanticGraphSymbolKind
 import io.github.amichne.kast.idea.diagnostics.KastBackendUiState
+import io.github.amichne.kast.indexstore.api.graph.SemanticGraphFileIndexUpdate
 import io.github.amichne.kast.indexstore.api.reference.DeclarationKind
 import io.github.amichne.kast.indexstore.api.reference.DeclarationRow
 import io.github.amichne.kast.indexstore.api.reference.DeclarationVisibility
@@ -122,6 +134,118 @@ class KastExplorerModelTest {
     }
 
     @Test
+    fun `semantic graph matches the name offset inside the declaration range`() {
+        val sourcePath = SemanticGraphSourcePath.parse("Example.kt")
+        val selected = semanticSymbol(
+            key = "class:Example",
+            name = "Example",
+            fqName = "io.demo.Example",
+            path = sourcePath,
+            startOffset = 0,
+            endOffset = 20,
+        )
+        val target = semanticSymbol(
+            key = "function:target",
+            name = "target",
+            fqName = "io.demo.target",
+            path = sourcePath,
+            startOffset = 22,
+            endOffset = 40,
+        )
+        val declaration = declaration("io.demo.Example", "Example.kt", 6)
+
+        SqliteSourceIndexStore(tempDir).use { store ->
+            store.ensureSchema()
+            store.replaceSemanticGraphFiles(
+                listOf(
+                    semanticUpdate(
+                        path = sourcePath,
+                        symbols = listOf(selected, target),
+                        relations = listOf(semanticRelation(selected, target)),
+                    ),
+                ),
+            )
+
+            val inspection = store.explore(
+                tempDir,
+                KastExplorerRequest.Inspect(KastExplorerSearchItem(declaration)),
+            ) as KastExplorerResult.Inspection
+
+            assertEquals(
+                listOf("io.demo.target"),
+                inspection.value.relations.map { relation -> relation.title.value },
+            )
+        }
+    }
+
+    @Test
+    fun `semantic graph falls back to the projected constructor target`() {
+        val sourcePath = SemanticGraphSourcePath.parse("Factory.kt")
+        val targetPath = SemanticGraphSourcePath.parse("Target.kt")
+        val selected = semanticSymbol(
+            key = "function:factory",
+            name = "factory",
+            fqName = "io.demo.factory",
+            path = sourcePath,
+            startOffset = 0,
+            endOffset = 20,
+        )
+        val projectedTarget = semanticSymbol(
+            key = "class:Target",
+            name = "Target",
+            fqName = "io.demo.Target",
+            path = targetPath,
+            startOffset = 0,
+            endOffset = 20,
+        )
+        val resolvedConstructor = semanticSymbol(
+            key = "constructor:Target",
+            name = "Target",
+            fqName = "io.demo.Target",
+            path = targetPath,
+            startOffset = 10,
+            endOffset = 18,
+        )
+
+        SqliteSourceIndexStore(tempDir).use { store ->
+            store.ensureSchema()
+            store.replaceSemanticGraphFiles(
+                listOf(
+                    semanticUpdate(
+                        path = sourcePath,
+                        symbols = listOf(selected),
+                        boundarySymbols = listOf(projectedTarget),
+                        relations = listOf(
+                            semanticRelation(
+                                selected,
+                                projectedTarget,
+                                resolvedTargetKey = resolvedConstructor.canonicalKey,
+                            ),
+                        ),
+                    ),
+                    semanticUpdate(
+                        path = targetPath,
+                        symbols = listOf(projectedTarget, resolvedConstructor),
+                        relations = emptyList(),
+                    ),
+                ),
+            )
+
+            val inspection = store.explore(
+                tempDir,
+                KastExplorerRequest.Inspect(
+                    KastExplorerSearchItem(declaration("io.demo.factory", "Factory.kt", 0)),
+                ),
+            ) as KastExplorerResult.Inspection
+
+            assertEquals(
+                listOf("io.demo.Target"),
+                inspection.value.relations.map { relation -> relation.title.value },
+            )
+        }
+    }
+
+    @Test
     fun `overview results are independent from interactive request ordering`() {
         assertTrue(
             shouldAcceptExplorerResult(
@@ -165,5 +289,56 @@ class KastExplorerModelTest {
         declarationOffset = offset,
         modulePath = ":demo",
         sourceSet = "main",
+    )
+
+    private fun semanticSymbol(
+        key: String,
+        name: String,
+        fqName: String,
+        path: SemanticGraphSourcePath,
+        startOffset: Int,
+        endOffset: Int,
+    ): SemanticGraphSymbol = SemanticGraphSymbol(
+        canonicalKey = SemanticGraphSymbolKey.parse(key),
+        kind = SemanticGraphSymbolKind.FUNCTION,
+        name = NonBlankString(name),
+        fqName = FqName(fqName),
+        path = path,
+        startOffset = ByteOffset(startOffset),
+        endOffset = ByteOffset(endOffset),
+        line = LineNumber(1),
+    )
+
+    private fun semanticRelation(
+        source: SemanticGraphSymbol,
+        target: SemanticGraphSymbol,
+        resolvedTargetKey: SemanticGraphSymbolKey? = null,
+    ): SemanticGraphRelation = SemanticGraphRelation(
+        sourceKey = source.canonicalKey,
+        targetKey = target.canonicalKey,
+        resolvedTargetKey = resolvedTargetKey,
+        kind = SemanticGraphRelationKind.CALLS,
+        sourcePath = source.path,
+        startOffset = source.startOffset,
+        endOffset = source.endOffset,
+        line = LineNumber(1),
+    )
+
+    private fun semanticUpdate(
+        path: SemanticGraphSourcePath,
+        symbols: List<SemanticGraphSymbol>,
+        boundarySymbols: List<SemanticGraphSymbol> = emptyList(),
+        relations: List<SemanticGraphRelation>,
+    ): SemanticGraphFileIndexUpdate = SemanticGraphFileIndexUpdate(
+        path = path,
+        packageName = "io.demo",
+        moduleName = ":demo",
+        contentHash = SemanticGraphSha256.parse("a".repeat(64)),
+        status = SemanticGraphFileStatus.REFRESHED,
+        diagnostics = emptyList(),
+        types = emptyList(),
+        symbols = symbols,
+        boundarySymbols = boundarySymbols,
+        relations = relations,
     )
 }

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.kt
@@ -163,6 +163,11 @@ class SqliteSourceIndexStore private constructor(
     fun declarationsWithSupertype(supertypeFqName: String): List<DeclarationRow> =
         declarationStore.declarationsWithSupertype(supertypeFqName)
 
+    fun searchDeclarations(
+        pattern: io.github.amichne.kast.api.contract.NonBlankString,
+        maxResults: PositiveInt,
+    ): List<DeclarationRow> = declarationStore.searchDeclarations(pattern, maxResults)
+
     fun appendPendingUpdate(
         op: String,
         path: String,

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/sqlite/references/SourceIndexDeclarationStore.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/sqlite/references/SourceIndexDeclarationStore.kt
@@ -1,5 +1,7 @@
 package io.github.amichne.kast.indexstore.store
 
+import io.github.amichne.kast.api.contract.NonBlankString
+import io.github.amichne.kast.api.contract.PositiveInt
 import io.github.amichne.kast.indexstore.api.index.SourceIndexFilePolicy
 import io.github.amichne.kast.indexstore.api.reference.*
 import java.sql.Connection
@@ -81,6 +83,63 @@ internal class SourceIndexDeclarationStore(
                             ),
                         )
                     }
+                }
+            }
+        }
+    }
+
+    fun searchDeclarations(
+        pattern: NonBlankString,
+        maxResults: PositiveInt,
+    ): List<DeclarationRow> = synchronized(state.writeLock) {
+        val conn = state.connection()
+        state.loadInterningTables(conn)
+        val query = pattern.value.trim()
+        val searchClause = if (query.length >= 3) {
+            "fq_names_fts MATCH ?"
+        } else {
+            "instr(lower(names.fq_name), lower(?)) > 0"
+        }
+        val source = if (query.length >= 3) {
+            """fq_names_fts
+               JOIN fq_names names ON names.fq_id = fq_names_fts.rowid"""
+        } else {
+            "fq_names names"
+        }
+        conn.prepareStatement(
+            """SELECT names.fq_name, declarations.kind, declarations.visibility,
+                      declarations.prefix_id, declarations.filename,
+                      declarations.declaration_offset, declarations.module_path,
+                      declarations.source_set
+               FROM $source
+               JOIN declarations ON declarations.fq_id = names.fq_id
+               WHERE $searchClause
+               ORDER BY names.fq_name, declarations.prefix_id, declarations.filename
+               LIMIT ?""",
+        ).use { statement ->
+            statement.setString(
+                1,
+                if (query.length >= 3) {
+                    "\"${query.replace("\"", "\"\"")}\""
+                } else {
+                    query
+                },
+            )
+            statement.setInt(2, maxResults.value)
+            val rows = statement.executeQuery()
+            buildList {
+                while (rows.next()) {
+                    add(
+                        DeclarationRow(
+                            fqName = rows.getString(1),
+                            kind = DeclarationKind.valueOf(rows.getString(2)),
+                            visibility = DeclarationVisibility.valueOf(rows.getString(3)),
+                            filePath = state.pathCodec.decode(rows.getInt(4), rows.getString(5)),
+                            declarationOffset = rows.getNullableInt(6),
+                            modulePath = rows.getString(7),
+                            sourceSet = rows.getString(8),
+                        ),
+                    )
                 }
             }
         }

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/store/source/SqliteSourceIndexExplorerTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/store/source/SqliteSourceIndexExplorerTest.kt
@@ -1,0 +1,58 @@
+package io.github.amichne.kast.indexstore
+
+import io.github.amichne.kast.api.contract.NonBlankString
+import io.github.amichne.kast.api.contract.PositiveInt
+import io.github.amichne.kast.indexstore.api.reference.DeclarationKind
+import io.github.amichne.kast.indexstore.api.reference.DeclarationRow
+import io.github.amichne.kast.indexstore.api.reference.DeclarationVisibility
+import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class SqliteSourceIndexExplorerTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `declaration search uses persistent FTS and supports short literal queries`() {
+        val store = SqliteSourceIndexStore(tempDir)
+        store.use {
+            store.ensureSchema()
+            val first = declaration("demo.search.SearchService", "SearchService.kt", 18)
+            val second = declaration("demo.search.ServiceRegistry", "ServiceRegistry.kt", 24)
+            val unrelated = declaration("demo.other.Unrelated", "Unrelated.kt", 12)
+            store.replaceDeclarationsFromFiles(
+                listOf(
+                    first.filePath to listOf(first),
+                    second.filePath to listOf(second),
+                    unrelated.filePath to listOf(unrelated),
+                ),
+            )
+
+            assertEquals(
+                listOf(first.fqName, second.fqName),
+                store.searchDeclarations(NonBlankString("Service"), PositiveInt(10)).map(DeclarationRow::fqName),
+            )
+            assertEquals(
+                listOf(first.fqName, second.fqName),
+                store.searchDeclarations(NonBlankString("Se"), PositiveInt(10)).map(DeclarationRow::fqName),
+            )
+        }
+    }
+
+    private fun declaration(
+        fqName: String,
+        fileName: String,
+        offset: Int,
+    ): DeclarationRow = DeclarationRow(
+        fqName = fqName,
+        kind = DeclarationKind.CLASS,
+        visibility = DeclarationVisibility.INTERNAL,
+        filePath = tempDir.resolve(fileName).toAbsolutePath().normalize().toString(),
+        declarationOffset = offset,
+        modulePath = ":demo",
+        sourceSet = "main",
+    )
+}


### PR DESCRIPTION
## Risk

- Plugin Verifier is compatible on IntelliJ 2026.2. The Android Studio target still reports the existing unresolved bundled Gradle plugin dependencies.
- Persisted semantic graph coverage is currently truthful at zero files for this workspace; the UI exposes that state instead of implying coverage.

## What

- Replace the diagnostics-first Kast tool window with a native Explore surface and retain Activity as the secondary tab.
- Add persistent FTS symbol search, current-caret lookup, exact source navigation, evidence metrics, overload-safe incoming references, and exact persisted graph relationships.
- Bound explorer reads in SQLite and preserve request ordering across indexing transitions.
- Address all four review findings: compatible graph identity, projected constructor fallback, exact overloaded-caret identity, and empty-search detail clearing.
- Fail closed when Current Symbol has no exact indexed path/offset match.

## Why

Kast already owns compiler, PSI, index, reference, and graph evidence, but the plugin exposed only an activity table. This makes that evidence directly explorable inside IDEA.

## Proof

- `./gradlew :index-store:test :backend-idea:test :backend-idea:buildPlugin`
- `python3 .github/scripts/check-repository-shape.py`
- Kast exact-root diagnostics: 4 review-touched Kotlin files analyzed, 0 errors, 0 warnings
- Live IDEA 2026.2: final plugin `0.17.8-18-ge789925a`, READY; populated-to-empty search clears prior details and disables source navigation
- Focused review regressions cover graph range identity, constructor fallback, exact Current Symbol selection, and fail-closed selection
- Current-head CI: 22 passed, 0 failed