### PR TITLE
fix: remove nested inventory read action

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/indexing/IdeaProjectIndexer.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/indexing/IdeaProjectIndexer.kt
@@ -47,6 +47,7 @@ internal class IdeaProjectIndexer(
     private val inventory = IdeaProjectModelWorkspaceFileInventory(
         project = project,
         workspaceIdentity = ideaWorkspaceIdentity,
+        workspaceModelReader = readGradleWorkspaceModel,
     )
 
     fun indexProject(config: KastConfig) {
@@ -71,9 +72,9 @@ internal class IdeaProjectIndexer(
 
     fun indexSourceIdentifiers(): Collection<String> {
         store.ensureSchema()
-        val gradleModel = runIdeaCancellableReadAction { readGradleWorkspaceModel() }
-        val gradleProvenance = IdeaGradleFileProvenance.fromWorkspaceModel(gradleModel, ideaWorkspaceIdentity)
-        val inventorySnapshot = inventory.snapshot(WorkspaceFileKindDomain.MIXED, gradleModel)
+        val captured = inventory.snapshotWithGradleModel(WorkspaceFileKindDomain.MIXED)
+        val gradleProvenance = IdeaGradleFileProvenance.fromWorkspaceModel(captured.gradleModel, ideaWorkspaceIdentity)
+        val inventorySnapshot = captured.inventory
         val ownerModuleNamesByPath = referenceIndexOwnersByPath(inventorySnapshot)
         val inventoryEntries = buildFileInventoryEntries(
             ownerModuleNamesByPath = ownerModuleNamesByPath,

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/indexing/IdeaProjectIndexer.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/indexing/IdeaProjectIndexer.kt
@@ -71,11 +71,9 @@ internal class IdeaProjectIndexer(
 
     fun indexSourceIdentifiers(): Collection<String> {
         store.ensureSchema()
-        val (gradleProvenance, inventorySnapshot) = runIdeaReadAction {
-            val gradleModel = readGradleWorkspaceModel()
-            IdeaGradleFileProvenance.fromWorkspaceModel(gradleModel, ideaWorkspaceIdentity) to
-                inventory.snapshot(WorkspaceFileKindDomain.MIXED, gradleModel)
-        }
+        val gradleModel = runIdeaCancellableReadAction { readGradleWorkspaceModel() }
+        val gradleProvenance = IdeaGradleFileProvenance.fromWorkspaceModel(gradleModel, ideaWorkspaceIdentity)
+        val inventorySnapshot = inventory.snapshot(WorkspaceFileKindDomain.MIXED, gradleModel)
         val ownerModuleNamesByPath = referenceIndexOwnersByPath(inventorySnapshot)
         val inventoryEntries = buildFileInventoryEntries(
             ownerModuleNamesByPath = ownerModuleNamesByPath,

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/inventory/core/IdeaProjectModelWorkspaceFileInventory.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/inventory/core/IdeaProjectModelWorkspaceFileInventory.kt
@@ -19,23 +19,56 @@ import io.github.amichne.kast.api.protocol.WorkspaceProjectModelIncompleteReason
 import java.nio.file.Path
 import java.util.concurrent.CancellationException
 
-internal class IdeaProjectModelWorkspaceFileInventory(
+internal class IdeaProjectModelWorkspaceFileInventory private constructor(
     private val workspaceIdentity: WorkspaceIdentity,
     private val projectModelAccess: IdeaWorkspaceFileProjectModelAccess,
+    private val readProjectModelSnapshot: () -> ProjectModelSnapshot,
 ) : IdeaWorkspaceFileInventory {
+    internal constructor(
+        workspaceIdentity: WorkspaceIdentity,
+        projectModelAccess: IdeaWorkspaceFileProjectModelAccess,
+    ) : this(
+        workspaceIdentity = workspaceIdentity,
+        projectModelAccess = projectModelAccess,
+        readProjectModelSnapshot = {
+            error("Gradle model capture is unavailable for injected project-model access")
+        },
+    )
+
     constructor(
         project: Project,
         workspaceIdentity: IdeaWorkspaceIdentity,
         workspaceModelReader: () -> IdeaGradleProjectLoadBridge.GradleWorkspaceModel = {
             IdeaGradleProjectLoadBridge.readWorkspaceModel(project)
         },
+    ) : this(workspaceIdentity, IdeaProjectModelAccess(project, workspaceModelReader))
+
+    private constructor(
+        workspaceIdentity: IdeaWorkspaceIdentity,
+        projectModelAccess: IdeaProjectModelAccess,
     ) : this(
         workspaceIdentity = workspaceIdentity.workspaceIdentity,
-        projectModelAccess = IdeaProjectModelAccess(project, workspaceModelReader),
+        projectModelAccess = projectModelAccess,
+        readProjectModelSnapshot = projectModelAccess::readSnapshot,
+    )
+
+    internal data class SnapshotWithGradleModel(
+        val gradleModel: IdeaGradleProjectLoadBridge.GradleWorkspaceModel,
+        val inventory: IdeaWorkspaceFileInventorySnapshot,
     )
 
     override fun snapshot(kindDomain: WorkspaceFileKindDomain): IdeaWorkspaceFileInventorySnapshot {
         return snapshot(kindDomain, projectModelAccess::read)
+    }
+
+    internal fun snapshotWithGradleModel(
+        kindDomain: WorkspaceFileKindDomain,
+    ): SnapshotWithGradleModel {
+        val captured = readAvailableProjectModel(readProjectModelSnapshot)
+        return SnapshotWithGradleModel(
+            gradleModel = captured.gradleModel,
+            inventory = readSnapshot(kindDomain, captured.projectModel),
+        )
     }
 
     internal fun snapshot(
@@ -50,6 +83,10 @@ internal class IdeaProjectModelWorkspaceFileInventory(
         kindDomain: WorkspaceFileKindDomain,
         readProjectModel: () -> IdeaWorkspaceFileProjectModel,
     ): IdeaWorkspaceFileInventorySnapshot {
+        return readSnapshot(kindDomain, readAvailableProjectModel(readProjectModel))
+    }
+
+    private fun <T> readAvailableProjectModel(readProjectModel: () -> T): T {
         if (projectModelAccess.isIndexing) {
             throw WorkspaceProjectModelIncompleteException(
                 WorkspaceProjectModelIncompleteReason.RUNTIME_INDEXING,
@@ -69,7 +106,7 @@ internal class IdeaProjectModelWorkspaceFileInventory(
                 message = "Gradle project model is unavailable: ${failure.message ?: failure.javaClass.simpleName}",
             )
         }
-        return readSnapshot(kindDomain, projectModel)
+        return projectModel
     }
 
     private fun readSnapshot(
@@ -192,10 +229,15 @@ internal class IdeaProjectModelWorkspaceFileInventory(
         override val isIndexing: Boolean
             get() = DumbService.isDumb(project)
 
-        override fun read(): IdeaWorkspaceFileProjectModel = runIdeaCancellableReadAction {
+        override fun read(): IdeaWorkspaceFileProjectModel = readSnapshot().projectModel
+
+        fun readSnapshot(): ProjectModelSnapshot = runIdeaCancellableReadAction {
             val gradleModel = workspaceModelReader()
             requireImportedGradleModelComplete(gradleModel)
-            readProjectModel(gradleModel)
+            ProjectModelSnapshot(
+                gradleModel = gradleModel,
+                projectModel = readProjectModel(gradleModel),
+            )
         }
 
         override fun read(
@@ -278,4 +320,9 @@ internal class IdeaProjectModelWorkspaceFileInventory(
             }
         }
     }
+
+    private data class ProjectModelSnapshot(
+        val gradleModel: IdeaGradleProjectLoadBridge.GradleWorkspaceModel,
+        val projectModel: IdeaWorkspaceFileProjectModel,
+    )
 }

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/workspace/IdeaProjectIndexerReadActionTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/workspace/IdeaProjectIndexerReadActionTest.kt
@@ -18,6 +18,7 @@ class IdeaProjectIndexerReadActionTest {
             .substringBefore("private fun indexSymbolRelationships")
 
         assertFalse(source.contains("runIdeaReadAction"))
-        assertTrue(source.contains("runIdeaCancellableReadAction { readGradleWorkspaceModel() }"))
+        assertFalse(source.contains("readGradleWorkspaceModel()"))
+        assertTrue(source.contains("inventory.snapshotWithGradleModel"))
     }
 }

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/workspace/IdeaProjectIndexerReadActionTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/workspace/IdeaProjectIndexerReadActionTest.kt
@@ -1,0 +1,23 @@
+package io.github.amichne.kast.idea
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class IdeaProjectIndexerReadActionTest {
+    @Test
+    fun `source indexing does not wrap the cancellable inventory in a blocking read action`() {
+        val sourcePath = listOf(
+            Path.of("src/main/kotlin/io/github/amichne/kast/idea/workspace/indexing/IdeaProjectIndexer.kt"),
+            Path.of("backend-idea/src/main/kotlin/io/github/amichne/kast/idea/workspace/indexing/IdeaProjectIndexer.kt"),
+        ).first(Files::exists)
+        val source = Files.readString(sourcePath)
+            .substringAfter("fun indexSourceIdentifiers(): Collection<String> {")
+            .substringBefore("private fun indexSymbolRelationships")
+
+        assertFalse(source.contains("runIdeaReadAction"))
+        assertTrue(source.contains("runIdeaCancellableReadAction { readGradleWorkspaceModel() }"))
+    }
+}


### PR DESCRIPTION
## Summary
- remove the blocking `runIdeaReadAction` that enclosed the cancellable project inventory scan
- read the Gradle model through the write-priority cancellable helper
- keep provenance and inventory construction outside any outer blocking read lock

## Proof
- RED: `IdeaProjectIndexerReadActionTest` failed on the nested blocking boundary
- GREEN: focused indexer/inventory tests pass
- `./gradlew :backend-idea:test --no-daemon`
- `git diff --check`