### PR TITLE
Define reproducible performance audit evidence contract

### DIFF
--- a/.github/scripts/release/benchmark/test-kast-audit-evidence-contract.py
+++ b/.github/scripts/release/benchmark/test-kast-audit-evidence-contract.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Focused contract test for reproducible Kast performance audit evidence."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+VALIDATOR = Path(__file__).with_name("validate-kast-audit-evidence.py")
+SCHEMA = (
+    REPOSITORY_ROOT
+    / "cli-rs/protocol/benchmarks/audit/kast-audit-evidence.schema.json"
+)
+FIXTURE = REPOSITORY_ROOT / "cli-rs/protocol/benchmarks/audit/complete.fixture.json"
+KPA_REQUIRED_BINDINGS = (
+    "environment.artifactRoot",
+    "environment.cacheRoot",
+    "environment.homeRoot",
+    "environment.installationRoot",
+    "environment.locale",
+    "environment.runtimeRoot",
+    "environment.socketPath",
+    "environment.temporaryRoot",
+    "environment.timezone",
+    "environment.variableDigestSha256",
+    "host.architecture",
+    "host.cpuModel",
+    "host.ide.buildNumber",
+    "host.ide.product",
+    "host.ide.version",
+    "host.logicalCpuCount",
+    "host.memoryBytes",
+    "host.operatingSystem",
+    "host.operatingSystemVersion",
+    "installation.binarySha256",
+    "installation.binaryVersion",
+    "installation.bundleSha256",
+    "installation.bundleSizeBytes",
+    "installation.runtimeArtifactSha256",
+    "installation.runtimeBuild",
+    "installation.sealedInstallationSha256",
+    "instrumentation.artifacts.manifestPath",
+    "instrumentation.artifacts.manifestSha256",
+    "instrumentation.artifacts.profilePath",
+    "instrumentation.artifacts.profileSha256",
+    "instrumentation.artifacts.tracePath",
+    "instrumentation.artifacts.traceSha256",
+    "instrumentation.profiler.configurationSha256",
+    "instrumentation.profiler.kind",
+    "instrumentation.profiler.samplePeriodMicros",
+    "instrumentation.profiler.settings",
+    "instrumentation.telemetryMode",
+    "instrumentation.tracingMode",
+    "metrics.allocationBytes",
+    "metrics.cpuNanos",
+    "metrics.gcPauseNanos",
+    "metrics.latencyNanos",
+    "metrics.lockWaitNanos",
+    "metrics.outputBytes",
+    "metrics.traceCorrelation.correlatedPhaseCount",
+    "metrics.traceCorrelation.requestId",
+    "metrics.traceCorrelation.traceId",
+    "runState.cacheState",
+    "runState.coldOrWarm",
+    "runState.indexingState",
+    "runState.relationshipsEnabled",
+    "runState.sourceIndexGeneration",
+    "source.commitSha",
+    "source.repository",
+    "source.treeSha",
+    "source.worktreeState",
+    "teardown.completedAt",
+    "teardown.evidenceSha256",
+    "teardown.processClosure",
+    "teardown.runtimeState",
+    "teardown.socketState",
+    "teardown.temporaryRootState",
+    "teardown.workspaceState",
+    "workload.arguments",
+    "workload.command",
+    "workload.concurrency",
+    "workload.inputSha256",
+    "workload.invocationCount",
+    "workload.iterationCount",
+    "workload.operation",
+    "workspace.buildCount",
+    "workspace.fileCount",
+    "workspace.gradleProjectCount",
+    "workspace.kotlinFileCount",
+    "workspace.shapeSha256",
+    "workspace.sourceBytes",
+)
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def canonical_json(payload: object) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def required_property_paths(payload: dict[str, object]) -> list[tuple[str, ...]]:
+    paths: list[tuple[str, ...]] = []
+
+    def visit(value: object, prefix: tuple[str, ...]) -> None:
+        if not isinstance(value, dict):
+            return
+        for key in sorted(value):
+            path = (*prefix, key)
+            paths.append(path)
+            visit(value[key], path)
+
+    visit(payload, ())
+    source = ("source",)
+    return [source, *(path for path in paths if path != source)]
+
+
+def without_path(
+    payload: dict[str, object], path: tuple[str, ...]
+) -> dict[str, object]:
+    candidate = copy.deepcopy(payload)
+    owner: dict[str, object] = candidate
+    for component in path[:-1]:
+        nested = owner[component]
+        if not isinstance(nested, dict):
+            fail(f"test path is not an object binding: {'.'.join(path)}")
+        owner = nested
+    del owner[path[-1]]
+    return candidate
+
+
+def require_named_bindings(payload: dict[str, object]) -> None:
+    for binding in KPA_REQUIRED_BINDINGS:
+        value: object = payload
+        for component in binding.split("."):
+            if not isinstance(value, dict) or component not in value:
+                fail(f"complete fixture is missing KPA-001 binding: {binding}")
+            value = value[component]
+
+
+def hermetic_environment(root: Path) -> dict[str, str]:
+    roots = {
+        "HOME": root / "home",
+        "KAST_ARTIFACT_ROOT": root / "artifacts",
+        "KAST_CACHE_HOME": root / "cache",
+        "KAST_HOME": root / "installation",
+        "KAST_RUNTIME_DIR": root / "runtime",
+        "KAST_SOCKET_PATH": root / "socket/kast.sock",
+        "TMPDIR": root / "temporary",
+    }
+    for name, path in roots.items():
+        directory = path.parent if name == "KAST_SOCKET_PATH" else path
+        directory.mkdir(parents=True, exist_ok=True)
+    return {
+        **{name: str(path) for name, path in roots.items()},
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+
+
+def run_validator(evidence: Path, environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    if not VALIDATOR.is_file():
+        # No validation boundary means malformed evidence is currently accepted.
+        return subprocess.CompletedProcess([], 0, "", "")
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR), "--evidence", str(evidence)],
+        cwd=REPOSITORY_ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def load_fixture() -> tuple[str, dict[str, object]]:
+    try:
+        raw = FIXTURE.read_text(encoding="utf-8")
+        payload = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"complete fixture is unreadable: {error}")
+    if not isinstance(payload, dict):
+        fail("complete fixture root must be an object")
+    return raw, payload
+
+
+def main() -> int:
+    fixture_raw, complete = load_fixture()
+    require_named_bindings(complete)
+    scratch_path: Path | None = None
+    with tempfile.TemporaryDirectory(prefix="kast-audit-contract-") as scratch:
+        scratch_path = Path(scratch)
+        environment = hermetic_environment(scratch_path)
+        evidence = scratch_path / "artifacts/evidence.json"
+
+        first_failure: subprocess.CompletedProcess[str] | None = None
+        for path in required_property_paths(complete):
+            evidence.write_text(canonical_json(without_path(complete, path)), encoding="utf-8")
+            result = run_validator(evidence, environment)
+            if result.returncode == 0:
+                fail(f"{'.'.join(path)}: validator accepted a missing required binding")
+            if first_failure is None:
+                first_failure = result
+
+        evidence.write_text(fixture_raw, encoding="utf-8")
+        complete_result = run_validator(evidence, environment)
+        if complete_result.returncode != 0:
+            fail(f"complete fixture was rejected: {complete_result.stderr.strip()}")
+
+        extra = copy.deepcopy(complete)
+        extra["unboundObservation"] = "not-governed"
+        evidence.write_text(canonical_json(extra), encoding="utf-8")
+        if run_validator(evidence, environment).returncode == 0:
+            fail("validator accepted an undeclared observation")
+
+        reversed_root = dict(reversed(list(complete.items())))
+        evidence.write_text(json.dumps(reversed_root, indent=2) + "\n", encoding="utf-8")
+        if run_validator(evidence, environment).returncode == 0:
+            fail("validator accepted non-canonical key ordering")
+
+        if fixture_raw != canonical_json(complete):
+            fail("complete fixture is not canonical JSON")
+        try:
+            schema_raw = SCHEMA.read_text(encoding="utf-8")
+            schema = json.loads(schema_raw)
+        except (OSError, json.JSONDecodeError) as error:
+            fail(f"audit schema is unreadable: {error}")
+        if schema_raw != canonical_json(schema):
+            fail("audit schema is not canonical JSON")
+        if schema.get("examples") != [complete]:
+            fail("schema complete example and canonical fixture have drifted")
+
+        evidence.write_text(canonical_json(without_path(complete, ("source",))), encoding="utf-8")
+        repeat = run_validator(evidence, environment)
+        if first_failure is None or repeat.stderr != first_failure.stderr:
+            fail("validator failure output is not deterministic")
+
+    if scratch_path is None or scratch_path.exists():
+        fail("hermetic test roots were not cleanly removed")
+    print("audit evidence contract: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release/benchmark/validate-kast-audit-evidence.py
+++ b/.github/scripts/release/benchmark/validate-kast-audit-evidence.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Validate one canonical Kast performance audit evidence manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+SCHEMA_PATH = (
+    REPOSITORY_ROOT
+    / "cli-rs/protocol/benchmarks/audit/kast-audit-evidence.schema.json"
+)
+
+
+def fail(message: str, exit_code: int = 1) -> NoReturn:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(exit_code)
+
+
+def load_json(path: Path, label: str) -> tuple[str, object]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        return raw, json.loads(raw)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"{label} is unreadable at {path}: {error}", 2)
+
+
+def canonical_json(payload: object) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def json_type_matches(value: object, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    return False
+
+
+def resolve_reference(root: dict[str, object], reference: str) -> dict[str, object]:
+    if not reference.startswith("#/"):
+        fail(f"schema uses unsupported reference: {reference}", 2)
+    value: object = root
+    for raw_component in reference[2:].split("/"):
+        component = raw_component.replace("~1", "/").replace("~0", "~")
+        if not isinstance(value, dict) or component not in value:
+            fail(f"schema reference does not resolve: {reference}", 2)
+        value = value[component]
+    if not isinstance(value, dict):
+        fail(f"schema reference is not an object: {reference}", 2)
+    return value
+
+
+def validate(
+    value: object,
+    schema: dict[str, object],
+    root: dict[str, object],
+    path: str,
+) -> None:
+    reference = schema.get("$ref")
+    if reference is not None:
+        if not isinstance(reference, str):
+            fail(f"schema reference at {path} is not a string", 2)
+        validate(value, resolve_reference(root, reference), root, path)
+        return
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        if not isinstance(expected_type, str) or not json_type_matches(value, expected_type):
+            fail(f"{path}: expected {expected_type}")
+
+    allowed_values = schema.get("enum")
+    if allowed_values is not None:
+        if not isinstance(allowed_values, list):
+            fail(f"schema enum at {path} is not an array", 2)
+        if value not in allowed_values:
+            fail(f"{path}: value is outside the closed set")
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        properties = schema.get("properties", {})
+        if not isinstance(required, list) or not all(isinstance(item, str) for item in required):
+            fail(f"schema required list at {path} is invalid", 2)
+        if not isinstance(properties, dict):
+            fail(f"schema properties at {path} is invalid", 2)
+        missing = [key for key in required if key not in value]
+        if missing:
+            fail(f"{path}: missing required binding {missing[0]}")
+        unexpected = sorted(set(value) - set(properties))
+        if schema.get("additionalProperties") is False and unexpected:
+            fail(f"{path}: undeclared binding {unexpected[0]}")
+        for key in sorted(value):
+            child_schema = properties.get(key)
+            if child_schema is None:
+                continue
+            if not isinstance(child_schema, dict):
+                fail(f"schema property {path}.{key} is invalid", 2)
+            validate(value[key], child_schema, root, f"{path}.{key}")
+
+    if isinstance(value, list):
+        minimum_items = schema.get("minItems")
+        if isinstance(minimum_items, int) and len(value) < minimum_items:
+            fail(f"{path}: array has fewer than {minimum_items} items")
+        if schema.get("uniqueItems") is True:
+            encoded = [json.dumps(item, sort_keys=True, separators=(",", ":")) for item in value]
+            if len(encoded) != len(set(encoded)):
+                fail(f"{path}: array items must be unique")
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            if not isinstance(item_schema, dict):
+                fail(f"schema items at {path} is invalid", 2)
+            for index, item in enumerate(value):
+                validate(item, item_schema, root, f"{path}[{index}]")
+
+    if isinstance(value, str):
+        minimum_length = schema.get("minLength")
+        if isinstance(minimum_length, int) and len(value) < minimum_length:
+            fail(f"{path}: string is shorter than {minimum_length}")
+        pattern = schema.get("pattern")
+        if pattern is not None:
+            if not isinstance(pattern, str):
+                fail(f"schema pattern at {path} is invalid", 2)
+            try:
+                matches = re.fullmatch(pattern, value) is not None
+            except re.error as error:
+                fail(f"schema pattern at {path} is invalid: {error}", 2)
+            if not matches:
+                fail(f"{path}: string does not match its contract")
+
+    if isinstance(value, int) and not isinstance(value, bool):
+        minimum = schema.get("minimum")
+        if isinstance(minimum, (int, float)) and value < minimum:
+            fail(f"{path}: value is below {minimum}")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    root.add_argument("--evidence", type=Path, required=True)
+    return root
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    _, schema_value = load_json(SCHEMA_PATH, "audit schema")
+    evidence_raw, evidence = load_json(arguments.evidence, "audit evidence")
+    if not isinstance(schema_value, dict):
+        fail("audit schema root must be an object", 2)
+    if evidence_raw != canonical_json(evidence):
+        fail("$: evidence is not canonical JSON")
+    validate(evidence, schema_value, schema_value, "$")
+    print("audit evidence: valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli-rs/protocol/benchmarks/audit/complete.fixture.json
+++ b/cli-rs/protocol/benchmarks/audit/complete.fixture.json
@@ -1,0 +1,129 @@
+{
+  "auditId": "kpa-001-pr-569-60dcf69d",
+  "environment": {
+    "artifactRoot": "audit/artifacts",
+    "cacheRoot": "audit/cache",
+    "homeRoot": "audit/home",
+    "installationRoot": "audit/installation",
+    "locale": "C.UTF-8",
+    "runtimeRoot": "audit/runtime",
+    "socketPath": "audit/socket/kast.sock",
+    "temporaryRoot": "audit/temporary",
+    "timezone": "UTC",
+    "type": "AUDIT_ENVIRONMENT",
+    "variableDigestSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "host": {
+    "architecture": "arm64",
+    "cpuModel": "Apple M4 Max",
+    "ide": {
+      "buildNumber": "262.12345.67",
+      "product": "INTELLIJ_IDEA",
+      "type": "IDE_IDENTITY",
+      "version": "2026.2"
+    },
+    "logicalCpuCount": 16,
+    "memoryBytes": 68719476736,
+    "operatingSystem": "MACOS",
+    "operatingSystemVersion": "15.6",
+    "type": "HOST_IDENTITY"
+  },
+  "installation": {
+    "binarySha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "binaryVersion": "0.21.6-15-ged0083718",
+    "bundleSha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "bundleSizeBytes": 734003200,
+    "runtimeArtifactSha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "runtimeBuild": "ed0083718",
+    "sealedInstallationSha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "type": "SEALED_INSTALLATION"
+  },
+  "instrumentation": {
+    "artifacts": {
+      "manifestPath": "raw/audit-manifest.json",
+      "manifestSha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "profilePath": "raw/runtime.jfr",
+      "profileSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "tracePath": "raw/backend-trace.jsonl",
+      "traceSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+      "type": "RAW_AUDIT_ARTIFACTS"
+    },
+    "profiler": {
+      "configurationSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+      "kind": "JFR",
+      "samplePeriodMicros": 10000,
+      "settings": "profile",
+      "type": "PROFILER_CONFIGURATION"
+    },
+    "telemetryMode": "OTLP_FILE",
+    "tracingMode": "REQUEST_PHASES",
+    "type": "INSTRUMENTATION_CONFIGURATION"
+  },
+  "metrics": {
+    "allocationBytes": 123456789,
+    "cpuNanos": 987654321,
+    "gcPauseNanos": 1234567,
+    "latencyNanos": 2345678901,
+    "lockWaitNanos": 7654321,
+    "outputBytes": 45678,
+    "traceCorrelation": {
+      "correlatedPhaseCount": 8,
+      "requestId": "req-019fe30e",
+      "traceId": "0123456789abcdef0123456789abcdef",
+      "type": "TRACE_CORRELATION"
+    },
+    "type": "AUDIT_METRICS"
+  },
+  "runState": {
+    "cacheState": "EMPTY",
+    "coldOrWarm": "COLD",
+    "indexingState": "READY",
+    "relationshipsEnabled": true,
+    "sourceIndexGeneration": 42,
+    "type": "AUDIT_RUN_STATE"
+  },
+  "schemaVersion": 1,
+  "source": {
+    "commitSha": "60dcf69d0431d38d8a2bb5476ee349a9f796829b",
+    "repository": "https://github.com/amichne/kast.git",
+    "treeSha": "4444444444444444444444444444444444444444",
+    "type": "EXACT_SOURCE",
+    "worktreeState": "CLEAN"
+  },
+  "teardown": {
+    "completedAt": "2026-08-08T20:00:00Z",
+    "evidenceSha256": "5555555555555555555555555555555555555555555555555555555555555555",
+    "processClosure": "PROVEN_EMPTY",
+    "runtimeState": "STOPPED",
+    "socketState": "ABSENT",
+    "temporaryRootState": "REMOVED",
+    "type": "CLEAN_TEARDOWN",
+    "workspaceState": "REMOVED"
+  },
+  "type": "KAST_PERFORMANCE_AUDIT",
+  "workload": {
+    "arguments": [
+      "agent",
+      "graph",
+      "summary",
+      "--output",
+      "json"
+    ],
+    "command": "kast",
+    "concurrency": 1,
+    "inputSha256": "6666666666666666666666666666666666666666666666666666666666666666",
+    "invocationCount": 5,
+    "iterationCount": 5,
+    "operation": "agent.graph.summary",
+    "type": "AUDIT_WORKLOAD"
+  },
+  "workspace": {
+    "buildCount": 1,
+    "fileCount": 842,
+    "gradleProjectCount": 12,
+    "kotlinFileCount": 719,
+    "shapeSha256": "7777777777777777777777777777777777777777777777777777777777777777",
+    "sourceBytes": 12582912,
+    "type": "WORKSPACE_SHAPE"
+  }
+}

--- a/cli-rs/protocol/benchmarks/audit/kast-audit-evidence.schema.json
+++ b/cli-rs/protocol/benchmarks/audit/kast-audit-evidence.schema.json
@@ -1,0 +1,1067 @@
+{
+  "$defs": {
+    "artifactBindings": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "RAW_AUDIT_ARTIFACTS"
+        }
+      ],
+      "properties": {
+        "manifestPath": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "manifestSha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "profilePath": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "profileSha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "tracePath": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "traceSha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "type": {
+          "enum": [
+            "RAW_AUDIT_ARTIFACTS"
+          ],
+          "examples": [
+            "RAW_AUDIT_ARTIFACTS"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifestPath",
+        "manifestSha256",
+        "profilePath",
+        "profileSha256",
+        "tracePath",
+        "traceSha256",
+        "type"
+      ],
+      "type": "object"
+    },
+    "environment": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "AUDIT_ENVIRONMENT"
+        }
+      ],
+      "properties": {
+        "artifactRoot": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "cacheRoot": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "homeRoot": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "installationRoot": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "locale": {
+          "examples": [
+            "C.UTF-8"
+          ],
+          "minLength": 1,
+          "type": "string"
+        },
+        "runtimeRoot": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "socketPath": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "temporaryRoot": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "timezone": {
+          "examples": [
+            "UTC"
+          ],
+          "minLength": 1,
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "AUDIT_ENVIRONMENT"
+          ],
+          "examples": [
+            "AUDIT_ENVIRONMENT"
+          ],
+          "type": "string"
+        },
+        "variableDigestSha256": {
+          "$ref": "#/$defs/hash64"
+        }
+      },
+      "required": [
+        "artifactRoot",
+        "cacheRoot",
+        "homeRoot",
+        "installationRoot",
+        "locale",
+        "runtimeRoot",
+        "socketPath",
+        "temporaryRoot",
+        "timezone",
+        "type",
+        "variableDigestSha256"
+      ],
+      "type": "object"
+    },
+    "hash40": {
+      "examples": [
+        "60dcf69d0431d38d8a2bb5476ee349a9f796829b"
+      ],
+      "pattern": "^[0-9a-f]{40}$",
+      "type": "string"
+    },
+    "hash64": {
+      "examples": [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      ],
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "host": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "HOST_IDENTITY"
+        }
+      ],
+      "properties": {
+        "architecture": {
+          "enum": [
+            "arm64",
+            "x86_64"
+          ],
+          "examples": [
+            "arm64"
+          ],
+          "type": "string"
+        },
+        "cpuModel": {
+          "examples": [
+            "Apple M4 Max"
+          ],
+          "minLength": 1,
+          "type": "string"
+        },
+        "ide": {
+          "$ref": "#/$defs/ide"
+        },
+        "logicalCpuCount": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "memoryBytes": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "operatingSystem": {
+          "enum": [
+            "LINUX",
+            "MACOS"
+          ],
+          "examples": [
+            "MACOS"
+          ],
+          "type": "string"
+        },
+        "operatingSystemVersion": {
+          "examples": [
+            "15.6"
+          ],
+          "minLength": 1,
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "HOST_IDENTITY"
+          ],
+          "examples": [
+            "HOST_IDENTITY"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture",
+        "cpuModel",
+        "ide",
+        "logicalCpuCount",
+        "memoryBytes",
+        "operatingSystem",
+        "operatingSystemVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ide": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "IDE_IDENTITY"
+        }
+      ],
+      "properties": {
+        "buildNumber": {
+          "examples": [
+            "262.12345.67"
+          ],
+          "minLength": 1,
+          "type": "string"
+        },
+        "product": {
+          "enum": [
+            "ANDROID_STUDIO",
+            "INTELLIJ_IDEA"
+          ],
+          "examples": [
+            "INTELLIJ_IDEA"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "IDE_IDENTITY"
+          ],
+          "examples": [
+            "IDE_IDENTITY"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "examples": [
+            "2026.2"
+          ],
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "buildNumber",
+        "product",
+        "type",
+        "version"
+      ],
+      "type": "object"
+    },
+    "installation": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "SEALED_INSTALLATION"
+        }
+      ],
+      "properties": {
+        "binarySha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "binaryVersion": {
+          "examples": [
+            "0.21.6-15-ged0083718"
+          ],
+          "minLength": 1,
+          "type": "string"
+        },
+        "bundleSha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "bundleSizeBytes": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "runtimeArtifactSha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "runtimeBuild": {
+          "examples": [
+            "ed0083718"
+          ],
+          "minLength": 1,
+          "type": "string"
+        },
+        "sealedInstallationSha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "type": {
+          "enum": [
+            "SEALED_INSTALLATION"
+          ],
+          "examples": [
+            "SEALED_INSTALLATION"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "binarySha256",
+        "binaryVersion",
+        "bundleSha256",
+        "bundleSizeBytes",
+        "runtimeArtifactSha256",
+        "runtimeBuild",
+        "sealedInstallationSha256",
+        "type"
+      ],
+      "type": "object"
+    },
+    "instrumentation": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "INSTRUMENTATION_CONFIGURATION"
+        }
+      ],
+      "properties": {
+        "artifacts": {
+          "$ref": "#/$defs/artifactBindings"
+        },
+        "profiler": {
+          "$ref": "#/$defs/profiler"
+        },
+        "telemetryMode": {
+          "enum": [
+            "DISABLED",
+            "OTLP_FILE"
+          ],
+          "examples": [
+            "OTLP_FILE"
+          ],
+          "type": "string"
+        },
+        "tracingMode": {
+          "enum": [
+            "DISABLED",
+            "REQUEST_PHASES"
+          ],
+          "examples": [
+            "REQUEST_PHASES"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "INSTRUMENTATION_CONFIGURATION"
+          ],
+          "examples": [
+            "INSTRUMENTATION_CONFIGURATION"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "artifacts",
+        "profiler",
+        "telemetryMode",
+        "tracingMode",
+        "type"
+      ],
+      "type": "object"
+    },
+    "metrics": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "AUDIT_METRICS"
+        }
+      ],
+      "properties": {
+        "allocationBytes": {
+          "$ref": "#/$defs/nonnegativeInteger"
+        },
+        "cpuNanos": {
+          "$ref": "#/$defs/nonnegativeInteger"
+        },
+        "gcPauseNanos": {
+          "$ref": "#/$defs/nonnegativeInteger"
+        },
+        "latencyNanos": {
+          "$ref": "#/$defs/nonnegativeInteger"
+        },
+        "lockWaitNanos": {
+          "$ref": "#/$defs/nonnegativeInteger"
+        },
+        "outputBytes": {
+          "$ref": "#/$defs/nonnegativeInteger"
+        },
+        "traceCorrelation": {
+          "$ref": "#/$defs/traceCorrelation"
+        },
+        "type": {
+          "enum": [
+            "AUDIT_METRICS"
+          ],
+          "examples": [
+            "AUDIT_METRICS"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "allocationBytes",
+        "cpuNanos",
+        "gcPauseNanos",
+        "latencyNanos",
+        "lockWaitNanos",
+        "outputBytes",
+        "traceCorrelation",
+        "type"
+      ],
+      "type": "object"
+    },
+    "nonnegativeInteger": {
+      "examples": [
+        0
+      ],
+      "minimum": 0,
+      "type": "integer"
+    },
+    "positiveInteger": {
+      "examples": [
+        1
+      ],
+      "minimum": 1,
+      "type": "integer"
+    },
+    "profiler": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "PROFILER_CONFIGURATION"
+        }
+      ],
+      "properties": {
+        "configurationSha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "kind": {
+          "enum": [
+            "ASYNC_PROFILER",
+            "JFR",
+            "NONE"
+          ],
+          "examples": [
+            "JFR"
+          ],
+          "type": "string"
+        },
+        "samplePeriodMicros": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "settings": {
+          "examples": [
+            "profile"
+          ],
+          "minLength": 1,
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "PROFILER_CONFIGURATION"
+          ],
+          "examples": [
+            "PROFILER_CONFIGURATION"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "configurationSha256",
+        "kind",
+        "samplePeriodMicros",
+        "settings",
+        "type"
+      ],
+      "type": "object"
+    },
+    "relativePath": {
+      "examples": [
+        "audit/artifacts"
+      ],
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._/-]+$",
+      "type": "string"
+    },
+    "runState": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "AUDIT_RUN_STATE"
+        }
+      ],
+      "properties": {
+        "cacheState": {
+          "enum": [
+            "EMPTY",
+            "PRIMED"
+          ],
+          "examples": [
+            "EMPTY"
+          ],
+          "type": "string"
+        },
+        "coldOrWarm": {
+          "enum": [
+            "COLD",
+            "WARM"
+          ],
+          "examples": [
+            "COLD"
+          ],
+          "type": "string"
+        },
+        "indexingState": {
+          "enum": [
+            "PARTIAL",
+            "READY"
+          ],
+          "examples": [
+            "READY"
+          ],
+          "type": "string"
+        },
+        "relationshipsEnabled": {
+          "examples": [
+            true
+          ],
+          "type": "boolean"
+        },
+        "sourceIndexGeneration": {
+          "$ref": "#/$defs/nonnegativeInteger"
+        },
+        "type": {
+          "enum": [
+            "AUDIT_RUN_STATE"
+          ],
+          "examples": [
+            "AUDIT_RUN_STATE"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "cacheState",
+        "coldOrWarm",
+        "indexingState",
+        "relationshipsEnabled",
+        "sourceIndexGeneration",
+        "type"
+      ],
+      "type": "object"
+    },
+    "source": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "EXACT_SOURCE"
+        }
+      ],
+      "properties": {
+        "commitSha": {
+          "$ref": "#/$defs/hash40"
+        },
+        "repository": {
+          "examples": [
+            "https://github.com/amichne/kast.git"
+          ],
+          "pattern": "^https://[^/]+/[^/]+/[^/]+\\.git$",
+          "type": "string"
+        },
+        "treeSha": {
+          "$ref": "#/$defs/hash40"
+        },
+        "type": {
+          "enum": [
+            "EXACT_SOURCE"
+          ],
+          "examples": [
+            "EXACT_SOURCE"
+          ],
+          "type": "string"
+        },
+        "worktreeState": {
+          "enum": [
+            "CLEAN"
+          ],
+          "examples": [
+            "CLEAN"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "commitSha",
+        "repository",
+        "treeSha",
+        "type",
+        "worktreeState"
+      ],
+      "type": "object"
+    },
+    "teardown": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "CLEAN_TEARDOWN"
+        }
+      ],
+      "properties": {
+        "completedAt": {
+          "examples": [
+            "2026-08-08T20:00:00Z"
+          ],
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+          "type": "string"
+        },
+        "evidenceSha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "processClosure": {
+          "enum": [
+            "PROVEN_EMPTY"
+          ],
+          "examples": [
+            "PROVEN_EMPTY"
+          ],
+          "type": "string"
+        },
+        "runtimeState": {
+          "enum": [
+            "STOPPED"
+          ],
+          "examples": [
+            "STOPPED"
+          ],
+          "type": "string"
+        },
+        "socketState": {
+          "enum": [
+            "ABSENT"
+          ],
+          "examples": [
+            "ABSENT"
+          ],
+          "type": "string"
+        },
+        "temporaryRootState": {
+          "enum": [
+            "REMOVED"
+          ],
+          "examples": [
+            "REMOVED"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "CLEAN_TEARDOWN"
+          ],
+          "examples": [
+            "CLEAN_TEARDOWN"
+          ],
+          "type": "string"
+        },
+        "workspaceState": {
+          "enum": [
+            "REMOVED"
+          ],
+          "examples": [
+            "REMOVED"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "completedAt",
+        "evidenceSha256",
+        "processClosure",
+        "runtimeState",
+        "socketState",
+        "temporaryRootState",
+        "type",
+        "workspaceState"
+      ],
+      "type": "object"
+    },
+    "traceCorrelation": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "TRACE_CORRELATION"
+        }
+      ],
+      "properties": {
+        "correlatedPhaseCount": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "requestId": {
+          "examples": [
+            "req-019fe30e"
+          ],
+          "minLength": 1,
+          "type": "string"
+        },
+        "traceId": {
+          "examples": [
+            "0123456789abcdef0123456789abcdef"
+          ],
+          "pattern": "^[0-9a-f]{32}$",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "TRACE_CORRELATION"
+          ],
+          "examples": [
+            "TRACE_CORRELATION"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "correlatedPhaseCount",
+        "requestId",
+        "traceId",
+        "type"
+      ],
+      "type": "object"
+    },
+    "workload": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "AUDIT_WORKLOAD"
+        }
+      ],
+      "properties": {
+        "arguments": {
+          "examples": [
+            [
+              "agent",
+              "graph",
+              "summary"
+            ]
+          ],
+          "items": {
+            "examples": [
+              "agent"
+            ],
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "command": {
+          "examples": [
+            "kast"
+          ],
+          "minLength": 1,
+          "type": "string"
+        },
+        "concurrency": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "inputSha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "invocationCount": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "iterationCount": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "operation": {
+          "examples": [
+            "agent.graph.summary"
+          ],
+          "pattern": "^[a-z][a-z0-9]*(?:[.-][a-z][a-z0-9]*)+$",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "AUDIT_WORKLOAD"
+          ],
+          "examples": [
+            "AUDIT_WORKLOAD"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "arguments",
+        "command",
+        "concurrency",
+        "inputSha256",
+        "invocationCount",
+        "iterationCount",
+        "operation",
+        "type"
+      ],
+      "type": "object"
+    },
+    "workspace": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "type": "WORKSPACE_SHAPE"
+        }
+      ],
+      "properties": {
+        "buildCount": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "fileCount": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "gradleProjectCount": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "kotlinFileCount": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "shapeSha256": {
+          "$ref": "#/$defs/hash64"
+        },
+        "sourceBytes": {
+          "$ref": "#/$defs/positiveInteger"
+        },
+        "type": {
+          "enum": [
+            "WORKSPACE_SHAPE"
+          ],
+          "examples": [
+            "WORKSPACE_SHAPE"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "buildCount",
+        "fileCount",
+        "gradleProjectCount",
+        "kotlinFileCount",
+        "shapeSha256",
+        "sourceBytes",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://kast.dev/schemas/kast-audit-evidence.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "examples": [
+    {
+      "auditId": "kpa-001-pr-569-60dcf69d",
+      "environment": {
+        "artifactRoot": "audit/artifacts",
+        "cacheRoot": "audit/cache",
+        "homeRoot": "audit/home",
+        "installationRoot": "audit/installation",
+        "locale": "C.UTF-8",
+        "runtimeRoot": "audit/runtime",
+        "socketPath": "audit/socket/kast.sock",
+        "temporaryRoot": "audit/temporary",
+        "timezone": "UTC",
+        "type": "AUDIT_ENVIRONMENT",
+        "variableDigestSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "host": {
+        "architecture": "arm64",
+        "cpuModel": "Apple M4 Max",
+        "ide": {
+          "buildNumber": "262.12345.67",
+          "product": "INTELLIJ_IDEA",
+          "type": "IDE_IDENTITY",
+          "version": "2026.2"
+        },
+        "logicalCpuCount": 16,
+        "memoryBytes": 68719476736,
+        "operatingSystem": "MACOS",
+        "operatingSystemVersion": "15.6",
+        "type": "HOST_IDENTITY"
+      },
+      "installation": {
+        "binarySha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "binaryVersion": "0.21.6-15-ged0083718",
+        "bundleSha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "bundleSizeBytes": 734003200,
+        "runtimeArtifactSha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "runtimeBuild": "ed0083718",
+        "sealedInstallationSha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "type": "SEALED_INSTALLATION"
+      },
+      "instrumentation": {
+        "artifacts": {
+          "manifestPath": "raw/audit-manifest.json",
+          "manifestSha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "profilePath": "raw/runtime.jfr",
+          "profileSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "tracePath": "raw/backend-trace.jsonl",
+          "traceSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "type": "RAW_AUDIT_ARTIFACTS"
+        },
+        "profiler": {
+          "configurationSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "kind": "JFR",
+          "samplePeriodMicros": 10000,
+          "settings": "profile",
+          "type": "PROFILER_CONFIGURATION"
+        },
+        "telemetryMode": "OTLP_FILE",
+        "tracingMode": "REQUEST_PHASES",
+        "type": "INSTRUMENTATION_CONFIGURATION"
+      },
+      "metrics": {
+        "allocationBytes": 123456789,
+        "cpuNanos": 987654321,
+        "gcPauseNanos": 1234567,
+        "latencyNanos": 2345678901,
+        "lockWaitNanos": 7654321,
+        "outputBytes": 45678,
+        "traceCorrelation": {
+          "correlatedPhaseCount": 8,
+          "requestId": "req-019fe30e",
+          "traceId": "0123456789abcdef0123456789abcdef",
+          "type": "TRACE_CORRELATION"
+        },
+        "type": "AUDIT_METRICS"
+      },
+      "runState": {
+        "cacheState": "EMPTY",
+        "coldOrWarm": "COLD",
+        "indexingState": "READY",
+        "relationshipsEnabled": true,
+        "sourceIndexGeneration": 42,
+        "type": "AUDIT_RUN_STATE"
+      },
+      "schemaVersion": 1,
+      "source": {
+        "commitSha": "60dcf69d0431d38d8a2bb5476ee349a9f796829b",
+        "repository": "https://github.com/amichne/kast.git",
+        "treeSha": "4444444444444444444444444444444444444444",
+        "type": "EXACT_SOURCE",
+        "worktreeState": "CLEAN"
+      },
+      "teardown": {
+        "completedAt": "2026-08-08T20:00:00Z",
+        "evidenceSha256": "5555555555555555555555555555555555555555555555555555555555555555",
+        "processClosure": "PROVEN_EMPTY",
+        "runtimeState": "STOPPED",
+        "socketState": "ABSENT",
+        "temporaryRootState": "REMOVED",
+        "type": "CLEAN_TEARDOWN",
+        "workspaceState": "REMOVED"
+      },
+      "type": "KAST_PERFORMANCE_AUDIT",
+      "workload": {
+        "arguments": [
+          "agent",
+          "graph",
+          "summary",
+          "--output",
+          "json"
+        ],
+        "command": "kast",
+        "concurrency": 1,
+        "inputSha256": "6666666666666666666666666666666666666666666666666666666666666666",
+        "invocationCount": 5,
+        "iterationCount": 5,
+        "operation": "agent.graph.summary",
+        "type": "AUDIT_WORKLOAD"
+      },
+      "workspace": {
+        "buildCount": 1,
+        "fileCount": 842,
+        "gradleProjectCount": 12,
+        "kotlinFileCount": 719,
+        "shapeSha256": "7777777777777777777777777777777777777777777777777777777777777777",
+        "sourceBytes": 12582912,
+        "type": "WORKSPACE_SHAPE"
+      }
+    }
+  ],
+  "properties": {
+    "auditId": {
+      "examples": [
+        "kpa-001-pr-569-60dcf69d"
+      ],
+      "pattern": "^[a-z0-9][a-z0-9.-]{0,127}$",
+      "type": "string"
+    },
+    "environment": {
+      "$ref": "#/$defs/environment"
+    },
+    "host": {
+      "$ref": "#/$defs/host"
+    },
+    "installation": {
+      "$ref": "#/$defs/installation"
+    },
+    "instrumentation": {
+      "$ref": "#/$defs/instrumentation"
+    },
+    "metrics": {
+      "$ref": "#/$defs/metrics"
+    },
+    "runState": {
+      "$ref": "#/$defs/runState"
+    },
+    "schemaVersion": {
+      "enum": [
+        1
+      ],
+      "examples": [
+        1
+      ],
+      "type": "integer"
+    },
+    "source": {
+      "$ref": "#/$defs/source"
+    },
+    "teardown": {
+      "$ref": "#/$defs/teardown"
+    },
+    "type": {
+      "enum": [
+        "KAST_PERFORMANCE_AUDIT"
+      ],
+      "examples": [
+        "KAST_PERFORMANCE_AUDIT"
+      ],
+      "type": "string"
+    },
+    "workload": {
+      "$ref": "#/$defs/workload"
+    },
+    "workspace": {
+      "$ref": "#/$defs/workspace"
+    }
+  },
+  "required": [
+    "auditId",
+    "environment",
+    "host",
+    "installation",
+    "instrumentation",
+    "metrics",
+    "runState",
+    "schemaVersion",
+    "source",
+    "teardown",
+    "type",
+    "workload",
+    "workspace"
+  ],
+  "title": "Kast reproducible performance audit evidence",
+  "type": "object"
+}


### PR DESCRIPTION
## Scope and callouts

This is a contract-only change. It captures no performance run, sets no performance budgets, and does not absorb #541 scale policy.

## What

- Add a closed Draft 2020-12 audit manifest binding exact source and sealed installation identity, host and IDE, hermetic environment, workspace/run state, workload/concurrency, instrumentation artifacts, metrics, trace correlation, and clean teardown.
- Add a deterministic stdlib validator that rejects missing or undeclared bindings and non-canonical JSON.
- Add a canonical complete fixture and focused hermetic RED/GREEN contract test.

## Validation

- `python3 .github/scripts/release/benchmark/test-kast-audit-evidence-contract.py`
- bundled schema `profile` and `policy`
- `.github/scripts/test-release-indexing-benchmark-contract.sh`
- `python3 .github/scripts/check-repository-shape.py --root .`
- `git diff --cached --check`

Closes #571