### PR TITLE
fix(idea): remove deprecated API bridges

### DIFF
--- a/backend-idea/build.gradle.kts
+++ b/backend-idea/build.gradle.kts
@@ -9,6 +9,7 @@ import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.jvm.tasks.Jar
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
@@ -138,6 +139,10 @@ intellijPlatform {
     }
 
     pluginVerification {
+        failureLevel.addAll(
+            VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
+            VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
+        )
         ides {
             create(IntelliJPlatformType.IntellijIdea, "2026.2")
             create(IntelliJPlatformType.AndroidStudio, "2026.1.2.10")

--- a/backend-idea/src/main/java/io/github/amichne/kast/idea/IdeaGradleProjectLoadBridge.java
+++ b/backend-idea/src/main/java/io/github/amichne/kast/idea/IdeaGradleProjectLoadBridge.java
@@ -86,24 +86,24 @@ public final class IdeaGradleProjectLoadBridge {
             ExternalSystemProgressNotificationManager.getInstance();
         ExternalSystemTaskNotificationListener listener = new ExternalSystemTaskNotificationListener() {
             @Override
-            public void onSuccess(ExternalSystemTaskId id) {
+            public void onSuccess(String projectPath, ExternalSystemTaskId id) {
                 importFuture.complete(null);
             }
 
             @Override
-            public void onFailure(ExternalSystemTaskId id, Exception error) {
+            public void onFailure(String projectPath, ExternalSystemTaskId id, Exception error) {
                 importFuture.completeExceptionally(error);
             }
 
             @Override
-            public void onCancel(ExternalSystemTaskId id) {
+            public void onCancel(String projectPath, ExternalSystemTaskId id) {
                 importFuture.completeExceptionally(
                     new CancellationException("Gradle project import was canceled")
                 );
             }
 
             @Override
-            public void onEnd(ExternalSystemTaskId id) {
+            public void onEnd(String projectPath, ExternalSystemTaskId id) {
                 completeFromTaskState(task, importFuture);
             }
         };

--- a/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastToolWindowFactory.kt
+++ b/backend-idea/src/main/kotlin/io/github/amichne/kast/idea/runtime/ui/KastToolWindowFactory.kt
@@ -22,7 +22,9 @@ import java.time.format.DateTimeFormatter
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
 import javax.swing.table.AbstractTableModel
+import kotlin.jvm.JvmDefaultWithoutCompatibility
 
+@JvmDefaultWithoutCompatibility
 internal class KastToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         val contentManager = toolWindow.contentManager


### PR DESCRIPTION
## Summary

- migrate Gradle import notifications to the project-path callbacks supported by IDEA 261 and 262
- prevent Kotlin from emitting deprecated ToolWindowFactory compatibility bridges for the factory class
- fail Plugin Verifier when deprecated or scheduled-for-removal APIs are detected

## Verification

- RED: verifyPlugin failed with DEPRECATED_API_USAGES and listed eight usages on each supported target
- GREEN: focused backend-idea tests pass
- GREEN: full backend-idea tests pass
- GREEN: verifyPlugin succeeds with zero deprecated and zero scheduled-for-removal usages
- javap confirms only project-path listener callbacks and no deprecated ToolWindowFactory bridges