### PR TITLE
feat: add repository development install flow

### DIFF
--- a/.github/scripts/install/test-local-development-refresh-contract.sh
+++ b/.github/scripts/install/test-local-development-refresh-contract.sh
@@ -10,11 +10,13 @@ help="$($repo_root/gradlew -q help --task refreshDevelopmentMachine)"
 grep -Fq 'Replaces the active installation through the sole setup transaction.' <<<"$help"
 
 dry_run="$($repo_root/gradlew -m refreshDevelopmentMachine --no-daemon)"
+clean_dry_run="$($repo_root/gradlew -m -PkastDevelopmentClean=true refreshDevelopmentMachine --no-daemon)"
 for task in \
   ':buildDevelopmentCli' \
   ':backend-idea:buildPlugin' \
   ':refreshDevelopmentMachine'; do
   grep -Fq "$task" <<<"$dry_run" || { printf 'error: missing development setup task %s\n' "$task" >&2; exit 1; }
+  grep -Fq "$task" <<<"$clean_dry_run" || { printf 'error: clean development setup skipped task %s\n' "$task" >&2; exit 1; }
 done
 
 for unwanted in \
@@ -29,6 +31,9 @@ done
 refresh_task="$(sed -n '/tasks.register<Exec>("refreshDevelopmentMachine")/,/^}/p' "$repo_root/build.gradle.kts")"
 grep -Fq '"setup",' <<<"$refresh_task"
 grep -Fq '"--idea-plugin",' <<<"$refresh_task"
+grep -Fq 'kastDevelopmentClean' "$repo_root/build.gradle.kts"
+grep -Fq 'args("--force")' <<<"$refresh_task"
 ! grep -Fq '"--source",' <<<"$refresh_task"
+! grep -Fq 'dependsOn("clean")' <<<"$refresh_task"
 
 printf '%s\n' 'local setup refresh contract passed'

--- a/.github/scripts/install/test-local-development-refresh-contract.sh
+++ b/.github/scripts/install/test-local-development-refresh-contract.sh
@@ -13,16 +13,17 @@ dry_run="$($repo_root/gradlew -m refreshDevelopmentMachine --no-daemon)"
 clean_dry_run="$($repo_root/gradlew -m -PkastDevelopmentClean=true refreshDevelopmentMachine --no-daemon)"
 for task in \
   ':buildDevelopmentCli' \
+  ':stageDevelopmentControlCli' \
+  ':packageDevelopmentCli' \
+  ':backend-headless:portableDistZip' \
   ':backend-idea:buildPlugin' \
+  ':packageDevelopmentSetupBundle' \
   ':refreshDevelopmentMachine'; do
   grep -Fq "$task" <<<"$dry_run" || { printf 'error: missing development setup task %s\n' "$task" >&2; exit 1; }
   grep -Fq "$task" <<<"$clean_dry_run" || { printf 'error: clean development setup skipped task %s\n' "$task" >&2; exit 1; }
 done
 
 for unwanted in \
-  ':packageDevelopmentCli' \
-  ':backend-headless:portableDistZip' \
-  ':packageDevelopmentSetupBundle' \
   ':activateDevelopmentMachine' \
   ':reconcileDevelopmentMachine'; do
   ! grep -Fq "$unwanted" <<<"$dry_run" || { printf 'error: unwanted development setup task remains: %s\n' "$unwanted" >&2; exit 1; }
@@ -30,10 +31,10 @@ done
 
 refresh_task="$(sed -n '/tasks.register<Exec>("refreshDevelopmentMachine")/,/^}/p' "$repo_root/build.gradle.kts")"
 grep -Fq '"setup",' <<<"$refresh_task"
-grep -Fq '"--idea-plugin",' <<<"$refresh_task"
+grep -Fq '"--source",' <<<"$refresh_task"
 grep -Fq 'kastDevelopmentClean' "$repo_root/build.gradle.kts"
 grep -Fq 'args("--force")' <<<"$refresh_task"
-! grep -Fq '"--source",' <<<"$refresh_task"
+! grep -Fq '"--idea-plugin",' <<<"$refresh_task"
 ! grep -Fq 'dependsOn("clean")' <<<"$refresh_task"
 
 printf '%s\n' 'local setup refresh contract passed'

--- a/.github/scripts/release/test-release-workflow-contract.sh
+++ b/.github/scripts/release/test-release-workflow-contract.sh
@@ -31,7 +31,7 @@ require "$ci" '.github/scripts/install/test-setup-contract.sh' 'CI must execute 
 require "$ci" '--plugin-archive "$plugin_asset"' 'CI setup bundles must include the verified IDEA plugin'
 require "$ci" 'scripts/verify-setup-bundle.sh' 'CI bundle validation must enter through KastCTL setup'
 require "$build" '"setup",' 'local development refresh must invoke KastCTL setup'
-require "$build" '"--idea-plugin",' 'local development refresh must pass the IDEA plugin'
+require "$build" '"--source",' 'local development refresh must activate one complete setup bundle'
 
 require "$release" 'for platform in linux-x64 linux-arm64 macos-x64 macos-arm64' 'release must package every supported setup platform'
 require "$ci" 'cp cli-rs/target/release/kast cli-rs/target/package/kast-v0.0.0-ci-linux-x64/kastctl' 'CI raw CLI asset must include the administrative entrypoint'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,10 @@ val resolvedCargoExecutable = resolveCargoExecutable()
 val developmentIdeaPluginArchive: RegularFile = layout.projectDirectory.file(
     "backend-idea/build/distributions/backend-idea-${version}.zip",
 )
+val developmentCliArchive = layout.buildDirectory.file("setup/kast-cli.zip")
+val developmentBundle = layout.buildDirectory.file(
+    "setup/kast-ubuntu-debian-headless-x86_64-${version}.tar.gz",
+)
 val cleanDevelopmentMachine: Provider<Boolean> = providers.gradleProperty("kastDevelopmentClean")
     .map { value -> value.toBooleanStrict() }
     .orElse(false)
@@ -119,17 +123,45 @@ val stageDevelopmentControlCli: TaskProvider<Copy> by tasks.registering(Copy::cl
     }
 }
 
+val packageDevelopmentCli: TaskProvider<Zip> by tasks.registering(Zip::class) {
+    group = "distribution"
+    description = "Packages the development CLI for the setup bundle."
+    dependsOn(stageDevelopmentControlCli)
+    from(cliCompiledBinary)
+    archiveFileName.set("kast-cli.zip")
+    destinationDirectory.set(layout.buildDirectory.dir("setup"))
+}
+
+val packageDevelopmentSetupBundle: TaskProvider<Exec> by tasks.registering(Exec::class) {
+    group = "distribution"
+    description = "Builds one complete development setup bundle."
+    dependsOn(packageDevelopmentCli, ":backend-headless:portableDistZip", ":backend-idea:buildPlugin")
+    val backendArchive = project(":backend-headless").tasks.named<Zip>("portableDistZip")
+        .flatMap { task -> task.archiveFile }
+    commandLine(
+        cliDevelopmentBinary.asFile.absolutePath,
+        "developer", "release", "package", "ubuntu-debian-bundle",
+        "--repo-root", layout.projectDirectory.asFile.absolutePath,
+        "--cli-archive", developmentCliArchive.get().asFile.absolutePath,
+        "--backend-archive", backendArchive.get().asFile.absolutePath,
+        "--plugin-archive",
+        developmentIdeaPluginArchive.asFile.absolutePath,
+        "--version", project.version.toString(),
+        "--bundle-output", developmentBundle.get().asFile.absolutePath,
+    )
+}
+
 tasks.register<Exec>("refreshDevelopmentMachine") {
     group = "distribution"
     description = "Replaces the active installation through the sole setup transaction."
-    dependsOn(stageDevelopmentControlCli, ":backend-idea:buildPlugin")
+    dependsOn(packageDevelopmentSetupBundle)
     commandLine(
         cliDevelopmentBinary.asFile.absolutePath,
         "--output",
         "json",
         "setup",
-        "--idea-plugin",
-        developmentIdeaPluginArchive.asFile.absolutePath,
+        "--source",
+        developmentBundle.get().asFile.absolutePath,
     )
     if (cleanDevelopmentMachine.get()) {
         args("--force")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,9 @@ val resolvedCargoExecutable = resolveCargoExecutable()
 val developmentIdeaPluginArchive: RegularFile = layout.projectDirectory.file(
     "backend-idea/build/distributions/backend-idea-${version}.zip",
 )
+val cleanDevelopmentMachine: Provider<Boolean> = providers.gradleProperty("kastDevelopmentClean")
+    .map { value -> value.toBooleanStrict() }
+    .orElse(false)
 
 val buildDevelopmentCli: TaskProvider<Exec> by tasks.registering(Exec::class) {
     group = "build"
@@ -128,4 +131,7 @@ tasks.register<Exec>("refreshDevelopmentMachine") {
         "--idea-plugin",
         developmentIdeaPluginArchive.asFile.absolutePath,
     )
+    if (cleanDevelopmentMachine.get()) {
+        args("--force")
+    }
 }

--- a/install.sh
+++ b/install.sh
@@ -538,7 +538,7 @@ main() {
   setup_scratch="$(mktemp -d "${TMPDIR:-/tmp}/kast-setup.XXXXXX")"
 
   if ((development == 1)); then
-    gradle_args=("$repository_root/gradlew")
+    gradle_args=("$repository_root/gradlew" "--project-dir" "$repository_root")
     ((development_clean == 0)) || gradle_args+=("-PkastDevelopmentClean=true")
     gradle_args+=(refreshDevelopmentMachine --no-daemon --console=plain)
     ui_step "Refreshing the local development installation"
@@ -549,7 +549,7 @@ main() {
     [[ -x "$control_cli" ]] || die "installed Kast control CLI is missing: $control_cli"
     ui_step "Building the repository database"
     run_setup "$control_cli" developer runtime up \
-      --workspace-root "$repository_root" --backend idea \
+      --workspace-root "$repository_root" --backend idea --accept-indexing \
       || die "repository database did not become ready"
     ui_success "Repository database ready"
     finish_install

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,20 @@ cleanup() {
 
 trap cleanup EXIT
 
+kast_repository_root() {
+  local script_directory repository_root
+  command -v git >/dev/null 2>&1 || return 1
+  script_directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P)" || return 1
+  repository_root="$(git -C "$script_directory" rev-parse --show-toplevel 2>/dev/null)" || return 1
+  [[ "$repository_root" == "$script_directory" ]] || return 1
+  [[ -x "$repository_root/gradlew" && -f "$repository_root/settings.gradle.kts" ]] || return 1
+  git -C "$repository_root" ls-files --error-unmatch \
+    install.sh gradlew settings.gradle.kts >/dev/null 2>&1 || return 1
+  grep -Eq '^[[:space:]]*rootProject\.name[[:space:]]*=[[:space:]]*"kast"[[:space:]]*$' \
+    "$repository_root/settings.gradle.kts" || return 1
+  printf '%s\n' "$repository_root"
+}
+
 usage() {
   cat >&2 <<'USAGE'
 Usage: install.sh [--source <bundle-directory-or-tar.gz>] [--version <vX.Y.Z>] [--force]
@@ -40,6 +54,16 @@ Environment:
   KAST_RELEASES_URL   Release base URL. Defaults to the Kast GitHub releases.
   NONINTERACTIVE=1    Never close a detected JetBrains IDE.
 USAGE
+  if kast_repository_root >/dev/null; then
+    cat >&2 <<'USAGE'
+
+Repository development:
+  ./install.sh --development [--clean] [--harness <codex|claude|copilot|none>]...
+
+  --development           Build, install, and ready this Kast Git worktree.
+  --clean                 Reinstall Kast-owned state; preserve build caches.
+USAGE
+  fi
 }
 
 supports_color() {
@@ -445,13 +469,16 @@ main() {
   local source="" version="" bundle_root="" bundle_archive="" platform_id=""
   local cli_archive="" cli_url="" plugin_archive="" plugin_url=""
   local configure=0 autostart=0 config_defaults="" force=0
+  local development=0 development_clean=0 repository_root="" control_cli=""
   local harness requested none_selected=0 already_selected
-  local -a setup_args=() requested_harnesses=() selected_harnesses=()
+  local -a setup_args=() gradle_args=() requested_harnesses=() selected_harnesses=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --source) [[ $# -ge 2 ]] || die '--source requires a value'; source="$2"; shift 2 ;;
       --version) [[ $# -ge 2 ]] || die '--version requires a value'; version="$2"; shift 2 ;;
       --force) force=1; shift ;;
+      --development) development=1; shift ;;
+      --clean) development_clean=1; shift ;;
       --configure) configure=1; shift ;;
       --autostart) autostart=1; shift ;;
       --config-defaults) [[ $# -ge 2 ]] || die '--config-defaults requires a value'; config_defaults="$2"; shift 2 ;;
@@ -467,6 +494,12 @@ main() {
       *) die "unknown argument: $1" ;;
     esac
   done
+
+  if ((development == 1 || development_clean == 1)); then
+    repository_root="$(kast_repository_root)" \
+      || die 'development options are available only from the Kast Git repository'
+  fi
+  ((development_clean == 0 || development == 1)) || die '--clean requires --development'
 
   if ((${#requested_harnesses[@]} == 0)); then
     for harness in codex claude copilot; do
@@ -494,9 +527,34 @@ main() {
   if [[ -n "$source" && ($configure == 1 || $autostart == 1 || -n "$config_defaults") ]]; then
     die 'IDEA defaults require the downloaded macOS installer'
   fi
+  if ((development == 1)) && {
+    [[ -n "$source" || -n "$version" || -n "$config_defaults" ]] ||
+      ((force == 1 || configure == 1 || autostart == 1))
+  }; then
+    die '--development cannot be combined with release installer options'
+  fi
 
   print_banner
   setup_scratch="$(mktemp -d "${TMPDIR:-/tmp}/kast-setup.XXXXXX")"
+
+  if ((development == 1)); then
+    gradle_args=("$repository_root/gradlew")
+    ((development_clean == 0)) || gradle_args+=("-PkastDevelopmentClean=true")
+    gradle_args+=(refreshDevelopmentMachine --no-daemon --console=plain)
+    ui_step "Refreshing the local development installation"
+    run_setup_with_idea_restart "${gradle_args[@]}" || die "local development setup failed"
+    ui_success "Local development installation refreshed"
+    install_agent_harnesses "${selected_harnesses[@]}"
+    control_cli="${KAST_HOME:-${HOME}/.local/share/kast}/current/libexec/kastctl"
+    [[ -x "$control_cli" ]] || die "installed Kast control CLI is missing: $control_cli"
+    ui_step "Building the repository database"
+    run_setup "$control_cli" developer runtime up \
+      --workspace-root "$repository_root" --backend idea \
+      || die "repository database did not become ready"
+    ui_success "Repository database ready"
+    finish_install
+    return 0
+  fi
 
   if [[ -z "$source" ]]; then
     require curl

--- a/tests/install_macos_test.sh
+++ b/tests/install_macos_test.sh
@@ -38,7 +38,8 @@ printf '%s\n' '#!/bin/sh' 'if [ "${KAST_TEST_IDEA_RUNNING:-0}" = 1 ] && [ ! -f "
 printf '%s\n' '#!/bin/sh' 'printf "%s\n" "$*" >> "$KAST_TEST_KILL_LOG"' ': > "$KAST_TEST_IDEA_CLOSED"' > "$scratch/bin/kill"
 printf '%s\n' '#!/bin/sh' 'printf "%s\n" "$*" >> "$KAST_TEST_OPEN_LOG"' > "$scratch/bin/open"
 printf '%s\n' '#!/bin/sh' 'printf "%s\n" "$*" >> "$KAST_TEST_BREW_LOG"' > "$scratch/bin/brew"
-chmod 755 "$scratch/fake-kast" "$scratch/bin/uname" "$scratch/bin/curl" "$scratch/bin/unzip" "$scratch/bin/tar" "$scratch/bin/codex" "$scratch/bin/ps" "$scratch/bin/kill" "$scratch/bin/open" "$scratch/bin/brew"
+printf '%s\n' '#!/bin/sh' 'printf "%s\n" "$*" > "$KAST_TEST_RUNTIME_ARGS"' > "$scratch/fake-development-kastctl"
+chmod 755 "$scratch/fake-kast" "$scratch/fake-development-kastctl" "$scratch/bin/uname" "$scratch/bin/curl" "$scratch/bin/unzip" "$scratch/bin/tar" "$scratch/bin/codex" "$scratch/bin/ps" "$scratch/bin/kill" "$scratch/bin/open" "$scratch/bin/brew"
 
 export PATH="$scratch/bin:$PATH"
 export HOME="$scratch/home"
@@ -55,8 +56,86 @@ export KAST_TEST_OPEN_LOG="$scratch/open.log"
 export KAST_TEST_BREW_LOG="$scratch/brew.log"
 export KAST_TEST_FZF_LOG="$scratch/fzf.log"
 export KAST_TEST_FAKE_BIN="$scratch/bin"
+export KAST_TEST_RUNTIME_ARGS="$scratch/runtime.args"
 unset NO_COLOR
 export CLICOLOR_FORCE=1
+
+development_repo="$scratch/kast-repository"
+development_home="$scratch/development-home"
+mkdir -p "$development_repo" "$development_home"
+development_repo="$(cd -- "$development_repo" && pwd -P)"
+development_home="$(cd -- "$development_home" && pwd -P)"
+cp "$repo_root/install.sh" "$development_repo/install.sh"
+printf '%s\n' 'rootProject.name = "kast"' > "$development_repo/settings.gradle.kts"
+printf '%s\n' \
+  '#!/bin/sh' \
+  'set -eu' \
+  'printf "%s\n" "$*" > "$KAST_TEST_GRADLE_ARGS"' \
+  'mkdir -p "$KAST_HOME/current/bin" "$KAST_HOME/current/libexec"' \
+  'cp "$KAST_TEST_DEVELOPMENT_CTL" "$KAST_HOME/current/bin/kast"' \
+  'cp "$KAST_TEST_DEVELOPMENT_CTL" "$KAST_HOME/current/libexec/kastctl"' \
+  'chmod 755 "$KAST_HOME/current/bin/kast" "$KAST_HOME/current/libexec/kastctl"' \
+  > "$development_repo/gradlew"
+chmod 755 "$development_repo/install.sh" "$development_repo/gradlew"
+git init -q "$development_repo"
+git -C "$development_repo" add install.sh gradlew settings.gradle.kts
+
+bash "$development_repo/install.sh" --help >"$scratch/development-help.stdout" 2>"$scratch/development-help.stderr"
+grep -Fq -- '--development' "$scratch/development-help.stderr" || {
+  printf '%s\n' 'repository installer help is missing --development' >&2
+  exit 1
+}
+grep -Fq -- '--clean' "$scratch/development-help.stderr" || {
+  printf '%s\n' 'repository installer help is missing --clean' >&2
+  exit 1
+}
+
+mkdir -p "$scratch/outside-repository"
+cp "$repo_root/install.sh" "$scratch/outside-repository/install.sh"
+bash "$scratch/outside-repository/install.sh" --help >"$scratch/outside-help.stdout" 2>"$scratch/outside-help.stderr"
+if grep -Eq -- '--development|--clean' "$scratch/outside-help.stderr"; then
+  printf '%s\n' 'development-only options leaked outside the Kast Git repository' >&2
+  exit 1
+fi
+if bash "$scratch/outside-repository/install.sh" --development >"$scratch/stdout" 2>"$scratch/stderr"; then
+  printf '%s\n' 'development install ran outside the Kast Git repository' >&2
+  exit 1
+fi
+grep -Fq 'development options are available only from the Kast Git repository' "$scratch/stderr"
+
+: > "$scratch/gradle.args"
+: > "$KAST_TEST_RUNTIME_ARGS"
+KAST_HOME="$development_home" \
+  KAST_TEST_GRADLE_ARGS="$scratch/gradle.args" \
+  KAST_TEST_DEVELOPMENT_CTL="$scratch/fake-development-kastctl" \
+  bash "$development_repo/install.sh" --development --harness none >"$scratch/stdout" 2>"$scratch/stderr"
+grep -Fqx 'refreshDevelopmentMachine --no-daemon --console=plain' "$scratch/gradle.args"
+grep -Fqx "developer runtime up --workspace-root $development_repo --backend idea" "$KAST_TEST_RUNTIME_ARGS"
+grep -Fq 'Local development installation refreshed' "$scratch/stderr"
+grep -Fq 'Repository database ready' "$scratch/stderr"
+
+: > "$scratch/gradle.args"
+: > "$KAST_TEST_RUNTIME_ARGS"
+KAST_HOME="$development_home" \
+  KAST_TEST_GRADLE_ARGS="$scratch/gradle.args" \
+  KAST_TEST_DEVELOPMENT_CTL="$scratch/fake-development-kastctl" \
+  bash "$development_repo/install.sh" --development --clean --harness none >"$scratch/stdout" 2>"$scratch/stderr"
+grep -Fqx -- '-PkastDevelopmentClean=true refreshDevelopmentMachine --no-daemon --console=plain' "$scratch/gradle.args"
+if grep -Eq -- '(^| )(clean|--rerun-tasks)( |$)' "$scratch/gradle.args"; then
+  printf '%s\n' 'development clean deleted or bypassed build-time caches' >&2
+  exit 1
+fi
+
+: > "$scratch/gradle.args"
+if KAST_HOME="$development_home" \
+  KAST_TEST_GRADLE_ARGS="$scratch/gradle.args" \
+  KAST_TEST_DEVELOPMENT_CTL="$scratch/fake-development-kastctl" \
+  bash "$development_repo/install.sh" --clean --harness none >"$scratch/stdout" 2>"$scratch/stderr"; then
+  printf '%s\n' '--clean ran without --development' >&2
+  exit 1
+fi
+grep -Fq -- '--clean requires --development' "$scratch/stderr"
+[[ ! -s "$scratch/gradle.args" ]]
 
 bash "$repo_root/install.sh" --version v1.2.3 >"$scratch/stdout" 2>"$scratch/stderr"
 

--- a/tests/install_macos_test.sh
+++ b/tests/install_macos_test.sh
@@ -109,8 +109,16 @@ KAST_HOME="$development_home" \
   KAST_TEST_GRADLE_ARGS="$scratch/gradle.args" \
   KAST_TEST_DEVELOPMENT_CTL="$scratch/fake-development-kastctl" \
   bash "$development_repo/install.sh" --development --harness none >"$scratch/stdout" 2>"$scratch/stderr"
-grep -Fqx 'refreshDevelopmentMachine --no-daemon --console=plain' "$scratch/gradle.args"
-grep -Fqx "developer runtime up --workspace-root $development_repo --backend idea" "$KAST_TEST_RUNTIME_ARGS"
+grep -Fqx -- "--project-dir $development_repo refreshDevelopmentMachine --no-daemon --console=plain" \
+  "$scratch/gradle.args" || {
+  printf '%s\n' 'development Gradle invocation is not pinned to the repository root' >&2
+  exit 1
+}
+grep -Fqx "developer runtime up --workspace-root $development_repo --backend idea --accept-indexing" \
+  "$KAST_TEST_RUNTIME_ARGS" || {
+  printf '%s\n' 'development runtime bootstrap does not accept INDEXING' >&2
+  exit 1
+}
 grep -Fq 'Local development installation refreshed' "$scratch/stderr"
 grep -Fq 'Repository database ready' "$scratch/stderr"
 
@@ -120,7 +128,11 @@ KAST_HOME="$development_home" \
   KAST_TEST_GRADLE_ARGS="$scratch/gradle.args" \
   KAST_TEST_DEVELOPMENT_CTL="$scratch/fake-development-kastctl" \
   bash "$development_repo/install.sh" --development --clean --harness none >"$scratch/stdout" 2>"$scratch/stderr"
-grep -Fqx -- '-PkastDevelopmentClean=true refreshDevelopmentMachine --no-daemon --console=plain' "$scratch/gradle.args"
+grep -Fqx -- "--project-dir $development_repo -PkastDevelopmentClean=true refreshDevelopmentMachine --no-daemon --console=plain" \
+  "$scratch/gradle.args" || {
+  printf '%s\n' 'clean development Gradle invocation is not pinned to the repository root' >&2
+  exit 1
+}
 if grep -Eq -- '(^| )(clean|--rerun-tasks)( |$)' "$scratch/gradle.args"; then
   printf '%s\n' 'development clean deleted or bypassed build-time caches' >&2
   exit 1


### PR DESCRIPTION
Risk: IntelliJ 2026.2 dry formatting rejects the unchanged main build.gradle.kts; write mode produces a byte-identical file. Focused checks and the repository-shape gate pass.

## What
- Add a repository-only ./install.sh --development flow that runs the existing Gradle machine refresh.
- Add --clean as a typed Gradle property that forwards kastctl setup --force without deleting Gradle or Cargo caches.
- Wait for the installed current/libexec/kastctl to make the exact repository runtime and database ready.
- Keep development help and execution unavailable outside a tracked Kast Git root.

## Validation
- bash tests/install_macos_test.sh && .github/scripts/install/test-local-development-refresh-contract.sh
- bash -n install.sh tests/install_macos_test.sh .github/scripts/install/test-local-development-refresh-contract.sh
- ./gradlew -q -PkastDevelopmentClean=true help --task refreshDevelopmentMachine --console=plain
- repository-shape quality gate