### PR TITLE
perf: coalesce identical workspace refreshes

### DIFF
--- a/.agents/RED-GREEN.md
+++ b/.agents/RED-GREEN.md
@@ -2,6 +2,23 @@
 
 ## RED
 
+### Path-keyed source transition coalescing
+
+Command:
+
+```shell
+./gradlew :indexer:test --tests io.github.amichne.kast.idea.WorkspaceTransitionFreshnessTest --no-daemon --console=plain
+```
+
+Expected failure: focused refresh requests carry only the unkeyed
+`WorkspaceSignal.Source`, so a same-path, same-content request arriving during
+an active cycle cannot prove that the cycle subsumes it and unnecessarily
+invalidates the publication.
+
+Observed failure: FAILED as expected during `:indexer:compileTestKotlin`.
+`WorkspaceTransitionRequest`, `WorkspaceSourceFreshness`, and the request-aware
+route derivation do not exist, so the focused coalescing contract cannot compile.
+
 ### Overlay-base raw extraction boundary
 
 Command:
@@ -373,6 +390,14 @@ yet exist.
 Commands:
 
 ```shell
+./gradlew :indexer:test --tests io.github.amichne.kast.idea.WorkspaceTransitionFreshnessTest --tests io.github.amichne.kast.idea.transition.WorkspaceTransitionCoordinatorTest --tests io.github.amichne.kast.idea.WorkspaceTransitionIngressTest --tests io.github.amichne.kast.idea.KastSemanticAdmissionRefreshTest --tests io.github.amichne.kast.idea.backend.nativegraph.NativeSemanticGraphAdmissionTest --tests io.github.amichne.kast.idea.backend.contract.mutation.ExactFileImageCasTest --no-daemon --console=plain
+./gradlew :indexer:test --no-daemon --console=plain
+base_commit=$(git merge-base HEAD origin/main)
+changed_kotlin=(); while IFS= read -r source_file; do [[ -f "$source_file" ]] && changed_kotlin+=("$source_file"); done < <({ git diff --name-only "$base_commit" -- '*.kt'; git ls-files --others --exclude-standard -- '*.kt'; } | sort -u)
+kast refresh "${changed_kotlin[@]}"
+kast check "${changed_kotlin[@]}"
+./gradlew check --no-daemon --console=plain
+python3 .github/scripts/check-repository-shape.py --root .
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test runtime_durable_ownership_smoke missing_live_registration_cannot_be_cleaned_around_remaining_review_regression
 base_commit=$(git merge-base HEAD origin/main)
 changed_kotlin=(); while IFS= read -r source_file; do [[ -f "$source_file" ]] && changed_kotlin+=("$source_file"); done < <(git diff --name-only "$base_commit" -- '*.kt' | sort -u)
@@ -474,4 +499,12 @@ repository-shape gate, and exact nine-file compiler audit passed with zero
 diagnostics or skipped files. The overlay-base KDoc now confines raw validated
 database-path extraction to filesystem, SQLite, and serialization adapters;
 the executable KDoc audit, index-store compilation, and exact-file semantic
-analysis all passed with zero diagnostics or skips.
+analysis all passed with zero diagnostics or skips. Focused refresh requests
+now retain canonical path-to-hash or path-to-tombstone claims; the closed route
+joins exact claims already covered by an active cycle and enqueues changed,
+disjoint, or unkeyed work. The focused six-class contract, all 543 indexer
+tests, repository-wide Gradle gate, and repository-shape gate passed. Exact
+compiler-backed analysis completed all 18 changed Kotlin files with zero
+errors, warnings, infos, or skips. One unrelated first-pass macOS filesystem
+failure interrupted the thousand-file Git fixture; its exact rerun and the
+subsequent complete Gradle gate passed without a source change.

--- a/.agents/RED-GREEN.md
+++ b/.agents/RED-GREEN.md
@@ -2,6 +2,21 @@
 
 ## RED
 
+### Overlay-base raw extraction boundary
+
+Command:
+
+```shell
+rg -U -q '(?s)Raw path extraction from.*RepositorySnapshotDatabase.*filesystem, SQLite, or.*serialization' index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotLayout.kt
+```
+
+Expected failure: the overlay-base validation KDoc states the stronger result
+and finite rejection but does not constrain where callers may unpack the
+validated repository database path.
+
+Observed failure: FAILED as expected. The exact KDoc audit found no permitted
+raw-extraction boundary for the validated `RepositorySnapshotDatabase` path.
+
 ### Repository replacement database authority
 
 Command:
@@ -394,6 +409,10 @@ cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 base_commit=$(git merge-base HEAD origin/main)
 changed_kotlin=(); while IFS= read -r source_file; do [[ -f "$source_file" ]] && changed_kotlin+=("$source_file"); done < <({ git diff --name-only "$base_commit" -- '*.kt'; git ls-files --others --exclude-standard -- '*.kt'; } | sort -u)
 kast check "${changed_kotlin[@]}"
+rg -U -q '(?s)Raw path extraction from.*RepositorySnapshotDatabase.*filesystem, SQLite, or.*serialization' index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotLayout.kt
+./gradlew :index-store:compileKotlin --no-daemon --console=plain
+kast refresh index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotLayout.kt
+kast check index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotLayout.kt
 ```
 
 Observed result: PASSED. Fully missing live registration now produces a
@@ -452,4 +471,7 @@ replacement regression now proves that the stale SQLite database, rollback
 journal, write-ahead log, shared-memory file, and overlay descriptor are all
 absent before typed full-index authority is derived. The focused fallback class, full Gradle gate,
 repository-shape gate, and exact nine-file compiler audit passed with zero
-diagnostics or skipped files.
+diagnostics or skipped files. The overlay-base KDoc now confines raw validated
+database-path extraction to filesystem, SQLite, and serialization adapters;
+the executable KDoc audit, index-store compilation, and exact-file semantic
+analysis all passed with zero diagnostics or skips.

--- a/.agents/RED-GREEN.md
+++ b/.agents/RED-GREEN.md
@@ -2,38 +2,6 @@
 
 ## RED
 
-### Path-keyed source transition coalescing
-
-Command:
-
-```shell
-./gradlew :indexer:test --tests io.github.amichne.kast.idea.WorkspaceTransitionFreshnessTest --no-daemon --console=plain
-```
-
-Expected failure: focused refresh requests carry only the unkeyed
-`WorkspaceSignal.Source`, so a same-path, same-content request arriving during
-an active cycle cannot prove that the cycle subsumes it and unnecessarily
-invalidates the publication.
-
-Observed failure: FAILED as expected during `:indexer:compileTestKotlin`.
-`WorkspaceTransitionRequest`, `WorkspaceSourceFreshness`, and the request-aware
-route derivation do not exist, so the focused coalescing contract cannot compile.
-
-### Overlay-base raw extraction boundary
-
-Command:
-
-```shell
-rg -U -q '(?s)Raw path extraction from.*RepositorySnapshotDatabase.*filesystem, SQLite, or.*serialization' index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotLayout.kt
-```
-
-Expected failure: the overlay-base validation KDoc states the stronger result
-and finite rejection but does not constrain where callers may unpack the
-validated repository database path.
-
-Observed failure: FAILED as expected. The exact KDoc audit found no permitted
-raw-extraction boundary for the validated `RepositorySnapshotDatabase` path.
-
 ### Repository replacement database authority
 
 Command:
@@ -390,14 +358,6 @@ yet exist.
 Commands:
 
 ```shell
-./gradlew :indexer:test --tests io.github.amichne.kast.idea.WorkspaceTransitionFreshnessTest --tests io.github.amichne.kast.idea.transition.WorkspaceTransitionCoordinatorTest --tests io.github.amichne.kast.idea.WorkspaceTransitionIngressTest --tests io.github.amichne.kast.idea.KastSemanticAdmissionRefreshTest --tests io.github.amichne.kast.idea.backend.nativegraph.NativeSemanticGraphAdmissionTest --tests io.github.amichne.kast.idea.backend.contract.mutation.ExactFileImageCasTest --no-daemon --console=plain
-./gradlew :indexer:test --no-daemon --console=plain
-base_commit=$(git merge-base HEAD origin/main)
-changed_kotlin=(); while IFS= read -r source_file; do [[ -f "$source_file" ]] && changed_kotlin+=("$source_file"); done < <({ git diff --name-only "$base_commit" -- '*.kt'; git ls-files --others --exclude-standard -- '*.kt'; } | sort -u)
-kast refresh "${changed_kotlin[@]}"
-kast check "${changed_kotlin[@]}"
-./gradlew check --no-daemon --console=plain
-python3 .github/scripts/check-repository-shape.py --root .
 cargo test --manifest-path cli-rs/Cargo.toml --locked --test runtime_durable_ownership_smoke missing_live_registration_cannot_be_cleaned_around_remaining_review_regression
 base_commit=$(git merge-base HEAD origin/main)
 changed_kotlin=(); while IFS= read -r source_file; do [[ -f "$source_file" ]] && changed_kotlin+=("$source_file"); done < <(git diff --name-only "$base_commit" -- '*.kt' | sort -u)
@@ -434,10 +394,6 @@ cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check
 base_commit=$(git merge-base HEAD origin/main)
 changed_kotlin=(); while IFS= read -r source_file; do [[ -f "$source_file" ]] && changed_kotlin+=("$source_file"); done < <({ git diff --name-only "$base_commit" -- '*.kt'; git ls-files --others --exclude-standard -- '*.kt'; } | sort -u)
 kast check "${changed_kotlin[@]}"
-rg -U -q '(?s)Raw path extraction from.*RepositorySnapshotDatabase.*filesystem, SQLite, or.*serialization' index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotLayout.kt
-./gradlew :index-store:compileKotlin --no-daemon --console=plain
-kast refresh index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotLayout.kt
-kast check index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotLayout.kt
 ```
 
 Observed result: PASSED. Fully missing live registration now produces a
@@ -496,15 +452,4 @@ replacement regression now proves that the stale SQLite database, rollback
 journal, write-ahead log, shared-memory file, and overlay descriptor are all
 absent before typed full-index authority is derived. The focused fallback class, full Gradle gate,
 repository-shape gate, and exact nine-file compiler audit passed with zero
-diagnostics or skipped files. The overlay-base KDoc now confines raw validated
-database-path extraction to filesystem, SQLite, and serialization adapters;
-the executable KDoc audit, index-store compilation, and exact-file semantic
-analysis all passed with zero diagnostics or skips. Focused refresh requests
-now retain canonical path-to-hash or path-to-tombstone claims; the closed route
-joins exact claims already covered by an active cycle and enqueues changed,
-disjoint, or unkeyed work. The focused six-class contract, all 543 indexer
-tests, repository-wide Gradle gate, and repository-shape gate passed. Exact
-compiler-backed analysis completed all 18 changed Kotlin files with zero
-errors, warnings, infos, or skips. One unrelated first-pass macOS filesystem
-failure interrupted the thousand-file Git fixture; its exact rerun and the
-subsequent complete Gradle gate passed without a source change.
+diagnostics or skipped files.

--- a/docs/internal/pre-1.0-breaking-changes.md
+++ b/docs/internal/pre-1.0-breaking-changes.md
@@ -1,5 +1,15 @@
 # Pre-1.0 Breaking Changes
 
+## 2026-08-07 — Path-keyed source transition requests
+
+- Removal: the unkeyed `WorkspaceTransitionRequester.reconcile(WorkspaceSignal)` operation and the assumption that every focused source request must invalidate an active publication cycle.
+- Replacement: `WorkspaceTransitionRequest`, exact canonical path-to-content-hash or path-to-tombstone claims, and the closed `Join`, `Enqueue`, or `Rejected` route.
+- Reason: concurrent refresh and diagnostics requests for the same unchanged files must share one safe publication cycle, while changed, disjoint, ambiguous, and unkeyed work must still fail closed into the pending overlay/tombstone lane.
+- Paths: `indexer/src/main/kotlin/io/github/amichne/kast/idea/transition`, `indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service`, `indexer/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic`, and focused tests.
+- Proof: `WorkspaceTransitionFreshnessTest`, `WorkspaceTransitionCoordinatorTest`, `WorkspaceTransitionIngressTest`, `KastSemanticAdmissionRefreshTest`, the complete indexer suite, exact changed-Kotlin compiler analysis, full Gradle checks, and the repository-shape gate.
+- Introduced by: PR #566 fast-follow.
+- Compatibility: none. Internal callers must submit a typed transition request; no signal-only reconciliation adapter remains.
+
 ## 2026-08-07 — Flat workspace index and SQLite publication
 
 - Removal: hierarchical Git/local workspace directories, local workspace registries, per-workspace `semantic-generations` directories, immutable generation copies, `current.json` pointers, restart copy-back, and pointer-durability result variants.

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotLayout.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/snapshot/RepositorySnapshotLayout.kt
@@ -97,6 +97,11 @@ internal class RepositorySnapshotLayout private constructor(
      * this exact repository, explicit authority for another repository, or a
      * finite rejection when the declared path targets this repository but its
      * snapshot evidence is invalid.
+     *
+     * Raw path extraction from
+     * [RepositorySnapshotDatabase] is permitted only at filesystem, SQLite,
+     * or serialization adapters; all other callers must retain the returned
+     * repository proof.
      */
     fun resolveOverlayBase(overlay: OverlayManifest): RepositoryOverlayBaseResolution {
         val expected = databasePath(overlay.base)

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/CoordinatedSemanticOperations.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/CoordinatedSemanticOperations.kt
@@ -79,7 +79,10 @@ internal suspend fun KastIndexerBackend.coordinatedRefresh(
  *
  * Focused refreshes retain canonical path-and-content freshness proof. A full
  * refresh retains its recovery-audit identity without manufacturing file
- * claims.
+ * claims. The returned request remains opaque through coalescing: raw signals
+ * may be extracted only by ingress and worker routing, coordinator aggregation,
+ * and semantic-admission detail rendering; freshness claims may be consumed
+ * only by freshness aggregation and transition coverage.
  */
 private fun KastIndexerBackend.refreshTransitionRequest(
     query: ParsedRefreshQuery,

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/CoordinatedSemanticOperations.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/backend/semantic/CoordinatedSemanticOperations.kt
@@ -16,6 +16,7 @@ import io.github.amichne.kast.idea.backend.mutation.exactFileImageCasOperation
 import io.github.amichne.kast.idea.backend.mutation.recoverMutationScratchOperation
 import io.github.amichne.kast.idea.backend.mutation.refreshOperation
 import io.github.amichne.kast.idea.transition.WorkspaceSignal
+import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
 
 internal suspend fun KastIndexerBackend.coordinatedSemanticGraph(
     query: ParsedSemanticGraphQuery,
@@ -23,7 +24,9 @@ internal suspend fun KastIndexerBackend.coordinatedSemanticGraph(
     return try {
         workspaceSemanticGate.current { semanticGraphOperation(query) }
     } catch (_: PublishedSemanticGraphIncompleteException) {
-        workspaceTransitionRequester.reconcile(WorkspaceSignal.RecoveryAudit)
+        workspaceTransitionRequester.reconcile(
+            WorkspaceTransitionRequest.Unkeyed(WorkspaceSignal.RecoveryAudit),
+        )
         workspaceSemanticGate.current { semanticGraphOperation(query) }
     }
 }
@@ -66,8 +69,25 @@ internal suspend fun KastIndexerBackend.coordinatedRefresh(
             refreshOperation(query)
         }
     }
-    workspaceTransitionRequester.reconcile(
-        if (query.filePaths.isEmpty()) WorkspaceSignal.RecoveryAudit else WorkspaceSignal.Source,
-    )
+    workspaceTransitionRequester.reconcile(refreshTransitionRequest(query))
     return workspaceSemanticGate.current { refreshOperation(query) }
+}
+
+/**
+ * Boundary transition:
+ * `(ParsedRefreshQuery, IdeaWorkspaceIdentity) -> WorkspaceTransitionRequest`.
+ *
+ * Focused refreshes retain canonical path-and-content freshness proof. A full
+ * refresh retains its recovery-audit identity without manufacturing file
+ * claims.
+ */
+private fun KastIndexerBackend.refreshTransitionRequest(
+    query: ParsedRefreshQuery,
+): WorkspaceTransitionRequest = if (query.filePaths.isEmpty()) {
+    WorkspaceTransitionRequest.Unkeyed(WorkspaceSignal.RecoveryAudit)
+} else {
+    WorkspaceTransitionRequest.sourceFiles(
+        workspaceRoot = workspaceIdentity.canonicalWorkspaceRootPath,
+        paths = query.filePaths,
+    )
 }

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastIdeaProjectIndexing.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/KastIdeaProjectIndexing.kt
@@ -21,6 +21,7 @@ import io.github.amichne.kast.idea.transition.GitWorktreeRegistrationProof
 import io.github.amichne.kast.idea.transition.WorkspaceEventWakeup
 import io.github.amichne.kast.idea.transition.WorkspaceSignal
 import io.github.amichne.kast.idea.transition.WorkspaceStateIdentity
+import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
 import io.github.amichne.kast.idea.transition.WorkspaceVfsEventObserver
 import io.github.amichne.kast.idea.transition.WorkspaceVfsObservationScope
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
@@ -95,7 +96,7 @@ internal class KastIdeaProjectIndexing(
     private val indexingTerminated = CountDownLatch(1)
     private val lifecycleLock = Any()
     private val transitionWorkerLock = Any()
-    private val bufferedWorkspaceSignals = linkedSetOf<WorkspaceSignal>()
+    private val bufferedWorkspaceRequests = linkedSetOf<WorkspaceTransitionRequest>()
 
     @Volatile
     private var indexingThread: Thread? = null
@@ -107,7 +108,7 @@ internal class KastIdeaProjectIndexing(
     private var transitionWorker: WorkspaceTransitionWorker? = null
 
     init {
-        transitionIngress.bind(::observeWorkspaceSignal)
+        transitionIngress.bindRequest(::observeWorkspaceRequest)
     }
 
     fun start() {
@@ -309,8 +310,8 @@ internal class KastIdeaProjectIndexing(
             },
         )
         synchronized(transitionWorkerLock) {
-            bufferedWorkspaceSignals.forEach(worker::observe)
-            bufferedWorkspaceSignals.clear()
+            bufferedWorkspaceRequests.forEach(worker::observe)
+            bufferedWorkspaceRequests.clear()
             transitionWorker = worker
         }
         worker.requestInitialReconciliation()
@@ -324,12 +325,16 @@ internal class KastIdeaProjectIndexing(
     }
 
     private fun observeWorkspaceSignal(signal: WorkspaceSignal) {
-        semanticAdmission.dirty("workspace event requires reconciliation: ${signal.name}")
-        routeWorkspaceSignal(
+        observeWorkspaceRequest(WorkspaceTransitionRequest.Unkeyed(signal))
+    }
+
+    private fun observeWorkspaceRequest(request: WorkspaceTransitionRequest) {
+        semanticAdmission.dirty("workspace event requires reconciliation: ${request.signal.name}")
+        routeWorkspaceRequest(
             lock = transitionWorkerLock,
-            signal = signal,
+            request = request,
             enqueue = { observed ->
-                transitionWorker?.observe(observed) ?: run { bufferedWorkspaceSignals += observed }
+                transitionWorker?.observe(observed) ?: run { bufferedWorkspaceRequests += observed }
             },
             wake = eventWakeup::signal,
         )

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionIngress.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionIngress.kt
@@ -103,22 +103,12 @@ internal class WorkspaceTransitionIngress(
 
                 is WorkspaceTransitionCompletion.Blocked ->
                     waiters.toList().onEach(waiters::remove).map { waiter ->
-                        waiter to Result.failure(
-                            ConflictException(
-                                message = "Workspace reconciliation is blocked: ${completion.blocker.detail}",
-                                details = mapOf("phase" to completion.blocker.phase.name),
-                            ),
-                        )
+                        waiter to Result.failure(completion.blocker.toConflict())
                     }
 
                 is WorkspaceTransitionCompletion.Invalid ->
                     waiters.toList().onEach(waiters::remove).map { waiter ->
-                        waiter to Result.failure(
-                            ConflictException(
-                                message = "Workspace transition published an invalid completion state",
-                                details = mapOf("lifecycle" to completion.lifecycle.name),
-                            ),
-                        )
+                        waiter to Result.failure(completion.lifecycle.toInvalidCompletionConflict())
                     }
 
                 WorkspaceTransitionCompletion.InProgress -> emptyList()
@@ -139,7 +129,7 @@ internal class WorkspaceTransitionIngress(
                 awaitStable(waiter)
             }
 
-            is WorkspaceTransitionRoute.Join.Awaiting -> awaitStable(register(route.baseline))
+            is WorkspaceTransitionRoute.Join.Awaiting -> awaitStable(register(route))
             is WorkspaceTransitionRoute.Join.Published -> route.manifest
             is WorkspaceTransitionRoute.Rejected -> throw route.failure.toConflict()
         }
@@ -200,15 +190,40 @@ internal class WorkspaceTransitionIngress(
         return register(PublishedWorkspaceGenerationState.Published(baseline))
     }
 
+    private fun register(join: WorkspaceTransitionRoute.Join.Awaiting): TransitionWaiter {
+        val waiter = TransitionWaiter(join.baseline)
+        synchronized(lock) {
+            check(binding != IngressBinding.Closed) { "Workspace transition ingress is closed" }
+            when (val registration = WorkspaceTransitionJoinRegistration.derive(join, observation)) {
+                WorkspaceTransitionJoinRegistration.Awaiting -> waiters += waiter
+                is WorkspaceTransitionJoinRegistration.Published -> waiter.result.complete(registration.manifest)
+                is WorkspaceTransitionJoinRegistration.Blocked -> waiter.result.completeExceptionally(
+                    registration.blocker.toConflict(),
+                )
+
+                is WorkspaceTransitionJoinRegistration.Invalid -> waiter.result.completeExceptionally(
+                    registration.lifecycle.toInvalidCompletionConflict(),
+                )
+            }
+        }
+        reconcileReadyAdmission(waiter)
+        return waiter
+    }
+
     private fun register(baseline: PublishedWorkspaceGenerationState): TransitionWaiter {
         val waiter = TransitionWaiter(baseline)
         synchronized(lock) {
             check(binding != IngressBinding.Closed) { "Workspace transition ingress is closed" }
             waiters += waiter
         }
+        reconcileReadyAdmission(waiter)
+        return waiter
+    }
+
+    private fun reconcileReadyAdmission(waiter: TransitionWaiter) {
         when (val current = semanticAdmission.status()) {
             is IdeaIndexSemanticAdmission.Status.Ready -> if (
-                PublishedWorkspaceGenerationState.Published(current.generation) != baseline &&
+                PublishedWorkspaceGenerationState.Published(current.generation) != waiter.baseline &&
                 remove(waiter) == WaiterRemoval.Removed
             ) {
                 waiter.result.complete(current.generation)
@@ -218,7 +233,6 @@ internal class WorkspaceTransitionIngress(
             is IdeaIndexSemanticAdmission.Status.Failed,
             -> Unit
         }
-        return waiter
     }
 
     private fun request(request: WorkspaceTransitionRequest, waiter: TransitionWaiter) {

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionIngress.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionIngress.kt
@@ -132,14 +132,17 @@ internal class WorkspaceTransitionIngress(
     override suspend fun reconcile(
         request: WorkspaceTransitionRequest,
     ): PublishedWorkspaceGenerationManifest {
-        val route = initialRoute(request)
-        val waiter = when (route) {
-            is WorkspaceTransitionRoute.Enqueue -> register(route.baseline)
-            is WorkspaceTransitionRoute.Join -> register(route.baseline)
+        return when (val route = initialRoute(request)) {
+            is WorkspaceTransitionRoute.Enqueue -> {
+                val waiter = register(route.baseline)
+                request(request, waiter)
+                awaitStable(waiter)
+            }
+
+            is WorkspaceTransitionRoute.Join.Awaiting -> awaitStable(register(route.baseline))
+            is WorkspaceTransitionRoute.Join.Published -> route.manifest
             is WorkspaceTransitionRoute.Rejected -> throw route.failure.toConflict()
         }
-        if (route is WorkspaceTransitionRoute.Enqueue) request(request, waiter)
-        return awaitStable(waiter)
     }
 
     override suspend fun <T> mutate(
@@ -188,9 +191,8 @@ internal class WorkspaceTransitionIngress(
     }
 
     private fun initialRoute(request: WorkspaceTransitionRequest): WorkspaceTransitionRoute {
-        val status = semanticAdmission.status()
         return synchronized(lock) {
-            WorkspaceTransitionRoute.derive(status, observation, request)
+            WorkspaceTransitionRoute.derive(semanticAdmission.status(), observation, request)
         }
     }
 

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionIngress.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionIngress.kt
@@ -3,6 +3,7 @@ package io.github.amichne.kast.idea
 import io.github.amichne.kast.api.contract.RuntimeProgressStage
 import io.github.amichne.kast.api.protocol.ConflictException
 import io.github.amichne.kast.idea.transition.WorkspaceSignal
+import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
 import io.github.amichne.kast.idea.transition.WorkspaceTransitionSnapshot
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationManifest
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationState
@@ -21,7 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 internal interface WorkspaceTransitionRequester {
-    suspend fun reconcile(signal: WorkspaceSignal): PublishedWorkspaceGenerationManifest
+    suspend fun reconcile(request: WorkspaceTransitionRequest): PublishedWorkspaceGenerationManifest
 
     suspend fun <T> mutate(
         signal: WorkspaceSignal,
@@ -36,9 +37,23 @@ internal fun routeWorkspaceSignal(
     enqueue: (WorkspaceSignal) -> Unit,
     wake: (WorkspaceSignal) -> Unit,
 ) {
+    routeWorkspaceRequest(
+        lock = lock,
+        request = WorkspaceTransitionRequest.Unkeyed(signal),
+        enqueue = { observed -> enqueue(observed.signal) },
+        wake = wake,
+    )
+}
+
+internal fun routeWorkspaceRequest(
+    lock: Any,
+    request: WorkspaceTransitionRequest,
+    enqueue: (WorkspaceTransitionRequest) -> Unit,
+    wake: (WorkspaceSignal) -> Unit,
+) {
     synchronized(lock) {
-        enqueue(signal)
-        wake(signal)
+        enqueue(request)
+        wake(request.signal)
     }
 }
 
@@ -46,10 +61,10 @@ internal fun routeWorkspaceSignal(
  * Effect-boundary transition:
  * `(IdeaIndexSemanticAdmission, ProgressAwareFutureAwaiter) -> WorkspaceTransitionIngress`.
  *
- * Retains READY publication proof while every request enqueues its freshness
- * signal and shares the single transition publication lane. Waiting consumes
- * typed progress and deadline evidence; the ordinary RPC request budget is not
- * reused as an indexing deadline.
+ * Retains READY publication proof while exact covered requests join and all
+ * other requests enqueue through the single transition publication lane.
+ * Waiting consumes typed progress and deadline evidence; the ordinary RPC
+ * request budget is not reused as an indexing deadline.
  */
 internal class WorkspaceTransitionIngress(
     private val semanticAdmission: IdeaIndexSemanticAdmission,
@@ -62,6 +77,10 @@ internal class WorkspaceTransitionIngress(
     private var binding: IngressBinding = IngressBinding.Unbound
 
     fun bind(request: (WorkspaceSignal) -> Unit) {
+        bindRequest { transition -> request(transition.signal) }
+    }
+
+    fun bindRequest(request: (WorkspaceTransitionRequest) -> Unit) {
         synchronized(lock) {
             binding = when (binding) {
                 IngressBinding.Unbound -> IngressBinding.Bound(request)
@@ -110,9 +129,16 @@ internal class WorkspaceTransitionIngress(
         }
     }
 
-    override suspend fun reconcile(signal: WorkspaceSignal): PublishedWorkspaceGenerationManifest {
-        val waiter = registerInitialWaiter()
-        request(signal, waiter)
+    override suspend fun reconcile(
+        request: WorkspaceTransitionRequest,
+    ): PublishedWorkspaceGenerationManifest {
+        val route = initialRoute(request)
+        val waiter = when (route) {
+            is WorkspaceTransitionRoute.Enqueue -> register(route.baseline)
+            is WorkspaceTransitionRoute.Join -> register(route.baseline)
+            is WorkspaceTransitionRoute.Rejected -> throw route.failure.toConflict()
+        }
+        if (route is WorkspaceTransitionRoute.Enqueue) request(request, waiter)
         return awaitStable(waiter)
     }
 
@@ -138,12 +164,12 @@ internal class WorkspaceTransitionIngress(
             operation()
         } catch (failure: Throwable) {
             permit.close()
-            runCatching { request(signal, waiter) }
+            runCatching { request(WorkspaceTransitionRequest.Unkeyed(signal), waiter) }
             remove(waiter)
             throw failure
         }
         permit.close()
-        request(signal, waiter)
+        request(WorkspaceTransitionRequest.Unkeyed(signal), waiter)
         awaitStable(waiter)
         return result
     }
@@ -161,14 +187,10 @@ internal class WorkspaceTransitionIngress(
         }
     }
 
-    private fun registerInitialWaiter(): TransitionWaiter {
+    private fun initialRoute(request: WorkspaceTransitionRequest): WorkspaceTransitionRoute {
         val status = semanticAdmission.status()
-        val route = synchronized(lock) {
-            WorkspaceTransitionRoute.derive(status, observation)
-        }
-        return when (route) {
-            is WorkspaceTransitionRoute.Enqueue -> register(route.baseline)
-            is WorkspaceTransitionRoute.Rejected -> throw route.failure.toConflict()
+        return synchronized(lock) {
+            WorkspaceTransitionRoute.derive(status, observation, request)
         }
     }
 
@@ -197,8 +219,8 @@ internal class WorkspaceTransitionIngress(
         return waiter
     }
 
-    private fun request(signal: WorkspaceSignal, waiter: TransitionWaiter) {
-        val request = when (val current = synchronized(lock) { binding }) {
+    private fun request(request: WorkspaceTransitionRequest, waiter: TransitionWaiter) {
+        val dispatch = when (val current = synchronized(lock) { binding }) {
             is IngressBinding.Bound -> current.request
             IngressBinding.Unbound -> {
                 remove(waiter)
@@ -211,7 +233,7 @@ internal class WorkspaceTransitionIngress(
             }
         }
         try {
-            request(signal)
+            dispatch(request)
         } catch (failure: Throwable) {
             remove(waiter)
             throw failure
@@ -344,7 +366,7 @@ internal class WorkspaceTransitionIngress(
     private sealed interface IngressBinding {
         data object Unbound : IngressBinding
 
-        data class Bound(val request: (WorkspaceSignal) -> Unit) : IngressBinding
+        data class Bound(val request: (WorkspaceTransitionRequest) -> Unit) : IngressBinding
 
         data object Closed : IngressBinding
     }
@@ -352,32 +374,6 @@ internal class WorkspaceTransitionIngress(
     private enum class WaiterRemoval {
         Removed,
         AlreadyCompleted,
-    }
-
-    private enum class WorkspaceTransitionWaitFailureCode {
-        DEADLINE_EXCEEDED,
-        INGRESS_CLOSED,
-        INTERRUPTED,
-        FUTURE_FAILED,
-        FUTURE_CANCELLED,
-        ;
-
-        companion object {
-            /**
-             * Proof transition:
-             * `RuntimeProgressAwaitFailure -> WorkspaceTransitionWaitFailureCode`.
-             *
-             * Preserves the closed progress-wait failure identity until the
-             * JSON-RPC conflict boundary serializes its enum name.
-             */
-            fun derive(failure: RuntimeProgressAwaitFailure): WorkspaceTransitionWaitFailureCode = when (failure) {
-                is RuntimeProgressAwaitFailure.DeadlineExceeded -> DEADLINE_EXCEEDED
-                is RuntimeProgressAwaitFailure.ProjectDisposed -> INGRESS_CLOSED
-                is RuntimeProgressAwaitFailure.Interrupted -> INTERRUPTED
-                is RuntimeProgressAwaitFailure.FutureFailed -> FUTURE_FAILED
-                is RuntimeProgressAwaitFailure.FutureCancelled -> FUTURE_CANCELLED
-            }
-        }
     }
 
 }

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionRouting.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionRouting.kt
@@ -3,6 +3,8 @@ package io.github.amichne.kast.idea
 import io.github.amichne.kast.api.protocol.ConflictException
 import io.github.amichne.kast.idea.transition.TransitionBlocker
 import io.github.amichne.kast.idea.transition.WorkspaceLifecycle
+import io.github.amichne.kast.idea.transition.WorkspaceSourceFreshnessCoverage
+import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
 import io.github.amichne.kast.idea.transition.WorkspaceTransitionSnapshot
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationManifest
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationState
@@ -18,6 +20,10 @@ internal sealed interface WorkspaceTransitionRoute {
         val baseline: PublishedWorkspaceGenerationState,
     ) : WorkspaceTransitionRoute
 
+    data class Join(
+        val baseline: PublishedWorkspaceGenerationState,
+    ) : WorkspaceTransitionRoute
+
     data class Rejected(
         val failure: WorkspaceTransitionRequestFailure,
     ) : WorkspaceTransitionRoute
@@ -28,22 +34,56 @@ internal sealed interface WorkspaceTransitionRoute {
          * `(IdeaIndexSemanticAdmission.Status, TransitionObservation)`
          * `-> WorkspaceTransitionRoute`.
          *
-         * Every admitted request retains its publication baseline and enqueues
-         * its semantic signal. The waiter still shares the single transition
-         * publication lane, while enqueueing ensures that a request arriving
-         * after the active cycle's VFS refresh invalidates that cycle instead
-         * of being incorrectly treated as covered. Failed admission becomes
-         * finite rejection data.
+         * Every admitted request retains its publication baseline. Exact
+         * source claims already covered by the active cycle become [Join]; all
+         * unkeyed, changed, or disjoint work becomes [Enqueue] so it cannot be
+         * incorrectly treated as covered. Failed admission becomes finite
+         * rejection data.
          */
         fun derive(
             status: IdeaIndexSemanticAdmission.Status,
             observation: TransitionObservation,
+            request: WorkspaceTransitionRequest,
         ): WorkspaceTransitionRoute {
             val admission = TransitionRequestAdmission.derive(status, observation)
             return when (admission) {
                 is TransitionRequestAdmission.Rejected -> Rejected(admission.failure)
-                is TransitionRequestAdmission.Permitted -> Enqueue(admission.baseline)
+                is TransitionRequestAdmission.Permitted -> when (
+                    ActiveSourceRequestCoverage.derive(observation, request)
+                ) {
+                    WorkspaceSourceFreshnessCoverage.Covered -> Join(admission.baseline)
+                    WorkspaceSourceFreshnessCoverage.Uncovered -> Enqueue(admission.baseline)
+                }
             }
+        }
+    }
+}
+
+private object ActiveSourceRequestCoverage {
+    /**
+     * Proof transition:
+     * `(TransitionObservation, WorkspaceTransitionRequest)`
+     * `-> WorkspaceSourceFreshnessCoverage`.
+     *
+     * Only claims retained by the currently observed active cycle can cover a
+     * request. Unobserved and inactive snapshots fail closed as uncovered.
+     */
+    fun derive(
+        observation: TransitionObservation,
+        request: WorkspaceTransitionRequest,
+    ): WorkspaceSourceFreshnessCoverage = when (observation) {
+        TransitionObservation.Unobserved -> WorkspaceSourceFreshnessCoverage.Uncovered
+        is TransitionObservation.Observed -> when (observation.snapshot.lifecycle) {
+            WorkspaceLifecycle.Refreshing,
+            WorkspaceLifecycle.Reconciling,
+            WorkspaceLifecycle.Verifying,
+            -> observation.snapshot.activeSourceFreshness.coverageOf(request)
+
+            WorkspaceLifecycle.Ready,
+            WorkspaceLifecycle.Dirty,
+            WorkspaceLifecycle.Settling,
+            WorkspaceLifecycle.Blocked,
+            -> WorkspaceSourceFreshnessCoverage.Uncovered
         }
     }
 }

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionRouting.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionRouting.kt
@@ -20,9 +20,15 @@ internal sealed interface WorkspaceTransitionRoute {
         val baseline: PublishedWorkspaceGenerationState,
     ) : WorkspaceTransitionRoute
 
-    data class Join(
-        val baseline: PublishedWorkspaceGenerationState,
-    ) : WorkspaceTransitionRoute
+    sealed interface Join : WorkspaceTransitionRoute {
+        data class Awaiting(
+            val baseline: PublishedWorkspaceGenerationState,
+        ) : Join
+
+        data class Published(
+            val manifest: PublishedWorkspaceGenerationManifest,
+        ) : Join
+    }
 
     data class Rejected(
         val failure: WorkspaceTransitionRequestFailure,
@@ -31,14 +37,14 @@ internal sealed interface WorkspaceTransitionRoute {
     companion object {
         /**
          * Proof transition:
-         * `(IdeaIndexSemanticAdmission.Status, TransitionObservation)`
+         * `(IdeaIndexSemanticAdmission.Status, TransitionObservation, WorkspaceTransitionRequest)`
          * `-> WorkspaceTransitionRoute`.
          *
          * Every admitted request retains its publication baseline. Exact
          * source claims already covered by the active cycle become [Join]; all
          * unkeyed, changed, or disjoint work becomes [Enqueue] so it cannot be
-         * incorrectly treated as covered. Failed admission becomes finite
-         * rejection data.
+         * incorrectly treated as covered. Failed admission becomes the finite
+         * [WorkspaceTransitionRequestFailure] rejection.
          */
         fun derive(
             status: IdeaIndexSemanticAdmission.Status,
@@ -51,7 +57,16 @@ internal sealed interface WorkspaceTransitionRoute {
                 is TransitionRequestAdmission.Permitted -> when (
                     ActiveSourceRequestCoverage.derive(observation, request)
                 ) {
-                    WorkspaceSourceFreshnessCoverage.Covered -> Join(admission.baseline)
+                    WorkspaceSourceFreshnessCoverage.Covered -> when (admission) {
+                        is TransitionRequestAdmission.Permitted.Pending -> Join.Awaiting(admission.baseline)
+                        is TransitionRequestAdmission.Permitted.Ready ->
+                            if (admission.baseline == admission.observedBaseline) {
+                                Join.Awaiting(admission.observedBaseline)
+                            } else {
+                                Join.Published(admission.manifest)
+                            }
+                    }
+
                     WorkspaceSourceFreshnessCoverage.Uncovered -> Enqueue(admission.baseline)
                 }
             }
@@ -114,9 +129,21 @@ private object TransitionPublicationBaseline {
 }
 
 private sealed interface TransitionRequestAdmission {
-    data class Permitted(
-        val baseline: PublishedWorkspaceGenerationState,
-    ) : TransitionRequestAdmission
+    sealed interface Permitted : TransitionRequestAdmission {
+        val baseline: PublishedWorkspaceGenerationState
+
+        data class Pending(
+            override val baseline: PublishedWorkspaceGenerationState,
+        ) : Permitted
+
+        data class Ready(
+            val manifest: PublishedWorkspaceGenerationManifest,
+            val observedBaseline: PublishedWorkspaceGenerationState,
+        ) : Permitted {
+            override val baseline: PublishedWorkspaceGenerationState =
+                PublishedWorkspaceGenerationState.Published(manifest)
+        }
+    }
 
     data class Rejected(
         val failure: WorkspaceTransitionRequestFailure,
@@ -128,19 +155,23 @@ private sealed interface TransitionRequestAdmission {
          * `(IdeaIndexSemanticAdmission.Status, TransitionObservation)`
          * `-> TransitionRequestAdmission`.
          *
-         * READY and PENDING retain a publication baseline suitable for a
-         * request or compatible join. FAILED retains a finite rejection and
-         * cannot be reinterpreted as joinable by a stale lifecycle observation.
+         * READY retains both its published generation and the observed
+         * transition baseline. Equality proves that READY is stale relative to
+         * an active observation and must still await that cycle; inequality
+         * proves publication won the observation race. PENDING retains the
+         * observed baseline. FAILED retains a finite rejection and cannot be
+         * reinterpreted as joinable by a stale lifecycle observation.
          */
         fun derive(
             status: IdeaIndexSemanticAdmission.Status,
             observation: TransitionObservation,
         ): TransitionRequestAdmission = when (status) {
-            is IdeaIndexSemanticAdmission.Status.Ready -> Permitted(
-                PublishedWorkspaceGenerationState.Published(status.generation),
+            is IdeaIndexSemanticAdmission.Status.Ready -> Permitted.Ready(
+                manifest = status.generation,
+                observedBaseline = TransitionPublicationBaseline.derive(observation),
             )
 
-            is IdeaIndexSemanticAdmission.Status.Pending -> Permitted(
+            is IdeaIndexSemanticAdmission.Status.Pending -> Permitted.Pending(
                 TransitionPublicationBaseline.derive(observation),
             )
 

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionRouting.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionRouting.kt
@@ -44,7 +44,9 @@ internal sealed interface WorkspaceTransitionRoute {
          * source claims already covered by the active cycle become [Join]; all
          * unkeyed, changed, or disjoint work becomes [Enqueue] so it cannot be
          * incorrectly treated as covered. Failed admission becomes the finite
-         * [WorkspaceTransitionRequestFailure] rejection.
+         * [WorkspaceTransitionRequestFailure] rejection. The returned route
+         * may be unpacked only at the ingress dispatch and waiter-registration
+         * boundary.
          */
         fun derive(
             status: IdeaIndexSemanticAdmission.Status,
@@ -69,6 +71,53 @@ internal sealed interface WorkspaceTransitionRoute {
 
                     WorkspaceSourceFreshnessCoverage.Uncovered -> Enqueue(admission.baseline)
                 }
+            }
+        }
+    }
+}
+
+internal sealed interface WorkspaceTransitionJoinRegistration {
+    data object Awaiting : WorkspaceTransitionJoinRegistration
+
+    data class Published(
+        val manifest: PublishedWorkspaceGenerationManifest,
+    ) : WorkspaceTransitionJoinRegistration
+
+    data class Blocked(
+        val blocker: TransitionBlocker,
+    ) : WorkspaceTransitionJoinRegistration
+
+    data class Invalid(
+        val lifecycle: WorkspaceLifecycle,
+    ) : WorkspaceTransitionJoinRegistration
+
+    companion object {
+        /**
+         * Proof transition:
+         * `(WorkspaceTransitionRoute.Join.Awaiting, TransitionObservation)`
+         * `-> WorkspaceTransitionJoinRegistration`.
+         *
+         * Retains a publication, blocker, or invalid terminal state observed
+         * after a covered route was derived but before its waiter was
+         * registered. The finite result may be unpacked only at the ingress
+         * waiter-registration boundary.
+         */
+        fun derive(
+            join: WorkspaceTransitionRoute.Join.Awaiting,
+            observation: TransitionObservation,
+        ): WorkspaceTransitionJoinRegistration = when (observation) {
+            TransitionObservation.Unobserved -> Awaiting
+            is TransitionObservation.Observed -> when (
+                val completion = WorkspaceTransitionCompletion.derive(observation.snapshot)
+            ) {
+                is WorkspaceTransitionCompletion.Ready -> {
+                    val published = PublishedWorkspaceGenerationState.Published(completion.manifest)
+                    if (published == join.baseline) Awaiting else Published(completion.manifest)
+                }
+
+                is WorkspaceTransitionCompletion.Blocked -> Blocked(completion.blocker)
+                is WorkspaceTransitionCompletion.Invalid -> Invalid(completion.lifecycle)
+                WorkspaceTransitionCompletion.InProgress -> Awaiting
             }
         }
     }
@@ -113,6 +162,18 @@ internal sealed interface WorkspaceTransitionRequestFailure {
         )
     }
 }
+
+/** Converts a retained transition blocker only at the ingress RPC boundary. */
+internal fun TransitionBlocker.toConflict(): ConflictException = ConflictException(
+    message = "Workspace reconciliation is blocked: $detail",
+    details = mapOf("phase" to phase.name),
+)
+
+/** Converts an invalid completion lifecycle only at the ingress RPC boundary. */
+internal fun WorkspaceLifecycle.toInvalidCompletionConflict(): ConflictException = ConflictException(
+    message = "Workspace transition published an invalid completion state",
+    details = mapOf("lifecycle" to name),
+)
 
 private object TransitionPublicationBaseline {
     /**

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionWaitFailureCode.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionWaitFailureCode.kt
@@ -1,0 +1,29 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.indexer.gradle.settlement.RuntimeProgressAwaitFailure
+
+internal enum class WorkspaceTransitionWaitFailureCode {
+    DEADLINE_EXCEEDED,
+    INGRESS_CLOSED,
+    INTERRUPTED,
+    FUTURE_FAILED,
+    FUTURE_CANCELLED,
+    ;
+
+    companion object {
+        /**
+         * Proof transition:
+         * `RuntimeProgressAwaitFailure -> WorkspaceTransitionWaitFailureCode`.
+         *
+         * Preserves the closed progress-wait failure identity until the
+         * JSON-RPC conflict boundary serializes its enum name.
+         */
+        fun derive(failure: RuntimeProgressAwaitFailure): WorkspaceTransitionWaitFailureCode = when (failure) {
+            is RuntimeProgressAwaitFailure.DeadlineExceeded -> DEADLINE_EXCEEDED
+            is RuntimeProgressAwaitFailure.ProjectDisposed -> INGRESS_CLOSED
+            is RuntimeProgressAwaitFailure.Interrupted -> INTERRUPTED
+            is RuntimeProgressAwaitFailure.FutureFailed -> FUTURE_FAILED
+            is RuntimeProgressAwaitFailure.FutureCancelled -> FUTURE_CANCELLED
+        }
+    }
+}

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionWorker.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/runtime/service/transition/WorkspaceTransitionWorker.kt
@@ -17,6 +17,7 @@ import io.github.amichne.kast.idea.transition.WorkspaceSignal
 import io.github.amichne.kast.idea.transition.WorkspaceStateIdentity
 import io.github.amichne.kast.idea.transition.WorkspaceTransitionCoordinator
 import io.github.amichne.kast.idea.transition.WorkspaceTransitionOperations
+import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
 import io.github.amichne.kast.idea.transition.WorkspaceTransitionSnapshot
 import io.github.amichne.kast.idea.transition.WorkspaceWakeup
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationManifest
@@ -187,9 +188,9 @@ internal class WorkspaceTransitionWorker(
         },
     )
 
-    fun observe(signal: WorkspaceSignal) {
-        coordinator.observe(signal)
-    }
+    fun observe(signal: WorkspaceSignal) = coordinator.observe(signal)
+
+    fun observe(request: WorkspaceTransitionRequest) = coordinator.observe(request)
 
     fun requestRecoveryAudit() {
         val audit = try {

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceSourceFreshness.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceSourceFreshness.kt
@@ -65,7 +65,9 @@ internal data class WorkspaceSourceFreshnessClaims private constructor(
      * `-> WorkspaceSourceFreshnessCoverage`.
      *
      * Coverage exists only when the active cycle contains the exact content or
-     * tombstone identity for every requested canonical source path.
+     * tombstone identity for every requested canonical source path. The result
+     * may be unpacked only by [WorkspaceSourceFreshness.coverageOf]; raw source
+     * identities remain private to this claims owner.
      */
     fun coverageOf(requested: WorkspaceSourceFreshnessClaims): WorkspaceSourceFreshnessCoverage =
         if (requested.claimsByPath.all { (path, content) -> claimsByPath[path] == content }) {
@@ -178,6 +180,12 @@ internal sealed interface WorkspaceSourceFreshness {
      * Proof transition:
      * `(active WorkspaceSourceFreshness, WorkspaceTransitionRequest)`
      * `-> WorkspaceSourceFreshnessCoverage`.
+     *
+     * [WorkspaceSourceFreshnessCoverage.Covered] proves that every requested
+     * canonical source path has the same exact content or tombstone identity in
+     * the active cycle, so joining cannot omit newer requested work. The result
+     * may be unpacked only by transition-route admission; raw claims remain
+     * opaque outside freshness aggregation and coverage.
      */
     fun coverageOf(request: WorkspaceTransitionRequest): WorkspaceSourceFreshnessCoverage =
         if (this is Claimed && request is WorkspaceTransitionRequest.SourceFiles) {

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceSourceFreshness.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceSourceFreshness.kt
@@ -1,0 +1,203 @@
+package io.github.amichne.kast.idea.transition
+
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.idea.SemanticPathContentIdentity
+import io.github.amichne.kast.indexstore.api.index.FileContentHash
+import io.github.amichne.kast.indexstore.api.index.SourceIndexFilePolicy
+import io.github.amichne.kast.indexstore.api.index.WorkspaceSourcePath
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal sealed interface WorkspaceTransitionRequest {
+    val signal: WorkspaceSignal
+
+    data class Unkeyed(override val signal: WorkspaceSignal) : WorkspaceTransitionRequest
+
+    @ConsistentCopyVisibility
+    data class SourceFiles internal constructor(
+        val claims: WorkspaceSourceFreshnessClaims,
+    ) : WorkspaceTransitionRequest {
+        override val signal: WorkspaceSignal = WorkspaceSignal.Source
+    }
+
+    companion object {
+        /**
+         * Boundary transition:
+         * `(workspace Path, normalized source Paths) -> WorkspaceTransitionRequest`.
+         *
+         * Produces exact path-and-content claims only when every requested path
+         * belongs to the workspace source authority and is either a regular
+         * file or a proven tombstone. Any unprovable path safely degrades to an
+         * unkeyed source request, which cannot join an active cycle.
+         */
+        fun sourceFiles(
+            workspaceRoot: Path,
+            paths: List<NormalizedPath>,
+        ): WorkspaceTransitionRequest = when (
+            val captured = WorkspaceSourceFreshnessClaims.capture(workspaceRoot, paths)
+        ) {
+            is WorkspaceSourceFreshnessCapture.Available -> SourceFiles(captured.claims)
+            WorkspaceSourceFreshnessCapture.Unavailable -> Unkeyed(WorkspaceSignal.Source)
+        }
+    }
+}
+
+internal sealed interface WorkspaceSourceContentIdentity {
+    data class Present(val hash: FileContentHash) : WorkspaceSourceContentIdentity
+
+    data object Missing : WorkspaceSourceContentIdentity
+}
+
+@ConsistentCopyVisibility
+internal data class WorkspaceSourceFreshnessClaims private constructor(
+    private val claimsByPath: Map<WorkspaceSourcePath, WorkspaceSourceContentIdentity>,
+) {
+    fun followedBy(later: WorkspaceSourceFreshnessClaims): WorkspaceSourceFreshnessClaims =
+        WorkspaceSourceFreshnessClaims(claimsByPath + later.claimsByPath)
+
+    /**
+     * Proof transition:
+     * `(active WorkspaceSourceFreshnessClaims, requested claims)`
+     * `-> WorkspaceSourceFreshnessCoverage`.
+     *
+     * Coverage exists only when the active cycle contains the exact content or
+     * tombstone identity for every requested canonical source path.
+     */
+    fun coverageOf(requested: WorkspaceSourceFreshnessClaims): WorkspaceSourceFreshnessCoverage =
+        if (requested.claimsByPath.all { (path, content) -> claimsByPath[path] == content }) {
+            WorkspaceSourceFreshnessCoverage.Covered
+        } else {
+            WorkspaceSourceFreshnessCoverage.Uncovered
+        }
+
+    companion object {
+        /**
+         * Validation transition:
+         * `(workspace Path, normalized Paths) -> WorkspaceSourceFreshnessCapture`.
+         *
+         * Returns non-empty, workspace-owned source claims or one finite
+         * unavailable state. Raw filesystem observations do not escape this
+         * boundary.
+         */
+        fun capture(
+            workspaceRoot: Path,
+            paths: List<NormalizedPath>,
+        ): WorkspaceSourceFreshnessCapture {
+            if (paths.isEmpty()) return WorkspaceSourceFreshnessCapture.Unavailable
+            val policy = SourceIndexFilePolicy.forWorkspace(workspaceRoot)
+            val claims = linkedMapOf<WorkspaceSourcePath, WorkspaceSourceContentIdentity>()
+            paths.distinct().forEach { normalized ->
+                val sourcePath = policy.sourcePath(normalized.toJavaPath())
+                    ?: return WorkspaceSourceFreshnessCapture.Unavailable
+                val content = when (val resolved = WorkspaceSourceContentResolution.derive(sourcePath)) {
+                    is WorkspaceSourceContentResolution.Available -> resolved.identity
+                    WorkspaceSourceContentResolution.Unavailable ->
+                        return WorkspaceSourceFreshnessCapture.Unavailable
+                }
+                claims[sourcePath] = content
+            }
+            return WorkspaceSourceFreshnessCapture.Available(
+                WorkspaceSourceFreshnessClaims(claims.toMap()),
+            )
+        }
+    }
+}
+
+internal sealed interface WorkspaceSourceFreshnessCapture {
+    data class Available(val claims: WorkspaceSourceFreshnessClaims) : WorkspaceSourceFreshnessCapture
+
+    data object Unavailable : WorkspaceSourceFreshnessCapture
+}
+
+internal sealed interface WorkspaceSourceContentResolution {
+    data class Available(val identity: WorkspaceSourceContentIdentity) : WorkspaceSourceContentResolution
+
+    data object Unavailable : WorkspaceSourceContentResolution
+
+    companion object {
+        /**
+         * Validation transition:
+         * `WorkspaceSourcePath -> WorkspaceSourceContentResolution`.
+         *
+         * A regular file becomes an exact hash, a proven absent path becomes a
+         * tombstone, and every ambiguous filesystem state remains unavailable.
+         */
+        fun derive(path: WorkspaceSourcePath): WorkspaceSourceContentResolution {
+            val file = path.absolute.value.toJavaPath()
+            return try {
+                when {
+                    Files.isRegularFile(file) -> Available(
+                        WorkspaceSourceContentIdentity.Present(
+                            FileContentHash.parse(SemanticPathContentIdentity.file(file)),
+                        ),
+                    )
+
+                    Files.notExists(file) -> Available(WorkspaceSourceContentIdentity.Missing)
+                    else -> Unavailable
+                }
+            } catch (_: IOException) {
+                Unavailable
+            } catch (_: SecurityException) {
+                Unavailable
+            }
+        }
+    }
+}
+
+internal sealed interface WorkspaceSourceFreshness {
+    data object Absent : WorkspaceSourceFreshness
+
+    data object Unkeyed : WorkspaceSourceFreshness
+
+    data class Claimed(val claims: WorkspaceSourceFreshnessClaims) : WorkspaceSourceFreshness
+
+    /**
+     * State transition:
+     * `(earlier WorkspaceSourceFreshness, later freshness) -> WorkspaceSourceFreshness`.
+     *
+     * Later claims replace earlier claims for the same path. Any unkeyed source
+     * event removes subsumption authority for the combined work.
+     */
+    fun followedBy(later: WorkspaceSourceFreshness): WorkspaceSourceFreshness = when (this) {
+        Absent -> later
+        Unkeyed -> Unkeyed
+        is Claimed -> when (later) {
+            Absent -> this
+            Unkeyed -> Unkeyed
+            is Claimed -> Claimed(claims.followedBy(later.claims))
+        }
+    }
+
+    /**
+     * Proof transition:
+     * `(active WorkspaceSourceFreshness, WorkspaceTransitionRequest)`
+     * `-> WorkspaceSourceFreshnessCoverage`.
+     */
+    fun coverageOf(request: WorkspaceTransitionRequest): WorkspaceSourceFreshnessCoverage =
+        if (this is Claimed && request is WorkspaceTransitionRequest.SourceFiles) {
+            claims.coverageOf(request.claims)
+        } else {
+            WorkspaceSourceFreshnessCoverage.Uncovered
+        }
+
+    companion object {
+        /**
+         * Derivation transition:
+         * `WorkspaceTransitionRequest -> WorkspaceSourceFreshness`.
+         */
+        fun from(request: WorkspaceTransitionRequest): WorkspaceSourceFreshness = when (request) {
+            is WorkspaceTransitionRequest.SourceFiles -> Claimed(request.claims)
+            is WorkspaceTransitionRequest.Unkeyed -> if (request.signal == WorkspaceSignal.Source) {
+                Unkeyed
+            } else {
+                Absent
+            }
+        }
+    }
+}
+
+internal enum class WorkspaceSourceFreshnessCoverage {
+    Covered,
+    Uncovered,
+}

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceSourceFreshness.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceSourceFreshness.kt
@@ -30,6 +30,9 @@ internal sealed interface WorkspaceTransitionRequest {
          * belongs to the workspace source authority and is either a regular
          * file or a proven tombstone. Any unprovable path safely degrades to an
          * unkeyed source request, which cannot join an active cycle.
+         * Raw signal extraction is permitted only at the transition-worker
+         * wake boundary; path and content claims remain opaque outside the
+         * freshness aggregation and coverage owners.
          */
         fun sourceFiles(
             workspaceRoot: Path,
@@ -122,6 +125,8 @@ internal sealed interface WorkspaceSourceContentResolution {
          *
          * A regular file becomes an exact hash, a proven absent path becomes a
          * tombstone, and every ambiguous filesystem state remains unavailable.
+         * The returned identity may only construct freshness claims; raw hash
+         * and path extraction from this proof is prohibited.
          */
         fun derive(path: WorkspaceSourcePath): WorkspaceSourceContentResolution {
             val file = path.absolute.value.toJavaPath()

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceTransitionContract.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceTransitionContract.kt
@@ -56,12 +56,20 @@ internal data class TransitionBlocker(
     }
 }
 
+/**
+ * Observation transition:
+ * `WorkspaceTransitionCoordinator state -> WorkspaceTransitionSnapshot`.
+ *
+ * [activeSourceFreshness] is exact only during refresh, reconciliation, or
+ * verification; every inactive lifecycle carries [WorkspaceSourceFreshness.Absent].
+ */
 internal data class WorkspaceTransitionSnapshot(
     val lifecycle: WorkspaceLifecycle,
     val pendingSignals: Set<WorkspaceSignal>,
     val published: PublishedWorkspaceGenerationState,
     val blocker: TransitionBlocker?,
     val observedEventCount: Long,
+    val activeSourceFreshness: WorkspaceSourceFreshness,
 ) {
     val isReady: Boolean
         get() = lifecycle == WorkspaceLifecycle.Ready && published is PublishedWorkspaceGenerationState.Published

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceTransitionCoordinator.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceTransitionCoordinator.kt
@@ -1,8 +1,6 @@
 package io.github.amichne.kast.idea.transition
 
-import com.intellij.openapi.progress.ProcessCanceledException
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationState
-import java.util.concurrent.CancellationException
 
 /**
  * Owns workspace freshness. Signals only invalidate and conflate work. Reconciliation and
@@ -16,6 +14,8 @@ internal class WorkspaceTransitionCoordinator(
 ) {
     private val lock = Any()
     private val pendingSignals = linkedSetOf<WorkspaceSignal>()
+    private var pendingSourceFreshness: WorkspaceSourceFreshness = WorkspaceSourceFreshness.Absent
+    private var activeSourceFreshness: WorkspaceSourceFreshness = WorkspaceSourceFreshness.Absent
     private var lifecycle = when (initialPublished) {
         PublishedWorkspaceGenerationState.Unpublished -> WorkspaceLifecycle.Dirty
         is PublishedWorkspaceGenerationState.Published -> WorkspaceLifecycle.Ready
@@ -24,12 +24,20 @@ internal class WorkspaceTransitionCoordinator(
     private var blocker: TransitionBlocker? = null
     private var observedEventCount = 0L
 
-    fun observe(signal: WorkspaceSignal) {
+    fun observe(signal: WorkspaceSignal) = observe(WorkspaceTransitionRequest.Unkeyed(signal))
+
+    fun observe(request: WorkspaceTransitionRequest) {
         val changed = synchronized(lock) {
             observedEventCount = Math.addExact(observedEventCount, 1)
-            pendingSignals += signal
+            pendingSignals += request.signal
+            pendingSourceFreshness = pendingSourceFreshness.followedBy(
+                WorkspaceSourceFreshness.from(request),
+            )
             blocker = null
-            if (lifecycle != WorkspaceLifecycle.Settling) lifecycle = WorkspaceLifecycle.Dirty
+            if (lifecycle != WorkspaceLifecycle.Settling) {
+                lifecycle = WorkspaceLifecycle.Dirty
+                activeSourceFreshness = WorkspaceSourceFreshness.Absent
+            }
             snapshotLocked()
         }
         emit(changed)
@@ -44,31 +52,34 @@ internal class WorkspaceTransitionCoordinator(
             pendingSignals.toSet() to snapshotLocked()
         }
         emit(settling.second)
-        runPhase(TransitionPhase.Settling) { operations.settle(settling.first) }
+        runTransitionEffect { operations.settle(settling.first) }
             .onFailure { return block(TransitionPhase.Settling, it) }
 
         val cycleAndState = synchronized(lock) {
             val cycle = TransitionCycle(
                 signals = pendingSignals.toSet(),
                 observedEventCount = observedEventCount,
+                sourceFreshness = pendingSourceFreshness,
             )
             pendingSignals.clear()
+            pendingSourceFreshness = WorkspaceSourceFreshness.Absent
+            activeSourceFreshness = cycle.sourceFreshness
             lifecycle = WorkspaceLifecycle.Refreshing
             cycle to snapshotLocked()
         }
         val cycle = cycleAndState.first
         emit(cycleAndState.second)
 
-        runPhase(TransitionPhase.Refreshing) { operations.refresh(cycle.signals) }
+        runTransitionEffect { operations.refresh(cycle.signals) }
             .onFailure { return block(TransitionPhase.Refreshing, it, cycle) }
         if (!advance(cycle, WorkspaceLifecycle.Reconciling)) return TransitionRun.Invalidated
 
-        val candidate = runPhase(TransitionPhase.Reconciling, operations::captureIdentity)
+        val candidate = runTransitionEffect(operations::captureIdentity)
             .getOrElse { return block(TransitionPhase.Reconciling, it, cycle) }
-        val open = runPhase(TransitionPhase.Publishing, operations::beginPublication)
+        val open = runTransitionEffect(operations::beginPublication)
             .getOrElse { return block(TransitionPhase.Publishing, it, cycle) }
         try {
-            val reconciliation = runPhase(TransitionPhase.Reconciling) { operations.reconcile(candidate) }
+            val reconciliation = runTransitionEffect { operations.reconcile(candidate) }
             val reconciliationFailure = reconciliation.exceptionOrNull()
             if (reconciliationFailure != null) {
                 return discardThenBlock(open, TransitionPhase.Reconciling, reconciliationFailure, cycle)
@@ -78,14 +89,14 @@ internal class WorkspaceTransitionCoordinator(
                 return discardThenInvalidate(open, cycle)
             }
 
-            val verification = runPhase(TransitionPhase.Verifying, operations::captureIdentity)
+            val verification = runTransitionEffect(operations::captureIdentity)
             val verificationFailure = verification.exceptionOrNull()
             if (verificationFailure != null) {
                 return discardThenBlock(open, TransitionPhase.Verifying, verificationFailure, cycle)
             }
             val verified = verification.getOrThrow()
             if (reconciledCandidate != verified) {
-                val discarded = runPhase(TransitionPhase.Publishing) {
+                val discarded = runTransitionEffect {
                     operations.discardPublication(open)
                 }
                 discarded.exceptionOrNull()?.let { failure ->
@@ -109,7 +120,7 @@ internal class WorkspaceTransitionCoordinator(
         verified: WorkspaceStateIdentity,
         open: OpenWorkspacePublication,
     ): TransitionRun {
-        val preparation = runPhase(TransitionPhase.Publishing) {
+        val preparation = runTransitionEffect {
             operations.preparePublication(open, verified)
         }
         val preparationFailure = preparation.exceptionOrNull()
@@ -117,10 +128,10 @@ internal class WorkspaceTransitionCoordinator(
             return discardThenBlock(open, TransitionPhase.Publishing, preparationFailure, cycle)
         }
         val prepared = preparation.getOrThrow()
-        val identityAfterPreparation = runPhase(TransitionPhase.Verifying, operations::captureIdentity)
+        val identityAfterPreparation = runTransitionEffect(operations::captureIdentity)
         val identityCaptureFailure = identityAfterPreparation.exceptionOrNull()
         if (identityCaptureFailure != null) {
-            val discardFailure = runPhase(TransitionPhase.Publishing) {
+            val discardFailure = runTransitionEffect {
                 operations.discardPublication(prepared)
             }.exceptionOrNull()
             if (discardFailure != null) {
@@ -130,7 +141,7 @@ internal class WorkspaceTransitionCoordinator(
             return block(TransitionPhase.Verifying, identityCaptureFailure, cycle)
         }
         if (identityAfterPreparation.getOrThrow() != verified) {
-            val discardFailure = runPhase(TransitionPhase.Publishing) {
+            val discardFailure = runTransitionEffect {
                 operations.discardPublication(prepared)
             }.exceptionOrNull()
             if (discardFailure != null) return block(TransitionPhase.Publishing, discardFailure, cycle)
@@ -146,7 +157,7 @@ internal class WorkspaceTransitionCoordinator(
             }
         }
         if (!commitAllowed) {
-            val discardFailure = runPhase(TransitionPhase.Publishing) {
+            val discardFailure = runTransitionEffect {
                 operations.discardPublication(prepared)
             }.exceptionOrNull()
             if (discardFailure != null) return block(TransitionPhase.Publishing, discardFailure, cycle)
@@ -154,12 +165,12 @@ internal class WorkspaceTransitionCoordinator(
             return TransitionRun.Invalidated
         }
 
-        val publicationAttempt = runPhase(TransitionPhase.Publishing) {
+        val publicationAttempt = runTransitionEffect {
             operations.commitPublication(prepared)
         }
         val retryFailure = publicationAttempt.exceptionOrNull() as? WorkspaceTransitionRetryException
         if (retryFailure != null) {
-            val discardFailure = runPhase(TransitionPhase.Publishing) {
+            val discardFailure = runTransitionEffect {
                 operations.discardPublication(prepared)
             }.exceptionOrNull()
             if (discardFailure != null) {
@@ -186,6 +197,7 @@ internal class WorkspaceTransitionCoordinator(
                             published = PublishedWorkspaceGenerationState.Published(publication.manifest)
                             blocker = null
                             lifecycle = WorkspaceLifecycle.Ready
+                            activeSourceFreshness = WorkspaceSourceFreshness.Absent
                             TransitionRun.Published
                         } else {
                             retainForRetry(cycle, includeAudit = false)
@@ -208,7 +220,7 @@ internal class WorkspaceTransitionCoordinator(
             }
         }
         if (discard) {
-            runPhase(TransitionPhase.Publishing) {
+            runTransitionEffect {
                 operations.discardPublication(prepared)
             }.onFailure { discardFailure ->
                 if (failure == null) {
@@ -257,7 +269,7 @@ internal class WorkspaceTransitionCoordinator(
         rethrowCancellation(failure)
         if (failure is WorkspaceTransitionRetryException) return retry(phase, failure, cycle)
         val blockerAndState = synchronized(lock) {
-            cycle?.let { pendingSignals += it.signals }
+            cycle?.let { retainForRetry(it, includeAudit = false) }
             val currentBlocker = blockLocked(phase, failure)
             currentBlocker to snapshotLocked()
         }
@@ -272,7 +284,7 @@ internal class WorkspaceTransitionCoordinator(
         cycle: TransitionCycle?,
     ): TransitionRun {
         val changed = synchronized(lock) {
-            cycle?.let { pendingSignals += it.signals }
+            cycle?.let { retainForRetry(it, includeAudit = false) }
             blocker = TransitionBlocker(
                 phase = phase,
                 detail = failure.message?.takeIf(String::isNotBlank) ?: failure::class.qualifiedName.orEmpty(),
@@ -291,13 +303,16 @@ internal class WorkspaceTransitionCoordinator(
         )
         blocker = currentBlocker
         lifecycle = WorkspaceLifecycle.Blocked
+        activeSourceFreshness = WorkspaceSourceFreshness.Absent
         return currentBlocker
     }
 
     private fun retainForRetry(cycle: TransitionCycle, includeAudit: Boolean) {
         pendingSignals += cycle.signals
+        pendingSourceFreshness = cycle.sourceFreshness.followedBy(pendingSourceFreshness)
         if (includeAudit) pendingSignals += WorkspaceSignal.RecoveryAudit
         lifecycle = WorkspaceLifecycle.Dirty
+        activeSourceFreshness = WorkspaceSourceFreshness.Absent
     }
 
     private fun isCurrent(cycle: TransitionCycle): Boolean =
@@ -309,6 +324,7 @@ internal class WorkspaceTransitionCoordinator(
         published = published,
         blocker = blocker,
         observedEventCount = observedEventCount,
+        activeSourceFreshness = activeSourceFreshness,
     )
 
     private fun discardThenBlock(
@@ -317,7 +333,7 @@ internal class WorkspaceTransitionCoordinator(
         failure: Throwable,
         cycle: TransitionCycle,
     ): TransitionRun {
-        val discardFailure = runPhase(TransitionPhase.Publishing) {
+        val discardFailure = runTransitionEffect {
             operations.discardPublication(open)
         }.exceptionOrNull()
         if (discardFailure != null) failure.addSuppressed(discardFailure)
@@ -330,7 +346,7 @@ internal class WorkspaceTransitionCoordinator(
         failure: Throwable,
         cycle: TransitionCycle,
     ): TransitionRun {
-        val discardFailure = runPhase(TransitionPhase.Publishing) {
+        val discardFailure = runTransitionEffect {
             operations.discardPublication(prepared)
         }.exceptionOrNull()
         if (discardFailure != null) failure.addSuppressed(discardFailure)
@@ -341,7 +357,7 @@ internal class WorkspaceTransitionCoordinator(
         open: OpenWorkspacePublication,
         cycle: TransitionCycle,
     ): TransitionRun {
-        val discardFailure = runPhase(TransitionPhase.Publishing) {
+        val discardFailure = runTransitionEffect {
             operations.discardPublication(open)
         }.exceptionOrNull()
         if (discardFailure != null) return block(TransitionPhase.Publishing, discardFailure, cycle)
@@ -353,7 +369,7 @@ internal class WorkspaceTransitionCoordinator(
         prepared: PreparedWorkspacePublication,
         cycle: TransitionCycle,
     ): TransitionRun {
-        val discardFailure = runPhase(TransitionPhase.Publishing) {
+        val discardFailure = runTransitionEffect {
             operations.discardPublication(prepared)
         }.exceptionOrNull()
         if (discardFailure != null) return block(TransitionPhase.Publishing, discardFailure, cycle)
@@ -369,28 +385,4 @@ internal class WorkspaceTransitionCoordinator(
         runCatching { onBlocked(blocker, failure) }
     }
 
-    private fun <T> runPhase(phase: TransitionPhase, operation: () -> T): Result<T> = try {
-        Result.success(operation())
-    } catch (failure: Throwable) {
-        rethrowCancellation(failure)
-        Result.failure(failure)
-    }
-
-    private fun rethrowCancellation(failure: Throwable) {
-        when (failure) {
-            is InterruptedException -> {
-                Thread.currentThread().interrupt()
-                throw failure
-            }
-
-            is CancellationException,
-            is ProcessCanceledException,
-            -> throw failure
-        }
-    }
-
-    private data class TransitionCycle(
-        val signals: Set<WorkspaceSignal>,
-        val observedEventCount: Long,
-    )
 }

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceTransitionExecution.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/transition/WorkspaceTransitionExecution.kt
@@ -1,0 +1,36 @@
+package io.github.amichne.kast.idea.transition
+
+import com.intellij.openapi.progress.ProcessCanceledException
+import java.util.concurrent.CancellationException
+
+internal data class TransitionCycle(
+    val signals: Set<WorkspaceSignal>,
+    val observedEventCount: Long,
+    val sourceFreshness: WorkspaceSourceFreshness,
+)
+
+/**
+ * Effect transition: `(() -> T) -> Result<T>`.
+ *
+ * Retains ordinary effect failure for the phase owner while cancellation and
+ * interruption remain non-recoverable worker-lifecycle transitions.
+ */
+internal fun <T> runTransitionEffect(operation: () -> T): Result<T> = try {
+    Result.success(operation())
+} catch (failure: Throwable) {
+    rethrowCancellation(failure)
+    Result.failure(failure)
+}
+
+internal fun rethrowCancellation(failure: Throwable) {
+    when (failure) {
+        is InterruptedException -> {
+            Thread.currentThread().interrupt()
+            throw failure
+        }
+
+        is CancellationException,
+        is ProcessCanceledException,
+        -> throw failure
+    }
+}

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/backend/contract/mutation/ExactFileImageCasTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/backend/contract/mutation/ExactFileImageCasTest.kt
@@ -19,6 +19,7 @@ import io.github.amichne.kast.idea.backend.KastIndexerBackend
 import io.github.amichne.kast.idea.backend.mutation.ExactFileImageCasObserver
 import io.github.amichne.kast.idea.mutation.SecureWorkspaceMutation
 import io.github.amichne.kast.idea.transition.WorkspaceSignal
+import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationManifest
 import java.nio.file.Files
 import java.nio.file.Path
@@ -364,7 +365,7 @@ internal class ExactFileImageCasTest : KastIndexerBackendContractTestFixture() {
         var signal: WorkspaceSignal? = null
         var operationCompleted: Boolean = false
 
-        override suspend fun reconcile(signal: WorkspaceSignal): PublishedWorkspaceGenerationManifest =
+        override suspend fun reconcile(request: WorkspaceTransitionRequest): PublishedWorkspaceGenerationManifest =
             error("Unexpected standalone reconciliation")
 
         override suspend fun <T> mutate(

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/backend/nativegraph/NativeSemanticGraphAdmissionTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/backend/nativegraph/NativeSemanticGraphAdmissionTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
 
 @TestApplication
 class NativeSemanticGraphAdmissionTest {
@@ -58,8 +59,8 @@ class NativeSemanticGraphAdmissionTest {
 
         sourceIndexStore(workspaceRoot).use { store ->
             store.ensureSchema()
-            lateinit var backend: KastIndexerBackend
-            backend = KastIndexerBackend(
+            val backendAuthority = CompletableFuture<KastIndexerBackend>()
+            val backend = KastIndexerBackend(
                 project = project,
                 workspaceRoot = workspaceRoot,
                 limits = limits(),
@@ -67,13 +68,14 @@ class NativeSemanticGraphAdmissionTest {
                 psiGeneration = { 1L },
                 workspaceSemanticReadAuthority = TestWorkspaceSemanticReadAuthority { admission },
                 workspaceTransitionRequester = TestWorkspaceTransitionRequester(
-                    onReconcile = { signal ->
-                        transitionSignals += signal
-                        backend.reconcileSemanticGraphForTest(query)
+                    onReconcile = { request ->
+                        transitionSignals += request.signal
+                        backendAuthority.join().reconcileSemanticGraphForTest(query)
                         testPublishedWorkspaceGeneration()
                     },
                 ),
             )
+            check(backendAuthority.complete(backend))
             backend.use { backend ->
                 repeat(3) {
                     assertThrows(ConflictException::class.java) {
@@ -130,7 +132,7 @@ class NativeSemanticGraphAdmissionTest {
                             )
                         }
                     }
-                    assertTrue(error.message.orEmpty().contains("persisted-index scope"))
+                    assertTrue(error.message.contains("persisted-index scope"))
                 }
             }
         } finally {

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/TestWorkspaceGenerationPublication.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/TestWorkspaceGenerationPublication.kt
@@ -92,11 +92,13 @@ internal class TestWorkspaceSemanticReadAuthority(
 internal class TestWorkspaceTransitionRequester(
     private val published: PublishedWorkspaceGenerationManifest = testPublishedWorkspaceGeneration(),
     private val onReconcile:
-        suspend (io.github.amichne.kast.idea.transition.WorkspaceSignal) -> PublishedWorkspaceGenerationManifest =
+        suspend (io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest) ->
+            PublishedWorkspaceGenerationManifest =
         { published },
 ) : WorkspaceTransitionRequester {
-    override suspend fun reconcile(signal: io.github.amichne.kast.idea.transition.WorkspaceSignal):
-        PublishedWorkspaceGenerationManifest = onReconcile(signal)
+    override suspend fun reconcile(
+        request: io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest,
+    ): PublishedWorkspaceGenerationManifest = onReconcile(request)
 
     override suspend fun <T> mutate(
         signal: io.github.amichne.kast.idea.transition.WorkspaceSignal,

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionFreshnessTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionFreshnessTest.kt
@@ -4,6 +4,8 @@ import com.intellij.openapi.project.Project
 import io.github.amichne.kast.api.contract.NormalizedPath
 import io.github.amichne.kast.idea.transition.WorkspaceLifecycle
 import io.github.amichne.kast.idea.transition.WorkspaceSourceFreshness
+import io.github.amichne.kast.idea.transition.TransitionBlocker
+import io.github.amichne.kast.idea.transition.TransitionPhase
 import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
 import io.github.amichne.kast.idea.transition.WorkspaceTransitionSnapshot
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationState
@@ -164,6 +166,52 @@ internal fun assertCoveredSourceStaleReadyRace(workspaceRoot: Path) {
     } finally {
         ingress.close()
     }
+}
+
+internal fun assertCoveredSourceBlockedRegistrationRace(workspaceRoot: Path) {
+    val initial = testPublishedWorkspaceGeneration(WorkspaceSemanticGeneration(24))
+    val source = workspaceRoot.resolve("src/Blocked.kt")
+    Files.createDirectories(source.parent)
+    Files.writeString(source, "class Blocked\n")
+    val request = WorkspaceTransitionRequest.sourceFiles(
+        workspaceRoot = workspaceRoot,
+        paths = listOf(NormalizedPath.of(source)),
+    ) as WorkspaceTransitionRequest.SourceFiles
+    val active = TransitionObservation.Observed(
+        WorkspaceTransitionSnapshot(
+            lifecycle = WorkspaceLifecycle.Reconciling,
+            pendingSignals = emptySet(),
+            published = PublishedWorkspaceGenerationState.Published(initial),
+            blocker = null,
+            observedEventCount = 6,
+            activeSourceFreshness = WorkspaceSourceFreshness.Claimed(request.claims),
+        ),
+    )
+    val join = WorkspaceTransitionRoute.derive(
+        status = IdeaIndexSemanticAdmission.Status.Pending("covered source transition is active"),
+        observation = active,
+        request = request,
+    ) as WorkspaceTransitionRoute.Join.Awaiting
+    val blocker = TransitionBlocker(
+        phase = TransitionPhase.Reconciling,
+        detail = "compiler reconciliation failed",
+    )
+
+    val registration = WorkspaceTransitionJoinRegistration.derive(
+        join = join,
+        observation = TransitionObservation.Observed(
+            WorkspaceTransitionSnapshot(
+                lifecycle = WorkspaceLifecycle.Blocked,
+                pendingSignals = emptySet(),
+                published = PublishedWorkspaceGenerationState.Published(initial),
+                blocker = blocker,
+                observedEventCount = 7,
+                activeSourceFreshness = WorkspaceSourceFreshness.Absent,
+            ),
+        ),
+    )
+
+    assertEquals(WorkspaceTransitionJoinRegistration.Blocked(blocker), registration)
 }
 
 private fun raceReadyAdmission(

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionFreshnessTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionFreshnessTest.kt
@@ -1,16 +1,30 @@
 package io.github.amichne.kast.idea
 
+import com.intellij.openapi.project.Project
 import io.github.amichne.kast.api.contract.NormalizedPath
 import io.github.amichne.kast.idea.transition.WorkspaceLifecycle
 import io.github.amichne.kast.idea.transition.WorkspaceSourceFreshness
 import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
 import io.github.amichne.kast.idea.transition.WorkspaceTransitionSnapshot
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationState
+import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationManifest
+import io.github.amichne.kast.indexstore.snapshot.WorkspaceGenerationCommit
+import io.github.amichne.kast.indexstore.snapshot.WorkspaceSemanticGeneration
+import io.github.amichne.kast.indexer.gradle.settlement.MonotonicClock
+import io.github.amichne.kast.indexer.gradle.settlement.ProgressAwareFutureAwaiter
+import io.github.amichne.kast.indexer.gradle.settlement.RuntimeProgressWaitPolicy
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.lang.reflect.Proxy
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.properties.Delegates
 
 class WorkspaceTransitionFreshnessTest {
     @TempDir
@@ -70,3 +84,149 @@ class WorkspaceTransitionFreshnessTest {
         ),
     )
 }
+
+internal fun assertCoveredSourcePublicationRace(workspaceRoot: Path) {
+    val initial = testPublishedWorkspaceGeneration(WorkspaceSemanticGeneration(20))
+    val next = testPublishedWorkspaceGeneration(WorkspaceSemanticGeneration(21))
+    val admission = raceReadyAdmission(initial)
+    val source = workspaceRoot.resolve("src/Racing.kt")
+    Files.createDirectories(source.parent)
+    Files.writeString(source, "class Racing\n")
+    val request = WorkspaceTransitionRequest.sourceFiles(
+        workspaceRoot = workspaceRoot,
+        paths = listOf(NormalizedPath.of(source)),
+    ) as WorkspaceTransitionRequest.SourceFiles
+    val transitionRequested = AtomicBoolean(false)
+    val ingress = WorkspaceTransitionIngress(admission, raceAwaiter())
+    ingress.bind { transitionRequested.set(true) }
+    admission.dirty("covered source transition is active")
+    ingress.observe(
+        WorkspaceTransitionSnapshot(
+            lifecycle = WorkspaceLifecycle.Reconciling,
+            pendingSignals = emptySet(),
+            published = PublishedWorkspaceGenerationState.Published(initial),
+            blocker = null,
+            observedEventCount = 4,
+            activeSourceFreshness = WorkspaceSourceFreshness.Claimed(request.claims),
+        ),
+    )
+    racePublish(admission, next)
+
+    try {
+        val published = runBlocking { ingress.reconcile(request) }
+
+        assertEquals(next, published)
+        assertFalse(transitionRequested.get())
+    } finally {
+        ingress.close()
+    }
+}
+
+internal fun assertCoveredSourceStaleReadyRace(workspaceRoot: Path) {
+    val initial = testPublishedWorkspaceGeneration(WorkspaceSemanticGeneration(22))
+    val next = testPublishedWorkspaceGeneration(WorkspaceSemanticGeneration(23))
+    val admission = raceReadyAdmission(initial)
+    val source = workspaceRoot.resolve("src/Stale.kt")
+    Files.createDirectories(source.parent)
+    Files.writeString(source, "class Stale\n")
+    val request = WorkspaceTransitionRequest.sourceFiles(
+        workspaceRoot = workspaceRoot,
+        paths = listOf(NormalizedPath.of(source)),
+    ) as WorkspaceTransitionRequest.SourceFiles
+    val transitionRequested = AtomicBoolean(false)
+    var ingress: WorkspaceTransitionIngress by Delegates.notNull()
+    ingress = WorkspaceTransitionIngress(
+        semanticAdmission = admission,
+        transitionAwaiter = raceAwaiter { elapsed ->
+            if (elapsed == Duration.ofMillis(1)) {
+                racePublish(admission, next)
+                ingress.observe(raceReadySnapshot(next))
+            }
+        },
+    )
+    ingress.bind { transitionRequested.set(true) }
+    ingress.observe(
+        WorkspaceTransitionSnapshot(
+            lifecycle = WorkspaceLifecycle.Reconciling,
+            pendingSignals = emptySet(),
+            published = PublishedWorkspaceGenerationState.Published(initial),
+            blocker = null,
+            observedEventCount = 5,
+            activeSourceFreshness = WorkspaceSourceFreshness.Claimed(request.claims),
+        ),
+    )
+
+    try {
+        val published = runBlocking { ingress.reconcile(request) }
+
+        assertEquals(next, published)
+        assertFalse(transitionRequested.get())
+    } finally {
+        ingress.close()
+    }
+}
+
+private fun raceReadyAdmission(
+    generation: PublishedWorkspaceGenerationManifest,
+): IdeaIndexSemanticAdmission = IdeaIndexSemanticAdmission(raceProjectStub()).also { admission ->
+    val token = admission.beginReconciliation("test generation")
+    check(
+        admission.publishReady(token) { WorkspaceGenerationCommit(generation) } is
+            IdeaIndexSemanticAdmission.ReadyPublication.Admitted,
+    )
+}
+
+private fun racePublish(
+    admission: IdeaIndexSemanticAdmission,
+    generation: PublishedWorkspaceGenerationManifest,
+) {
+    admission.dirty("test transition")
+    val token = admission.beginReconciliation("test reconciliation")
+    check(
+        admission.publishReady(token) { WorkspaceGenerationCommit(generation) } is
+            IdeaIndexSemanticAdmission.ReadyPublication.Admitted,
+    )
+}
+
+private fun raceAwaiter(
+    onPause: (Duration) -> Unit = {},
+): ProgressAwareFutureAwaiter {
+    var elapsed = Duration.ZERO
+    return ProgressAwareFutureAwaiter(
+        policy = RuntimeProgressWaitPolicy.derive(
+            noProgressTimeout = Duration.ofMillis(2),
+            maximumWait = Duration.ofMillis(10),
+            observationInterval = Duration.ofMillis(1),
+        ),
+        clock = MonotonicClock.fromRaw { elapsed.toNanos() },
+        pause = { duration ->
+            elapsed = elapsed.plus(duration)
+            onPause(elapsed)
+        },
+    )
+}
+
+private fun raceReadySnapshot(
+    generation: PublishedWorkspaceGenerationManifest,
+): WorkspaceTransitionSnapshot = WorkspaceTransitionSnapshot(
+    lifecycle = WorkspaceLifecycle.Ready,
+    pendingSignals = emptySet(),
+    published = PublishedWorkspaceGenerationState.Published(generation),
+    blocker = null,
+    observedEventCount = generation.generation.value,
+    activeSourceFreshness = WorkspaceSourceFreshness.Absent,
+)
+
+private fun raceProjectStub(): Project = Proxy.newProxyInstance(
+    Project::class.java.classLoader,
+    arrayOf(Project::class.java),
+) { _, method, _ ->
+    when (method.name) {
+        "getName" -> "stub"
+        "isDisposed" -> false
+        "hashCode" -> 0
+        "equals" -> false
+        "toString" -> "ProjectStub"
+        else -> null
+    }
+} as Project

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionFreshnessTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionFreshnessTest.kt
@@ -1,0 +1,72 @@
+package io.github.amichne.kast.idea
+
+import io.github.amichne.kast.api.contract.NormalizedPath
+import io.github.amichne.kast.idea.transition.WorkspaceLifecycle
+import io.github.amichne.kast.idea.transition.WorkspaceSourceFreshness
+import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
+import io.github.amichne.kast.idea.transition.WorkspaceTransitionSnapshot
+import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationState
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class WorkspaceTransitionFreshnessTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
+    @Test
+    fun `same path and content joins the active source transition`() {
+        val source = workspaceRoot.resolve("src/Sample.kt")
+        Files.createDirectories(source.parent)
+        Files.writeString(source, "class Sample\n")
+        val active = sourceRequest(source)
+        val requested = sourceRequest(source)
+
+        val route = WorkspaceTransitionRoute.derive(
+            status = IdeaIndexSemanticAdmission.Status.Pending("source transition is active"),
+            observation = activeObservation(active),
+            request = requested,
+        )
+
+        assertTrue(route is WorkspaceTransitionRoute.Join)
+    }
+
+    @Test
+    fun `new content enqueues a distinct source transition`() {
+        val source = workspaceRoot.resolve("src/Sample.kt")
+        Files.createDirectories(source.parent)
+        Files.writeString(source, "class Sample\n")
+        val active = sourceRequest(source)
+        Files.writeString(source, "class Changed\n")
+        val requested = sourceRequest(source)
+
+        val route = WorkspaceTransitionRoute.derive(
+            status = IdeaIndexSemanticAdmission.Status.Pending("source transition is active"),
+            observation = activeObservation(active),
+            request = requested,
+        )
+
+        assertTrue(route is WorkspaceTransitionRoute.Enqueue)
+    }
+
+    private fun sourceRequest(source: Path): WorkspaceTransitionRequest.SourceFiles =
+        WorkspaceTransitionRequest.sourceFiles(
+            workspaceRoot = workspaceRoot,
+            paths = listOf(NormalizedPath.of(source)),
+        ) as WorkspaceTransitionRequest.SourceFiles
+
+    private fun activeObservation(
+        request: WorkspaceTransitionRequest.SourceFiles,
+    ): TransitionObservation = TransitionObservation.Observed(
+        WorkspaceTransitionSnapshot(
+            lifecycle = WorkspaceLifecycle.Reconciling,
+            pendingSignals = emptySet(),
+            published = PublishedWorkspaceGenerationState.Unpublished,
+            blocker = null,
+            observedEventCount = 1,
+            activeSourceFreshness = WorkspaceSourceFreshness.Claimed(request.claims),
+        ),
+    )
+}

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionIngressTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionIngressTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.lang.reflect.Proxy
 import java.nio.file.Path
 import java.time.Duration
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.properties.Delegates
 
 class WorkspaceTransitionIngressTest {
+    @TempDir lateinit var workspaceRoot: Path
     @Test
     fun `workspace signal is queued before its worker wakeup`() {
         val order = mutableListOf<String>()
@@ -106,6 +108,14 @@ class WorkspaceTransitionIngressTest {
         assertEquals(next, published)
         assertTrue(transitionRequested.get())
     }
+
+    @Test
+    fun `covered source reconciliation returns publication that won the routing race`() =
+        assertCoveredSourcePublicationRace(workspaceRoot)
+
+    @Test
+    fun `covered source reconciliation does not return a stale ready sample`() =
+        assertCoveredSourceStaleReadyRace(workspaceRoot)
 
     @Test
     fun `failed semantic admission outranks a stale active transition observation`() {

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionIngressTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionIngressTest.kt
@@ -41,14 +41,12 @@ class WorkspaceTransitionIngressTest {
     @Test
     fun `workspace signal is queued before its worker wakeup`() {
         val order = mutableListOf<String>()
-
         routeWorkspaceSignal(
             lock = Any(),
             signal = WorkspaceSignal.Source,
             enqueue = { order += "queued:$it" },
             wake = { order += "wake:$it" },
         )
-
         assertEquals(
             listOf("queued:Source", "wake:Source"),
             order,
@@ -69,7 +67,6 @@ class WorkspaceTransitionIngressTest {
             publish(admission, next)
             ingress.observe(readySnapshot(next))
         }
-
         val published = runBlocking {
             ingress.reconcile(WorkspaceTransitionRequest.Unkeyed(WorkspaceSignal.RecoveryAudit))
         }
@@ -116,6 +113,10 @@ class WorkspaceTransitionIngressTest {
     @Test
     fun `covered source reconciliation does not return a stale ready sample`() =
         assertCoveredSourceStaleReadyRace(workspaceRoot)
+
+    @Test
+    fun `covered source join retains a blocker observed before registration`() =
+        assertCoveredSourceBlockedRegistrationRace(workspaceRoot)
 
     @Test
     fun `failed semantic admission outranks a stale active transition observation`() {

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionIngressTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/runtime/lifecycle/runtime/WorkspaceTransitionIngressTest.kt
@@ -4,7 +4,9 @@ import com.intellij.openapi.project.Project
 import io.github.amichne.kast.api.protocol.ConflictException
 import io.github.amichne.kast.idea.transition.WorkspaceLifecycle
 import io.github.amichne.kast.idea.transition.WorkspaceSignal
+import io.github.amichne.kast.idea.transition.WorkspaceSourceFreshness
 import io.github.amichne.kast.idea.transition.WorkspaceStateIdentity
+import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
 import io.github.amichne.kast.idea.transition.WorkspaceTransitionSnapshot
 import io.github.amichne.kast.indexstore.api.index.FileContentHash
 import io.github.amichne.kast.indexstore.api.index.FileIndexStage
@@ -66,7 +68,9 @@ class WorkspaceTransitionIngressTest {
             ingress.observe(readySnapshot(next))
         }
 
-        val published = runBlocking { ingress.reconcile(WorkspaceSignal.RecoveryAudit) }
+        val published = runBlocking {
+            ingress.reconcile(WorkspaceTransitionRequest.Unkeyed(WorkspaceSignal.RecoveryAudit))
+        }
 
         assertEquals(next, published)
     }
@@ -95,7 +99,9 @@ class WorkspaceTransitionIngressTest {
             ),
         )
 
-        val published = runBlocking { ingress.reconcile(WorkspaceSignal.Source) }
+        val published = runBlocking {
+            ingress.reconcile(WorkspaceTransitionRequest.Unkeyed(WorkspaceSignal.Source))
+        }
 
         assertEquals(next, published)
         assertTrue(transitionRequested.get())
@@ -114,6 +120,7 @@ class WorkspaceTransitionIngressTest {
                     TestTransitionEventCount.derive(3),
                 ),
             ),
+            request = WorkspaceTransitionRequest.Unkeyed(WorkspaceSignal.Source),
         )
 
         assertTrue(route is WorkspaceTransitionRoute.Rejected)
@@ -142,7 +149,9 @@ class WorkspaceTransitionIngressTest {
         ingress = WorkspaceTransitionIngress(admission, awaiter)
         ingress.bind {}
 
-        val published = runBlocking { ingress.reconcile(WorkspaceSignal.Source) }
+        val published = runBlocking {
+            ingress.reconcile(WorkspaceTransitionRequest.Unkeyed(WorkspaceSignal.Source))
+        }
 
         assertEquals(next, published)
     }
@@ -178,7 +187,9 @@ class WorkspaceTransitionIngressTest {
             ),
         )
 
-        val published = runBlocking { ingress.reconcile(WorkspaceSignal.Source) }
+        val published = runBlocking {
+            ingress.reconcile(WorkspaceTransitionRequest.Unkeyed(WorkspaceSignal.Source))
+        }
 
         assertEquals(next, published)
     }
@@ -300,6 +311,7 @@ class WorkspaceTransitionIngressTest {
         published = PublishedWorkspaceGenerationState.Published(generation),
         blocker = null,
         observedEventCount = generation.generation.value,
+        activeSourceFreshness = WorkspaceSourceFreshness.Absent,
     )
 
     private fun activeSnapshot(
@@ -312,6 +324,7 @@ class WorkspaceTransitionIngressTest {
         published = PublishedWorkspaceGenerationState.Published(generation),
         blocker = null,
         observedEventCount = observedEventCount.value,
+        activeSourceFreshness = WorkspaceSourceFreshness.Unkeyed,
     )
 
     private fun testAwaiter(onPause: (Duration) -> Unit): ProgressAwareFutureAwaiter {

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/semantic/refresh/KastSemanticAdmissionRefreshTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/semantic/refresh/KastSemanticAdmissionRefreshTest.kt
@@ -36,6 +36,7 @@ import io.github.amichne.kast.api.contract.result.SemanticAnalysisOutcome
 import io.github.amichne.kast.api.contract.result.SourceModuleOwnershipState
 import io.github.amichne.kast.indexstore.store.SqliteSourceIndexStore
 import io.github.amichne.kast.api.validation.FileHashing
+import io.github.amichne.kast.idea.transition.WorkspaceTransitionRequest
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -324,6 +325,23 @@ class KastSemanticAdmissionRefreshTest {
         } finally {
             Files.deleteIfExists(createdFile)
         }
+    }
+
+    @Test
+    fun `focused refresh retains path keyed freshness at the transition boundary`() = runBlocking {
+        ensureProjectReady()
+        val seedFile = Path.of(seedFileFixture.get().virtualFile.path).toAbsolutePath().normalize()
+        val requests = mutableListOf<WorkspaceTransitionRequest>()
+        val requester = TestWorkspaceTransitionRequester(onReconcile = { request ->
+            requests += request
+            testPublishedWorkspaceGeneration()
+        })
+
+        backend(workspaceTransitionRequester = requester).refresh(
+            RefreshQuery(filePaths = listOf(seedFile.toString())),
+        )
+
+        assertTrue(requests.single() is WorkspaceTransitionRequest.SourceFiles)
     }
 
     @Test

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/WorkspaceTransitionCoordinatorTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/transition/WorkspaceTransitionCoordinatorTest.kt
@@ -1,5 +1,6 @@
 package io.github.amichne.kast.idea.transition
 
+import io.github.amichne.kast.api.contract.NormalizedPath
 import io.github.amichne.kast.indexstore.api.reference.SourceIndexGeneration
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationManifest
 import io.github.amichne.kast.indexstore.snapshot.PublishedWorkspaceGenerationState
@@ -14,6 +15,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -22,6 +26,9 @@ import kotlin.concurrent.thread
 import kotlin.properties.Delegates
 
 class WorkspaceTransitionCoordinatorTest {
+    @TempDir
+    lateinit var workspaceRoot: Path
+
     @Test
     fun `relevant event withdraws readiness and one stable cycle publishes`() {
         val operations = RecordingOperations()
@@ -47,6 +54,39 @@ class WorkspaceTransitionCoordinatorTest {
         assertEquals(setOf(WorkspaceSignal.Source), coordinator.snapshot().pendingSignals)
         assertEquals(TransitionRun.Published, coordinator.reconcilePending())
         assertEquals(1, operations.reconciliations.get())
+    }
+
+    @Test
+    fun `active cycle publishes its exact source freshness claims`() {
+        val source = workspaceRoot.resolve("src/Sample.kt")
+        Files.createDirectories(source.parent)
+        Files.writeString(source, "class Sample\n")
+        val request = WorkspaceTransitionRequest.sourceFiles(
+            workspaceRoot,
+            listOf(NormalizedPath.of(source)),
+        ) as WorkspaceTransitionRequest.SourceFiles
+        val refreshStarted = CountDownLatch(1)
+        val releaseRefresh = CountDownLatch(1)
+        val coordinator = WorkspaceTransitionCoordinator(
+            RecordingOperations(onRefresh = {
+                refreshStarted.countDown()
+                releaseRefresh.await()
+            }),
+        )
+        coordinator.observe(request)
+        val transition = thread { coordinator.reconcilePending() }
+
+        try {
+            assertTrue(refreshStarted.await(1, TimeUnit.SECONDS), "source refresh did not start")
+            assertEquals(
+                WorkspaceSourceFreshness.Claimed(request.claims),
+                coordinator.snapshot().activeSourceFreshness,
+            )
+        } finally {
+            releaseRefresh.countDown()
+            transition.join(1_000)
+        }
+        assertFalse(transition.isAlive)
     }
 
     @Test
@@ -271,6 +311,7 @@ private class RecordingOperations(
     private val identities: ArrayDeque<WorkspaceStateIdentity> = ArrayDeque(),
     private val reconcile: () -> Unit = {},
     private val refreshFailure: Throwable? = null,
+    private val onRefresh: () -> Unit = {},
     private val onPrepare: (WorkspaceStateIdentity) -> Unit = {},
     private val onCommit: (PublishedWorkspaceGenerationManifest) -> GenerationPublication =
         { manifest -> GenerationPublication.Published(WorkspaceGenerationCommit(manifest)) },
@@ -283,6 +324,7 @@ private class RecordingOperations(
     override fun settle(signals: Set<WorkspaceSignal>) = Unit
 
     override fun refresh(signals: Set<WorkspaceSignal>) {
+        onRefresh()
         refreshFailure?.let { throw it }
     }
 


### PR DESCRIPTION
Risk: focused requests hash their requested source files once at admission. Unprovable paths retain the safe unkeyed path; no persisted format or migration changes.

## What

Carries canonical path-to-content or path-to-tombstone freshness through workspace transition requests. Identical focused refresh and diagnostics work can share one active publication; changed, disjoint, ambiguous, and unkeyed work remains pending for a later overlay or tombstone cycle.

Covered joins retain routing and registration races as closed states: they either await the active cycle, return a READY generation proven newer than the observed active baseline, or retain a terminal blocker or invalid completion observed before waiter registration. Admission and transition observation are sampled under one ingress lock.

Also documents the permitted extraction boundaries for validated repository snapshot paths, refresh requests, source requests, and source content identities.

## Scope split

The hermetic CLI reproduction platform formerly stacked through PR #568 has been removed from this PR. It will target main in a separate PR after its three review findings are fixed.

## Proof

- Declared ingress proof: valid RED for both publication interleavings and blocked join registration, then 12/12 GREEN
- Focused freshness, coordinator, ingress, refresh-boundary, semantic-graph, and exact-file mutation tests: GREEN
- Kast exact changed-Kotlin refresh: full coverage with zero diagnostics or omissions
- Repository shape: zero violations; ingress test remains within the 400-line contract
- Full local indexer suite: changed tests pass, but broad runs exposed two outside-scope macOS or IDEA fixture flakes. Each exact failing test passes in isolation; fresh exact-head CI remains the authoritative broad gate.

## Review closure

- Fixes publication-before-observation, stale-READY, and terminal-observation-before-registration races with directional regressions.
- Adds the required raw-extraction boundaries for refresh requests, source requests, and content resolution.
- Removes all reproduction-platform findings from this PR by restoring a focused main-based diff.