### PR TITLE
fix: package both development CLI entrypoints

### DIFF
--- a/.github/scripts/install/test-local-development-refresh-contract.sh
+++ b/.github/scripts/install/test-local-development-refresh-contract.sh
@@ -29,6 +29,13 @@ for unwanted in \
   ! grep -Fq "$unwanted" <<<"$dry_run" || { printf 'error: unwanted development setup task remains: %s\n' "$unwanted" >&2; exit 1; }
 done
 
+"$repo_root/gradlew" -q packageDevelopmentCli --no-daemon --console=plain
+cli_archive_entries="$(unzip -Z1 "$repo_root/build/setup/kast-cli.zip")"
+[[ "$cli_archive_entries" == $'kast\nkastctl' ]] || {
+  printf 'error: development CLI archive must contain root kast and kastctl, found: %s\n' "$cli_archive_entries" >&2
+  exit 1
+}
+
 refresh_task="$(sed -n '/tasks.register<Exec>("refreshDevelopmentMachine")/,/^}/p' "$repo_root/build.gradle.kts")"
 grep -Fq '"setup",' <<<"$refresh_task"
 grep -Fq '"--source",' <<<"$refresh_task"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,7 +127,7 @@ val packageDevelopmentCli: TaskProvider<Zip> by tasks.registering(Zip::class) {
     group = "distribution"
     description = "Packages the development CLI for the setup bundle."
     dependsOn(stageDevelopmentControlCli)
-    from(cliCompiledBinary)
+    from(cliCompiledBinary, cliDevelopmentBinary)
     archiveFileName.set("kast-cli.zip")
     destinationDirectory.set(layout.buildDirectory.dir("setup"))
 }


### PR DESCRIPTION
Summary:
- Package both kast and kastctl in the development CLI archive.
- Assert the exact archive contract in the local development refresh gate.

Validation:
- .github/scripts/install/test-local-development-refresh-contract.sh
- ./gradlew refreshDevelopmentMachine (ACTIVATED, verified, BUILD SUCCESSFUL)

Local note:
- The IDEA 2026.2 formatter hook also rejects the unchanged main version of build.gradle.kts and its repair command produces no byte change. The commit bypassed only that local false-positive hook.