### PR TITLE
fix: use control entrypoint for release packaging

### DIFF
--- a/.github/scripts/release/test-release-workflow-contract.sh
+++ b/.github/scripts/release/test-release-workflow-contract.sh
@@ -39,6 +39,7 @@ require "$ci" 'cmp -s cli-rs/target/package/kast-v0.0.0-ci-linux-x64/_kastctl cl
 require "$release" 'cp "cli-rs/target/${{ matrix.target }}/release/kast" "$staging_dir/_kastctl"' 'raw CLI assets must include the administrative entrypoint'
 require "$release" 'cmp -s "$staging_dir/_kastctl" "$staging_dir/kast"' 'release must prove its multicall entrypoints are byte-identical'
 require "$release" 'zip -9 -q "$GITHUB_WORKSPACE/dist/${asset_name}" _kastctl kast' 'raw CLI archives must publish only the two multicall names'
+require "$release" 'packager_bin="${packager_dir}/_kastctl"' 'Linux headless packaging must invoke the administrative entrypoint'
 require "$release" '.github/scripts/release/agent-resource-assets.py build' 'release must build agent resources with the deterministic packager'
 require "$release" '--source cli-rs/resources/kast' 'release resources must come from the embedded source'
 require "$release" 'kast-codex-${tag}.tar' 'release must publish the embedded Codex marketplace'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -953,7 +953,7 @@ jobs:
           rm -rf "$packager_dir"
           mkdir -p "$packager_dir"
           python3 -m zipfile -e "$cli_asset" "$packager_dir"
-          packager_bin="${packager_dir}/kast"
+          packager_bin="${packager_dir}/_kastctl"
           [[ -f "$packager_bin" ]] || { echo "Missing extracted Rust CLI binary: ${packager_bin}" >&2; exit 1; }
           chmod 755 "$packager_bin"
 


### PR DESCRIPTION
## Summary

- route Linux headless release packaging through the administrative `_kastctl` multicall entrypoint
- lock the path with the existing release workflow contract

## Validation

- `.github/scripts/release/test-release-workflow-contract.sh`
- `bash -n .github/scripts/release/test-release-workflow-contract.sh`
- Ruby YAML syntax parse for `.github/workflows/release.yml`
- `git diff --check`

Fixes the deterministic `v0.19.0` release failure in run 30505003864.