### PR TITLE
fix: accept declaration input with trailing newline

### DIFF
--- a/cli-rs/src/agent/plan/operation.rs
+++ b/cli-rs/src/agent/plan/operation.rs
@@ -71,10 +71,6 @@ impl PreparedOperation {
         }
     }
 
-    fn requires_content(&self) -> bool {
-        !matches!(self, Self::Rename { .. })
-    }
-
     fn into_stored(self, preview: &Value) -> Result<StoredOperation> {
         match self {
             Self::Rename { .. } => AgentRenameAuthority::from_projected_result(preview)

--- a/cli-rs/src/agent/plan/parts/execution/change.rs
+++ b/cli-rs/src/agent/plan/parts/execution/change.rs
@@ -11,12 +11,12 @@ pub(crate) fn run_change(args: KastChangePlanArgs, output_format: OutputFormat) 
         }
     };
     let selector = prepared.selector().map(str::to_string);
-    let content = prepared.requires_content().then(read_stdin).transpose()?;
+    let content = PreparedPlanContent::read_for(&prepared)?;
     let plan_id = Uuid::new_v4();
     let paths = PlanPaths::new(plan_id);
     let preview_content = content
-        .as_deref()
-        .map(TemporaryPreviewContent::create)
+        .as_ref()
+        .map(|content| TemporaryPreviewContent::create(content.as_bytes()))
         .transpose()?;
     let preview = agent_adapter::projected_value(prepared.command(
         workspace_root.clone(),
@@ -31,14 +31,16 @@ pub(crate) fn run_change(args: KastChangePlanArgs, output_format: OutputFormat) 
     let preview_result = projected_result(&preview)?;
     let stored_operation = prepared.into_stored(preview_result)?;
     let public_plan = public_plan(preview_result);
-    let content_sha256 = content.as_deref().map(manifest::sha256_bytes);
+    let content_sha256 = content
+        .as_ref()
+        .map(|content| manifest::sha256_bytes(content.as_bytes()));
     if let Err(message) = stored_operation.validate_content_sha256(content_sha256.as_deref()) {
         return Err(CliError::new("KAST_INVALID_AGENT_RESULT", message));
     }
 
     ensure_private_directory(&paths.directory)?;
-    if let Some(content) = content.as_deref()
-        && let Err(error) = write_private_file(&paths.content, content)
+    if let Some(content) = content.as_ref()
+        && let Err(error) = write_private_file(&paths.content, content.as_bytes())
     {
         return Err(error);
     }
@@ -69,6 +71,41 @@ pub(crate) fn run_change(args: KastChangePlanArgs, output_format: OutputFormat) 
         &result,
     )?;
     Ok(0)
+}
+
+struct PreparedPlanContent {
+    bytes: Vec<u8>,
+}
+
+impl PreparedPlanContent {
+    fn read_for(operation: &PreparedOperation) -> Result<Option<Self>> {
+        match operation {
+            PreparedOperation::Rename { .. } => Ok(None),
+            PreparedOperation::AddFile { .. } | PreparedOperation::Replace { .. } => {
+                read_stdin().map(Self::exact).map(Some)
+            }
+            PreparedOperation::AddDeclaration { .. } => {
+                read_stdin().map(Self::declaration).map(Some)
+            }
+        }
+    }
+
+    fn exact(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
+    fn declaration(mut bytes: Vec<u8>) -> Self {
+        if bytes.ends_with(b"\r\n") {
+            bytes.truncate(bytes.len() - 2);
+        } else if bytes.ends_with(b"\n") {
+            bytes.truncate(bytes.len() - 1);
+        }
+        Self { bytes }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
 }
 
 struct TemporaryPreviewContent {

--- a/cli-rs/tests/agent/public/kast_public_operations/plans/addition_and_refresh.rs
+++ b/cli-rs/tests/agent/public/kast_public_operations/plans/addition_and_refresh.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+include!("declaration_input.rs");
+
 #[test]
 fn change_add_declaration_persists_restart_safe_file_bottom_authority() {
     let fixture = tempfile::tempdir().expect("fixture");

--- a/cli-rs/tests/agent/public/kast_public_operations/plans/declaration_input.rs
+++ b/cli-rs/tests/agent/public/kast_public_operations/plans/declaration_input.rs
@@ -1,0 +1,130 @@
+#[test]
+fn change_add_declaration_normalizes_one_terminal_line_ending() {
+    let declaration = "class Added";
+    for (case, input) in [
+        ("no-final-newline", declaration),
+        ("lf", "class Added\n"),
+        ("crlf", "class Added\r\n"),
+    ] {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let home = fixture.path().join("home");
+        let config_home = fixture.path().join("config");
+        let workspace = fixture.path().join("workspace");
+        let source_root = workspace.join("src/main/kotlin");
+        std::fs::create_dir_all(&source_root).expect("source root");
+        std::fs::write(workspace.join("settings.gradle.kts"), "").expect("settings");
+        let target = source_root.join("Existing.kt");
+        let preimage = b"class Existing\n";
+        std::fs::write(&target, preimage).expect("existing source");
+        let workspace = workspace.canonicalize().expect("canonical workspace");
+        let target = target.canonicalize().expect("canonical target");
+        let preview =
+            public_exact_add_declaration_preview(&workspace, &target, preimage, declaration);
+        let backend = spawn_scripted_indexer_backend(
+            &home,
+            &config_home,
+            &workspace,
+            &fixture.path().join(format!("{case}.sock")),
+            vec![("raw/plan-add-declaration", preview)],
+        );
+        let binary = write_active_kast_for_test(&home, &config_home);
+        let mut change = installed_public_kast(&binary, &home, &config_home, &workspace);
+        change.args([
+            "change",
+            "plan",
+            "add-declaration",
+            "--file",
+            target.to_str().expect("target"),
+        ]);
+        let change = run_with_stdin(change, input);
+        let requests = backend
+            .join()
+            .unwrap_or_else(|_| panic!("{case} planner backend"));
+        assert!(change.status.success(), "{case}: {change:?}");
+        let request = requests
+            .iter()
+            .find(|request| request["method"] == "raw/plan-add-declaration")
+            .unwrap_or_else(|| panic!("{case}: add-declaration request in {requests:#?}"));
+        assert_eq!(
+            request["params"]["proposedDeclaration"], declaration,
+            "{case}: planner receives normalized declaration text"
+        );
+        let public = decode(&change);
+        assert_eq!(
+            public["plan"]["preview"]["proposedDeclaration"], declaration,
+            "{case}: public preview"
+        );
+        let plan_id = public["planId"].as_str().expect("plan id");
+        let plans = home.join(".local/share/kast/state/agent-plans");
+        assert_eq!(
+            std::fs::read(plans.join(format!("{plan_id}.content")))
+                .expect("stored declaration content"),
+            declaration.as_bytes(),
+            "{case}: persisted content"
+        );
+        let stored: Value = serde_json::from_slice(
+            &std::fs::read(plans.join(format!("{plan_id}.json"))).expect("stored plan"),
+        )
+        .expect("stored plan JSON");
+        assert_eq!(
+            stored["contentSha256"],
+            source_sha256(declaration.as_bytes()),
+            "{case}: persisted digest"
+        );
+    }
+}
+
+#[test]
+fn change_add_declaration_retains_typed_rejection_for_invalid_content() {
+    for (case, input) in [
+        ("blank-only", " \r\n"),
+        ("multiple-declarations", "class First\nclass Second\n"),
+    ] {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let home = fixture.path().join("home");
+        let config_home = fixture.path().join("config");
+        let workspace = fixture.path().join("workspace");
+        let source_root = workspace.join("src/main/kotlin");
+        std::fs::create_dir_all(&source_root).expect("source root");
+        std::fs::write(workspace.join("settings.gradle.kts"), "").expect("settings");
+        let target = source_root.join("Existing.kt");
+        std::fs::write(&target, "class Existing\n").expect("existing source");
+        let workspace = workspace.canonicalize().expect("canonical workspace");
+        let target = target.canonicalize().expect("canonical target");
+        let backend = spawn_scripted_indexer_backend(
+            &home,
+            &config_home,
+            &workspace,
+            &fixture.path().join(format!("invalid-{case}.sock")),
+            vec![(
+                "raw/plan-add-declaration",
+                scripted_json_rpc_error(
+                    "INVALID_ADDITION_CONTENT",
+                    "Add-declaration requires exactly one valid declaration.",
+                    json!({"case": case}),
+                    false,
+                ),
+            )],
+        );
+        let binary = write_active_kast_for_test(&home, &config_home);
+        let mut change = installed_public_kast(&binary, &home, &config_home, &workspace);
+        change.args([
+            "change",
+            "plan",
+            "add-declaration",
+            "--file",
+            target.to_str().expect("target"),
+        ]);
+        let change = run_with_stdin(change, input);
+        backend
+            .join()
+            .unwrap_or_else(|_| panic!("{case} planner backend"));
+        assert_eq!(change.status.code(), Some(1), "{case}: {change:?}");
+        let envelope = decode_envelope(&change);
+        assert_eq!(envelope["result"]["type"], "rejected", "{case}");
+        assert_eq!(
+            envelope["result"]["failure"]["code"], "INVALID_ADDITION_CONTENT",
+            "{case}"
+        );
+    }
+}


### PR DESCRIPTION
## What

Normalize exactly one conventional LF or CRLF at the add-declaration stdin boundary while preserving exact add-file and replacement content. Carry the normalized bytes through preview, digest, and private plan persistence.

Add public-operation coverage for no-final-newline, LF, CRLF, stored declaration bytes/digest, blank-only rejection, and multi-declaration rejection.

## Why

Ordinary pipe and file input commonly supplies one terminal line ending. The semantic add-declaration planner already treats that input as the same declaration, but the plan ingress previously forwarded and hashed the shell boundary newline as declaration content.

## Validation

- RED checkpoint `12a626ef`: focused suite rejected LF as `INVALID_ADDITION_CONTENT` while the no-final-newline control passed.
- GREEN: `cargo test --locked --manifest-path cli-rs/Cargo.toml --test kast_public_operations addition_and_refresh` (10 passed)
- Regression: `cargo test --locked --manifest-path cli-rs/Cargo.toml --test kast_public_operations` (38 passed)
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `python3 .github/scripts/check-repository-shape.py`
- `git diff --check HEAD`

Closes #581