### PR TITLE
fix: restore verified add-file mutations

### DIFF
--- a/cli-rs/src/agent/plan/parts/verification/comparison.rs
+++ b/cli-rs/src/agent/plan/parts/verification/comparison.rs
@@ -75,6 +75,7 @@ fn validate_diagnostics_page(
         })
         .collect::<Vec<_>>();
     if page.semantic_outcome != ProtocolAnalysisOutcome::Complete
+        || page.schema_version != crate::SCHEMA_VERSION
         || page.requested_file_count != expected_files.len()
         || page.analyzed_file_count != expected_files.len()
         || page.skipped_file_count != 0

--- a/cli-rs/src/agent/plan/parts/verification/protocol.rs
+++ b/cli-rs/src/agent/plan/parts/verification/protocol.rs
@@ -207,6 +207,7 @@ struct ProtocolDiagnosticsEvidence {
     requested_file_count: usize,
     analyzed_file_count: usize,
     skipped_file_count: usize,
+    schema_version: u32,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]

--- a/cli-rs/src/agent/plan/parts/verification/rollback_tests.rs
+++ b/cli-rs/src/agent/plan/parts/verification/rollback_tests.rs
@@ -9,6 +9,55 @@
         }
     }
 
+    fn diagnostics_page(schema_version: u32) -> ProtocolDiagnosticsEvidence {
+        serde_json::from_value(serde_json::json!({
+            "diagnostics": [],
+            "fileStatuses": [{
+                "filePath": "/workspace/src/Checked.kt",
+                "state": "ANALYZED"
+            }],
+            "fileHashes": [{
+                "filePath": "/workspace/src/Checked.kt",
+                "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }],
+            "severityCounts": {"error": 0, "warning": 0, "info": 0, "total": 0},
+            "cardinality": {"type": "EXACT", "totalCount": 0},
+            "semanticOutcome": "COMPLETE",
+            "requestedFileCount": 1,
+            "analyzedFileCount": 1,
+            "skippedFileCount": 0,
+            "schemaVersion": schema_version
+        }))
+        .expect("closed live diagnostics evidence")
+    }
+
+    fn validate_diagnostics_schema(schema_version: u32) -> Result<()> {
+        let expected_files = [CompilerDiagnosticFileHash {
+            file_path: "/workspace/src/Checked.kt".to_string(),
+            sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .to_string(),
+        }];
+        validate_diagnostics_page(
+            diagnostics_page(schema_version),
+            &expected_files,
+            &mut None,
+            &mut None,
+            &mut Vec::new(),
+            &mut None,
+            &mut BTreeSet::new(),
+        )
+    }
+
+    #[test]
+    fn diagnostics_accept_the_live_schema_version() {
+        assert!(validate_diagnostics_schema(crate::SCHEMA_VERSION).is_ok());
+    }
+
+    #[test]
+    fn diagnostics_reject_a_different_schema_version() {
+        assert!(validate_diagnostics_schema(crate::SCHEMA_VERSION - 1).is_err());
+    }
+
     #[test]
     fn existing_file_rollback_requires_restored_semantic_admission() {
         let refresh = serde_json::from_value(serde_json::json!({

--- a/cli-rs/tests/agent/public/kast_public_operations/support.rs
+++ b/cli-rs/tests/agent/public/kast_public_operations/support.rs
@@ -377,7 +377,8 @@ pub(super) fn independent_diagnostics(
             "info": infos,
             "total": total
         },
-        "cardinality": {"type": "EXACT", "totalCount": total}
+        "cardinality": {"type": "EXACT", "totalCount": total},
+        "schemaVersion": 6
     });
     if let Some(page) = page {
         result["page"] = page;

--- a/cli-rs/tests/support/core/backends/unified_verification.rs
+++ b/cli-rs/tests/support/core/backends/unified_verification.rs
@@ -69,6 +69,7 @@ pub(super) fn unified_diagnostics(paths: &[serde_json::Value]) -> serde_json::Va
         "skippedFileCount": 0,
         "severityCounts": {"error": 0, "warning": 0, "info": 0, "total": 0},
         "cardinality": {"type": "EXACT", "totalCount": 0},
+        "schemaVersion": 6,
     })
 }
 

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/backend/mutation/addition/AdditionOwnerContext.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/backend/mutation/addition/AdditionOwnerContext.kt
@@ -67,6 +67,18 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.*
 
+private data class AdditionGradleOwnerIdentity(
+    val sourceRoot: AdditionSourceRoot,
+    val gradleBuildRoot: AdditionGradleBuildRoot,
+    val gradleProjectPath: AdditionGradleProjectPath,
+    val sourceSetName: AdditionGradleSourceSetName,
+)
+
+private data class AdditionOwnerObservation(
+    val gradleOwner: AdditionGradleOwnerIdentity,
+    val ideaModuleName: AdditionIdeaModuleName,
+)
+
 internal fun KastIndexerBackend.exactAdditionOwner(target: Path): AdditionOwnerSnapshot {
     val model = workspaceModelReader()
     if (!model.importedModelComplete()) failAddition(
@@ -80,33 +92,44 @@ internal fun KastIndexerBackend.exactAdditionOwner(target: Path): AdditionOwnerS
             sourceSet.sourceRoots().mapNotNull { rawRoot ->
                 val sourceRoot = rawRoot.toAbsolutePath().normalize()
                 sourceRoot.takeIf { normalizedTarget != it && normalizedTarget.startsWith(it) }?.let {
-                    Triple(module, sourceSet, sourceRoot)
+                    AdditionOwnerObservation(
+                        gradleOwner = AdditionGradleOwnerIdentity(
+                            sourceRoot = AdditionSourceRoot.parse(sourceRoot.toString()),
+                            gradleBuildRoot = AdditionGradleBuildRoot.parse(
+                                module.linkedBuildRoot().toAbsolutePath().normalize().toString(),
+                            ),
+                            gradleProjectPath = AdditionGradleProjectPath.parse(module.gradleProjectPath()),
+                            sourceSetName = AdditionGradleSourceSetName.of(sourceSet.sourceSetName()),
+                        ),
+                        ideaModuleName = AdditionIdeaModuleName.of(module.ideaModuleName()),
+                    )
                 }
             }
         }
     }
-    val mostSpecificDepth = candidates.maxOfOrNull { it.third.nameCount } ?: failAddition(
+    val mostSpecificDepth = candidates.maxOfOrNull { Path.of(it.gradleOwner.sourceRoot.value).nameCount } ?: failAddition(
         AdditionProofLimitation.SOURCE_OWNER_UNPROVEN,
         "The target has no exact Gradle source-set owner",
     )
-    val exact = candidates.filter { it.third.nameCount == mostSpecificDepth }.distinctBy { candidate ->
-        listOf(
-            candidate.first.ideaModuleName(),
-            candidate.first.linkedBuildRoot().toString(),
-            candidate.first.gradleProjectPath(),
-            candidate.second.sourceSetName(),
-            candidate.third.toString(),
-        )
-    }
-    if (exact.size != 1) failAddition(
+    val exactGradleOwners = candidates
+        .filter { Path.of(it.gradleOwner.sourceRoot.value).nameCount == mostSpecificDepth }
+        .groupBy(AdditionOwnerObservation::gradleOwner)
+    if (exactGradleOwners.size != 1) failAddition(
         AdditionProofLimitation.SOURCE_OWNER_AMBIGUOUS,
         "The target has more than one exact Gradle source-set owner",
     )
-    val (module, sourceSet, sourceRoot) = exact.single()
+    val (gradleOwner, observations) = exactGradleOwners.entries.single()
+    val sourceRoot = Path.of(gradleOwner.sourceRoot.value)
     requireAdditionPathAuthority(sourceRoot, "model-owned source root")
+    val ideaModuleName = exactAdditionIdeaModule(
+        target = normalizedTarget,
+        sourceRoot = sourceRoot,
+        observations = observations,
+    )
     val modelSourceRoots = model.moduleAssociations().flatMap { association ->
         association.sourceSets().flatMap { it.sourceRoots() }
-    }.map { it.toAbsolutePath().normalize() }
+    }
+        .map { it.toAbsolutePath().normalize() }
         .distinct()
         .sortedBy(Path::toString)
     modelSourceRoots.forEach { modelSourceRoot ->
@@ -119,11 +142,11 @@ internal fun KastIndexerBackend.exactAdditionOwner(target: Path): AdditionOwnerS
     val anchorSourceFiles = sourceFilesUnder(sourceRoot)
     return AdditionOwnerSnapshot(
         owner = AdditionSourceOwner.of(
-            sourceRoot = AdditionSourceRoot.parse(sourceRoot.toString()),
-            ideaModuleName = AdditionIdeaModuleName.of(module.ideaModuleName()),
-            gradleBuildRoot = AdditionGradleBuildRoot.parse(module.linkedBuildRoot().toAbsolutePath().normalize().toString()),
-            gradleProjectPath = AdditionGradleProjectPath.parse(module.gradleProjectPath()),
-            sourceSetName = AdditionGradleSourceSetName.of(sourceSet.sourceSetName()),
+            sourceRoot = gradleOwner.sourceRoot,
+            ideaModuleName = ideaModuleName,
+            gradleBuildRoot = gradleOwner.gradleBuildRoot,
+            gradleProjectPath = gradleOwner.gradleProjectPath,
+            sourceSetName = gradleOwner.sourceSetName,
         ),
         modelFingerprint = AdditionProjectModelFingerprint.of(projectModelFingerprint(model)),
         classpathFingerprint = AdditionClasspathFingerprint.of(
@@ -131,6 +154,37 @@ internal fun KastIndexerBackend.exactAdditionOwner(target: Path): AdditionOwnerS
         ),
         sourceFiles = sourceFiles,
         anchorSourceFiles = anchorSourceFiles,
+    )
+}
+
+private fun KastIndexerBackend.exactAdditionIdeaModule(
+    target: Path,
+    sourceRoot: Path,
+    observations: List<AdditionOwnerObservation>,
+): AdditionIdeaModuleName {
+    val observedModuleNames = observations
+        .map(AdditionOwnerObservation::ideaModuleName)
+        .distinct()
+        .sortedBy(AdditionIdeaModuleName::value)
+    if (observedModuleNames.size == 1) return observedModuleNames.single()
+
+    val indexedModuleNames = sequenceOf(
+        target.takeIf { Files.exists(it, NOFOLLOW_LINKS) },
+        target.parent,
+        sourceRoot,
+    ).filterNotNull()
+        .distinct()
+        .mapNotNull(LocalFileSystem.getInstance()::findFileByNioFile)
+        .mapNotNull { ProjectFileIndex.getInstance(project).getModuleForFile(it)?.name }
+        .distinct()
+        .toList()
+    if (indexedModuleNames.size != 1) failAddition(
+        AdditionProofLimitation.SOURCE_OWNER_UNPROVEN,
+        "The exact Gradle source-set owner has no unique indexed IDEA module",
+    )
+    return observedModuleNames.singleOrNull { it.value == indexedModuleNames.single() } ?: failAddition(
+        AdditionProofLimitation.SOURCE_OWNER_UNPROVEN,
+        "The indexed IDEA module does not observe the exact Gradle source-set owner",
     )
 }
 

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/backend/contract/mutation/addition/ExactAdditionSourceRootPolicyTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/backend/contract/mutation/addition/ExactAdditionSourceRootPolicyTest.kt
@@ -1,10 +1,12 @@
 package io.github.amichne.kast.idea
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.testFramework.junit5.TestApplication
 import io.github.amichne.kast.api.contract.query.AddDeclarationPlanQuery
+import io.github.amichne.kast.api.contract.query.AddFilePlanQuery
 import io.github.amichne.kast.api.contract.result.AdditionTargetPath
 import io.github.amichne.kast.api.contract.result.AdditionTargetPreimageSha256
 import io.github.amichne.kast.api.protocol.AdditionProofIncompleteException
@@ -20,6 +22,79 @@ import org.junit.jupiter.api.Test
 
 @TestApplication
 internal class ExactAdditionSourceRootPolicyTest : ExactAdditionPlanningTestSupport() {
+    @Test
+    fun `duplicate observations of one source set remain one exact owner`() = runBlocking {
+        ensureProjectReady()
+        val sourceRoot = sourceRoot()
+        val workspaceRoot = requireNotNull(sourceRoot.parent)
+        val ideaModuleName = ApplicationManager.getApplication().runReadAction<String> {
+            requireNotNull(
+                ProjectFileIndex.getInstance(project).getModuleForFile(sampleFile.virtualFile),
+            ).name
+        }
+        val exactObservation = association(ideaModuleName, workspaceRoot, ":", "main", sourceRoot)
+        val aggregateObservation = association(
+            "$ideaModuleName.aggregate",
+            workspaceRoot,
+            ":",
+            "main",
+            sourceRoot,
+        )
+        val target = sourceRoot.resolve("DuplicateOwnerObservation.kt")
+        val query = AddFilePlanQuery(
+            targetPath = AdditionTargetPath.parse(target.toString()),
+            proposedContent = "package demo\n\nclass DuplicateOwnerObservation\n",
+        )
+
+        val forward = backend(
+            workspaceRoot,
+            workspaceModelReader = model(workspaceRoot, listOf(aggregateObservation, exactObservation)),
+        ).planAddFile(query)
+        val reversed = backend(
+            workspaceRoot,
+            workspaceModelReader = model(workspaceRoot, listOf(exactObservation, aggregateObservation)),
+        ).planAddFile(query)
+
+        assertEquals(ideaModuleName, forward.proof.owner.ideaModuleName.value)
+        assertEquals(forward.proof.owner, reversed.proof.owner)
+    }
+
+    @Test
+    fun `duplicate observations without the indexed module remain unproven`() = runBlocking {
+        ensureProjectReady()
+        val sourceRoot = sourceRoot()
+        val workspaceRoot = requireNotNull(sourceRoot.parent)
+        val ideaModuleName = ApplicationManager.getApplication().runReadAction<String> {
+            requireNotNull(
+                ProjectFileIndex.getInstance(project).getModuleForFile(sampleFile.virtualFile),
+            ).name
+        }
+        val target = sourceRoot.resolve("UnprovenDuplicateOwnerObservation.kt")
+
+        val failure = assertThrows(AdditionProofIncompleteException::class.java) {
+            runBlocking {
+                backend(
+                    workspaceRoot,
+                    workspaceModelReader = model(
+                        workspaceRoot,
+                        listOf(
+                            association("$ideaModuleName.aggregate", workspaceRoot, ":", "main", sourceRoot),
+                            association("$ideaModuleName.other", workspaceRoot, ":", "main", sourceRoot),
+                        ),
+                    ),
+                ).planAddFile(
+                    AddFilePlanQuery(
+                        targetPath = AdditionTargetPath.parse(target.toString()),
+                        proposedContent = "package demo\n\nclass UnprovenDuplicateOwnerObservation\n",
+                    ),
+                )
+            }
+        }
+
+        assertLimitation(failure, AdditionProofLimitation.SOURCE_OWNER_UNPROVEN)
+        assertFalse(Files.exists(target))
+    }
+
     @Test
     fun `add declaration rejects every hard-excluded model-owned source root`() = runBlocking {
         ensureProjectReady()


### PR DESCRIPTION
## What

- Accept duplicate live observations of one Gradle source-set owner while retaining rejection for distinct owners.
- Require live compiler diagnostics evidence to match the current protocol schema.

## Why

The v0.21.2 fresh-workspace proof stopped legitimate one-module add-file planning because one Gradle owner appeared through two IDEA projections. After that repair, apply exposed a second producer-consumer mismatch because schema version 6 was rejected as an unknown diagnostics field.

## Proof

- Focused owner RED/GREEN and distinct-owner rejection
- 1,035 JVM/indexer tests plus the 11-test performance lane
- Rust fmt, denied-warning clippy, and all 652 Rust tests
- Repository shape and release contracts
- Fresh one-module public plan, verified apply, byte-identical replay, and Gradle compilation