### PR TITLE
Publish snapshots through immutable releases

### DIFF
--- a/.github/scripts/install/test-snapshot-installer-contract.sh
+++ b/.github/scripts/install/test-snapshot-installer-contract.sh
@@ -11,6 +11,11 @@ require() {
   grep -Fq -- "$text" "$file" || die "$message"
 }
 
+reject() {
+  local file="$1" text="$2" message="$3"
+  ! grep -Fq -- "$text" "$file" || die "$message"
+}
+
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
 installer="$repo_root/install.sh"
 workflow="$repo_root/.github/workflows/snapshot.yml"
@@ -41,6 +46,7 @@ cat >"$scratch/bin/curl" <<'SH'
 set -euo pipefail
 printf '%s\n' "$*" >>"${KAST_SNAPSHOT_TEST_CURL_LOG:?}"
 output=""
+url=""
 while (($# > 0)); do
   case "$1" in
     -o|--output)
@@ -48,11 +54,15 @@ while (($# > 0)); do
       output="$2"
       shift 2
       ;;
-    *) shift ;;
+    *) url="$1"; shift ;;
   esac
 done
-[[ -n "$output" ]]
-cp "${KAST_SNAPSHOT_TEST_ARCHIVE:?}" "$output"
+if [[ -n "$output" ]]; then
+  cp "${KAST_SNAPSHOT_TEST_ARCHIVE:?}" "$output"
+else
+  [[ "$url" == "${KAST_SNAPSHOT_TEST_API_URL:?}" ]]
+  printf '[{"tag_name":"%s","prerelease":true}]\n' "${KAST_SNAPSHOT_TEST_TAG:?}"
+fi
 SH
 chmod 755 "$scratch/bin/curl"
 
@@ -71,7 +81,10 @@ run_installer() {
     PATH="$scratch/bin:$PATH" \
     KAST_HOME="$scratch/kast-home" \
     KAST_RELEASES_URL="https://downloads.example.invalid/releases" \
+    KAST_RELEASES_API_URL="https://api.example.invalid/releases" \
     KAST_SNAPSHOT_TEST_ARCHIVE="$scratch/kast-snapshot.tar.gz" \
+    KAST_SNAPSHOT_TEST_API_URL="https://api.example.invalid/releases" \
+    KAST_SNAPSHOT_TEST_TAG="snapshot-ce211e2a805f" \
     KAST_SNAPSHOT_TEST_CURL_LOG="$scratch/curl.log" \
     KAST_SNAPSHOT_TEST_SETUP_LOG="$scratch/setup.log" \
     "$installer" "$@" >"$scratch/stdout" 2>"$scratch/stderr"
@@ -80,9 +93,13 @@ run_installer() {
 run_installer --snapshot --harness none \
   || { sed -n '1,120p' "$scratch/stderr" >&2; die "--snapshot installation failed"; }
 grep -Fq -- \
-  "https://downloads.example.invalid/releases/download/snapshot/kast-${platform}-snapshot.tar.gz" \
+  "https://api.example.invalid/releases" \
   "$scratch/curl.log" \
-  || die "--snapshot did not download the rolling snapshot asset"
+  || die "--snapshot did not resolve the newest published snapshot"
+grep -Fq -- \
+  "https://downloads.example.invalid/releases/download/snapshot-ce211e2a805f/kast-${platform}-snapshot.tar.gz" \
+  "$scratch/curl.log" \
+  || die "--snapshot did not download the resolved immutable snapshot asset"
 grep -Eq '^setup --source .*/kast-snapshot$' "$scratch/setup.log" \
   || die "--snapshot did not delegate installation to kastctl"
 
@@ -125,16 +142,26 @@ require "$workflow" 'release_tag: snapshot' \
   "snapshot build inputs must use the rolling snapshot asset name"
 require "$workflow" 'version: ${{ needs.validate.outputs.snapshot-tag }}' \
   "snapshot bundles must embed the resolved snapshot version"
-require "$workflow" 'gh release create snapshot' \
-  "snapshot publication must create the rolling prerelease"
+require "$workflow" 'snapshot_tag="snapshot-${source_sha:0:12}"' \
+  "snapshot publication must derive an immutable source tag"
+require "$workflow" 'gh release create "$snapshot_tag"' \
+  "snapshot publication must create a source-specific prerelease"
+require "$workflow" '--draft' \
+  "snapshot assets must upload before immutable publication"
+require "$workflow" '--draft=false' \
+  "snapshot publication must make the verified draft visible"
 require "$workflow" '--prerelease' \
   "snapshot release must not be presented as stable"
-require "$workflow" 'gh release upload snapshot' \
+require "$workflow" 'gh release upload "$snapshot_tag"' \
   "snapshot publication must upload installable bundles"
 require "$workflow" 'dist/kast-*-snapshot.tar.gz' \
   "snapshot publication must use installer-stable asset names"
 require "$workflow" '--clobber' \
-  "rolling snapshot assets must replace the previous merge build"
+  "draft snapshot reruns must replace incomplete assets"
+require "$workflow" 'isImmutable' \
+  "snapshot publication must verify the immutable result"
+reject "$workflow" 'git/refs/tags/snapshot' \
+  "snapshot publication must not move a shared release tag"
 
 require "$setup_builder" 'version:' \
   "setup bundle builder must accept an explicit bundle version"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -487,39 +487,56 @@ jobs:
               || { echo "Refusing to publish stale snapshot ${source_sha}; main is ${current_main}" >&2; exit 1; }
           fi
 
-          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/snapshot" >/dev/null 2>&1; then
-            gh api --method PATCH \
-              "repos/${GITHUB_REPOSITORY}/git/refs/tags/snapshot" \
-              -f sha="$source_sha" \
-              -F force=true >/dev/null
-          else
-            gh api --method POST \
-              "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref=refs/tags/snapshot \
-              -f sha="$source_sha" >/dev/null
-          fi
-
+          snapshot_tag="snapshot-${source_sha:0:12}"
           printf -v notes 'Source: %s\nVersion: %s' \
             "$source_sha" \
             "${{ needs.validate.outputs.snapshot-tag }}"
-          if gh release view snapshot --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release edit snapshot \
+
+          verify_immutable_release() {
+            gh release view "$snapshot_tag" \
               --repo "$GITHUB_REPOSITORY" \
-              --prerelease \
-              --target "$source_sha" \
-              --title "Latest snapshot" \
-              --notes "$notes"
+              --json assets,isImmutable,targetCommitish \
+              | jq -e --arg source_sha "$source_sha" '
+                  .isImmutable == true
+                  and .targetCommitish == $source_sha
+                  and ([.assets[].name] | sort) == [
+                    "kast-linux-arm64-snapshot.tar.gz",
+                    "kast-linux-arm64-snapshot.tar.gz.sha256",
+                    "kast-linux-x64-snapshot.tar.gz",
+                    "kast-linux-x64-snapshot.tar.gz.sha256",
+                    "kast-macos-arm64-snapshot.tar.gz",
+                    "kast-macos-arm64-snapshot.tar.gz.sha256",
+                    "kast-macos-x64-snapshot.tar.gz",
+                    "kast-macos-x64-snapshot.tar.gz.sha256"
+                  ]
+                ' >/dev/null
+          }
+
+          if gh release view "$snapshot_tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if gh release view "$snapshot_tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json isImmutable \
+              --jq .isImmutable \
+              | grep -Fx true >/dev/null; then
+              verify_immutable_release
+              exit 0
+            fi
           else
-            gh release create snapshot \
+            gh release create "$snapshot_tag" \
               --repo "$GITHUB_REPOSITORY" \
-              --verify-tag \
-              --prerelease \
+              --draft \
               --target "$source_sha" \
-              --title "Latest snapshot" \
+              --title "Snapshot ${source_sha:0:12}" \
               --notes "$notes"
           fi
-          gh release upload snapshot \
+
+          gh release upload "$snapshot_tag" \
             --repo "$GITHUB_REPOSITORY" \
             dist/kast-*-snapshot.tar.gz \
             dist/kast-*-snapshot.tar.gz.sha256 \
             --clobber
+          gh release edit "$snapshot_tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false \
+            --prerelease
+          verify_immutable_release

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 set -Eeuo pipefail
 
 RELEASES_URL="${KAST_RELEASES_URL:-https://github.com/amichne/kast/releases}"
+RELEASES_API_URL="${KAST_RELEASES_API_URL:-https://api.github.com/repos/amichne/kast/releases}"
 setup_scratch=""
 
 cleanup() {
@@ -47,6 +48,8 @@ Options:
 Environment:
   KAST_HOME          Active install root. Defaults to ~/.local/share/kast.
   KAST_RELEASES_URL  Release base URL. Defaults to the Kast GitHub releases.
+  KAST_RELEASES_API_URL
+                     Releases API used to resolve the latest snapshot.
 USAGE
   if kast_repository_root >/dev/null; then
     cat >&2 <<'USAGE'
@@ -148,6 +151,24 @@ latest_version() {
   printf '%s\n' "${effective##*/}"
 }
 
+latest_snapshot_tag() {
+  local tag
+  tag="$(
+    curl -fsSL -H 'Accept: application/vnd.github+json' "$RELEASES_API_URL" \
+      | awk '
+          /"tag_name"[[:space:]]*:[[:space:]]*"snapshot-[^"]+"/ {
+            value = $0
+            sub(/^.*"tag_name"[[:space:]]*:[[:space:]]*"/, "", value)
+            sub(/".*$/, "", value)
+            print value
+            exit
+          }
+        '
+  )"
+  [[ -n "$tag" ]] || die 'no published snapshot is available'
+  printf '%s\n' "$tag"
+}
+
 download_artifact() {
   local label="$1" url="$2" destination="$3"
   ui_step "Downloading ${label}"
@@ -190,7 +211,7 @@ finish_install() {
 }
 
 main() {
-  local source="" version="" bundle_root="" bundle_archive="" platform_id=""
+  local source="" version="" artifact_version="" bundle_root="" bundle_archive="" platform_id=""
   local force=0 snapshot=0 development=0 development_clean=0 repository_root="" active_agent=""
   local harness requested none_selected=0 already_selected
   local -a setup_args=() gradle_args=() requested_harnesses=() selected_harnesses=()
@@ -273,12 +294,14 @@ main() {
   if [[ -z "$source" ]]; then
     require curl
     ui_step "Resolving release"
-    ((snapshot == 0)) || version="snapshot"
+    ((snapshot == 0)) || version="$(latest_snapshot_tag)"
     version="${version:-$(latest_version)}"
+    artifact_version="$version"
+    ((snapshot == 0)) || artifact_version="snapshot"
     platform_id="$(platform)"
     ui_info "${version} · ${platform_id}"
     bundle_archive="${setup_scratch}/kast-bundle.tar.gz"
-    source="${RELEASES_URL}/download/${version}/kast-${platform_id}-${version}.tar.gz"
+    source="${RELEASES_URL}/download/${version}/kast-${platform_id}-${artifact_version}.tar.gz"
     download_artifact "Kast bundle" "$source" "$bundle_archive"
     source="$bundle_archive"
   fi


### PR DESCRIPTION
## What

- publish each merged-main snapshot under `snapshot-<source-sha>`
- upload all bundles to a draft before publishing the immutable prerelease
- resolve the newest published snapshot tag in `install.sh --snapshot`
- ignore the failed legacy `snapshot` release

## Why

The first merged publication built all bundles but GitHub rejected asset replacement because published releases are immutable. [Run 30969230907](https://github.com/amichne/kast/actions/runs/30969230907) failed with HTTP 422 at the final upload.

## Validation

- `bash .github/scripts/install/test-snapshot-installer-contract.sh`
- `bash .github/scripts/install/test-macos-installer-contract.sh`
- `bash .github/scripts/release/test-release-workflow-contract.sh`
- `python3 .github/scripts/check-repository-shape.py`
- snapshot workflow YAML parse
- `git diff --check`