### PR TITLE
Harden dangling worktree metadata and expose developer routing

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/ServerLaunchOptions.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/ServerLaunchOptions.kt
@@ -20,6 +20,7 @@ data class ServerLaunchOptions(
     val maxResults: Int,
     val maxConcurrentRequests: Int,
     val profilingOverride: ProfilingConfigOverride? = null,
+    val linkedWorktreeLaunchClaim: LinkedWorktreeLaunchClaim? = null,
 ) {
     companion object {
         fun parse(
@@ -79,6 +80,7 @@ data class ServerLaunchOptions(
                 maxResults = values["max-results"]?.toInt() ?: resolvedConfig.server.maxResults.value,
                 maxConcurrentRequests = values["max-concurrent-requests"]?.toInt() ?: resolvedConfig.server.maxConcurrentRequests.value,
                 profilingOverride = parseProfilingOverride(values),
+                linkedWorktreeLaunchClaim = LinkedWorktreeLaunchClaim.fromValues(values),
             )
         }
 
@@ -135,5 +137,9 @@ data class ServerLaunchOptions(
         profilingOverride?.modes?.value?.let { add("--profile-modes=$it") }
         profilingOverride?.durationSeconds?.value?.let { add("--profile-duration=$it") }
         profilingOverride?.otlpEndpoint?.value?.orNull?.let { add("--profile-otlp-endpoint=$it") }
+        linkedWorktreeLaunchClaim?.let { claim ->
+            add("--${LinkedWorktreeLaunchClaim.GIT_FILE_ARGUMENT}=${claim.gitFile}")
+            add("--${LinkedWorktreeLaunchClaim.GIT_DIRECTORY_ARGUMENT}=${claim.gitDirectory}")
+        }
     }
 }

--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/config/LinkedWorktreeLaunchClaim.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/config/LinkedWorktreeLaunchClaim.kt
@@ -1,0 +1,48 @@
+package io.github.amichne.kast.api.client
+
+import java.nio.file.Path
+
+class LinkedWorktreeLaunchClaim private constructor(
+    val gitFile: Path,
+    val gitDirectory: Path,
+) {
+    override fun equals(other: Any?): Boolean = other is LinkedWorktreeLaunchClaim &&
+        gitFile == other.gitFile && gitDirectory == other.gitDirectory
+
+    override fun hashCode(): Int = 31 * gitFile.hashCode() + gitDirectory.hashCode()
+
+    override fun toString(): String = "LinkedWorktreeLaunchClaim(gitFile=$gitFile, gitDirectory=$gitDirectory)"
+
+    companion object {
+        const val GIT_FILE_ARGUMENT = "linked-worktree-git-file"
+        const val GIT_DIRECTORY_ARGUMENT = "linked-worktree-git-directory"
+
+        fun of(
+            gitFile: Path,
+            gitDirectory: Path,
+        ): LinkedWorktreeLaunchClaim {
+            val normalizedGitFile = gitFile.toAbsolutePath().normalize()
+            val normalizedGitDirectory = gitDirectory.toAbsolutePath().normalize()
+            require(normalizedGitFile.fileName?.toString() == ".git") {
+                "Linked-worktree launch Git file must be named .git"
+            }
+            require(normalizedGitDirectory.parent?.fileName?.toString() == "worktrees") {
+                "Linked-worktree launch Git directory must be inside a worktrees directory"
+            }
+            return LinkedWorktreeLaunchClaim(normalizedGitFile, normalizedGitDirectory)
+        }
+
+        internal fun fromValues(values: Map<String, String>): LinkedWorktreeLaunchClaim? {
+            val rawGitFile = values[GIT_FILE_ARGUMENT]
+            val rawGitDirectory = values[GIT_DIRECTORY_ARGUMENT]
+            check((rawGitFile == null) == (rawGitDirectory == null)) {
+                "Linked-worktree launch claim requires both --$GIT_FILE_ARGUMENT and --$GIT_DIRECTORY_ARGUMENT"
+            }
+            return if (rawGitFile == null || rawGitDirectory == null) {
+                null
+            } else {
+                of(Path.of(rawGitFile), Path.of(rawGitDirectory))
+            }
+        }
+    }
+}

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/config/ServerLaunchOptionsTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/config/ServerLaunchOptionsTest.kt
@@ -7,6 +7,7 @@ import io.github.amichne.kast.api.client.fields.ServerRequestTimeoutMillis
 import io.github.amichne.kast.api.contract.*
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -118,5 +119,32 @@ class ServerLaunchOptionsTest {
         assertTrue(options.toCliArguments().contains("--profile-modes=cpu,alloc"))
         assertTrue(options.toCliArguments().contains("--profile-duration=45"))
         assertTrue(options.toCliArguments().contains("--profile-otlp-endpoint=http://localhost:4317"))
+    }
+
+    @Test
+    fun `linked worktree launch claim is complete and round trips`() {
+        val gitFile = tempDir.resolve("workspace/.git").toAbsolutePath().normalize()
+        val gitDirectory = tempDir.resolve("repository/.git/worktrees/workspace").toAbsolutePath().normalize()
+        val options = ServerLaunchOptions.fromValues(
+            mapOf(
+                "workspace-root" to tempDir.toString(),
+                "linked-worktree-git-file" to gitFile.toString(),
+                "linked-worktree-git-directory" to gitDirectory.toString(),
+            ),
+        )
+
+        assertEquals(gitFile, options.linkedWorktreeLaunchClaim?.gitFile)
+        assertEquals(gitDirectory, options.linkedWorktreeLaunchClaim?.gitDirectory)
+        assertEquals(options.linkedWorktreeLaunchClaim, ServerLaunchOptions.parse(
+            options.toCliArguments().toTypedArray(),
+        ).linkedWorktreeLaunchClaim)
+        assertThrows(IllegalStateException::class.java) {
+            ServerLaunchOptions.fromValues(
+                mapOf(
+                    "workspace-root" to tempDir.toString(),
+                    "linked-worktree-git-file" to gitFile.toString(),
+                ),
+            )
+        }
     }
 }

--- a/cli-rs/resources/kast/SKILL.md
+++ b/cli-rs/resources/kast/SKILL.md
@@ -32,5 +32,9 @@ Use `kast` as the public interface for Kotlin and Gradle semantic work.
   exact source pre-state.
 - Retrying a terminal plan or recovery receipt does not repeat source writes.
 
+For setup, runtime control, local-state inspection, raw RPC, or release work,
+invoke `/kast:developer`. Read `developerOperations.cli` from `kast`; do not
+assume `kastctl` is on `PATH`.
+
 Do not infer semantic success from an empty result. Read `limitation` and the
 suggested `next` commands when evidence is unavailable.

--- a/cli-rs/resources/kast/developer/SKILL.md
+++ b/cli-rs/resources/kast/developer/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: developer
+description: Use when a user explicitly requests Kast setup, runtime control, configuration, local-state inspection, raw RPC, or release engineering beyond the public Kast semantic operations.
+---
+
+# Kast developer operations
+
+Use the installed control CLI only for the requested developer operation.
+
+1. Run `kast` from the target workspace.
+2. Read `developerOperations.cli` from the result. Treat that exact path as the
+   executable authority. Do not assume `kastctl` is on `PATH`.
+3. Execute `developerOperations.cli` with `developerOperations.helpArgs` as
+   separate arguments before using the control surface. Live help defines the
+   available commands. Do not evaluate the path and arguments as a shell string.
+4. Pass the target root explicitly when the selected command accepts
+   `--workspace-root`.
+
+Keep compiler-backed discovery, diagnostics, graph analysis, and validated
+changes on the public `kast` interface. Treat setup, configuration writes,
+runtime stop or restart, raw RPC, and release operations as mutations. Run them
+only when the user authorized that operation.

--- a/cli-rs/src/configuration/config/launch.rs
+++ b/cli-rs/src/configuration/config/launch.rs
@@ -19,6 +19,15 @@ pub fn server_launch_args(args: &DaemonStartArgs, config: &KastConfig) -> Result
         .map(normalize)
         .unwrap_or_else(|| default_socket_path_for_config(config, &workspace_root));
     let mut result = vec![format!("--workspace-root={}", workspace_root.display())];
+    if let Some(claim) = linked_worktree_registration_claim(&workspace_root) {
+        result.extend([
+            format!("--linked-worktree-git-file={}", claim.git_file.display()),
+            format!(
+                "--linked-worktree-git-directory={}",
+                claim.git_directory.display()
+            ),
+        ]);
+    }
     if args.stdio {
         result.push("--stdio".to_string());
     } else {

--- a/cli-rs/src/configuration/config/tests/workspace/git.rs
+++ b/cli-rs/src/configuration/config/tests/workspace/git.rs
@@ -120,3 +120,209 @@
                 .expect("without origin"),
         );
     }
+
+    #[test]
+    fn server_launch_args_include_a_live_linked_worktree_registration_claim() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (worktree, git_directory) = create_linked_worktree(temp.path());
+
+        let launch_args = server_launch_args(
+            &daemon_start_args(&worktree),
+            &KastConfig::defaults(),
+        )
+        .expect("launch arguments");
+
+        assert!(launch_args.contains(&format!(
+            "--linked-worktree-git-file={}",
+            worktree.join(".git").display()
+        )));
+        assert!(launch_args.contains(&format!(
+            "--linked-worktree-git-directory={}",
+            git_directory.display()
+        )));
+    }
+
+    #[test]
+    fn server_launch_args_omit_a_linked_worktree_claim_for_a_mismatched_backlink() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (worktree, git_directory) = create_linked_worktree(temp.path());
+        let forged_git_file = temp.path().join("forged/.git");
+        fs::create_dir_all(forged_git_file.parent().expect("forged parent"))
+            .expect("forged parent directory");
+        fs::write(&forged_git_file, "forged\n").expect("forged Git file");
+        fs::write(
+            git_directory.join("gitdir"),
+            format!("{}\n", forged_git_file.display()),
+        )
+        .expect("mismatched backlink");
+
+        let launch_args = server_launch_args(
+            &daemon_start_args(&worktree),
+            &KastConfig::defaults(),
+        )
+        .expect("launch arguments");
+
+        assert!(!launch_args.iter().any(|argument| {
+            argument.starts_with("--linked-worktree-git-file=")
+                || argument.starts_with("--linked-worktree-git-directory=")
+        }));
+    }
+
+    #[test]
+    fn server_launch_args_omit_an_unregistered_bidirectional_filesystem_claim() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (_, registered_git_directory) = create_linked_worktree(temp.path());
+        let common_git_directory = registered_git_directory
+            .parent()
+            .and_then(Path::parent)
+            .expect("common Git directory");
+        let forged_worktree = temp.path().join("forged-worktree");
+        let forged_git_file = forged_worktree.join(".git");
+        let forged_git_directory = common_git_directory.join("worktrees/forged-worktree");
+        fs::create_dir(&forged_worktree).expect("forged worktree directory");
+        fs::create_dir(&forged_git_directory).expect("forged Git directory");
+        fs::write(
+            &forged_git_file,
+            format!("gitdir: {}\n", forged_git_directory.display()),
+        )
+        .expect("forged Git file");
+        fs::write(
+            forged_git_directory.join("gitdir"),
+            format!("{}\n", forged_git_file.display()),
+        )
+        .expect("forged backlink");
+
+        let launch_args = server_launch_args(
+            &daemon_start_args(&forged_worktree),
+            &KastConfig::defaults(),
+        )
+        .expect("launch arguments");
+
+        assert!(!launch_args.iter().any(|argument| {
+            argument.starts_with("--linked-worktree-git-file=")
+                || argument.starts_with("--linked-worktree-git-directory=")
+        }));
+    }
+
+    #[test]
+    fn server_launch_args_ignore_poisoned_repository_selection_environment() {
+        const PROBE_WORKSPACE: &str = "KAST_TEST_LINKED_CLAIM_WORKSPACE";
+        if let Some(workspace) = std::env::var_os(PROBE_WORKSPACE) {
+            let launch_args = server_launch_args(
+                &daemon_start_args(Path::new(&workspace)),
+                &KastConfig::defaults(),
+            )
+            .expect("launch arguments");
+            assert!(!launch_args.iter().any(|argument| {
+                argument.starts_with("--linked-worktree-git-file=")
+                    || argument.starts_with("--linked-worktree-git-directory=")
+            }));
+            return;
+        }
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (_, registered_git_directory) = create_linked_worktree(temp.path());
+        let fixture_root = fs::canonicalize(temp.path()).expect("canonical fixture root");
+        let forged_worktree = fixture_root.join("forged-worktree");
+        let forged_git_file = forged_worktree.join(".git");
+        let common_git_directory = registered_git_directory
+            .parent()
+            .and_then(Path::parent)
+            .expect("common Git directory");
+        let forged_git_directory = common_git_directory.join("worktrees/poisoned-forgery");
+        fs::create_dir(&forged_worktree).expect("forged worktree directory");
+        fs::create_dir(&forged_git_directory).expect("forged Git directory");
+        fs::write(
+            &forged_git_file,
+            format!("gitdir: {}\n", forged_git_directory.display()),
+        )
+        .expect("forged Git file");
+        fs::write(
+            forged_git_directory.join("gitdir"),
+            format!("{}\n", forged_git_file.display()),
+        )
+        .expect("forged backlink");
+        fs::copy(
+            registered_git_directory.join("HEAD"),
+            forged_git_directory.join("HEAD"),
+        )
+        .expect("forged Git HEAD");
+        let output = std::process::Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "config::tests::server_launch_args_ignore_poisoned_repository_selection_environment",
+                "--nocapture",
+            ])
+            .env(PROBE_WORKSPACE, &forged_worktree)
+            .env("GIT_DIR", &forged_git_directory)
+            .env("GIT_WORK_TREE", &forged_worktree)
+            .env("GIT_COMMON_DIR", common_git_directory)
+            .output()
+            .expect("poisoned Git environment probe");
+
+        assert!(
+            output.status.success(),
+            "poisoned Git environment emitted a launch claim:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    fn create_linked_worktree(root: &Path) -> (PathBuf, PathBuf) {
+        let root = fs::canonicalize(root).expect("canonical fixture root");
+        let primary = root.join("primary");
+        let worktree = root.join("linked");
+        fs::create_dir(&primary).expect("primary directory");
+        let git = |working_directory: &Path, args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .args(args)
+                .current_dir(working_directory)
+                .status()
+                .expect("git command");
+            assert!(status.success(), "git command failed: {args:?}");
+        };
+        git(&primary, &["init", "--quiet"]);
+        git(&primary, &["config", "user.email", "fixture@example.test"]);
+        git(&primary, &["config", "user.name", "Fixture"]);
+        git(&primary, &["commit", "--quiet", "--allow-empty", "-m", "base"]);
+        git(
+            &primary,
+            &[
+                "worktree",
+                "add",
+                "--quiet",
+                "-b",
+                "fixture-linked",
+                worktree.to_str().expect("UTF-8 worktree path"),
+            ],
+        );
+
+        let git_file = fs::read_to_string(worktree.join(".git")).expect("Git file");
+        let git_directory = PathBuf::from(
+            git_file
+                .trim()
+                .strip_prefix("gitdir: ")
+                .expect("Git directory directive"),
+        );
+        (worktree, git_directory)
+    }
+
+    fn daemon_start_args(workspace_root: &Path) -> DaemonStartArgs {
+        DaemonStartArgs {
+            workspace_root: Some(workspace_root.to_path_buf()),
+            runtime_libs_dir: None,
+            idea_home: None,
+            socket_path: None,
+            module_name: None,
+            source_roots: None,
+            classpath: None,
+            request_timeout_ms: None,
+            max_results: None,
+            max_concurrent_requests: None,
+            stdio: false,
+            profile: false,
+            profile_modes: None,
+            profile_duration: None,
+            profile_otlp_endpoint: None,
+        }
+    }

--- a/cli-rs/src/configuration/config/workspace/git.rs
+++ b/cli-rs/src/configuration/config/workspace/git.rs
@@ -1,11 +1,84 @@
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 struct GitWorkspace {
     toplevel: PathBuf,
     common_dir: PathBuf,
     git_dir: PathBuf,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct LinkedWorktreeRegistrationClaim {
+    git_file: PathBuf,
+    git_directory: PathBuf,
+}
+
+fn linked_worktree_registration_claim(
+    workspace_root: &Path,
+) -> Option<LinkedWorktreeRegistrationClaim> {
+    let git_file = normalize(workspace_root.join(".git"));
+    if !path_entry_type(&git_file).ok().flatten()?.is_file() {
+        return None;
+    }
+    let git_directory = registered_path(&git_file, Some("gitdir: "))?;
+    let worktrees_directory = git_directory.parent()?;
+    if worktrees_directory.file_name()? != "worktrees"
+        || !path_entry_type(&git_directory).ok().flatten()?.is_dir()
+    {
+        return None;
+    }
+    let backlink = git_directory.join("gitdir");
+    if !path_entry_type(&backlink).ok().flatten()?.is_file() {
+        return None;
+    }
+    let registered_git_file = registered_path(&backlink, None)?;
+    if fs::canonicalize(&registered_git_file).ok()? != fs::canonicalize(&git_file).ok()? {
+        return None;
+    }
+    let registered_workspace = GitWorkspace {
+        toplevel: normalize(workspace_root.to_path_buf()),
+        common_dir: normalize(worktrees_directory.parent()?.to_path_buf()),
+        git_dir: git_directory.clone(),
+    };
+    if git_workspace(workspace_root)? != registered_workspace {
+        return None;
+    }
+    Some(LinkedWorktreeRegistrationClaim {
+        git_file,
+        git_directory,
+    })
+}
+
+fn registered_path(path: &Path, prefix: Option<&str>) -> Option<PathBuf> {
+    let contents = fs::read_to_string(path).ok()?;
+    let line = contents.trim_end_matches(&['\n', '\r'][..]);
+    if line.contains(['\n', '\r']) {
+        return None;
+    }
+    let raw_path = match prefix {
+        Some(prefix) => line.strip_prefix(prefix)?,
+        None => line,
+    };
+    if raw_path.is_empty() {
+        return None;
+    }
+    let parsed = PathBuf::from(raw_path);
+    Some(normalize(if parsed.is_absolute() {
+        parsed
+    } else {
+        path.parent()?.join(parsed)
+    }))
+}
+
 const MAX_LEGACY_REPOSITORY_DEPTH: usize = 32;
+const GIT_REPOSITORY_SELECTION_ENVIRONMENT: [&str; 8] = [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+];
 
 fn git_workspace(workspace_root: &Path) -> Option<GitWorkspace> {
     let toplevel = git_path(workspace_root, &["rev-parse", "--show-toplevel"])?;
@@ -239,11 +312,12 @@ fn git_path(workspace_root: &Path, args: &[&str]) -> Option<PathBuf> {
 }
 
 fn git_output(workspace_root: &Path, args: &[&str]) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .args(args)
-        .current_dir(workspace_root)
-        .output()
-        .ok()?;
+    let mut command = std::process::Command::new("git");
+    command.args(args).current_dir(workspace_root);
+    for name in GIT_REPOSITORY_SELECTION_ENVIRONMENT {
+        command.env_remove(name);
+    }
+    let output = command.output().ok()?;
     if !output.status.success() {
         return None;
     }

--- a/cli-rs/src/interface/cli/agent/agent_surface.rs
+++ b/cli-rs/src/interface/cli/agent/agent_surface.rs
@@ -3,7 +3,8 @@
     name = "kast",
     version = version(),
     about = "Compiler-backed Kotlin knowledge and changes for coding agents.",
-    disable_help_subcommand = true
+    disable_help_subcommand = true,
+    after_help = "Developer operations: run `kast` to read `developerOperations`, then invoke `/kast:developer`."
 )]
 pub struct KastCli {
     #[command(subcommand)]

--- a/cli-rs/src/interface/entrypoint/invocation.rs
+++ b/cli-rs/src/interface/entrypoint/invocation.rs
@@ -1,5 +1,9 @@
 fn invoked_entrypoint() -> Option<Entrypoint> {
-    match Path::new(&current_executable_argument())
+    entrypoint_for_path(Path::new(&current_executable_argument()))
+}
+
+fn entrypoint_for_path(path: &Path) -> Option<Entrypoint> {
+    match path
         .file_stem()
         .and_then(|name| name.to_str())
     {

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -138,6 +138,7 @@ struct KastHome {
     ready: bool,
     runtime: String,
     reference_index_ready: bool,
+    developer_operations: install::DeveloperOperationsRoute,
     #[serde(skip_serializing_if = "Option::is_none")]
     limitation: Option<String>,
     next: Vec<String>,
@@ -173,6 +174,9 @@ fn run_kast_agent(cli: KastCli) -> Result<i32> {
 }
 
 fn kast_home(root: PathBuf) -> Result<KastHome> {
+    let developer_paths = manifest::resolve_paths()?;
+    let developer_operations =
+        install::DeveloperOperationsRoute::try_from_cli_path(&developer_paths.active_binary)?;
     let readiness = self_mgmt::doctor(cli::ReadyTarget::Agent, Some(&root))?;
     let mut runtime_state = "DOWN".to_string();
     let mut reference_index_ready = false;
@@ -218,6 +222,7 @@ fn kast_home(root: PathBuf) -> Result<KastHome> {
         ready,
         runtime: runtime_state,
         reference_index_ready,
+        developer_operations,
         limitation,
         next,
     })

--- a/cli-rs/src/operations/install/agent_resources.rs
+++ b/cli-rs/src/operations/install/agent_resources.rs
@@ -1,5 +1,6 @@
 const KAST_AGENT_SKILL: &str =
     include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/kast/SKILL.md"));
+const KAST_DEVELOPER_SKILL: &str = include_str!("../../../resources/kast/developer/SKILL.md");
 const KAST_CODEX_MARKETPLACE: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/resources/kast/codex/marketplace.json"
@@ -49,7 +50,8 @@ struct AgentResourceDigestOverrides<'a> {
     provider: &'static str,
     hooks: &'a str,
     plugin: &'a str,
-    skill: &'a str,
+    kast_skill: &'a str,
+    developer_skill: &'a str,
 }
 
 pub fn install_agent_resources(requested: &[KastHarness]) -> Result<()> {
@@ -165,7 +167,8 @@ fn materialize_agent_harness(harness: KastHarness) -> Result<PathBuf> {
         .join("agent-resources")
         .join(digest)
         .join(harness_name(harness));
-    let skill = render_agent_resource(KAST_AGENT_SKILL);
+    let kast_skill = render_agent_resource(KAST_AGENT_SKILL);
+    let developer_skill = render_agent_resource(KAST_DEVELOPER_SKILL);
     let (marketplace_path, plugin_path, hooks_path, marketplace, plugin, hooks) = match harness {
         KastHarness::Codex => (
             ".agents/plugins/marketplace.json",
@@ -196,7 +199,11 @@ fn materialize_agent_harness(harness: KastHarness) -> Result<PathBuf> {
         (marketplace_path, render_agent_resource(marketplace)),
         (plugin_path, render_agent_resource(plugin)),
         (hooks_path, render_agent_resource(hooks)),
-        ("plugins/kast/skills/kast/SKILL.md", skill),
+        ("plugins/kast/skills/kast/SKILL.md", kast_skill),
+        (
+            "plugins/kast/skills/developer/SKILL.md",
+            developer_skill,
+        ),
     ] {
         let target = root.join(relative);
         let parent = target.parent().ok_or_else(|| {
@@ -259,7 +266,8 @@ pub(crate) fn validate_agent_harness_activation(
     };
     let plugin = read_resource(plugin_path)?;
     let hooks = read_resource(hooks_path)?;
-    let skill = read_resource("skills/kast/SKILL.md")?;
+    let kast_skill = read_resource("skills/kast/SKILL.md")?;
+    let developer_skill = read_resource("skills/developer/SKILL.md")?;
     let detected_identity = serde_json::from_str::<InstalledAgentPluginIdentity>(&plugin).ok();
     let detected_version = detected_identity
         .as_ref()
@@ -269,11 +277,13 @@ pub(crate) fn validate_agent_harness_activation(
         provider: harness_name(harness),
         hooks: &hooks,
         plugin: &plugin,
-        skill: &skill,
+        kast_skill: &kast_skill,
+        developer_skill: &developer_skill,
     }));
     let expected_plugin = render_agent_resource(expected_plugin);
     let expected_hooks = render_agent_resource(expected_hooks);
-    let expected_skill = render_agent_resource(KAST_AGENT_SKILL);
+    let expected_kast_skill = render_agent_resource(KAST_AGENT_SKILL);
+    let expected_developer_skill = render_agent_resource(KAST_DEVELOPER_SKILL);
     let mut mismatches = Vec::new();
     if detected_identity
         .as_ref()
@@ -287,7 +297,7 @@ pub(crate) fn validate_agent_harness_activation(
     if hooks != expected_hooks {
         mismatches.push("hook digest mismatch");
     }
-    if skill != expected_skill {
+    if kast_skill != expected_kast_skill || developer_skill != expected_developer_skill {
         mismatches.push("skill digest mismatch");
     }
     if mismatches.is_empty() && detected_digest == expected_digest {
@@ -343,7 +353,8 @@ fn agent_resources_digest() -> String {
 fn agent_resources_digest_with(overrides: Option<&AgentResourceDigestOverrides<'_>>) -> String {
     let mut digest = Sha256::new();
     for (path, contents) in [
-        ("SKILL.md", KAST_AGENT_SKILL),
+        ("skills/kast/SKILL.md", KAST_AGENT_SKILL),
+        ("skills/developer/SKILL.md", KAST_DEVELOPER_SKILL),
         ("claude/hooks.json", KAST_CLAUDE_HOOKS),
         ("claude/marketplace.json", KAST_CLAUDE_MARKETPLACE),
         ("claude/plugin.json", KAST_CLAUDE_PLUGIN),
@@ -355,7 +366,8 @@ fn agent_resources_digest_with(overrides: Option<&AgentResourceDigestOverrides<'
         ("copilot/plugin.json", KAST_COPILOT_PLUGIN),
     ] {
         let overridden = overrides.and_then(|overrides| match path {
-            "SKILL.md" => Some(overrides.skill),
+            "skills/kast/SKILL.md" => Some(overrides.kast_skill),
+            "skills/developer/SKILL.md" => Some(overrides.developer_skill),
             path if path == format!("{}/hooks.json", overrides.provider) => {
                 Some(overrides.hooks)
             }

--- a/cli-rs/src/operations/install/bundle_entrypoint.rs
+++ b/cli-rs/src/operations/install/bundle_entrypoint.rs
@@ -44,13 +44,13 @@ fn setup_bundle(source: PathBuf, mode: SetupMode) -> Result<SetupResult> {
                 )?;
             }
             if verify_activated_bundle(&bundle, &targets).is_ok() {
-                return Ok(setup_result(
+                return setup_result(
                     &bundle,
                     &targets,
                     SetupStatus::Current,
                     legacy_archive.backup_path(),
                     &retired_plugin_removal,
-                ));
+                );
             }
         }
 
@@ -87,13 +87,13 @@ fn setup_bundle(source: PathBuf, mode: SetupMode) -> Result<SetupResult> {
                 &legacy_archive,
             ));
         }
-        Ok(setup_result(
+        setup_result(
             &bundle,
             &targets,
             SetupStatus::Activated,
             backup.as_deref().or_else(|| legacy_archive.backup_path()),
             &retired_plugin_removal,
-        ))
+        )
     })
 }
 
@@ -270,8 +270,8 @@ fn setup_result(
     status: SetupStatus,
     backup: Option<&Path>,
     retired_plugin_removal: &RetiredPublicPluginRemoval,
-) -> SetupResult {
-    SetupResult {
+) -> Result<SetupResult> {
+    Ok(SetupResult {
         result_type: "KAST_SETUP",
         status,
         release_digest: bundle.release_digest.clone(),
@@ -279,6 +279,9 @@ fn setup_result(
         kast_home: targets.resolved.install_root.display().to_string(),
         current: targets.current_link.display().to_string(),
         active_binary: targets.resolved.active_binary.display().to_string(),
+        developer_operations: DeveloperOperationsRoute::try_from_cli_path(
+            &targets.resolved.active_binary,
+        )?,
         backup: backup.map(|path| path.display().to_string()),
         restart_requirement: retired_plugin_removal.restart_requirement.clone(),
         artifacts: bundle
@@ -294,5 +297,5 @@ fn setup_result(
             .collect(),
         verified: true,
         schema_version: SCHEMA_VERSION,
-    }
+    })
 }

--- a/cli-rs/src/operations/install/types.rs
+++ b/cli-rs/src/operations/install/types.rs
@@ -5,6 +5,45 @@ pub enum SetupStatus {
     Current,
 }
 
+const DEVELOPER_SKILL_REFERENCE: &str = "/kast:developer";
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DeveloperOperationsRoute {
+    pub cli: String,
+    pub help_args: [&'static str; 1],
+    pub skill: &'static str,
+}
+
+impl DeveloperOperationsRoute {
+    pub(crate) fn try_from_cli_path(path: &Path) -> Result<Self> {
+        let control_cli = ControlCliPath::parse(path)?;
+        Ok(Self {
+            cli: control_cli.0.display().to_string(),
+            help_args: ["--help"],
+            skill: DEVELOPER_SKILL_REFERENCE,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ControlCliPath(PathBuf);
+
+impl ControlCliPath {
+    fn parse(path: &Path) -> Result<Self> {
+        if crate::entrypoint_for_path(path) == Some(crate::Entrypoint::Control) {
+            return Ok(Self(path.to_path_buf()));
+        }
+        Err(CliError::new(
+            "DEVELOPER_OPERATIONS_ROUTE_INVALID",
+            format!(
+                "Developer operations require a `kastctl` executable path, got {}.",
+                path.display()
+            ),
+        ))
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SetupMode {
     Reconcile,
@@ -32,6 +71,7 @@ pub struct SetupResult {
     pub kast_home: String,
     pub current: String,
     pub active_binary: String,
+    pub developer_operations: DeveloperOperationsRoute,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli-rs/src/operations/install/types.rs
+++ b/cli-rs/src/operations/install/types.rs
@@ -31,13 +31,18 @@ struct ControlCliPath(PathBuf);
 
 impl ControlCliPath {
     fn parse(path: &Path) -> Result<Self> {
-        if crate::entrypoint_for_path(path) == Some(crate::Entrypoint::Control) {
+        let is_executable_file = fs::metadata(path)
+            .is_ok_and(|metadata| metadata.is_file())
+            && is_executable(path).unwrap_or(false);
+        if crate::entrypoint_for_path(path) == Some(crate::Entrypoint::Control)
+            && is_executable_file
+        {
             return Ok(Self(path.to_path_buf()));
         }
         Err(CliError::new(
             "DEVELOPER_OPERATIONS_ROUTE_INVALID",
             format!(
-                "Developer operations require a `kastctl` executable path, got {}.",
+                "Developer operations require an existing executable `kastctl` path, got {}.",
                 path.display()
             ),
         ))

--- a/cli-rs/tests/agent/public/kast_agent_surface.rs
+++ b/cli-rs/tests/agent/public/kast_agent_surface.rs
@@ -1,3 +1,5 @@
+#[path = "kast_agent_surface/developer_route.rs"]
+mod developer_route;
 #[path = "../../support/mod.rs"]
 mod support;
 
@@ -7,10 +9,13 @@ use std::process::Command;
 
 use rusqlite::params;
 use sha2::{Digest, Sha256};
-use support::workspace_files::WorkspaceIndexFixture;
 #[cfg(target_os = "macos")]
-use support::{default_bin_dir, write_current_cli_install_manifest_for_test};
-use support::{published_semantic_command_for_reads, workspace_database_path_for_test};
+use support::default_bin_dir;
+use support::workspace_files::WorkspaceIndexFixture;
+use support::{
+    published_semantic_command_for_reads, workspace_database_path_for_test,
+    write_current_cli_install_manifest_for_test,
+};
 
 fn named(name: &str) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_kast"));
@@ -42,9 +47,17 @@ fn help_exposes_only_the_agent_contract() {
     ] {
         assert!(stdout.contains(command), "missing {command}: {stdout}");
     }
-    for legacy in ["setup", "developer", "rpc", "--output", "schemaVersion"] {
+    for private_command in ["\n  setup ", "\n  developer ", "\n  rpc "] {
+        assert!(
+            !stdout.contains(private_command),
+            "leaked private command {private_command}: {stdout}"
+        );
+    }
+    for legacy in ["--output", "schemaVersion"] {
         assert!(!stdout.contains(legacy), "leaked {legacy}: {stdout}");
     }
+    assert!(stdout.contains("developerOperations"), "{stdout}");
+    assert!(stdout.contains("/kast:developer"), "{stdout}");
 
     let graph = named("kast")
         .args(["graph", "--help"])
@@ -104,30 +117,6 @@ fn removed_output_flag_is_a_usage_error() {
     assert!(stdout.contains("--output"), "{stdout}");
     assert!(stdout.contains("next:"), "{stdout}");
     assert!(output.stderr.is_empty(), "{output:?}");
-}
-
-#[test]
-fn home_reports_live_workspace_state_without_protocol_cruft() {
-    let state = tempfile::tempdir().expect("temporary state");
-    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("repository root");
-    let output = named("kast")
-        .current_dir(workspace)
-        .env("KAST_HOME", state.path().join("kast"))
-        .env("XDG_CONFIG_HOME", state.path().join("config"))
-        .output()
-        .expect("run kast home");
-
-    assert!(output.status.success(), "{output:?}");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("root:"), "{stdout}");
-    assert!(stdout.contains("ready:"), "{stdout}");
-    assert!(stdout.contains("referenceIndexReady:"), "{stdout}");
-    assert!(stdout.contains("next["), "{stdout}");
-    for cruft in ["state: UNKNOWN", "schemaVersion", "ok:", "method:"] {
-        assert!(!stdout.contains(cruft), "leaked {cruft}: {stdout}");
-    }
 }
 
 #[cfg(target_os = "macos")]

--- a/cli-rs/tests/agent/public/kast_agent_surface/developer_route.rs
+++ b/cli-rs/tests/agent/public/kast_agent_surface/developer_route.rs
@@ -1,0 +1,118 @@
+use super::*;
+
+#[test]
+fn home_reports_live_workspace_state_without_protocol_cruft() {
+    let state = tempfile::tempdir().expect("temporary state");
+    let kast_home = state.path().join("kast home with spaces");
+    let developer_cli = kast_home.join("current/libexec/kastctl");
+    std::fs::create_dir_all(developer_cli.parent().expect("developer CLI parent"))
+        .expect("developer CLI directory");
+    std::fs::copy(env!("CARGO_BIN_EXE_kast"), &developer_cli).expect("developer CLI fixture");
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repository root");
+    let output = named("kast")
+        .current_dir(workspace)
+        .env("KAST_HOME", &kast_home)
+        .env("XDG_CONFIG_HOME", state.path().join("config"))
+        .output()
+        .expect("run kast home");
+
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("root:"), "{stdout}");
+    assert!(stdout.contains("ready:"), "{stdout}");
+    assert!(stdout.contains("referenceIndexReady:"), "{stdout}");
+    assert!(stdout.contains("next["), "{stdout}");
+    let decoded: serde_json::Value =
+        toon_format::decode_default(stdout.trim()).expect("home output is valid TOON");
+    assert_eq!(
+        decoded["developerOperations"]["cli"],
+        developer_cli.display().to_string()
+    );
+    assert_eq!(
+        decoded["developerOperations"]["helpArgs"],
+        serde_json::json!(["--help"]),
+    );
+    assert_eq!(decoded["developerOperations"]["skill"], "/kast:developer");
+    let help_args = decoded["developerOperations"]["helpArgs"]
+        .as_array()
+        .expect("developer help args")
+        .iter()
+        .map(|argument| argument.as_str().expect("developer help argument"));
+    let help = Command::new(&developer_cli)
+        .args(help_args)
+        .output()
+        .expect("run routed developer help");
+    assert!(help.status.success(), "{help:?}");
+    assert!(
+        String::from_utf8_lossy(&help.stdout).contains("Usage: kastctl"),
+        "{help:?}"
+    );
+    for cruft in ["state: UNKNOWN", "schemaVersion", "ok:", "method:"] {
+        assert!(!stdout.contains(cruft), "leaked {cruft}: {stdout}");
+    }
+}
+
+#[test]
+fn home_rejects_an_invalid_install_receipt_instead_of_fabricating_a_developer_route() {
+    let state = tempfile::tempdir().expect("temporary state");
+    let kast_home = state.path().join("kast");
+    std::fs::create_dir_all(kast_home.join("current")).expect("current install directory");
+    std::fs::write(kast_home.join("current/receipt.json"), "{not-json")
+        .expect("invalid install receipt");
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repository root");
+
+    let output = named("kast")
+        .current_dir(workspace)
+        .env("KAST_HOME", &kast_home)
+        .env("XDG_CONFIG_HOME", state.path().join("config"))
+        .output()
+        .expect("run kast home");
+
+    assert!(!output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("INSTALL_MANIFEST_INVALID"), "{stdout}");
+    assert!(!stdout.contains("developerOperations"), "{stdout}");
+}
+
+#[test]
+fn home_rejects_a_receipt_whose_developer_route_is_not_the_control_entrypoint() {
+    let state = tempfile::tempdir().expect("temporary state");
+    let home = state.path().join("home");
+    let config_home = state.path().join("config");
+    write_current_cli_install_manifest_for_test(&home, &config_home);
+    let kast_home = home.join(".local/share/kast");
+    let receipt_path = kast_home.join("current/receipt.json");
+    let mut receipt: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&receipt_path).expect("install receipt"))
+            .expect("install receipt JSON");
+    receipt["entrypoints"]["activeBinary"] =
+        serde_json::json!(kast_home.join("current/bin/kast").display().to_string());
+    std::fs::write(
+        &receipt_path,
+        serde_json::to_vec_pretty(&receipt).expect("install receipt JSON"),
+    )
+    .expect("updated install receipt");
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repository root");
+
+    let output = named("kast")
+        .current_dir(workspace)
+        .env("HOME", &home)
+        .env("KAST_HOME", &kast_home)
+        .env("KAST_CONFIG_HOME", &config_home)
+        .output()
+        .expect("run kast home");
+
+    assert!(!output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("DEVELOPER_OPERATIONS_ROUTE_INVALID"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("developerOperations"), "{stdout}");
+}

--- a/cli-rs/tests/agent/public/kast_agent_surface/developer_route.rs
+++ b/cli-rs/tests/agent/public/kast_agent_surface/developer_route.rs
@@ -79,6 +79,63 @@ fn home_rejects_an_invalid_install_receipt_instead_of_fabricating_a_developer_ro
 }
 
 #[test]
+fn home_rejects_a_missing_control_executable_instead_of_publishing_its_path() {
+    let state = tempfile::tempdir().expect("temporary state");
+    let kast_home = state.path().join("empty-kast-home");
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repository root");
+
+    let output = named("kast")
+        .current_dir(workspace)
+        .env("KAST_HOME", &kast_home)
+        .env("XDG_CONFIG_HOME", state.path().join("config"))
+        .output()
+        .expect("run kast home");
+
+    assert!(!output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("DEVELOPER_OPERATIONS_ROUTE_INVALID"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("developerOperations"), "{stdout}");
+}
+
+#[cfg(unix)]
+#[test]
+fn home_rejects_a_non_executable_control_file_instead_of_publishing_its_path() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let state = tempfile::tempdir().expect("temporary state");
+    let kast_home = state.path().join("kast-home");
+    let developer_cli = kast_home.join("current/libexec/kastctl");
+    std::fs::create_dir_all(developer_cli.parent().expect("developer CLI parent"))
+        .expect("developer CLI directory");
+    std::fs::write(&developer_cli, b"not executable").expect("developer CLI fixture");
+    std::fs::set_permissions(&developer_cli, std::fs::Permissions::from_mode(0o644))
+        .expect("non-executable developer CLI permissions");
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repository root");
+
+    let output = named("kast")
+        .current_dir(workspace)
+        .env("KAST_HOME", &kast_home)
+        .env("XDG_CONFIG_HOME", state.path().join("config"))
+        .output()
+        .expect("run kast home");
+
+    assert!(!output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("DEVELOPER_OPERATIONS_ROUTE_INVALID"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("developerOperations"), "{stdout}");
+}
+
+#[test]
 fn home_rejects_a_receipt_whose_developer_route_is_not_the_control_entrypoint() {
     let state = tempfile::tempdir().expect("temporary state");
     let home = state.path().join("home");

--- a/cli-rs/tests/agent/public/kast_resources.rs
+++ b/cli-rs/tests/agent/public/kast_resources.rs
@@ -58,6 +58,7 @@ fn embedded_provider_resource_sources_are_complete_and_local() {
         "copilot/hooks.json",
         "copilot/marketplace.json",
         "copilot/plugin.json",
+        "developer/SKILL.md",
     ];
     assert_eq!(resource_files(&root), expected);
 
@@ -74,6 +75,7 @@ fn embedded_provider_resource_sources_are_complete_and_local() {
                 .unwrap_or_else(|error| panic!("{path} is not valid JSON: {error}"));
         }
     }
+    skill_tests::assert_developer_route_sources(&root);
 }
 
 fn write_provider(path: &Path) {
@@ -394,3 +396,5 @@ const HARNESSES: [HarnessCase; 3] = [
 mod activation_tests;
 #[path = "kast_resources/install.rs"]
 mod install_tests;
+#[path = "kast_resources/skills.rs"]
+mod skill_tests;

--- a/cli-rs/tests/agent/public/kast_resources/activation.rs
+++ b/cli-rs/tests/agent/public/kast_resources/activation.rs
@@ -38,6 +38,11 @@ fn every_harness_activation_requires_matching_cli_plugin_hook_and_skill() {
         );
 
         let plugin_root = installed_plugin_root(&kast_home, harness.name);
+        assert!(
+            plugin_root.join("skills/developer/SKILL.md").is_file(),
+            "{} developer skill was not materialized",
+            harness.name,
+        );
         assert_provider_hook_schema(&plugin_root, harness);
         let command = hook_command(&plugin_root, harness.hooks_path, harness.session_pointer);
         assert!(
@@ -162,6 +167,27 @@ fn every_harness_activation_requires_matching_cli_plugin_hook_and_skill() {
         let original_skill = fs::read_to_string(&skill_path).expect("read installed skill");
         fs::write(&skill_path, format!("{original_skill}\ntampered\n"))
             .expect("write skill mismatch");
+        assert_activation_blocked(
+            &run_hook(
+                &command,
+                fixture.path(),
+                &kast_home,
+                &plugin_root,
+                session_start_input(fixture.path()),
+            ),
+            harness.name,
+            "skill digest mismatch",
+        );
+        fs::write(&skill_path, &original_skill).expect("restore installed Kast skill");
+
+        let developer_skill_path = plugin_root.join("skills/developer/SKILL.md");
+        let original_developer_skill =
+            fs::read_to_string(&developer_skill_path).expect("read installed developer skill");
+        fs::write(
+            &developer_skill_path,
+            format!("{original_developer_skill}\ntampered\n"),
+        )
+        .expect("write developer skill mismatch");
         assert_activation_blocked(
             &run_hook(
                 &command,

--- a/cli-rs/tests/agent/public/kast_resources/skills.rs
+++ b/cli-rs/tests/agent/public/kast_resources/skills.rs
@@ -1,0 +1,20 @@
+use std::fs;
+use std::path::Path;
+
+pub(super) fn assert_developer_route_sources(root: &Path) {
+    let kast_skill = fs::read_to_string(root.join("SKILL.md")).expect("read Kast skill");
+    assert!(kast_skill.contains("/kast:developer"), "{kast_skill}");
+    assert!(
+        kast_skill.contains("developerOperations.cli"),
+        "{kast_skill}"
+    );
+    let developer_skill =
+        fs::read_to_string(root.join("developer/SKILL.md")).expect("read developer skill");
+    for instruction in [
+        "developerOperations.cli",
+        "developerOperations.helpArgs",
+        "Do not assume `kastctl` is on `PATH`",
+    ] {
+        assert!(developer_skill.contains(instruction), "{developer_skill}");
+    }
+}

--- a/cli-rs/tests/surface/setup/activation_and_concurrency.rs
+++ b/cli-rs/tests/surface/setup/activation_and_concurrency.rs
@@ -49,6 +49,14 @@ fn setup_activates_one_validated_release_and_converges_on_rerun() {
     assert_eq!(first["type"], "KAST_SETUP");
     assert_eq!(first["status"], "ACTIVATED");
     assert_eq!(first["verified"], true);
+    let developer_cli = kast_home.join("current/libexec/kastctl");
+    assert_eq!(first["developerOperations"]["cli"], developer_cli.display().to_string());
+    assert_eq!(
+        first["developerOperations"]["helpArgs"],
+        serde_json::json!(["--help"]),
+    );
+    assert_eq!(first["developerOperations"]["skill"], "/kast:developer");
+    assert_eq!(first["activeBinary"], first["developerOperations"]["cli"]);
     let release_digest = first["releaseDigest"].as_str().expect("release digest");
     assert_eq!(release_digest.len(), 64);
     let release = kast_home.join("releases").join(release_digest);
@@ -82,6 +90,7 @@ fn setup_activates_one_validated_release_and_converges_on_rerun() {
     assert_eq!(second["status"], "CURRENT", "{second_stderr}");
     assert_eq!(second["releaseDigest"], release_digest);
     assert_eq!(second["verified"], true);
+    assert_eq!(second["developerOperations"], first["developerOperations"]);
 
     std::fs::write(kast_home.join("staging/junk"), "stale").expect("stale staging");
     let third = setup(&home, &kast_home, &source);

--- a/cli-rs/tests/surface/setup/migration_and_rollback.rs
+++ b/cli-rs/tests/surface/setup/migration_and_rollback.rs
@@ -29,6 +29,27 @@ fn setup_keeps_manifest_active_binary_private() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).expect("setup JSON");
+    let routed_cli = Path::new(
+        result["developerOperations"]["cli"]
+            .as_str()
+            .expect("developer CLI route"),
+    );
+    assert_eq!(routed_cli, kast_home.join("current/commands/kastctl"));
+    let help_args = result["developerOperations"]["helpArgs"]
+        .as_array()
+        .expect("developer help args")
+        .iter()
+        .map(|argument| argument.as_str().expect("developer help argument"));
+    let help = Command::new(routed_cli)
+        .args(help_args)
+        .output()
+        .expect("run routed developer help");
+    assert!(help.status.success(), "{help:?}");
+    assert!(
+        String::from_utf8_lossy(&help.stdout).contains("Usage: kastctl"),
+        "{help:?}"
+    );
     assert!(kast_home.join("current/commands/kastctl").is_file());
     assert!(!home.join(".local/bin/_kastctl").exists());
     assert_eq!(

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/IndexerServerRuntime.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/IndexerServerRuntime.kt
@@ -10,6 +10,7 @@ import io.github.amichne.kast.api.client.KastConfig
 import io.github.amichne.kast.api.client.defaultSocketPath
 import io.github.amichne.kast.api.contract.AnalysisTransport
 import io.github.amichne.kast.api.validation.ParsedSemanticGraphQuery
+import io.github.amichne.kast.idea.transition.GitWorktreeRegistrationProof
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import io.github.amichne.kast.indexstore.snapshot.ProducerVersion
 import io.github.amichne.kast.indexstore.snapshot.WorkspaceDatabaseExportEvidence
@@ -42,6 +43,7 @@ object IndexerServerRuntime {
             config = config,
             lifecycleController = lifecycleController,
             indexAdmission = IndexerAdmission.fromStartIndexing(startProjectIndexing),
+            registrationProof = null,
         )
     }
 
@@ -65,6 +67,30 @@ object IndexerServerRuntime {
             config = config,
             lifecycleController = lifecycleController,
             indexAdmission = IndexerAdmission.fromStartIndexing(startProjectIndexing),
+            registrationProof = null,
+        )
+    }
+
+    internal fun startWithRegistrationProof(
+        project: Project,
+        workspaceRoot: Path,
+        transport: AnalysisTransport,
+        config: KastConfig,
+        registrationProof: GitWorktreeRegistrationProof?,
+    ): RunningIndexer {
+        val workspaceIdentity = IdeaWorkspaceIdentity.fromProject(
+            project = project,
+            workspaceRoot = workspaceRoot,
+            descriptorDirectory = config.paths.descriptorDir.toPath(),
+        )
+        return startResolved(
+            project = project,
+            workspaceIdentity = workspaceIdentity,
+            transport = transport,
+            config = config,
+            lifecycleController = RuntimeLifecycleController.Unavailable,
+            indexAdmission = IndexerAdmission.fromStartIndexing(true),
+            registrationProof = registrationProof,
         )
     }
 
@@ -75,6 +101,7 @@ object IndexerServerRuntime {
         config: KastConfig,
         lifecycleController: RuntimeLifecycleController,
         indexAdmission: IndexerAdmission,
+        registrationProof: GitWorktreeRegistrationProof?,
     ): RunningIndexer {
         KastStructuredTrace.event(
             eventName = "indexer.runtime.start_requested",
@@ -209,6 +236,7 @@ object IndexerServerRuntime {
                     diagnostics = diagnostics,
                     indexStore = sourceIndexStore,
                     semanticAdmission = semanticAdmission,
+                    gitWorktreeRegistrationProof = registrationProof,
                     transitionIngress = transitionIngress,
                     snapshotCoordinator = snapshotCoordinator,
                     scopeCache = indexingScopeCache,

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastIdeaProjectIndexing.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastIdeaProjectIndexing.kt
@@ -17,6 +17,7 @@ import io.github.amichne.kast.idea.transition.IdeaKotlinCompilerIdentityResolver
 import io.github.amichne.kast.idea.transition.BuildSemanticInputIdentity
 import io.github.amichne.kast.idea.transition.BuildSemanticInputIdentityResolver
 import io.github.amichne.kast.idea.transition.GitWorktreeTransitionGuard
+import io.github.amichne.kast.idea.transition.GitWorktreeRegistrationProof
 import io.github.amichne.kast.idea.transition.WorkspaceEventWakeup
 import io.github.amichne.kast.idea.transition.WorkspaceSignal
 import io.github.amichne.kast.idea.transition.WorkspaceStateIdentity
@@ -37,6 +38,7 @@ internal class KastIdeaProjectIndexing(
     private val diagnostics: KastDiagnosticsService = KastDiagnosticsService.getInstance(project),
     private val indexStore: SqliteSourceIndexStore = SqliteSourceIndexStore(workspaceIdentity.workspaceIdentity),
     private val semanticAdmission: IdeaIndexSemanticAdmission = IdeaIndexSemanticAdmission(project),
+    private val gitWorktreeRegistrationProof: GitWorktreeRegistrationProof? = null,
     private val transitionIngress: WorkspaceTransitionIngress = WorkspaceTransitionIngress(
         semanticAdmission,
         TimeUnit.MINUTES.toMillis(5),
@@ -263,7 +265,10 @@ internal class KastIdeaProjectIndexing(
             resolveBuildSemanticInputIdentity = ::currentBuildSemanticInputIdentity,
             semanticAdmission = semanticAdmission,
             eventWakeup = eventWakeup,
-            gitWorktreeTransitionGuard = GitWorktreeTransitionGuard.exactRoot(workspaceRoot),
+            gitWorktreeTransitionGuard = GitWorktreeTransitionGuard.exactRoot(
+                workspaceRoot,
+                gitWorktreeRegistrationProof,
+            ),
             refreshWorkspace = { signals -> refreshWorkspace(project, gradleBuildRoot, signals) },
             loadLiveConfig = { lastValid -> liveConfigLoader(workspaceRoot, lastValid) },
             captureCandidate = { liveConfig, buildSemanticInputIdentity ->

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionWorker.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionWorker.kt
@@ -304,7 +304,9 @@ internal class WorkspaceTransitionWorker(
 
     private fun requireStableGitWorktreeTransition() {
         when (val transition = gitWorktreeTransitionGuard.inspect()) {
-            GitWorktreeTransitionStatus.Stable -> Unit
+            GitWorktreeTransitionStatus.Stable,
+            is GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory,
+            -> Unit
             is GitWorktreeTransitionStatus.InProgress ->
                 throw GitWorktreeTransitionInProgressException(transition)
             is GitWorktreeTransitionStatus.Unavailable ->

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeRegistrationProof.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeRegistrationProof.kt
@@ -1,0 +1,297 @@
+package io.github.amichne.kast.idea.transition
+
+import io.github.amichne.kast.api.client.LinkedWorktreeLaunchClaim
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.InvalidPathException
+import java.nio.file.LinkOption
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
+
+@JvmInline
+internal value class GitMetadataFileSystemIdentity(val value: String) {
+    init {
+        require(value.isNotBlank()) { "Git file-system identity must not be blank" }
+    }
+}
+
+internal data class RegisteredLinkedWorktreeIdentity(
+    val gitFile: Path,
+    val gitDirectory: Path,
+    val gitFileSystemIdentity: GitMetadataFileSystemIdentity,
+    val gitDirectoryFileSystemIdentity: GitMetadataFileSystemIdentity,
+) {
+    init {
+        require(gitFile.isAbsolute) { "Registered linked-worktree Git file must be absolute" }
+        require(gitDirectory.isAbsolute) { "Registered linked-worktree Git directory must be absolute" }
+    }
+}
+
+internal class GitWorktreeRegistrationProof private constructor(
+    internal val identity: RegisteredLinkedWorktreeIdentity,
+) {
+    companion object {
+        fun capture(
+            workspaceRoot: Path,
+            claim: LinkedWorktreeLaunchClaim,
+        ): GitWorktreeRegistrationProof {
+            val registeredBeforeGit = GitWorktreeRegistrationInspector.observe(workspaceRoot)
+                as? GitWorktreeRegistrationObservation.Registered
+                ?: error("Linked-worktree launch claim is not currently registered")
+            check(registeredBeforeGit.identity.gitFile == claim.gitFile) {
+                "Linked-worktree launch Git file does not match the exact workspace"
+            }
+            check(registeredBeforeGit.identity.gitDirectory == claim.gitDirectory) {
+                "Linked-worktree launch Git directory does not match the registered workspace"
+            }
+            val resolvedByGit = resolveRegisteredWorktree(workspaceRoot)
+                ?: error("Git does not resolve the linked-worktree launch claim")
+            check(sameExistingPath(resolvedByGit.workspaceRoot, workspaceRoot)) {
+                "Git resolved a different linked-worktree root"
+            }
+            check(sameExistingPath(resolvedByGit.gitDirectory, claim.gitDirectory)) {
+                "Git resolved a different linked-worktree Git directory"
+            }
+            check(sameExistingPath(resolvedByGit.commonGitDirectory, claim.gitDirectory.parent.parent)) {
+                "Git resolved a different common Git directory"
+            }
+            val registeredAfterGit = GitWorktreeRegistrationInspector.observe(workspaceRoot)
+                as? GitWorktreeRegistrationObservation.Registered
+                ?: error("Linked-worktree registration changed during launch proof capture")
+            check(registeredAfterGit.identity == registeredBeforeGit.identity) {
+                "Linked-worktree registration changed during launch proof capture"
+            }
+            return GitWorktreeRegistrationProof(registeredAfterGit.identity)
+        }
+
+        private fun sameExistingPath(first: Path, second: Path): Boolean = try {
+            Files.isSameFile(first, second)
+        } catch (_: IOException) {
+            false
+        } catch (_: SecurityException) {
+            false
+        }
+
+        private fun resolveRegisteredWorktree(workspaceRoot: Path): ResolvedGitWorktreeRegistration? {
+            val command = listOf(
+                "git",
+                "rev-parse",
+                "--path-format=absolute",
+                "--show-toplevel",
+                "--absolute-git-dir",
+                "--git-common-dir",
+            )
+            val process = runCatching {
+                ProcessBuilder(command).also { builder ->
+                    GIT_REPOSITORY_SELECTION_ENVIRONMENT.forEach(builder.environment()::remove)
+                }.directory(workspaceRoot.toFile()).redirectErrorStream(true).start()
+            }.getOrNull() ?: return null
+            val output = process.inputStream.use { input -> input.readAllBytes().toString(Charsets.UTF_8) }
+            if (process.waitFor() != 0) return null
+            val paths = output.trimEnd('\n', '\r').lineSequence()
+                .map { raw -> Path.of(raw.removeSuffix("\r")).toAbsolutePath().normalize() }
+                .toList()
+            if (paths.size != 3) return null
+            return ResolvedGitWorktreeRegistration(
+                workspaceRoot = paths[0],
+                gitDirectory = paths[1],
+                commonGitDirectory = paths[2],
+            )
+        }
+
+        private val GIT_REPOSITORY_SELECTION_ENVIRONMENT = setOf(
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_COMMON_DIR",
+            "GIT_INDEX_FILE",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "GIT_CEILING_DIRECTORIES",
+            "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+        )
+    }
+}
+
+private data class ResolvedGitWorktreeRegistration(
+    val workspaceRoot: Path,
+    val gitDirectory: Path,
+    val commonGitDirectory: Path,
+)
+
+internal sealed interface GitWorktreeRegistrationObservation {
+    data object NotLinked : GitWorktreeRegistrationObservation
+
+    data class Registered(
+        val identity: RegisteredLinkedWorktreeIdentity,
+    ) : GitWorktreeRegistrationObservation
+
+    data class ProvenMissingDirectory(
+        val gitFile: Path,
+        val gitDirectory: Path,
+    ) : GitWorktreeRegistrationObservation
+
+    data class UnprovenMissingDirectory(
+        val gitFile: Path,
+        val gitDirectory: Path,
+    ) : GitWorktreeRegistrationObservation
+
+    data class Unavailable(val detail: String) : GitWorktreeRegistrationObservation
+}
+
+internal object GitWorktreeRegistrationInspector {
+    fun observe(
+        workspaceRoot: Path,
+        proof: GitWorktreeRegistrationProof? = null,
+    ): GitWorktreeRegistrationObservation {
+        val root = workspaceRoot.toAbsolutePath().normalize()
+        val expected = proof?.identity
+        val gitFile = expected?.gitFile ?: root.resolve(".git")
+        if (gitFile != root.resolve(".git")) {
+            return unavailable("Launch proof Git file does not belong to exact workspace $root")
+        }
+        val gitFileAttributes = readAttributes(gitFile)
+        if (gitFileAttributes == null) {
+            return if (!Files.notExists(gitFile, LinkOption.NOFOLLOW_LINKS)) {
+                unavailable("Cannot inspect linked-worktree Git file: $gitFile")
+            } else if (expected == null) {
+                GitWorktreeRegistrationObservation.NotLinked
+            } else {
+                unavailable("Registered linked-worktree Git file is unavailable: $gitFile")
+            }
+        }
+        if (!gitFileAttributes.isRegularFile) {
+            return if (expected == null && gitFileAttributes.isDirectory) {
+                GitWorktreeRegistrationObservation.NotLinked
+            } else {
+                unavailable("Linked-worktree Git file is not a regular file: $gitFile")
+            }
+        }
+        val gitDirectory = resolveGitDirectory(gitFile)
+            ?: return unavailable("Linked-worktree Git file is malformed: $gitFile")
+        if (expected != null && gitDirectory != expected.gitDirectory) {
+            return unavailable("Linked-worktree Git directory changed after launch: $gitDirectory")
+        }
+        val worktreesDirectory = gitDirectory.parent
+            ?: return GitWorktreeRegistrationObservation.NotLinked
+        if (worktreesDirectory.fileName?.toString() != WORKTREES_DIRECTORY_NAME) {
+            return if (expected == null) {
+                GitWorktreeRegistrationObservation.NotLinked
+            } else {
+                unavailable("Launch proof Git directory is not a linked-worktree directory: $gitDirectory")
+            }
+        }
+        val commonGitDirectory = worktreesDirectory.parent
+            ?: return unavailable("Linked-worktree Git directory has no common Git directory: $gitDirectory")
+        if (!isCommonGitDirectory(commonGitDirectory)) {
+            return unavailable("Linked-worktree common Git directory is unavailable: $commonGitDirectory")
+        }
+        val fileSystemIdentity = gitFileAttributes.fileKey()
+            ?.toString()
+            ?.takeIf(String::isNotBlank)
+            ?.let(::GitMetadataFileSystemIdentity)
+            ?: return unavailable("Linked-worktree Git file has no stable file-system identity: $gitFile")
+        if (expected != null && fileSystemIdentity != expected.gitFileSystemIdentity) {
+            return unavailable("Linked-worktree Git file identity changed after launch: $gitFile")
+        }
+        val gitDirectoryAttributes = readAttributes(gitDirectory)
+        if (gitDirectoryAttributes == null) {
+            if (!Files.notExists(gitDirectory, LinkOption.NOFOLLOW_LINKS)) {
+                return unavailable("Cannot inspect linked-worktree Git directory: $gitDirectory")
+            }
+            return if (expected == null) {
+                GitWorktreeRegistrationObservation.UnprovenMissingDirectory(gitFile, gitDirectory)
+            } else {
+                GitWorktreeRegistrationObservation.ProvenMissingDirectory(gitFile, gitDirectory)
+            }
+        }
+        if (!gitDirectoryAttributes.isDirectory) {
+            return unavailable("Linked-worktree Git directory is not a directory: $gitDirectory")
+        }
+        val gitDirectoryFileSystemIdentity = gitDirectoryAttributes.fileKey()
+            ?.toString()
+            ?.takeIf(String::isNotBlank)
+            ?.let(::GitMetadataFileSystemIdentity)
+            ?: return unavailable("Linked-worktree Git directory has no stable file-system identity: $gitDirectory")
+        if (expected != null && gitDirectoryFileSystemIdentity != expected.gitDirectoryFileSystemIdentity) {
+            return unavailable("Linked-worktree Git directory identity changed after launch: $gitDirectory")
+        }
+        val registrationFile = gitDirectory.resolve(GIT_FILE_REGISTRATION_NAME)
+        val registeredGitFile = resolvePathFile(registrationFile)
+            ?: return unavailable("Linked-worktree registration backlink is unavailable: $registrationFile")
+        val sameGitFile = try {
+            Files.isSameFile(registeredGitFile, gitFile)
+        } catch (_: IOException) {
+            false
+        } catch (_: SecurityException) {
+            false
+        }
+        if (!sameGitFile) {
+            return unavailable("Linked-worktree registration backlink does not match $gitFile")
+        }
+        val identity = RegisteredLinkedWorktreeIdentity(
+            gitFile = gitFile,
+            gitDirectory = gitDirectory,
+            gitFileSystemIdentity = fileSystemIdentity,
+            gitDirectoryFileSystemIdentity = gitDirectoryFileSystemIdentity,
+        )
+        if (expected != null && identity != expected) {
+            return unavailable("Linked-worktree registration identity changed after launch: $gitFile")
+        }
+        return GitWorktreeRegistrationObservation.Registered(identity)
+    }
+
+    private fun resolveGitDirectory(gitFile: Path): Path? {
+        val directive = readSingleLine(gitFile) ?: return null
+        if (!directive.startsWith(GIT_DIRECTORY_PREFIX)) return null
+        val rawGitDirectory = directive.removePrefix(GIT_DIRECTORY_PREFIX).takeIf(String::isNotBlank)
+            ?: return null
+        return resolvePath(rawGitDirectory, gitFile.parent)
+    }
+
+    private fun resolvePathFile(path: Path): Path? {
+        val rawPath = readSingleLine(path)?.takeIf(String::isNotBlank) ?: return null
+        return resolvePath(rawPath, path.parent)
+    }
+
+    private fun readSingleLine(path: Path): String? = try {
+        Files.readString(path).trimEnd('\n', '\r').takeUnless { value -> '\n' in value || '\r' in value }
+    } catch (_: IOException) {
+        null
+    } catch (_: SecurityException) {
+        null
+    }
+
+    private fun resolvePath(rawPath: String, relativeTo: Path): Path? {
+        val parsed = try {
+            Path.of(rawPath)
+        } catch (_: InvalidPathException) {
+            return null
+        }
+        return (if (parsed.isAbsolute) parsed else relativeTo.resolve(parsed)).toAbsolutePath().normalize()
+    }
+
+    private fun isCommonGitDirectory(directory: Path): Boolean {
+        val directoryAttributes = readAttributes(directory) ?: return false
+        val headAttributes = readAttributes(directory.resolve("HEAD")) ?: return false
+        val objectsAttributes = readAttributes(directory.resolve("objects")) ?: return false
+        return directoryAttributes.isDirectory && headAttributes.isRegularFile && objectsAttributes.isDirectory
+    }
+
+    private fun readAttributes(path: Path): BasicFileAttributes? = try {
+        Files.readAttributes(path, BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+    } catch (_: NoSuchFileException) {
+        null
+    } catch (_: IOException) {
+        null
+    } catch (_: SecurityException) {
+        null
+    }
+
+    private fun unavailable(detail: String): GitWorktreeRegistrationObservation.Unavailable =
+        GitWorktreeRegistrationObservation.Unavailable(detail)
+
+    private const val GIT_DIRECTORY_PREFIX = "gitdir: "
+    private const val GIT_FILE_REGISTRATION_NAME = "gitdir"
+    private const val WORKTREES_DIRECTORY_NAME = "worktrees"
+}

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuard.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuard.kt
@@ -95,10 +95,15 @@ private class ResolvedGitWorktreeTransitionGuard(
     workspaceRoot: Path,
 ) : GitWorktreeTransitionGuard {
     private val root = workspaceRoot.toAbsolutePath().normalize()
+    private var registeredLinkedWorktree: RegisteredLinkedWorktree? = null
 
+    @Synchronized
     override fun inspect(): GitWorktreeTransitionStatus {
         val resolved = resolveMarkerPaths()
-        if (resolved is GitMarkerPathResolution.NotGitWorktree) return GitWorktreeTransitionStatus.Stable
+        if (resolved is GitMarkerPathResolution.NotGitWorktree) {
+            registeredLinkedWorktree = null
+            return GitWorktreeTransitionStatus.Stable
+        }
         if (resolved is GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory) {
             return GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(
                 gitFile = resolved.gitFile,
@@ -106,8 +111,17 @@ private class ResolvedGitWorktreeTransitionGuard(
             )
         }
         if (resolved is GitMarkerPathResolution.Unavailable) {
+            registeredLinkedWorktree = null
             return GitWorktreeTransitionStatus.Unavailable(resolved.detail)
         }
+        val currentRegistration = resolveRegisteredLinkedWorktree()
+        if (currentRegistration == null && pointsAtLinkedWorktreeGitDirectory()) {
+            registeredLinkedWorktree = null
+            return GitWorktreeTransitionStatus.Unavailable(
+                "Git resolved exact-worktree metadata without bidirectional registration identity for $root",
+            )
+        }
+        registeredLinkedWorktree = currentRegistration
         val markers = linkedSetOf<GitWorktreeTransitionMarkerEvidence>()
         (resolved as GitMarkerPathResolution.Resolved).markers.forEach { evidence ->
             try {
@@ -224,35 +238,80 @@ private class ResolvedGitWorktreeTransitionGuard(
         gitFile: Path,
         gitFileAttributes: BasicFileAttributes,
     ): GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory? {
-        if (!gitFileAttributes.isRegularFile) return null
-        val directive = try {
-            Files.readString(gitFile).trimEnd('\n', '\r')
-        } catch (_: IOException) {
-            return null
-        } catch (_: SecurityException) {
-            return null
-        }
-        if ('\n' in directive || '\r' in directive || !directive.startsWith(GIT_DIRECTORY_PREFIX)) return null
-        val rawGitDirectory = directive.removePrefix(GIT_DIRECTORY_PREFIX).takeIf(String::isNotBlank)
-            ?: return null
-        val parsed = try {
-            Path.of(rawGitDirectory)
-        } catch (_: InvalidPathException) {
-            return null
-        }
-        val gitDirectory = (if (parsed.isAbsolute) parsed else gitFile.parent.resolve(parsed))
-            .toAbsolutePath()
-            .normalize()
+        val gitDirectory = resolveGitDirectory(gitFile, gitFileAttributes) ?: return null
         val worktreesDirectory = gitDirectory.parent ?: return null
         if (worktreesDirectory.fileName?.toString() != WORKTREES_DIRECTORY_NAME) return null
         if (readAttributesOrNull(worktreesDirectory)?.isDirectory != true) return null
         val commonGitDirectory = worktreesDirectory.parent ?: return null
         if (!isCommonGitDirectory(commonGitDirectory)) return null
         if (!Files.notExists(gitDirectory, LinkOption.NOFOLLOW_LINKS)) return null
+        if (registeredLinkedWorktree != RegisteredLinkedWorktree(gitFile, gitDirectory)) return null
         return GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory(
             gitFile = gitFile.toAbsolutePath().normalize(),
             gitDirectory = gitDirectory,
         )
+    }
+
+    private fun resolveRegisteredLinkedWorktree(): RegisteredLinkedWorktree? {
+        val gitFile = root.resolve(".git").toAbsolutePath().normalize()
+        val gitFileAttributes = readAttributesOrNull(gitFile) ?: return null
+        val gitDirectory = resolveGitDirectory(gitFile, gitFileAttributes) ?: return null
+        val worktreesDirectory = gitDirectory.parent ?: return null
+        if (worktreesDirectory.fileName?.toString() != WORKTREES_DIRECTORY_NAME) return null
+        val commonGitDirectory = worktreesDirectory.parent ?: return null
+        if (!isCommonGitDirectory(commonGitDirectory)) return null
+        if (readAttributesOrNull(gitDirectory)?.isDirectory != true) return null
+        val registrationFile = gitDirectory.resolve(GIT_FILE_REGISTRATION_NAME)
+        val registeredGitFile = resolvePathFile(registrationFile) ?: return null
+        val sameGitFile = try {
+            Files.isSameFile(registeredGitFile, gitFile)
+        } catch (_: IOException) {
+            false
+        } catch (_: SecurityException) {
+            false
+        }
+        return if (sameGitFile) RegisteredLinkedWorktree(gitFile, gitDirectory) else null
+    }
+
+    private fun pointsAtLinkedWorktreeGitDirectory(): Boolean {
+        val gitFile = root.resolve(".git").toAbsolutePath().normalize()
+        val gitFileAttributes = readAttributesOrNull(gitFile) ?: return false
+        val gitDirectory = resolveGitDirectory(gitFile, gitFileAttributes) ?: return false
+        return gitDirectory.parent?.fileName?.toString() == WORKTREES_DIRECTORY_NAME
+    }
+
+    private fun resolveGitDirectory(
+        gitFile: Path,
+        gitFileAttributes: BasicFileAttributes,
+    ): Path? {
+        if (!gitFileAttributes.isRegularFile) return null
+        val directive = readSingleLine(gitFile) ?: return null
+        if (!directive.startsWith(GIT_DIRECTORY_PREFIX)) return null
+        val rawGitDirectory = directive.removePrefix(GIT_DIRECTORY_PREFIX).takeIf(String::isNotBlank)
+            ?: return null
+        return resolvePath(rawGitDirectory, gitFile.parent)
+    }
+
+    private fun resolvePathFile(path: Path): Path? {
+        val rawPath = readSingleLine(path)?.takeIf(String::isNotBlank) ?: return null
+        return resolvePath(rawPath, path.parent)
+    }
+
+    private fun readSingleLine(path: Path): String? = try {
+        Files.readString(path).trimEnd('\n', '\r').takeUnless { value -> '\n' in value || '\r' in value }
+    } catch (_: IOException) {
+        null
+    } catch (_: SecurityException) {
+        null
+    }
+
+    private fun resolvePath(rawPath: String, relativeTo: Path): Path? {
+        val parsed = try {
+            Path.of(rawPath)
+        } catch (_: InvalidPathException) {
+            return null
+        }
+        return (if (parsed.isAbsolute) parsed else relativeTo.resolve(parsed)).toAbsolutePath().normalize()
     }
 
     private fun isCommonGitDirectory(directory: Path): Boolean {
@@ -276,7 +335,18 @@ private class ResolvedGitWorktreeTransitionGuard(
 
     private companion object {
         private const val GIT_DIRECTORY_PREFIX = "gitdir: "
+        private const val GIT_FILE_REGISTRATION_NAME = "gitdir"
         private const val WORKTREES_DIRECTORY_NAME = "worktrees"
+    }
+}
+
+private data class RegisteredLinkedWorktree(
+    val gitFile: Path,
+    val gitDirectory: Path,
+) {
+    init {
+        require(gitFile.isAbsolute) { "Registered linked-worktree Git file must be absolute" }
+        require(gitDirectory.isAbsolute) { "Registered linked-worktree Git directory must be absolute" }
     }
 }
 

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuard.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuard.kt
@@ -2,6 +2,7 @@ package io.github.amichne.kast.idea.transition
 
 import java.io.IOException
 import java.nio.file.Files
+import java.nio.file.InvalidPathException
 import java.nio.file.LinkOption
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
@@ -22,6 +23,16 @@ internal fun interface GitWorktreeTransitionGuard {
 
 internal sealed interface GitWorktreeTransitionStatus {
     data object Stable : GitWorktreeTransitionStatus
+
+    data class MissingLinkedWorktreeGitDirectory(
+        val gitFile: Path,
+        val gitDirectory: Path,
+    ) : GitWorktreeTransitionStatus {
+        init {
+            require(gitFile.isAbsolute) { "Linked-worktree Git file must be absolute" }
+            require(gitDirectory.isAbsolute) { "Linked-worktree Git directory must be absolute" }
+        }
+    }
 
     data class Unavailable(val detail: String) : GitWorktreeTransitionStatus {
         init {
@@ -77,6 +88,12 @@ private class ResolvedGitWorktreeTransitionGuard(
     override fun inspect(): GitWorktreeTransitionStatus {
         val resolved = resolveMarkerPaths()
         if (resolved is GitMarkerPathResolution.NotGitWorktree) return GitWorktreeTransitionStatus.Stable
+        if (resolved is GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory) {
+            return GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(
+                gitFile = resolved.gitFile,
+                gitDirectory = resolved.gitDirectory,
+            )
+        }
         if (resolved is GitMarkerPathResolution.Unavailable) {
             return GitWorktreeTransitionStatus.Unavailable(resolved.detail)
         }
@@ -157,19 +174,104 @@ private class ResolvedGitWorktreeTransitionGuard(
         )
     }
 
-    private fun unavailableOrNotGit(detail: String): GitMarkerPathResolution =
-        if (generateSequence(root, Path::getParent).any { directory ->
-                Files.exists(directory.resolve(".git"), LinkOption.NOFOLLOW_LINKS)
+    private fun unavailableOrNotGit(detail: String): GitMarkerPathResolution {
+        var directory: Path? = root
+        while (directory != null) {
+            val currentDirectory = directory
+            val gitFile = currentDirectory.resolve(".git")
+            val attributes = try {
+                Files.readAttributes(
+                    gitFile,
+                    BasicFileAttributes::class.java,
+                    LinkOption.NOFOLLOW_LINKS,
+                )
+            } catch (_: NoSuchFileException) {
+                directory = currentDirectory.parent
+                continue
+            } catch (failure: IOException) {
+                return GitMarkerPathResolution.Unavailable(
+                    "Cannot inspect Git metadata at $gitFile: " +
+                        (failure.message ?: failure::class.qualifiedName.orEmpty()),
+                )
+            } catch (failure: SecurityException) {
+                return GitMarkerPathResolution.Unavailable(
+                    "Cannot inspect Git metadata at $gitFile: " +
+                        (failure.message ?: failure::class.qualifiedName.orEmpty()),
+                )
             }
-        ) {
-            GitMarkerPathResolution.Unavailable(detail)
-        } else {
-            GitMarkerPathResolution.NotGitWorktree
+            return missingLinkedWorktreeGitDirectory(gitFile, attributes)
+                ?: GitMarkerPathResolution.Unavailable(detail)
         }
+        return GitMarkerPathResolution.NotGitWorktree
+    }
+
+    private fun missingLinkedWorktreeGitDirectory(
+        gitFile: Path,
+        gitFileAttributes: BasicFileAttributes,
+    ): GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory? {
+        if (!gitFileAttributes.isRegularFile) return null
+        val directive = try {
+            Files.readString(gitFile).trimEnd('\n', '\r')
+        } catch (_: IOException) {
+            return null
+        } catch (_: SecurityException) {
+            return null
+        }
+        if ('\n' in directive || '\r' in directive || !directive.startsWith(GIT_DIRECTORY_PREFIX)) return null
+        val rawGitDirectory = directive.removePrefix(GIT_DIRECTORY_PREFIX).takeIf(String::isNotBlank)
+            ?: return null
+        val parsed = try {
+            Path.of(rawGitDirectory)
+        } catch (_: InvalidPathException) {
+            return null
+        }
+        val gitDirectory = (if (parsed.isAbsolute) parsed else gitFile.parent.resolve(parsed))
+            .toAbsolutePath()
+            .normalize()
+        val worktreesDirectory = gitDirectory.parent ?: return null
+        if (worktreesDirectory.fileName?.toString() != WORKTREES_DIRECTORY_NAME) return null
+        if (readAttributesOrNull(worktreesDirectory)?.isDirectory != true) return null
+        val commonGitDirectory = worktreesDirectory.parent ?: return null
+        if (!isCommonGitDirectory(commonGitDirectory)) return null
+        if (!Files.notExists(gitDirectory, LinkOption.NOFOLLOW_LINKS)) return null
+        return GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory(
+            gitFile = gitFile.toAbsolutePath().normalize(),
+            gitDirectory = gitDirectory,
+        )
+    }
+
+    private fun isCommonGitDirectory(directory: Path): Boolean {
+        val directoryAttributes = readAttributesOrNull(directory) ?: return false
+        val headAttributes = readAttributesOrNull(directory.resolve("HEAD")) ?: return false
+        val objectsAttributes = readAttributesOrNull(directory.resolve("objects")) ?: return false
+        return directoryAttributes.isDirectory && headAttributes.isRegularFile && objectsAttributes.isDirectory
+    }
+
+    private fun readAttributesOrNull(path: Path): BasicFileAttributes? = try {
+        Files.readAttributes(
+            path,
+            BasicFileAttributes::class.java,
+            LinkOption.NOFOLLOW_LINKS,
+        )
+    } catch (_: IOException) {
+        null
+    } catch (_: SecurityException) {
+        null
+    }
+
+    private companion object {
+        private const val GIT_DIRECTORY_PREFIX = "gitdir: "
+        private const val WORKTREES_DIRECTORY_NAME = "worktrees"
+    }
 }
 
 private sealed interface GitMarkerPathResolution {
     data object NotGitWorktree : GitMarkerPathResolution
+
+    data class MissingLinkedWorktreeGitDirectory(
+        val gitFile: Path,
+        val gitDirectory: Path,
+    ) : GitMarkerPathResolution
 
     data class Unavailable(val detail: String) : GitMarkerPathResolution
 

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuard.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuard.kt
@@ -16,8 +16,18 @@ internal fun interface GitWorktreeTransitionGuard {
             GitWorktreeTransitionStatus.Stable
         }
 
-        fun exactRoot(workspaceRoot: Path): GitWorktreeTransitionGuard =
-            ResolvedGitWorktreeTransitionGuard(workspaceRoot)
+        fun exactRoot(
+            workspaceRoot: Path,
+            registrationProof: GitWorktreeRegistrationProof? = null,
+            markerReader: GitWorktreeTransitionMarkerReader = GitWorktreeTransitionMarkerReader.filesystem(),
+            resolutionObserver: GitWorktreeTransitionResolutionObserver =
+                GitWorktreeTransitionResolutionObserver.noop(),
+        ): GitWorktreeTransitionGuard = ResolvedGitWorktreeTransitionGuard(
+            workspaceRoot,
+            registrationProof,
+            markerReader,
+            resolutionObserver,
+        )
     }
 }
 
@@ -80,6 +90,25 @@ internal data class GitWorktreeTransitionMarkerEvidence(
     }
 }
 
+internal fun interface GitWorktreeTransitionMarkerReader {
+    @Throws(IOException::class, SecurityException::class)
+    fun read(path: Path)
+
+    companion object {
+        fun filesystem(): GitWorktreeTransitionMarkerReader = GitWorktreeTransitionMarkerReader { path ->
+            Files.readAttributes(path, BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+        }
+    }
+}
+
+internal fun interface GitWorktreeTransitionResolutionObserver {
+    fun resolved()
+
+    companion object {
+        fun noop(): GitWorktreeTransitionResolutionObserver = GitWorktreeTransitionResolutionObserver {}
+    }
+}
+
 internal class GitWorktreeTransitionInProgressException(
     val transition: GitWorktreeTransitionStatus.InProgress,
 ) : WorkspaceTransitionRetryException(
@@ -93,43 +122,41 @@ internal class GitWorktreeTransitionInspectionException(
 
 private class ResolvedGitWorktreeTransitionGuard(
     workspaceRoot: Path,
+    private val registrationProof: GitWorktreeRegistrationProof?,
+    private val markerReader: GitWorktreeTransitionMarkerReader,
+    private val resolutionObserver: GitWorktreeTransitionResolutionObserver,
 ) : GitWorktreeTransitionGuard {
     private val root = workspaceRoot.toAbsolutePath().normalize()
-    private var registeredLinkedWorktree: RegisteredLinkedWorktree? = null
 
-    @Synchronized
     override fun inspect(): GitWorktreeTransitionStatus {
         val resolved = resolveMarkerPaths()
-        if (resolved is GitMarkerPathResolution.NotGitWorktree) {
-            registeredLinkedWorktree = null
-            return GitWorktreeTransitionStatus.Stable
-        }
+        if (resolved is GitMarkerPathResolution.NotGitWorktree) return GitWorktreeTransitionStatus.Stable
         if (resolved is GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory) {
-            return GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(
-                gitFile = resolved.gitFile,
-                gitDirectory = resolved.gitDirectory,
-            )
+            return resolved.toStatus()
         }
         if (resolved is GitMarkerPathResolution.Unavailable) {
-            registeredLinkedWorktree = null
             return GitWorktreeTransitionStatus.Unavailable(resolved.detail)
         }
-        val currentRegistration = resolveRegisteredLinkedWorktree()
-        if (currentRegistration == null && pointsAtLinkedWorktreeGitDirectory()) {
-            registeredLinkedWorktree = null
-            return GitWorktreeTransitionStatus.Unavailable(
-                "Git resolved exact-worktree metadata without bidirectional registration identity for $root",
-            )
+        resolved as GitMarkerPathResolution.Resolved
+        resolutionObserver.resolved()
+        val registrationBeforeMarkers = GitWorktreeRegistrationInspector.observe(root, registrationProof)
+        val registrationIdentity = when (registrationBeforeMarkers) {
+            GitWorktreeRegistrationObservation.NotLinked -> null
+            is GitWorktreeRegistrationObservation.Registered -> registrationBeforeMarkers.identity
+            is GitWorktreeRegistrationObservation.ProvenMissingDirectory ->
+                return registrationBeforeMarkers.toStatus()
+            is GitWorktreeRegistrationObservation.UnprovenMissingDirectory ->
+                return registrationBeforeMarkers.unprovenStatus()
+            is GitWorktreeRegistrationObservation.Unavailable ->
+                return GitWorktreeTransitionStatus.Unavailable(registrationBeforeMarkers.detail)
         }
-        registeredLinkedWorktree = currentRegistration
+        resolutionMismatch(resolved, registrationIdentity)?.let { detail ->
+            return GitWorktreeTransitionStatus.Unavailable(detail)
+        }
         val markers = linkedSetOf<GitWorktreeTransitionMarkerEvidence>()
-        (resolved as GitMarkerPathResolution.Resolved).markers.forEach { evidence ->
+        resolved.markers.forEach { evidence ->
             try {
-                Files.readAttributes(
-                    evidence.path,
-                    BasicFileAttributes::class.java,
-                    LinkOption.NOFOLLOW_LINKS,
-                )
+                markerReader.read(evidence.path)
                 markers += evidence
             } catch (_: NoSuchFileException) {
                 // The exact-worktree marker is absent.
@@ -145,6 +172,28 @@ private class ResolvedGitWorktreeTransitionGuard(
                 )
             }
         }
+        when (val registrationAfterMarkers = GitWorktreeRegistrationInspector.observe(root, registrationProof)) {
+            is GitWorktreeRegistrationObservation.ProvenMissingDirectory ->
+                return registrationAfterMarkers.toStatus()
+            is GitWorktreeRegistrationObservation.UnprovenMissingDirectory ->
+                return registrationAfterMarkers.unprovenStatus()
+            is GitWorktreeRegistrationObservation.Unavailable ->
+                return GitWorktreeTransitionStatus.Unavailable(registrationAfterMarkers.detail)
+            is GitWorktreeRegistrationObservation.Registered -> {
+                if (registrationAfterMarkers.identity != registrationIdentity) {
+                    return GitWorktreeTransitionStatus.Unavailable(
+                        "Linked-worktree registration changed while transition markers were inspected: $root",
+                    )
+                }
+            }
+            GitWorktreeRegistrationObservation.NotLinked -> {
+                if (registrationIdentity != null) {
+                    return GitWorktreeTransitionStatus.Unavailable(
+                        "Linked-worktree registration disappeared while transition markers were inspected: $root",
+                    )
+                }
+            }
+        }
         return if (markers.isEmpty()) {
             GitWorktreeTransitionStatus.Stable
         } else {
@@ -157,6 +206,9 @@ private class ResolvedGitWorktreeTransitionGuard(
             add("git")
             add("rev-parse")
             add("--path-format=absolute")
+            add("--show-toplevel")
+            add("--absolute-git-dir")
+            add("--git-common-dir")
             GitWorktreeTransitionMarker.entries.forEach { marker ->
                 add("--git-path")
                 add(marker.gitPath)
@@ -187,28 +239,95 @@ private class ResolvedGitWorktreeTransitionGuard(
         val resolved = output.trimEnd('\n', '\r')
             .split('\n')
             .map { line -> line.removeSuffix("\r") }
-        if (resolved.size != GitWorktreeTransitionMarker.entries.size) {
+        val expectedPathCount = GitWorktreeTransitionMarker.entries.size + GIT_IDENTITY_PATH_COUNT
+        if (resolved.size != expectedPathCount) {
             return GitMarkerPathResolution.Unavailable(
-                "Git returned ${resolved.size} transition paths; expected ${GitWorktreeTransitionMarker.entries.size}",
+                "Git returned ${resolved.size} identity and transition paths; expected $expectedPathCount",
+            )
+        }
+        val paths = resolved.map { rawPath ->
+            resolveOutputPath(rawPath) ?: return GitMarkerPathResolution.Unavailable(
+                "Git returned an invalid exact-worktree metadata path: $rawPath",
             )
         }
         return GitMarkerPathResolution.Resolved(
-            GitWorktreeTransitionMarker.entries.zip(resolved)
-            .mapTo(linkedSetOf()) { (marker, rawPath) ->
-                val path = Path.of(rawPath).let { candidate ->
-                    if (candidate.isAbsolute) candidate else root.resolve(candidate)
-                }.toAbsolutePath().normalize()
-                GitWorktreeTransitionMarkerEvidence(marker, path)
-            },
+            workspaceRoot = paths[0],
+            gitDirectory = paths[1],
+            commonGitDirectory = paths[2],
+            markers = GitWorktreeTransitionMarker.entries.zip(paths.drop(GIT_IDENTITY_PATH_COUNT))
+                .mapTo(linkedSetOf()) { (marker, path) ->
+                    GitWorktreeTransitionMarkerEvidence(marker, path)
+                },
         )
     }
 
+    private fun resolveOutputPath(rawPath: String): Path? {
+        val candidate = try {
+            Path.of(rawPath)
+        } catch (_: InvalidPathException) {
+            return null
+        }
+        return (if (candidate.isAbsolute) candidate else root.resolve(candidate))
+            .toAbsolutePath()
+            .normalize()
+    }
+
+    private fun resolutionMismatch(
+        resolved: GitMarkerPathResolution.Resolved,
+        registrationIdentity: RegisteredLinkedWorktreeIdentity?,
+    ): String? {
+        if (!sameExistingPath(resolved.workspaceRoot, root)) {
+            return "Git resolved transition markers for a different workspace root: ${resolved.workspaceRoot}"
+        }
+        if (registrationIdentity == null) return null
+        if (!sameExistingPath(resolved.gitDirectory, registrationIdentity.gitDirectory)) {
+            return "Git resolved transition markers for a different linked-worktree Git directory: " +
+                resolved.gitDirectory
+        }
+        val registeredCommonGitDirectory = registrationIdentity.gitDirectory.parent?.parent
+            ?: return "Registered linked-worktree Git directory has no common Git directory"
+        if (!sameExistingPath(resolved.commonGitDirectory, registeredCommonGitDirectory)) {
+            return "Git resolved transition markers for a different common Git directory: " +
+                resolved.commonGitDirectory
+        }
+        return null
+    }
+
+    private fun sameExistingPath(first: Path, second: Path): Boolean = try {
+        Files.isSameFile(first, second)
+    } catch (_: IOException) {
+        false
+    } catch (_: SecurityException) {
+        false
+    }
+
     private fun unavailableOrNotGit(detail: String): GitMarkerPathResolution {
+        when (val registration = GitWorktreeRegistrationInspector.observe(root, registrationProof)) {
+            is GitWorktreeRegistrationObservation.ProvenMissingDirectory -> {
+                return GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory(
+                    registration.gitFile,
+                    registration.gitDirectory,
+                )
+            }
+            is GitWorktreeRegistrationObservation.UnprovenMissingDirectory -> {
+                return GitMarkerPathResolution.Unavailable(
+                    "Missing linked-worktree Git directory has no exact launch registration proof: " +
+                        registration.gitDirectory,
+                )
+            }
+            is GitWorktreeRegistrationObservation.Unavailable -> {
+                return GitMarkerPathResolution.Unavailable(registration.detail)
+            }
+            is GitWorktreeRegistrationObservation.Registered -> {
+                return GitMarkerPathResolution.Unavailable(detail)
+            }
+            GitWorktreeRegistrationObservation.NotLinked -> Unit
+        }
         var directory: Path? = root
         while (directory != null) {
             val currentDirectory = directory
             val gitFile = currentDirectory.resolve(".git")
-            val attributes = try {
+            try {
                 Files.readAttributes(
                     gitFile,
                     BasicFileAttributes::class.java,
@@ -228,127 +347,26 @@ private class ResolvedGitWorktreeTransitionGuard(
                         (failure.message ?: failure::class.qualifiedName.orEmpty()),
                 )
             }
-            return missingLinkedWorktreeGitDirectory(gitFile, attributes)
-                ?: GitMarkerPathResolution.Unavailable(detail)
+            return GitMarkerPathResolution.Unavailable(detail)
         }
         return GitMarkerPathResolution.NotGitWorktree
     }
 
-    private fun missingLinkedWorktreeGitDirectory(
-        gitFile: Path,
-        gitFileAttributes: BasicFileAttributes,
-    ): GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory? {
-        val gitDirectory = resolveGitDirectory(gitFile, gitFileAttributes) ?: return null
-        val worktreesDirectory = gitDirectory.parent ?: return null
-        if (worktreesDirectory.fileName?.toString() != WORKTREES_DIRECTORY_NAME) return null
-        if (readAttributesOrNull(worktreesDirectory)?.isDirectory != true) return null
-        val commonGitDirectory = worktreesDirectory.parent ?: return null
-        if (!isCommonGitDirectory(commonGitDirectory)) return null
-        if (!Files.notExists(gitDirectory, LinkOption.NOFOLLOW_LINKS)) return null
-        if (registeredLinkedWorktree != RegisteredLinkedWorktree(gitFile, gitDirectory)) return null
-        return GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory(
-            gitFile = gitFile.toAbsolutePath().normalize(),
-            gitDirectory = gitDirectory,
-        )
-    }
-
-    private fun resolveRegisteredLinkedWorktree(): RegisteredLinkedWorktree? {
-        val gitFile = root.resolve(".git").toAbsolutePath().normalize()
-        val gitFileAttributes = readAttributesOrNull(gitFile) ?: return null
-        val gitDirectory = resolveGitDirectory(gitFile, gitFileAttributes) ?: return null
-        val worktreesDirectory = gitDirectory.parent ?: return null
-        if (worktreesDirectory.fileName?.toString() != WORKTREES_DIRECTORY_NAME) return null
-        val commonGitDirectory = worktreesDirectory.parent ?: return null
-        if (!isCommonGitDirectory(commonGitDirectory)) return null
-        if (readAttributesOrNull(gitDirectory)?.isDirectory != true) return null
-        val registrationFile = gitDirectory.resolve(GIT_FILE_REGISTRATION_NAME)
-        val registeredGitFile = resolvePathFile(registrationFile) ?: return null
-        val sameGitFile = try {
-            Files.isSameFile(registeredGitFile, gitFile)
-        } catch (_: IOException) {
-            false
-        } catch (_: SecurityException) {
-            false
-        }
-        return if (sameGitFile) RegisteredLinkedWorktree(gitFile, gitDirectory) else null
-    }
-
-    private fun pointsAtLinkedWorktreeGitDirectory(): Boolean {
-        val gitFile = root.resolve(".git").toAbsolutePath().normalize()
-        val gitFileAttributes = readAttributesOrNull(gitFile) ?: return false
-        val gitDirectory = resolveGitDirectory(gitFile, gitFileAttributes) ?: return false
-        return gitDirectory.parent?.fileName?.toString() == WORKTREES_DIRECTORY_NAME
-    }
-
-    private fun resolveGitDirectory(
-        gitFile: Path,
-        gitFileAttributes: BasicFileAttributes,
-    ): Path? {
-        if (!gitFileAttributes.isRegularFile) return null
-        val directive = readSingleLine(gitFile) ?: return null
-        if (!directive.startsWith(GIT_DIRECTORY_PREFIX)) return null
-        val rawGitDirectory = directive.removePrefix(GIT_DIRECTORY_PREFIX).takeIf(String::isNotBlank)
-            ?: return null
-        return resolvePath(rawGitDirectory, gitFile.parent)
-    }
-
-    private fun resolvePathFile(path: Path): Path? {
-        val rawPath = readSingleLine(path)?.takeIf(String::isNotBlank) ?: return null
-        return resolvePath(rawPath, path.parent)
-    }
-
-    private fun readSingleLine(path: Path): String? = try {
-        Files.readString(path).trimEnd('\n', '\r').takeUnless { value -> '\n' in value || '\r' in value }
-    } catch (_: IOException) {
-        null
-    } catch (_: SecurityException) {
-        null
-    }
-
-    private fun resolvePath(rawPath: String, relativeTo: Path): Path? {
-        val parsed = try {
-            Path.of(rawPath)
-        } catch (_: InvalidPathException) {
-            return null
-        }
-        return (if (parsed.isAbsolute) parsed else relativeTo.resolve(parsed)).toAbsolutePath().normalize()
-    }
-
-    private fun isCommonGitDirectory(directory: Path): Boolean {
-        val directoryAttributes = readAttributesOrNull(directory) ?: return false
-        val headAttributes = readAttributesOrNull(directory.resolve("HEAD")) ?: return false
-        val objectsAttributes = readAttributesOrNull(directory.resolve("objects")) ?: return false
-        return directoryAttributes.isDirectory && headAttributes.isRegularFile && objectsAttributes.isDirectory
-    }
-
-    private fun readAttributesOrNull(path: Path): BasicFileAttributes? = try {
-        Files.readAttributes(
-            path,
-            BasicFileAttributes::class.java,
-            LinkOption.NOFOLLOW_LINKS,
-        )
-    } catch (_: IOException) {
-        null
-    } catch (_: SecurityException) {
-        null
-    }
-
     private companion object {
-        private const val GIT_DIRECTORY_PREFIX = "gitdir: "
-        private const val GIT_FILE_REGISTRATION_NAME = "gitdir"
-        private const val WORKTREES_DIRECTORY_NAME = "worktrees"
+        private const val GIT_IDENTITY_PATH_COUNT = 3
     }
 }
 
-private data class RegisteredLinkedWorktree(
-    val gitFile: Path,
-    val gitDirectory: Path,
-) {
-    init {
-        require(gitFile.isAbsolute) { "Registered linked-worktree Git file must be absolute" }
-        require(gitDirectory.isAbsolute) { "Registered linked-worktree Git directory must be absolute" }
-    }
-}
+private fun GitWorktreeRegistrationObservation.ProvenMissingDirectory.toStatus() =
+    GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(gitFile, gitDirectory)
+
+private fun GitWorktreeRegistrationObservation.UnprovenMissingDirectory.unprovenStatus() =
+    GitWorktreeTransitionStatus.Unavailable(
+        "Missing linked-worktree Git directory has no exact launch registration proof: $gitDirectory",
+    )
+
+private fun GitMarkerPathResolution.MissingLinkedWorktreeGitDirectory.toStatus() =
+    GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(gitFile, gitDirectory)
 
 private sealed interface GitMarkerPathResolution {
     data object NotGitWorktree : GitMarkerPathResolution
@@ -361,6 +379,9 @@ private sealed interface GitMarkerPathResolution {
     data class Unavailable(val detail: String) : GitMarkerPathResolution
 
     data class Resolved(
+        val workspaceRoot: Path,
+        val gitDirectory: Path,
+        val commonGitDirectory: Path,
         val markers: Set<GitWorktreeTransitionMarkerEvidence>,
     ) : GitMarkerPathResolution
 }

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuard.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuard.kt
@@ -60,6 +60,17 @@ internal enum class GitWorktreeTransitionMarker(internal val gitPath: String) {
     SEQUENCER("sequencer"),
 }
 
+private enum class GitRepositorySelectionEnvironment(val variable: String) {
+    GIT_DIR("GIT_DIR"),
+    GIT_WORK_TREE("GIT_WORK_TREE"),
+    GIT_COMMON_DIR("GIT_COMMON_DIR"),
+    GIT_INDEX_FILE("GIT_INDEX_FILE"),
+    GIT_OBJECT_DIRECTORY("GIT_OBJECT_DIRECTORY"),
+    GIT_ALTERNATE_OBJECT_DIRECTORIES("GIT_ALTERNATE_OBJECT_DIRECTORIES"),
+    GIT_CEILING_DIRECTORIES("GIT_CEILING_DIRECTORIES"),
+    GIT_DISCOVERY_ACROSS_FILESYSTEM("GIT_DISCOVERY_ACROSS_FILESYSTEM"),
+}
+
 internal data class GitWorktreeTransitionMarkerEvidence(
     val marker: GitWorktreeTransitionMarker,
     val path: Path,
@@ -138,7 +149,11 @@ private class ResolvedGitWorktreeTransitionGuard(
             }
         }
         val process = runCatching {
-            ProcessBuilder(command)
+            ProcessBuilder(command).also { builder ->
+                GitRepositorySelectionEnvironment.entries.forEach { selection ->
+                    builder.environment().remove(selection.variable)
+                }
+            }
                 .directory(root.toFile())
                 .redirectErrorStream(true)
                 .start()

--- a/indexer/src/main/kotlin/io/github/amichne/kast/indexer/KastIndexerRuntime.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/indexer/KastIndexerRuntime.kt
@@ -7,6 +7,7 @@ import io.github.amichne.kast.api.client.ServerLaunchOptions
 import io.github.amichne.kast.api.contract.AnalysisTransport
 import io.github.amichne.kast.idea.IndexerServerRuntime
 import io.github.amichne.kast.idea.RunningIndexer
+import io.github.amichne.kast.idea.transition.GitWorktreeRegistrationProof
 import io.github.amichne.kast.indexer.gradle.bootstrap.GradleProjectImportBridge
 import io.github.amichne.kast.indexer.project.ProjectOpener
 import kotlinx.coroutines.runBlocking
@@ -91,17 +92,21 @@ object KastIndexerRuntime {
         configureSystemProperties()
         val serverOptions = options.serverOptions
         val workspaceRoot = serverOptions.workspaceRoot
+        val registrationProof = serverOptions.linkedWorktreeLaunchClaim?.let { claim ->
+            GitWorktreeRegistrationProof.capture(workspaceRoot, claim)
+        }
         GradleProjectImportBridge.configureIndexerApplication()
         val project = projectOpener.openProject(workspaceRoot)
         val config = options.runtimeConfig ?: KastConfig.load(
             workspaceRoot = workspaceRoot,
             overrides = KastConfigOverride(profiling = serverOptions.profilingOverride),
         )
-        val indexerRuntime = IndexerServerRuntime.start(
+        val indexerRuntime = IndexerServerRuntime.startWithRegistrationProof(
             project = project,
             workspaceRoot = workspaceRoot,
             transport = serverOptions.transport,
             config = config,
+            registrationProof = registrationProof,
         )
         val status = runBlocking { indexerRuntime.backend.runtimeStatus() }
         check(status.backendName == "indexer") {

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/WorkspaceTransitionWorkerBuildSemanticTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/WorkspaceTransitionWorkerBuildSemanticTest.kt
@@ -5,6 +5,7 @@ import io.github.amichne.kast.api.client.KastConfig
 import io.github.amichne.kast.idea.diagnostics.KastSourceIndexSummary
 import io.github.amichne.kast.idea.transition.BuildSemanticInputIdentity
 import io.github.amichne.kast.idea.transition.GitWorktreeTransitionGuard
+import io.github.amichne.kast.idea.transition.GitWorktreeTransitionInspectionException
 import io.github.amichne.kast.idea.transition.GitWorktreeTransitionMarker
 import io.github.amichne.kast.idea.transition.GitWorktreeTransitionMarkerEvidence
 import io.github.amichne.kast.idea.transition.GitWorktreeTransitionStatus
@@ -15,7 +16,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.lang.reflect.Proxy
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
@@ -26,6 +29,98 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 
 class WorkspaceTransitionWorkerBuildSemanticTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `missing linked-worktree Git directory does not block reconciliation`() {
+        val repository = committedRepository()
+        val workspace = tempDir.resolve("broken-linked-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val gitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
+            .toAbsolutePath()
+            .normalize()
+        Files.move(gitDirectory, tempDir.resolve("displaced-worktree-git-directory"))
+        val stableBuildInputs = BuildSemanticInputIdentity("stable-build-inputs")
+        val publications = mutableListOf<WorkspaceStateIdentity>()
+        val failures = mutableListOf<Throwable>()
+        val worker = WorkspaceTransitionWorker(
+            initialConfig = KastConfig.defaults(),
+            initialModelBuildSemanticIdentity = stableBuildInputs,
+            resolveBuildSemanticInputIdentity = { stableBuildInputs },
+            semanticAdmission = IdeaIndexSemanticAdmission(projectStub()),
+            eventWakeup = WorkspaceEventWakeup(),
+            gitWorktreeTransitionGuard = GitWorktreeTransitionGuard.exactRoot(workspace),
+            refreshWorkspace = {},
+            loadLiveConfig = { it },
+            captureCandidate = { _, _ ->
+                WorkspaceReconciliationCandidate(
+                    identity = WorkspaceStateIdentity("workspace-without-linked-git-directory"),
+                    indexingCandidate = null,
+                )
+            },
+            runIndexingPass = { _, _, _ -> IndexingPassResult(KastSourceIndexSummary(), graphFailure = null) },
+            workspaceGenerationPublication = TestWorkspaceGenerationPublication(onCommit = publications::add),
+            waitForNextPass = { false },
+            isCancelled = { false },
+            onConfigFallback = {},
+            onCompleted = {},
+            onFailure = failures::add,
+            onTransition = {},
+        )
+
+        worker.observe(WorkspaceSignal.GitWorktree)
+        worker.run()
+
+        assertTrue(failures.isEmpty(), "missing linked-worktree metadata must not report a worker failure")
+        assertEquals(
+            listOf(WorkspaceStateIdentity("workspace-without-linked-git-directory")),
+            publications,
+        )
+    }
+
+    @Test
+    fun `missing non-worktree Git directory remains blocked`() {
+        val repository = committedRepository()
+        val workspace = tempDir.resolve("separate-git-directory-workspace").also(Files::createDirectories)
+        val unregisteredDirectory = repository.resolve(".git/worktrees/unregistered")
+        Files.writeString(workspace.resolve(".git"), "gitdir: $unregisteredDirectory")
+        val stableBuildInputs = BuildSemanticInputIdentity("stable-build-inputs")
+        val publications = mutableListOf<WorkspaceStateIdentity>()
+        val failures = mutableListOf<Throwable>()
+        val worker = WorkspaceTransitionWorker(
+            initialConfig = KastConfig.defaults(),
+            initialModelBuildSemanticIdentity = stableBuildInputs,
+            resolveBuildSemanticInputIdentity = { stableBuildInputs },
+            semanticAdmission = IdeaIndexSemanticAdmission(projectStub()),
+            eventWakeup = WorkspaceEventWakeup(),
+            gitWorktreeTransitionGuard = GitWorktreeTransitionGuard.exactRoot(workspace),
+            refreshWorkspace = {},
+            loadLiveConfig = { it },
+            captureCandidate = { _, _ ->
+                WorkspaceReconciliationCandidate(
+                    identity = WorkspaceStateIdentity("unavailable-git-directory"),
+                    indexingCandidate = null,
+                )
+            },
+            runIndexingPass = { _, _, _ -> IndexingPassResult(KastSourceIndexSummary(), graphFailure = null) },
+            workspaceGenerationPublication = TestWorkspaceGenerationPublication(onCommit = publications::add),
+            waitForNextPass = { false },
+            isCancelled = { false },
+            onConfigFallback = {},
+            onCompleted = {},
+            onFailure = failures::add,
+            onTransition = {},
+        )
+
+        worker.observe(WorkspaceSignal.GitWorktree)
+        worker.run()
+
+        assertTrue(publications.isEmpty(), "unavailable non-worktree metadata must block publication")
+        assertEquals(1, failures.size)
+        assertTrue(failures.single() is GitWorktreeTransitionInspectionException)
+    }
+
     @Test
     fun `checkout starting after refresh cannot cross the publication boundary`() {
         val stableBuildInputs = BuildSemanticInputIdentity("stable-build-inputs")
@@ -249,6 +344,31 @@ class WorkspaceTransitionWorkerBuildSemanticTest {
             refreshedSignals,
         )
         assertEquals(listOf(WorkspaceStateIdentity("state-changed-build-inputs")), publications)
+    }
+
+    private fun committedRepository(): Path {
+        val repository = tempDir.resolve("repository").also(Files::createDirectories)
+        git(repository, "init")
+        git(repository, "config", "user.name", "Kast Test")
+        git(repository, "config", "user.email", "kast@example.invalid")
+        Files.writeString(repository.resolve("README.md"), "initial")
+        git(repository, "add", "README.md")
+        git(repository, "commit", "-m", "initial")
+        return repository
+    }
+
+    private fun git(directory: Path, vararg arguments: String) {
+        gitOutput(directory, *arguments)
+    }
+
+    private fun gitOutput(directory: Path, vararg arguments: String): String {
+        val process = ProcessBuilder("git", *arguments)
+            .directory(directory.toFile())
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.use { input -> input.readAllBytes().toString(Charsets.UTF_8) }
+        assertTrue(process.waitFor() == 0, "git ${arguments.joinToString(" ")} failed: $output")
+        return output.trim()
     }
 
     private fun projectStub(): Project = Proxy.newProxyInstance(

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/WorkspaceTransitionWorkerBuildSemanticTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/WorkspaceTransitionWorkerBuildSemanticTest.kt
@@ -40,6 +40,8 @@ class WorkspaceTransitionWorkerBuildSemanticTest {
         val gitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
             .toAbsolutePath()
             .normalize()
+        val gitWorktreeTransitionGuard = GitWorktreeTransitionGuard.exactRoot(workspace)
+        assertEquals(GitWorktreeTransitionStatus.Stable, gitWorktreeTransitionGuard.inspect())
         Files.move(gitDirectory, tempDir.resolve("displaced-worktree-git-directory"))
         val stableBuildInputs = BuildSemanticInputIdentity("stable-build-inputs")
         val publications = mutableListOf<WorkspaceStateIdentity>()
@@ -50,7 +52,7 @@ class WorkspaceTransitionWorkerBuildSemanticTest {
             resolveBuildSemanticInputIdentity = { stableBuildInputs },
             semanticAdmission = IdeaIndexSemanticAdmission(projectStub()),
             eventWakeup = WorkspaceEventWakeup(),
-            gitWorktreeTransitionGuard = GitWorktreeTransitionGuard.exactRoot(workspace),
+            gitWorktreeTransitionGuard = gitWorktreeTransitionGuard,
             refreshWorkspace = {},
             loadLiveConfig = { it },
             captureCandidate = { _, _ ->
@@ -82,6 +84,8 @@ class WorkspaceTransitionWorkerBuildSemanticTest {
     @Test
     fun `missing non-worktree Git directory remains blocked`() {
         val repository = committedRepository()
+        val registeredWorktree = tempDir.resolve("registered-worktree")
+        git(repository, "worktree", "add", "--detach", registeredWorktree.toString(), "HEAD")
         val workspace = tempDir.resolve("separate-git-directory-workspace").also(Files::createDirectories)
         val unregisteredDirectory = repository.resolve(".git/worktrees/unregistered")
         Files.writeString(workspace.resolve(".git"), "gitdir: $unregisteredDirectory")

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/WorkspaceTransitionWorkerBuildSemanticTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/WorkspaceTransitionWorkerBuildSemanticTest.kt
@@ -2,12 +2,14 @@ package io.github.amichne.kast.idea
 
 import com.intellij.openapi.project.Project
 import io.github.amichne.kast.api.client.KastConfig
+import io.github.amichne.kast.api.client.LinkedWorktreeLaunchClaim
 import io.github.amichne.kast.idea.diagnostics.KastSourceIndexSummary
 import io.github.amichne.kast.idea.transition.BuildSemanticInputIdentity
 import io.github.amichne.kast.idea.transition.GitWorktreeTransitionGuard
 import io.github.amichne.kast.idea.transition.GitWorktreeTransitionInspectionException
 import io.github.amichne.kast.idea.transition.GitWorktreeTransitionMarker
 import io.github.amichne.kast.idea.transition.GitWorktreeTransitionMarkerEvidence
+import io.github.amichne.kast.idea.transition.GitWorktreeRegistrationProof
 import io.github.amichne.kast.idea.transition.GitWorktreeTransitionStatus
 import io.github.amichne.kast.idea.transition.WorkspaceEventWakeup
 import io.github.amichne.kast.idea.transition.WorkspaceSignal
@@ -40,8 +42,10 @@ class WorkspaceTransitionWorkerBuildSemanticTest {
         val gitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
             .toAbsolutePath()
             .normalize()
-        val gitWorktreeTransitionGuard = GitWorktreeTransitionGuard.exactRoot(workspace)
-        assertEquals(GitWorktreeTransitionStatus.Stable, gitWorktreeTransitionGuard.inspect())
+        val registrationProof = GitWorktreeRegistrationProof.capture(
+            workspace,
+            LinkedWorktreeLaunchClaim.of(workspace.resolve(".git"), gitDirectory),
+        )
         Files.move(gitDirectory, tempDir.resolve("displaced-worktree-git-directory"))
         val stableBuildInputs = BuildSemanticInputIdentity("stable-build-inputs")
         val publications = mutableListOf<WorkspaceStateIdentity>()
@@ -52,7 +56,7 @@ class WorkspaceTransitionWorkerBuildSemanticTest {
             resolveBuildSemanticInputIdentity = { stableBuildInputs },
             semanticAdmission = IdeaIndexSemanticAdmission(projectStub()),
             eventWakeup = WorkspaceEventWakeup(),
-            gitWorktreeTransitionGuard = gitWorktreeTransitionGuard,
+            gitWorktreeTransitionGuard = GitWorktreeTransitionGuard.exactRoot(workspace, registrationProof),
             refreshWorkspace = {},
             loadLiveConfig = { it },
             captureCandidate = { _, _ ->

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeRegistrationProofTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeRegistrationProofTest.kt
@@ -1,0 +1,103 @@
+package io.github.amichne.kast.idea.transition
+
+import io.github.amichne.kast.api.client.LinkedWorktreeLaunchClaim
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class GitWorktreeRegistrationProofTest {
+    @TempDir
+    lateinit var root: Path
+
+    @Test
+    fun `capture rejects a launch claim for a different worktree admin directory`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("claimed-worktree")
+        val alternateWorkspace = root.resolve("alternate-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        git(repository, "worktree", "add", "--detach", alternateWorkspace.toString(), "HEAD")
+        val alternateGitDirectory = absoluteGitDirectory(alternateWorkspace)
+
+        assertThrows(IllegalStateException::class.java) {
+            GitWorktreeRegistrationProof.capture(
+                workspace,
+                LinkedWorktreeLaunchClaim.of(workspace.resolve(".git"), alternateGitDirectory),
+            )
+        }
+    }
+
+    @Test
+    fun `capture rejects a registration with a mismatched backlink`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("mismatched-backlink-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val gitDirectory = absoluteGitDirectory(workspace)
+        val forgedGitFile = root.resolve("forged/.git")
+        Files.createDirectories(forgedGitFile.parent)
+        Files.writeString(forgedGitFile, "forged\n")
+        Files.writeString(gitDirectory.resolve("gitdir"), "$forgedGitFile\n")
+
+        assertThrows(IllegalStateException::class.java) {
+            GitWorktreeRegistrationProof.capture(
+                workspace,
+                LinkedWorktreeLaunchClaim.of(workspace.resolve(".git"), gitDirectory),
+            )
+        }
+    }
+
+    @Test
+    fun `proof rejects a same-path replacement admin directory`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("replaced-admin-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val gitDirectory = absoluteGitDirectory(workspace)
+        val proof = GitWorktreeRegistrationProof.capture(
+            workspace,
+            LinkedWorktreeLaunchClaim.of(workspace.resolve(".git"), gitDirectory),
+        )
+        Files.move(gitDirectory, root.resolve("displaced-admin-directory"))
+        Files.createDirectory(gitDirectory)
+        Files.writeString(gitDirectory.resolve("gitdir"), "${workspace.resolve(".git")}\n")
+
+        val status = GitWorktreeTransitionGuard.exactRoot(workspace, proof).inspect()
+
+        assertTrue(status is GitWorktreeTransitionStatus.Unavailable)
+    }
+
+    private fun committedRepository(): Path {
+        val repository = root.resolve("repository").also(Files::createDirectories)
+        git(repository, "init")
+        git(repository, "config", "user.name", "Kast Test")
+        git(repository, "config", "user.email", "kast@example.invalid")
+        Files.writeString(repository.resolve("README.md"), "initial")
+        git(repository, "add", "README.md")
+        git(repository, "commit", "-m", "initial")
+        return repository
+    }
+
+    private fun absoluteGitDirectory(workspace: Path): Path = Path.of(
+        gitOutput(workspace, "rev-parse", "--absolute-git-dir"),
+    ).toAbsolutePath().normalize()
+
+    private fun git(directory: Path, vararg arguments: String) {
+        val process = ProcessBuilder("git", *arguments)
+            .directory(directory.toFile())
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.use { input -> input.readAllBytes().toString(Charsets.UTF_8) }
+        assertTrue(process.waitFor() == 0, "git ${arguments.joinToString(" ")} failed: $output")
+    }
+
+    private fun gitOutput(directory: Path, vararg arguments: String): String {
+        val process = ProcessBuilder("git", *arguments)
+            .directory(directory.toFile())
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.use { input -> input.readAllBytes().toString(Charsets.UTF_8) }
+        assertTrue(process.waitFor() == 0, "git ${arguments.joinToString(" ")} failed: $output")
+        return output.trim()
+    }
+}

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardPoisonProbe.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardPoisonProbe.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.idea.transition
 
+import io.github.amichne.kast.api.client.LinkedWorktreeLaunchClaim
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.system.exitProcess
@@ -13,18 +14,16 @@ object GitWorktreeTransitionGuardPoisonProbe {
         val workspace = Path.of(arguments[0]).toAbsolutePath().normalize()
         val missingGitDirectory = Path.of(arguments[1]).toAbsolutePath().normalize()
         val displacedGitDirectory = Path.of(arguments[2]).toAbsolutePath().normalize()
-        val guard = GitWorktreeTransitionGuard.exactRoot(workspace)
-        val initial = guard.inspect()
-        if (initial != GitWorktreeTransitionStatus.Stable) {
-            System.err.println("Expected initial Stable registration proof but observed $initial")
-            exitProcess(1)
-        }
+        val proof = GitWorktreeRegistrationProof.capture(
+            workspace,
+            LinkedWorktreeLaunchClaim.of(workspace.resolve(".git"), missingGitDirectory),
+        )
         Files.move(missingGitDirectory, displacedGitDirectory)
         val expected = GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(
             gitFile = workspace.resolve(".git"),
             gitDirectory = missingGitDirectory,
         )
-        val observed = guard.inspect()
+        val observed = GitWorktreeTransitionGuard.exactRoot(workspace, proof).inspect()
         if (observed != expected) {
             System.err.println("Expected $expected but observed $observed")
             exitProcess(1)

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardPoisonProbe.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardPoisonProbe.kt
@@ -1,0 +1,22 @@
+package io.github.amichne.kast.idea.transition
+
+import java.nio.file.Path
+import kotlin.system.exitProcess
+
+object GitWorktreeTransitionGuardPoisonProbe {
+    @JvmStatic
+    fun main(arguments: Array<String>) {
+        require(arguments.size == 2) { "Expected workspace root and missing Git directory" }
+        val workspace = Path.of(arguments[0]).toAbsolutePath().normalize()
+        val missingGitDirectory = Path.of(arguments[1]).toAbsolutePath().normalize()
+        val expected = GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(
+            gitFile = workspace.resolve(".git"),
+            gitDirectory = missingGitDirectory,
+        )
+        val observed = GitWorktreeTransitionGuard.exactRoot(workspace).inspect()
+        if (observed != expected) {
+            System.err.println("Expected $expected but observed $observed")
+            exitProcess(1)
+        }
+    }
+}

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardPoisonProbe.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardPoisonProbe.kt
@@ -1,19 +1,30 @@
 package io.github.amichne.kast.idea.transition
 
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.system.exitProcess
 
 object GitWorktreeTransitionGuardPoisonProbe {
     @JvmStatic
     fun main(arguments: Array<String>) {
-        require(arguments.size == 2) { "Expected workspace root and missing Git directory" }
+        require(arguments.size == 3) {
+            "Expected workspace root, registered Git directory, and displaced Git directory"
+        }
         val workspace = Path.of(arguments[0]).toAbsolutePath().normalize()
         val missingGitDirectory = Path.of(arguments[1]).toAbsolutePath().normalize()
+        val displacedGitDirectory = Path.of(arguments[2]).toAbsolutePath().normalize()
+        val guard = GitWorktreeTransitionGuard.exactRoot(workspace)
+        val initial = guard.inspect()
+        if (initial != GitWorktreeTransitionStatus.Stable) {
+            System.err.println("Expected initial Stable registration proof but observed $initial")
+            exitProcess(1)
+        }
+        Files.move(missingGitDirectory, displacedGitDirectory)
         val expected = GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(
             gitFile = workspace.resolve(".git"),
             gitDirectory = missingGitDirectory,
         )
-        val observed = GitWorktreeTransitionGuard.exactRoot(workspace).inspect()
+        val observed = guard.inspect()
         if (observed != expected) {
             System.err.println("Expected $expected but observed $observed")
             exitProcess(1)

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardTest.kt
@@ -67,6 +67,37 @@ class GitWorktreeTransitionGuardTest {
     }
 
     @Test
+    fun `ambient Git repository selection cannot hide a missing worktree directory`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("poisoned-broken-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val missingGitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
+            .toAbsolutePath()
+            .normalize()
+        Files.move(missingGitDirectory, root.resolve("displaced-poisoned-worktree-git-directory"))
+        val unrelatedRepository = root.resolve("unrelated-repository").also(Files::createDirectories)
+        git(unrelatedRepository, "init")
+
+        val java = Path.of(System.getProperty("java.home"), "bin", "java")
+        val probe = ProcessBuilder(
+            java.toString(),
+            "-cp",
+            System.getProperty("java.class.path"),
+            GitWorktreeTransitionGuardPoisonProbe::class.java.name,
+            workspace.toString(),
+            missingGitDirectory.toString(),
+        ).redirectErrorStream(true)
+        probe.environment()["GIT_DIR"] = unrelatedRepository.resolve(".git").toString()
+        probe.environment()["GIT_WORK_TREE"] = workspace.toString()
+        probe.environment()["GIT_COMMON_DIR"] = unrelatedRepository.resolve(".git").toString()
+        probe.environment()["GIT_INDEX_FILE"] = unrelatedRepository.resolve(".git/index").toString()
+        val process = probe.start()
+        val output = process.inputStream.use { input -> input.readAllBytes().toString(Charsets.UTF_8) }
+
+        assertTrue(process.waitFor() == 0, output)
+    }
+
+    @Test
     fun `missing non-worktree Git directory remains unavailable`() {
         val repository = committedRepository()
         val workspace = root.resolve("separate-git-directory-workspace").also(Files::createDirectories)

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardTest.kt
@@ -1,8 +1,12 @@
 package io.github.amichne.kast.idea.transition
 
+import io.github.amichne.kast.api.client.LinkedWorktreeLaunchClaim
+import java.io.IOException
 import java.nio.file.FileSystems
 import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.PosixFilePermissions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -53,11 +57,10 @@ class GitWorktreeTransitionGuardTest {
         val missingGitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
             .toAbsolutePath()
             .normalize()
-        val guard = GitWorktreeTransitionGuard.exactRoot(workspace)
-        assertEquals(GitWorktreeTransitionStatus.Stable, guard.inspect())
+        val proof = registrationProof(workspace, missingGitDirectory)
         Files.move(missingGitDirectory, root.resolve("displaced-worktree-git-directory"))
 
-        val status = guard.inspect()
+        val status = GitWorktreeTransitionGuard.exactRoot(workspace, proof).inspect()
 
         assertEquals(
             GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(
@@ -116,6 +119,141 @@ class GitWorktreeTransitionGuardTest {
     }
 
     @Test
+    fun `launch proof fails closed when the registered Git file disappears`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("deleted-git-file-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val gitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
+            .toAbsolutePath()
+            .normalize()
+        val proof = registrationProof(workspace, gitDirectory)
+        Files.delete(workspace.resolve(".git"))
+
+        val status = GitWorktreeTransitionGuard.exactRoot(workspace, proof).inspect()
+
+        assertTrue(status is GitWorktreeTransitionStatus.Unavailable)
+    }
+
+    @Test
+    fun `launch proof rejects a same-path replacement Git file`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("replaced-git-file-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val gitFile = workspace.resolve(".git")
+        val gitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
+            .toAbsolutePath()
+            .normalize()
+        val proof = registrationProof(workspace, gitDirectory)
+        Files.move(gitDirectory, root.resolve("displaced-replaced-worktree-git-directory"))
+        val directive = Files.readString(gitFile)
+        Files.delete(gitFile)
+        Files.writeString(gitFile, directive)
+
+        val status = GitWorktreeTransitionGuard.exactRoot(workspace, proof).inspect()
+
+        assertTrue(status is GitWorktreeTransitionStatus.Unavailable)
+    }
+
+    @Test
+    fun `in-progress inspection does not authorize a later missing Git directory`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("transitioning-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val gitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
+            .toAbsolutePath()
+            .normalize()
+        val indexLock = gitDirectory.resolve("index.lock")
+        val guard = GitWorktreeTransitionGuard.exactRoot(workspace)
+        Files.writeString(indexLock, "transition")
+        assertTrue(guard.inspect() is GitWorktreeTransitionStatus.InProgress)
+        Files.delete(indexLock)
+        Files.move(gitDirectory, root.resolve("displaced-transitioning-worktree-git-directory"))
+
+        val status = guard.inspect()
+
+        assertTrue(status is GitWorktreeTransitionStatus.Unavailable)
+    }
+
+    @Test
+    fun `Git directory disappearing during marker inspection never reports stable`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("mid-inspection-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val gitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
+            .toAbsolutePath()
+            .normalize()
+        val proof = registrationProof(workspace, gitDirectory)
+        val displaced = root.resolve("displaced-mid-inspection-worktree-git-directory")
+        var moved = false
+        val markerReader = GitWorktreeTransitionMarkerReader { path ->
+            if (!moved) {
+                Files.move(gitDirectory, displaced)
+                moved = true
+            }
+            Files.readAttributes(path, BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+        }
+
+        val status = GitWorktreeTransitionGuard.exactRoot(workspace, proof, markerReader).inspect()
+
+        assertTrue(status is GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory)
+    }
+
+    @Test
+    fun `marker paths resolved from a swapped Git directive never report stable`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("resolution-epoch-worktree")
+        val alternateWorkspace = root.resolve("alternate-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        git(repository, "worktree", "add", "--detach", alternateWorkspace.toString(), "HEAD")
+        val gitFile = workspace.resolve(".git")
+        val gitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
+            .toAbsolutePath()
+            .normalize()
+        val alternateGitDirectory = Path.of(
+            gitOutput(alternateWorkspace, "rev-parse", "--absolute-git-dir"),
+        ).toAbsolutePath().normalize()
+        val proof = registrationProof(workspace, gitDirectory)
+        val registeredDirective = Files.readString(gitFile)
+        Files.writeString(gitFile, "gitdir: $alternateGitDirectory\n")
+        val resolutionObserver = GitWorktreeTransitionResolutionObserver {
+            Files.writeString(gitFile, registeredDirective)
+        }
+
+        val status = GitWorktreeTransitionGuard.exactRoot(
+            workspace,
+            proof,
+            resolutionObserver = resolutionObserver,
+        ).inspect()
+
+        assertTrue(status is GitWorktreeTransitionStatus.Unavailable)
+    }
+
+    @Test
+    fun `marker inspection failure does not authorize a later missing Git directory`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("marker-failure-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val gitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
+            .toAbsolutePath()
+            .normalize()
+        var failed = false
+        val markerReader = GitWorktreeTransitionMarkerReader { path ->
+            if (!failed) {
+                failed = true
+                throw IOException("injected marker failure: $path")
+            }
+            Files.readAttributes(path, BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+        }
+        val guard = GitWorktreeTransitionGuard.exactRoot(workspace, markerReader = markerReader)
+        assertTrue(guard.inspect() is GitWorktreeTransitionStatus.Unavailable)
+        Files.move(gitDirectory, root.resolve("displaced-marker-failure-worktree-git-directory"))
+
+        val status = guard.inspect()
+
+        assertTrue(status is GitWorktreeTransitionStatus.Unavailable)
+    }
+
+    @Test
     fun `missing non-worktree Git directory remains unavailable`() {
         val repository = committedRepository()
         val registeredWorktree = root.resolve("registered-worktree")
@@ -165,6 +303,14 @@ class GitWorktreeTransitionGuardTest {
         git(repository, "commit", "-m", "initial")
         return repository
     }
+
+    private fun registrationProof(
+        workspace: Path,
+        gitDirectory: Path,
+    ): GitWorktreeRegistrationProof = GitWorktreeRegistrationProof.capture(
+        workspace,
+        LinkedWorktreeLaunchClaim.of(workspace.resolve(".git"), gitDirectory),
+    )
 
     private fun git(directory: Path, vararg arguments: String) {
         val process = ProcessBuilder("git", *arguments)

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardTest.kt
@@ -53,9 +53,11 @@ class GitWorktreeTransitionGuardTest {
         val missingGitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
             .toAbsolutePath()
             .normalize()
+        val guard = GitWorktreeTransitionGuard.exactRoot(workspace)
+        assertEquals(GitWorktreeTransitionStatus.Stable, guard.inspect())
         Files.move(missingGitDirectory, root.resolve("displaced-worktree-git-directory"))
 
-        val status = GitWorktreeTransitionGuard.exactRoot(workspace).inspect()
+        val status = guard.inspect()
 
         assertEquals(
             GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(
@@ -74,7 +76,7 @@ class GitWorktreeTransitionGuardTest {
         val missingGitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
             .toAbsolutePath()
             .normalize()
-        Files.move(missingGitDirectory, root.resolve("displaced-poisoned-worktree-git-directory"))
+        val displacedGitDirectory = root.resolve("displaced-poisoned-worktree-git-directory")
         val unrelatedRepository = root.resolve("unrelated-repository").also(Files::createDirectories)
         git(unrelatedRepository, "init")
 
@@ -86,6 +88,7 @@ class GitWorktreeTransitionGuardTest {
             GitWorktreeTransitionGuardPoisonProbe::class.java.name,
             workspace.toString(),
             missingGitDirectory.toString(),
+            displacedGitDirectory.toString(),
         ).redirectErrorStream(true)
         probe.environment()["GIT_DIR"] = unrelatedRepository.resolve(".git").toString()
         probe.environment()["GIT_WORK_TREE"] = workspace.toString()
@@ -98,8 +101,25 @@ class GitWorktreeTransitionGuardTest {
     }
 
     @Test
+    fun `missing linked-worktree Git directory without prior identity proof remains unavailable`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("unproven-broken-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val missingGitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
+            .toAbsolutePath()
+            .normalize()
+        Files.move(missingGitDirectory, root.resolve("displaced-unproven-worktree-git-directory"))
+
+        val status = GitWorktreeTransitionGuard.exactRoot(workspace).inspect()
+
+        assertTrue(status is GitWorktreeTransitionStatus.Unavailable)
+    }
+
+    @Test
     fun `missing non-worktree Git directory remains unavailable`() {
         val repository = committedRepository()
+        val registeredWorktree = root.resolve("registered-worktree")
+        git(repository, "worktree", "add", "--detach", registeredWorktree.toString(), "HEAD")
         val workspace = root.resolve("separate-git-directory-workspace").also(Files::createDirectories)
         val unregisteredDirectory = repository.resolve(".git/worktrees/unregistered")
         Files.writeString(workspace.resolve(".git"), "gitdir: $unregisteredDirectory")

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/GitWorktreeTransitionGuardTest.kt
@@ -1,10 +1,13 @@
 package io.github.amichne.kast.idea.transition
 
+import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
@@ -42,13 +45,74 @@ class GitWorktreeTransitionGuardTest {
     }
 
     @Test
-    fun `Git metadata with unavailable exact-worktree paths fails closed`() {
-        val workspace = root.resolve("broken-worktree").also(Files::createDirectories)
-        Files.writeString(workspace.resolve(".git"), "gitdir: ${root.resolve("missing-git-directory")}")
+    fun `missing linked-worktree Git directory is explicit nonblocking evidence`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("broken-worktree")
+        git(repository, "worktree", "add", "--detach", workspace.toString(), "HEAD")
+        val gitFile = workspace.resolve(".git")
+        val missingGitDirectory = Path.of(gitOutput(workspace, "rev-parse", "--absolute-git-dir"))
+            .toAbsolutePath()
+            .normalize()
+        Files.move(missingGitDirectory, root.resolve("displaced-worktree-git-directory"))
 
-        val unavailable = GitWorktreeTransitionGuard.exactRoot(workspace).inspect()
+        val status = GitWorktreeTransitionGuard.exactRoot(workspace).inspect()
 
-        assertTrue(unavailable is GitWorktreeTransitionStatus.Unavailable)
+        assertEquals(
+            GitWorktreeTransitionStatus.MissingLinkedWorktreeGitDirectory(
+                gitFile = gitFile,
+                gitDirectory = missingGitDirectory,
+            ),
+            status,
+        )
+    }
+
+    @Test
+    fun `missing non-worktree Git directory remains unavailable`() {
+        val repository = committedRepository()
+        val workspace = root.resolve("separate-git-directory-workspace").also(Files::createDirectories)
+        val unregisteredDirectory = repository.resolve(".git/worktrees/unregistered")
+        Files.writeString(workspace.resolve(".git"), "gitdir: $unregisteredDirectory")
+
+        val status = GitWorktreeTransitionGuard.exactRoot(workspace).inspect()
+
+        assertTrue(status is GitWorktreeTransitionStatus.Unavailable)
+    }
+
+    @Test
+    fun `indeterminate Git metadata remains unavailable`() {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"))
+        val workspace = root.resolve("unreadable-workspace").also(Files::createDirectories)
+        val ownerPermissions = PosixFilePermissions.fromString("rwx------")
+        Files.setPosixFilePermissions(workspace, PosixFilePermissions.fromString("r--------"))
+
+        val status = try {
+            GitWorktreeTransitionGuard.exactRoot(workspace).inspect()
+        } finally {
+            Files.setPosixFilePermissions(workspace, ownerPermissions)
+        }
+
+        assertTrue(status is GitWorktreeTransitionStatus.Unavailable)
+    }
+
+    @Test
+    fun `malformed Git metadata remains unavailable`() {
+        val workspace = root.resolve("malformed-worktree").also(Files::createDirectories)
+        Files.writeString(workspace.resolve(".git"), "not a gitdir directive")
+
+        val status = GitWorktreeTransitionGuard.exactRoot(workspace).inspect()
+
+        assertTrue(status is GitWorktreeTransitionStatus.Unavailable)
+    }
+
+    private fun committedRepository(): Path {
+        val repository = root.resolve("repository").also(Files::createDirectories)
+        git(repository, "init")
+        git(repository, "config", "user.name", "Kast Test")
+        git(repository, "config", "user.email", "kast@example.invalid")
+        Files.writeString(repository.resolve("README.md"), "initial")
+        git(repository, "add", "README.md")
+        git(repository, "commit", "-m", "initial")
+        return repository
     }
 
     private fun git(directory: Path, vararg arguments: String) {


### PR DESCRIPTION
## Summary

- treat only a proven missing linked-worktree administrative directory as nonblocking; malformed, separate, unregistered, and indeterminate Git metadata remain fail-closed
- expose a receipt-validated developerOperations route from setup and bare kast with structured help arguments and the /kast:developer skill reference
- materialize and digest-check the developer skill for Codex, Claude, and Copilot while keeping the public semantic grammar closed

## Validation

- ./gradlew :indexer:test :analysis-api:test && cargo test --manifest-path cli-rs/Cargo.toml
- cargo clippy --manifest-path cli-rs/Cargo.toml --all-targets --all-features -- -D warnings
- cargo fmt --manifest-path cli-rs/Cargo.toml --check
- python3 .github/scripts/check-repository-shape.py --root .
- developer skill quick validation
- installed kast 0.21.4 exact-root startup reached READY with reference indexing ready