### PR TITLE
fix: honor machine output for CLI failures

### DIFF
--- a/cli-rs/src/interface/output/core.rs
+++ b/cli-rs/src/interface/output/core.rs
@@ -2,9 +2,53 @@ pub fn print_json(value: &impl Serialize) -> Result<()> {
     print_structured(value, OutputFormat::Json)
 }
 
-pub(crate) fn print_structured(value: &impl Serialize, format: OutputFormat) -> Result<()> {
+pub(crate) fn print_structured(value: &impl Serialize, fallback: OutputFormat) -> Result<()> {
+    let format = InvocationMachineOutput::selected()
+        .map(InvocationMachineOutput::format)
+        .unwrap_or(fallback);
     io::stdout().write_all(render_structured_output(value, format)?.as_bytes())?;
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InvocationMachineOutput {
+    Json,
+    Toon,
+}
+
+impl InvocationMachineOutput {
+    fn selected() -> Option<Self> {
+        let mut args = std::env::args_os().skip(1);
+        while let Some(arg) = args.next() {
+            let Some(arg) = arg.to_str() else {
+                continue;
+            };
+            if arg == "--output" {
+                return args
+                    .next()
+                    .and_then(|value| value.to_str().and_then(Self::parse));
+            }
+            if let Some(value) = arg.strip_prefix("--output=") {
+                return Self::parse(value);
+            }
+        }
+        None
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "json" => Some(Self::Json),
+            "toon" => Some(Self::Toon),
+            _ => None,
+        }
+    }
+
+    fn format(self) -> OutputFormat {
+        match self {
+            Self::Json => OutputFormat::Json,
+            Self::Toon => OutputFormat::Toon,
+        }
+    }
 }
 
 pub(crate) fn render_structured_output(
@@ -13,22 +57,30 @@ pub(crate) fn render_structured_output(
 ) -> Result<String> {
     match format {
         OutputFormat::Json => {
-            let mut rendered = serde_json::to_string_pretty(value)?;
-            rendered.push('\n');
-            Ok(rendered)
+            Ok(with_one_trailing_newline(serde_json::to_string_pretty(
+                value,
+            )?))
         }
         OutputFormat::Toon => {
             let value = serde_json::to_value(value)?;
             let rendered = toon_format::encode_default(&value)
                 .map_err(|error| CliError::new("TOON_ENCODE_ERROR", error.to_string()))?;
-            Ok(rendered)
+            Ok(with_one_trailing_newline(rendered))
         }
         OutputFormat::Human => {
-            let mut rendered = serde_json::to_string_pretty(value)?;
-            rendered.push('\n');
-            Ok(rendered)
+            Ok(with_one_trailing_newline(serde_json::to_string_pretty(
+                value,
+            )?))
         }
     }
+}
+
+fn with_one_trailing_newline(mut rendered: String) -> String {
+    while rendered.ends_with('\n') {
+        rendered.pop();
+    }
+    rendered.push('\n');
+    rendered
 }
 
 pub fn print_error(error: &CliError, output: OutputFormat) -> Result<()> {

--- a/cli-rs/tests/agent/output_format.rs
+++ b/cli-rs/tests/agent/output_format.rs
@@ -3,6 +3,7 @@ mod support;
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as STANDARD_BASE64};
 use sha2::{Digest as _, Sha256};
+use std::os::{fd::AsRawFd, unix::process::CommandExt};
 use support::*;
 
 fn rename_backend(
@@ -112,6 +113,153 @@ fn rename_backend(
 fn decode_toon(bytes: &[u8]) -> serde_json::Value {
     let output = std::str::from_utf8(bytes).expect("toon output should be utf-8");
     toon_format::decode_default(output.trim()).expect("toon output should decode")
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FailureCase {
+    Parsing,
+    Validation,
+    LocalState,
+    BackendRejection,
+    InvalidContinuation,
+    BusyPlan,
+    RecoveryUnavailable,
+    Unexpected,
+}
+
+impl FailureCase {
+    fn marker(self) -> &'static str {
+        match self {
+            Self::Parsing | Self::LocalState => "CLI_USAGE",
+            Self::Validation => "PLAN_ID_MALFORMED",
+            Self::BackendRejection => "backend-rejected",
+            Self::InvalidContinuation => "GRAPH_PAGE_TOKEN_MALFORMED",
+            Self::BusyPlan => "KAST_PLAN_BUSY",
+            Self::RecoveryUnavailable => "KAST_PLAN_UNAVAILABLE",
+            Self::Unexpected => "IO_ERROR",
+        }
+    }
+
+    fn args(self, format: &str, id: &str) -> Vec<String> {
+        let tail: &[&str] = match self {
+            Self::Parsing => &["--unknown-machine-flag"],
+            Self::Validation => &["change", "apply", "--plan-id", "invalid"],
+            Self::LocalState => &["file", "list", "--match", "["],
+            Self::BackendRejection => &["symbol", "resolve", "--query", "sample.Missing"],
+            Self::InvalidContinuation => {
+                &["graph", "nodes", "--continuation", "not-a-continuation"]
+            }
+            Self::BusyPlan => &["change", "apply", "--plan-id", id],
+            Self::RecoveryUnavailable => &["change", "recover", "--recovery-id", id],
+            Self::Unexpected => &["change", "apply", "--plan-id", id],
+        };
+        ["--output", format]
+            .into_iter()
+            .chain(tail.iter().copied())
+            .map(str::to_string)
+            .collect()
+    }
+}
+
+fn public_kast(home: &Path, config_home: &Path, workspace: &Path) -> std::process::Command {
+    let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_kast"));
+    command
+        .arg0("kast")
+        .current_dir(workspace)
+        .env("HOME", home)
+        .env("KAST_HOME", home.join(".local/share/kast"))
+        .env("KAST_CONFIG_HOME", config_home);
+    command
+}
+
+fn assert_canonical_machine_failure(
+    case: FailureCase,
+    format: &str,
+    output: &std::process::Output,
+) {
+    assert!(!output.status.success(), "{case:?}/{format}: {output:?}");
+    assert!(
+        output.stdout.ends_with(b"\n") && !output.stdout.ends_with(b"\n\n"),
+        "{case:?}/{format} must end with exactly one newline: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let value = match format {
+        "json" => serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "{case:?} emitted invalid JSON: {error}; stdout={}",
+                String::from_utf8_lossy(&output.stdout)
+            )
+        }),
+        "toon" => decode_toon(&output.stdout),
+        _ => unreachable!("closed test format"),
+    };
+    assert!(
+        value["schemaVersion"] == 2 && value["status"] == "rejected"
+            || value["error"].is_string()
+                && value["message"].is_string()
+                && value["next"].is_string(),
+        "{case:?}/{format} emitted a non-canonical failure: {value:#}"
+    );
+    assert!(
+        value.to_string().contains(case.marker()),
+        "{case:?}/{format} missed {}: {value:#}",
+        case.marker()
+    );
+}
+
+#[test]
+fn every_cli_failure_honors_the_selected_machine_output() {
+    const ID: &str = "b4d176ef-f0b9-4d54-9a3a-1ab659924452";
+    let cases = [
+        FailureCase::Parsing,
+        FailureCase::Validation,
+        FailureCase::LocalState,
+        FailureCase::BackendRejection,
+        FailureCase::InvalidContinuation,
+        FailureCase::BusyPlan,
+        FailureCase::RecoveryUnavailable,
+        FailureCase::Unexpected,
+    ];
+    for format in ["json", "toon"] {
+        for case in cases {
+            let temp = tempfile::tempdir().expect("failure fixture");
+            let home = temp.path().join("home");
+            let config_home = temp.path().join("config");
+            let workspace = temp.path().join("workspace");
+            std::fs::create_dir_all(&workspace).expect("workspace");
+            let mut lock = None;
+            if matches!(
+                case,
+                FailureCase::BusyPlan | FailureCase::RecoveryUnavailable
+            ) {
+                let directory = default_install_root(&home).join("state/agent-plans");
+                std::fs::create_dir_all(&directory).expect("plan directory");
+                if matches!(case, FailureCase::BusyPlan) {
+                    let file = std::fs::OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .create(true)
+                        .truncate(false)
+                        .open(directory.join(format!("{ID}.lock")))
+                        .expect("plan lock");
+                    assert_eq!(unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) }, 0);
+                    lock = Some(file);
+                }
+            }
+            let mut command = public_kast(&home, &config_home, &workspace);
+            if matches!(case, FailureCase::Unexpected) {
+                let blocked = temp.path().join("not-a-directory");
+                std::fs::write(&blocked, "blocked").expect("blocked install root");
+                command.env("KAST_HOME", blocked);
+            }
+            let output = command
+                .args(case.args(format, ID))
+                .output()
+                .expect("machine failure");
+            assert_canonical_machine_failure(case, format, &output);
+            drop(lock);
+        }
+    }
 }
 
 #[test]

--- a/cli-rs/tests/agent_workspace_files_smoke/types/unavailable.rs
+++ b/cli-rs/tests/agent_workspace_files_smoke/types/unavailable.rs
@@ -15,8 +15,8 @@ fn unavailable_error_has_one_structured_recovery_action_and_toon_stdout_discipli
     );
     let toon = std::str::from_utf8(&output.stdout).expect("TOON UTF-8");
     assert!(
-        !output.stdout.ends_with(b"\n"),
-        "TOON stdout must not have a trailing newline: {toon:?}"
+        output.stdout.ends_with(b"\n") && !output.stdout.ends_with(b"\n\n"),
+        "TOON stdout must end with exactly one newline: {toon:?}"
     );
     let document: serde_json::Value =
         toon_format::decode_default(toon).expect("workspace-files TOON");


### PR DESCRIPTION
## What

- honor the selected JSON or TOON format for parsing, validation, local-state, backend, busy-plan, unavailable-recovery, and unexpected CLI failures
- terminate every machine document with exactly one newline
- add table-driven public CLI coverage for both machine formats

## Why

Machine-output selection must remain authoritative even when command parsing or execution fails, so agents always receive one parseable canonical envelope without diagnostics mixed into stdout.

## Validation

- `cargo test --locked --manifest-path cli-rs/Cargo.toml --test agent_output_format_smoke`
- `cargo test --locked --manifest-path cli-rs/Cargo.toml --test agent_output_format_smoke --test kast_public_operations`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `python3 .github/scripts/check-repository-shape.py`
- `git diff --check`

Closes #580