### PR TITLE
Remove the Unix socket handler cleanup lock convoy

### DIFF
--- a/analysis-server/src/main/kotlin/io/github/amichne/kast/server/transport/LocalRpcServer.kt
+++ b/analysis-server/src/main/kotlin/io/github/amichne/kast/server/transport/LocalRpcServer.kt
@@ -21,8 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
-import java.util.Collections
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.concurrent.thread
 import kotlin.io.path.deleteIfExists
 
@@ -35,13 +34,35 @@ internal data class BoundSocketEvidence(
     val socketOwnerUid: SocketOwnerUid,
 )
 
+private sealed interface UnixSocketHandlerLifecycle {
+    data object Accepting : UnixSocketHandlerLifecycle
+
+    data object Closed : UnixSocketHandlerLifecycle
+}
+
+private sealed interface UnixSocketHandlerAdmission {
+    data object Accepted : UnixSocketHandlerAdmission
+
+    data object RejectedAfterClose : UnixSocketHandlerAdmission
+}
+
+private sealed interface UnixSocketHandlerShutdown {
+    data class Started(
+        val acceptedClients: List<SocketChannel>,
+        val activeHandlers: List<Thread>,
+    ) : UnixSocketHandlerShutdown
+
+    data object AlreadyClosed : UnixSocketHandlerShutdown
+}
+
 internal class UnixDomainSocketRpcServer(
     private val socketPath: Path,
     private val dispatcher: RpcAnalysisDispatcher,
 ) : LocalRpcServer {
-    private val closed = AtomicBoolean(false)
-    private val handlers = Collections.synchronizedSet(mutableSetOf<Thread>())
-    private val clients = mutableSetOf<SocketChannel>()
+    private val handlerLifecycleLock = Any()
+    private var handlerLifecycle: UnixSocketHandlerLifecycle = UnixSocketHandlerLifecycle.Accepting
+    private val handlers = ConcurrentHashMap.newKeySet<Thread>()
+    private val clients = ConcurrentHashMap.newKeySet<SocketChannel>()
     private val serverChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
     @Volatile
     private var boundEvidence: BoundSocketEvidence? = null
@@ -78,35 +99,34 @@ internal class UnixDomainSocketRpcServer(
     }
 
     override fun close() {
-        if (!closed.compareAndSet(false, true)) {
-            return
-        }
-        val deadlineNanos = System.nanoTime() + RPC_CLOSE_TIMEOUT_NANOS
-        runCatching { serverChannel.close() }
-        val currentThread = Thread.currentThread()
-        val (acceptedClients, activeHandlers) = synchronized(handlers) {
-            clients.toList() to handlers.toList()
-        }
-        acceptedClients.forEach { client ->
-            runCatching { client.close() }
-        }
-        activeHandlers.forEach { handler ->
-            if (handler !== currentThread) {
-                handler.interrupt()
+        when (val shutdown = beginHandlerShutdown()) {
+            UnixSocketHandlerShutdown.AlreadyClosed -> return
+            is UnixSocketHandlerShutdown.Started -> {
+                val deadlineNanos = System.nanoTime() + RPC_CLOSE_TIMEOUT_NANOS
+                runCatching { serverChannel.close() }
+                val currentThread = Thread.currentThread()
+                shutdown.acceptedClients.forEach { client ->
+                    runCatching { client.close() }
+                }
+                shutdown.activeHandlers.forEach { handler ->
+                    if (handler !== currentThread) {
+                        handler.interrupt()
+                    }
+                }
+                joinRpcThreadsUntil(
+                    threads = listOf(acceptThread) + shutdown.activeHandlers,
+                    currentThread = currentThread,
+                    deadlineNanos = deadlineNanos,
+                )
+                if (boundEvidence == readBoundSocketEvidenceOrNull(socketPath)) {
+                    socketPath.deleteIfExists()
+                }
             }
-        }
-        joinRpcThreadsUntil(
-            threads = listOf(acceptThread) + activeHandlers,
-            currentThread = currentThread,
-            deadlineNanos = deadlineNanos,
-        )
-        if (boundEvidence == readBoundSocketEvidenceOrNull(socketPath)) {
-            socketPath.deleteIfExists()
         }
     }
 
     private fun acceptLoop() {
-        while (!closed.get()) {
+        while (true) {
             val client = runCatching { serverChannel.accept() }.getOrNull() ?: break
             val handler = thread(
                 start = false,
@@ -116,27 +136,63 @@ internal class UnixDomainSocketRpcServer(
                 try {
                     client.use(::handleClient)
                 } finally {
-                    synchronized(handlers) {
-                        clients.remove(client)
-                        handlers.remove(Thread.currentThread())
-                    }
+                    clients.remove(client)
+                    handlers.remove(Thread.currentThread())
                 }
             }
-            val started = synchronized(handlers) {
-                if (closed.get()) {
-                    false
-                } else {
-                    clients += client
-                    handlers += handler
-                    handler.start()
-                    true
+            when (admitHandler(client, handler)) {
+                UnixSocketHandlerAdmission.Accepted -> Unit
+                UnixSocketHandlerAdmission.RejectedAfterClose -> {
+                    runCatching { client.close() }
+                        .onFailure { throw it }
+                    break
                 }
             }
-            if (!started) {
-                runCatching { client.close() }
-                .onFailure { throw it }
-                break
+        }
+    }
+
+    /**
+     * Proof transition: `(SocketChannel, Thread) -> UnixSocketHandlerAdmission`.
+     *
+     * [UnixSocketHandlerAdmission.Accepted] establishes that both resources are owned by this server,
+     * registered for shutdown, and that the handler has started. The closed expected failure is
+     * [UnixSocketHandlerAdmission.RejectedAfterClose]. Raw resource extraction remains confined to the
+     * socket accept boundary, where rejected clients are closed.
+     */
+    private fun admitHandler(
+        client: SocketChannel,
+        handler: Thread,
+    ): UnixSocketHandlerAdmission = synchronized(handlerLifecycleLock) {
+        when (handlerLifecycle) {
+            UnixSocketHandlerLifecycle.Accepting -> {
+                clients += client
+                handlers += handler
+                handler.start()
+                UnixSocketHandlerAdmission.Accepted
             }
+
+            UnixSocketHandlerLifecycle.Closed -> UnixSocketHandlerAdmission.RejectedAfterClose
+        }
+    }
+
+    /**
+     * Proof transition: `UnixSocketHandlerLifecycle -> UnixSocketHandlerShutdown`.
+     *
+     * [UnixSocketHandlerShutdown.Started] establishes closed admission and carries the complete owned-resource
+     * snapshot that existed at the transition. [UnixSocketHandlerShutdown.AlreadyClosed] is the closed expected
+     * idempotency outcome. Raw client and thread extraction is permitted only at the transport close boundary.
+     */
+    private fun beginHandlerShutdown(): UnixSocketHandlerShutdown = synchronized(handlerLifecycleLock) {
+        when (handlerLifecycle) {
+            UnixSocketHandlerLifecycle.Accepting -> {
+                handlerLifecycle = UnixSocketHandlerLifecycle.Closed
+                UnixSocketHandlerShutdown.Started(
+                    acceptedClients = clients.toList(),
+                    activeHandlers = handlers.toList(),
+                )
+            }
+
+            UnixSocketHandlerLifecycle.Closed -> UnixSocketHandlerShutdown.AlreadyClosed
         }
     }
 

--- a/analysis-server/src/test/kotlin/io/github/amichne/kast/server/socket/UnixSocketAnalysisServerTransportLifecycleTest.kt
+++ b/analysis-server/src/test/kotlin/io/github/amichne/kast/server/socket/UnixSocketAnalysisServerTransportLifecycleTest.kt
@@ -1,0 +1,151 @@
+package io.github.amichne.kast.server
+
+import io.github.amichne.kast.api.protocol.JsonRpcRequest
+import io.github.amichne.kast.testing.FakeAnalysisBackend
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.io.path.exists
+
+class UnixSocketAnalysisServerTransportLifecycleTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    private val json = Json {
+        encodeDefaults = true
+        explicitNulls = false
+        prettyPrint = false
+    }
+
+    @Test
+    fun `completed unix socket handlers do not convoy on the handler registry monitor`() {
+        val socketPath = tempDir.resolve("run").resolve("cleanup-convoy.sock")
+        val server = UnixDomainSocketRpcServer(
+            socketPath = socketPath,
+            dispatcher = RpcAnalysisDispatcher(
+                backend = FakeAnalysisBackend.sample(tempDir),
+                config = AnalysisServerConfig(),
+            ),
+        ).start()
+        val responses = CopyOnWriteArrayList<String>()
+        val clientFailures = CopyOnWriteArrayList<Throwable>()
+        val responsesComplete = CountDownLatch(CLIENT_COUNT)
+        val releaseClients = CountDownLatch(1)
+        val clients = List(CLIENT_COUNT) { requestId ->
+            thread(name = "kast-test-uds-client-$requestId") {
+                runCatching {
+                    responses += callSocketUntilReleased(
+                        socketPath = socketPath,
+                        requestId = requestId,
+                        responsesComplete = responsesComplete,
+                        releaseClients = releaseClients,
+                    )
+                }.onFailure(clientFailures::add)
+            }
+        }
+
+        try {
+            assertTrue(
+                responsesComplete.await(CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                "Unix socket clients did not all receive complete responses",
+            )
+            val handlerRegistry = handlerRegistry(server)
+            val acceptedHandlers = synchronized(handlerRegistry) {
+                handlerRegistry.map { entry ->
+                    checkNotNull(entry as? Thread) { "Handler registry contained a non-thread owner" }
+                }
+            }
+            assertEquals(CLIENT_COUNT, acceptedHandlers.size, "Handler cardinality exceeded accepted client ownership")
+
+            synchronized(handlerRegistry) {
+                releaseClients.countDown()
+                joinRpcThreadsUntil(
+                    threads = clients,
+                    currentThread = Thread.currentThread(),
+                    deadlineNanos = deadlineAfter(CLIENT_TIMEOUT_SECONDS),
+                )
+                assertTrue(clients.none(Thread::isAlive), "Unix socket clients did not close cleanly")
+                joinRpcThreadsUntil(
+                    threads = acceptedHandlers,
+                    currentThread = Thread.currentThread(),
+                    deadlineNanos = deadlineAfter(HANDLER_TIMEOUT_SECONDS),
+                )
+                assertTrue(
+                    acceptedHandlers.none(Thread::isAlive),
+                    "Unix socket handler cleanup convoyed on the shared handler registry monitor",
+                )
+            }
+
+            assertEquals(CLIENT_COUNT, responses.size, "Unix socket transport lost completed responses")
+            assertTrue(clientFailures.isEmpty(), "Unix socket clients failed: $clientFailures")
+            assertTrue(handlerRegistry(server).isEmpty(), "Unix socket server retained completed handlers")
+
+            server.close()
+
+            assertFalse(acceptThread(server).isAlive, "Unix socket server retained its accept thread")
+            assertFalse(socketPath.exists(), "Unix socket server retained its socket path")
+        } finally {
+            releaseClients.countDown()
+            clients.forEach { client -> client.join(TimeUnit.SECONDS.toMillis(CLIENT_TIMEOUT_SECONDS)) }
+            server.close()
+        }
+    }
+
+    private fun callSocketUntilReleased(
+        socketPath: Path,
+        requestId: Int,
+        responsesComplete: CountDownLatch,
+        releaseClients: CountDownLatch,
+    ): String = SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+        channel.connect(UnixDomainSocketAddress.of(socketPath))
+        val writer = Channels.newWriter(channel, StandardCharsets.UTF_8.name()).buffered()
+        val reader = Channels.newReader(channel, StandardCharsets.UTF_8.name()).buffered()
+        writer.write(
+            json.encodeToString(
+                JsonRpcRequest.serializer(),
+                JsonRpcRequest(id = JsonPrimitive(requestId), method = "runtime/status"),
+            ),
+        )
+        writer.newLine()
+        writer.flush()
+        val response = checkNotNull(reader.readLine())
+        responsesComplete.countDown()
+        check(releaseClients.await(CLIENT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            "Timed out waiting to release Unix socket client"
+        }
+        response
+    }
+
+    private fun handlerRegistry(server: UnixDomainSocketRpcServer): Collection<*> {
+        val field = server.javaClass.getDeclaredField("handlers").apply { trySetAccessible() }
+        return checkNotNull(field.get(server) as? Collection<*>)
+    }
+
+    private fun acceptThread(server: UnixDomainSocketRpcServer): Thread {
+        val field = server.javaClass.getDeclaredField("acceptThread").apply { trySetAccessible() }
+        return checkNotNull(field.get(server) as? Thread)
+    }
+
+    private fun deadlineAfter(seconds: Long): Long =
+        System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds)
+
+    private companion object {
+        const val CLIENT_COUNT = 16
+        const val CLIENT_TIMEOUT_SECONDS = 10L
+        const val HANDLER_TIMEOUT_SECONDS = 5L
+    }
+}


### PR DESCRIPTION
## What

- move Unix socket handler completion off the shared admission/shutdown monitor
- encode handler admission and shutdown as closed typed transitions while retaining exact client/thread ownership
- add a deterministic 16-client transport stress test for complete responses, bounded cardinality, cleanup liveness, and leak-free close

## Why

Fixes #576 (`KPA-006`). Completed RPC handlers currently serialize on the same monitor used for server admission and shutdown snapshots.

## Scope

- `analysis-server/src/main/kotlin/io/github/amichne/kast/server/transport/LocalRpcServer.kt`
- `analysis-server/src/test/kotlin/io/github/amichne/kast/server/socket/UnixSocketAnalysisServerTransportLifecycleTest.kt`

No TCP transport or public RPC protocol behavior changes.

## Evidence

- Baseline: focused lifecycle suite passed at `fa72ae46a3c0dd09f398ba8dbbafcb347fd1e988`
- RED: identical focused command failed only with `Unix socket handler cleanup convoyed on the shared handler registry monitor`
- GREEN: identical focused command passed all 10 lifecycle tests
- Regression: `./gradlew :analysis-server:test` passed
- Shape: repository-shape contract and checker passed; 1,634 governed files, 0 violations
- Hygiene: cached diff check passed

All Gradle state, artifacts, install/config/cache/socket roots, and reports were isolated under `/private/tmp/kast-576-evidence-fa72ae46`. The workload uses deterministic latch/monitor coordination; no performance profiler or timing-only contention claim is involved.
