### PR TITLE
feat: expose safe topology diagnostics

### DIFF
--- a/.agents/skills/kast-diagnostics/SKILL.md
+++ b/.agents/skills/kast-diagnostics/SKILL.md
@@ -42,6 +42,8 @@ allowlist_json() {
       then listed(["active-release", "missing"]; $value)
       elif $field == "backendName"
       then listed(["idea", "headless"]; $value)
+      elif $field == "scope"
+      then listed(["SYMBOL", "PACKAGE", "MODULE"]; $value)
       elif $field == "detail"
       then listed(["basic", "verbose"]; $value)
       elif $field == "scopes"
@@ -139,13 +141,13 @@ AGENT_HELP="$("$KASTCTL" agent --help 2>/dev/null)"
 GRAPH_HELP="$("$KASTCTL" agent graph --help 2>/dev/null)"
 test -n "$AGENT_HELP" || exit 1
 test -n "$GRAPH_HELP" || exit 1
-GRAPH_SUMMARY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
+SYMBOL_SUMMARY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
   --scope symbol --operation summary 2>/dev/null)"
-MODULE_TOPOLOGY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
-  --scope module --operation topology 2>/dev/null)"
-PACKAGE_COMMUNITIES="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
-  --scope package --operation communities 2>/dev/null)"
-printf '%s\n' "$GRAPH_SUMMARY" "$MODULE_TOPOLOGY" "$PACKAGE_COMMUNITIES" |
+MODULE_SUMMARY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
+  --scope module --operation summary 2>/dev/null)"
+PACKAGE_SUMMARY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
+  --scope package --operation summary 2>/dev/null)"
+printf '%s\n' "$SYMBOL_SUMMARY" "$MODULE_SUMMARY" "$PACKAGE_SUMMARY" |
   allowlist_json
 ```
 

--- a/.agents/skills/kast-diagnostics/SKILL.md
+++ b/.agents/skills/kast-diagnostics/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: kast-diagnostics
+description: Diagnose Kast readiness, indexing, timeouts, configuration, telemetry, profiling, logs, and read-only source-index topology when commands stall, evidence is incomplete, or enterprise-scale performance needs inspection.
+---
+
+# Kast Diagnostics
+
+Diagnose the exact workspace from typed local evidence. Treat reported enterprise scale and timing as genuine; do not require a smaller reproduction.
+
+## Establish the local control surface
+
+Run from the canonical workspace root. Resolve the active release-local control CLI only into a shell variable; never print or persist its absolute path.
+
+```shell
+command -v jq >/dev/null
+allowlist_json() {
+  jq '
+    def listed($values; $value): ($values | index($value)) != null;
+    def safe_string($field; $value):
+      if $field == "state"
+      then listed(["STARTING", "INDEXING", "READY", "DEGRADED", "INCOMPLETE",
+        "UNAVAILABLE", "CURRENT", "QUALIFIED", "COMPLETE", "LIMITED", "FAILED",
+        "EXTERNAL_BOUNDARY"]; $value)
+      elif $field == "qualification"
+      then listed(["CURRENT", "QUALIFIED"]; $value)
+      elif $field == "installAuthority"
+      then listed(["active-release", "missing"]; $value)
+      elif $field == "backendName"
+      then listed(["idea", "headless"]; $value)
+      elif $field == "detail"
+      then listed(["basic", "verbose"]; $value)
+      elif $field == "scopes"
+      then ($value | split(",") | all(.[];
+        listed(["all", "references", "call-hierarchy", "type-hierarchy",
+          "implementations", "completions", "semantic-insertion-point",
+          "diagnostics", "optimize-imports", "resolve", "workspace-files",
+          "workspace-symbol-search", "workspace-search", "read-action",
+          "file-outline", "apply-edits", "refresh"]; .)))
+      elif $field == "modes"
+      then ($value | split(",") | all(.[]; listed(["cpu", "alloc", "lock", "wall"]; .)))
+      else false end;
+    [paths(scalars) as $path
+      | ($path[-1] | tostring) as $field
+      | getpath($path) as $value
+      | select(
+          (($value | type) == "boolean"
+            and listed(["ok", "ready", "healthy", "active", "indexing", "reachable",
+              "referenceIndexReady", "installed", "enabled", "truncated"]; $field))
+          or (($value | type) == "number"
+            and (listed(["generation", "total", "indexed", "excluded", "pending",
+              "limited", "failed", "stale", "parallelism", "batchSize",
+              "modulePriorityDepth", "nodeCount", "edgeOccurrenceCount",
+              "weightedEdgeCount", "componentCount", "stronglyConnectedComponentCount",
+              "communityCount", "loadNanos", "computeNanos", "databaseBytes",
+              "peakRssBytes", "queryP95Micros", "requestTimeoutMillis",
+              "maxConcurrentRequests", "maxResults", "toolingApiTimeoutMillis",
+              "identifierIndexWaitMillis", "debounceMillis", "durationSeconds",
+              "occurrenceCount", "sourceFileCount", "sourceModuleCount",
+              "targetSymbolCount", "targetFileCount", "targetModuleCount",
+              "externalTargetCount", "referenceCount", "publicApiCount",
+              "internalLeakCount", "indexCompleteness", "depth", "totalCount",
+              "returnedCount", "nextOffset", "limit", "offset"]; $field)))
+          or (($value | type) == "string" and safe_string($field; $value))
+        )
+      | {field: $field, value: $value}]
+  ' 2>/dev/null
+}
+KASTCTL="${KAST_HOME:-$HOME/.local/share/kast}/current/libexec/kastctl"
+test -x "$KASTCTL"
+READY_JSON="$("$KASTCTL" --output json ready --workspace-root "$PWD" --for agent 2>/dev/null)"
+STATUS_JSON="$("$KASTCTL" --output json status --workspace-root "$PWD" --backend idea 2>/dev/null)"
+printf '%s\n' "$READY_JSON" "$STATUS_JSON" | allowlist_json
+```
+
+Inspect before starting or restarting anything. Distinguish runtime reachability, Gradle readiness, reference-index readiness, and persisted graph coverage. Never echo the captured JSON. Use `allowlist_json` in the same local shell invocation before producing user-visible output; if `jq` or safe filtering is unavailable, do not run the diagnostic.
+
+## Inspect configuration and paths locally
+
+```shell
+CONFIG_JSON="$("$KASTCTL" --output json config list --workspace-root "$PWD" 2>/dev/null)"
+PATHS_JSON="$("$KASTCTL" --output json developer inspect paths --workspace-root "$PWD" --idea 2>/dev/null)"
+printf '%s\n' "$CONFIG_JSON" | allowlist_json
+```
+
+Use the first result to identify effective values and mutable fields. Use the second only to locate the current IDEA and Kast logs. Never echo either variable. Report only closed status names, booleans, allowlisted counts and durations, and the exact configuration keys named in this skill.
+
+There is no typed log-reader command. Run searches only over the relevant time window, capture stdout into a variable, and discard stderr with `2>/dev/null`. Never echo the capture or report log-derived strings, including error codes; reduce it locally to counts and timings. Never return raw log lines, paths, project names, symbols, endpoints, tokens, process descriptors, sockets, or PIDs. Do not enable `KAST_IDEA_TRACE`; it records extensive host and workspace metadata.
+
+## Change one supported knob at a time
+
+Select only keys listed as mutable by `config list`. Record the inherited value locally, set one override, restart once, reproduce once, then unset the override and restart to restore inheritance.
+
+Configuration and runtime mutations require explicit user authorization. For diagnose, explain, or inspect requests, stop after recommending the single evidence-backed key.
+
+```shell
+"$KASTCTL" config set <KEY> <VALUE> --workspace-root "$PWD"
+"$KASTCTL" developer runtime restart \
+  --workspace-root "$PWD" --backend idea --accept-indexing
+"$KASTCTL" config unset <KEY> --workspace-root "$PWD"
+```
+
+Route symptoms to these current mutable keys:
+
+- request saturation: `server.requestTimeoutMillis`, `server.maxConcurrentRequests`, `server.maxResults`
+- Gradle or identifier waits: `gradle.toolingApiTimeoutMillis`, `indexing.identifierIndexWaitMillis`
+- relationship indexing: `indexing.relationships.enabled`, `.batchSize`, `.parallelism`, `.modulePriorityDepth`
+- project lifecycle: `projectOpen.gradleLoadEnabled`, `backends.idea.enabled`, `watcher.debounceMillis`
+- telemetry: `telemetry.enabled`, `.scopes`, `.detail`
+- profiling: `profiling.enabled`, `.modes`, `.durationSeconds`, `.emitManifest`
+
+Prefer one narrow telemetry scope such as `references`, `type-hierarchy`, `workspace-files`, `workspace-symbol-search`, `read-action`, or `refresh`; use `basic` detail before `verbose`. Profiling modes are `cpu`, `alloc`, `lock`, and `wall`. Configuration acceptance does not prove a profile was recorded: the current runtime parses profiling settings but has no reliable profile-capture consumer. Say so instead of promising an artifact.
+
+## Read the source index through typed commands
+
+Use the public Rust graph surface for generation-checked, SQLite read-only, query-only projections:
+
+```shell
+GRAPH_SUMMARY="$(kast graph summary --scope symbol 2>/dev/null)"
+MODULE_TOPOLOGY="$(kast graph topology --scope module 2>/dev/null)"
+PACKAGE_COMMUNITIES="$(kast graph communities --scope package 2>/dev/null)"
+```
+
+Use bounded typed metrics when a focused query answers the diagnostic:
+
+```shell
+METRICS_JSON="$("$KASTCTL" --output json developer inspect metrics fan-in \
+  --workspace-root "$PWD" --limit 50 2>/dev/null)"
+printf '%s\n' "$METRICS_JSON" | allowlist_json
+# Substitute fan-out, impact, coupling, or search only when that typed query is needed.
+```
+
+Never echo captured topology or metric payloads; they can contain repository names. Extract only the allowlisted numeric facts and closed state or qualification values before reporting. Never invoke `sqlite3`, expose `--database`, construct SQL, mutate the index, or copy the database. Prefer module or package projections over full symbol topology for large repositories.
+
+## Report
+
+Return the observed state transition, the typed command family with sensitive operands replaced by `<REDACTED>`, sanitized timing/count evidence, the single changed key and restoration status, and the next smallest action. Separate observed failures from static risks.

--- a/.agents/skills/kast-diagnostics/SKILL.md
+++ b/.agents/skills/kast-diagnostics/SKILL.md
@@ -48,7 +48,7 @@ allowlist_json() {
       then listed(["basic", "verbose"]; $value)
       elif $field == "scopes"
       then ($value | split(",") | all(.[];
-        listed(["all", "references", "call-hierarchy", "type-hierarchy",
+        listed(["all", "rename", "references", "call-hierarchy", "type-hierarchy",
           "implementations", "completions", "semantic-insertion-point",
           "diagnostics", "optimize-imports", "resolve", "workspace-files",
           "workspace-symbol-search", "workspace-search", "read-action",

--- a/.agents/skills/kast-diagnostics/SKILL.md
+++ b/.agents/skills/kast-diagnostics/SKILL.md
@@ -115,7 +115,9 @@ Prefer one narrow telemetry scope such as `references`, `type-hierarchy`, `works
 Use the repository-mandated Rust graph command for generation-checked, SQLite read-only, query-only projections. Read its scoped help first.
 
 ```shell
+AGENT_HELP="$("$KASTCTL" agent --help 2>/dev/null)"
 GRAPH_HELP="$("$KASTCTL" agent graph --help 2>/dev/null)"
+test -n "$AGENT_HELP" || exit 1
 test -n "$GRAPH_HELP" || exit 1
 GRAPH_SUMMARY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
   --scope symbol --operation summary 2>/dev/null)"

--- a/.agents/skills/kast-diagnostics/SKILL.md
+++ b/.agents/skills/kast-diagnostics/SKILL.md
@@ -36,12 +36,12 @@ allowlist_json() {
       if $field == "state"
       then listed(["STARTING", "INDEXING", "READY", "DEGRADED", "INCOMPLETE",
         "UNAVAILABLE", "CURRENT", "QUALIFIED", "COMPLETE", "LIMITED", "FAILED",
-        "EXTERNAL_BOUNDARY"]; $value)
+        "EXTERNAL_BOUNDARY", "managed", "missing"]; $value)
       elif $field == "qualification"
       then listed(["CURRENT", "QUALIFIED"]; $value)
       elif $field == "installAuthority"
       then listed(["active-release", "missing"]; $value)
-      elif $field == "backendName"
+      elif ($field == "backendName" or $field == "kind")
       then listed(["idea", "headless"]; $value)
       elif $field == "scope"
       then listed(["SYMBOL", "PACKAGE", "MODULE"]; $value)
@@ -90,41 +90,49 @@ allowlist_json() {
 }
 KASTCTL="${KAST_HOME:-$HOME/.local/share/kast}/current/libexec/kastctl"
 test -x "$KASTCTL" || exit 1
-READY_JSON="$("$KASTCTL" --output json ready --workspace-root "$PWD" --for agent 2>/dev/null)"
+READY_JSON="$("$KASTCTL" --output json ready --workspace-root "$PWD" --for agent 2>/dev/null)" || :
+test -n "$READY_JSON" || exit 1
+printf '%s\n' "$READY_JSON" | allowlist_json || exit 1
 BACKEND="$(printf '%s\n' "$READY_JSON" | jq -er '
-  select((.ok == true) and (.agentEnvironment.ok == true))
+  select(.agentEnvironment.ok == true)
   | .agentEnvironment.backend
   | select(.state == "managed")
   | .kind
   | select(. == "idea" or . == "headless")
-' 2>/dev/null)" || exit 1
-STATUS_JSON="$("$KASTCTL" --output json status --workspace-root "$PWD" \
-  --backend "$BACKEND" 2>/dev/null)"
-printf '%s\n' "$READY_JSON" "$STATUS_JSON" | allowlist_json
+' 2>/dev/null)" || BACKEND=
+if [ -n "$BACKEND" ]; then
+  STATUS_JSON="$("$KASTCTL" --output json status --workspace-root "$PWD" \
+    --backend "$BACKEND" 2>/dev/null)" || :
+  test -n "$STATUS_JSON" || exit 1
+  printf '%s\n' "$STATUS_JSON" | allowlist_json || exit 1
+fi
 ```
 
-Inspect before starting or restarting anything. Distinguish runtime reachability, Gradle readiness, reference-index readiness, and persisted graph coverage. Never echo the captured JSON. Use `allowlist_json` in the same local shell invocation before producing user-visible output; if `jq` or safe filtering is unavailable, do not run the diagnostic.
+Inspect before starting or restarting anything. Distinguish runtime reachability, Gradle readiness, reference-index readiness, and persisted graph coverage. If readiness cannot select one managed backend, report its sanitized evidence and skip only the backend-dependent status and path steps. Never echo the captured JSON. Use `allowlist_json` in the same local shell invocation before producing user-visible output; if `jq` or safe filtering is unavailable, do not run the diagnostic.
 
 ## Inspect configuration and paths locally
 
 ```shell
-CONFIG_JSON="$("$KASTCTL" --output json config list --workspace-root "$PWD" 2>/dev/null)"
-case "$BACKEND" in
-  idea) PATHS_JSON="$("$KASTCTL" --output json developer inspect paths \
-    --workspace-root "$PWD" --idea 2>/dev/null)" ;;
-  headless) PATHS_JSON="$("$KASTCTL" --output json developer inspect paths \
-    --workspace-root "$PWD" 2>/dev/null)" ;;
-esac
-printf '%s\n' "$CONFIG_JSON" | allowlist_json
+CONFIG_JSON="$("$KASTCTL" --output json config list --workspace-root "$PWD" 2>/dev/null)" || :
+test -n "$CONFIG_JSON" || exit 1
+printf '%s\n' "$CONFIG_JSON" | allowlist_json || exit 1
+if [ -n "$BACKEND" ]; then
+  case "$BACKEND" in
+    idea) PATHS_JSON="$("$KASTCTL" --output json developer inspect paths \
+      --workspace-root "$PWD" --idea 2>/dev/null)" ;;
+    headless) PATHS_JSON="$("$KASTCTL" --output json developer inspect paths \
+      --workspace-root "$PWD" 2>/dev/null)" ;;
+  esac
+fi
 ```
 
-Use the first result to identify effective values and mutable fields. Use the second only to locate the active backend's Kast logs. Never echo either variable. Report only closed status names, booleans, allowlisted counts and durations, and the exact configuration keys named in this skill.
+Use the first result to identify effective values and mutable fields. When present, use the second only to locate the active backend's Kast logs. Never echo either variable. Report only closed status names, booleans, allowlisted counts and durations, and the exact configuration keys named in this skill.
 
 There is no typed log-reader command. Run searches only over the relevant time window, capture stdout into a variable, and discard stderr with `2>/dev/null`. Never echo the capture or report log-derived strings, including error codes; reduce it locally to counts and timings. Never return raw log lines, paths, project names, symbols, endpoints, tokens, process descriptors, sockets, or PIDs. Do not enable `KAST_IDEA_TRACE`; it records extensive host and workspace metadata.
 
 ## Change one supported knob at a time
 
-Configuration and runtime mutations require explicit user authorization. For diagnose, explain, or inspect requests, stop after recommending the single evidence-backed key.
+Configuration and runtime mutations require explicit user authorization and an initially selected `$BACKEND`. For diagnose, explain, or inspect requests, stop after recommending the single evidence-backed key.
 
 For an authorized one-key experiment:
 

--- a/.agents/skills/kast-diagnostics/SKILL.md
+++ b/.agents/skills/kast-diagnostics/SKILL.md
@@ -16,6 +16,21 @@ command -v jq >/dev/null || exit 1
 allowlist_json() {
   jq '
     def listed($values; $value): ($values | index($value)) != null;
+    def config_keys: [
+      "server.requestTimeoutMillis", "server.maxConcurrentRequests", "server.maxResults",
+      "gradle.toolingApiTimeoutMillis", "indexing.identifierIndexWaitMillis",
+      "indexing.relationships.enabled", "indexing.relationships.batchSize",
+      "indexing.relationships.parallelism", "indexing.relationships.modulePriorityDepth",
+      "projectOpen.gradleLoadEnabled", "backends.idea.enabled", "watcher.debounceMillis",
+      "telemetry.enabled", "telemetry.scopes", "telemetry.detail", "profiling.enabled",
+      "profiling.modes", "profiling.durationSeconds", "profiling.emitManifest"
+    ];
+    def config_path($path):
+      ($path | map(tostring) | join(".")) as $dotted
+      | if ($dotted | startswith("effective."))
+        then ($dotted | ltrimstr("effective.")) as $key
+          | if listed(config_keys; $key) then $key else null end
+        else null end;
     def safe_string($field; $value):
       if $field == "state"
       then listed(["STARTING", "INDEXING", "READY", "DEGRADED", "INCOMPLETE",
@@ -38,14 +53,18 @@ allowlist_json() {
           "file-outline", "apply-edits", "refresh"]; .)))
       elif $field == "modes"
       then ($value | split(",") | all(.[]; listed(["cpu", "alloc", "lock", "wall"]; .)))
+      elif $field == "key"
+      then listed(config_keys; $value)
       else false end;
-    [paths(scalars) as $path
+    [paths((type == "string") or (type == "number") or (type == "boolean")) as $path
       | ($path[-1] | tostring) as $field
       | getpath($path) as $value
+      | config_path($path) as $config_path
       | select(
           (($value | type) == "boolean"
             and listed(["ok", "ready", "healthy", "active", "indexing", "reachable",
-              "referenceIndexReady", "installed", "enabled", "truncated"]; $field))
+              "referenceIndexReady", "installed", "enabled", "truncated",
+              "gradleLoadEnabled", "emitManifest"]; $field))
           or (($value | type) == "number"
             and (listed(["generation", "total", "indexed", "excluded", "pending",
               "limited", "failed", "stale", "parallelism", "batchSize",
@@ -62,7 +81,8 @@ allowlist_json() {
               "returnedCount", "nextOffset", "limit", "offset"]; $field)))
           or (($value | type) == "string" and safe_string($field; $value))
         )
-      | {field: $field, value: $value}]
+      | {field: (if $field == "key" then "mutableKey"
+          elif $config_path != null then $config_path else $field end), value: $value}]
   ' 2>/dev/null
 }
 KASTCTL="${KAST_HOME:-$HOME/.local/share/kast}/current/libexec/kastctl"

--- a/.agents/skills/kast-diagnostics/SKILL.md
+++ b/.agents/skills/kast-diagnostics/SKILL.md
@@ -21,7 +21,8 @@ allowlist_json() {
       "gradle.toolingApiTimeoutMillis", "indexing.identifierIndexWaitMillis",
       "indexing.relationships.enabled", "indexing.relationships.batchSize",
       "indexing.relationships.parallelism", "indexing.relationships.modulePriorityDepth",
-      "projectOpen.gradleLoadEnabled", "backends.idea.enabled", "watcher.debounceMillis",
+      "projectOpen.gradleLoadEnabled", "backends.idea.enabled", "backends.headless.enabled",
+      "watcher.debounceMillis",
       "telemetry.enabled", "telemetry.scopes", "telemetry.detail", "profiling.enabled",
       "profiling.modes", "profiling.durationSeconds", "profiling.emitManifest"
     ];
@@ -90,7 +91,15 @@ allowlist_json() {
 KASTCTL="${KAST_HOME:-$HOME/.local/share/kast}/current/libexec/kastctl"
 test -x "$KASTCTL" || exit 1
 READY_JSON="$("$KASTCTL" --output json ready --workspace-root "$PWD" --for agent 2>/dev/null)"
-STATUS_JSON="$("$KASTCTL" --output json status --workspace-root "$PWD" --backend idea 2>/dev/null)"
+BACKEND="$(printf '%s\n' "$READY_JSON" | jq -er '
+  select((.ok == true) and (.agentEnvironment.ok == true))
+  | .agentEnvironment.backend
+  | select(.state == "managed")
+  | .kind
+  | select(. == "idea" or . == "headless")
+' 2>/dev/null)" || exit 1
+STATUS_JSON="$("$KASTCTL" --output json status --workspace-root "$PWD" \
+  --backend "$BACKEND" 2>/dev/null)"
 printf '%s\n' "$READY_JSON" "$STATUS_JSON" | allowlist_json
 ```
 
@@ -100,11 +109,16 @@ Inspect before starting or restarting anything. Distinguish runtime reachability
 
 ```shell
 CONFIG_JSON="$("$KASTCTL" --output json config list --workspace-root "$PWD" 2>/dev/null)"
-PATHS_JSON="$("$KASTCTL" --output json developer inspect paths --workspace-root "$PWD" --idea 2>/dev/null)"
+case "$BACKEND" in
+  idea) PATHS_JSON="$("$KASTCTL" --output json developer inspect paths \
+    --workspace-root "$PWD" --idea 2>/dev/null)" ;;
+  headless) PATHS_JSON="$("$KASTCTL" --output json developer inspect paths \
+    --workspace-root "$PWD" 2>/dev/null)" ;;
+esac
 printf '%s\n' "$CONFIG_JSON" | allowlist_json
 ```
 
-Use the first result to identify effective values and mutable fields. Use the second only to locate the current IDEA and Kast logs. Never echo either variable. Report only closed status names, booleans, allowlisted counts and durations, and the exact configuration keys named in this skill.
+Use the first result to identify effective values and mutable fields. Use the second only to locate the active backend's Kast logs. Never echo either variable. Report only closed status names, booleans, allowlisted counts and durations, and the exact configuration keys named in this skill.
 
 There is no typed log-reader command. Run searches only over the relevant time window, capture stdout into a variable, and discard stderr with `2>/dev/null`. Never echo the capture or report log-derived strings, including error codes; reduce it locally to counts and timings. Never return raw log lines, paths, project names, symbols, endpoints, tokens, process descriptors, sockets, or PIDs. Do not enable `KAST_IDEA_TRACE`; it records extensive host and workspace metadata.
 
@@ -115,9 +129,9 @@ Configuration and runtime mutations require explicit user authorization. For dia
 For an authorized one-key experiment:
 
 1. Select exactly one key from the `config_keys` allowlist that `config list` reports as mutable. Re-run `config list` immediately before mutation. Require one successful response at the same schema version, one matching mutable field, a scalar effective value matching its declared `valueType`, and a boolean `workspaceOverride`. Keep the value and flag only in memory.
-2. Register cleanup for normal exit, command failure, and HUP/INT/TERM before `config set`. Cleanup must restore with `config set` when `workspaceOverride` was true, otherwise `config unset`, and then run `developer runtime restart --backend idea --accept-indexing`.
-3. Set the temporary value, restart, and reproduce once.
-4. After cleanup, independently capture `config list` and `status`. Require the original effective value, `valueType`, and `workspaceOverride`, plus a reachable, healthy, active IDEA runtime in `INDEXING` or `READY` at the same schema version.
+2. Register cleanup for normal exit, command failure, and HUP/INT/TERM before `config set`. Cleanup must restore with `config set` when `workspaceOverride` was true, otherwise `config unset`, and then run `developer runtime restart --backend "$BACKEND" --accept-indexing`.
+3. Set the temporary value, restart the same `$BACKEND`, and reproduce once.
+4. After cleanup, independently capture `config list` and `status --backend "$BACKEND"`. Require the original effective value, `valueType`, and `workspaceOverride`, plus a reachable, healthy, active runtime for that backend in `INDEXING` or `READY` at the same schema version.
 5. Treat any cleanup command or verification failure as `RESTORE_FAILED`, overriding the reproduction result. Report `RESTORED` separately only after both checks pass. Never suppress cleanup status or print the captured payloads.
 
 Route symptoms to these current mutable keys:
@@ -125,7 +139,7 @@ Route symptoms to these current mutable keys:
 - request saturation: `server.requestTimeoutMillis`, `server.maxConcurrentRequests`, `server.maxResults`
 - Gradle or identifier waits: `gradle.toolingApiTimeoutMillis`, `indexing.identifierIndexWaitMillis`
 - relationship indexing: `indexing.relationships.enabled`, `.batchSize`, `.parallelism`, `.modulePriorityDepth`
-- project lifecycle: `projectOpen.gradleLoadEnabled`, `backends.idea.enabled`, `watcher.debounceMillis`
+- project lifecycle: `projectOpen.gradleLoadEnabled`, `backends.idea.enabled`, `backends.headless.enabled`, `watcher.debounceMillis`
 - telemetry: `telemetry.enabled`, `.scopes`, `.detail`
 - profiling: `profiling.enabled`, `.modes`, `.durationSeconds`, `.emitManifest`
 

--- a/.agents/skills/kast-diagnostics/SKILL.md
+++ b/.agents/skills/kast-diagnostics/SKILL.md
@@ -110,73 +110,15 @@ There is no typed log-reader command. Run searches only over the relevant time w
 
 ## Change one supported knob at a time
 
-Select one key below that `config list` reports as mutable. Capture its effective scalar and `workspaceOverride` flag from the unprinted `CONFIG_JSON`, then run the mutation in one guarded subshell. Restore the original value when an override existed; otherwise remove the temporary override. Always restart after restoration.
-
 Configuration and runtime mutations require explicit user authorization. For diagnose, explain, or inspect requests, stop after recommending the single evidence-backed key.
 
-```shell
-(
-  set -eu
-  KEY="<KEY>"
-  TEMPORARY_VALUE="<VALUE>"
-  case "$KEY" in
-    server.requestTimeoutMillis|server.maxConcurrentRequests|server.maxResults|\
-    gradle.toolingApiTimeoutMillis|indexing.identifierIndexWaitMillis|\
-    indexing.relationships.enabled|indexing.relationships.batchSize|\
-    indexing.relationships.parallelism|indexing.relationships.modulePriorityDepth|\
-    projectOpen.gradleLoadEnabled|backends.idea.enabled|watcher.debounceMillis|\
-    telemetry.enabled|telemetry.scopes|telemetry.detail|profiling.enabled|\
-    profiling.modes|profiling.durationSeconds|profiling.emitManifest) ;;
-    *) exit 1 ;;
-  esac
-  EXPECTED_SCHEMA_VERSION="$(printf '%s\n' "$READY_JSON" |
-    jq -ser 'select(length == 1) | .[0].schemaVersion |
-      select((type == "number") and (. > 0) and (floor == .))' 2>/dev/null)"
-  ORIGINAL_STATE="$(printf '%s\n' "$CONFIG_JSON" |
-    jq -cse --arg key "$KEY" --argjson schema "$EXPECTED_SCHEMA_VERSION" '
-    select(length == 1)
-    | .[0]
-    | select((.ok == true) and (.schemaVersion == $schema))
-    | select((.mutableFields | type) == "array")
-    | . as $config
-    | [.mutableFields[] | select(.key == $key)] as $fields
-    | select(($fields | length) == 1)
-    | $fields[0] as $field
-    | ($config.effective | getpath($key | split("."))) as $value
-    | select(($field.workspaceOverride | type) == "boolean")
-    | select((($field.valueType == "boolean") and (($value | type) == "boolean"))
-        or (($field.valueType == "integer") and (($value | type) == "number")
-          and ($value == ($value | floor)) and ($value >= 0)
-          and ($value <= 9007199254740991))
-        or (($field.valueType == "string") and (($value | type) == "string")))
-    | {hadOverride: $field.workspaceOverride, value: $value}
-  ' 2>/dev/null)" || exit 1
-  ORIGINAL_HAD_OVERRIDE="$(printf '%s' "$ORIGINAL_STATE" |
-    jq -er '.hadOverride | tostring' 2>/dev/null)"
-  ORIGINAL_VALUE="$(printf '%s' "$ORIGINAL_STATE" |
-    jq -er '.value | tostring' 2>/dev/null)"
-  restore_config() {
-    original_status=$?
-    trap - HUP INT TERM
-    if [ "$ORIGINAL_HAD_OVERRIDE" = true ]; then
-      "$KASTCTL" config set "$KEY" "$ORIGINAL_VALUE" \
-        --workspace-root "$PWD" >/dev/null 2>&1
-    else
-      "$KASTCTL" config unset "$KEY" --workspace-root "$PWD" >/dev/null 2>&1
-    fi
-    "$KASTCTL" developer runtime restart \
-      --workspace-root "$PWD" --backend idea --accept-indexing >/dev/null 2>&1
-    return "$original_status"
-  }
-  trap restore_config EXIT
-  trap 'exit 130' HUP INT TERM
-  "$KASTCTL" config set "$KEY" "$TEMPORARY_VALUE" \
-    --workspace-root "$PWD" >/dev/null 2>&1
-  "$KASTCTL" developer runtime restart \
-    --workspace-root "$PWD" --backend idea --accept-indexing >/dev/null 2>&1
-  # Run one reproduction here and sanitize its captured output.
-)
-```
+For an authorized one-key experiment:
+
+1. Select exactly one key from the `config_keys` allowlist that `config list` reports as mutable. Re-run `config list` immediately before mutation. Require one successful response at the same schema version, one matching mutable field, a scalar effective value matching its declared `valueType`, and a boolean `workspaceOverride`. Keep the value and flag only in memory.
+2. Register cleanup for normal exit, command failure, and HUP/INT/TERM before `config set`. Cleanup must restore with `config set` when `workspaceOverride` was true, otherwise `config unset`, and then run `developer runtime restart --backend idea --accept-indexing`.
+3. Set the temporary value, restart, and reproduce once.
+4. After cleanup, independently capture `config list` and `status`. Require the original effective value, `valueType`, and `workspaceOverride`, plus a reachable, healthy, active IDEA runtime in `INDEXING` or `READY` at the same schema version.
+5. Treat any cleanup command or verification failure as `RESTORE_FAILED`, overriding the reproduction result. Report `RESTORED` separately only after both checks pass. Never suppress cleanup status or print the captured payloads.
 
 Route symptoms to these current mutable keys:
 
@@ -198,15 +140,14 @@ AGENT_HELP="$("$KASTCTL" agent --help 2>/dev/null)"
 GRAPH_HELP="$("$KASTCTL" agent graph --help 2>/dev/null)"
 test -n "$AGENT_HELP" || exit 1
 test -n "$GRAPH_HELP" || exit 1
-SYMBOL_SUMMARY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
-  --scope symbol --operation summary 2>/dev/null)"
 MODULE_SUMMARY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
   --scope module --operation summary 2>/dev/null)"
 PACKAGE_SUMMARY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
   --scope package --operation summary 2>/dev/null)"
-printf '%s\n' "$SYMBOL_SUMMARY" "$MODULE_SUMMARY" "$PACKAGE_SUMMARY" |
-  allowlist_json
+printf '%s\n' "$MODULE_SUMMARY" "$PACKAGE_SUMMARY" | allowlist_json
 ```
+
+Run the symbol summary only when symbol-wide analytics are specifically required and the module/package evidence justifies its cost.
 
 Use bounded typed metrics when a focused query answers the diagnostic:
 

--- a/.agents/skills/kast-diagnostics/SKILL.md
+++ b/.agents/skills/kast-diagnostics/SKILL.md
@@ -110,15 +110,72 @@ There is no typed log-reader command. Run searches only over the relevant time w
 
 ## Change one supported knob at a time
 
-Select only keys listed as mutable by `config list`. Record the inherited value locally, set one override, restart once, reproduce once, then unset the override and restart to restore inheritance.
+Select one key below that `config list` reports as mutable. Capture its effective scalar and `workspaceOverride` flag from the unprinted `CONFIG_JSON`, then run the mutation in one guarded subshell. Restore the original value when an override existed; otherwise remove the temporary override. Always restart after restoration.
 
 Configuration and runtime mutations require explicit user authorization. For diagnose, explain, or inspect requests, stop after recommending the single evidence-backed key.
 
 ```shell
-"$KASTCTL" config set <KEY> <VALUE> --workspace-root "$PWD"
-"$KASTCTL" developer runtime restart \
-  --workspace-root "$PWD" --backend idea --accept-indexing
-"$KASTCTL" config unset <KEY> --workspace-root "$PWD"
+(
+  set -eu
+  KEY="<KEY>"
+  TEMPORARY_VALUE="<VALUE>"
+  case "$KEY" in
+    server.requestTimeoutMillis|server.maxConcurrentRequests|server.maxResults|\
+    gradle.toolingApiTimeoutMillis|indexing.identifierIndexWaitMillis|\
+    indexing.relationships.enabled|indexing.relationships.batchSize|\
+    indexing.relationships.parallelism|indexing.relationships.modulePriorityDepth|\
+    projectOpen.gradleLoadEnabled|backends.idea.enabled|watcher.debounceMillis|\
+    telemetry.enabled|telemetry.scopes|telemetry.detail|profiling.enabled|\
+    profiling.modes|profiling.durationSeconds|profiling.emitManifest) ;;
+    *) exit 1 ;;
+  esac
+  EXPECTED_SCHEMA_VERSION="$(printf '%s\n' "$READY_JSON" |
+    jq -ser 'select(length == 1) | .[0].schemaVersion |
+      select((type == "number") and (. > 0) and (floor == .))' 2>/dev/null)"
+  ORIGINAL_STATE="$(printf '%s\n' "$CONFIG_JSON" |
+    jq -cse --arg key "$KEY" --argjson schema "$EXPECTED_SCHEMA_VERSION" '
+    select(length == 1)
+    | .[0]
+    | select((.ok == true) and (.schemaVersion == $schema))
+    | select((.mutableFields | type) == "array")
+    | . as $config
+    | [.mutableFields[] | select(.key == $key)] as $fields
+    | select(($fields | length) == 1)
+    | $fields[0] as $field
+    | ($config.effective | getpath($key | split("."))) as $value
+    | select(($field.workspaceOverride | type) == "boolean")
+    | select((($field.valueType == "boolean") and (($value | type) == "boolean"))
+        or (($field.valueType == "integer") and (($value | type) == "number")
+          and ($value == ($value | floor)) and ($value >= 0)
+          and ($value <= 9007199254740991))
+        or (($field.valueType == "string") and (($value | type) == "string")))
+    | {hadOverride: $field.workspaceOverride, value: $value}
+  ' 2>/dev/null)" || exit 1
+  ORIGINAL_HAD_OVERRIDE="$(printf '%s' "$ORIGINAL_STATE" |
+    jq -er '.hadOverride | tostring' 2>/dev/null)"
+  ORIGINAL_VALUE="$(printf '%s' "$ORIGINAL_STATE" |
+    jq -er '.value | tostring' 2>/dev/null)"
+  restore_config() {
+    original_status=$?
+    trap - HUP INT TERM
+    if [ "$ORIGINAL_HAD_OVERRIDE" = true ]; then
+      "$KASTCTL" config set "$KEY" "$ORIGINAL_VALUE" \
+        --workspace-root "$PWD" >/dev/null 2>&1
+    else
+      "$KASTCTL" config unset "$KEY" --workspace-root "$PWD" >/dev/null 2>&1
+    fi
+    "$KASTCTL" developer runtime restart \
+      --workspace-root "$PWD" --backend idea --accept-indexing >/dev/null 2>&1
+    return "$original_status"
+  }
+  trap restore_config EXIT
+  trap 'exit 130' HUP INT TERM
+  "$KASTCTL" config set "$KEY" "$TEMPORARY_VALUE" \
+    --workspace-root "$PWD" >/dev/null 2>&1
+  "$KASTCTL" developer runtime restart \
+    --workspace-root "$PWD" --backend idea --accept-indexing >/dev/null 2>&1
+  # Run one reproduction here and sanitize its captured output.
+)
 ```
 
 Route symptoms to these current mutable keys:

--- a/.agents/skills/kast-diagnostics/SKILL.md
+++ b/.agents/skills/kast-diagnostics/SKILL.md
@@ -12,7 +12,7 @@ Diagnose the exact workspace from typed local evidence. Treat reported enterpris
 Run from the canonical workspace root. Resolve the active release-local control CLI only into a shell variable; never print or persist its absolute path.
 
 ```shell
-command -v jq >/dev/null
+command -v jq >/dev/null || exit 1
 allowlist_json() {
   jq '
     def listed($values; $value): ($values | index($value)) != null;
@@ -66,7 +66,7 @@ allowlist_json() {
   ' 2>/dev/null
 }
 KASTCTL="${KAST_HOME:-$HOME/.local/share/kast}/current/libexec/kastctl"
-test -x "$KASTCTL"
+test -x "$KASTCTL" || exit 1
 READY_JSON="$("$KASTCTL" --output json ready --workspace-root "$PWD" --for agent 2>/dev/null)"
 STATUS_JSON="$("$KASTCTL" --output json status --workspace-root "$PWD" --backend idea 2>/dev/null)"
 printf '%s\n' "$READY_JSON" "$STATUS_JSON" | allowlist_json
@@ -112,12 +112,19 @@ Prefer one narrow telemetry scope such as `references`, `type-hierarchy`, `works
 
 ## Read the source index through typed commands
 
-Use the public Rust graph surface for generation-checked, SQLite read-only, query-only projections:
+Use the repository-mandated Rust graph command for generation-checked, SQLite read-only, query-only projections. Read its scoped help first.
 
 ```shell
-GRAPH_SUMMARY="$(kast graph summary --scope symbol 2>/dev/null)"
-MODULE_TOPOLOGY="$(kast graph topology --scope module 2>/dev/null)"
-PACKAGE_COMMUNITIES="$(kast graph communities --scope package 2>/dev/null)"
+GRAPH_HELP="$("$KASTCTL" agent graph --help 2>/dev/null)"
+test -n "$GRAPH_HELP" || exit 1
+GRAPH_SUMMARY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
+  --scope symbol --operation summary 2>/dev/null)"
+MODULE_TOPOLOGY="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
+  --scope module --operation topology 2>/dev/null)"
+PACKAGE_COMMUNITIES="$("$KASTCTL" --output json agent graph --workspace-root "$PWD" \
+  --scope package --operation communities 2>/dev/null)"
+printf '%s\n' "$GRAPH_SUMMARY" "$MODULE_TOPOLOGY" "$PACKAGE_COMMUNITIES" |
+  allowlist_json
 ```
 
 Use bounded typed metrics when a focused query answers the diagnostic:

--- a/.agents/skills/kast-diagnostics/agents/openai.yaml
+++ b/.agents/skills/kast-diagnostics/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Kast Diagnostics"
+  short_description: "Diagnose Kast safely from typed local evidence"
+  default_prompt: "Use $kast-diagnostics to diagnose this Kast workspace without exposing secrets."

--- a/cli-rs/src/agent/adapter/commands.rs
+++ b/cli-rs/src/agent/adapter/commands.rs
@@ -176,25 +176,39 @@ pub(crate) fn run_symbol(args: KastSymbolArgs) -> Result<i32> {
 
 pub(crate) fn run_graph(args: KastGraphArgs) -> Result<i32> {
     let workspace_root = config::resolve_workspace_root(None)?;
-    match args.command.unwrap_or(KastGraphCommand::Summary) {
-        KastGraphCommand::Summary => {
-            print_native_graph(workspace_root, NativeGraphOperation::Summary, None, None)
-        }
+    match args
+        .command
+        .unwrap_or(KastGraphCommand::Summary(KastGraphProjectionArgs {
+            scope: KastGraphScope::Symbol,
+        })) {
+        KastGraphCommand::Summary(projection) => print_native_graph(
+            workspace_root,
+            NativeGraphOperation::Summary,
+            Some(projection.scope.into()),
+            None,
+            None,
+        ),
         KastGraphCommand::Nodes { page } => {
-            print_native_graph(workspace_root, NativeGraphOperation::Nodes, None, page)
+            print_native_graph(workspace_root, NativeGraphOperation::Nodes, None, None, page)
         }
         KastGraphCommand::Neighbors { symbol } => print_native_graph(
             workspace_root,
             NativeGraphOperation::Neighbors,
+            None,
             Some(symbol),
             None,
         ),
-        KastGraphCommand::Topology => {
-            print_native_graph(workspace_root, NativeGraphOperation::Topology, None, None)
-        }
-        KastGraphCommand::Communities => print_native_graph(
+        KastGraphCommand::Topology(projection) => print_native_graph(
+            workspace_root,
+            NativeGraphOperation::Topology,
+            Some(projection.scope.into()),
+            None,
+            None,
+        ),
+        KastGraphCommand::Communities(projection) => print_native_graph(
             workspace_root,
             NativeGraphOperation::Communities,
+            Some(projection.scope.into()),
             None,
             None,
         ),

--- a/cli-rs/src/agent/adapter/graph.rs
+++ b/cli-rs/src/agent/adapter/graph.rs
@@ -5,6 +5,7 @@ pub(crate) fn print_projected(command: AgentCommand) -> Result<i32> {
 fn print_native_graph(
     workspace_root: PathBuf,
     operation: NativeGraphOperation,
+    scope: Option<NativeGraphScope>,
     symbol: Option<String>,
     page: Option<KastGraphNodesPageToken>,
 ) -> Result<i32> {
@@ -51,9 +52,9 @@ fn print_native_graph(
     let envelope = projected_value(native_graph_command(
         workspace_root,
         operation,
+        scope,
         symbol,
-        Vec::new(),
-        Vec::new(),
+        NativeGraphFileChanges::default(),
         Some(admission.generation()),
         after_id,
     ))?;
@@ -113,19 +114,19 @@ fn print_native_graph(
 fn native_graph_command(
     workspace_root: PathBuf,
     operation: NativeGraphOperation,
+    scope: Option<NativeGraphScope>,
     symbol: Option<String>,
-    file_paths: Vec<String>,
-    removed_file_paths: Vec<String>,
+    file_changes: NativeGraphFileChanges,
     generation: Option<u64>,
     after_id: Option<u64>,
 ) -> AgentCommand {
     AgentCommand::Graph(AgentNativeGraphArgs {
         runtime: agent_runtime(workspace_root),
         database: None,
-        scope: None,
+        scope,
         operation,
-        file_paths,
-        removed_file_paths,
+        file_paths: file_changes.file_paths,
+        removed_file_paths: file_changes.removed_file_paths,
         modules: Vec::new(),
         source_sets: Vec::new(),
         exclusive: false,
@@ -135,6 +136,12 @@ fn native_graph_command(
         limit: (operation == NativeGraphOperation::Nodes).then_some(500),
         resolution: None,
     })
+}
+
+#[derive(Default)]
+struct NativeGraphFileChanges {
+    file_paths: Vec<String>,
+    removed_file_paths: Vec<String>,
 }
 
 fn run_symbol_relation(

--- a/cli-rs/src/agent/adapter/mod.rs
+++ b/cli-rs/src/agent/adapter/mod.rs
@@ -6,8 +6,9 @@ use crate::cli::{
     AgentRelationLimit, AgentRelationViewArgs, AgentReusableSymbolSelectorArgs, AgentRuntimeArgs,
     AgentSelectorHandle, AgentSymbolArgs, AgentSymbolMode, AgentSymbolViewArgs,
     AgentWorkspaceFilesArgs, AgentWorkspaceFilesField, AgentWorkspaceFilesViewArgs, KastGraphArgs,
-    KastGraphCommand, KastGraphNodesPageToken, KastPathsArgs, KastRefreshArgs, KastRefreshCommand,
-    KastSymbolArgs, KastSymbolCommand, NativeGraphOperation, OutputFormat, WorkspaceDirtyFilter,
+    KastGraphCommand, KastGraphNodesPageToken, KastGraphProjectionArgs, KastGraphScope,
+    KastPathsArgs, KastRefreshArgs, KastRefreshCommand, KastSymbolArgs, KastSymbolCommand,
+    NativeGraphOperation, NativeGraphScope, OutputFormat, WorkspaceDirtyFilter,
     WorkspaceFilesPublicPageToken, WorkspaceRelativeGlob,
 };
 use crate::error::{CliError, Result};

--- a/cli-rs/src/agent/adapter/refresh.rs
+++ b/cli-rs/src/agent/adapter/refresh.rs
@@ -120,8 +120,11 @@ pub(crate) fn run_refresh(args: KastRefreshArgs) -> Result<i32> {
             workspace_root.clone(),
             NativeGraphOperation::Refresh,
             None,
-            graph_paths,
-            graph_removed_paths,
+            None,
+            NativeGraphFileChanges {
+                file_paths: graph_paths,
+                removed_file_paths: graph_removed_paths,
+            },
             None,
             None,
         ))?;

--- a/cli-rs/src/configuration/config/workspace/mutation.rs
+++ b/cli-rs/src/configuration/config/workspace/mutation.rs
@@ -5,6 +5,7 @@ use toml_edit::{DocumentMut, Item, Table, TableLike};
 pub struct MutableConfigField {
     pub key: &'static str,
     pub value_type: ConfigValueType,
+    pub workspace_override: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -24,7 +25,11 @@ struct ConfigFieldSpec {
 impl ConfigFieldSpec {
     const fn new(key: &'static str, value_type: ConfigValueType) -> Self {
         Self {
-            field: MutableConfigField { key, value_type },
+            field: MutableConfigField {
+                key,
+                value_type,
+                workspace_override: false,
+            },
             minimum: None,
         }
     }
@@ -34,6 +39,7 @@ impl ConfigFieldSpec {
             field: MutableConfigField {
                 key,
                 value_type: ConfigValueType::Integer,
+                workspace_override: false,
             },
             minimum: Some(1),
         }
@@ -127,6 +133,7 @@ pub struct WorkspaceConfigMutation {
 pub fn list_workspace_config(workspace_root: PathBuf) -> Result<WorkspaceConfigList> {
     let workspace_root = resolve_workspace_root(Some(workspace_root))?;
     let workspace_config = workspace_config_path(&workspace_root)?;
+    let workspace_document = read_workspace_config(&workspace_config)?;
     let global_config = global_config_path();
     Ok(WorkspaceConfigList {
         ok: true,
@@ -147,7 +154,16 @@ pub fn list_workspace_config(workspace_root: PathBuf) -> Result<WorkspaceConfigL
         effective: KastConfig::load(&workspace_root)?,
         mutable_fields: MUTABLE_CONFIG_FIELDS
             .iter()
-            .map(|spec| spec.field)
+            .map(|spec| {
+                let path = spec.field.key.split('.').collect::<Vec<_>>();
+                MutableConfigField {
+                    workspace_override: document_contains_value(
+                        workspace_document.as_table(),
+                        &path,
+                    ),
+                    ..spec.field
+                }
+            })
             .collect(),
         schema_version: SCHEMA_VERSION,
     })
@@ -357,4 +373,17 @@ fn remove_document_value(table: &mut dyn TableLike, path: &[&str]) -> bool {
         table.remove(head);
     }
     removed
+}
+
+fn document_contains_value(table: &dyn TableLike, path: &[&str]) -> bool {
+    let Some((head, tail)) = path.split_first() else {
+        return false;
+    };
+    let Some(item) = table.get(head) else {
+        return false;
+    };
+    tail.is_empty()
+        || item
+            .as_table_like()
+            .is_some_and(|child| document_contains_value(child, tail))
 }

--- a/cli-rs/src/interface/cli/agent/agent_surface.rs
+++ b/cli-rs/src/interface/cli/agent/agent_surface.rs
@@ -161,10 +161,34 @@ pub struct KastGraphArgs {
     pub command: Option<KastGraphCommand>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum KastGraphScope {
+    Symbol,
+    Package,
+    Module,
+}
+
+impl From<KastGraphScope> for NativeGraphScope {
+    fn from(scope: KastGraphScope) -> Self {
+        match scope {
+            KastGraphScope::Symbol => Self::Symbol,
+            KastGraphScope::Package => Self::Package,
+            KastGraphScope::Module => Self::Module,
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct KastGraphProjectionArgs {
+    /// Read-only topology projection.
+    #[arg(long, value_enum, default_value_t = KastGraphScope::Symbol)]
+    pub scope: KastGraphScope,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum KastGraphCommand {
     /// Summarize graph coverage and size.
-    Summary,
+    Summary(KastGraphProjectionArgs),
     /// Enumerate graph nodes.
     Nodes {
         /// Opaque continuation returned as `nextPage`.
@@ -174,9 +198,9 @@ pub enum KastGraphCommand {
     /// Show adjacent nodes for one symbol.
     Neighbors { symbol: String },
     /// Report topology statistics.
-    Topology,
+    Topology(KastGraphProjectionArgs),
     /// Report deterministic graph communities.
-    Communities,
+    Communities(KastGraphProjectionArgs),
     /// Report the bounded impact of one symbol.
     Impact {
         symbol: String,

--- a/cli-rs/tests/agent/public/kast_agent_surface.rs
+++ b/cli-rs/tests/agent/public/kast_agent_surface.rs
@@ -222,62 +222,6 @@ fn graph_summary_is_a_direct_deterministic_toon_result_without_protocol_cruft() 
 }
 
 #[test]
-fn public_graph_exposes_read_only_topology() {
-    let fixture = tempfile::tempdir().expect("temporary graph fixture");
-    let home = fixture.path().join("home");
-    let workspace = fixture.path().join("workspace");
-    std::fs::create_dir_all(&workspace).expect("workspace");
-    std::fs::write(workspace.join("settings.gradle.kts"), "").expect("Gradle marker");
-    let workspace = workspace.canonicalize().expect("canonical workspace");
-    let _index = seed_public_graph(&workspace, false);
-
-    for (operation, scope, expected) in [
-        ("summary", "symbol", "SYMBOL"),
-        ("topology", "package", "PACKAGE"),
-        ("communities", "module", "MODULE"),
-    ] {
-        let output = named("kast")
-            .current_dir(&workspace)
-            .env("HOME", &home)
-            .env("KAST_CONFIG_HOME", fixture.path().join("config"))
-            .args(["graph", operation, "--scope", scope])
-            .output()
-            .unwrap_or_else(|error| panic!("run graph {operation} at {scope} scope: {error}"));
-        assert!(
-            output.status.success(),
-            "stdout={} stderr={}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let decoded: serde_json::Value = toon_format::decode_default(
-            std::str::from_utf8(&output.stdout)
-                .expect("UTF-8 graph projection")
-                .trim(),
-        )
-        .expect("graph projection is valid TOON");
-        assert_eq!(decoded["scope"], expected, "{decoded:#}");
-    }
-
-    let help = named("kast")
-        .args(["graph", "topology", "--help"])
-        .output()
-        .expect("run topology help");
-    assert!(help.status.success(), "{help:?}");
-    let help = String::from_utf8(help.stdout).expect("UTF-8 topology help");
-    assert!(help.contains("--scope <SCOPE>"), "{help}");
-    assert!(
-        help.contains("possible values: symbol, package, module"),
-        "{help}"
-    );
-    for unsafe_surface in ["file", "database", "sql"] {
-        assert!(
-            !help.to_ascii_lowercase().contains(unsafe_surface),
-            "public graph help leaked {unsafe_surface}: {help}"
-        );
-    }
-}
-
-#[test]
 fn public_graph_nodes_exposes_and_consumes_an_opaque_next_page() {
     let fixture = tempfile::tempdir().expect("temporary graph fixture");
     let home = fixture.path().join("home");

--- a/cli-rs/tests/agent/public/kast_agent_surface.rs
+++ b/cli-rs/tests/agent/public/kast_agent_surface.rs
@@ -222,6 +222,62 @@ fn graph_summary_is_a_direct_deterministic_toon_result_without_protocol_cruft() 
 }
 
 #[test]
+fn public_graph_exposes_read_only_topology() {
+    let fixture = tempfile::tempdir().expect("temporary graph fixture");
+    let home = fixture.path().join("home");
+    let workspace = fixture.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(workspace.join("settings.gradle.kts"), "").expect("Gradle marker");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let _index = seed_public_graph(&workspace, false);
+
+    for (operation, scope, expected) in [
+        ("summary", "symbol", "SYMBOL"),
+        ("topology", "package", "PACKAGE"),
+        ("communities", "module", "MODULE"),
+    ] {
+        let output = named("kast")
+            .current_dir(&workspace)
+            .env("HOME", &home)
+            .env("KAST_CONFIG_HOME", fixture.path().join("config"))
+            .args(["graph", operation, "--scope", scope])
+            .output()
+            .unwrap_or_else(|error| panic!("run graph {operation} at {scope} scope: {error}"));
+        assert!(
+            output.status.success(),
+            "stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let decoded: serde_json::Value = toon_format::decode_default(
+            std::str::from_utf8(&output.stdout)
+                .expect("UTF-8 graph projection")
+                .trim(),
+        )
+        .expect("graph projection is valid TOON");
+        assert_eq!(decoded["scope"], expected, "{decoded:#}");
+    }
+
+    let help = named("kast")
+        .args(["graph", "topology", "--help"])
+        .output()
+        .expect("run topology help");
+    assert!(help.status.success(), "{help:?}");
+    let help = String::from_utf8(help.stdout).expect("UTF-8 topology help");
+    assert!(help.contains("--scope <SCOPE>"), "{help}");
+    assert!(
+        help.contains("possible values: symbol, package, module"),
+        "{help}"
+    );
+    for unsafe_surface in ["file", "database", "sql"] {
+        assert!(
+            !help.to_ascii_lowercase().contains(unsafe_surface),
+            "public graph help leaked {unsafe_surface}: {help}"
+        );
+    }
+}
+
+#[test]
 fn public_graph_nodes_exposes_and_consumes_an_opaque_next_page() {
     let fixture = tempfile::tempdir().expect("temporary graph fixture");
     let home = fixture.path().join("home");

--- a/cli-rs/tests/agent/public/surface/graph_fixture_and_dispatch.rs
+++ b/cli-rs/tests/agent/public/surface/graph_fixture_and_dispatch.rs
@@ -75,6 +75,62 @@ fn seed_public_graph(workspace: &Path, stale: bool) -> WorkspaceIndexFixture {
 }
 
 #[test]
+fn public_graph_exposes_read_only_topology() {
+    let fixture = tempfile::tempdir().expect("temporary graph fixture");
+    let home = fixture.path().join("home");
+    let workspace = fixture.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(workspace.join("settings.gradle.kts"), "").expect("Gradle marker");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let _index = seed_public_graph(&workspace, false);
+
+    for (operation, scope, expected) in [
+        ("summary", "symbol", "SYMBOL"),
+        ("topology", "package", "PACKAGE"),
+        ("communities", "module", "MODULE"),
+    ] {
+        let output = named("kast")
+            .current_dir(&workspace)
+            .env("HOME", &home)
+            .env("KAST_CONFIG_HOME", fixture.path().join("config"))
+            .args(["graph", operation, "--scope", scope])
+            .output()
+            .unwrap_or_else(|error| panic!("run graph {operation} at {scope} scope: {error}"));
+        assert!(
+            output.status.success(),
+            "stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let decoded: serde_json::Value = toon_format::decode_default(
+            std::str::from_utf8(&output.stdout)
+                .expect("UTF-8 graph projection")
+                .trim(),
+        )
+        .expect("graph projection is valid TOON");
+        assert_eq!(decoded["scope"], expected, "{decoded:#}");
+    }
+
+    let help = named("kast")
+        .args(["graph", "topology", "--help"])
+        .output()
+        .expect("run topology help");
+    assert!(help.status.success(), "{help:?}");
+    let help = String::from_utf8(help.stdout).expect("UTF-8 topology help");
+    assert!(help.contains("--scope <SCOPE>"), "{help}");
+    assert!(
+        help.contains("possible values: symbol, package, module"),
+        "{help}"
+    );
+    for unsafe_surface in ["file", "database", "sql"] {
+        assert!(
+            !help.to_ascii_lowercase().contains(unsafe_surface),
+            "public graph help leaked {unsafe_surface}: {help}"
+        );
+    }
+}
+
+#[test]
 fn public_read_commands_delegate_to_typed_operations() {
     let fixture = tempfile::tempdir().expect("temporary workspace");
     let workspace = fixture.path().join("workspace");

--- a/cli-rs/tests/agent/public/surface/graph_fixture_and_dispatch.rs
+++ b/cli-rs/tests/agent/public/surface/graph_fixture_and_dispatch.rs
@@ -33,6 +33,18 @@ fn seed_public_graph(workspace: &Path, stale: bool) -> WorkspaceIndexFixture {
                  kind TEXT NOT NULL,
                  context TEXT NOT NULL
              );
+             CREATE VIEW semantic_module_quotient AS
+                 SELECT source_file.module_name AS source_container,
+                        target_file.module_name AS target_container,
+                        edges.kind, edges.context, COUNT(*) AS weight
+                 FROM semantic_edge_occurrences edges
+                 JOIN semantic_symbols source ON source.id = edges.source_id
+                 JOIN semantic_symbols target ON target.id = edges.target_id
+                 JOIN semantic_files source_file ON source_file.id = source.file_id
+                 JOIN semantic_files target_file ON target_file.id = target.file_id
+                 WHERE source_file.module_name IS NOT NULL
+                   AND target_file.module_name IS NOT NULL
+                 GROUP BY 1, 2, edges.kind, edges.context;
              INSERT INTO semantic_symbols VALUES
                  (1, 'class:sample.Source', 'CLASS', 'Source', 1),
                  (2, 'class:sample.Target', 'CLASS', 'Target', 1);

--- a/cli-rs/tests/surface/config_cli.rs
+++ b/cli-rs/tests/surface/config_cli.rs
@@ -15,6 +15,17 @@ fn run(home: &Path, config_home: &Path, workspace: &Path, args: &[&str]) -> std:
         .expect("config command")
 }
 
+fn workspace_override(listed: &serde_json::Value, key: &str) -> bool {
+    listed["mutableFields"]
+        .as_array()
+        .expect("mutable fields")
+        .iter()
+        .find(|field| field["key"] == key)
+        .unwrap_or_else(|| panic!("missing mutable field {key}"))["workspaceOverride"]
+        .as_bool()
+        .expect("workspace override flag")
+}
+
 #[test]
 fn explicit_config_home_owns_the_global_config_file() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -80,6 +91,10 @@ fn workspace_config_lists_sets_and_unsets_effective_values() {
             .any(|field| field["key"] == "indexing.relationships.parallelism"),
         "{listed:#}",
     );
+    assert!(
+        !workspace_override(&listed, "indexing.relationships.parallelism"),
+        "{listed:#}",
+    );
 
     let set = run(
         &home,
@@ -96,6 +111,12 @@ fn workspace_config_lists_sets_and_unsets_effective_values() {
     let set: serde_json::Value = serde_json::from_slice(&set.stdout).expect("set JSON");
     assert_eq!(set["status"], "updated");
     assert_eq!(set["effectiveValue"], 2);
+    let listed = run(&home, &config_home, &workspace, &["list"]);
+    let listed: serde_json::Value = serde_json::from_slice(&listed.stdout).expect("list JSON");
+    assert!(
+        workspace_override(&listed, "indexing.relationships.parallelism"),
+        "{listed:#}",
+    );
 
     let config_path = PathBuf::from(set["configPath"].as_str().expect("config path"));
     let first_contents = std::fs::read_to_string(&config_path).expect("workspace config");
@@ -134,6 +155,12 @@ fn workspace_config_lists_sets_and_unsets_effective_values() {
     let unset: serde_json::Value = serde_json::from_slice(&unset.stdout).expect("unset JSON");
     assert_eq!(unset["status"], "updated");
     assert_eq!(unset["effectiveValue"], 4);
+    let listed = run(&home, &config_home, &workspace, &["list"]);
+    let listed: serde_json::Value = serde_json::from_slice(&listed.stdout).expect("list JSON");
+    assert!(
+        !workspace_override(&listed, "indexing.relationships.parallelism"),
+        "{listed:#}",
+    );
 
     let repeated = run(
         &home,


### PR DESCRIPTION
## Summary
- expose typed symbol, package, and module projections on the public read-only Rust graph surface
- add a repository-owned Kast diagnostics skill with closed redaction and mutation gates
- keep arbitrary SQL, database selection, and index mutation private

## Verification
- cargo test --manifest-path cli-rs/Cargo.toml --locked
- cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets -- -D warnings
- skill quick validator
- adversarial fresh-agent forward test