### PR TITLE
Publish installable snapshots from main

### DIFF
--- a/.github/scripts/install/test-snapshot-installer-contract.sh
+++ b/.github/scripts/install/test-snapshot-installer-contract.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'snapshot installer contract: %s\n' "$*" >&2
+  exit 1
+}
+
+require() {
+  local file="$1" text="$2" message="$3"
+  grep -Fq -- "$text" "$file" || die "$message"
+}
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
+installer="$repo_root/install.sh"
+workflow="$repo_root/.github/workflows/snapshot.yml"
+setup_builder="$repo_root/.github/scripts/release/actions/build-setup-bundle/action.yml"
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/kast-snapshot-installer-contract.XXXXXX")"
+cleanup() {
+  find "$scratch" -depth -delete
+}
+trap cleanup EXIT
+
+bundle="$scratch/kast-snapshot"
+mkdir -p "$bundle/bin" "$bundle/libexec" "$scratch/bin" "$scratch/user"
+
+cat >"$bundle/bin/kast" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+cat >"$bundle/libexec/kastctl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${KAST_SNAPSHOT_TEST_SETUP_LOG:?}"
+SH
+chmod 755 "$bundle/bin/kast" "$bundle/libexec/kastctl"
+tar -czf "$scratch/kast-snapshot.tar.gz" -C "$scratch" "$(basename -- "$bundle")"
+
+cat >"$scratch/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${KAST_SNAPSHOT_TEST_CURL_LOG:?}"
+output=""
+while (($# > 0)); do
+  case "$1" in
+    -o|--output)
+      [[ $# -ge 2 ]]
+      output="$2"
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+[[ -n "$output" ]]
+cp "${KAST_SNAPSHOT_TEST_ARCHIVE:?}" "$output"
+SH
+chmod 755 "$scratch/bin/curl"
+
+case "$(uname -s):$(uname -m)" in
+  Darwin:x86_64) platform=macos-x64 ;;
+  Darwin:arm64|Darwin:aarch64) platform=macos-arm64 ;;
+  Linux:x86_64|Linux:amd64) platform=linux-x64 ;;
+  Linux:arm64|Linux:aarch64) platform=linux-arm64 ;;
+  *) die "test host platform is unsupported" ;;
+esac
+
+run_installer() {
+  : >"$scratch/curl.log"
+  : >"$scratch/setup.log"
+  HOME="$scratch/user" \
+    PATH="$scratch/bin:$PATH" \
+    KAST_HOME="$scratch/kast-home" \
+    KAST_RELEASES_URL="https://downloads.example.invalid/releases" \
+    KAST_SNAPSHOT_TEST_ARCHIVE="$scratch/kast-snapshot.tar.gz" \
+    KAST_SNAPSHOT_TEST_CURL_LOG="$scratch/curl.log" \
+    KAST_SNAPSHOT_TEST_SETUP_LOG="$scratch/setup.log" \
+    "$installer" "$@" >"$scratch/stdout" 2>"$scratch/stderr"
+}
+
+run_installer --snapshot --harness none \
+  || { sed -n '1,120p' "$scratch/stderr" >&2; die "--snapshot installation failed"; }
+grep -Fq -- \
+  "https://downloads.example.invalid/releases/download/snapshot/kast-${platform}-snapshot.tar.gz" \
+  "$scratch/curl.log" \
+  || die "--snapshot did not download the rolling snapshot asset"
+grep -Eq '^setup --source .*/kast-snapshot$' "$scratch/setup.log" \
+  || die "--snapshot did not delegate installation to kastctl"
+
+run_installer --version v9.8.7 --harness none \
+  || { sed -n '1,120p' "$scratch/stderr" >&2; die "stable version installation regressed"; }
+grep -Fq -- \
+  "https://downloads.example.invalid/releases/download/v9.8.7/kast-${platform}-v9.8.7.tar.gz" \
+  "$scratch/curl.log" \
+  || die "stable version download contract changed"
+
+if run_installer --snapshot --version v9.8.7 --harness none; then
+  die "--snapshot must reject --version"
+fi
+
+require "$installer" '[--snapshot]' "installer usage must advertise --snapshot"
+require "$installer" '--snapshot         Install the latest snapshot build.' \
+  "installer help must define --snapshot"
+
+for job in build-cli build-indexer build-setup-bundles publish-snapshot-release; do
+  require "$workflow" "  ${job}:" "snapshot workflow is missing ${job}"
+done
+for platform_id in linux-x64 linux-arm64 macos-x64 macos-arm64; do
+  require "$workflow" "asset_id: ${platform_id}" \
+    "snapshot CLI matrix is missing ${platform_id}"
+  require "$workflow" "- ${platform_id}" \
+    "snapshot setup matrix is missing ${platform_id}"
+done
+
+require "$workflow" "github.event.workflow_run.conclusion == 'success'" \
+  "snapshot publication must require successful main CI"
+require "$workflow" 'ref: ${{ needs.validate.outputs.source-sha }}' \
+  "snapshot builds must check out the exact successful main source"
+require "$workflow" 'bash .github/scripts/install/test-snapshot-installer-contract.sh' \
+  "snapshot publication must run its installer contract before building"
+require "$workflow" 'uses: ./.github/scripts/release/actions/build-cli' \
+  "snapshot CLI builds must reuse the retained-byte builder"
+require "$workflow" 'uses: ./.github/scripts/release/actions/build-setup-bundle' \
+  "snapshot setup builds must reuse the release bundle builder"
+require "$workflow" 'release_tag: snapshot' \
+  "snapshot build inputs must use the rolling snapshot asset name"
+require "$workflow" 'version: ${{ needs.validate.outputs.snapshot-tag }}' \
+  "snapshot bundles must embed the resolved snapshot version"
+require "$workflow" 'gh release create snapshot' \
+  "snapshot publication must create the rolling prerelease"
+require "$workflow" '--prerelease' \
+  "snapshot release must not be presented as stable"
+require "$workflow" 'gh release upload snapshot' \
+  "snapshot publication must upload installable bundles"
+require "$workflow" 'dist/kast-*-snapshot.tar.gz' \
+  "snapshot publication must use installer-stable asset names"
+require "$workflow" '--clobber' \
+  "rolling snapshot assets must replace the previous merge build"
+
+require "$setup_builder" 'version:' \
+  "setup bundle builder must accept an explicit bundle version"
+require "$setup_builder" 'version="${{ inputs.version }}"' \
+  "setup bundle builder must resolve its explicit version"
+require "$setup_builder" '[[ -n "$version" ]] || version="$tag"' \
+  "stable setup bundles must retain tag-based version behavior"
+require "$setup_builder" '--version "$version"' \
+  "setup bundle builder must embed the resolved bundle version"
+
+bash -n "$installer"
+printf '%s\n' 'snapshot installer contract passed'

--- a/.github/scripts/release/actions/build-setup-bundle/action.yml
+++ b/.github/scripts/release/actions/build-setup-bundle/action.yml
@@ -8,6 +8,10 @@ inputs:
   tag:
     description: Release tag
     required: true
+  version:
+    description: Bundle version; defaults to the release tag
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -36,6 +40,8 @@ runs:
       run: |
         set -euo pipefail
         tag="${{ inputs.tag }}"
+        version="${{ inputs.version }}"
+        [[ -n "$version" ]] || version="$tag"
         platform="${{ inputs.platform }}"
         cli_asset="provenance-cli/kast-${tag}-${platform}.zip"
         packager_archive="provenance-cli/kast-${tag}-linux-x64.zip"
@@ -74,7 +80,7 @@ runs:
           --cli-archive "$cli_asset" \
           --indexer-archive "$indexer_asset" \
           --platform "$platform" \
-          --version "$tag" \
+          --version "$version" \
           --bundle-output "$asset"
         python3 - "$asset" "dist/provenance/build-provenance-setup-${platform}.json" "$platform" <<'PY'
         import hashlib, json, os, sys

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -24,7 +24,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
-  group: snapshot-${{ github.event.workflow_run.head_sha || github.sha }}
+  group: snapshot-${{ github.event_name == 'workflow_run' && 'main' || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       snapshot-version: ${{ steps.snapshot-version.outputs.value }}
+      snapshot-tag: ${{ steps.snapshot-version.outputs.tag }}
       publish-snapshot: ${{ steps.snapshot-version.outputs.publish }}
       source-sha: ${{ steps.snapshot-version.outputs.source-sha }}
     steps:
@@ -40,6 +41,9 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
+
+      - name: Test snapshot installer contract
+        run: bash .github/scripts/install/test-snapshot-installer-contract.sh
 
       - name: Set up Java for manual snapshot validation
         if: github.event_name == 'workflow_dispatch'
@@ -73,6 +77,7 @@ jobs:
             base="$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo v0.0.0)"
             version="${base#v}-SNAPSHOT"
           fi
+          version="${version#v}"
 
           if [[ "$require_snapshot" == "true" && "$version" != *-SNAPSHOT ]]; then
             echo "ERROR: snapshot version must end with -SNAPSHOT" >&2
@@ -85,7 +90,13 @@ jobs:
             publish_snapshot=true
           fi
 
+          if [[ "$source_sha" != "$GITHUB_SHA" ]]; then
+            echo "ERROR: snapshot workflow source ${source_sha} differs from workflow source ${GITHUB_SHA}" >&2
+            exit 1
+          fi
+
           printf 'value=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          printf 'tag=v%s\n' "$version" >> "$GITHUB_OUTPUT"
           printf 'publish=%s\n' "$publish_snapshot" >> "$GITHUB_OUTPUT"
           printf 'source-sha=%s\n' "$source_sha" >> "$GITHUB_OUTPUT"
 
@@ -150,6 +161,147 @@ jobs:
           path: ci-ledgers/maven-publication.json
           if-no-files-found: error
           retention-days: 3
+
+  build-cli:
+    name: Build snapshot CLI (${{ matrix.asset_id }})
+    needs: validate
+    if: needs.validate.outputs.publish-snapshot == 'true'
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - asset_id: linux-x64
+            runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            cache_key: source-bound-cli-release
+          - asset_id: linux-arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            cache_key: release-cli-linux-arm64
+          - asset_id: macos-x64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+            cache_key: release-cli-macos-x64
+          - asset_id: macos-arm64
+            runner: macos-14
+            target: aarch64-apple-darwin
+            cache_key: release-cli-macos-arm64
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.validate.outputs.source-sha }}
+      - uses: ./.github/scripts/release/actions/build-cli
+        with:
+          asset_id: ${{ matrix.asset_id }}
+          target: ${{ matrix.target }}
+          cache_key: ${{ matrix.cache_key }}
+          release_tag: snapshot
+          release_version: ${{ needs.validate.outputs.snapshot-version }}
+
+  build-indexer:
+    name: Build snapshot indexer
+    needs: validate
+    if: needs.validate.outputs.publish-snapshot == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.validate.outputs.source-sha }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Free disk for indexer packaging
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL
+
+      - uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-cleanup: always
+
+      - name: Build retained snapshot indexer
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf indexer/build/portable-dist indexer/build/distributions
+          ./scripts/ci-gradle-retry.sh ./gradlew \
+            -Pversion="${{ needs.validate.outputs.snapshot-version }}" \
+            :indexer:syncRuntimeLibs \
+            :indexer:syncPortableDist \
+            :indexer:verifyPortableDistLayout \
+            :indexer:portableDistZip \
+            --no-daemon
+          mapfile -t indexer_zips < <(find indexer/build/distributions -maxdepth 1 -type f -name 'indexer-*-portable.zip' -print)
+          [[ "${#indexer_zips[@]}" -eq 1 ]] \
+            || { echo "Expected one portable indexer zip, found ${#indexer_zips[@]}" >&2; exit 1; }
+          mkdir -p dist
+          cp "${indexer_zips[0]}" dist/indexer.zip
+          scripts/verify-ci-artifact-ledger.py record \
+            --output dist/build-ledger-indexer.json \
+            --git-sha "${{ needs.validate.outputs.source-sha }}" \
+            --source-ref refs/tags/snapshot \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --artifact-kind release-indexer \
+            --artifact-name indexer.zip \
+            --artifact-path dist/indexer.zip \
+            --producer-job build-indexer \
+            --build-command-id snapshot-indexer-build
+
+      - name: Retain snapshot indexer
+        uses: actions/upload-artifact@v6
+        with:
+          name: indexer-${{ github.run_id }}
+          path: |
+            dist/indexer.zip
+            dist/build-ledger-indexer.json
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 3
+
+  build-setup-bundles:
+    name: Build snapshot setup bundle (${{ matrix.platform }})
+    needs:
+      - validate
+      - build-cli
+      - build-indexer
+    if: >-
+      always() &&
+      needs.validate.outputs.publish-snapshot == 'true' &&
+      needs.build-cli.result == 'success' &&
+      needs.build-indexer.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux-x64
+          - linux-arm64
+          - macos-x64
+          - macos-arm64
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.validate.outputs.source-sha }}
+      - uses: ./.github/scripts/release/actions/build-setup-bundle
+        with:
+          platform: ${{ matrix.platform }}
+          tag: snapshot
+          version: ${{ needs.validate.outputs.snapshot-tag }}
 
   publish-github-packages:
     runs-on: ubuntu-latest
@@ -276,3 +428,98 @@ jobs:
             --no-configuration-cache \
             --no-daemon \
             --stacktrace
+
+  publish-snapshot-release:
+    name: Publish installable snapshot
+    needs:
+      - validate
+      - build-setup-bundles
+      - publish-github-packages
+      - publish-maven-central
+    if: >-
+      always() &&
+      needs.validate.outputs.publish-snapshot == 'true' &&
+      needs.build-setup-bundles.result == 'success' &&
+      needs.publish-github-packages.result == 'success' &&
+      needs.publish-maven-central.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.validate.outputs.source-sha }}
+
+      - name: Download retained snapshot bundles
+        uses: actions/download-artifact@v7
+        with:
+          pattern: setup-bundle-*-${{ github.run_id }}
+          path: dist
+          merge-multiple: true
+
+      - name: Verify retained snapshot bundles
+        shell: bash
+        run: |
+          set -euo pipefail
+          for platform in linux-x64 linux-arm64 macos-x64 macos-arm64; do
+            asset="dist/kast-${platform}-snapshot.tar.gz"
+            scripts/verify-ci-artifact-ledger.py verify \
+              --ledger "dist/provenance/build-ledger-setup-${platform}.json" \
+              --git-sha "${{ needs.validate.outputs.source-sha }}" \
+              --require-kind "release-setup-${platform}" \
+              --artifact "release-setup-${platform}=${asset}"
+            (cd dist && sha256sum -c "$(basename -- "$asset").sha256")
+          done
+          mapfile -t snapshot_bundles < <(find dist -maxdepth 1 -type f -name 'kast-*-snapshot.tar.gz' -print)
+          [[ "${#snapshot_bundles[@]}" -eq 4 ]] \
+            || { echo "Expected four snapshot bundles, found ${#snapshot_bundles[@]}" >&2; exit 1; }
+
+      - name: Publish rolling snapshot prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_sha="${{ needs.validate.outputs.source-sha }}"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" ]]; then
+            current_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq .object.sha)"
+            [[ "$current_main" == "$source_sha" ]] \
+              || { echo "Refusing to publish stale snapshot ${source_sha}; main is ${current_main}" >&2; exit 1; }
+          fi
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/snapshot" >/dev/null 2>&1; then
+            gh api --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/git/refs/tags/snapshot" \
+              -f sha="$source_sha" \
+              -F force=true >/dev/null
+          else
+            gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref=refs/tags/snapshot \
+              -f sha="$source_sha" >/dev/null
+          fi
+
+          printf -v notes 'Source: %s\nVersion: %s' \
+            "$source_sha" \
+            "${{ needs.validate.outputs.snapshot-tag }}"
+          if gh release view snapshot --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit snapshot \
+              --repo "$GITHUB_REPOSITORY" \
+              --prerelease \
+              --target "$source_sha" \
+              --title "Latest snapshot" \
+              --notes "$notes"
+          else
+            gh release create snapshot \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --prerelease \
+              --target "$source_sha" \
+              --title "Latest snapshot" \
+              --notes "$notes"
+          fi
+          gh release upload snapshot \
+            --repo "$GITHUB_REPOSITORY" \
+            dist/kast-*-snapshot.tar.gz \
+            dist/kast-*-snapshot.tar.gz.sha256 \
+            --clobber

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ kast_repository_root() {
 
 usage() {
   cat >&2 <<'USAGE'
-Usage: install.sh [--source <bundle-directory-or-tar.gz>] [--version <vX.Y.Z>] [--force]
+Usage: install.sh [--source <bundle-directory-or-tar.gz>] [--version <vX.Y.Z>] [--snapshot] [--force]
                   [--harness <codex|claude|copilot|none>]...
 
 Downloads one platform bundle when --source is omitted, then delegates every
@@ -40,6 +40,7 @@ Options:
                      Defaults to every detected harness; none disables it.
   --source PATH      Install a local bundle directory or tar.gz archive.
   --version VERSION  Install an exact release instead of the latest release.
+  --snapshot         Install the latest snapshot build.
   --force            Remove prior Kast-owned state before reinstalling.
   -h, --help         Show this help.
 
@@ -190,7 +191,7 @@ finish_install() {
 
 main() {
   local source="" version="" bundle_root="" bundle_archive="" platform_id=""
-  local force=0 development=0 development_clean=0 repository_root="" active_agent=""
+  local force=0 snapshot=0 development=0 development_clean=0 repository_root="" active_agent=""
   local harness requested none_selected=0 already_selected
   local -a setup_args=() gradle_args=() requested_harnesses=() selected_harnesses=()
 
@@ -198,6 +199,7 @@ main() {
     case "$1" in
       --source) [[ $# -ge 2 ]] || die '--source requires a value'; source="$2"; shift 2 ;;
       --version) [[ $# -ge 2 ]] || die '--version requires a value'; version="$2"; shift 2 ;;
+      --snapshot) snapshot=1; shift ;;
       --force) force=1; shift ;;
       --development) development=1; shift ;;
       --clean) development_clean=1; shift ;;
@@ -219,8 +221,11 @@ main() {
       || die 'development options are available only from the Kast Git repository'
   fi
   ((development_clean == 0 || development == 1)) || die '--clean requires --development'
-  if ((development == 1)) && { [[ -n "$source" || -n "$version" ]] || ((force == 1)); }; then
+  if ((development == 1)) && { [[ -n "$source" || -n "$version" ]] || ((snapshot == 1 || force == 1)); }; then
     die '--development cannot be combined with release installer options'
+  fi
+  if ((snapshot == 1)) && [[ -n "$source" || -n "$version" ]]; then
+    die '--snapshot cannot be combined with --source or --version'
   fi
 
   if ((${#requested_harnesses[@]} == 0)); then
@@ -268,6 +273,7 @@ main() {
   if [[ -z "$source" ]]; then
     require curl
     ui_step "Resolving release"
+    ((snapshot == 0)) || version="snapshot"
     version="${version:-$(latest_version)}"
     platform_id="$(platform)"
     ui_info "${version} · ${platform_id}"


### PR DESCRIPTION
## What

- build CLI, indexer, and setup bundles for all supported platforms after green `main` CI
- publish verified bundles to the rolling `snapshot` prerelease
- add `install.sh --snapshot` without changing stable version resolution

## Why

Main snapshots make merged work installable before the next stable release.

## Validation

- `bash .github/scripts/install/test-snapshot-installer-contract.sh`
- `bash .github/scripts/install/test-macos-installer-contract.sh`
- `bash .github/scripts/release/test-release-workflow-contract.sh`
- `python3 .github/scripts/check-repository-shape.py`
- snapshot workflow YAML parse
- `git diff --check`