### PR TITLE
Admit projection contract namespace in shape checks

### DIFF
--- a/.github/scripts/check-repository-shape.py
+++ b/.github/scripts/check-repository-shape.py
@@ -15,6 +15,11 @@ from typing import Sequence
 
 MAX_PHYSICAL_LINES = 400
 MAX_DIRECT_CHILDREN = 10
+AUTHORIZED_DIRECT_CHILDREN = {
+    Path("analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract"): frozenset(
+        {"transformation"}
+    ),
+}
 SOURCE_SUFFIXES = frozenset({".kt", ".kts", ".rs"})
 SHAPE_ATTRIBUTE = "repository-shape"
 EXCLUDED_KINDS = frozenset({"binary", "generated", "lock"})
@@ -280,9 +285,14 @@ def inspect(root: Path) -> ShapeReport:
     )
     directory_violations = tuple(
         sorted(
-            DirectoryViolation(str(path), len(entries))
+            DirectoryViolation(
+                str(path),
+                len(entries - AUTHORIZED_DIRECT_CHILDREN.get(path, frozenset())),
+            )
             for path, entries in children.items()
-            if path != Path() and len(entries) > MAX_DIRECT_CHILDREN
+            if path != Path()
+            and len(entries - AUTHORIZED_DIRECT_CHILDREN.get(path, frozenset()))
+            > MAX_DIRECT_CHILDREN
         )
     )
     return ShapeReport(

--- a/.github/scripts/test-repository-shape-contract.sh
+++ b/.github/scripts/test-repository-shape-contract.sh
@@ -119,6 +119,34 @@ grep -Fq '"child-limit",11,10' "$directory_output"
 
 rm "$fixture/child-limit/11.txt"
 git -C "$fixture" add -u "$fixture/child-limit/11.txt"
+
+contract_root="$fixture/analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract"
+for child in $(seq 1 10); do
+  mkdir -p "$contract_root/child-$child"
+  printf 'contract child %s\n' "$child" >"$contract_root/child-$child/Type.kt"
+done
+mkdir -p "$contract_root/transformation"
+printf 'projection contract\n' >"$contract_root/transformation/Projection.kt"
+git -C "$fixture" add "$fixture/analysis-api"
+authorized_namespace_output="$fixture/authorized-namespace-output.txt"
+if ! python3 "$checker" --root "$fixture" >"$authorized_namespace_output"; then
+  grep -F '"analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract",11,10' "$authorized_namespace_output" >&2
+  printf '%s\n' 'expected the authorized projection contract namespace to pass' >&2
+  exit 1
+fi
+
+mkdir -p "$contract_root/unrelated-extra"
+printf 'unrelated contract child\n' >"$contract_root/unrelated-extra/Type.kt"
+git -C "$fixture" add "$contract_root/unrelated-extra/Type.kt"
+unrelated_child_output="$fixture/unrelated-child-output.txt"
+if python3 "$checker" --root "$fixture" >"$unrelated_child_output"; then
+  printf '%s\n' 'expected an unrelated eleventh contract child to fail' >&2
+  exit 1
+fi
+grep -Fq '"analysis-api/src/main/kotlin/io/github/amichne/kast/api/contract",11,10' "$unrelated_child_output"
+
+rm "$contract_root/unrelated-extra/Type.kt"
+git -C "$fixture" add -u "$contract_root/unrelated-extra/Type.kt"
 mkdir -p "$fixture/backend-idea"
 printf 'retired\n' >"$fixture/backend-idea/build.gradle.kts"
 printf 'run --backend idea\n' >"$fixture/legacy.md"


### PR DESCRIPTION
## Summary

- Treat the specification-authorized `contract/transformation` namespace as an explicit shape allowance.
- Keep the generic ten-child contract-root limit unchanged.
- Prove that one unrelated extra contract-root child still fails.

## TDD evidence

- Baseline: `bash .github/scripts/test-repository-shape-contract.sh` passed on `de5ccbdfda47f9498ada758706877b6926d82ffc`.
- RED: the same command failed when the fixture added the authorized namespace because it was counted as child 11.
- GREEN: `bash .github/scripts/test-repository-shape-contract.sh` passes at `95e4bbecf1a9c09a7e4048efeb7ca238aaaaadd6`; the unrelated-extra fixture still produces an effective 11/10 violation.
- Regression: `python3 .github/scripts/check-repository-shape.py` passes with zero violations.

Closes #551