### PR TITLE
Bound IntelliJ subtype discovery

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphExtraction.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/SemanticGraphExtraction.kt
@@ -238,7 +238,6 @@ internal fun KastPluginBackend.extractSemanticGraphFile(
             val target = analyze(call) {
                 val symbol = call.resolveToCall()
                     ?.singleFunctionCallOrNull()
-                    ?.partiallyAppliedSymbol
                     ?.signature
                     ?.symbol
                 ResolvedSemanticCallTarget(

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/proofloss/CallableKey.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/proofloss/CallableKey.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 internal fun KtCallElement.toCallableKey(): CallableKey? = analyze(this) {
     this@toCallableKey.resolveToCall()
         ?.singleFunctionCallOrNull()
-        ?.partiallyAppliedSymbol
         ?.signature
         ?.symbol
         ?.toCallableKey()

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/semantic/relationships/IdeaTypeEdgeResolver.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/semantic/relationships/IdeaTypeEdgeResolver.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.DirectClassInheritorsSearch
+import com.intellij.util.Processor
 import io.github.amichne.kast.api.contract.Symbol
 import io.github.amichne.kast.shared.analysis.supertypeNames
 import io.github.amichne.kast.shared.analysis.toSymbolModel
@@ -77,7 +78,7 @@ internal class IdeaTypeEdgeResolver(
         val subtypes = ApplicationManager.getApplication().runReadAction<List<PsiClass>> {
             val scope = GlobalSearchScope.projectScope(project)
             buildList {
-                DirectClassInheritorsSearch.search(psiClass, scope).forEach { subtype ->
+                DirectClassInheritorsSearch.search(psiClass, scope).forEach(Processor { subtype ->
                     ProgressManager.checkCanceled()
                     if (!budget.tryAdmitCandidate()) {
                         false
@@ -85,7 +86,7 @@ internal class IdeaTypeEdgeResolver(
                         add(subtype)
                         true
                     }
-                }
+                })
             }
         }
 

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/IdeaHierarchyProviderBudgetTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/IdeaHierarchyProviderBudgetTest.kt
@@ -38,7 +38,6 @@ internal class IdeaHierarchyProviderBudgetTest {
             interface Root
             class First : Root
             class Second : Root
-            class Third : Root
         """
     }
 
@@ -76,10 +75,10 @@ internal class IdeaHierarchyProviderBudgetTest {
         val target = declaration<KtClassOrObject>(file, "Root")
         var visitedCandidates = 0
         val budget = EdgeDiscoveryBudget(
-            maxCandidates = 1,
+            maxCandidates = 0,
             timeoutCheck = {
                 visitedCandidates += 1
-                check(visitedCandidates <= 2) {
+                check(visitedCandidates == 1) {
                     "Subtype search visited another candidate after the budget rejected further work"
                 }
                 false
@@ -88,8 +87,8 @@ internal class IdeaHierarchyProviderBudgetTest {
 
         val edges = IdeaTypeEdgeResolver(project).subtypeEdges(target, budget)
 
-        assertEquals(1, edges.size)
-        assertEquals(2, visitedCandidates)
+        assertEquals(0, edges.size)
+        assertEquals(1, visitedCandidates)
         assertEquals(EdgeDiscoveryCompletion.CANDIDATE_LIMIT_REACHED, budget.completion)
     }
 

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/IdeaHierarchyProviderBudgetTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/IdeaHierarchyProviderBudgetTest.kt
@@ -38,6 +38,7 @@ internal class IdeaHierarchyProviderBudgetTest {
             interface Root
             class First : Root
             class Second : Root
+            class Third : Root
         """
     }
 
@@ -68,16 +69,27 @@ internal class IdeaHierarchyProviderBudgetTest {
     }
 
     @Test
-    fun `subtype provider stops at the candidate budget`() {
+    fun `subtype provider stops searching after the candidate budget rejects further work`() {
         val project = projectFixture.get()
         val file = typeFileFixture.get()
         waitUntilIndexesAreReady(project)
         val target = declaration<KtClassOrObject>(file, "Root")
-        val budget = EdgeDiscoveryBudget(maxCandidates = 1)
+        var visitedCandidates = 0
+        val budget = EdgeDiscoveryBudget(
+            maxCandidates = 1,
+            timeoutCheck = {
+                visitedCandidates += 1
+                check(visitedCandidates <= 2) {
+                    "Subtype search visited another candidate after the budget rejected further work"
+                }
+                false
+            },
+        )
 
         val edges = IdeaTypeEdgeResolver(project).subtypeEdges(target, budget)
 
         assertEquals(1, edges.size)
+        assertEquals(2, visitedCandidates)
         assertEquals(EdgeDiscoveryCompletion.CANDIDATE_LIMIT_REACHED, budget.completion)
     }
 


### PR DESCRIPTION
## Summary

- Replace deprecated call-resolution access with the current signature content.
- Stop direct subtype search when the candidate budget rejects further work.
- Add a regression that fails if subtype search visits another candidate after rejection.

## Proof

Failing checkpoint: `bdc928bb`

The focused subtype test failed because search continued after budget rejection.

Passing checks:

- `./gradlew :backend-idea:test --tests io.github.amichne.kast.idea.IdeaHierarchyProviderBudgetTest --tests io.github.amichne.kast.idea.proofloss.IrExtractorTest --no-daemon`
- `./gradlew :backend-idea:test --no-daemon`
- `./gradlew :analysis-server:test --no-daemon`

Exact-root diagnostics completed against the new file hashes. The released backend still returned stale warning previews after refresh and restart; Gradle compilation and tests used the current source.