### PR TITLE
fix: omit IDEA platform runtimes from plugin ZIP

### DIFF
--- a/backend-idea/build.gradle.kts
+++ b/backend-idea/build.gradle.kts
@@ -102,6 +102,13 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.0")
 }
 
+configurations.named("intellijPlatformRuntimeClasspath") {
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-jdk8")
+}
+
 val headlessRuntimeElements: Configuration by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false

--- a/backend-idea/build.gradle.kts
+++ b/backend-idea/build.gradle.kts
@@ -183,6 +183,7 @@ tasks.register<VerifyPluginXmlPresentTask>("verifyPluginXmlPresent") {
     distributionsDirectory.set(layout.buildDirectory.dir("distributions"))
     expectedPluginId.set("io.github.amichne.kast")
     rejectedPluginId.set("io.github.amichne.kast.idea")
+    forbiddenBundledJarPrefixes.set(listOf("kotlin-stdlib-", "kotlinx-coroutines-"))
 }
 
 tasks.withType<Test>().configureEach {

--- a/build-logic/src/main/kotlin/support/tasks/VerifyPluginXmlPresentTask.kt
+++ b/build-logic/src/main/kotlin/support/tasks/VerifyPluginXmlPresentTask.kt
@@ -11,9 +11,17 @@ import java.io.File
 import java.util.jar.JarInputStream
 import java.util.zip.ZipFile
 
-internal fun selectPluginZip(distributionsDirectory: File): File =
-    distributionsDirectory.listFiles()?.firstOrNull { it.name.endsWith(".zip") }
-        ?: error("No plugin zip found in $distributionsDirectory")
+internal fun selectPluginZip(distributionsDirectory: File): File {
+    val pluginZips = distributionsDirectory.listFiles()
+        ?.filter { it.isFile && it.name.endsWith(".zip") }
+        ?.sortedBy(File::getName)
+        .orEmpty()
+    check(pluginZips.size == 1) {
+        "Expected exactly one plugin zip in $distributionsDirectory, " +
+            "found ${pluginZips.size}: ${pluginZips.joinToString { it.name }}"
+    }
+    return pluginZips.single()
+}
 
 abstract class VerifyPluginXmlPresentTask : DefaultTask() {
     init {

--- a/build-logic/src/main/kotlin/support/tasks/VerifyPluginXmlPresentTask.kt
+++ b/build-logic/src/main/kotlin/support/tasks/VerifyPluginXmlPresentTask.kt
@@ -1,5 +1,6 @@
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
@@ -10,6 +11,10 @@ import java.util.jar.JarInputStream
 import java.util.zip.ZipFile
 
 abstract class VerifyPluginXmlPresentTask : DefaultTask() {
+    init {
+        forbiddenBundledJarPrefixes.convention(emptyList())
+    }
+
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val distributionsDirectory: DirectoryProperty
@@ -20,6 +25,9 @@ abstract class VerifyPluginXmlPresentTask : DefaultTask() {
     @get:Input
     abstract val rejectedPluginId: Property<String>
 
+    @get:Input
+    abstract val forbiddenBundledJarPrefixes: ListProperty<String>
+
     @TaskAction
     fun verify() {
         val distDir = distributionsDirectory.get().asFile
@@ -27,6 +35,19 @@ abstract class VerifyPluginXmlPresentTask : DefaultTask() {
             ?: error("No plugin zip found in $distDir")
 
         val content = ZipFile(pluginZip).use { zipFile ->
+            val forbiddenBundledJars = zipFile.entries().asSequence()
+                .filter { entry -> !entry.isDirectory && entry.name.endsWith(".jar") }
+                .map { entry -> entry.name.substringAfterLast('/') }
+                .filter { jarName ->
+                    forbiddenBundledJarPrefixes.get().any(jarName::startsWith)
+                }
+                .sorted()
+                .toList()
+            check(forbiddenBundledJars.isEmpty()) {
+                "Plugin ZIP must not bundle IDEA platform-provided runtime JARs: " +
+                    forbiddenBundledJars.joinToString()
+            }
+
             zipFile.entries().asSequence()
                 .firstOrNull { entry -> !entry.isDirectory && entry.name == "META-INF/plugin.xml" }
                 ?.let { entry -> zipFile.getInputStream(entry).bufferedReader().use { reader -> reader.readText() } }

--- a/build-logic/src/main/kotlin/support/tasks/VerifyPluginXmlPresentTask.kt
+++ b/build-logic/src/main/kotlin/support/tasks/VerifyPluginXmlPresentTask.kt
@@ -7,8 +7,13 @@ import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 import java.util.jar.JarInputStream
 import java.util.zip.ZipFile
+
+internal fun selectPluginZip(distributionsDirectory: File): File =
+    distributionsDirectory.listFiles()?.firstOrNull { it.name.endsWith(".zip") }
+        ?: error("No plugin zip found in $distributionsDirectory")
 
 abstract class VerifyPluginXmlPresentTask : DefaultTask() {
     init {
@@ -31,8 +36,7 @@ abstract class VerifyPluginXmlPresentTask : DefaultTask() {
     @TaskAction
     fun verify() {
         val distDir = distributionsDirectory.get().asFile
-        val pluginZip = distDir.listFiles()?.firstOrNull { it.name.endsWith(".zip") }
-            ?: error("No plugin zip found in $distDir")
+        val pluginZip = selectPluginZip(distDir)
 
         val content = ZipFile(pluginZip).use { zipFile ->
             val forbiddenBundledJars = zipFile.entries().asSequence()

--- a/build-logic/src/test/kotlin/VerifyPluginXmlPresentTaskTest.kt
+++ b/build-logic/src/test/kotlin/VerifyPluginXmlPresentTaskTest.kt
@@ -1,0 +1,24 @@
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class VerifyPluginXmlPresentTaskTest {
+    @Test
+    fun `multiple plugin zips are rejected`(@TempDir distributionsDirectory: Path) {
+        Files.createFile(distributionsDirectory.resolve("current.zip"))
+        Files.createFile(distributionsDirectory.resolve("stale.zip"))
+
+        val failure = assertThrows(IllegalStateException::class.java) {
+            selectPluginZip(distributionsDirectory.toFile())
+        }
+
+        assertEquals(
+            "Expected exactly one plugin zip in ${distributionsDirectory.toFile()}, " +
+                "found 2: current.zip, stale.zip",
+            failure.message,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- exclude Kotlin stdlib and coroutines only from `intellijPlatformRuntimeClasspath`, the `buildPlugin` distribution boundary
- extend the existing ZIP contract to reject platform-provided Kotlin runtime JARs
- preserve shared and headless dependency declarations and the existing IDEA/Android Studio verifier matrix

## RED / GREEN

- RED `cc31e79c`: `./gradlew :backend-idea:verifyPluginXmlPresent --no-daemon --console=plain` failed on `kotlin-stdlib-2.4.10.jar`, `kotlinx-coroutines-core-jvm-1.10.2.jar`, and `kotlinx-coroutines-jdk8-1.10.2.jar`
- GREEN `cf6269dd`: the unchanged command passes and the resulting ZIP contains none of those runtime families

## Validation

- `./gradlew :backend-idea:verifyPluginXmlPresent --no-daemon --console=plain`
- `./gradlew :backend-idea:verifyPluginProjectConfiguration :backend-idea:verifyPluginStructure :backend-idea:verifyPluginXmlPresent --no-daemon --console=plain`
- `./gradlew :backend-headless:dependencies --configuration headlessPluginRuntime --no-daemon --console=plain` confirms stdlib and coroutines remain resolved for the headless package
- Kast diagnostics: 0 errors, warnings, or infos for the typed ZIP verifier

`verifyPluginProjectConfiguration` remains successful while emitting its static stdlib/coroutines advisories because the shared/headless configurations intentionally retain those dependencies; the built IDEA ZIP contract is the distribution-specific authority.