### PR TITLE
Improve Kast agent tooling surface

### DIFF
--- a/.github/scripts/release/agent-resource-assets.py
+++ b/.github/scripts/release/agent-resource-assets.py
@@ -41,7 +41,7 @@ def version_from_tag(tag: str) -> str:
 
 def source_digest(source: Path) -> str:
     value = hashlib.sha256()
-    paths = [source / "SKILL.md"]
+    paths = [source / "SKILL.md", source / "developer/SKILL.md"]
     paths.extend(
         source / provider / name
         for provider in sorted(PROVIDERS)
@@ -61,6 +61,7 @@ def rendered_files(source: Path, provider: str, version: str) -> dict[str, bytes
         marketplace: source / provider / "marketplace.json",
         plugin: source / provider / "plugin.json",
         hooks: source / provider / "hooks.json",
+        "plugins/kast/skills/developer/SKILL.md": source / "developer/SKILL.md",
         "plugins/kast/skills/kast/SKILL.md": source / "SKILL.md",
     }
     rendered = {
@@ -167,6 +168,7 @@ def verify(release_dir: Path, tag: str, git_sha: str) -> None:
 def verify_archive(contents: bytes, provider: str, version: str) -> None:
     expected = {
         *PROVIDERS[provider],
+        "plugins/kast/skills/developer/SKILL.md",
         "plugins/kast/skills/kast/SKILL.md",
     }
     with tarfile.open(fileobj=io.BytesIO(contents), mode="r:") as archive:

--- a/.github/scripts/release/test-agent-resource-assets.py
+++ b/.github/scripts/release/test-agent-resource-assets.py
@@ -15,6 +15,41 @@ SHA = "a" * 40
 
 
 class AgentResourceAssetsTest(unittest.TestCase):
+    def test_codex_resources_expose_the_agent_operating_contract(self) -> None:
+        source = ROOT / "cli-rs/resources/kast"
+        plugin = json.loads((source / "codex/plugin.json").read_text(encoding="utf-8"))
+        interface = plugin["interface"]
+
+        self.assertEqual("Austin Michne", plugin["author"]["name"])
+        self.assertEqual("Developer Tools", interface["category"])
+        self.assertEqual(["Read", "Write"], interface["capabilities"])
+        self.assertLessEqual(len(interface["shortDescription"]), 30)
+        self.assertGreaterEqual(len(interface["defaultPrompt"]), 3)
+
+        kast_skill = " ".join(
+            (source / "SKILL.md").read_text(encoding="utf-8").split()
+        )
+        for required in (
+            "compact TOON",
+            "nextPage",
+            "standard input",
+            "planId",
+            "limitation",
+            "/kast:developer",
+        ):
+            self.assertIn(required, kast_skill)
+
+        developer_skill = " ".join(
+            (source / "developer/SKILL.md").read_text(encoding="utf-8").split()
+        )
+        for required in (
+            "developerOperations.helpArgs",
+            "error code",
+            "limitation",
+            "next",
+        ):
+            self.assertIn(required, developer_skill)
+
     def test_assets_are_deterministic_versioned_and_verified(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -56,6 +91,7 @@ class AgentResourceAssetsTest(unittest.TestCase):
                         ".agents/plugins/marketplace.json",
                         "plugins/kast/.codex-plugin/plugin.json",
                         "plugins/kast/hooks/hooks.json",
+                        "plugins/kast/skills/developer/SKILL.md",
                         "plugins/kast/skills/kast/SKILL.md",
                     },
                     {member.name for member in members},
@@ -100,6 +136,11 @@ class AgentResourceAssetsTest(unittest.TestCase):
     def write_source(source: Path) -> None:
         source.mkdir(parents=True)
         (source / "SKILL.md").write_text("Use `kast`.\n", encoding="utf-8")
+        developer = source / "developer"
+        developer.mkdir()
+        (developer / "SKILL.md").write_text(
+            "Use the installed Kast control CLI.\n", encoding="utf-8"
+        )
         for provider in ("codex", "claude", "copilot"):
             directory = source / provider
             directory.mkdir()

--- a/cli-rs/resources/kast/SKILL.md
+++ b/cli-rs/resources/kast/SKILL.md
@@ -1,40 +1,61 @@
 ---
 name: kast
-description: Use for compiler-backed Kotlin and Gradle discovery, reference indexing, symbol relationships, graph analysis, diagnostics, and validated changes.
+description: Use when Kotlin or Gradle work needs compiler-backed file discovery, symbol and reference traversal, graph analysis, diagnostics, or validated source changes through the Kast CLI.
 ---
 
 # Kast
 
 Use `kast` as the public interface for Kotlin and Gradle semantic work.
 
-- Run `kast` to inspect current workspace readiness and suggested next actions.
-- Run `kast up` to start or reuse the semantic runtime.
-- Run `kast refresh [PATH...]` after source changes.
-- Run `kast refresh external <FAILURE_ID>...` only when an eligible file-local
-  failure should remain as an explicit external `UNKNOWN` graph boundary.
-- Run `kast files [PATTERN]` to discover Kotlin source and script files.
-- Run `kast symbol find <QUERY>` to locate symbols, then use `show`, `refs`,
-  `callers`, `callees`, `implementations`, `supertypes`, or `subtypes`.
-- Run `kast graph summary` for graph coverage and size. Use `topology`,
-  `communities`, `neighbors`, or `impact` for structural and statistical
-  questions.
-- When a result has `nextPage`, repeat the same `files`, symbol relationship,
-  `graph nodes`, or `graph impact` command with `--page <nextPage>`.
-- Run `kast check [PATH...]` for compiler diagnostics.
-- Run `kast change` with `rename`, `replace`, `add-file`, or `add-declaration`
-  to create a root-bound plan. Review its preview, proof, and limitations.
-- Run `kast apply <PLAN_ID>`. Kast owns the workspace lease, revalidates the
-  plan, applies it, and verifies the postcondition before it returns a receipt.
-- Treat only `VERIFIED` as success. Read `REJECTED`, `CONFLICTED`,
-  `ROLLED_BACK`, or `RECOVERY_REQUIRED` as typed non-success outcomes.
-- After `RECOVERY_REQUIRED`, run `kast recover <RECOVERY_ID>`. Recovery can run
-  in a new process and either verifies the intended result or restores the
-  exact source pre-state.
-- Retrying a terminal plan or recovery receipt does not repeat source writes.
+## Operate
 
-For setup, runtime control, local-state inspection, raw RPC, or release work,
-invoke `/kast:developer`. Read `developerOperations.cli` from `kast`; do not
-assume `kastctl` is on `PATH`.
+1. Run `kast` from the target workspace. Confirm the selected `root`, `ready`,
+   `referenceIndexReady`, `limitation`, and `next` fields.
+2. If evidence is not ready, run the exact suggested `next` command, usually
+   `kast up`, then retry the requested semantic command.
+3. Run `kast <command> --help` when syntax is uncertain. Do not use the retired
+   `kast agent` surface or assume `kastctl` is on `PATH`.
 
-Do not infer semantic success from an empty result. Read `limitation` and the
-suggested `next` commands when evidence is unavailable.
+Select the narrowest operation:
+
+- Use `kast files [PATTERN]` for Kotlin source and script inventory.
+- Use `kast symbol find <QUERY>`, then `show`, `refs`, `callers`, `callees`,
+  `implementations`, `supertypes`, or `subtypes` with the returned identity.
+- Use `kast graph summary`, `nodes`, `neighbors`, `topology`, `communities`, or
+  `impact` for persisted structure and bounded impact.
+- Use `kast check [PATH...]` for compiler diagnostics.
+- Use `kast refresh [PATH...]` after direct source edits. Externalize an
+  eligible failure only when the user accepts an explicit `UNKNOWN` boundary.
+
+## Compose validated changes
+
+Use `kast change rename`, `replace`, `add-file`, or `add-declaration` to create
+one root-bound plan. The last three commands read Kotlin content from standard
+input. Use a quoted heredoc or pipe a trusted file so the shell does not alter
+complex source text.
+
+Review the preview, proof, and limitations before writing. Capture the exact
+`planId`, then run `kast apply <PLAN_ID>` as a separate command. Do not pipe a
+new plan directly into `apply`.
+
+Treat only `VERIFIED` as success. For `RECOVERY_REQUIRED`, capture the exact
+`recoveryId` and run `kast recover <RECOVERY_ID>`. Treat `REJECTED`,
+`CONFLICTED`, and `ROLLED_BACK` as typed non-success outcomes. Retrying a
+terminal receipt does not repeat source writes.
+
+## Read and present evidence
+
+Kast emits compact TOON without an output-format flag. Read named fields; do
+not scrape display position. When a result has `nextPage`, repeat the same
+`files`, symbol relationship, `graph nodes`, or `graph impact` command with
+`--page <nextPage>`. Aggregate only the requested evidence and stop when
+`nextPage` is absent.
+
+Present the outcome first, then the decisive symbols, files, proof, or
+limitations, followed by the next action. Do not paste the full result when a
+small field set proves the claim. Never treat an empty result as complete when
+coverage, `limitation`, or `next` says otherwise.
+
+For setup, runtime control, configuration, local-state inspection, raw RPC, or
+release work, invoke `/kast:developer`. Read `developerOperations.cli` from
+`kast`; do not invent or reuse a control path.

--- a/cli-rs/resources/kast/codex/marketplace.json
+++ b/cli-rs/resources/kast/codex/marketplace.json
@@ -5,7 +5,7 @@
   "name": "kast",
   "plugins": [
     {
-      "category": "Coding",
+      "category": "Developer Tools",
       "name": "kast",
       "policy": {
         "authentication": "ON_INSTALL",

--- a/cli-rs/resources/kast/codex/plugin.json
+++ b/cli-rs/resources/kast/codex/plugin.json
@@ -1,18 +1,36 @@
 {
+  "author": {
+    "name": "Austin Michne",
+    "url": "https://github.com/amichne"
+  },
   "description": "Compiler-backed Kotlin and Gradle semantics for coding agents.",
-  "hooks": [
-    "./hooks/hooks.json"
-  ],
+  "homepage": "https://github.com/amichne/kast",
   "interface": {
     "capabilities": [
-      "Interactive",
+      "Read",
       "Write"
     ],
-    "category": "Coding",
+    "category": "Developer Tools",
+    "defaultPrompt": [
+      "Use Kast to trace this Kotlin symbol's callers and impact before changing it.",
+      "Use Kast to diagnose the changed Kotlin files and present only actionable compiler evidence.",
+      "Use Kast to plan, review, and verify this Kotlin rename."
+    ],
+    "developerName": "Austin Michne",
     "displayName": "Kast",
-    "shortDescription": "Compiler-backed Kotlin and Gradle semantics"
+    "longDescription": "Use compiler-backed Kotlin and Gradle evidence to discover code, traverse symbols and references, inspect graph impact, diagnose changes, and apply verified semantic edits.",
+    "shortDescription": "Kotlin and Gradle semantics",
+    "websiteURL": "https://github.com/amichne/kast"
   },
+  "keywords": [
+    "coding-agents",
+    "gradle",
+    "kotlin",
+    "semantic-analysis"
+  ],
+  "license": "MIT",
   "name": "kast",
+  "repository": "https://github.com/amichne/kast",
   "skills": "./skills/",
   "version": "${KAST_VERSION}"
 }

--- a/cli-rs/resources/kast/developer/SKILL.md
+++ b/cli-rs/resources/kast/developer/SKILL.md
@@ -1,22 +1,30 @@
 ---
 name: developer
-description: Use when a user explicitly requests Kast setup, runtime control, configuration, local-state inspection, raw RPC, or release engineering beyond the public Kast semantic operations.
+description: Use when a user explicitly requests Kast setup, runtime control, configuration, local-state inspection, raw RPC, repair, or release engineering beyond the public semantic operations; do not use for public semantic work.
 ---
 
 # Kast developer operations
 
 Use the installed control CLI only for the requested developer operation.
 
-1. Run `kast` from the target workspace.
-2. Read `developerOperations.cli` from the result. Treat that exact path as the
-   executable authority. Do not assume `kastctl` is on `PATH`.
-3. Execute `developerOperations.cli` with `developerOperations.helpArgs` as
-   separate arguments before using the control surface. Live help defines the
-   available commands. Do not evaluate the path and arguments as a shell string.
+1. Run `kast` from the target workspace. Confirm that it selected the intended
+   root.
+2. Read `developerOperations.cli` and `developerOperations.helpArgs`. Treat the
+   exact path and each help argument as separate process arguments. Do not
+   evaluate them as a shell string. Do not assume `kastctl` is on `PATH`.
+3. Run that live help before selecting a control command. Do not reuse command
+   names or arguments from memory.
 4. Pass the target root explicitly when the selected command accepts
    `--workspace-root`.
 
+If an operation fails, preserve its error code, message, `limitation`, and
+`next` fields. Resolve the failed predicate or run its exact suggested action;
+do not substitute a generic reset, restart, refresh, or repair.
+
 Keep compiler-backed discovery, diagnostics, graph analysis, and validated
 changes on the public `kast` interface. Treat setup, configuration writes,
-runtime stop or restart, raw RPC, and release operations as mutations. Run them
-only when the user authorized that operation.
+runtime stop or restart, raw RPC, repair, and release operations as mutations.
+Run them only when the user authorized that exact operation.
+
+Present the result as outcome, decisive evidence or blocker, and next action.
+Omit unrelated state and full help output after the required command is known.


### PR DESCRIPTION
## Summary

- package the developer recovery skill in every release-matched agent resource archive
- teach concise readiness, live-help, pagination, stdin composition, typed recovery, and evidence-presentation workflows
- add accurate Codex marketplace metadata and starter prompts

## Validation

- `python3 .github/scripts/release/test-agent-resource-assets.py`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test kast_resources`
- `.github/scripts/docs/test-docs-content-contract.sh`
- Skill Creator `quick_validate.py` for both packaged skills
- materialized archive build and verification
- Plugin Eval comparison: 0/F to 72/C, six failures resolved; remaining legal URL findings are optional fields and were not fabricated