### PR TITLE
fix: reuse release artifacts across retries

### DIFF
--- a/.github/scripts/release/actions/build-cli/action.yml
+++ b/.github/scripts/release/actions/build-cli/action.yml
@@ -1,0 +1,127 @@
+name: Build release CLI asset
+description: Build, verify, package, and retain one release CLI asset
+
+inputs:
+  asset_id:
+    description: Release platform identifier
+    required: true
+  target:
+    description: Rust target triple
+    required: true
+  cache_key:
+    description: Trusted Rust cache key
+    required: true
+  release_tag:
+    description: Release tag
+    required: true
+  release_version:
+    description: Release version without the v prefix
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ inputs.target }}
+
+    - name: Restore platform Rust release build
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+      with:
+        workspaces: cli-rs -> target
+        shared-key: ${{ inputs.cache_key }}
+        cache-bin: "false"
+
+    - name: Build Rust CLI
+      working-directory: cli-rs
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ "${{ inputs.asset_id }}" == 'linux-x64' ]]; then
+          KAST_VERSION="${{ inputs.release_version }}" cargo build --release --locked
+        else
+          KAST_VERSION="${{ inputs.release_version }}" \
+            cargo build --release --locked --target "${{ inputs.target }}"
+        fi
+
+    - name: Smoke Rust CLI
+      working-directory: cli-rs
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ "${{ inputs.asset_id }}" == 'linux-x64' ]]; then
+          bin="target/release/kast"
+        else
+          bin="target/${{ inputs.target }}/release/kast"
+        fi
+        smoke_dir="$RUNNER_TEMP/kast-cli-smoke"
+        mkdir -p "$smoke_dir"
+        cp "$bin" "$smoke_dir/kastctl"
+        cp "$bin" "$smoke_dir/kast"
+        "$smoke_dir/kastctl" --help >/dev/null
+        "$smoke_dir/kastctl" version | grep -Fx "Kast CLI ${{ inputs.release_version }}" >/dev/null
+        "$smoke_dir/kast" --help >/dev/null
+        cmp -s "$smoke_dir/kastctl" "$smoke_dir/kast"
+
+    - name: Package CLI asset
+      shell: bash
+      run: |
+        set -euo pipefail
+        tag="${{ inputs.release_tag }}"
+        asset_name="kast-${tag}-${{ inputs.asset_id }}.zip"
+        staging_dir="$RUNNER_TEMP/kast-${{ inputs.asset_id }}"
+        rm -rf "$staging_dir" dist
+        mkdir -p "$staging_dir" dist
+        if [[ "${{ inputs.asset_id }}" == 'linux-x64' ]]; then
+          binary="cli-rs/target/release/kast"
+        else
+          binary="cli-rs/target/${{ inputs.target }}/release/kast"
+        fi
+        cp "$binary" "$staging_dir/kastctl"
+        cp "$binary" "$staging_dir/kast"
+        chmod 755 "$staging_dir/kastctl" "$staging_dir/kast"
+        cmp -s "$staging_dir/kastctl" "$staging_dir/kast"
+        (cd "$staging_dir" && zip -9 -q "$GITHUB_WORKSPACE/dist/${asset_name}" kastctl kast)
+        python3 - "$GITHUB_WORKSPACE/dist/${asset_name}" "dist/build-provenance-cli-${{ inputs.asset_id }}.json" <<'PY'
+        import hashlib
+        import json
+        import os
+        import sys
+        from pathlib import Path
+        asset = Path(sys.argv[1])
+        output = Path(sys.argv[2])
+        digest = hashlib.sha256(asset.read_bytes()).hexdigest()
+        payload = {
+            "runId": os.environ["GITHUB_RUN_ID"],
+            "runNumber": os.environ["GITHUB_RUN_NUMBER"],
+            "runAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
+            "sha": os.environ["GITHUB_SHA"],
+            "ref": os.environ["GITHUB_REF"],
+            "workflowRef": os.environ["GITHUB_WORKFLOW_REF"],
+            "actor": os.environ["GITHUB_ACTOR"],
+            "platformId": "cli-${{ inputs.asset_id }}",
+            "assetName": asset.name,
+            "assetDigest": "sha256:" + digest,
+        }
+        output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        PY
+        scripts/verify-ci-artifact-ledger.py record \
+          --output "dist/build-ledger-cli-${{ inputs.asset_id }}.json" \
+          --git-sha "$GITHUB_SHA" \
+          --source-ref "refs/tags/${tag}" \
+          --workflow-run-id "$GITHUB_RUN_ID" \
+          --artifact-kind "release-cli-${{ inputs.asset_id }}" \
+          --artifact-name "$asset_name" \
+          --artifact-path "dist/${asset_name}" \
+          --producer-job "build-cli-${{ inputs.asset_id }}" \
+          --build-command-id "release-rust-cli-${{ inputs.asset_id }}"
+
+    - name: Retain CLI build artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: rust-cli-${{ inputs.asset_id }}-${{ github.run_id }}
+        path: dist/
+        if-no-files-found: error
+        compression-level: 0
+        retention-days: 30

--- a/.github/scripts/release/actions/build-setup-bundle/action.yml
+++ b/.github/scripts/release/actions/build-setup-bundle/action.yml
@@ -1,0 +1,136 @@
+name: Build release setup bundle
+description: Build, verify, and retain one release setup bundle
+
+inputs:
+  platform:
+    description: Setup bundle platform identifier
+    required: true
+  tag:
+    description: Release tag
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download Linux packager CLI
+      uses: actions/download-artifact@v7
+      with:
+        name: rust-cli-linux-x64-${{ github.run_id }}
+        path: provenance-cli
+
+    - name: Download target CLI
+      if: inputs.platform != 'linux-x64'
+      uses: actions/download-artifact@v7
+      with:
+        name: rust-cli-${{ inputs.platform }}-${{ github.run_id }}
+        path: provenance-cli
+
+    - name: Download headless backend artifact
+      uses: actions/download-artifact@v7
+      with:
+        name: headless-backend-${{ github.run_id }}
+        path: headless-backend
+
+    - name: Download IDEA plugin artifact
+      uses: actions/download-artifact@v7
+      with:
+        name: idea-plugin-${{ github.run_id }}
+        path: idea-plugin
+
+    - name: Build setup bundle
+      shell: bash
+      run: |
+        set -euo pipefail
+        tag="${{ inputs.tag }}"
+        platform="${{ inputs.platform }}"
+        cli_asset="provenance-cli/kast-${tag}-${platform}.zip"
+        packager_archive="provenance-cli/kast-${tag}-linux-x64.zip"
+        backend_asset="headless-backend/headless.zip"
+        plugin_asset="idea-plugin/kast-idea-${tag}.zip"
+        work="$RUNNER_TEMP/kast-setup-bundle"
+        asset="dist/kast-${platform}-${tag}.tar.gz"
+        rm -rf "$work" dist
+        mkdir -p "$work/packager" dist/provenance
+        [[ -f "$cli_asset" ]] || { echo "Missing platform CLI asset: ${cli_asset}" >&2; exit 1; }
+        [[ -f "$packager_archive" ]] || { echo "Missing Linux packager CLI: ${packager_archive}" >&2; exit 1; }
+        [[ -f "$backend_asset" ]] || { echo "Missing headless backend asset: ${backend_asset}" >&2; exit 1; }
+        [[ -f "$plugin_asset" ]] || { echo "Missing IDEA plugin asset: ${plugin_asset}" >&2; exit 1; }
+        cli_evidence=(
+          --ledger provenance-cli/build-ledger-cli-linux-x64.json
+          --require-kind release-cli-linux-x64
+          --artifact "release-cli-linux-x64=provenance-cli/kast-${tag}-linux-x64.zip"
+        )
+        if [[ "$platform" != "linux-x64" ]]; then
+          cli_evidence+=(
+            --ledger "provenance-cli/build-ledger-cli-${platform}.json"
+            --require-kind "release-cli-${platform}"
+            --artifact "release-cli-${platform}=${cli_asset}"
+          )
+        fi
+        scripts/verify-ci-artifact-ledger.py verify \
+          "${cli_evidence[@]}" \
+          --ledger headless-backend/build-ledger-headless-backend.json \
+          --ledger idea-plugin/build-ledger-idea-plugin.json \
+          --git-sha "$GITHUB_SHA" \
+          --require-kind release-headless-backend \
+          --require-kind release-idea-plugin \
+          --artifact "release-headless-backend=${backend_asset}" \
+          --artifact "release-idea-plugin=${plugin_asset}"
+        python3 -m zipfile -e "$packager_archive" "$work/packager"
+        packager_bin="$work/packager/kastctl"
+        [[ -f "$packager_bin" ]] || { echo "Missing extracted Rust CLI binary: ${packager_bin}" >&2; exit 1; }
+        chmod 755 "$packager_bin"
+        "$packager_bin" developer release package ubuntu-debian-bundle \
+          --repo-root "$PWD" \
+          --cli-archive "$cli_asset" \
+          --backend-archive "$backend_asset" \
+          --plugin-archive "$plugin_asset" \
+          --platform "$platform" \
+          --version "$tag" \
+          --bundle-output "$asset"
+        python3 - "$asset" "dist/provenance/build-provenance-setup-${platform}.json" "$platform" <<'PY'
+        import hashlib, json, os, sys
+        from pathlib import Path
+        asset = Path(sys.argv[1])
+        payload = {
+            "runId": os.environ["GITHUB_RUN_ID"],
+            "runNumber": os.environ["GITHUB_RUN_NUMBER"],
+            "runAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
+            "sha": os.environ["GITHUB_SHA"],
+            "ref": os.environ["GITHUB_REF"],
+            "workflowRef": os.environ["GITHUB_WORKFLOW_REF"],
+            "actor": os.environ["GITHUB_ACTOR"],
+            "platformId": f"setup-{sys.argv[3]}",
+            "assetName": asset.name,
+            "assetDigest": "sha256:" + hashlib.sha256(asset.read_bytes()).hexdigest(),
+        }
+        Path(sys.argv[2]).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        PY
+        scripts/verify-ci-artifact-ledger.py record \
+          --output "dist/provenance/build-ledger-setup-${platform}.json" \
+          --git-sha "$GITHUB_SHA" \
+          --source-ref "refs/tags/${tag}" \
+          --workflow-run-id "$GITHUB_RUN_ID" \
+          --artifact-kind "release-setup-${platform}" \
+          --artifact-name "$(basename -- "$asset")" \
+          --artifact-path "$asset" \
+          --producer-job "build-setup-${platform}" \
+          --build-command-id "release-setup-${platform}-package"
+        scripts/verify-ci-artifact-ledger.py verify \
+          --ledger "dist/provenance/build-ledger-setup-${platform}.json" \
+          --git-sha "$GITHUB_SHA" \
+          --require-kind "release-setup-${platform}" \
+          --artifact "release-setup-${platform}=${asset}"
+        (cd dist && sha256sum -c "$(basename -- "$asset").sha256")
+
+    - name: Retain setup bundle
+      uses: actions/upload-artifact@v6
+      with:
+        name: setup-bundle-${{ inputs.platform }}-${{ github.run_id }}
+        path: |
+          dist/kast-${{ inputs.platform }}-${{ inputs.tag }}.tar.gz
+          dist/kast-${{ inputs.platform }}-${{ inputs.tag }}.tar.gz.sha256
+          dist/provenance/
+        if-no-files-found: error
+        compression-level: 0
+        retention-days: 30

--- a/.github/scripts/release/actions/publish-cli/action.yml
+++ b/.github/scripts/release/actions/publish-cli/action.yml
@@ -1,0 +1,42 @@
+name: Publish release CLI asset
+description: Verify and publish one retained release CLI asset
+
+inputs:
+  asset_id:
+    description: Release platform identifier
+    required: true
+  tag:
+    description: Release tag
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download retained CLI asset
+      uses: actions/download-artifact@v7
+      with:
+        name: rust-cli-${{ inputs.asset_id }}-${{ github.run_id }}
+        path: dist
+
+    - name: Verify and publish retained CLI asset
+      shell: bash
+      run: |
+        set -euo pipefail
+        tag="${{ inputs.tag }}"
+        scripts/verify-ci-artifact-ledger.py verify \
+          --ledger "dist/build-ledger-cli-${{ inputs.asset_id }}.json" \
+          --git-sha "$GITHUB_SHA" \
+          --require-kind "release-cli-${{ inputs.asset_id }}" \
+          --artifact "release-cli-${{ inputs.asset_id }}=dist/kast-${tag}-${{ inputs.asset_id }}.zip"
+        .github/scripts/release/upload-immutable-release-asset.sh \
+          --tag "$tag" \
+          --asset "dist/kast-${tag}-${{ inputs.asset_id }}.zip"
+
+    - name: Retain CLI provenance
+      uses: actions/upload-artifact@v6
+      with:
+        name: cli-provenance-${{ inputs.asset_id }}-${{ github.run_id }}
+        path: dist/build-provenance-cli-${{ inputs.asset_id }}.json
+        if-no-files-found: error
+        overwrite: true
+        retention-days: 30

--- a/.github/scripts/release/actions/publish-setup-bundle/action.yml
+++ b/.github/scripts/release/actions/publish-setup-bundle/action.yml
@@ -1,0 +1,44 @@
+name: Publish release setup bundle
+description: Verify and publish one retained release setup bundle
+
+inputs:
+  platform:
+    description: Setup bundle platform identifier
+    required: true
+  tag:
+    description: Release tag
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download retained setup bundle
+      uses: actions/download-artifact@v7
+      with:
+        name: setup-bundle-${{ inputs.platform }}-${{ github.run_id }}
+        path: dist
+
+    - name: Verify and publish retained setup bundle
+      shell: bash
+      run: |
+        set -euo pipefail
+        tag="${{ inputs.tag }}"
+        platform="${{ inputs.platform }}"
+        asset="dist/kast-${platform}-${tag}.tar.gz"
+        scripts/verify-ci-artifact-ledger.py verify \
+          --ledger "dist/provenance/build-ledger-setup-${platform}.json" \
+          --git-sha "$GITHUB_SHA" \
+          --require-kind "release-setup-${platform}" \
+          --artifact "release-setup-${platform}=${asset}"
+        (cd dist && sha256sum -c "$(basename -- "$asset").sha256")
+        .github/scripts/release/upload-immutable-release-asset.sh --tag "$tag" --asset "$asset"
+        .github/scripts/release/upload-immutable-release-asset.sh --tag "$tag" --asset "${asset}.sha256"
+
+    - name: Retain setup bundle provenance
+      uses: actions/upload-artifact@v6
+      with:
+        name: setup-bundle-provenance-${{ inputs.platform }}-${{ github.run_id }}
+        path: dist/provenance/
+        if-no-files-found: error
+        overwrite: true
+        retention-days: 30

--- a/.github/scripts/release/metadata/release-workflow-model.json
+++ b/.github/scripts/release/metadata/release-workflow-model.json
@@ -1,0 +1,438 @@
+{
+  "schemaVersion": 1,
+  "evidenceMode": "structural-only",
+  "provenance": {
+    "description": "Expanded release retry-isolation topology. Performance claims require a completed candidate release.",
+    "observedAt": "2026-07-30",
+    "source": ".github/workflows/release.yml",
+    "sourceSha256": "4a1cc18b9cf9a429c2c55814376fb5cf1912b5a30b7ab0bffe824a5de9b294e3"
+  },
+  "tasks": [
+    {
+      "id": "prepare-release",
+      "needs": [],
+      "outputs": []
+    },
+    {
+      "id": "validate-jvm",
+      "needs": [
+        "prepare-release"
+      ],
+      "outputs": [
+        "release-jvm-validation"
+      ]
+    },
+    {
+      "id": "publish-maven-central",
+      "needs": [
+        "prepare-release",
+        "validate-jvm"
+      ],
+      "outputs": [
+        "release-maven-publication"
+      ]
+    },
+    {
+      "id": "build-openapi-spec",
+      "needs": [
+        "prepare-release"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "publish-openapi-spec",
+      "needs": [
+        "prepare-release",
+        "build-openapi-spec"
+      ],
+      "outputs": [
+        "release-openapi-asset"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "build-cli-linux-x64",
+      "needs": [
+        "prepare-release"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "build-cli-linux-arm64",
+      "needs": [
+        "prepare-release"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "build-cli-macos-x64",
+      "needs": [
+        "prepare-release"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "build-cli-macos-arm64",
+      "needs": [
+        "prepare-release"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "publish-cli-linux-x64",
+      "needs": [
+        "prepare-release",
+        "build-cli-linux-x64"
+      ],
+      "outputs": [
+        "release-cli-linux-x64-asset"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "publish-cli-linux-arm64",
+      "needs": [
+        "prepare-release",
+        "build-cli-linux-arm64"
+      ],
+      "outputs": [
+        "release-cli-linux-arm64-asset"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "publish-cli-macos-x64",
+      "needs": [
+        "prepare-release",
+        "build-cli-macos-x64"
+      ],
+      "outputs": [
+        "release-cli-macos-x64-asset"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "publish-cli-macos-arm64",
+      "needs": [
+        "prepare-release",
+        "build-cli-macos-arm64"
+      ],
+      "outputs": [
+        "release-cli-macos-arm64-asset"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "build-agent-resources",
+      "needs": [
+        "prepare-release"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "publish-agent-resources",
+      "needs": [
+        "prepare-release",
+        "build-agent-resources"
+      ],
+      "outputs": [
+        "release-agent-resource-assets"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "build-idea-plugin",
+      "needs": [
+        "prepare-release"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "publish-idea-plugin",
+      "needs": [
+        "prepare-release",
+        "build-idea-plugin"
+      ],
+      "outputs": [
+        "release-idea-plugin-assets"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "build-headless-backend",
+      "needs": [
+        "prepare-release"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "build-linux-headless-tarball",
+      "needs": [
+        "prepare-release",
+        "build-cli-linux-x64",
+        "build-headless-backend",
+        "build-idea-plugin"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "publish-linux-headless-assets",
+      "needs": [
+        "prepare-release",
+        "build-linux-headless-tarball"
+      ],
+      "outputs": [
+        "release-linux-headless-assets"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "build-setup-linux-x64",
+      "needs": [
+        "prepare-release",
+        "build-cli-linux-x64",
+        "build-idea-plugin",
+        "build-headless-backend"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "build-setup-linux-arm64",
+      "needs": [
+        "prepare-release",
+        "build-cli-linux-x64",
+        "build-cli-linux-arm64",
+        "build-idea-plugin",
+        "build-headless-backend"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "build-setup-macos-x64",
+      "needs": [
+        "prepare-release",
+        "build-cli-linux-x64",
+        "build-cli-macos-x64",
+        "build-idea-plugin",
+        "build-headless-backend"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "build-setup-macos-arm64",
+      "needs": [
+        "prepare-release",
+        "build-cli-linux-x64",
+        "build-cli-macos-arm64",
+        "build-idea-plugin",
+        "build-headless-backend"
+      ],
+      "outputs": []
+    },
+    {
+      "id": "publish-setup-linux-x64",
+      "needs": [
+        "prepare-release",
+        "build-setup-linux-x64"
+      ],
+      "outputs": [
+        "release-setup-linux-x64-asset",
+        "release-setup-linux-x64-sidecar",
+        "release-setup-linux-x64-provenance"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "publish-setup-linux-arm64",
+      "needs": [
+        "prepare-release",
+        "build-setup-linux-arm64"
+      ],
+      "outputs": [
+        "release-setup-linux-arm64-asset",
+        "release-setup-linux-arm64-sidecar",
+        "release-setup-linux-arm64-provenance"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "publish-setup-macos-x64",
+      "needs": [
+        "prepare-release",
+        "build-setup-macos-x64"
+      ],
+      "outputs": [
+        "release-setup-macos-x64-asset",
+        "release-setup-macos-x64-sidecar",
+        "release-setup-macos-x64-provenance"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "publish-setup-macos-arm64",
+      "needs": [
+        "prepare-release",
+        "build-setup-macos-arm64"
+      ],
+      "outputs": [
+        "release-setup-macos-arm64-asset",
+        "release-setup-macos-arm64-sidecar",
+        "release-setup-macos-arm64-provenance"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": true,
+      "publishesProductAssets": true,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "real-repository-indexing-ktor",
+      "needs": [
+        "prepare-release",
+        "build-linux-headless-tarball"
+      ],
+      "outputs": [
+        "release-index-ktor-proof"
+      ]
+    },
+    {
+      "id": "real-repository-indexing-spring-boot",
+      "needs": [
+        "prepare-release",
+        "build-linux-headless-tarball"
+      ],
+      "outputs": [
+        "release-index-spring-boot-proof"
+      ]
+    },
+    {
+      "id": "real-repository-indexing-okhttp",
+      "needs": [
+        "prepare-release",
+        "build-linux-headless-tarball"
+      ],
+      "outputs": [
+        "release-index-okhttp-proof"
+      ]
+    },
+    {
+      "id": "build-release-metadata",
+      "needs": [
+        "prepare-release",
+        "validate-jvm",
+        "publish-openapi-spec",
+        "publish-cli-linux-x64",
+        "publish-cli-linux-arm64",
+        "publish-cli-macos-x64",
+        "publish-cli-macos-arm64",
+        "publish-agent-resources",
+        "publish-idea-plugin",
+        "publish-linux-headless-assets",
+        "publish-setup-linux-x64",
+        "publish-setup-linux-arm64",
+        "publish-setup-macos-x64",
+        "publish-setup-macos-arm64",
+        "real-repository-indexing-ktor",
+        "real-repository-indexing-spring-boot",
+        "real-repository-indexing-okhttp"
+      ],
+      "outputs": [
+        "retained-release-metadata"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": false,
+      "publishesProductAssets": false,
+      "publishesMetadataAssets": false
+    },
+    {
+      "id": "publish-release",
+      "needs": [
+        "prepare-release",
+        "build-release-metadata"
+      ],
+      "outputs": [
+        "release-combined-provenance",
+        "release-sha256sums",
+        "published-release"
+      ],
+      "consumesRetainedAssets": true,
+      "consumesProductBytes": false,
+      "publishesProductAssets": false,
+      "publishesMetadataAssets": true
+    },
+    {
+      "id": "verify-release-state",
+      "needs": [
+        "prepare-release",
+        "publish-release"
+      ],
+      "outputs": [
+        "release-published-state-proof"
+      ]
+    }
+  ],
+  "requiredOutputs": [
+    "release-jvm-validation",
+    "release-maven-publication",
+    "release-openapi-asset",
+    "release-cli-linux-x64-asset",
+    "release-cli-linux-arm64-asset",
+    "release-cli-macos-x64-asset",
+    "release-cli-macos-arm64-asset",
+    "release-agent-resource-assets",
+    "release-idea-plugin-assets",
+    "release-linux-headless-assets",
+    "release-setup-linux-x64-asset",
+    "release-setup-linux-x64-sidecar",
+    "release-setup-linux-x64-provenance",
+    "release-setup-linux-arm64-asset",
+    "release-setup-linux-arm64-sidecar",
+    "release-setup-linux-arm64-provenance",
+    "release-setup-macos-x64-asset",
+    "release-setup-macos-x64-sidecar",
+    "release-setup-macos-x64-provenance",
+    "release-setup-macos-arm64-asset",
+    "release-setup-macos-arm64-sidecar",
+    "release-setup-macos-arm64-provenance",
+    "release-index-ktor-proof",
+    "release-index-spring-boot-proof",
+    "release-index-okhttp-proof",
+    "retained-release-metadata",
+    "release-combined-provenance",
+    "release-sha256sums",
+    "published-release",
+    "release-published-state-proof"
+  ]
+}

--- a/.github/scripts/release/metadata/render-release-checksums.py
+++ b/.github/scripts/release/metadata/render-release-checksums.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+
+SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"error: {message}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render SHA256SUMS from build provenance and uploaded release metadata."
+    )
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--provenance", required=True, type=Path)
+    parser.add_argument("--assets", required=True, type=Path)
+    parser.add_argument("--sidecars", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    return parser.parse_args()
+
+
+def load_object(path: Path) -> dict:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"cannot read JSON object {path}: {error}")
+    if not isinstance(payload, dict):
+        fail(f"JSON value is not an object: {path}")
+    return payload
+
+
+def expected_sidecar(asset_name: str) -> str | None:
+    if asset_name.endswith(".tar.gz"):
+        return f"{asset_name}.sha256"
+    if asset_name.endswith(".tar.zst"):
+        return f"{asset_name.removesuffix('.tar.zst')}.sha256"
+    return None
+
+
+def expected_assets(tag: str) -> dict[str, str]:
+    return {
+        "cli-linux-arm64": f"kast-{tag}-linux-arm64.zip",
+        "cli-linux-x64": f"kast-{tag}-linux-x64.zip",
+        "cli-macos-arm64": f"kast-{tag}-macos-arm64.zip",
+        "cli-macos-x64": f"kast-{tag}-macos-x64.zip",
+        "gradle-ro-cache": "gradle-ro-dep-cache.tar.zst",
+        "headless-linux-x64": "kast-headless-linux-x64.tar.zst",
+        "openapi": "openapi.yaml",
+        "runtime-manifest": "kast-runtime-manifest.json",
+        "setup-linux-arm64": f"kast-linux-arm64-{tag}.tar.gz",
+        "setup-linux-x64": f"kast-linux-x64-{tag}.tar.gz",
+        "setup-macos-arm64": f"kast-macos-arm64-{tag}.tar.gz",
+        "setup-macos-x64": f"kast-macos-x64-{tag}.tar.gz",
+        "ubuntu-debian-headless-x86_64": (
+            f"kast-ubuntu-debian-headless-x86_64-{tag}.tar.gz"
+        ),
+    }
+
+
+def provenance_assets(payload: dict, tag: str) -> dict[str, str]:
+    builds = payload.get("builds")
+    if not isinstance(builds, list) or not builds:
+        fail("build provenance must contain a non-empty builds array")
+    required_names = expected_assets(tag)
+    expected: dict[str, str] = {}
+    platforms: set[str] = set()
+    for entry in builds:
+        if not isinstance(entry, dict):
+            fail("build provenance entries must be objects")
+        platform = entry.get("platformId")
+        name = entry.get("assetName")
+        digest = entry.get("assetDigest")
+        if not isinstance(platform, str) or not platform:
+            fail("build provenance entry has no platformId")
+        if platform in platforms:
+            fail(f"duplicate build provenance platform: {platform}")
+        platforms.add(platform)
+        required_name = required_names.get(platform)
+        if required_name is None:
+            fail(f"unexpected build provenance platform: {platform}")
+        if not isinstance(name, str) or not name:
+            fail(f"build provenance entry {platform} has no assetName")
+        if name != required_name:
+            fail(
+                f"provenance asset mismatch for {platform}: "
+                f"expected {required_name}, got {name}"
+            )
+        if name in expected:
+            fail(f"duplicate build provenance asset: {name}")
+        if not isinstance(digest, str) or SHA256.fullmatch(digest) is None:
+            fail(f"build provenance entry {platform} has an invalid assetDigest")
+        expected[name] = digest
+    return expected
+
+
+def release_assets(payload: dict) -> dict[str, dict]:
+    assets = payload.get("assets")
+    if not isinstance(assets, list):
+        fail("release metadata must contain an assets array")
+    indexed: dict[str, dict] = {}
+    for asset in assets:
+        if not isinstance(asset, dict):
+            fail("release asset entries must be objects")
+        name = asset.get("name")
+        if not isinstance(name, str) or not name:
+            fail("release asset entry has no name")
+        if name in indexed:
+            fail(f"duplicate release asset: {name}")
+        indexed[name] = asset
+    return indexed
+
+
+def release_product_assets(remote: dict[str, dict], tag: str) -> set[str]:
+    plugin_name = f"kast-idea-{tag}.zip"
+    return {
+        name
+        for name in remote
+        if (
+            name.endswith(".zip")
+            or name.endswith(".tar.gz")
+            or name.endswith(".tar.zst")
+            or name == "kast-runtime-manifest.json"
+            or name == "openapi.yaml"
+        )
+        and name != plugin_name
+        and not name.endswith(".tar.gz.sha256")
+        and not name.endswith(".tar.zst.sha256")
+    }
+
+
+def require_uploaded(
+    remote_assets: dict[str, dict], name: str, expected_digest: str
+) -> None:
+    remote = remote_assets.get(name)
+    if remote is None:
+        fail(f"release asset is missing: {name}")
+    if remote.get("state") != "uploaded":
+        fail(f"release asset is not uploaded: {name}")
+    if remote.get("digest") != expected_digest:
+        fail(f"release asset digest does not match provenance: {name}")
+
+
+def read_sidecar(path: Path, asset_name: str) -> str:
+    try:
+        lines = [
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except OSError as error:
+        fail(f"cannot read checksum sidecar {path}: {error}")
+    if len(lines) != 1:
+        fail(f"checksum sidecar must contain one entry: {path.name}")
+    parts = lines[0].split()
+    if len(parts) != 2 or parts[1] != asset_name:
+        fail(f"checksum sidecar does not name {asset_name}: {path.name}")
+    digest = f"sha256:{parts[0]}"
+    if SHA256.fullmatch(digest) is None:
+        fail(f"checksum sidecar has an invalid digest: {path.name}")
+    return digest
+
+
+def render(
+    *, tag: str, provenance: Path, assets: Path, sidecars: Path, output: Path
+) -> None:
+    if not tag.startswith("v"):
+        fail(f"release tag must start with v: {tag}")
+    expected = provenance_assets(load_object(provenance), tag)
+    remote = release_assets(load_object(assets))
+    unexpected_products = sorted(release_product_assets(remote, tag) - set(expected))
+    if unexpected_products:
+        fail(f"unexpected release product asset: {unexpected_products}")
+    expected_sidecars = {
+        sidecar: asset
+        for asset in expected
+        if (sidecar := expected_sidecar(asset)) is not None
+    }
+    actual_sidecars = {path.name for path in sidecars.glob("*.sha256") if path.is_file()}
+    if actual_sidecars != set(expected_sidecars):
+        missing = sorted(set(expected_sidecars) - actual_sidecars)
+        unexpected = sorted(actual_sidecars - set(expected_sidecars))
+        fail(f"checksum sidecar set mismatch: missing={missing} unexpected={unexpected}")
+
+    for name, digest in expected.items():
+        require_uploaded(remote, name, digest)
+    for sidecar_name, asset_name in expected_sidecars.items():
+        sidecar_path = sidecars / sidecar_name
+        if read_sidecar(sidecar_path, asset_name) != expected[asset_name]:
+            fail(f"checksum sidecar digest does not match provenance: {sidecar_name}")
+        sidecar_digest = "sha256:" + hashlib.sha256(sidecar_path.read_bytes()).hexdigest()
+        require_uploaded(remote, sidecar_name, sidecar_digest)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        "".join(
+            f"{expected[name].removeprefix('sha256:')}  {name}\n"
+            for name in sorted(expected)
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    render(
+        tag=args.tag,
+        provenance=args.provenance,
+        assets=args.assets,
+        sidecars=args.sidecars,
+        output=args.output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/release/metadata/test-render-release-checksums.py
+++ b/.github/scripts/release/metadata/test-render-release-checksums.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("render-release-checksums.py")
+TAG = "v9.8.7"
+ZIP_NAME = f"kast-{TAG}-linux-x64.zip"
+BUNDLE_NAME = f"kast-linux-x64-{TAG}.tar.gz"
+ZIP_DIGEST = "a" * 64
+BUNDLE_DIGEST = "b" * 64
+
+
+class RenderReleaseChecksumsTest(unittest.TestCase):
+    def run_renderer(
+        self,
+        *,
+        bundle_state: str = "uploaded",
+        sidecar_digest: str = BUNDLE_DIGEST,
+        swap_platforms: bool = False,
+        zip_name: str = ZIP_NAME,
+        extra_product: str | None = None,
+        bundle_platform: str = "setup-linux-x64",
+        bundle_name: str = BUNDLE_NAME,
+    ) -> subprocess.CompletedProcess[str]:
+        scratch = Path(self.temp_dir.name)
+        sidecars = scratch / "sidecars"
+        sidecars.mkdir(exist_ok=True)
+        sidecar_name = f"{bundle_name}.sha256"
+        sidecar = sidecars / sidecar_name
+        sidecar.write_text(
+            f"{sidecar_digest}  {bundle_name}\n",
+            encoding="utf-8",
+        )
+        provenance = {
+            "builds": [
+                {
+                    "platformId": "cli-linux-x64" if swap_platforms else bundle_platform,
+                    "assetName": bundle_name,
+                    "assetDigest": f"sha256:{BUNDLE_DIGEST}",
+                },
+                {
+                    "platformId": "setup-linux-x64" if swap_platforms else "cli-linux-x64",
+                    "assetName": zip_name,
+                    "assetDigest": f"sha256:{ZIP_DIGEST}",
+                },
+            ]
+        }
+        assets = {
+            "assets": [
+                {
+                    "name": bundle_name,
+                    "state": bundle_state,
+                    "digest": f"sha256:{BUNDLE_DIGEST}",
+                },
+                {
+                    "name": zip_name,
+                    "state": "uploaded",
+                    "digest": f"sha256:{ZIP_DIGEST}",
+                },
+                {
+                    "name": f"kast-idea-{TAG}.zip",
+                    "state": "uploaded",
+                    "digest": f"sha256:{'d' * 64}",
+                },
+                {
+                    "name": sidecar_name,
+                    "state": "uploaded",
+                    "digest": "sha256:" + hashlib.sha256(sidecar.read_bytes()).hexdigest(),
+                },
+            ]
+        }
+        if extra_product is not None:
+            assets["assets"].append(
+                {
+                    "name": extra_product,
+                    "state": "uploaded",
+                    "digest": f"sha256:{'e' * 64}",
+                }
+            )
+        provenance_path = scratch / "provenance.json"
+        assets_path = scratch / "assets.json"
+        output = scratch / "SHA256SUMS"
+        provenance_path.write_text(json.dumps(provenance), encoding="utf-8")
+        assets_path.write_text(json.dumps(assets), encoding="utf-8")
+        result = subprocess.run(
+            [
+                str(SCRIPT),
+                "--tag",
+                TAG,
+                "--provenance",
+                str(provenance_path),
+                "--assets",
+                str(assets_path),
+                "--sidecars",
+                str(sidecars),
+                "--output",
+                str(output),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.output = output
+        return result
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="kast-release-checksums.")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_renders_provenance_digests_without_release_asset_bytes(self) -> None:
+        result = self.run_renderer()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            self.output.read_text(encoding="utf-8"),
+            f"{BUNDLE_DIGEST}  {BUNDLE_NAME}\n{ZIP_DIGEST}  {ZIP_NAME}\n",
+        )
+
+    def test_rejects_incomplete_remote_asset(self) -> None:
+        result = self.run_renderer(bundle_state="starter")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(f"release asset is not uploaded: {BUNDLE_NAME}", result.stderr)
+
+    def test_rejects_sidecar_that_disagrees_with_provenance(self) -> None:
+        result = self.run_renderer(sidecar_digest="c" * 64)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("checksum sidecar digest does not match provenance", result.stderr)
+
+    def test_rejects_swapped_platform_assets(self) -> None:
+        result = self.run_renderer(swap_platforms=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("provenance asset mismatch", result.stderr)
+
+    def test_rejects_asset_from_another_tag(self) -> None:
+        result = self.run_renderer(zip_name="kast-v9.8.6-linux-x64.zip")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("provenance asset mismatch", result.stderr)
+
+    def test_rejects_unexpected_remote_product_asset(self) -> None:
+        result = self.run_renderer(extra_product="kast-v1.0.0-linux-x64.zip")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unexpected release product asset", result.stderr)
+
+    def test_accepts_real_ubuntu_headless_platform_name(self) -> None:
+        result = self.run_renderer(
+            bundle_platform="ubuntu-debian-headless-x86_64",
+            bundle_name=f"kast-ubuntu-debian-headless-x86_64-{TAG}.tar.gz",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/release/test-release-workflow-contract.sh
+++ b/.github/scripts/release/test-release-workflow-contract.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
 ci="$repo_root/.github/workflows/ci.yml"
 release="$repo_root/.github/workflows/release.yml"
+cli_builder="$repo_root/.github/scripts/release/actions/build-cli/action.yml"
+setup_builder="$repo_root/.github/scripts/release/actions/build-setup-bundle/action.yml"
+cli_publisher="$repo_root/.github/scripts/release/actions/publish-cli/action.yml"
+setup_publisher="$repo_root/.github/scripts/release/actions/publish-setup-bundle/action.yml"
 build="$repo_root/build.gradle.kts"
 verify_assets="$repo_root/scripts/release/verify-release-assets.sh"
 verify_state="$repo_root/scripts/release/verify-release-state.sh"
@@ -11,9 +15,22 @@ verify_setup="$repo_root/scripts/verify-setup-bundle.sh"
 release_preflight="$(sed -n '/^  release-preflight:/,/^  bump-version:/p' "$release")"
 bump_version="$(sed -n '/^  bump-version:/,/^  prepare-release:/p' "$release")"
 prepare_release="$(sed -n '/^  prepare-release:/,/^  validate-jvm:/p' "$release")"
-build_openapi="$(sed -n '/^  build-openapi-spec:/,/^  publish-maven-central:/p' "$release")"
-publish_maven="$(sed -n '/^  publish-maven-central:/,/^  build-cli:/p' "$release")"
-real_repository_indexing="$(sed -n '/^  real-repository-indexing:/,/^  publish-release:/p' "$release")"
+build_openapi="$(sed -n '/^  build-openapi-spec:/,/^  publish-openapi-spec:/p' "$release")"
+publish_openapi="$(sed -n '/^  publish-openapi-spec:/,/^  publish-maven-central:/p' "$release")"
+publish_maven="$(sed -n '/^  publish-maven-central:/,/^  build-cli-linux-x64:/p' "$release")"
+build_cli="$(sed -n '/^  build-cli-linux-x64:/,/^  publish-cli-linux-x64:/p' "$release")"
+publish_cli="$(sed -n '/^  publish-cli-linux-x64:/,/^  build-agent-resources:/p' "$release")"
+build_agent_resources="$(sed -n '/^  build-agent-resources:/,/^  publish-agent-resources:/p' "$release")"
+publish_agent_resources="$(sed -n '/^  publish-agent-resources:/,/^  build-idea-plugin:/p' "$release")"
+build_idea_plugin="$(sed -n '/^  build-idea-plugin:/,/^  publish-idea-plugin:/p' "$release")"
+publish_idea_plugin="$(sed -n '/^  publish-idea-plugin:/,/^  build-headless-backend:/p' "$release")"
+build_headless_backend="$(sed -n '/^  build-headless-backend:/,/^  build-linux-headless-tarball:/p' "$release")"
+build_linux_headless="$(sed -n '/^  build-linux-headless-tarball:/,/^  publish-linux-headless-assets:/p' "$release")"
+publish_linux_headless="$(sed -n '/^  publish-linux-headless-assets:/,/^  build-setup-linux-x64:/p' "$release")"
+build_setup_bundle="$(sed -n '/^  build-setup-linux-x64:/,/^  publish-setup-linux-x64:/p' "$release")"
+publish_setup_bundle="$(sed -n '/^  publish-setup-linux-x64:/,/^  real-repository-indexing:/p' "$release")"
+real_repository_indexing="$(sed -n '/^  real-repository-indexing:/,/^  build-release-metadata:/p' "$release")"
+build_release_metadata="$(sed -n '/^  build-release-metadata:/,/^  publish-release:/p' "$release")"
 publish_release="$(sed -n '/^  publish-release:/,/^  verify-release-state:/p' "$release")"
 verify_release="$(sed -n '/^  verify-release-state:/,$p' "$release")"
 
@@ -33,12 +50,12 @@ require "$ci" 'scripts/verify-setup-bundle.sh' 'CI bundle validation must enter 
 require "$build" '"setup",' 'local development refresh must invoke KastCTL setup'
 require "$build" '"--source",' 'local development refresh must activate one complete setup bundle'
 
-require "$release" 'for platform in linux-x64 linux-arm64 macos-x64 macos-arm64' 'release must package every supported setup platform'
 require "$ci" 'cp cli-rs/target/release/kast cli-rs/target/package/kast-v0.0.0-ci-linux-x64/kastctl' 'CI raw CLI asset must include the administrative entrypoint'
 require "$ci" 'cmp -s cli-rs/target/package/kast-v0.0.0-ci-linux-x64/kastctl cli-rs/target/package/kast-v0.0.0-ci-linux-x64/kast' 'CI must prove its multicall entrypoints are byte-identical'
-require "$release" 'cp "cli-rs/target/${{ matrix.target }}/release/kast" "$staging_dir/kastctl"' 'raw CLI assets must include the administrative entrypoint'
-require "$release" 'cmp -s "$staging_dir/kastctl" "$staging_dir/kast"' 'release must prove its multicall entrypoints are byte-identical'
-require "$release" 'zip -9 -q "$GITHUB_WORKSPACE/dist/${asset_name}" kastctl kast' 'raw CLI archives must publish only the two multicall names'
+require "$cli_builder" 'cp "$binary" "$staging_dir/kastctl"' 'raw CLI assets must include the administrative entrypoint'
+require "$cli_builder" 'cmp -s "$staging_dir/kastctl" "$staging_dir/kast"' 'release must prove its multicall entrypoints are byte-identical'
+require "$cli_builder" 'zip -9 -q "$GITHUB_WORKSPACE/dist/${asset_name}" kastctl kast' 'raw CLI archives must publish only the two multicall names'
+require "$cli_builder" '"$smoke_dir/kastctl" version | grep -Fx "Kast CLI ${{ inputs.release_version }}"' 'cached CLI builds must report the requested release version'
 require "$release" 'packager_bin="${packager_dir}/kastctl"' 'Linux headless packaging must invoke the administrative entrypoint'
 require "$release" "grep -F './libexec/kastctl'" 'headless runtime must keep KastCTL out of bin'
 require "$release" '.github/scripts/release/agent-resource-assets.py build' 'release must build agent resources with the deterministic packager'
@@ -52,8 +69,179 @@ reject "$release" 'kagent' 'release workflow must not publish the retired kagent
 for platform in linux-x64 linux-arm64 macos-x64 macos-arm64; do
   require "$verify_assets" "kast-$platform-{tag}.tar.gz" "release verifier must require $platform setup bundle"
 done
-require "$release" '--plugin-archive "$work/kast-idea-${tag}.zip"' 'release bundles must include the release-matched IDEA plugin'
+require "$setup_builder" '--plugin-archive "$plugin_asset"' 'release bundles must include the release-matched IDEA plugin'
 require "$release" 'scripts/verify-setup-bundle.sh' 'release validation must enter through KastCTL setup'
+for platform in linux-x64 linux-arm64 macos-x64 macos-arm64; do
+  grep -Fq "build-cli-$platform:" <<<"$build_cli" \
+    || { printf 'error: CLI producer must address %s independently\n' "$platform" >&2; exit 1; }
+  grep -Fq "asset_id: $platform" <<<"$build_cli" \
+    || { printf 'error: CLI producer must select %s\n' "$platform" >&2; exit 1; }
+done
+[[ "$(grep -Fc 'uses: ./.github/scripts/release/actions/build-cli' <<<"$build_cli")" -eq 4 ]] \
+  || { printf '%s\n' 'error: every CLI platform must use the shared build action' >&2; exit 1; }
+for platform in linux-x64 linux-arm64 macos-x64 macos-arm64; do
+  grep -Fq "publish-cli-$platform:" <<<"$publish_cli" \
+    || { printf 'error: CLI publisher must address %s independently\n' "$platform" >&2; exit 1; }
+done
+[[ "$(grep -Fc 'uses: ./.github/scripts/release/actions/publish-cli' <<<"$publish_cli")" -eq 4 ]] \
+  || { printf '%s\n' 'error: every CLI platform must use the shared publisher action' >&2; exit 1; }
+grep -Fq -- '- build-cli-linux-x64' <<<"$build_linux_headless" \
+  || { printf '%s\n' 'error: Linux packaging must wait for its Linux x64 CLI producer' >&2; exit 1; }
+for unrelated_cli in build-cli-linux-arm64 build-cli-macos-x64 build-cli-macos-arm64; do
+  ! grep -Fq -- "- $unrelated_cli" <<<"$build_linux_headless" \
+    || { printf 'error: Linux packaging must not wait for unrelated CLI producer %s\n' "$unrelated_cli" >&2; exit 1; }
+done
+for platform in linux-x64 linux-arm64 macos-x64 macos-arm64; do
+  grep -Fq "build-setup-$platform:" <<<"$build_setup_bundle" \
+    || { printf 'error: setup bundle producer must address %s independently\n' "$platform" >&2; exit 1; }
+  grep -Fq "platform: $platform" <<<"$build_setup_bundle" \
+    || { printf 'error: setup bundle producer must select %s\n' "$platform" >&2; exit 1; }
+done
+[[ "$(grep -Fc 'uses: ./.github/scripts/release/actions/build-setup-bundle' <<<"$build_setup_bundle")" -eq 4 ]] \
+  || { printf '%s\n' 'error: every setup platform must use the shared build action' >&2; exit 1; }
+grep -Fq 'setup-bundle-${{ inputs.platform }}-${{ github.run_id }}' "$setup_builder" \
+  || { printf '%s\n' 'error: setup bundle producers must retain their output for publication retries' >&2; exit 1; }
+grep -Fq 'compression-level: 0' "$setup_builder" \
+  || { printf '%s\n' 'error: compressed setup bundles must not be recompressed as workflow artifacts' >&2; exit 1; }
+for platform in linux-x64 linux-arm64 macos-x64 macos-arm64; do
+  grep -Fq "publish-setup-$platform:" <<<"$publish_setup_bundle" \
+    || { printf 'error: setup publisher must address %s independently\n' "$platform" >&2; exit 1; }
+done
+[[ "$(grep -Fc 'uses: ./.github/scripts/release/actions/publish-setup-bundle' <<<"$publish_setup_bundle")" -eq 4 ]] \
+  || { printf '%s\n' 'error: every setup platform must use the shared publisher action' >&2; exit 1; }
+grep -Fq 'name: setup-bundle-${{ inputs.platform }}-${{ github.run_id }}' "$setup_publisher" \
+  || { printf '%s\n' 'error: setup publishers must consume retained setup bundles' >&2; exit 1; }
+grep -Fq '.github/scripts/release/upload-immutable-release-asset.sh' "$setup_publisher" \
+  || { printf '%s\n' 'error: setup publishers must use immutable upload recovery' >&2; exit 1; }
+grep -Fq 'setup-bundle-provenance-${{ inputs.platform }}-${{ github.run_id }}' "$setup_publisher" \
+  || { printf '%s\n' 'error: setup publishers must retain provenance for metadata-only finalization' >&2; exit 1; }
+for producer in \
+  "$build_openapi" \
+  "$build_agent_resources" \
+  "$build_idea_plugin" \
+  "$build_linux_headless"
+do
+  ! grep -Fq '.github/scripts/release/upload-immutable-release-asset.sh' <<<"$producer" \
+    || { printf '%s\n' 'error: release producers must retain bytes before publication' >&2; exit 1; }
+done
+! grep -Fq '.github/scripts/release/upload-immutable-release-asset.sh' "$cli_builder" \
+  || { printf '%s\n' 'error: CLI producers must retain bytes before publication' >&2; exit 1; }
+grep -Fq 'name: openapi-spec-${{ github.run_id }}' <<<"$build_openapi" \
+  || { printf '%s\n' 'error: OpenAPI producer must retain its release bytes' >&2; exit 1; }
+grep -Fq 'name: rust-cli-${{ inputs.asset_id }}-${{ github.run_id }}' "$cli_builder" \
+  || { printf '%s\n' 'error: CLI producers must retain their release bytes' >&2; exit 1; }
+grep -Fq 'name: agent-resources-${{ github.run_id }}' <<<"$build_agent_resources" \
+  || { printf '%s\n' 'error: agent-resource producer must retain its release bytes' >&2; exit 1; }
+grep -Fq 'verify-ci-artifact-ledger.py record' <<<"$build_agent_resources" \
+  || { printf '%s\n' 'error: agent-resource producer must ledger every retained asset' >&2; exit 1; }
+grep -Fq 'name: idea-plugin-${{ github.run_id }}' <<<"$build_idea_plugin" \
+  || { printf '%s\n' 'error: IDEA plugin producer must retain its release bytes' >&2; exit 1; }
+grep -Fq 'name: linux-headless-tarball-${{ github.run_id }}' <<<"$build_linux_headless" \
+  || { printf '%s\n' 'error: Linux producer must retain its release bytes' >&2; exit 1; }
+for publisher in \
+  "$publish_openapi" \
+  "$publish_agent_resources" \
+  "$publish_idea_plugin" \
+  "$publish_linux_headless"
+do
+  grep -Fq '.github/scripts/release/upload-immutable-release-asset.sh' <<<"$publisher" \
+    || { printf '%s\n' 'error: retained release bytes must have a dedicated publisher' >&2; exit 1; }
+  ! grep -Eq 'cargo build|./gradlew|agent-resource-assets.py build|developer release package|:backend-idea:buildPlugin' <<<"$publisher" \
+    || { printf '%s\n' 'error: release publishers must not rebuild retained bytes' >&2; exit 1; }
+done
+grep -Fq '.github/scripts/release/upload-immutable-release-asset.sh' "$cli_publisher" \
+  || { printf '%s\n' 'error: retained CLI bytes must have a dedicated publisher' >&2; exit 1; }
+! grep -Eq 'cargo build|./gradlew' "$cli_publisher" \
+  || { printf '%s\n' 'error: CLI publishers must not rebuild retained bytes' >&2; exit 1; }
+grep -Fq 'name: openapi-spec-${{ github.run_id }}' <<<"$publish_openapi" \
+  || { printf '%s\n' 'error: OpenAPI publisher must consume its retained artifact' >&2; exit 1; }
+grep -Fq 'name: rust-cli-${{ inputs.asset_id }}-${{ github.run_id }}' "$cli_publisher" \
+  || { printf '%s\n' 'error: CLI publisher must consume its retained artifact' >&2; exit 1; }
+grep -Fq 'name: agent-resources-${{ github.run_id }}' <<<"$publish_agent_resources" \
+  || { printf '%s\n' 'error: agent-resource publisher must consume its retained artifact' >&2; exit 1; }
+grep -Fq 'verify-ci-artifact-ledger.py verify' <<<"$publish_agent_resources" \
+  || { printf '%s\n' 'error: agent-resource publisher must verify retained bytes against their ledger' >&2; exit 1; }
+grep -Fq 'name: idea-plugin-${{ github.run_id }}' <<<"$publish_idea_plugin" \
+  || { printf '%s\n' 'error: IDEA plugin publisher must consume its retained artifact' >&2; exit 1; }
+grep -Fq 'name: linux-headless-tarball-${{ github.run_id }}' <<<"$publish_linux_headless" \
+  || { printf '%s\n' 'error: Linux publisher must consume its retained artifact' >&2; exit 1; }
+grep -Fq 'name: idea-plugin-${{ github.run_id }}' "$setup_builder" \
+  || { printf '%s\n' 'error: setup builders must consume the retained IDEA plugin' >&2; exit 1; }
+! grep -Fq 'gh release download' "$setup_builder" \
+  || { printf '%s\n' 'error: setup builders must not use a draft release as artifact transport' >&2; exit 1; }
+grep -Fq 'name: idea-plugin-${{ github.run_id }}' <<<"$build_linux_headless" \
+  || { printf '%s\n' 'error: Linux builders must consume the retained IDEA plugin' >&2; exit 1; }
+! grep -Fq 'gh release download' <<<"$build_linux_headless" \
+  || { printf '%s\n' 'error: Linux builders must not use a draft release as artifact transport' >&2; exit 1; }
+[[ "$(grep -Fc 'uses: actions/upload-artifact@v6' <<<"$build_headless_backend")" -eq 1 ]] \
+  || { printf '%s\n' 'error: headless producer outputs must be retained by one atomic upload' >&2; exit 1; }
+grep -Fq 'dist/gradle-ro-cache/' <<<"$build_headless_backend" \
+  || { printf '%s\n' 'error: the atomic headless artifact must retain the Gradle cache' >&2; exit 1; }
+! grep -Fq 'name: gradle-ro-cache-${{ github.run_id }}' <<<"$release" \
+  || { printf '%s\n' 'error: the Gradle cache must not use a second collision-prone artifact upload' >&2; exit 1; }
+grep -Fq 'name: headless-backend-${{ github.run_id }}' <<<"$publish_linux_headless" \
+  || { printf '%s\n' 'error: Linux publication must consume the atomic headless artifact' >&2; exit 1; }
+! grep -Fq 'developer release package ubuntu-debian-bundle' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: publication must not rebuild setup bundles' >&2; exit 1; }
+! grep -Fq 'gh release download "$tag" --dir release-assets' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: publication must not download full release assets' >&2; exit 1; }
+grep -Fq 'pattern: cli-provenance-*-${{ github.run_id }}' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: publication must consume metadata-only CLI provenance artifacts' >&2; exit 1; }
+grep -Fq 'pattern: linux-headless-provenance-*' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: publication must consume metadata-only Linux provenance artifacts' >&2; exit 1; }
+! grep -Fq 'pattern: rust-cli-*-${{ github.run_id }}' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: publication must not download full CLI artifacts' >&2; exit 1; }
+! grep -Fq 'pattern: linux-headless-tarball-*' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: publication must not download the full Linux distribution artifact' >&2; exit 1; }
+! grep -Fq 'verify-ci-artifact-ledger.py verify' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: metadata-only publication must not consume receipt-owned product bytes' >&2; exit 1; }
+grep -Fq '.github/scripts/release/metadata/render-release-checksums.py' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: publication must render checksums from verified provenance metadata' >&2; exit 1; }
+grep -Fq "timeout 60s gh release download" <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: required sidecar downloads must have a bounded timeout' >&2; exit 1; }
+grep -Fq 'sleep "$attempt"' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: sidecar download retries must back off' >&2; exit 1; }
+grep -Fq 'name: Generate SHA256SUMS' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: provenance must be validated before final metadata upload' >&2; exit 1; }
+grep -Fq 'name: release-metadata-${{ github.run_id }}' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: validated release metadata must be retained before publication' >&2; exit 1; }
+grep -Fq 'name: release-metadata-${{ github.run_id }}' <<<"$publish_release" \
+  || { printf '%s\n' 'error: final publication must consume retained metadata' >&2; exit 1; }
+grep -Fq '.github/scripts/release/upload-immutable-release-asset.sh' <<<"$publish_release" \
+  || { printf '%s\n' 'error: final publication must use immutable metadata upload recovery' >&2; exit 1; }
+! grep -Fq '.github/scripts/release/metadata/render-release-checksums.py' <<<"$publish_release" \
+  || { printf '%s\n' 'error: a publish retry must not regenerate retained metadata' >&2; exit 1; }
+grep -Fq 'if [[ "$release_body" != *"$provenance_marker"* ]]' <<<"$publish_release" \
+  || { printf '%s\n' 'error: release annotation retries must be idempotent' >&2; exit 1; }
+for retained_artifact_section in \
+  "$build_openapi" \
+  "$build_agent_resources" \
+  "$build_idea_plugin" \
+  "$build_linux_headless" \
+  "$build_release_metadata"
+do
+  grep -Fq 'retention-days: 30' <<<"$retained_artifact_section" \
+    || { printf '%s\n' 'error: retained release artifacts must survive the 30-day rerun window' >&2; exit 1; }
+done
+for retained_artifact_action in \
+  "$cli_builder" \
+  "$setup_builder" \
+  "$cli_publisher" \
+  "$setup_publisher"
+do
+  grep -Fq 'retention-days: 30' "$retained_artifact_action" \
+    || { printf '%s\n' 'error: retained release artifacts must survive the 30-day rerun window' >&2; exit 1; }
+done
+for workflow_surface in \
+  "$release" \
+  "$cli_builder" \
+  "$setup_builder" \
+  "$cli_publisher" \
+  "$setup_publisher"
+do
+  ! grep -Eq 'retention-days:[[:space:]]+3([[:space:]]|$)' "$workflow_surface" \
+    || { printf '%s\n' 'error: release artifacts expire before the supported rerun window' >&2; exit 1; }
+done
 require "$release" './scripts/ci-gradle-retry.sh ./gradlew \' 'headless release must invoke Gradle directly through the CI retry helper'
 require "$release" 'stageHeadlessDist \' 'headless release must stage the portable distribution'
 require "$release" ':backend-headless:verifyHeadlessPortableDistLayout \' 'headless release must verify the portable distribution layout'
@@ -68,6 +256,18 @@ reject "$release" './kast.sh' 'release workflow still depends on the deleted bui
 
 grep -Fq './gradlew test' <<<"$release_preflight" \
   || { printf '%s\n' 'error: release dispatch must validate JVM tests before creating a tag' >&2; exit 1; }
+grep -Fq 'uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32' <<<"$release_preflight" \
+  || { printf '%s\n' 'error: release preflight must reuse the exact-SHA Rust validation cache' >&2; exit 1; }
+grep -Fq 'shared-key: rust-cli-validation' <<<"$release_preflight" \
+  || { printf '%s\n' 'error: release preflight Rust cache must match the CI validation owner' >&2; exit 1; }
+grep -Fq "[[ \"\${{ inputs.asset_id }}\" == 'linux-x64' ]]" "$cli_builder" \
+  || { printf '%s\n' 'error: the Linux x64 release build must select the CI-compatible cache and target layout' >&2; exit 1; }
+grep -Fq 'shared-key: ${{ inputs.cache_key }}' "$cli_builder" \
+  || { printf '%s\n' 'error: release CLI producers must select an explicit trusted cache' >&2; exit 1; }
+grep -Fq 'cache_key: source-bound-cli-release' <<<"$build_cli" \
+  || { printf '%s\n' 'error: the Linux x64 release build must reuse the trusted main CI cache' >&2; exit 1; }
+grep -Fq 'bin="target/release/kast"' "$cli_builder" \
+  || { printf '%s\n' 'error: the Linux x64 release build must use the same target layout as main CI' >&2; exit 1; }
 grep -Fq 'needs: [release-preflight]' <<<"$bump_version" \
   || { printf '%s\n' 'error: version tagging must depend on release preflight' >&2; exit 1; }
 grep -Fq 'token: ${{ secrets.RELEASE_GITHUB_TOKEN }}' <<<"$bump_version" \
@@ -88,13 +288,26 @@ grep -Fq 'continue-on-error: true' <<<"$publish_maven" \
   || { printf '%s\n' 'error: OpenAPI build must not wait for unrelated JVM validation' >&2; exit 1; }
 grep -Fq "vars.CI_AUX_IDEA_PERFORMANCE != 'optional'" <<<"$real_repository_indexing" \
   || { printf '%s\n' 'error: lean releases must skip the optional real-repository performance gate' >&2; exit 1; }
-grep -Fq "vars.CI_AUX_IDEA_PERFORMANCE == 'optional'" <<<"$publish_release" \
+grep -Fq "vars.CI_AUX_IDEA_PERFORMANCE == 'optional'" <<<"$build_release_metadata" \
   || { printf '%s\n' 'error: release publication must recognize the lean profile' >&2; exit 1; }
-grep -Fq "needs.real-repository-indexing.result == 'skipped'" <<<"$publish_release" \
+grep -Fq "needs.real-repository-indexing.result == 'skipped'" <<<"$build_release_metadata" \
   || { printf '%s\n' 'error: publication must accept an intentionally skipped performance gate' >&2; exit 1; }
-for artifact_job in build-cli build-agent-resources build-idea-plugin build-headless-backend; do
-  grep -Fq -- "- $artifact_job" <<<"$publish_release" \
-    || { printf 'error: %s release artifacts must remain mandatory\n' "$artifact_job" >&2; exit 1; }
+for artifact_job in \
+  publish-openapi-spec \
+  publish-cli-linux-x64 \
+  publish-cli-linux-arm64 \
+  publish-cli-macos-x64 \
+  publish-cli-macos-arm64 \
+  publish-agent-resources \
+  publish-idea-plugin \
+  publish-linux-headless-assets \
+  publish-setup-linux-x64 \
+  publish-setup-linux-arm64 \
+  publish-setup-macos-x64 \
+  publish-setup-macos-arm64
+do
+  grep -Fq -- "- $artifact_job" <<<"$build_release_metadata" \
+    || { printf 'error: %s release publication must remain mandatory\n' "$artifact_job" >&2; exit 1; }
 done
 grep -Fq 'needs.publish-release.result }}" != "success"' <<<"$verify_release" \
   || { printf '%s\n' 'error: published-state verification must require successful publication' >&2; exit 1; }
@@ -106,5 +319,218 @@ for file in "$ci" "$release" "$verify_state"; do
   reject "$file" 'kast machine' 'retired machine authority remains in release flow'
   reject "$file" 'kast repair' 'retired repair authority remains in release flow'
 done
+
+reject "$release" '--clobber' 'release assets must never bypass immutable upload recovery'
+"$repo_root/.github/scripts/release/test-upload-immutable-release-asset.sh"
+python3 "$repo_root/.github/scripts/release/metadata/test-render-release-checksums.py"
+python3 - \
+  "$repo_root/.github/scripts/release/metadata/release-workflow-model.json" \
+  "$release" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+model = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+release_bytes = Path(sys.argv[2]).read_bytes()
+if model.get("schemaVersion") != 1 or model.get("evidenceMode") != "structural-only":
+    raise SystemExit("error: release graph must use structural-only evidence")
+if model.get("provenance", {}).get("sourceSha256") != hashlib.sha256(release_bytes).hexdigest():
+    raise SystemExit("error: release graph must bind to the exact release workflow")
+encoded = json.dumps(model)
+if "durationSamplesSeconds" in encoded or "observedWorkflowDuration" in encoded:
+    raise SystemExit("error: release graph must not invent candidate timing samples")
+if "publishesReleaseAssets" in encoded:
+    raise SystemExit("error: release graph must distinguish product assets from metadata assets")
+
+tasks = {task["id"]: task for task in model["tasks"]}
+if len(tasks) != len(model["tasks"]):
+    raise SystemExit("error: release graph task IDs must be unique")
+for task_id, task in tasks.items():
+    unknown = set(task["needs"]) - set(tasks)
+    if unknown:
+        raise SystemExit(f"error: {task_id} has unknown dependencies: {sorted(unknown)}")
+
+cli_builds = {
+    "build-cli-linux-x64",
+    "build-cli-linux-arm64",
+    "build-cli-macos-x64",
+    "build-cli-macos-arm64",
+}
+cli_publishers = {
+    "publish-cli-linux-x64",
+    "publish-cli-linux-arm64",
+    "publish-cli-macos-x64",
+    "publish-cli-macos-arm64",
+}
+setup_builds = {
+    "build-setup-linux-x64",
+    "build-setup-linux-arm64",
+    "build-setup-macos-x64",
+    "build-setup-macos-arm64",
+}
+setup_publishers = {
+    "publish-setup-linux-x64",
+    "publish-setup-linux-arm64",
+    "publish-setup-macos-x64",
+    "publish-setup-macos-arm64",
+}
+repository_gates = {
+    "real-repository-indexing-ktor",
+    "real-repository-indexing-spring-boot",
+    "real-repository-indexing-okhttp",
+}
+expected_tasks = {
+    "prepare-release",
+    "validate-jvm",
+    "publish-maven-central",
+    "build-openapi-spec",
+    "publish-openapi-spec",
+    "build-agent-resources",
+    "publish-agent-resources",
+    "build-idea-plugin",
+    "publish-idea-plugin",
+    "build-headless-backend",
+    "build-linux-headless-tarball",
+    "publish-linux-headless-assets",
+    "build-release-metadata",
+    "publish-release",
+    "verify-release-state",
+} | cli_builds | cli_publishers | setup_builds | setup_publishers | repository_gates
+if set(tasks) != expected_tasks:
+    raise SystemExit("error: release graph must expand every required job and matrix cell")
+
+fixed_needs = {
+    "prepare-release": set(),
+    "validate-jvm": {"prepare-release"},
+    "publish-maven-central": {"prepare-release", "validate-jvm"},
+    "build-openapi-spec": {"prepare-release"},
+    "publish-openapi-spec": {"prepare-release", "build-openapi-spec"},
+    "build-agent-resources": {"prepare-release"},
+    "publish-agent-resources": {"prepare-release", "build-agent-resources"},
+    "build-idea-plugin": {"prepare-release"},
+    "publish-idea-plugin": {"prepare-release", "build-idea-plugin"},
+    "build-headless-backend": {"prepare-release"},
+    "build-linux-headless-tarball": {
+        "prepare-release",
+        "build-cli-linux-x64",
+        "build-headless-backend",
+        "build-idea-plugin",
+    },
+    "publish-linux-headless-assets": {
+        "prepare-release",
+        "build-linux-headless-tarball",
+    },
+}
+for task_id, expected in fixed_needs.items():
+    if set(tasks[task_id]["needs"]) != expected:
+        raise SystemExit(f"error: {task_id} has the wrong dependencies")
+for task_id in cli_builds:
+    if set(tasks[task_id]["needs"]) != {"prepare-release"}:
+        raise SystemExit(f"error: {task_id} has the wrong producer dependencies")
+for task_id in cli_publishers:
+    platform = task_id.removeprefix("publish-cli-")
+    if set(tasks[task_id]["needs"]) != {
+        "prepare-release",
+        f"build-cli-{platform}",
+    }:
+        raise SystemExit(f"error: {task_id} must wait only for its retained CLI asset")
+for task_id in setup_builds:
+    platform = task_id.removeprefix("build-setup-")
+    expected = {
+        "prepare-release",
+        "build-cli-linux-x64",
+        f"build-cli-{platform}",
+        "build-idea-plugin",
+        "build-headless-backend",
+    }
+    if set(tasks[task_id]["needs"]) != expected:
+        raise SystemExit(f"error: {task_id} must wait only for its actual CLI inputs")
+for task_id in setup_publishers:
+    task = tasks[task_id]
+    platform = task_id.removeprefix("publish-setup-")
+    if set(task["needs"]) != {
+        "prepare-release",
+        f"build-setup-{platform}",
+    }:
+        raise SystemExit(f"error: {task_id} must wait only for its retained setup bundle")
+    if not task["consumesRetainedAssets"] or not task["publishesProductAssets"]:
+        raise SystemExit(f"error: {task_id} must publish retained bytes")
+artifact_publishers = {
+    "publish-openapi-spec",
+    "publish-agent-resources",
+    "publish-idea-plugin",
+    "publish-linux-headless-assets",
+} | cli_publishers | setup_publishers
+for task_id in artifact_publishers:
+    task = tasks[task_id]
+    if (
+        not task["consumesRetainedAssets"]
+        or not task["consumesProductBytes"]
+        or not task["publishesProductAssets"]
+        or task["publishesMetadataAssets"]
+    ):
+        raise SystemExit(f"error: {task_id} must publish only retained product bytes")
+for task_id in repository_gates:
+    if set(tasks[task_id]["needs"]) != {
+        "prepare-release",
+        "build-linux-headless-tarball",
+    }:
+        raise SystemExit(f"error: {task_id} has the wrong release gate dependencies")
+
+metadata_builder = tasks["build-release-metadata"]
+expected_metadata_needs = {
+    "prepare-release",
+    "validate-jvm",
+    "publish-openapi-spec",
+    "publish-agent-resources",
+    "publish-idea-plugin",
+    "publish-linux-headless-assets",
+} | cli_publishers | setup_publishers | repository_gates
+if set(metadata_builder["needs"]) != expected_metadata_needs:
+    raise SystemExit("error: metadata finalization must wait for every asset publisher")
+if (
+    metadata_builder["consumesProductBytes"]
+    or metadata_builder["publishesProductAssets"]
+    or metadata_builder["publishesMetadataAssets"]
+):
+    raise SystemExit("error: release metadata must be built without product bytes")
+
+finalizer = tasks["publish-release"]
+if set(finalizer["needs"]) != {"prepare-release", "build-release-metadata"}:
+    raise SystemExit("error: final publication must consume the retained metadata artifact")
+if (
+    finalizer["consumesProductBytes"]
+    or finalizer["publishesProductAssets"]
+    or not finalizer["publishesMetadataAssets"]
+):
+    raise SystemExit("error: release finalization must remain metadata-only")
+if set(tasks["verify-release-state"]["needs"]) != {
+    "prepare-release",
+    "publish-release",
+}:
+    raise SystemExit("error: published-state verification must follow finalization")
+
+remaining = set(tasks)
+resolved = set()
+while remaining:
+    ready = {
+        task_id for task_id in remaining
+        if set(tasks[task_id]["needs"]) <= resolved
+    }
+    if not ready:
+        raise SystemExit("error: release graph contains a dependency cycle")
+    resolved |= ready
+    remaining -= ready
+
+output_owners = {}
+for task_id, task in tasks.items():
+    for output in task["outputs"]:
+        if output in output_owners:
+            raise SystemExit(f"error: duplicate release graph output: {output}")
+        output_owners[output] = task_id
+if set(output_owners) != set(model["requiredOutputs"]):
+    raise SystemExit("error: release graph outputs must match the required proof set")
+PY
 
 printf '%s\n' 'release setup workflow contract passed'

--- a/.github/scripts/release/test-upload-immutable-release-asset.sh
+++ b/.github/scripts/release/test-upload-immutable-release-asset.sh
@@ -81,6 +81,10 @@ apply_jq() {
 printf '%s\n' "$*" >>"$FAKE_GH_LOG"
 
 if [[ "${1:-} ${2:-}" == "release view" ]]; then
+  inspect_count="$(increment "$FAKE_GH_INSPECT_COUNT")"
+  if [[ "$FAKE_GH_SCENARIO" == "inspect-retry" && "$inspect_count" -eq 1 ]]; then
+    exit 88
+  fi
   if [[ "$FAKE_GH_SCENARIO" == "inspect-timeout" ]]; then
     /bin/sleep 5
     exit 1
@@ -157,6 +161,11 @@ if [[ "${1:-} ${2:-}" == "release upload" ]]; then
       printf 'starter|null|%s|0\n' "$((100 + upload_count))" >"$FAKE_GH_STATE"
       exit 1
       ;;
+    inspect-retry)
+      cp "$4" "$FAKE_GH_REMOTE_ASSET"
+      printf 'uploaded|sha256:%s|104|1\n' "$FAKE_GH_LOCAL_DIGEST" >"$FAKE_GH_STATE"
+      exit 0
+      ;;
     *)
       exit 97
       ;;
@@ -221,6 +230,7 @@ upload_count_file="$scratch/upload-count"
 download_count_file="$scratch/download-count"
 delete_count_file="$scratch/delete-count"
 api_get_count_file="$scratch/api-get-count"
+inspect_count_file="$scratch/inspect-count"
 printf '%s\n' "release bytes" >"$asset"
 local_digest="$(openssl dgst -sha256 -r "$asset" | awk '{ print $1 }')"
 asset_name="$(basename -- "$asset")"
@@ -242,7 +252,8 @@ reset_case() {
     "$upload_count_file" \
     "$download_count_file" \
     "$delete_count_file" \
-    "$api_get_count_file"
+    "$api_get_count_file" \
+    "$inspect_count_file"
   : >"$log_file"
 }
 
@@ -255,6 +266,7 @@ run_uploader() {
     FAKE_GH_API_GET_COUNT="$api_get_count_file" \
     FAKE_GH_DELETE_COUNT="$delete_count_file" \
     FAKE_GH_DOWNLOAD_COUNT="$download_count_file" \
+    FAKE_GH_INSPECT_COUNT="$inspect_count_file" \
     FAKE_GH_LOCAL_DIGEST="$local_digest" \
     FAKE_GH_LOG="$log_file" \
     FAKE_GH_REMOTE_ASSET="$remote_asset" \
@@ -338,6 +350,12 @@ run_uploader starter-becomes-uploaded "$scratch/starter-transition.out"
 expect_equal 0 "$uploader_status" "starter transition status"
 expect_equal 1 "$(counter "$upload_count_file")" "starter transition uploads"
 expect_equal 0 "$(counter "$delete_count_file")" "starter transition deletions"
+
+reset_case
+run_uploader inspect-retry "$scratch/inspect-retry.out"
+expect_equal 0 "$uploader_status" "transient release inspection status"
+expect_equal 3 "$(counter "$inspect_count_file")" "transient release inspection attempts"
+expect_equal 1 "$(counter "$upload_count_file")" "transient release inspection uploads"
 
 reset_case
 run_uploader inspect-fail "$scratch/inspect-fail.out"

--- a/.github/scripts/release/test-upload-immutable-release-asset.sh
+++ b/.github/scripts/release/test-upload-immutable-release-asset.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
+uploader="$repo_root/.github/scripts/release/upload-immutable-release-asset.sh"
+[[ -x "$uploader" ]] || die "Missing release asset uploader: $uploader"
+command -v jq >/dev/null 2>&1 || die "jq is required"
+
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/kast-release-upload-test.XXXXXX")"
+cleanup() {
+  rm -rf "$scratch"
+}
+trap cleanup EXIT
+
+fake_bin="$scratch/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$fake_bin/sleep"
+
+cat >"$fake_bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+increment() {
+  local path="$1" value=0
+  [[ ! -f "$path" ]] || value="$(<"$path")"
+  value=$((value + 1))
+  printf '%s\n' "$value" >"$path"
+  printf '%s\n' "$value"
+}
+
+read_state() {
+  asset_state=""
+  asset_digest=""
+  asset_id=""
+  asset_size=""
+  [[ ! -s "$FAKE_GH_STATE" ]] \
+    || IFS='|' read -r asset_state asset_digest asset_id asset_size <"$FAKE_GH_STATE"
+}
+
+asset_json() {
+  read_state
+  [[ -n "$asset_state" ]] || return 1
+  if [[ "$asset_digest" == "null" ]]; then
+    jq -cn \
+      --arg api_url "https://api.github.com/repos/example/kast/releases/assets/${asset_id}" \
+      --arg name "$FAKE_GH_ASSET_NAME" \
+      --arg state "$asset_state" \
+      --argjson id "$asset_id" \
+      --argjson size "${asset_size:-0}" \
+      '{apiUrl:$api_url,url:$api_url,digest:null,id:$id,name:$name,size:$size,state:$state}'
+  else
+    jq -cn \
+      --arg api_url "https://api.github.com/repos/example/kast/releases/assets/${asset_id}" \
+      --arg digest "$asset_digest" \
+      --arg name "$FAKE_GH_ASSET_NAME" \
+      --arg state "$asset_state" \
+      --argjson id "$asset_id" \
+      --argjson size "${asset_size:-1}" \
+      '{apiUrl:$api_url,url:$api_url,digest:$digest,id:$id,name:$name,size:$size,state:$state}'
+  fi
+}
+
+apply_jq() {
+  local payload="$1" expression="$2"
+  if [[ -n "$expression" ]]; then
+    jq -r "$expression" <<<"$payload"
+  else
+    printf '%s\n' "$payload"
+  fi
+}
+
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+
+if [[ "${1:-} ${2:-}" == "release view" ]]; then
+  if [[ "$FAKE_GH_SCENARIO" == "inspect-timeout" ]]; then
+    /bin/sleep 5
+    exit 1
+  fi
+  [[ "$FAKE_GH_SCENARIO" != "inspect-fail" ]] || exit 88
+  shift 2
+  expression=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --jq|-q)
+        expression="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  if asset="$(asset_json)"; then
+    payload="$(jq -cn --argjson asset "$asset" '{assets:[$asset]}')"
+  else
+    payload='{"assets":[]}'
+  fi
+  apply_jq "$payload" "$expression"
+  exit 0
+fi
+
+if [[ "${1:-} ${2:-}" == "release download" ]]; then
+  increment "$FAKE_GH_DOWNLOAD_COUNT" >/dev/null
+  read_state
+  [[ "$asset_state" == "uploaded" ]] || exit 1
+  shift 2
+  destination=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dir)
+        destination="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  [[ -n "$destination" ]] || exit 2
+  mkdir -p "$destination"
+  cp "$FAKE_GH_REMOTE_ASSET" "$destination/$FAKE_GH_ASSET_NAME"
+  exit 0
+fi
+
+if [[ "${1:-} ${2:-}" == "release upload" ]]; then
+  [[ " $* " != *" --clobber "* ]] || exit 96
+  upload_count="$(increment "$FAKE_GH_UPLOAD_COUNT")"
+  case "$FAKE_GH_SCENARIO" in
+    starter-retry)
+      if [[ "$upload_count" -eq 1 ]]; then
+        printf 'starter|null|101|0\n' >"$FAKE_GH_STATE"
+        exit 1
+      fi
+      cp "$4" "$FAKE_GH_REMOTE_ASSET"
+      printf 'uploaded|sha256:%s|102|1\n' "$FAKE_GH_LOCAL_DIGEST" >"$FAKE_GH_STATE"
+      exit 0
+      ;;
+    starter-becomes-uploaded)
+      cp "$4" "$FAKE_GH_REMOTE_ASSET"
+      printf 'starter|null|103|0\n' >"$FAKE_GH_STATE"
+      exit 1
+      ;;
+    timeout)
+      /bin/sleep 5
+      exit 1
+      ;;
+    always-fail)
+      printf 'starter|null|%s|0\n' "$((100 + upload_count))" >"$FAKE_GH_STATE"
+      exit 1
+      ;;
+    *)
+      exit 97
+      ;;
+  esac
+fi
+
+if [[ "${1:-}" == "api" ]]; then
+  shift
+  method="GET"
+  expression=""
+  endpoint=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --method|-X)
+        method="$2"
+        shift 2
+        ;;
+      --jq|-q)
+        expression="$2"
+        shift 2
+        ;;
+      --silent)
+        shift
+        ;;
+      *)
+        endpoint="$1"
+        shift
+        ;;
+    esac
+  done
+  read_state
+  if [[ "$method" == "DELETE" ]]; then
+    [[ "$asset_state" == "starter" && "$asset_digest" == "null" ]] || exit 98
+    [[ "$endpoint" == *"/releases/assets/${asset_id}" ]] || exit 99
+    increment "$FAKE_GH_DELETE_COUNT" >/dev/null
+    rm -f "$FAKE_GH_STATE"
+    exit 0
+  fi
+  if [[ "$FAKE_GH_SCENARIO" == "starter-becomes-uploaded" ]]; then
+    api_get_count="$(increment "$FAKE_GH_API_GET_COUNT")"
+    if [[ "$api_get_count" -eq 1 ]]; then
+      asset="$(asset_json)" || exit 1
+      printf 'uploaded|sha256:%s|103|1\n' "$FAKE_GH_LOCAL_DIGEST" >"$FAKE_GH_STATE"
+      apply_jq "$asset" "$expression"
+      exit 0
+    fi
+  fi
+  asset="$(asset_json)" || exit 1
+  apply_jq "$asset" "$expression"
+  exit 0
+fi
+
+exit 100
+SH
+chmod +x "$fake_bin/gh"
+
+asset="$scratch/asset.bin"
+remote_asset="$scratch/remote.bin"
+state_file="$scratch/state"
+log_file="$scratch/gh.log"
+upload_count_file="$scratch/upload-count"
+download_count_file="$scratch/download-count"
+delete_count_file="$scratch/delete-count"
+api_get_count_file="$scratch/api-get-count"
+printf '%s\n' "release bytes" >"$asset"
+local_digest="$(openssl dgst -sha256 -r "$asset" | awk '{ print $1 }')"
+asset_name="$(basename -- "$asset")"
+failures=0
+
+counter() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    cat "$path"
+  else
+    printf '0\n'
+  fi
+}
+
+reset_case() {
+  rm -f \
+    "$state_file" \
+    "$remote_asset" \
+    "$upload_count_file" \
+    "$download_count_file" \
+    "$delete_count_file" \
+    "$api_get_count_file"
+  : >"$log_file"
+}
+
+run_uploader() {
+  local scenario="$1" output="$2" attempts="${3:-3}"
+  local timeout_seconds="${4:-300}" metadata_timeout_seconds="${5:-30}"
+  set +e
+  PATH="$fake_bin:$PATH" \
+    FAKE_GH_ASSET_NAME="$asset_name" \
+    FAKE_GH_API_GET_COUNT="$api_get_count_file" \
+    FAKE_GH_DELETE_COUNT="$delete_count_file" \
+    FAKE_GH_DOWNLOAD_COUNT="$download_count_file" \
+    FAKE_GH_LOCAL_DIGEST="$local_digest" \
+    FAKE_GH_LOG="$log_file" \
+    FAKE_GH_REMOTE_ASSET="$remote_asset" \
+    FAKE_GH_SCENARIO="$scenario" \
+    FAKE_GH_STATE="$state_file" \
+    FAKE_GH_UPLOAD_COUNT="$upload_count_file" \
+    KAST_RELEASE_METADATA_TIMEOUT_SECONDS="$metadata_timeout_seconds" \
+    KAST_RELEASE_UPLOAD_ATTEMPTS="$attempts" \
+    KAST_RELEASE_UPLOAD_SETTLE_ATTEMPTS=3 \
+    KAST_RELEASE_UPLOAD_TIMEOUT_SECONDS="$timeout_seconds" \
+    "$uploader" --tag v1.2.3 --asset "$asset" >"$output" 2>&1
+  uploader_status="$?"
+  set -e
+}
+
+expect_equal() {
+  local expected="$1" actual="$2" message="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'error: %s: expected %s, got %s\n' "$message" "$expected" "$actual" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+reset_case
+run_uploader starter-retry "$scratch/starter-retry.out"
+expect_equal 0 "$uploader_status" "interrupted upload recovery status"
+expect_equal 2 "$(counter "$upload_count_file")" "interrupted upload attempts"
+expect_equal 1 "$(counter "$delete_count_file")" "incomplete starter cleanup"
+
+reset_case
+cp "$asset" "$remote_asset"
+printf 'uploaded|sha256:%s|201|1\n' "$local_digest" >"$state_file"
+run_uploader forbid-upload "$scratch/reuse.out"
+expect_equal 0 "$uploader_status" "matching immutable asset status"
+expect_equal 0 "$(counter "$download_count_file")" "matching digest downloads"
+expect_equal 0 "$(counter "$upload_count_file")" "matching digest uploads"
+expect_equal 0 "$(counter "$delete_count_file")" "matching digest deletions"
+
+reset_case
+printf '%s\n' "different bytes" >"$remote_asset"
+remote_digest="$(openssl dgst -sha256 -r "$remote_asset" | awk '{ print $1 }')"
+printf 'uploaded|sha256:%s|301|1\n' "$remote_digest" >"$state_file"
+run_uploader forbid-upload "$scratch/mismatch.out"
+[[ "$uploader_status" -ne 0 ]] || {
+  printf '%s\n' 'error: mismatched immutable asset unexpectedly succeeded' >&2
+  failures=$((failures + 1))
+}
+expect_equal 0 "$(counter "$upload_count_file")" "mismatch uploads"
+expect_equal 0 "$(counter "$delete_count_file")" "mismatch deletions"
+
+reset_case
+run_uploader always-fail "$scratch/bounded.out"
+[[ "$uploader_status" -ne 0 ]] || {
+  printf '%s\n' 'error: exhausted upload attempts unexpectedly succeeded' >&2
+  failures=$((failures + 1))
+}
+expect_equal 3 "$(counter "$upload_count_file")" "bounded upload attempts"
+expect_equal 3 "$(counter "$delete_count_file")" "bounded starter cleanup"
+
+reset_case
+cp "$asset" "$remote_asset"
+printf 'uploaded|null|401|1\n' >"$state_file"
+run_uploader forbid-upload "$scratch/no-digest.out"
+expect_equal 0 "$uploader_status" "uploaded asset without API digest status"
+expect_equal 1 "$(counter "$download_count_file")" "uploaded asset fallback download"
+expect_equal 0 "$(counter "$upload_count_file")" "uploaded asset fallback uploads"
+expect_equal 0 "$(counter "$delete_count_file")" "uploaded asset fallback deletions"
+
+reset_case
+printf 'starter|null|501|4\n' >"$state_file"
+run_uploader forbid-upload "$scratch/nonempty-starter.out"
+[[ "$uploader_status" -ne 0 ]] || {
+  printf '%s\n' 'error: non-empty starter asset unexpectedly succeeded' >&2
+  failures=$((failures + 1))
+}
+expect_equal 0 "$(counter "$upload_count_file")" "non-empty starter uploads"
+expect_equal 0 "$(counter "$delete_count_file")" "non-empty starter deletions"
+
+reset_case
+run_uploader starter-becomes-uploaded "$scratch/starter-transition.out"
+expect_equal 0 "$uploader_status" "starter transition status"
+expect_equal 1 "$(counter "$upload_count_file")" "starter transition uploads"
+expect_equal 0 "$(counter "$delete_count_file")" "starter transition deletions"
+
+reset_case
+run_uploader inspect-fail "$scratch/inspect-fail.out"
+[[ "$uploader_status" -ne 0 ]] || {
+  printf '%s\n' 'error: failed release inspection unexpectedly succeeded' >&2
+  failures=$((failures + 1))
+}
+expect_equal 0 "$(counter "$upload_count_file")" "inspection failure uploads"
+expect_equal 0 "$(counter "$delete_count_file")" "inspection failure deletions"
+
+reset_case
+run_uploader inspect-timeout "$scratch/inspect-timeout.out" 1 1 1
+[[ "$uploader_status" -ne 0 ]] || {
+  printf '%s\n' 'error: timed-out release inspection unexpectedly succeeded' >&2
+  failures=$((failures + 1))
+}
+expect_equal 0 "$(counter "$upload_count_file")" "inspection timeout uploads"
+expect_equal 0 "$(counter "$delete_count_file")" "inspection timeout deletions"
+
+reset_case
+run_uploader timeout "$scratch/timeout.out" 1 1
+[[ "$uploader_status" -ne 0 ]] || {
+  printf '%s\n' 'error: timed-out release upload unexpectedly succeeded' >&2
+  failures=$((failures + 1))
+}
+expect_equal 1 "$(counter "$upload_count_file")" "timed-out upload attempts"
+expect_equal 0 "$(counter "$delete_count_file")" "timed-out upload deletions"
+
+[[ "$failures" -eq 0 ]] || die "${failures} immutable release upload contract checks failed"
+printf '%s\n' "immutable release upload recovery contract passed"

--- a/.github/scripts/release/upload-immutable-release-asset.sh
+++ b/.github/scripts/release/upload-immutable-release-asset.sh
@@ -105,9 +105,17 @@ PY
 }
 
 inspect_asset() {
-  local payload matches
-  payload="$(run_gh_with_timeout "$metadata_timeout_seconds" release view "$tag" --json assets)" \
-    || die "Unable to inspect release assets for ${tag}"
+  local payload matches inspection
+  for ((inspection = 1; inspection <= upload_attempts; inspection += 1)); do
+    if payload="$(run_gh_with_timeout "$metadata_timeout_seconds" release view "$tag" --json assets)"; then
+      break
+    fi
+    [[ "$inspection" -lt "$upload_attempts" ]] \
+      || die "Unable to inspect release assets for ${tag}"
+    printf 'Retrying release asset inspection for %s after attempt %s failed\n' \
+      "$tag" "$inspection" >&2
+    sleep "$inspection"
+  done
   matches="$(jq -c --arg name "$asset_name" \
     '[.assets[] | select(.name == $name)]' <<<"$payload")" \
     || die "Unable to parse release assets for ${tag}"

--- a/.github/scripts/release/upload-immutable-release-asset.sh
+++ b/.github/scripts/release/upload-immutable-release-asset.sh
@@ -11,7 +11,8 @@ usage() {
 Usage: .github/scripts/release/upload-immutable-release-asset.sh --tag <tag> --asset <path>
 
 Upload one GitHub release asset exactly once. If the named asset already exists,
-download it and prove byte identity instead of replacing it.
+prove byte identity instead of replacing it. Remove only an incomplete starter
+asset before a bounded upload retry.
 USAGE
 }
 
@@ -52,37 +53,192 @@ done
 [[ -n "$asset" ]] || { usage; die "--asset is required"; }
 [[ -f "$asset" ]] || die "Release asset does not exist: $asset"
 command -v gh >/dev/null 2>&1 || die "gh is required to upload release assets"
+command -v jq >/dev/null 2>&1 || die "jq is required to inspect release assets"
+command -v python3 >/dev/null 2>&1 || die "python3 is required to bound release uploads"
 
 asset_name="$(basename -- "$asset")"
-asset_names="$(gh release view "$tag" --json assets --jq '.assets[].name')" \
-  || die "Unable to inspect release assets for ${tag}"
-existing_count="$(awk -v name="$asset_name" '$0 == name { count += 1 } END { print count + 0 }' <<< "$asset_names")"
+local_digest="$(openssl dgst -sha256 -r "$asset" | awk '{ print $1 }')"
+upload_attempts="${KAST_RELEASE_UPLOAD_ATTEMPTS:-3}"
+upload_timeout_seconds="${KAST_RELEASE_UPLOAD_TIMEOUT_SECONDS:-300}"
+metadata_timeout_seconds="${KAST_RELEASE_METADATA_TIMEOUT_SECONDS:-30}"
+settle_attempts="${KAST_RELEASE_UPLOAD_SETTLE_ATTEMPTS:-3}"
+[[ "$upload_attempts" =~ ^[1-9][0-9]*$ ]] \
+  || die "KAST_RELEASE_UPLOAD_ATTEMPTS must be a positive integer"
+[[ "$upload_timeout_seconds" =~ ^[1-9][0-9]*$ ]] \
+  || die "KAST_RELEASE_UPLOAD_TIMEOUT_SECONDS must be a positive integer"
+[[ "$metadata_timeout_seconds" =~ ^[1-9][0-9]*$ ]] \
+  || die "KAST_RELEASE_METADATA_TIMEOUT_SECONDS must be a positive integer"
+[[ "$settle_attempts" =~ ^[1-9][0-9]*$ ]] \
+  || die "KAST_RELEASE_UPLOAD_SETTLE_ATTEMPTS must be a positive integer"
+scratch_dir=""
+remote_state=""
+remote_digest=""
+remote_api_url=""
+remote_size=""
+remote_count=0
 
-if [[ "$existing_count" -gt 1 ]]; then
-  die "Release ${tag} contains duplicate assets named ${asset_name}"
-fi
+# shellcheck disable=SC2329 # Invoked indirectly by the EXIT trap.
+cleanup() {
+  [[ -z "$scratch_dir" ]] || rm -rf "$scratch_dir"
+}
+trap cleanup EXIT
 
-if [[ "$existing_count" -eq 1 ]]; then
+run_gh_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+  python3 - "$timeout_seconds" "$@" <<'PY'
+import subprocess
+import sys
+
+timeout = int(sys.argv[1])
+command = ["gh", *sys.argv[2:]]
+try:
+    result = subprocess.run(command, timeout=timeout, check=False)
+except subprocess.TimeoutExpired:
+    print(
+        f"error: gh command exceeded {timeout} seconds: {' '.join(command[1:])}",
+        file=sys.stderr,
+    )
+    raise SystemExit(124)
+raise SystemExit(result.returncode)
+PY
+}
+
+inspect_asset() {
+  local payload matches
+  payload="$(run_gh_with_timeout "$metadata_timeout_seconds" release view "$tag" --json assets)" \
+    || die "Unable to inspect release assets for ${tag}"
+  matches="$(jq -c --arg name "$asset_name" \
+    '[.assets[] | select(.name == $name)]' <<<"$payload")" \
+    || die "Unable to parse release assets for ${tag}"
+  remote_count="$(jq -r 'length' <<<"$matches")"
+  [[ "$remote_count" -le 1 ]] \
+    || die "Release ${tag} contains duplicate assets named ${asset_name}"
+  remote_state=""
+  remote_digest=""
+  remote_api_url=""
+  remote_size=""
+  if [[ "$remote_count" -eq 1 ]]; then
+    remote_state="$(jq -r '.[0].state // ""' <<<"$matches")"
+    remote_digest="$(jq -r '.[0].digest // ""' <<<"$matches")"
+    remote_api_url="$(jq -r '.[0].apiUrl // ""' <<<"$matches")"
+    remote_size="$(jq -r '.[0].size // ""' <<<"$matches")"
+  fi
+}
+
+verify_uploaded_asset() {
+  [[ "$remote_state" == "uploaded" ]] \
+    || die "Release asset ${tag}/${asset_name} is not uploaded"
+  if [[ -n "$remote_digest" ]]; then
+    [[ "$remote_digest" == "sha256:${local_digest}" ]] \
+      || die "Local asset ${asset_name} (sha256:${local_digest}) differs from immutable release asset ${tag}/${asset_name} (${remote_digest})"
+    printf 'Verified immutable release asset digest %s/%s\n' "$tag" "$asset_name"
+    return
+  fi
+
   scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/kast-release-asset.XXXXXX")"
-  # shellcheck disable=SC2329 # Invoked indirectly by the EXIT trap.
-  cleanup() {
-    rm -rf "$scratch_dir"
-  }
-  trap cleanup EXIT
-
-  gh release download "$tag" --pattern "$asset_name" --dir "$scratch_dir" \
+  run_gh_with_timeout "$upload_timeout_seconds" \
+    release download "$tag" --pattern "$asset_name" --dir "$scratch_dir" \
     || die "Unable to download immutable release asset ${asset_name} from ${tag}"
   downloaded_asset="${scratch_dir}/${asset_name}"
   [[ -f "$downloaded_asset" ]] \
     || die "Release ${tag} reported ${asset_name}, but the asset could not be downloaded"
   if ! cmp -s "$asset" "$downloaded_asset"; then
-    local_digest="$(openssl dgst -sha256 -r "$asset" | awk '{ print $1 }')"
-    remote_digest="$(openssl dgst -sha256 -r "$downloaded_asset" | awk '{ print $1 }')"
-    die "Local asset ${asset_name} (${local_digest}) differs from immutable release asset ${tag}/${asset_name} (${remote_digest})"
+    downloaded_digest="$(openssl dgst -sha256 -r "$downloaded_asset" | awk '{ print $1 }')"
+    die "Local asset ${asset_name} (${local_digest}) differs from immutable release asset ${tag}/${asset_name} (${downloaded_digest})"
   fi
   printf 'Verified byte-identical immutable release asset %s/%s\n' "$tag" "$asset_name"
+}
+
+settle_incomplete_asset() {
+  local endpoint current current_name current_state current_digest current_url current_size poll
+  [[ "$remote_state" == "starter" && -z "$remote_digest" && "$remote_size" == "0" ]] \
+    || die "Release asset ${tag}/${asset_name} has unsafe incomplete state=${remote_state} digest=${remote_digest:-null} size=${remote_size:-unknown}"
+  [[ "$remote_api_url" =~ ^https://api\.github\.com/repos/[^/]+/[^/]+/releases/assets/[0-9]+$ ]] \
+    || die "Release asset ${tag}/${asset_name} has no valid API URL"
+  endpoint="${remote_api_url#https://api.github.com/}"
+  for ((poll = 1; poll <= settle_attempts; poll += 1)); do
+    [[ "$poll" -eq 1 ]] || sleep 1
+    current="$(run_gh_with_timeout "$metadata_timeout_seconds" api "$endpoint")" \
+      || die "Unable to recheck incomplete release asset ${tag}/${asset_name}"
+    current_name="$(jq -r '.name // ""' <<<"$current")"
+    current_state="$(jq -r '.state // ""' <<<"$current")"
+    current_digest="$(jq -r '.digest // ""' <<<"$current")"
+    current_url="$(jq -r '.apiUrl // .url // ""' <<<"$current")"
+    current_size="$(jq -r '.size // ""' <<<"$current")"
+    [[ "$current_name" == "$asset_name" ]] \
+      || die "Incomplete release asset identity changed for ${tag}/${asset_name}"
+    [[ "$current_url" == "$remote_api_url" ]] \
+      || die "Incomplete release asset API identity changed for ${tag}/${asset_name}"
+    case "$current_state" in
+      uploaded)
+        remote_state="$current_state"
+        remote_digest="$current_digest"
+        remote_size="$current_size"
+        verify_uploaded_asset
+        return 0
+        ;;
+      starter)
+        [[ -z "$current_digest" && "$current_size" == "0" ]] \
+          || die "Release asset ${tag}/${asset_name} changed while settling: state=${current_state} digest=${current_digest:-null} size=${current_size:-unknown}"
+        ;;
+      *)
+        die "Release asset ${tag}/${asset_name} changed while settling: state=${current_state:-missing}"
+        ;;
+    esac
+  done
+
+  # The workflow concurrency group gives each tag one writer. The upload
+  # subprocess has exited and the same empty asset stayed stable while polled.
+  run_gh_with_timeout "$metadata_timeout_seconds" \
+    api --method DELETE "$endpoint" --silent \
+    || die "Unable to delete incomplete release asset ${tag}/${asset_name}"
+  printf 'Deleted incomplete release asset %s/%s\n' "$tag" "$asset_name"
+  return 1
+}
+
+reconcile_asset() {
+  inspect_asset
+  if [[ "$remote_count" -eq 0 ]]; then
+    return 1
+  fi
+  case "$remote_state" in
+    uploaded)
+      verify_uploaded_asset
+      return 0
+      ;;
+    starter)
+      if settle_incomplete_asset; then
+        return 0
+      fi
+      return 1
+      ;;
+    *)
+      die "Release asset ${tag}/${asset_name} has unsupported state=${remote_state:-missing}"
+      ;;
+  esac
+}
+
+upload_once() {
+  run_gh_with_timeout "$upload_timeout_seconds" release upload "$tag" "$asset"
+}
+
+if reconcile_asset; then
   exit 0
 fi
 
-gh release upload "$tag" "$asset"
-printf 'Uploaded immutable release asset %s/%s\n' "$tag" "$asset_name"
+for ((attempt = 1; attempt <= upload_attempts; attempt += 1)); do
+  upload_status=0
+  upload_once || upload_status="$?"
+  if reconcile_asset; then
+    printf 'Uploaded immutable release asset %s/%s\n' "$tag" "$asset_name"
+    exit 0
+  fi
+  if [[ "$attempt" -lt "$upload_attempts" ]]; then
+    printf 'Retrying release asset upload %s/%s after attempt %s failed with %s\n' \
+      "$tag" "$asset_name" "$attempt" "$upload_status" >&2
+    sleep "$attempt"
+  fi
+done
+
+die "Unable to upload immutable release asset ${tag}/${asset_name} after ${upload_attempts} attempts"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   release-preflight:
     name: Preflight release automation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
 
@@ -56,6 +56,13 @@ jobs:
           cache-cleanup: always
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust validation build
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          workspaces: cli-rs -> target
+          shared-key: rust-cli-validation
+          cache-bin: "false"
 
       - name: Verify the sole setup contract
         run: .github/scripts/install/test-setup-contract.sh
@@ -241,7 +248,7 @@ jobs:
     if: always() && needs.prepare-release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -299,7 +306,35 @@ jobs:
             --producer-job build-openapi-spec \
             --build-command-id release-stage-openapi-spec
 
-      - name: Upload OpenAPI release asset
+      - name: Upload OpenAPI workflow artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: openapi-spec-${{ github.run_id }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30
+
+  publish-openapi-spec:
+    name: Publish OpenAPI spec
+    needs:
+      - prepare-release
+      - build-openapi-spec
+    if: always() && needs.prepare-release.result == 'success' && needs.build-openapi-spec.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Download retained OpenAPI asset
+        uses: actions/download-artifact@v7
+        with:
+          name: openapi-spec-${{ github.run_id }}
+          path: dist
+
+      - name: Verify and publish retained OpenAPI asset
         env:
           GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
         shell: bash
@@ -315,13 +350,14 @@ jobs:
             --tag "$tag" \
             --asset dist/openapi.yaml
 
-      - name: Upload OpenAPI workflow artifact
-        if: always()
+      - name: Retain OpenAPI provenance
         uses: actions/upload-artifact@v6
         with:
-          name: openapi-spec-${{ github.run_id }}
-          path: dist/
+          name: openapi-provenance-${{ github.run_id }}
+          path: dist/build-provenance-openapi.json
           if-no-files-found: error
+          overwrite: true
+          retention-days: 30
 
   publish-maven-central:
     name: Publish Maven Central
@@ -480,138 +516,88 @@ jobs:
             --attempts 30 \
             --delay-seconds 20
 
-  build-cli:
-    name: Build Rust CLI asset (${{ matrix.asset_id }})
+  build-cli-linux-x64:
+    name: Build Rust CLI asset (linux-x64)
     needs: [prepare-release]
     if: always() && needs.prepare-release.result == 'success'
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-22.04
     permissions:
-      contents: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - asset_id: linux-x64
-            runner: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
-          - asset_id: linux-arm64
-            runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-          - asset_id: macos-x64
-            runner: macos-15-intel
-            target: x86_64-apple-darwin
-          - asset_id: macos-arm64
-            runner: macos-14
-            target: aarch64-apple-darwin
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare-release.outputs.release_tag }}
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/scripts/release/actions/build-cli
         with:
-          targets: ${{ matrix.target }}
+          asset_id: linux-x64
+          target: x86_64-unknown-linux-gnu
+          cache_key: source-bound-cli-release
+          release_tag: ${{ needs.prepare-release.outputs.release_tag }}
+          release_version: ${{ needs.prepare-release.outputs.release_version }}
 
-      - name: Build Rust CLI
-        working-directory: cli-rs
-        shell: bash
-        run: |
-          set -euo pipefail
-          KAST_VERSION="${{ needs.prepare-release.outputs.release_version }}" \
-            cargo build --release --locked --target "${{ matrix.target }}"
-
-      - name: Smoke Rust CLI
-        working-directory: cli-rs
-        shell: bash
-        run: |
-          set -euo pipefail
-          bin="target/${{ matrix.target }}/release/kast"
-          smoke_dir="$RUNNER_TEMP/kast-cli-smoke"
-          mkdir -p "$smoke_dir"
-          cp "$bin" "$smoke_dir/kastctl"
-          cp "$bin" "$smoke_dir/kast"
-          "$smoke_dir/kastctl" --help >/dev/null
-          "$smoke_dir/kastctl" version | grep -F "Kast CLI" >/dev/null
-          "$smoke_dir/kast" --help >/dev/null
-          cmp -s "$smoke_dir/kastctl" "$smoke_dir/kast"
-
-      - name: Package CLI asset
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag="${{ needs.prepare-release.outputs.release_tag }}"
-          asset_name="kast-${tag}-${{ matrix.asset_id }}.zip"
-          staging_dir="$RUNNER_TEMP/kast-${{ matrix.asset_id }}"
-          rm -rf "$staging_dir" dist
-          mkdir -p "$staging_dir" dist
-          cp "cli-rs/target/${{ matrix.target }}/release/kast" "$staging_dir/kastctl"
-          cp "cli-rs/target/${{ matrix.target }}/release/kast" "$staging_dir/kast"
-          chmod 755 "$staging_dir/kastctl" "$staging_dir/kast"
-          cmp -s "$staging_dir/kastctl" "$staging_dir/kast"
-          (cd "$staging_dir" && zip -9 -q "$GITHUB_WORKSPACE/dist/${asset_name}" kastctl kast)
-          python3 - "$GITHUB_WORKSPACE/dist/${asset_name}" "dist/build-provenance-cli-${{ matrix.asset_id }}.json" <<'PY'
-          import hashlib
-          import json
-          import os
-          import sys
-          from pathlib import Path
-          asset = Path(sys.argv[1])
-          output = Path(sys.argv[2])
-          digest = hashlib.sha256(asset.read_bytes()).hexdigest()
-          payload = {
-              "runId": os.environ["GITHUB_RUN_ID"],
-              "runNumber": os.environ["GITHUB_RUN_NUMBER"],
-              "runAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
-              "sha": os.environ["GITHUB_SHA"],
-              "ref": os.environ["GITHUB_REF"],
-              "workflowRef": os.environ["GITHUB_WORKFLOW_REF"],
-              "actor": os.environ["GITHUB_ACTOR"],
-              "platformId": "cli-${{ matrix.asset_id }}",
-              "assetName": asset.name,
-              "assetDigest": "sha256:" + digest,
-          }
-          output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          PY
-          scripts/verify-ci-artifact-ledger.py record \
-            --output "dist/build-ledger-cli-${{ matrix.asset_id }}.json" \
-            --git-sha "$GITHUB_SHA" \
-            --source-ref "refs/tags/${tag}" \
-            --workflow-run-id "$GITHUB_RUN_ID" \
-            --artifact-kind "release-cli-${{ matrix.asset_id }}" \
-            --artifact-name "$asset_name" \
-            --artifact-path "dist/${asset_name}" \
-            --producer-job "build-cli-${{ matrix.asset_id }}" \
-            --build-command-id "release-rust-cli-${{ matrix.asset_id }}"
-
-      - name: Upload CLI asset
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag="${{ needs.prepare-release.outputs.release_tag }}"
-          scripts/verify-ci-artifact-ledger.py verify \
-            --ledger "dist/build-ledger-cli-${{ matrix.asset_id }}.json" \
-            --git-sha "$GITHUB_SHA" \
-            --require-kind "release-cli-${{ matrix.asset_id }}" \
-            --artifact "release-cli-${{ matrix.asset_id }}=dist/kast-${tag}-${{ matrix.asset_id }}.zip"
-          .github/scripts/release/upload-immutable-release-asset.sh \
-            --tag "$tag" \
-            --asset "dist/kast-${tag}-${{ matrix.asset_id }}.zip"
-
-      - name: Upload CLI build artifact
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: rust-cli-${{ matrix.asset_id }}-${{ github.run_id }}
-          path: dist/
-          if-no-files-found: warn
-
-  build-agent-resources:
-    name: Build agent resource assets
+  build-cli-linux-arm64:
+    name: Build Rust CLI asset (linux-arm64)
     needs: [prepare-release]
     if: always() && needs.prepare-release.result == 'success'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/build-cli
+        with:
+          asset_id: linux-arm64
+          target: aarch64-unknown-linux-gnu
+          cache_key: release-cli-linux-arm64
+          release_tag: ${{ needs.prepare-release.outputs.release_tag }}
+          release_version: ${{ needs.prepare-release.outputs.release_version }}
+
+  build-cli-macos-x64:
+    name: Build Rust CLI asset (macos-x64)
+    needs: [prepare-release]
+    if: always() && needs.prepare-release.result == 'success'
+    runs-on: macos-15-intel
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/build-cli
+        with:
+          asset_id: macos-x64
+          target: x86_64-apple-darwin
+          cache_key: release-cli-macos-x64
+          release_tag: ${{ needs.prepare-release.outputs.release_tag }}
+          release_version: ${{ needs.prepare-release.outputs.release_version }}
+
+  build-cli-macos-arm64:
+    name: Build Rust CLI asset (macos-arm64)
+    needs: [prepare-release]
+    if: always() && needs.prepare-release.result == 'success'
+    runs-on: macos-14
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/build-cli
+        with:
+          asset_id: macos-arm64
+          target: aarch64-apple-darwin
+          cache_key: release-cli-macos-arm64
+          release_tag: ${{ needs.prepare-release.outputs.release_tag }}
+          release_version: ${{ needs.prepare-release.outputs.release_version }}
+
+  publish-cli-linux-x64:
+    name: Publish Rust CLI asset (linux-x64)
+    needs:
+      - prepare-release
+      - build-cli-linux-x64
+    if: always() && needs.prepare-release.result == 'success' && needs.build-cli-linux-x64.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -619,15 +605,91 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare-release.outputs.release_tag }}
-
-      - name: Build and publish deterministic agent resources
+      - uses: ./.github/scripts/release/actions/publish-cli
         env:
           GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        with:
+          asset_id: linux-x64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  publish-cli-linux-arm64:
+    name: Publish Rust CLI asset (linux-arm64)
+    needs:
+      - prepare-release
+      - build-cli-linux-arm64
+    if: always() && needs.prepare-release.result == 'success' && needs.build-cli-linux-arm64.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/publish-cli
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        with:
+          asset_id: linux-arm64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  publish-cli-macos-x64:
+    name: Publish Rust CLI asset (macos-x64)
+    needs:
+      - prepare-release
+      - build-cli-macos-x64
+    if: always() && needs.prepare-release.result == 'success' && needs.build-cli-macos-x64.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/publish-cli
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        with:
+          asset_id: macos-x64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  publish-cli-macos-arm64:
+    name: Publish Rust CLI asset (macos-arm64)
+    needs:
+      - prepare-release
+      - build-cli-macos-arm64
+    if: always() && needs.prepare-release.result == 'success' && needs.build-cli-macos-arm64.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/publish-cli
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        with:
+          asset_id: macos-arm64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  build-agent-resources:
+    name: Build agent resource assets
+    needs: [prepare-release]
+    if: always() && needs.prepare-release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Build deterministic agent resources
         shell: bash
         run: |
           set -euo pipefail
           tag="${{ needs.prepare-release.outputs.release_tag }}"
-          output="$RUNNER_TEMP/kast-agent-resources"
+          output="dist/agent-resources"
           .github/scripts/release/agent-resource-assets.py build \
             --source cli-rs/resources/kast \
             --output "$output" \
@@ -637,6 +699,95 @@ jobs:
             --release-dir "$output" \
             --tag "$tag" \
             --git-sha "$GITHUB_SHA"
+          mkdir -p dist/agent-resource-ledgers
+          for specification in \
+            "codex-archive|kast-codex-${tag}.tar" \
+            "codex-checksum|kast-codex-${tag}.tar.sha256sum" \
+            "claude-archive|kast-claude-${tag}.tar" \
+            "claude-checksum|kast-claude-${tag}.tar.sha256sum" \
+            "copilot-archive|kast-copilot-${tag}.tar" \
+            "copilot-checksum|kast-copilot-${tag}.tar.sha256sum" \
+            "provenance|kast-agent-resources-provenance.json"
+          do
+            IFS='|' read -r asset_id asset_name <<<"$specification"
+            scripts/verify-ci-artifact-ledger.py record \
+              --output "dist/agent-resource-ledgers/${asset_id}.json" \
+              --git-sha "$GITHUB_SHA" \
+              --source-ref "refs/tags/${tag}" \
+              --workflow-run-id "$GITHUB_RUN_ID" \
+              --artifact-kind "release-agent-resource-${asset_id}" \
+              --artifact-name "$asset_name" \
+              --artifact-path "${output}/${asset_name}" \
+              --producer-job build-agent-resources \
+              --build-command-id release-agent-resources
+          done
+
+      - name: Retain agent resource assets
+        uses: actions/upload-artifact@v6
+        with:
+          name: agent-resources-${{ github.run_id }}
+          path: |
+            dist/agent-resources/
+            dist/agent-resource-ledgers/
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+  publish-agent-resources:
+    name: Publish agent resource assets
+    needs:
+      - prepare-release
+      - build-agent-resources
+    if: always() && needs.prepare-release.result == 'success' && needs.build-agent-resources.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Download retained agent resource assets
+        uses: actions/download-artifact@v7
+        with:
+          name: agent-resources-${{ github.run_id }}
+          path: dist
+
+      - name: Verify and publish retained agent resource assets
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          output="dist/agent-resources"
+          .github/scripts/release/agent-resource-assets.py verify \
+            --release-dir "$output" \
+            --tag "$tag" \
+            --git-sha "$GITHUB_SHA"
+          ledger_args=()
+          required_kind_args=()
+          artifact_args=()
+          for specification in \
+            "codex-archive|kast-codex-${tag}.tar" \
+            "codex-checksum|kast-codex-${tag}.tar.sha256sum" \
+            "claude-archive|kast-claude-${tag}.tar" \
+            "claude-checksum|kast-claude-${tag}.tar.sha256sum" \
+            "copilot-archive|kast-copilot-${tag}.tar" \
+            "copilot-checksum|kast-copilot-${tag}.tar.sha256sum" \
+            "provenance|kast-agent-resources-provenance.json"
+          do
+            IFS='|' read -r asset_id asset_name <<<"$specification"
+            artifact_kind="release-agent-resource-${asset_id}"
+            ledger_args+=(--ledger "dist/agent-resource-ledgers/${asset_id}.json")
+            required_kind_args+=(--require-kind "$artifact_kind")
+            artifact_args+=(--artifact "${artifact_kind}=${output}/${asset_name}")
+          done
+          scripts/verify-ci-artifact-ledger.py verify \
+            "${ledger_args[@]}" \
+            --git-sha "$GITHUB_SHA" \
+            "${required_kind_args[@]}" \
+            "${artifact_args[@]}"
           for asset in \
             "$output/kast-codex-${tag}.tar" \
             "$output/kast-codex-${tag}.tar.sha256sum" \
@@ -657,7 +808,7 @@ jobs:
     if: always() && needs.prepare-release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -701,9 +852,7 @@ jobs:
           :backend-idea:buildPlugin
           -Pversion="${{ needs.prepare-release.outputs.release_version }}"
 
-      - name: Upload IDEA plugin and update feed
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+      - name: Stage IDEA plugin and update feed
         shell: bash
         run: |
           set -euo pipefail
@@ -725,7 +874,78 @@ jobs:
             -e "s/#tag#/${tag}/g" \
             -e "s/#version#/${version}/g" \
             packaging/jetbrains/updatePlugins.xml > "$feed_path"
-          gh release upload "$tag" "$asset_path" "$feed_path" --clobber
+          scripts/verify-ci-artifact-ledger.py record \
+            --output dist/build-ledger-idea-plugin.json \
+            --git-sha "$GITHUB_SHA" \
+            --source-ref "refs/tags/${tag}" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --artifact-kind release-idea-plugin \
+            --artifact-name "$asset_name" \
+            --artifact-path "$asset_path" \
+            --producer-job build-idea-plugin \
+            --build-command-id release-idea-plugin-build
+          scripts/verify-ci-artifact-ledger.py record \
+            --output dist/build-ledger-idea-update-feed.json \
+            --git-sha "$GITHUB_SHA" \
+            --source-ref "refs/tags/${tag}" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --artifact-kind release-idea-update-feed \
+            --artifact-name updatePlugins.xml \
+            --artifact-path "$feed_path" \
+            --producer-job build-idea-plugin \
+            --build-command-id release-idea-update-feed
+
+      - name: Retain IDEA plugin assets
+        uses: actions/upload-artifact@v6
+        with:
+          name: idea-plugin-${{ github.run_id }}
+          path: dist/
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+  publish-idea-plugin:
+    name: Publish IDEA plugin assets
+    needs:
+      - prepare-release
+      - build-idea-plugin
+    if: always() && needs.prepare-release.result == 'success' && needs.build-idea-plugin.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Download retained IDEA plugin assets
+        uses: actions/download-artifact@v7
+        with:
+          name: idea-plugin-${{ github.run_id }}
+          path: dist
+
+      - name: Verify and publish retained IDEA plugin assets
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          asset_path="dist/kast-idea-${tag}.zip"
+          feed_path="dist/updatePlugins.xml"
+          scripts/verify-ci-artifact-ledger.py verify \
+            --ledger dist/build-ledger-idea-plugin.json \
+            --ledger dist/build-ledger-idea-update-feed.json \
+            --git-sha "$GITHUB_SHA" \
+            --require-kind release-idea-plugin \
+            --require-kind release-idea-update-feed \
+            --artifact "release-idea-plugin=${asset_path}" \
+            --artifact "release-idea-update-feed=${feed_path}"
+          for asset in "$asset_path" "$feed_path"; do
+            .github/scripts/release/upload-immutable-release-asset.sh \
+              --tag "$tag" \
+              --asset "$asset"
+          done
 
   build-headless-backend:
     name: Build headless backend
@@ -870,24 +1090,33 @@ jobs:
             --build-command-id release-gradle-ro-cache
 
       - name: Upload headless backend artifact
-        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: headless-backend-${{ github.run_id }}
-          path: dist/
-          if-no-files-found: warn
+          path: |
+            dist/headless.zip
+            dist/build-ledger-headless-backend.json
+            dist/gradle-ro-cache/
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
 
   build-linux-headless-tarball:
     name: Build Linux headless tarball
     needs:
       - prepare-release
-      - build-cli
+      - build-cli-linux-x64
       - build-headless-backend
       - build-idea-plugin
-    if: always() && needs.prepare-release.result == 'success' && needs.build-cli.result == 'success' && needs.build-headless-backend.result == 'success' && needs.build-idea-plugin.result == 'success'
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.build-cli-linux-x64.result == 'success' &&
+      needs.build-headless-backend.result == 'success' &&
+      needs.build-idea-plugin.result == 'success'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -905,6 +1134,12 @@ jobs:
           name: rust-cli-linux-x64-${{ github.run_id }}
           path: release-assets
 
+      - name: Download IDEA plugin artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: idea-plugin-${{ github.run_id }}
+          path: release-assets
+
       - name: Ensure zstd is available
         shell: bash
         run: |
@@ -915,8 +1150,6 @@ jobs:
           fi
 
       - name: Package Linux headless tarball
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -933,20 +1166,22 @@ jobs:
           rm -rf dist
           mkdir -p dist
           [[ -f "$backend_asset" ]] || { echo "Missing headless backend artifact: ${backend_asset}" >&2; exit 1; }
-          gh release download "$tag" --pattern "kast-idea-${tag}.zip" --dir release-assets
           [[ -f "$plugin_asset" ]] || { echo "Missing IDEA plugin artifact: ${plugin_asset}" >&2; exit 1; }
           [[ -f "$gradle_cache_asset" ]] || { echo "Missing Gradle read-only cache artifact: ${gradle_cache_asset}" >&2; exit 1; }
           [[ -f "$gradle_cache_sidecar" ]] || { echo "Missing Gradle read-only cache checksum: ${gradle_cache_sidecar}" >&2; exit 1; }
           [[ -f "$gradle_cache_provenance" ]] || { echo "Missing Gradle read-only cache provenance: ${gradle_cache_provenance}" >&2; exit 1; }
           scripts/verify-ci-artifact-ledger.py verify \
             --ledger release-assets/build-ledger-cli-linux-x64.json \
+            --ledger release-assets/build-ledger-idea-plugin.json \
             --ledger headless-backend/build-ledger-headless-backend.json \
             --ledger "${gradle_cache_dir}/build-ledger-gradle-ro-cache.json" \
             --git-sha "$GITHUB_SHA" \
             --require-kind release-cli-linux-x64 \
+            --require-kind release-idea-plugin \
             --require-kind release-headless-backend \
             --require-kind release-gradle-ro-cache \
             --artifact "release-cli-linux-x64=${cli_asset}" \
+            --artifact "release-idea-plugin=${plugin_asset}" \
             --artifact "release-headless-backend=${backend_asset}" \
             --artifact "release-gradle-ro-cache=${gradle_cache_asset}"
           packager_dir="${RUNNER_TEMP}/kast-release-packager"
@@ -1109,7 +1344,51 @@ jobs:
               raise SystemExit("runtime manifest artifactSha256 does not match tarball")
           PY
 
-      - name: Upload Linux headless tarball
+      - name: Retain Linux headless assets
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-headless-tarball-${{ github.run_id }}
+          path: |
+            dist/kast-ubuntu-debian-headless-x86_64-${{ needs.prepare-release.outputs.release_tag }}.tar.gz
+            dist/kast-ubuntu-debian-headless-x86_64-${{ needs.prepare-release.outputs.release_tag }}.tar.gz.sha256
+            dist/kast-headless-linux-x64.tar.zst
+            dist/kast-headless-linux-x64.sha256
+            dist/kast-runtime-manifest.json
+            dist/provenance/
+            dist/build-ledger-ubuntu-debian-headless.json
+            dist/build-ledger-headless-linux-x64.json
+            dist/build-ledger-runtime-manifest.json
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+  publish-linux-headless-assets:
+    name: Publish Linux headless assets
+    needs:
+      - prepare-release
+      - build-linux-headless-tarball
+    if: always() && needs.prepare-release.result == 'success' && needs.build-linux-headless-tarball.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Download retained Linux headless assets
+        uses: actions/download-artifact@v7
+        with:
+          name: linux-headless-tarball-${{ github.run_id }}
+          path: dist
+
+      - name: Download retained headless build inputs
+        uses: actions/download-artifact@v7
+        with:
+          name: headless-backend-${{ github.run_id }}
+          path: headless-input
+
+      - name: Verify and publish retained Linux headless assets
         env:
           GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
         shell: bash
@@ -1121,7 +1400,7 @@ jobs:
             --ledger dist/build-ledger-ubuntu-debian-headless.json \
             --ledger dist/build-ledger-headless-linux-x64.json \
             --ledger dist/build-ledger-runtime-manifest.json \
-            --ledger dist/build-ledger-gradle-ro-cache.json \
+            --ledger headless-input/gradle-ro-cache/build-ledger-gradle-ro-cache.json \
             --git-sha "$GITHUB_SHA" \
             --require-kind release-ubuntu-debian-headless-x86_64 \
             --require-kind release-headless-linux-x64 \
@@ -1130,26 +1409,223 @@ jobs:
             --artifact "release-ubuntu-debian-headless-x86_64=${bundle_asset}" \
             --artifact release-headless-linux-x64=dist/kast-headless-linux-x64.tar.zst \
             --artifact release-runtime-manifest=dist/kast-runtime-manifest.json \
-            --artifact release-gradle-ro-cache=dist/gradle-ro-dep-cache.tar.zst
+            --artifact release-gradle-ro-cache=headless-input/gradle-ro-cache/gradle-ro-dep-cache.tar.zst
           for asset in \
             "$bundle_asset" \
             "${bundle_asset}.sha256" \
             dist/kast-headless-linux-x64.tar.zst \
             dist/kast-headless-linux-x64.sha256 \
-            dist/kast-runtime-manifest.json
+            dist/kast-runtime-manifest.json \
+            headless-input/gradle-ro-cache/gradle-ro-dep-cache.tar.zst \
+            headless-input/gradle-ro-cache/gradle-ro-dep-cache.sha256
           do
             .github/scripts/release/upload-immutable-release-asset.sh \
               --tag "$tag" \
               --asset "$asset"
           done
 
-      - name: Upload Linux headless tarball artifact
-        if: always()
+      - name: Retain Linux headless provenance
         uses: actions/upload-artifact@v6
         with:
-          name: linux-headless-tarball-${{ github.run_id }}
-          path: dist/
-          if-no-files-found: warn
+          name: linux-headless-provenance-${{ github.run_id }}
+          path: dist/provenance/
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 30
+
+  build-setup-linux-x64:
+    name: Build setup bundle (linux-x64)
+    needs:
+      - prepare-release
+      - build-cli-linux-x64
+      - build-idea-plugin
+      - build-headless-backend
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.build-cli-linux-x64.result == 'success' &&
+      needs.build-idea-plugin.result == 'success' &&
+      needs.build-headless-backend.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/build-setup-bundle
+        with:
+          platform: linux-x64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  build-setup-linux-arm64:
+    name: Build setup bundle (linux-arm64)
+    needs:
+      - prepare-release
+      - build-cli-linux-x64
+      - build-cli-linux-arm64
+      - build-idea-plugin
+      - build-headless-backend
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.build-cli-linux-x64.result == 'success' &&
+      needs.build-cli-linux-arm64.result == 'success' &&
+      needs.build-idea-plugin.result == 'success' &&
+      needs.build-headless-backend.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/build-setup-bundle
+        with:
+          platform: linux-arm64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  build-setup-macos-x64:
+    name: Build setup bundle (macos-x64)
+    needs:
+      - prepare-release
+      - build-cli-linux-x64
+      - build-cli-macos-x64
+      - build-idea-plugin
+      - build-headless-backend
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.build-cli-linux-x64.result == 'success' &&
+      needs.build-cli-macos-x64.result == 'success' &&
+      needs.build-idea-plugin.result == 'success' &&
+      needs.build-headless-backend.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/build-setup-bundle
+        with:
+          platform: macos-x64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  build-setup-macos-arm64:
+    name: Build setup bundle (macos-arm64)
+    needs:
+      - prepare-release
+      - build-cli-linux-x64
+      - build-cli-macos-arm64
+      - build-idea-plugin
+      - build-headless-backend
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.build-cli-linux-x64.result == 'success' &&
+      needs.build-cli-macos-arm64.result == 'success' &&
+      needs.build-idea-plugin.result == 'success' &&
+      needs.build-headless-backend.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/build-setup-bundle
+        with:
+          platform: macos-arm64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  publish-setup-linux-x64:
+    name: Publish setup bundle (linux-x64)
+    needs:
+      - prepare-release
+      - build-setup-linux-x64
+    if: always() && needs.prepare-release.result == 'success' && needs.build-setup-linux-x64.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/publish-setup-bundle
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        with:
+          platform: linux-x64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  publish-setup-linux-arm64:
+    name: Publish setup bundle (linux-arm64)
+    needs:
+      - prepare-release
+      - build-setup-linux-arm64
+    if: always() && needs.prepare-release.result == 'success' && needs.build-setup-linux-arm64.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/publish-setup-bundle
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        with:
+          platform: linux-arm64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  publish-setup-macos-x64:
+    name: Publish setup bundle (macos-x64)
+    needs:
+      - prepare-release
+      - build-setup-macos-x64
+    if: always() && needs.prepare-release.result == 'success' && needs.build-setup-macos-x64.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/publish-setup-bundle
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        with:
+          platform: macos-x64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
+
+  publish-setup-macos-arm64:
+    name: Publish setup bundle (macos-arm64)
+    needs:
+      - prepare-release
+      - build-setup-macos-arm64
+    if: always() && needs.prepare-release.result == 'success' && needs.build-setup-macos-arm64.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+      - uses: ./.github/scripts/release/actions/publish-setup-bundle
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        with:
+          platform: macos-arm64
+          tag: ${{ needs.prepare-release.outputs.release_tag }}
 
   real-repository-indexing:
     name: Index ${{ matrix.name }}
@@ -1231,28 +1707,40 @@ jobs:
             --bundle "$bundle" \
             --cache-root "${{ runner.temp }}/kast-real-repository-cache"
 
-  publish-release:
-    name: Publish release
+  build-release-metadata:
+    name: Build release metadata
     needs:
       - prepare-release
       - validate-jvm
-      - build-openapi-spec
-      - build-cli
-      - build-agent-resources
-      - build-idea-plugin
-      - build-headless-backend
-      - build-linux-headless-tarball
+      - publish-openapi-spec
+      - publish-cli-linux-x64
+      - publish-cli-linux-arm64
+      - publish-cli-macos-x64
+      - publish-cli-macos-arm64
+      - publish-agent-resources
+      - publish-idea-plugin
+      - publish-linux-headless-assets
+      - publish-setup-linux-x64
+      - publish-setup-linux-arm64
+      - publish-setup-macos-x64
+      - publish-setup-macos-arm64
       - real-repository-indexing
     if: >-
       always() &&
       needs.prepare-release.result == 'success' &&
       needs.validate-jvm.result == 'success' &&
-      needs.build-openapi-spec.result == 'success' &&
-      needs.build-cli.result == 'success' &&
-      needs.build-agent-resources.result == 'success' &&
-      needs.build-idea-plugin.result == 'success' &&
-      needs.build-headless-backend.result == 'success' &&
-      needs.build-linux-headless-tarball.result == 'success' &&
+      needs.publish-openapi-spec.result == 'success' &&
+      needs.publish-cli-linux-x64.result == 'success' &&
+      needs.publish-cli-linux-arm64.result == 'success' &&
+      needs.publish-cli-macos-x64.result == 'success' &&
+      needs.publish-cli-macos-arm64.result == 'success' &&
+      needs.publish-agent-resources.result == 'success' &&
+      needs.publish-idea-plugin.result == 'success' &&
+      needs.publish-linux-headless-assets.result == 'success' &&
+      needs.publish-setup-linux-x64.result == 'success' &&
+      needs.publish-setup-linux-arm64.result == 'success' &&
+      needs.publish-setup-macos-x64.result == 'success' &&
+      needs.publish-setup-macos-arm64.result == 'success' &&
       (
         needs.real-repository-indexing.result == 'success' ||
         (
@@ -1262,7 +1750,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v5
 
@@ -1270,127 +1758,29 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           path: provenance-cli
-          pattern: rust-cli-*-${{ github.run_id }}
+          pattern: cli-provenance-*-${{ github.run_id }}
           merge-multiple: true
 
       - name: Download Linux headless tarball provenance
         uses: actions/download-artifact@v7
         with:
           path: provenance-linux-headless
-          pattern: linux-headless-tarball-*
+          pattern: linux-headless-provenance-*
           merge-multiple: true
 
       - name: Download OpenAPI provenance
         uses: actions/download-artifact@v7
         with:
           path: provenance-openapi
-          pattern: openapi-spec-*
+          pattern: openapi-provenance-*
           merge-multiple: true
 
-      - name: Verify release build ledgers
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag="${{ needs.prepare-release.outputs.release_tag }}"
-          scripts/verify-ci-artifact-ledger.py verify \
-            --ledger provenance-cli/build-ledger-cli-linux-x64.json \
-            --ledger provenance-cli/build-ledger-cli-linux-arm64.json \
-            --ledger provenance-cli/build-ledger-cli-macos-x64.json \
-            --ledger provenance-cli/build-ledger-cli-macos-arm64.json \
-            --ledger provenance-linux-headless/build-ledger-ubuntu-debian-headless.json \
-            --ledger provenance-linux-headless/build-ledger-headless-linux-x64.json \
-            --ledger provenance-linux-headless/build-ledger-runtime-manifest.json \
-            --ledger provenance-linux-headless/build-ledger-gradle-ro-cache.json \
-            --ledger provenance-openapi/build-ledger-openapi.json \
-            --git-sha "$GITHUB_SHA" \
-            --require-kind release-cli-linux-x64 \
-            --require-kind release-cli-linux-arm64 \
-            --require-kind release-cli-macos-x64 \
-            --require-kind release-cli-macos-arm64 \
-            --require-kind release-ubuntu-debian-headless-x86_64 \
-            --require-kind release-headless-linux-x64 \
-            --require-kind release-runtime-manifest \
-            --require-kind release-gradle-ro-cache \
-            --require-kind release-openapi \
-            --artifact "release-cli-linux-x64=provenance-cli/kast-${tag}-linux-x64.zip" \
-            --artifact "release-cli-linux-arm64=provenance-cli/kast-${tag}-linux-arm64.zip" \
-            --artifact "release-cli-macos-x64=provenance-cli/kast-${tag}-macos-x64.zip" \
-            --artifact "release-cli-macos-arm64=provenance-cli/kast-${tag}-macos-arm64.zip" \
-            --artifact "release-ubuntu-debian-headless-x86_64=provenance-linux-headless/kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz" \
-            --artifact "release-headless-linux-x64=provenance-linux-headless/kast-headless-linux-x64.tar.zst" \
-            --artifact "release-runtime-manifest=provenance-linux-headless/kast-runtime-manifest.json" \
-            --artifact "release-gradle-ro-cache=provenance-linux-headless/gradle-ro-dep-cache.tar.zst" \
-            --artifact "release-openapi=provenance-openapi/openapi.yaml"
-
-      - name: Upload Gradle read-only cache release asset
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag="${{ needs.prepare-release.outputs.release_tag }}"
-          cache_asset="provenance-linux-headless/gradle-ro-dep-cache.tar.zst"
-          cache_sidecar="provenance-linux-headless/gradle-ro-dep-cache.sha256"
-          [[ -f "$cache_asset" ]] || { echo "Missing Gradle read-only cache artifact: ${cache_asset}" >&2; exit 1; }
-          [[ -f "$cache_sidecar" ]] || { echo "Missing Gradle read-only cache checksum: ${cache_sidecar}" >&2; exit 1; }
-          (cd provenance-linux-headless && sha256sum -c gradle-ro-dep-cache.sha256)
-          for asset in "$cache_asset" "$cache_sidecar"; do
-            .github/scripts/release/upload-immutable-release-asset.sh \
-              --tag "$tag" \
-              --asset "$asset"
-          done
-
-      - name: Build and upload setup bundles for every CLI platform
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag="${{ needs.prepare-release.outputs.release_tag }}"
-          source_bundle="provenance-linux-headless/kast-ubuntu-debian-headless-x86_64-${tag}.tar.gz"
-          work="$RUNNER_TEMP/kast-setup-bundles"
-          rm -rf "$work"
-          mkdir -p "$work/source" "$work/backend/backend-headless" "$work/packager"
-          tar -xzf "$source_bundle" -C "$work/source"
-          source_root="$(find "$work/source" -mindepth 1 -maxdepth 1 -type d -print -quit)"
-          backend_root="$(find "$source_root/lib/backends" -mindepth 1 -maxdepth 1 -type d -name 'headless-*' -print -quit)"
-          cp -R "$backend_root/." "$work/backend/backend-headless/"
-          (cd "$work/backend" && zip -X -0 -q -r "$work/backend.zip" backend-headless)
-          gh release download "$tag" --pattern "kast-idea-${tag}.zip" --dir "$work"
-          python3 -m zipfile -e "provenance-cli/kast-${tag}-linux-x64.zip" "$work/packager"
-          chmod 755 "$work/packager/kastctl"
-          mkdir -p dist/provenance
-          for platform in linux-x64 linux-arm64 macos-x64 macos-arm64; do
-            asset="dist/kast-${platform}-${tag}.tar.gz"
-            "$work/packager/kastctl" developer release package ubuntu-debian-bundle \
-              --repo-root "$PWD" \
-              --cli-archive "provenance-cli/kast-${tag}-${platform}.zip" \
-              --backend-archive "$work/backend.zip" \
-              --plugin-archive "$work/kast-idea-${tag}.zip" \
-              --platform "$platform" \
-              --version "$tag" \
-              --bundle-output "$asset"
-            python3 - "$asset" "dist/provenance/build-provenance-setup-${platform}.json" "$platform" <<'PY'
-          import hashlib, json, os, sys
-          from pathlib import Path
-          asset = Path(sys.argv[1])
-          payload = {
-              "runId": os.environ["GITHUB_RUN_ID"],
-              "runNumber": os.environ["GITHUB_RUN_NUMBER"],
-              "runAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
-              "sha": os.environ["GITHUB_SHA"],
-              "ref": os.environ["GITHUB_REF"],
-              "workflowRef": os.environ["GITHUB_WORKFLOW_REF"],
-              "actor": os.environ["GITHUB_ACTOR"],
-              "platformId": f"setup-{sys.argv[3]}",
-              "assetName": asset.name,
-              "assetDigest": "sha256:" + hashlib.sha256(asset.read_bytes()).hexdigest(),
-          }
-          Path(sys.argv[2]).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          PY
-            .github/scripts/release/upload-immutable-release-asset.sh --tag "$tag" --asset "$asset"
-            .github/scripts/release/upload-immutable-release-asset.sh --tag "$tag" --asset "${asset}.sha256"
-          done
+      - name: Download setup bundle provenance
+        uses: actions/download-artifact@v7
+        with:
+          path: provenance-setup
+          pattern: setup-bundle-provenance-*-${{ github.run_id }}
+          merge-multiple: true
 
       - name: Assemble combined provenance
         shell: bash
@@ -1402,66 +1792,83 @@ jobs:
             provenance-cli \
             provenance-linux-headless \
             provenance-openapi \
-            dist/provenance
+            provenance-setup
 
-      - name: Upload combined provenance
+      - name: Generate SHA256SUMS
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
           tag="${{ needs.prepare-release.outputs.release_tag }}"
-          .github/scripts/release/upload-immutable-release-asset.sh \
-            --tag "$tag" \
-            --asset dist/build-provenance.json
-
-      - name: Generate and upload SHA256SUMS
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag="${{ needs.prepare-release.outputs.release_tag }}"
-          rm -rf release-assets
-          mkdir -p release-assets
-          gh release download "$tag" --dir release-assets --pattern '*.zip'
-          gh release download "$tag" --dir release-assets --pattern '*.tar.gz' || true
-          gh release download "$tag" --dir release-assets --pattern '*.tar.zst' || true
-          gh release download "$tag" --dir release-assets --pattern '*.sha256' || true
-          gh release download "$tag" --dir release-assets --pattern 'openapi.yaml'
-          gh release download "$tag" --dir release-assets --pattern 'kast-runtime-manifest.json'
-          gh release download "$tag" --dir release-assets --pattern 'build-provenance.json'
-          mapfile -t expected_assets < <(python3 - release-assets/build-provenance.json <<'PY'
-          import json
-          import sys
-          from pathlib import Path
-          payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-          for entry in payload.get("builds", []):
-              asset = entry.get("assetName")
-              if isinstance(asset, str):
-                  print(asset)
-          PY
-          )
-          expected_sidecars=()
-          for asset in "${expected_assets[@]}"; do
-            if [[ "$asset" == *.tar.gz ]]; then
-              expected_sidecars+=("${asset}.sha256")
-            elif [[ "$asset" == *.tar.zst ]]; then
-              expected_sidecars+=("${asset%.tar.zst}.sha256")
+          rm -rf release-metadata
+          mkdir -p release-metadata
+          for attempt in 1 2 3; do
+            rm -rf release-metadata/sidecars
+            mkdir -p release-metadata/sidecars
+            if timeout 60s gh release download \
+              "$tag" \
+              --dir release-metadata/sidecars \
+              --pattern '*.sha256'
+            then
+              break
             fi
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "Unable to download release checksum sidecars after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$attempt"
           done
-          for asset in "${expected_assets[@]}"; do
-            [[ -f "release-assets/${asset}" ]] || { echo "Missing release asset: ${asset}" >&2; exit 1; }
-          done
-          for sidecar in "${expected_sidecars[@]}"; do
-            [[ -f "release-assets/${sidecar}" ]] || { echo "Missing release checksum sidecar: ${sidecar}" >&2; exit 1; }
-          done
-          (cd release-assets && sha256sum "${expected_assets[@]}") > SHA256SUMS
-          cp SHA256SUMS release-assets/SHA256SUMS
-          ./scripts/release/verify-release-assets.sh --release-dir release-assets --tag "$tag"
-          .github/scripts/release/upload-immutable-release-asset.sh \
+          timeout 30s gh release view "$tag" --json assets > release-metadata/assets.json
+          .github/scripts/release/metadata/render-release-checksums.py \
             --tag "$tag" \
-            --asset SHA256SUMS
+            --provenance dist/build-provenance.json \
+            --assets release-metadata/assets.json \
+            --sidecars release-metadata/sidecars \
+            --output dist/SHA256SUMS
+
+      - name: Retain release metadata
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-metadata-${{ github.run_id }}
+          path: |
+            dist/build-provenance.json
+            dist/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 30
+
+  publish-release:
+    name: Publish release
+    needs:
+      - prepare-release
+      - build-release-metadata
+    if: always() && needs.prepare-release.result == 'success' && needs.build-release-metadata.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Download retained release metadata
+        uses: actions/download-artifact@v7
+        with:
+          name: release-metadata-${{ github.run_id }}
+          path: dist
+
+      - name: Upload retained release metadata
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.prepare-release.outputs.release_tag }}"
+          for asset in dist/build-provenance.json dist/SHA256SUMS; do
+            .github/scripts/release/upload-immutable-release-asset.sh \
+              --tag "$tag" \
+              --asset "$asset"
+          done
 
       - name: Publish draft release with provenance annotation
         env:
@@ -1477,11 +1884,17 @@ jobs:
           else
             release_flags+=(--latest)
           fi
-          gh release edit "$tag" "${release_flags[@]}" \
-            --notes "$(gh release view "$tag" --json body -q .body)
+          provenance_marker="**Build provenance:** [CI Run #${{ github.run_number }}]($run_url)"
+          release_body="$(timeout 30s gh release view "$tag" --json body -q .body)"
+          release_notes="$release_body"
+          if [[ "$release_body" != *"$provenance_marker"* ]]; then
+            release_notes="${release_body}
 
           ---
-          **Build provenance:** [CI Run #${{ github.run_number }}]($run_url)"
+          ${provenance_marker}"
+          fi
+          timeout 30s gh release edit "$tag" "${release_flags[@]}" \
+            --notes "$release_notes"
 
   verify-release-state:
     name: Verify published release state


### PR DESCRIPTION
## What

- Build each expensive release product once, retain it for 30 days, and publish from verified retained bytes.
- Give CLI and setup platforms causal producer and publisher jobs so uploads start without unrelated matrix joins.
- Recover interrupted immutable uploads and generate final checksums from metadata only.
- Reuse the trusted Linux x64 CI Rust cache and retain headless inputs atomically.

## Why

Release run 30594590900 rebuilt nondeterministic setup bundles after a transient download failure, then stalled on an incomplete large upload. The workflow coupled production to publication and made retries repeat expensive work.

## Validation

- release workflow contract
- immutable upload recovery contract
- checksum renderer tests
- provenance and release-asset verifier tests
- YAML, shellcheck, runtime compatibility, installer, graph model, and repository-shape contracts
- two independent no-finding reviews

## Risk

This changes release orchestration only. The exact-head tag workflow remains the publication proof before v0.20.3 is accepted.