### PR TITLE
Fix release indexing cardinality after durable source scans

### DIFF
--- a/cli-rs/src/semantics/workspace_inventory/parts/index/progress.rs
+++ b/cli-rs/src/semantics/workspace_inventory/parts/index/progress.rs
@@ -63,6 +63,42 @@ fn read_module_progress(
     Ok((progress, invalid_count))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceFileStageProgress {
+    Complete,
+    Incomplete,
+}
+
+fn read_source_file_stage_progress(
+    transaction: &Transaction<'_>,
+) -> Result<SourceFileStageProgress, ReadDatabaseError> {
+    let (total_count, complete_count) = transaction
+        .query_row(
+            r#"SELECT COUNT(*),
+                      COALESCE(SUM(CASE
+                          WHEN outcomes.content_hash = manifest.content_hash
+                           AND outcomes.stage_version = manifest.desired_source_version
+                           AND outcomes.outcome_status = 'COMPLETE'
+                          THEN 1 ELSE 0 END), 0)
+               FROM file_manifest manifest
+               LEFT JOIN file_stage_outcomes outcomes
+                 ON outcomes.prefix_id = manifest.prefix_id
+                AND outcomes.filename = manifest.filename
+                AND outcomes.stage = 'SOURCE'
+               WHERE manifest.filename GLOB '*.kt'"#,
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .map_err(incompatible_sql)?;
+    Ok(
+        if total_count > 0 && complete_count == total_count {
+            SourceFileStageProgress::Complete
+        } else {
+            SourceFileStageProgress::Incomplete
+        },
+    )
+}
+
 fn read_pending_count(
     transaction: &Transaction<'_>,
 ) -> Result<SourceIndexPendingCount, ReadDatabaseError> {

--- a/cli-rs/src/semantics/workspace_inventory/parts/index/progress.rs
+++ b/cli-rs/src/semantics/workspace_inventory/parts/index/progress.rs
@@ -66,6 +66,7 @@ fn read_module_progress(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SourceFileStageProgress {
     Complete,
+    Empty,
     Incomplete,
 }
 
@@ -85,18 +86,18 @@ fn read_source_file_stage_progress(
                  ON outcomes.prefix_id = manifest.prefix_id
                 AND outcomes.filename = manifest.filename
                 AND outcomes.stage = 'SOURCE'
-               WHERE manifest.filename GLOB '*.kt'"#,
+               WHERE manifest.filename GLOB '*.kt'
+                 AND manifest.content_hash IS NOT NULL
+                 AND manifest.desired_source_version IS NOT NULL"#,
             [],
             |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
         )
         .map_err(incompatible_sql)?;
-    Ok(
-        if total_count > 0 && complete_count == total_count {
-            SourceFileStageProgress::Complete
-        } else {
-            SourceFileStageProgress::Incomplete
-        },
-    )
+    Ok(match (total_count, complete_count) {
+        (0, 0) => SourceFileStageProgress::Empty,
+        (total, complete) if total == complete => SourceFileStageProgress::Complete,
+        _ => SourceFileStageProgress::Incomplete,
+    })
 }
 
 fn read_pending_count(

--- a/cli-rs/src/semantics/workspace_inventory/parts/index/read.rs
+++ b/cli-rs/src/semantics/workspace_inventory/parts/index/read.rs
@@ -62,6 +62,7 @@ fn read_transaction(
     verify_required_structure(transaction)?;
     let generation = read_generation(transaction)?;
     let (module_progress, invalid_progress_count) = read_module_progress(transaction)?;
+    let source_file_stage_progress = read_source_file_stage_progress(transaction)?;
     let pending_count = read_pending_count(transaction)?;
     let stamp = SourceIndexSnapshotStamp::new(
         generation,
@@ -238,13 +239,17 @@ fn read_transaction(
             usize::try_from(stamp.pending_count().value()).unwrap_or(usize::MAX),
         );
     }
-    if stamp.module_progress().is_empty()
+    let relationship_progress_incomplete = stamp.module_progress().is_empty()
         || stamp.module_progress().iter().any(|progress| {
             progress.status() != super::model::SourceIndexProgressStatus::Complete
                 || progress.indexed_file_count() != progress.total_file_count()
-        })
-    {
+        });
+    let source_progress_incomplete =
+        source_file_stage_progress == SourceFileStageProgress::Incomplete;
+    if source_progress_incomplete {
         candidate_partial = true;
+    }
+    if source_progress_incomplete || relationship_progress_incomplete {
         increment_limitation(
             &mut limitations,
             WorkspaceInventoryLimitationCode::SourceIndexProgressIncomplete,

--- a/cli-rs/src/semantics/workspace_inventory/parts/index/read.rs
+++ b/cli-rs/src/semantics/workspace_inventory/parts/index/read.rs
@@ -244,8 +244,19 @@ fn read_transaction(
             progress.status() != super::model::SourceIndexProgressStatus::Complete
                 || progress.indexed_file_count() != progress.total_file_count()
         });
-    let source_progress_incomplete =
-        source_file_stage_progress == SourceFileStageProgress::Incomplete;
+    let relationship_progress_terminal = !stamp.module_progress().is_empty()
+        && stamp.module_progress().iter().all(|progress| {
+            matches!(
+                progress.status(),
+                super::model::SourceIndexProgressStatus::Complete
+                    | super::model::SourceIndexProgressStatus::Failed
+            ) && progress.indexed_file_count() == progress.total_file_count()
+        });
+    let source_progress_incomplete = match source_file_stage_progress {
+        SourceFileStageProgress::Complete => !relationship_progress_terminal,
+        SourceFileStageProgress::Empty => relationship_progress_incomplete,
+        SourceFileStageProgress::Incomplete => true,
+    };
     if source_progress_incomplete {
         candidate_partial = true;
     }

--- a/cli-rs/tests/agent_workspace_files_smoke/evidence/index_incomplete.rs
+++ b/cli-rs/tests/agent_workspace_files_smoke/evidence/index_incomplete.rs
@@ -56,3 +56,69 @@ fn incomplete_index_evidence_counts_backend_only_source_as_unknown() {
         "incomplete source-index evidence must remain UNKNOWN: {stdout:#}"
     );
 }
+
+#[test]
+fn completed_source_stage_keeps_exact_cardinality_when_relationships_are_limited() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(
+        workspace.join("settings.gradle.kts"),
+        "rootProject.name = \"fixture\"\n",
+    )
+    .expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = create_workspace_index(&home, &workspace, "limited-relationships", 1);
+    index
+        .connection()
+        .execute(
+            "UPDATE file_stage_outcomes
+             SET outcome_status = 'LIMITED',
+                 limitations_json = '[\"UNRESOLVED_RELATIONSHIP\"]'
+             WHERE stage = 'RELATIONSHIPS'",
+            [],
+        )
+        .expect("limited relationship outcome");
+    index.seed_progress("app", "FAILED", 1, 1);
+    let source = workspace.join("src/main/kotlin/sample/Source0000.kt");
+    let backend = spawn_single_owned_workspace_files_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &temp.path().join("limited-relationships.sock"),
+        &source,
+    );
+
+    let output = kast(&home, &config_home)
+        .args([
+            "--output",
+            "json",
+            "agent",
+            "workspace-files",
+            "--workspace-root",
+            workspace.to_str().expect("UTF-8 workspace"),
+            "--backend",
+            "idea",
+            "--kind",
+            "source",
+            "--count",
+        ])
+        .output()
+        .expect("limited relationship count");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    backend.join().expect("limited relationship backend");
+    let stdout: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("limited relationship JSON");
+    assert_eq!(
+        stdout["result"]["cardinality"],
+        serde_json::json!({"type": "EXACT", "totalCount": 1}),
+        "complete durable source stages must prove exact file cardinality: {stdout:#}"
+    );
+}


### PR DESCRIPTION
Fixes the three real-repository indexing failures in release run 30454754199.

The durable index can finish every SOURCE stage while relationship coverage is LIMITED. Workspace inventory previously derived candidate cardinality from relationship module progress, so complete source inventories were reported as KNOWN_MINIMUM and the release gate failed. Candidate exactness now follows terminal source-stage evidence while relationship limitations remain explicit.

RED: completed_source_stage_keeps_exact_cardinality_when_relationships_are_limited failed with KNOWN_MINIMUM.
GREEN: focused regression; 54 workspace_inventory tests; all 33 agent_workspace_files_smoke tests; cargo fmt; release benchmark contract; cargo clippy --all-targets --all-features -D warnings.