### PR TITLE
fix: wait for exact-source CI before release

### DIFF
--- a/.github/scripts/release/metadata/release-workflow-model.json
+++ b/.github/scripts/release/metadata/release-workflow-model.json
@@ -5,7 +5,7 @@
     "description": "Release topology for one retained indexer and four canonical setup bundles. Timing claims require completed workflow evidence.",
     "observedAt": "2026-08-02",
     "source": ".github/workflows/release.yml",
-    "sourceSha256": "cb81ab67d107b91cf7681331c021facea4b3867e3c95814e3e204eddd30b85ac"
+    "sourceSha256": "3c466ecede792f4e98e8e885252466df055203bc6b58cc7d6a259de09fcc5785"
   },
   "tasks": [
     {

--- a/.github/scripts/release/test-release-workflow-contract.sh
+++ b/.github/scripts/release/test-release-workflow-contract.sh
@@ -62,6 +62,13 @@ reject "$release" 'runtime-manifest' "release must not publish a second runtime 
 reject "$release" 'ubuntu-debian-headless' "release must not publish a legacy Linux bundle"
 reject "$release" 'linux-headless' "release must not publish a standalone runtime product"
 
+require "$release" 'timeout-minutes: 30' \
+  "release preflight must bound the exact-source CI wait"
+require "$release" 'gh run watch "$ci_run_id" --exit-status --interval 10' \
+  "release preflight must wait for exact-source CI to complete"
+reject "$release" '-f status=success' \
+  "release preflight must discover in-progress exact-source CI"
+
 for exact_ci_evidence in \
   'actions: read' \
   'GH_TOKEN: ${{ github.token }}' \
@@ -70,7 +77,6 @@ for exact_ci_evidence in \
   '-f branch=main' \
   '-f event=push' \
   '-f head_sha="$GITHUB_SHA"' \
-  '-f status=success' \
   '.head_sha == $sha' \
   '.head_branch == "main"' \
   '.path == ".github/workflows/ci.yml"' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
   release-preflight:
     name: Preflight release automation
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     outputs:
       run_id: ${{ steps.exact-source-ci.outputs.run_id }}
     permissions:
@@ -62,20 +63,30 @@ jobs:
             -f branch=main \
             -f event=push \
             -f head_sha="$GITHUB_SHA" \
-            -f status=success \
             -f per_page=100)"
           ci_run_id="$(jq -er --arg sha "$GITHUB_SHA" '
             [.workflow_runs[] | select(
               .head_sha == $sha
               and .head_branch == "main"
               and .path == ".github/workflows/ci.yml"
-              and .event == "push"
-              and .status == "completed"
-              and .conclusion == "success")]
+              and .event == "push")]
             | sort_by(.run_attempt)
             | last
             | .id
           ' <<<"$ci_runs")" \
+            || { printf 'error: exact source CI is unavailable for %s\n' "$GITHUB_SHA" >&2; exit 1; }
+          gh run watch "$ci_run_id" --exit-status --interval 10 \
+            || { printf 'error: exact source CI did not finish green for %s\n' "$GITHUB_SHA" >&2; exit 1; }
+          ci_run="$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${ci_run_id}")"
+          jq -e --arg sha "$GITHUB_SHA" '
+            .head_sha == $sha
+            and .head_branch == "main"
+            and .path == ".github/workflows/ci.yml"
+            and .event == "push"
+            and .status == "completed"
+            and .conclusion == "success"
+          ' <<<"$ci_run" >/dev/null \
             || { printf 'error: exact source CI is not green for %s\n' "$GITHUB_SHA" >&2; exit 1; }
           ci_artifacts="$(gh api --method GET \
             "repos/${GITHUB_REPOSITORY}/actions/runs/${ci_run_id}/artifacts" \


### PR DESCRIPTION
## Summary
- discover the exact main CI run even while it is in progress
- wait up to the preflight job bound, then revalidate terminal success
- lock the behavior in the release workflow contract and bound model

## Failure evidence
Release run 30735455089 started while exact-source CI run 30735409100 was still in progress, so success-only discovery failed immediately.

## Validation
- .github/scripts/release/test-release-workflow-contract.sh
- git diff --check

## Local limitation
- actionlint is not installed locally