### PR TITLE
fix: quarantine failed release artifacts

### DIFF
--- a/.github/scripts/release/metadata/release-workflow-model.json
+++ b/.github/scripts/release/metadata/release-workflow-model.json
@@ -5,7 +5,7 @@
     "description": "Release topology for one retained indexer and four canonical setup bundles. Timing claims require completed workflow evidence.",
     "observedAt": "2026-08-02",
     "source": ".github/workflows/release.yml",
-    "sourceSha256": "3c466ecede792f4e98e8e885252466df055203bc6b58cc7d6a259de09fcc5785"
+    "sourceSha256": "9658650613a047c68273d55cb88a5b6f9929cbd2752a5f82c161ed9fda8de8f5"
   },
   "tasks": [
     {
@@ -15,7 +15,7 @@
     },
     {
       "id": "publish-maven-central",
-      "needs": ["prepare-release"],
+      "needs": ["prepare-release", "real-repository-indexing"],
       "outputs": ["release-maven-publication"]
     },
     {
@@ -25,7 +25,7 @@
     },
     {
       "id": "publish-openapi-spec",
-      "needs": ["prepare-release", "build-openapi-spec"],
+      "needs": ["prepare-release", "build-openapi-spec", "real-repository-indexing"],
       "outputs": ["release-openapi-asset"]
     },
     {
@@ -40,7 +40,7 @@
     },
     {
       "id": "publish-agent-resources",
-      "needs": ["prepare-release", "build-agent-resources"],
+      "needs": ["prepare-release", "build-agent-resources", "real-repository-indexing"],
       "outputs": ["release-agent-resource-assets"]
     },
     {
@@ -55,7 +55,7 @@
     },
     {
       "id": "publish-setup-bundles",
-      "needs": ["prepare-release", "build-setup-bundles"],
+      "needs": ["prepare-release", "build-setup-bundles", "real-repository-indexing"],
       "outputs": [
         "release-setup-linux-x64-asset",
         "release-setup-linux-x64-sidecar",

--- a/.github/scripts/release/test-release-workflow-contract.sh
+++ b/.github/scripts/release/test-release-workflow-contract.sh
@@ -49,6 +49,7 @@ expected_workflow_jobs="$(printf '%s\n' \
   publish-openapi-spec \
   publish-release \
   publish-setup-bundles \
+  quarantine-failed-release-artifacts \
   real-repository-indexing \
   release-preflight \
   verify-release-state | sort)"
@@ -64,8 +65,8 @@ reject "$release" 'linux-headless' "release must not publish a standalone runtim
 
 require "$release" 'timeout-minutes: 30' \
   "release preflight must bound the exact-source CI wait"
-require "$release" 'gh run watch "$ci_run_id" --exit-status --interval 10' \
-  "release preflight must wait for exact-source CI to complete"
+require "$release" 'gh run watch "$ci_run_id" --repo "$GITHUB_REPOSITORY" --exit-status --interval 10' \
+  "release preflight must wait for exact-source CI with explicit repository context"
 reject "$release" '-f status=success' \
   "release preflight must discover in-progress exact-source CI"
 
@@ -154,6 +155,48 @@ require "$release" "-name 'kast-linux-x64-*.tar.gz'" \
 require "$release" 'scripts/release/benchmark-real-repositories.sh' \
   "release must retain real-repository indexing proof"
 
+workflow_job() {
+  local job="$1"
+  awk -v job="$job" '
+    $0 == "  " job ":" { selected=1 }
+    selected && $0 ~ /^  [a-z0-9][a-z0-9-]*:$/ && $0 != "  " job ":" { exit }
+    selected { print }
+  ' "$release"
+}
+
+for publication_job in \
+  publish-maven-central \
+  publish-openapi-spec \
+  publish-agent-resources \
+  publish-setup-bundles; do
+  publication_contract="$(workflow_job "$publication_job")"
+  [[ "$publication_contract" == *'- real-repository-indexing'* ]] \
+    || die "${publication_job} must wait for real-repository setup validation"
+  [[ "$publication_contract" == *"needs.real-repository-indexing.result == 'success'"* ]] \
+    || die "${publication_job} must reject a failed real-repository setup validation"
+done
+
+quarantine_contract="$(workflow_job quarantine-failed-release-artifacts)"
+for producer_job in \
+  build-openapi-spec \
+  build-cli \
+  build-agent-resources \
+  build-indexer \
+  build-setup-bundles \
+  real-repository-indexing; do
+  [[ "$quarantine_contract" == *"- $producer_job"* ]] \
+    || die "failed-artifact quarantine must wait for $producer_job"
+done
+for quarantine_evidence in \
+  "needs.real-repository-indexing.result != 'success'" \
+  'actions: write' \
+  'actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100' \
+  "mapfile -t artifact_ids" \
+  'actions/artifacts/$artifact_id'; do
+  [[ "$quarantine_contract" == *"$quarantine_evidence"* ]] \
+    || die "failed-artifact quarantine is missing: $quarantine_evidence"
+done
+
 for retained_product in \
   publish-openapi-spec \
   publish-agent-resources \
@@ -225,15 +268,15 @@ if set(tasks) != expected_tasks:
 
 expected_needs = {
     "prepare-release": set(),
-    "publish-maven-central": {"prepare-release"},
+    "publish-maven-central": {"prepare-release", "real-repository-indexing"},
     "build-openapi-spec": {"prepare-release"},
-    "publish-openapi-spec": {"prepare-release", "build-openapi-spec"},
+    "publish-openapi-spec": {"prepare-release", "build-openapi-spec", "real-repository-indexing"},
     "build-cli": {"prepare-release"},
     "build-agent-resources": {"prepare-release"},
-    "publish-agent-resources": {"prepare-release", "build-agent-resources"},
+    "publish-agent-resources": {"prepare-release", "build-agent-resources", "real-repository-indexing"},
     "build-indexer": {"prepare-release"},
     "build-setup-bundles": {"prepare-release", "build-cli", "build-indexer"},
-    "publish-setup-bundles": {"prepare-release", "build-setup-bundles"},
+    "publish-setup-bundles": {"prepare-release", "build-setup-bundles", "real-repository-indexing"},
     "real-repository-indexing": {"prepare-release", "build-setup-bundles"},
     "build-release-metadata": {
         "prepare-release",

--- a/.github/scripts/test-release-indexing-benchmark-contract.sh
+++ b/.github/scripts/test-release-indexing-benchmark-contract.sh
@@ -71,7 +71,19 @@ require "$runner" 'kastctl config list' 'benchmark must capture effective worksp
 require "$runner" "kastctl config set indexing.relationships.enabled \"\$relationships_enabled\"" 'benchmark must apply the declared relationship indexing plan'
 require "$runner" "if [[ \"\$relationships_enabled\" == true ]]" 'relationship tuning must apply only when relationship indexing is enabled'
 require "$runner" 'kastctl config set indexing.relationships.parallelism 2' 'benchmark must exercise relationship indexing configuration'
-require "$runner" "cat \"\$scratch/runtime.json\" >&2" 'runtime readiness failures must preserve their typed evidence'
+require "$runner" 'run_json_command()' 'benchmark must centralize typed command failure reporting'
+require "$runner" 'cat "$output" >&2' 'typed command failures must preserve their response payload'
+require "$runner" 'run_generation_bound_graph_refresh()' 'benchmark must own bounded generation-conflict recovery'
+require "$runner" 'graph_refresh_attempts=3' 'graph refresh recovery must have a fixed attempt bound'
+require "$runner" 'expectedGeneration' 'graph refresh recovery must require typed expected-generation evidence'
+require "$runner" 'actualGeneration' 'graph refresh recovery must require typed actual-generation evidence'
+require "$runner" 'run_json_command "$scratch/runtime.json" developer runtime up' 'runtime readiness must use typed failure reporting'
+require "$runner" 'wait_for_exact_workspace_index()' 'benchmark must wait for typed exact workspace evidence'
+require "$runner" 'wait_for_exact_workspace_index "$scratch/workspace-files.json" "$wait_timeout_ms" agent workspace-files' 'workspace indexing must use the release timeout'
+reject "$runner" 'run_json_command "$scratch/workspace-files.json" agent workspace-files' 'workspace indexing must not accept the first partial result'
+require "$runner" 'run_generation_bound_graph_refresh "$scratch/graph-refresh.json" agent graph' 'graph refresh must use bounded typed conflict recovery'
+reject "$runner" 'run_json_command "$scratch/graph-refresh.json" agent graph' 'graph refresh must not bypass bounded generation-conflict recovery'
+require "$runner" 'run_json_command "$scratch/graph.json" agent graph' 'graph summary must use typed failure reporting'
 require "$runner" 'settings.gradle.kts' 'benchmark must recognize Kotlin Gradle build roots'
 require "$runner" 'settings.gradle' 'benchmark must recognize Groovy Gradle build roots'
 # shellcheck disable=SC2016 # Runner variables are intentionally matched literally.
@@ -79,6 +91,10 @@ require "$runner" 'scoped_graph_file="${graph_path#"$workspace"/}"' 'benchmark m
 require "$runner" '--operation refresh' 'benchmark must populate the native graph through the compiler indexer'
 require "$runner" "--file-path \"\$scoped_graph_file\"" 'benchmark must refresh the pinned Kotlin source within the selected Gradle root'
 require "$runner" '--exclusive' 'benchmark graph evidence must stay within the pinned probe scope'
+require "$runner" 'verify_benchmark_evidence()' 'benchmark must centralize typed evidence validation'
+require "$runner" 'refreshed_paths' 'benchmark must identify the exact refreshed probe'
+require "$runner" 'file.get("status") not in {"REFRESHED", "REMOVED"}' 'exclusive graph validation must reject unknown coverage states'
+reject "$runner" 'len(coverage) != 1' 'exclusive graph validation must allow typed removals beside the refreshed probe'
 require "$runner" 'Semantic graph refresh was incomplete' 'benchmark must verify compiler graph coverage'
 reject "$runner" '--accept-indexing' 'benchmark must wait for the runtime to become ready'
 
@@ -115,6 +131,77 @@ reject_graph_file src/Probe.kts
 source "$runner"
 scope_fixture="$(mktemp -d "${TMPDIR:-/tmp}/kast-release-scope.XXXXXX")"
 trap 'rm -rf -- "$scope_fixture"' EXIT
+
+graph_refresh_attempt_file="$scope_fixture/graph-refresh-attempts"
+graph_refresh_scenario=generation-conflict-once
+kastctl() {
+  local attempt=0
+  [[ ! -f "$graph_refresh_attempt_file" ]] || read -r attempt <"$graph_refresh_attempt_file"
+  attempt=$((attempt + 1))
+  printf '%s\n' "$attempt" >"$graph_refresh_attempt_file"
+  if [[ "$graph_refresh_scenario" == workspace-partial-once ]]; then
+    if [[ "$attempt" -eq 1 ]]; then
+      printf '%s\n' '{"ok":true,"result":{"cardinality":{"type":"KNOWN_MINIMUM","knownMinimumCount":98}}}'
+    else
+      printf '%s\n' '{"ok":true,"result":{"cardinality":{"type":"EXACT","totalCount":98}}}'
+    fi
+    return 0
+  fi
+  if [[ "$graph_refresh_scenario" == workspace-empty ]]; then
+    printf '%s\n' '{"ok":true,"result":{"cardinality":{"type":"EXACT","totalCount":0}}}'
+    return 0
+  fi
+  if [[ "$graph_refresh_scenario" == generation-conflict-once && "$attempt" -eq 1 ]]; then
+    printf '%s\n' '{"ok":false,"error":{"code":"CONFLICT","details":{"rpcError":{"data":{"details":{"expectedGeneration":"1","actualGeneration":"2"}}}}}}'
+    return 1
+  fi
+  if [[ "$graph_refresh_scenario" == other-conflict ]]; then
+    printf '%s\n' '{"ok":false,"error":{"code":"CONFLICT","details":{"rpcError":{"data":{"details":{"expectedPsiGeneration":"1","actualPsiGeneration":"2"}}}}}}'
+    return 1
+  fi
+  printf '%s\n' '{"ok":true,"result":{"generation":2}}'
+}
+
+run_generation_bound_graph_refresh "$scope_fixture/graph-refresh.json" agent graph --operation refresh
+[[ "$(cat "$graph_refresh_attempt_file")" == 2 ]] \
+  || { printf 'error: generation conflict was not retried exactly once\n' >&2; exit 1; }
+graph_refresh_scenario=other-conflict
+rm -f "$graph_refresh_attempt_file"
+if run_generation_bound_graph_refresh "$scope_fixture/other-conflict.json" agent graph --operation refresh 2>/dev/null; then
+  printf 'error: non-generation conflict unexpectedly succeeded\n' >&2
+  exit 1
+fi
+[[ "$(cat "$graph_refresh_attempt_file")" == 1 ]] \
+  || { printf 'error: non-generation conflict was retried\n' >&2; exit 1; }
+
+graph_refresh_scenario=workspace-partial-once
+rm -f "$graph_refresh_attempt_file"
+KAST_RELEASE_INDEX_POLL_SECONDS=0 \
+  wait_for_exact_workspace_index "$scope_fixture/workspace-files.json" 10000 agent workspace-files --count
+[[ "$(cat "$graph_refresh_attempt_file")" == 2 ]] \
+  || { printf 'error: partial workspace evidence was not polled to exactness\n' >&2; exit 1; }
+graph_refresh_scenario=workspace-empty
+rm -f "$graph_refresh_attempt_file"
+if KAST_RELEASE_INDEX_POLL_SECONDS=0 \
+    wait_for_exact_workspace_index "$scope_fixture/workspace-empty.json" 10000 agent workspace-files --count 2>/dev/null; then
+  printf 'error: exact empty workspace unexpectedly succeeded\n' >&2
+  exit 1
+fi
+[[ "$(cat "$graph_refresh_attempt_file")" == 1 ]] \
+  || { printf 'error: exact empty workspace was retried\n' >&2; exit 1; }
+
+printf '%s\n' '{"ok":true,"result":{"cardinality":{"type":"EXACT","totalCount":2}}}' \
+  >"$scope_fixture/evidence-workspace.json"
+printf '%s\n' '{"ok":true,"result":{"symbolCount":4,"coverage":{"files":[{"path":"src/Probe.kt","status":"REFRESHED"},{"path":"src/Other.kt","status":"REMOVED"}]}}}' \
+  >"$scope_fixture/evidence-refresh.json"
+printf '%s\n' '{"ok":true,"result":{"nodeCount":4}}' \
+  >"$scope_fixture/evidence-graph.json"
+verify_benchmark_evidence \
+  "$scope_fixture/evidence-workspace.json" \
+  "$scope_fixture/evidence-refresh.json" \
+  "$scope_fixture/evidence-graph.json" \
+  src/Probe.kt
+
 repository_fixture="$scope_fixture/repository"
 ktor_fixture="$repository_fixture/ktor-test-server"
 mkdir -p "$ktor_fixture/src/main/kotlin/test/server" "$repository_fixture/okcurl/src/main/kotlin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
             | .id
           ' <<<"$ci_runs")" \
             || { printf 'error: exact source CI is unavailable for %s\n' "$GITHUB_SHA" >&2; exit 1; }
-          gh run watch "$ci_run_id" --exit-status --interval 10 \
+          gh run watch "$ci_run_id" --repo "$GITHUB_REPOSITORY" --exit-status --interval 10 \
             || { printf 'error: exact source CI did not finish green for %s\n' "$GITHUB_SHA" >&2; exit 1; }
           ci_run="$(gh api --method GET \
             "repos/${GITHUB_REPOSITORY}/actions/runs/${ci_run_id}")"
@@ -287,7 +287,12 @@ jobs:
     needs:
       - prepare-release
       - build-openapi-spec
-    if: always() && needs.prepare-release.result == 'success' && needs.build-openapi-spec.result == 'success'
+      - real-repository-indexing
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.build-openapi-spec.result == 'success' &&
+      needs.real-repository-indexing.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -329,8 +334,13 @@ jobs:
 
   publish-maven-central:
     name: Publish Maven Central
-    needs: [prepare-release]
-    if: always() && needs.prepare-release.result == 'success'
+    needs:
+      - prepare-release
+      - real-repository-indexing
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.real-repository-indexing.result == 'success'
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
@@ -600,7 +610,12 @@ jobs:
     needs:
       - prepare-release
       - build-agent-resources
-    if: always() && needs.prepare-release.result == 'success' && needs.build-agent-resources.result == 'success'
+      - real-repository-indexing
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.build-agent-resources.result == 'success' &&
+      needs.real-repository-indexing.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -772,10 +787,12 @@ jobs:
     needs:
       - prepare-release
       - build-setup-bundles
+      - real-repository-indexing
     if: >-
       always() &&
       needs.prepare-release.result == 'success' &&
-      needs.build-setup-bundles.result == 'success'
+      needs.build-setup-bundles.result == 'success' &&
+      needs.real-repository-indexing.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -877,6 +894,41 @@ jobs:
             --relationships-enabled "${{ matrix.relationships_enabled }}" \
             --bundle "$bundle" \
             --cache-root "${{ runner.temp }}/kast-real-repository-cache"
+
+  quarantine-failed-release-artifacts:
+    name: Quarantine failed release artifacts
+    needs:
+      - prepare-release
+      - build-openapi-spec
+      - build-cli
+      - build-agent-resources
+      - build-indexer
+      - build-setup-bundles
+      - real-repository-indexing
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.real-repository-indexing.result != 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Delete artifacts from the failed release run
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t artifact_ids < <(
+            gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" \
+              --jq '.artifacts[].id'
+          )
+          for artifact_id in "${artifact_ids[@]}"; do
+            gh api --method DELETE \
+              "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id"
+          done
 
 
   build-release-metadata:

--- a/scripts/release/benchmark-real-repositories.sh
+++ b/scripts/release/benchmark-real-repositories.sh
@@ -45,6 +45,144 @@ configure_gradle_java_paths() {
     >"$gradle_user_dir/gradle.properties"
 }
 
+run_json_command() {
+  local output="$1"
+  shift
+  if ! kastctl --output json "$@" >"$output"; then
+    cat "$output" >&2
+    return 1
+  fi
+}
+
+workspace_index_state() {
+  local output="$1"
+  python3 - "$output" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+try:
+    payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(2)
+
+cardinality = payload.get("result", {}).get("cardinality", {})
+if payload.get("ok") is not True:
+    raise SystemExit(2)
+if cardinality.get("type") == "EXACT":
+    raise SystemExit(0 if cardinality.get("totalCount", 0) > 0 else 2)
+if cardinality.get("type") == "KNOWN_MINIMUM":
+    raise SystemExit(1)
+raise SystemExit(2)
+PY
+}
+
+wait_for_exact_workspace_index() {
+  local output="$1" timeout_ms="$2" state
+  local poll_seconds="${KAST_RELEASE_INDEX_POLL_SECONDS:-5}"
+  local timeout_seconds=$(((timeout_ms + 999) / 1000))
+  local deadline=$((SECONDS + timeout_seconds))
+  shift 2
+  [[ "$poll_seconds" =~ ^[0-9]+$ ]] \
+    || { printf 'error: workspace index poll seconds must be a non-negative integer\n' >&2; return 1; }
+  while true; do
+    if ! run_json_command "$output" "$@"; then
+      return 1
+    fi
+    if workspace_index_state "$output"; then
+      return 0
+    else
+      state=$?
+    fi
+    if [[ "$state" -ne 1 ]]; then
+      cat "$output" >&2
+      printf 'error: workspace indexing returned invalid or empty exact evidence\n' >&2
+      return 1
+    fi
+    if [[ "$SECONDS" -ge "$deadline" ]]; then
+      cat "$output" >&2
+      printf 'error: workspace indexing did not reach exact evidence within %sms\n' "$timeout_ms" >&2
+      return 1
+    fi
+    printf 'Workspace indexing is partial; waiting for exact evidence\n' >&2
+    sleep "$poll_seconds"
+  done
+}
+
+is_source_generation_conflict() {
+  local output="$1"
+  python3 - "$output" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+try:
+    payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+
+error = payload.get("error", {})
+details = error.get("details", {}).get("rpcError", {}).get("data", {}).get("details", {})
+if (
+    error.get("code") != "CONFLICT"
+    or details.get("expectedGeneration") is None
+    or details.get("actualGeneration") is None
+):
+    raise SystemExit(1)
+PY
+}
+
+run_generation_bound_graph_refresh() {
+  local output="$1" attempt graph_refresh_attempts=3
+  shift
+  for ((attempt = 1; attempt <= graph_refresh_attempts; attempt += 1)); do
+    if run_json_command "$output" "$@"; then
+      return 0
+    fi
+    if [[ "$attempt" -eq "$graph_refresh_attempts" ]] \
+        || ! is_source_generation_conflict "$output"; then
+      return 1
+    fi
+    printf 'Source generation changed during graph refresh; retrying (%s/%s)\n' \
+      "$attempt" "$graph_refresh_attempts" >&2
+  done
+  return 1
+}
+
+verify_benchmark_evidence() {
+  local workspace_output="$1" refresh_output="$2" graph_output="$3" expected_graph_path="$4"
+  python3 - "$workspace_output" "$refresh_output" "$graph_output" "$expected_graph_path" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+workspace_files = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+cardinality = workspace_files.get("result", {}).get("cardinality", {})
+if cardinality.get("type") != "EXACT" or cardinality.get("totalCount", 0) <= 0:
+    raise SystemExit(f"workspace indexing was not complete: {cardinality}")
+
+refresh = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+coverage = refresh.get("result", {}).get("coverage", {}).get("files", [])
+expected_graph_path = sys.argv[4]
+refreshed_paths = [
+    file.get("path")
+    for file in coverage
+    if file.get("status") == "REFRESHED"
+]
+if (
+    not refresh.get("ok")
+    or refresh.get("result", {}).get("symbolCount", 0) <= 0
+    or refreshed_paths != [expected_graph_path]
+    or any(file.get("status") not in {"REFRESHED", "REMOVED"} for file in coverage)
+):
+    raise SystemExit(f"Semantic graph refresh was incomplete: {refresh}")
+
+graph = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+if not graph.get("ok") or graph.get("result", {}).get("nodeCount", 0) <= 0:
+    raise SystemExit("native graph summary was unavailable")
+PY
+}
+
 [[ "${BASH_SOURCE[0]}" == "$0" ]] || return 0
 
 name=
@@ -148,47 +286,25 @@ if [[ "$relationships_enabled" == true ]]; then
 fi
 kastctl config set gradle.toolingApiTimeoutMillis "$wait_timeout_ms" --workspace-root "$workspace" >/dev/null
 kastctl config list --workspace-root "$workspace" >"$scratch/effective-config.toon"
-if ! kastctl --output json developer runtime up \
+run_json_command "$scratch/runtime.json" developer runtime up \
     --workspace-root "$workspace" \
-    --wait-timeout-ms "$wait_timeout_ms" >"$scratch/runtime.json"; then
-  cat "$scratch/runtime.json" >&2
-  exit 1
-fi
-kastctl --output json agent workspace-files \
+    --wait-timeout-ms "$wait_timeout_ms"
+wait_for_exact_workspace_index "$scratch/workspace-files.json" "$wait_timeout_ms" agent workspace-files \
   --workspace-root "$workspace" \
-  --count >"$scratch/workspace-files.json"
-kastctl --output json agent graph \
+  --count
+run_generation_bound_graph_refresh "$scratch/graph-refresh.json" agent graph \
   --workspace-root "$workspace" \
   --operation refresh \
   --file-path "$scoped_graph_file" \
-  --exclusive >"$scratch/graph-refresh.json"
-kastctl --output json agent graph \
+  --exclusive
+run_json_command "$scratch/graph.json" agent graph \
   --workspace-root "$workspace" \
-  --operation summary >"$scratch/graph.json"
+  --operation summary
 
-python3 - "$scratch/workspace-files.json" "$scratch/graph-refresh.json" "$scratch/graph.json" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-workspace_files = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-cardinality = workspace_files["result"]["cardinality"]
-if cardinality.get("type") != "EXACT" or cardinality.get("totalCount", 0) <= 0:
-    raise SystemExit(f"workspace indexing was not complete: {cardinality}")
-
-refresh = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
-coverage = refresh.get("result", {}).get("coverage", {}).get("files", [])
-if (
-    not refresh.get("ok")
-    or refresh.get("result", {}).get("symbolCount", 0) <= 0
-    or len(coverage) != 1
-    or coverage[0].get("status") != "REFRESHED"
-):
-    raise SystemExit(f"Semantic graph refresh was incomplete: {refresh}")
-
-graph = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
-if not graph.get("ok") or graph.get("result", {}).get("nodeCount", 0) <= 0:
-    raise SystemExit("native graph summary was unavailable")
-PY
+verify_benchmark_evidence \
+  "$scratch/workspace-files.json" \
+  "$scratch/graph-refresh.json" \
+  "$scratch/graph.json" \
+  "$scoped_graph_file"
 
 printf 'benchmark %s passed at %s\n' "$name" "$revision"


### PR DESCRIPTION
## Summary

- Give the preflight CI watcher explicit repository context.
- Require real-repository setup validation before any external publication.
- Delete current-run artifacts when setup validation fails.
- Wait for exact workspace evidence, retry only typed source-generation conflicts, and accept typed exclusive-removal coverage.

## Proof

- .github/scripts/release/test-release-workflow-contract.sh
- .github/scripts/test-release-indexing-benchmark-contract.sh
- shellcheck scripts/release/benchmark-real-repositories.sh
- Parsed .github/workflows/release.yml as YAML.
- Ran the v0.20.5 Linux ARM bundle against the pinned Spring repository at d523770246f2ddb586868e4a9e55cafce7e0d6f8; the benchmark passed.

## Cleanup

Deleted the v0.20.5 draft release and all 16 artifacts retained by failed release run 30759097294. Kept tag v0.20.5 at ae13b1056b456ea3a5a0e1f5f9bf9431a2f90c06.