### PR TITLE
fix: preserve configured enterprise request timeout

### DIFF
--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisServerConfig.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisServerConfig.kt
@@ -30,7 +30,8 @@ data class AnalysisServerConfig(
     /**
      * Returns the effective request timeout in milliseconds, scaling up [requestTimeoutMillis]
      * logarithmically for large workspaces (> 1 000 files) to avoid spurious timeouts on slow
-     * machines or during first-run indexing. The result is capped at 300 seconds (300 000 ms).
+     * machines or during first-run indexing. Automatic scaling is capped at 300 seconds
+     * (300 000 ms) without reducing the configured base.
      *
      * Formula (for workspaceFileCount > 1 000):
      *   effectiveTimeout = requestTimeoutMillis * log2(workspaceFileCount / 1_000)
@@ -41,7 +42,9 @@ data class AnalysisServerConfig(
             val currentWorkspaceFileCount = workspaceFileCountProvider?.invoke() ?: workspaceFileCount
             if (currentWorkspaceFileCount <= 1_000) return requestTimeoutMillis
             val scaleFactor = (ln(currentWorkspaceFileCount.toDouble() / 1_000.0) / ln(2.0)).coerceAtLeast(1.0)
-            return (requestTimeoutMillis * scaleFactor).toLong().coerceAtMost(300_000L)
+            return (requestTimeoutMillis * scaleFactor).toLong()
+                .coerceAtMost(300_000L)
+                .coerceAtLeast(requestTimeoutMillis)
         }
 
     init {

--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisServerConfig.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/AnalysisServerConfig.kt
@@ -34,8 +34,10 @@ data class AnalysisServerConfig(
      * (300 000 ms) without reducing the configured base.
      *
      * Formula (for workspaceFileCount > 1 000):
-     *   effectiveTimeout = requestTimeoutMillis * log2(workspaceFileCount / 1_000)
-     *   capped at 300_000 ms
+     *   effectiveTimeout = max(
+     *       requestTimeoutMillis,
+     *       min(requestTimeoutMillis * log2(workspaceFileCount / 1_000), 300_000),
+     *   )
      */
     val effectiveRequestTimeoutMillis: Long
         get() {

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/DynamicTimeoutScalingTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/DynamicTimeoutScalingTest.kt
@@ -77,6 +77,12 @@ class DynamicTimeoutScalingTest {
     }
 
     @Test
+    fun effectiveTimeoutNeverReducesConfiguredBase() {
+        val config = AnalysisServerConfig(requestTimeoutMillis = 600_000L, workspaceFileCount = 1_000_000)
+        assertEquals(600_000L, config.effectiveRequestTimeoutMillis)
+    }
+
+    @Test
     fun effectiveTimeoutCapEnforcedEvenWhenScalingExceedsIt() {
         // With 100_000 files and 200_000ms base: scale ≈ log2(100) ≈ 6.64 → 1_328_000ms >> 300_000ms cap
         val config = AnalysisServerConfig(requestTimeoutMillis = 200_000L, workspaceFileCount = 100_000)


### PR DESCRIPTION
## Summary

- preserve an explicitly configured request timeout when automatic enterprise scaling reaches its 300-second ceiling
- document the effective timeout formula as a floor at the configured base
- add the focused RED/GREEN regression requested by the exact-head review on #489

## Verification

- `./gradlew :analysis-server:test --tests io.github.amichne.kast.server.DynamicTimeoutScalingTest --no-daemon`
- `JAVA_TOOL_OPTIONS=-Djava.io.tmpdir=/tmp ./gradlew :backend-idea:test :analysis-server:test --no-daemon`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- exact post-rebase tree matches the fully verified pre-rebase tree