### PR TITLE
feat: eagerly index references on project open

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/startup/KastProjectOpenAutoIndexing.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/startup/KastProjectOpenAutoIndexing.kt
@@ -45,25 +45,23 @@ internal object KastProjectOpenAutoIndexing {
             LOG.warn("Kast IDEA backend startup failed for $workspaceRoot", backendStartFailure)
             return false
         }
+        startReferenceIndex(project)
 
         if (config.projectOpen.gradleLoadEnabled.value) {
             val gradleLoadResult = loadGradleProject(workspaceRoot, config) { failure ->
-                if (failure == null) {
-                    startReferenceIndex(project)
-                } else {
+                if (failure != null) {
                     failReadiness(project, failure)
                 }
             }
             KastProjectOpenGradleLoad.log(gradleLoadResult)
             when (gradleLoadResult) {
                 is ProjectOpenGradleLoadResult.Requested -> {}
-                is ProjectOpenGradleLoadResult.Skipped -> startReferenceIndex(project)
+                is ProjectOpenGradleLoadResult.Skipped -> {}
                 is ProjectOpenGradleLoadResult.Failed ->
                     failReadiness(project, IllegalStateException(gradleLoadResult.message))
             }
         } else {
             LOG.info("Kast Gradle project load skipped because projectOpen.gradleLoadEnabled is disabled")
-            startReferenceIndex(project)
         }
         return true
     }

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/KastProjectOpenAutoIndexingTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/KastProjectOpenAutoIndexingTest.kt
@@ -33,7 +33,7 @@ class KastProjectOpenAutoIndexingTest {
     lateinit var tempDir: Path
 
     @Test
-    fun `project open reports indexing then waits for Gradle before starting reference index`() {
+    fun `project open starts reference index eagerly before Gradle project load completes`() {
         val project = projectFixture.get()
         var loadedGradleWorkspaceRoot: Path? = null
         var startedProject: Project? = null
@@ -62,9 +62,9 @@ class KastProjectOpenAutoIndexingTest {
 
         assertTrue(started)
         assertSame(project, startedProject)
-        assertEquals(listOf("backend", "gradle"), events)
+        assertEquals(listOf("backend", "index", "gradle"), events)
         gradleCompletion?.invoke(null)
-        assertEquals(listOf("backend", "gradle", "index"), events)
+        assertEquals(listOf("backend", "index", "gradle"), events)
         assertNotNull(loadedGradleWorkspaceRoot)
         assertEquals(loadedGradleWorkspaceRoot, loadedGradleWorkspaceRoot?.toAbsolutePath()?.normalize())
     }


### PR DESCRIPTION
## Summary
- Start reference indexing immediately after the IDEA backend starts for an opened project.
- Keep Gradle project loading and failure reporting without making successful completion the indexing trigger.

## Validation
- RED: KastProjectOpenAutoIndexingTest failed with backend, gradle instead of backend, index, gradle.
- GREEN: ./gradlew :backend-idea:test --tests io.github.amichne.kast.idea.KastProjectOpenAutoIndexingTest
- Kast diagnostics: 2 files analyzed, 0 diagnostics.