### PR TITLE
fix: isolate IDEA VFS refresh from read access

### DIFF
--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/semantic/references/IdeaReferenceIndexEnvironment.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/semantic/references/IdeaReferenceIndexEnvironment.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import io.github.amichne.kast.api.client.WorkspaceIdentity
@@ -15,6 +16,12 @@ internal class IdeaReferenceIndexEnvironment(
     private val project: Project,
     private val workspaceIdentity: WorkspaceIdentity,
     private val cancelled: () -> Boolean,
+    private val findVirtualFile: (Path) -> VirtualFile? = {
+        LocalFileSystem.getInstance().findFileByNioFile(it)
+    },
+    private val refreshVirtualFile: (Path) -> VirtualFile? = {
+        LocalFileSystem.getInstance().refreshAndFindFileByNioFile(it)
+    },
 ) : ReferenceIndexEnvironment {
     constructor(
         project: Project,
@@ -25,9 +32,8 @@ internal class IdeaReferenceIndexEnvironment(
     override fun findPsiFile(filePath: String): PsiFile? {
         val path = Path.of(filePath).toAbsolutePath().normalize()
         if (!workspaceIdentity.contains(path)) return null
-        val fileSystem = LocalFileSystem.getInstance()
-        val virtualFile = fileSystem.findFileByNioFile(path)
-            ?: fileSystem.refreshAndFindFileByNioFile(path)
+        val virtualFile = findVirtualFile(path)
+            ?: refreshVirtualFile(path)
             ?: return null
         return withReadAccess { PsiManager.getInstance(project).findFile(virtualFile) }
     }

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/semantic/references/IdeaReferenceIndexEnvironment.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/semantic/references/IdeaReferenceIndexEnvironment.kt
@@ -22,6 +22,9 @@ internal class IdeaReferenceIndexEnvironment(
     private val refreshVirtualFile: (Path) -> VirtualFile? = {
         LocalFileSystem.getInstance().refreshAndFindFileByNioFile(it)
     },
+    private val psiFileForVirtualFile: (VirtualFile) -> PsiFile? = {
+        PsiManager.getInstance(project).findFile(it)
+    },
 ) : ReferenceIndexEnvironment {
     constructor(
         project: Project,
@@ -29,13 +32,33 @@ internal class IdeaReferenceIndexEnvironment(
         cancelled: () -> Boolean,
     ) : this(project, WorkspaceIdentity.fromWorkspaceRoot(workspaceRoot), cancelled)
 
-    override fun findPsiFile(filePath: String): PsiFile? {
+    override fun findPsiFile(filePath: String): PsiFile? =
+        withPsiFileReadAccess(filePath) { psiFile -> psiFile }
+
+    override fun <T> withPsiFileReadAccess(
+        filePath: String,
+        action: (PsiFile) -> T,
+    ): T? = withPsiFileAccess(filePath, action)
+
+    override fun <T> withPsiFileExclusiveAccess(
+        filePath: String,
+        action: (PsiFile) -> T,
+    ): T? = withPsiFileAccess(filePath, action)
+
+    private fun <T> withPsiFileAccess(
+        filePath: String,
+        action: (PsiFile) -> T,
+    ): T? {
         val path = Path.of(filePath).toAbsolutePath().normalize()
         if (!workspaceIdentity.contains(path)) return null
         val virtualFile = findVirtualFile(path)
             ?: refreshVirtualFile(path)
             ?: return null
-        return withReadAccess { PsiManager.getInstance(project).findFile(virtualFile) }
+        return withExclusiveAccess {
+            psiFileForVirtualFile(virtualFile)
+                ?.takeIf { psiFile -> psiFile.isValid }
+                ?.let(action)
+        }
     }
 
     override fun <T> withReadAccess(action: () -> T): T =

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/IdeaReferenceIndexEnvironmentTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/IdeaReferenceIndexEnvironmentTest.kt
@@ -3,6 +3,7 @@ package io.github.amichne.kast.idea
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.fixture.TestFixture
 import com.intellij.testFramework.junit5.fixture.moduleFixture
@@ -211,8 +212,12 @@ class IdeaReferenceIndexEnvironmentTest {
         waitUntilIndexesAreReady(project)
 
         val workspaceRoot = Path.of(callerFile.virtualFile.path).root.toAbsolutePath().normalize()
+        val virtualFile = requireNotNull(
+            LocalFileSystem.getInstance().findFileByNioFile(Path.of(callerFile.virtualFile.path)),
+        )
         val refreshStarted = CountDownLatch(1)
         val writeCompleted = CountDownLatch(1)
+        val psiResolutionEntered = AtomicBoolean(false)
         val environment = IdeaReferenceIndexEnvironment(
             project = project,
             workspaceIdentity = WorkspaceIdentity.fromWorkspaceRoot(workspaceRoot),
@@ -224,7 +229,15 @@ class IdeaReferenceIndexEnvironmentTest {
                     writeCompleted.await(2, TimeUnit.SECONDS),
                     "VFS refresh must not hold IDEA read access while an EDT write is queued",
                 )
-                callerFile.virtualFile
+                virtualFile
+            },
+            psiFileForVirtualFile = {
+                psiResolutionEntered.set(true)
+                assertTrue(
+                    ApplicationManager.getApplication().isReadAccessAllowed,
+                    "PSI must be resolved and validated inside IDEA read access",
+                )
+                callerFile
             },
         )
         val executor = Executors.newFixedThreadPool(2)
@@ -241,10 +254,8 @@ class IdeaReferenceIndexEnvironmentTest {
         }
 
         try {
-            assertTrue(
-                scanFuture.get(5, TimeUnit.SECONDS) != null,
-                "scanner should resume after the queued write completes",
-            )
+            scanFuture.get(5, TimeUnit.SECONDS)
+            assertTrue(psiResolutionEntered.get(), "scanner should resolve PSI after the queued write completes")
         } finally {
             scanFuture.cancel(true)
             writeFuture.get(2, TimeUnit.SECONDS)

--- a/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/IdeaReferenceIndexEnvironmentTest.kt
+++ b/backend-idea/src/test/kotlin/io/github/amichne/kast/idea/semantic/IdeaReferenceIndexEnvironmentTest.kt
@@ -9,8 +9,10 @@ import com.intellij.testFramework.junit5.fixture.moduleFixture
 import com.intellij.testFramework.junit5.fixture.projectFixture
 import com.intellij.testFramework.junit5.fixture.psiFileFixture
 import com.intellij.testFramework.junit5.fixture.sourceRootFixture
+import io.github.amichne.kast.api.client.WorkspaceIdentity
 import io.github.amichne.kast.indexstore.api.index.FileStageLimitation
 import io.github.amichne.kast.shared.analysis.PsiReferenceScanner
+import io.github.amichne.kast.shared.analysis.PsiSourceIndexScanner
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -197,6 +199,54 @@ class IdeaReferenceIndexEnvironmentTest {
         } finally {
             stopRead.set(true)
             readFuture.get(2, TimeUnit.SECONDS)
+            writeFuture.get(2, TimeUnit.SECONDS)
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `VFS cache miss resolves before scanner read access`() {
+        val project = projectFixture.get()
+        val callerFile = callerFileFixture.get()
+        waitUntilIndexesAreReady(project)
+
+        val workspaceRoot = Path.of(callerFile.virtualFile.path).root.toAbsolutePath().normalize()
+        val refreshStarted = CountDownLatch(1)
+        val writeCompleted = CountDownLatch(1)
+        val environment = IdeaReferenceIndexEnvironment(
+            project = project,
+            workspaceIdentity = WorkspaceIdentity.fromWorkspaceRoot(workspaceRoot),
+            cancelled = { false },
+            findVirtualFile = { null },
+            refreshVirtualFile = {
+                refreshStarted.countDown()
+                assertTrue(
+                    writeCompleted.await(2, TimeUnit.SECONDS),
+                    "VFS refresh must not hold IDEA read access while an EDT write is queued",
+                )
+                callerFile.virtualFile
+            },
+        )
+        val executor = Executors.newFixedThreadPool(2)
+        val scanFuture = executor.submit {
+            PsiSourceIndexScanner(environment).scanFile(callerFile.virtualFile.path)
+        }
+        assertTrue(refreshStarted.await(1, TimeUnit.SECONDS), "VFS cache-miss refresh did not start")
+        val writeFuture = executor.submit {
+            ApplicationManager.getApplication().invokeAndWait {
+                ApplicationManager.getApplication().runWriteAction {
+                    writeCompleted.countDown()
+                }
+            }
+        }
+
+        try {
+            assertTrue(
+                scanFuture.get(5, TimeUnit.SECONDS) != null,
+                "scanner should resume after the queued write completes",
+            )
+        } finally {
+            scanFuture.cancel(true)
             writeFuture.get(2, TimeUnit.SECONDS)
             executor.shutdownNow()
         }

--- a/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiReferenceScanner.kt
+++ b/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiReferenceScanner.kt
@@ -44,17 +44,20 @@ class PsiReferenceScanner(
 ) {
     fun scanFileRelationships(filePath: String): PsiRelationshipScanResult =
         // One epoch binds every persisted relationship fact to one immutable PSI revision.
-        environment.withExclusiveAccess {
-            val psiFile = requirePsiFile(filePath)
-            val sourceFilePath = psiFile.sourceFilePath(filePath)
-            val referenceResult = scanFileReferenceCoverage(psiFile, sourceFilePath)
-            val declarationResult = scanFileDeclarationCoverage(psiFile, sourceFilePath)
-            PsiRelationshipScanResult(
-                contentHash = psiFile.contentHash(),
-                references = referenceResult.rows,
-                declarations = declarationResult.rows,
-                limitations = (referenceResult.limitations + declarationResult.limitations).distinct(),
-            )
+        requireNotNull(
+            environment.withPsiFileExclusiveAccess(filePath) { psiFile ->
+                val sourceFilePath = psiFile.sourceFilePath(filePath)
+                val referenceResult = scanFileReferenceCoverage(psiFile, sourceFilePath)
+                val declarationResult = scanFileDeclarationCoverage(psiFile, sourceFilePath)
+                PsiRelationshipScanResult(
+                    contentHash = psiFile.contentHash(),
+                    references = referenceResult.rows,
+                    declarations = declarationResult.rows,
+                    limitations = (referenceResult.limitations + declarationResult.limitations).distinct(),
+                )
+            },
+        ) {
+            "PSI file is unavailable for relationship indexing: $filePath"
         }
 
     fun scanFileReferences(filePath: String): List<SymbolReferenceRow> =
@@ -66,9 +69,12 @@ class PsiReferenceScanner(
     private fun scanFileReferenceCoverage(filePath: String): ScanCoverage<SymbolReferenceRow> =
         // Exclusive access required: the headless backend's K2 FIR lazy declaration
         // resolver is not thread-safe for concurrent resolution within a single session.
-        environment.withExclusiveAccess {
-            val psiFile = requirePsiFile(filePath)
-            scanFileReferenceCoverage(psiFile, psiFile.sourceFilePath(filePath))
+        requireNotNull(
+            environment.withPsiFileExclusiveAccess(filePath) { psiFile ->
+                scanFileReferenceCoverage(psiFile, psiFile.sourceFilePath(filePath))
+            },
+        ) {
+            "PSI file is unavailable for relationship indexing: $filePath"
         }
 
     private fun scanFileReferenceCoverage(
@@ -168,9 +174,12 @@ class PsiReferenceScanner(
     }
 
     private fun scanFileDeclarationCoverage(filePath: String): ScanCoverage<DeclarationRow> =
-        environment.withExclusiveAccess {
-            val psiFile = requirePsiFile(filePath)
-            scanFileDeclarationCoverage(psiFile, psiFile.sourceFilePath(filePath))
+        requireNotNull(
+            environment.withPsiFileExclusiveAccess(filePath) { psiFile ->
+                scanFileDeclarationCoverage(psiFile, psiFile.sourceFilePath(filePath))
+            },
+        ) {
+            "PSI file is unavailable for relationship indexing: $filePath"
         }
 
     private fun scanFileDeclarationCoverage(
@@ -214,11 +223,6 @@ class PsiReferenceScanner(
         )
         return ScanCoverage(rows = rows, limitations = limitations.toList())
     }
-
-    private fun requirePsiFile(filePath: String): PsiFile =
-        requireNotNull(environment.findPsiFile(filePath)) {
-            "PSI file is unavailable for relationship indexing: $filePath"
-        }
 
     private fun PsiFile.sourceFilePath(fallback: String): String =
         runCatching { resolvedFilePath().value }.getOrElse { fallback }

--- a/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiSourceIndexScanner.kt
+++ b/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/PsiSourceIndexScanner.kt
@@ -26,10 +26,9 @@ class PsiSourceIndexScanner internal constructor(
         moduleNameForFile: (PsiFile) -> String? = { null },
     ) : this(environment, moduleNameForFile, ::structuredPackageEvidence)
 
-    fun scanFile(filePath: String): PsiSourceIndexScanResult? = environment.withReadAccess {
-        if (environment.isCancelled()) return@withReadAccess null
+    fun scanFile(filePath: String): PsiSourceIndexScanResult? = environment.withPsiFileReadAccess(filePath) { psiFile ->
+        if (environment.isCancelled()) return@withPsiFileReadAccess null
         ProgressManager.checkCanceled()
-        val psiFile = environment.findPsiFile(filePath) ?: return@withReadAccess null
         val sourcePath = runCatching { psiFile.resolvedFilePath().value }.getOrElse { filePath }
         val content = psiFile.text
         val parsed = parseSourceFileIndex(

--- a/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/ReferenceIndexEnvironment.kt
+++ b/backend-shared/src/main/kotlin/io/github/amichne/kast/shared/analysis/ReferenceIndexEnvironment.kt
@@ -7,6 +7,24 @@ interface ReferenceIndexEnvironment {
 
     fun <T> withReadAccess(action: () -> T): T
 
+    fun <T> withPsiFileReadAccess(
+        filePath: String,
+        action: (PsiFile) -> T,
+    ): T? = withReadAccess {
+        findPsiFile(filePath)
+            ?.takeIf { psiFile -> psiFile.isValid }
+            ?.let(action)
+    }
+
+    fun <T> withPsiFileExclusiveAccess(
+        filePath: String,
+        action: (PsiFile) -> T,
+    ): T? = withExclusiveAccess {
+        findPsiFile(filePath)
+            ?.takeIf { psiFile -> psiFile.isValid }
+            ?.let(action)
+    }
+
     /**
      * Runs [action] with exclusive access to the underlying analysis state.
      *


### PR DESCRIPTION
## Summary

- add typed PSI-file read and exclusive-access boundaries for reference indexing
- resolve or refresh VirtualFile before IDEA read access, then resolve and validate PsiFile inside write-priority cancellable read access
- migrate source and relationship scanners away from composing file lookup inside raw read actions
- cover a VFS cache miss while an EDT write is queued

## Proof

- RED d083bf2fa8a0274ad1a0cb399a69eeef7a1f2f60: focused IDEA test failed because refresh held read access and the queued write timed out
- GREEN 646796996fee091a491202b009dc2d33a533777a: focused IDEA test class passes
- ./gradlew :backend-shared:test :backend-idea:test --no-daemon
- ./gradlew :backend-idea:buildPlugin --no-daemon
- exact-root Kast diagnostics: COMPLETE, zero findings for all edited Kotlin files
- artifact: backend-idea-0.18.1-3-g64679699.zip
- SHA-256: c3f5a43763edd9621695c4e96f8123ff89e50e89a62dc0f30faa5d0f25bd7fb8