### PR TITLE
fix: authorize release metadata finalization

### DIFF
--- a/.github/scripts/release/metadata/release-workflow-model.json
+++ b/.github/scripts/release/metadata/release-workflow-model.json
@@ -5,7 +5,7 @@
     "description": "Expanded release retry-isolation topology. Performance claims require a completed candidate release.",
     "observedAt": "2026-07-30",
     "source": ".github/workflows/release.yml",
-    "sourceSha256": "4a1cc18b9cf9a429c2c55814376fb5cf1912b5a30b7ab0bffe824a5de9b294e3"
+    "sourceSha256": "4e1fb887dd7a23d8f7d480858d05ebbb88ef3fe7f555fab99a13f5676bf01d59"
   },
   "tasks": [
     {

--- a/.github/scripts/release/test-release-workflow-contract.sh
+++ b/.github/scripts/release/test-release-workflow-contract.sh
@@ -199,6 +199,10 @@ grep -Fq '.github/scripts/release/metadata/render-release-checksums.py' <<<"$bui
   || { printf '%s\n' 'error: publication must render checksums from verified provenance metadata' >&2; exit 1; }
 grep -Fq "timeout 60s gh release download" <<<"$build_release_metadata" \
   || { printf '%s\n' 'error: required sidecar downloads must have a bounded timeout' >&2; exit 1; }
+grep -Fq 'contents: write' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: release metadata must be allowed to read the draft release' >&2; exit 1; }
+grep -Fq 'GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}' <<<"$build_release_metadata" \
+  || { printf '%s\n' 'error: release metadata must use the draft release owner token' >&2; exit 1; }
 grep -Fq 'sleep "$attempt"' <<<"$build_release_metadata" \
   || { printf '%s\n' 'error: sidecar download retries must back off' >&2; exit 1; }
 grep -Fq 'name: Generate SHA256SUMS' <<<"$build_release_metadata" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1750,7 +1750,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v5
 
@@ -1796,7 +1796,7 @@ jobs:
 
       - name: Generate SHA256SUMS
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
Summary:
- Let release metadata read the draft release with the same release token used to create it.
- Give the metadata job the required contents permission.
- Add the regression contract and refresh the exact workflow model hash.

Failure evidence:
- Release run 30606387628: Build release metadata failed with `release not found` after Prepare release created draft `untagged-7ce16208ba569d82c963`.

Validation:
- bash .github/scripts/release/test-release-workflow-contract.sh