### PR TITLE
fix: prevent IDEA inventory read starvation

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/semantic/read/IdeaReadAction.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/semantic/read/IdeaReadAction.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.idea
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.readAction
 import io.github.amichne.kast.api.validation.*
@@ -14,6 +15,9 @@ import io.github.amichne.kast.idea.backend.*
 import java.util.concurrent.Callable
 
 internal inline fun <T> runIdeaReadAction(crossinline action: () -> T): T =
+    ApplicationManager.getApplication().runReadAction<T> { action() }
+
+internal inline fun <T> runIdeaCancellableReadAction(crossinline action: () -> T): T =
     ReadAction.nonBlocking(Callable { action() }).executeSynchronously()
 
 internal suspend inline fun <T> timedReadAction(

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/semantic/read/IdeaReadAction.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/semantic/read/IdeaReadAction.kt
@@ -1,6 +1,6 @@
 package io.github.amichne.kast.idea
 
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.readAction
 import io.github.amichne.kast.api.validation.*
 import io.github.amichne.kast.idea.*
@@ -11,9 +11,10 @@ import io.github.amichne.kast.idea.backend.diagnostics.*
 import io.github.amichne.kast.idea.backend.mutation.*
 import io.github.amichne.kast.idea.backend.workspace.*
 import io.github.amichne.kast.idea.backend.*
+import java.util.concurrent.Callable
 
 internal inline fun <T> runIdeaReadAction(crossinline action: () -> T): T =
-    ApplicationManager.getApplication().runReadAction<T> { action() }
+    ReadAction.nonBlocking(Callable { action() }).executeSynchronously()
 
 internal suspend inline fun <T> timedReadAction(
     telemetry: IdeaBackendTelemetry,

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/inventory/core/IdeaProjectModelWorkspaceFileInventory.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/inventory/core/IdeaProjectModelWorkspaceFileInventory.kt
@@ -192,15 +192,21 @@ internal class IdeaProjectModelWorkspaceFileInventory(
         override val isIndexing: Boolean
             get() = DumbService.isDumb(project)
 
-        override fun read(): IdeaWorkspaceFileProjectModel = runIdeaReadAction {
+        override fun read(): IdeaWorkspaceFileProjectModel = runIdeaCancellableReadAction {
             val gradleModel = workspaceModelReader()
             requireImportedGradleModelComplete(gradleModel)
-            read(gradleModel)
+            readProjectModel(gradleModel)
         }
 
         override fun read(
             gradleModel: IdeaGradleProjectLoadBridge.GradleWorkspaceModel,
-        ): IdeaWorkspaceFileProjectModel = runIdeaReadAction {
+        ): IdeaWorkspaceFileProjectModel = runIdeaCancellableReadAction {
+            readProjectModel(gradleModel)
+        }
+
+        private fun readProjectModel(
+            gradleModel: IdeaGradleProjectLoadBridge.GradleWorkspaceModel,
+        ): IdeaWorkspaceFileProjectModel {
             val kotlinFileType = FileTypeManager.getInstance().findFileTypeByName("Kotlin")
                 ?: throw IllegalStateException("Kotlin file type is unavailable from the IDEA project model")
             val modules = ModuleManager.getInstance(project).modules
@@ -214,7 +220,7 @@ internal class IdeaProjectModelWorkspaceFileInventory(
                             ?.toNioPath()
                     }
                 }.toSet()
-            IdeaWorkspaceFileProjectModel(
+            return IdeaWorkspaceFileProjectModel(
                 modules = modules,
                 linkedBuildRoots = gradleModel.linkedBuildRoots(),
                 moduleAssociations = gradleModel.moduleAssociations().map { association ->

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/ReadActionBatchingTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/ReadActionBatchingTest.kt
@@ -2,6 +2,7 @@ package io.github.amichne.kast.idea
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressManager
+import com.intellij.testFramework.junit5.TestApplication
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -11,6 +12,7 @@ import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
+@TestApplication
 class ReadActionBatchingTest {
     @Test
     fun `synchronous read yields to a pending IDEA write action`() {

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/ReadActionBatchingTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/ReadActionBatchingTest.kt
@@ -22,7 +22,7 @@ class ReadActionBatchingTest {
         val stopRead = AtomicBoolean(false)
         val executor = Executors.newFixedThreadPool(2)
         val readFuture = executor.submit {
-            runIdeaReadAction {
+            runIdeaCancellableReadAction {
                 readStarted.countDown()
                 while (writeCompleted.count > 0 && !stopRead.get()) {
                     ProgressManager.checkCanceled()

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/ReadActionBatchingTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/ReadActionBatchingTest.kt
@@ -1,10 +1,59 @@
 package io.github.amichne.kast.idea
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProgressManager
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 class ReadActionBatchingTest {
+    @Test
+    fun `synchronous read yields to a pending IDEA write action`() {
+        val application = ApplicationManager.getApplication()
+        val readStarted = CountDownLatch(1)
+        val writeCompleted = CountDownLatch(1)
+        val stopRead = AtomicBoolean(false)
+        val executor = Executors.newFixedThreadPool(2)
+        val readFuture = executor.submit {
+            runIdeaReadAction {
+                readStarted.countDown()
+                while (writeCompleted.count > 0 && !stopRead.get()) {
+                    ProgressManager.checkCanceled()
+                    Thread.sleep(10)
+                }
+            }
+        }
+        var writeFuture: Future<*>? = null
+
+        try {
+            assertTrue(readStarted.await(1, TimeUnit.SECONDS), "test read action did not start")
+            writeFuture = executor.submit {
+                application.invokeAndWait {
+                    application.runWriteAction {
+                        writeCompleted.countDown()
+                    }
+                }
+            }
+
+            assertTrue(
+                writeCompleted.await(2, TimeUnit.SECONDS),
+                "Kast synchronous read action should yield when IDEA needs a write action",
+            )
+            readFuture.get(2, TimeUnit.SECONDS)
+            writeFuture.get(2, TimeUnit.SECONDS)
+        } finally {
+            stopRead.set(true)
+            readFuture.cancel(true)
+            writeFuture?.cancel(true)
+            executor.shutdownNow()
+        }
+    }
+
     @Test
     fun `collect in short read actions collects once and processes items in batches`() {
         var initialReadCalls = 0


### PR DESCRIPTION
## Summary

- route workspace inventory model reads through IntelliJ non-blocking read actions
- remove the nested inventory read action
- prove a pending IDEA write preempts the cancellable read

## Validation

- ./gradlew :backend-idea:test --tests *ReadActionBatchingTest* --no-daemon
- ./gradlew :backend-idea:test --tests *IdeaWorkspaceFileInventoryTest* --tests *IdeaWorkspaceFilePagingTest* --tests *IdeaGradleFileProvenanceTest* --no-daemon
- ./gradlew :backend-idea:test --tests *KastPluginBackendContractTest* --tests *KastIdeaBackendRuntimeTest* --no-daemon
- ./gradlew :backend-idea:test --no-daemon
- Kast diagnostics: 3 files analyzed, 0 diagnostics