### PR TITLE
Scale derived topology edge aggregation

### DIFF
--- a/cli-rs/src/agent/navigation/native_graph/graph/derived_topology/derive.rs
+++ b/cli-rs/src/agent/navigation/native_graph/graph/derived_topology/derive.rs
@@ -1,3 +1,5 @@
+include!("projection_work.rs");
+
 fn derive_reference_topology(
     snapshot: ReferenceTopologySnapshot,
     previous: Option<&DerivedTopologyArtifact>,
@@ -31,8 +33,9 @@ fn derive_reference_topology(
             .collect(),
     );
     let memberships = native_weighted_leiden(&graph, DERIVED_TOPOLOGY_RESOLUTION);
-    let (nodes, communities) =
+    let (nodes, communities, work) =
         derived_topology_projection(&snapshot.nodes, &snapshot.edges, &positions, &memberships);
+    emit_derived_topology_work_evidence(work);
     let (lineage, changes) = previous.map_or((None, None), |previous| {
         (
             Some(derived_topology_lineage(previous, &communities)),
@@ -69,12 +72,26 @@ fn derived_topology_projection(
     edges: &[ReferenceEdgeInput],
     positions: &BTreeMap<String, usize>,
     memberships: &[usize],
-) -> (Vec<DerivedTopologyNode>, Vec<DerivedTopologyCommunity>) {
+) -> (
+    Vec<DerivedTopologyNode>,
+    Vec<DerivedTopologyCommunity>,
+    DerivedTopologyProjectionWork,
+) {
     let mut incoming = vec![0usize; inputs.len()];
     let mut outgoing = vec![0usize; inputs.len()];
     let mut cross_community = vec![0usize; inputs.len()];
     let mut weighted_degree = vec![0.0; inputs.len()];
+    let mut members = BTreeMap::<usize, Vec<usize>>::new();
+    for (node, &community) in memberships.iter().enumerate() {
+        members.entry(community).or_default().push(node);
+    }
+    let mut community_edges = members
+        .keys()
+        .map(|&community| (community, DerivedTopologyCommunityEdgeMetrics::default()))
+        .collect::<BTreeMap<_, _>>();
+    let mut edge_visits = 0;
     for edge in edges {
+        edge_visits += 1;
         let (Some(&source), Some(&target)) =
             (positions.get(&edge.source), positions.get(&edge.target))
         else {
@@ -84,14 +101,25 @@ fn derived_topology_projection(
         incoming[target] += edge.occurrence_count;
         weighted_degree[source] += edge.normalized_weight;
         weighted_degree[target] += edge.normalized_weight;
-        if memberships[source] != memberships[target] {
+        let source_community = memberships[source];
+        let target_community = memberships[target];
+        if source_community == target_community {
+            community_edges
+                .get_mut(&source_community)
+                .expect("node memberships establish community edge metrics")
+                .record_internal(edge);
+        } else {
             cross_community[source] += edge.occurrence_count;
             cross_community[target] += edge.occurrence_count;
+            community_edges
+                .get_mut(&source_community)
+                .expect("source membership establishes community edge metrics")
+                .record_external(edge);
+            community_edges
+                .get_mut(&target_community)
+                .expect("target membership establishes community edge metrics")
+                .record_external(edge);
         }
-    }
-    let mut members = BTreeMap::<usize, Vec<usize>>::new();
-    for (node, &community) in memberships.iter().enumerate() {
-        members.entry(community).or_default().push(node);
     }
     let communities = members
         .iter()
@@ -100,9 +128,10 @@ fn derived_topology_projection(
                 community,
                 members,
                 inputs,
-                edges,
-                positions,
                 &weighted_degree,
+                community_edges
+                    .get(&community)
+                    .expect("community members establish community edge metrics"),
             )
         })
         .collect::<Vec<_>>();
@@ -152,42 +181,22 @@ fn derived_topology_projection(
             }
         })
         .collect();
-    (nodes, communities)
+    let work = DerivedTopologyProjectionWork {
+        node_count: inputs.len(),
+        edge_count: edges.len(),
+        community_count: communities.len(),
+        edge_visits,
+    };
+    (nodes, communities, work)
 }
 
 fn derived_topology_community(
     community: usize,
     members: &[usize],
     nodes: &[ReferenceNodeInput],
-    edges: &[ReferenceEdgeInput],
-    positions: &BTreeMap<String, usize>,
     weighted_degree: &[f64],
+    edge_metrics: &DerivedTopologyCommunityEdgeMetrics,
 ) -> DerivedTopologyCommunity {
-    let member_set = members.iter().copied().collect::<BTreeSet<_>>();
-    let mut internal_edge_count = 0;
-    let mut external_edge_count = 0;
-    let mut internal_weight = 0.0;
-    let mut external_weight = 0.0;
-    let mut relationship_kinds = BTreeMap::new();
-    for edge in edges {
-        let (Some(&source), Some(&target)) =
-            (positions.get(&edge.source), positions.get(&edge.target))
-        else {
-            continue;
-        };
-        let source_member = member_set.contains(&source);
-        let target_member = member_set.contains(&target);
-        if source_member && target_member {
-            internal_edge_count += 1;
-            internal_weight += edge.normalized_weight;
-        } else if source_member || target_member {
-            external_edge_count += 1;
-            external_weight += edge.normalized_weight;
-        } else {
-            continue;
-        }
-        *relationship_kinds.entry(edge.kind).or_default() += edge.occurrence_count;
-    }
     let mut term_counts = BTreeMap::<String, usize>::new();
     for &member in members {
         for term in semantic_label_terms(&nodes[member].name) {
@@ -214,8 +223,10 @@ fn derived_topology_community(
             .total_cmp(&weighted_degree[left])
             .then_with(|| nodes[left].key.cmp(&nodes[right].key))
     });
-    let total_weight = internal_weight + external_weight;
-    let volume = internal_weight.mul_add(2.0, external_weight);
+    let total_weight = edge_metrics.internal_weight + edge_metrics.external_weight;
+    let volume = edge_metrics
+        .internal_weight
+        .mul_add(2.0, edge_metrics.external_weight);
     DerivedTopologyCommunity {
         id: community,
         label: label_terms.join("-"),
@@ -225,17 +236,17 @@ fn derived_topology_community(
             .map(|&member| nodes[member].key.clone())
             .collect(),
         member_count: members.len(),
-        internal_edge_count,
-        external_edge_count,
-        internal_weight,
-        external_weight,
+        internal_edge_count: edge_metrics.internal_edge_count,
+        external_edge_count: edge_metrics.external_edge_count,
+        internal_weight: edge_metrics.internal_weight,
+        external_weight: edge_metrics.external_weight,
         cohesion: if total_weight > 0.0 {
-            internal_weight / total_weight
+            edge_metrics.internal_weight / total_weight
         } else {
             0.0
         },
         conductance: if volume > 0.0 {
-            external_weight / volume
+            edge_metrics.external_weight / volume
         } else {
             0.0
         },
@@ -244,7 +255,7 @@ fn derived_topology_community(
             .take(3)
             .map(|member| nodes[member].key.clone())
             .collect(),
-        relationship_kinds,
+        relationship_kinds: edge_metrics.relationship_kinds.clone(),
     }
 }
 

--- a/cli-rs/src/agent/navigation/native_graph/graph/derived_topology/projection_work.rs
+++ b/cli-rs/src/agent/navigation/native_graph/graph/derived_topology/projection_work.rs
@@ -1,0 +1,53 @@
+const DERIVED_TOPOLOGY_WORK_EVIDENCE_PREFIX: &str =
+    "KAST_TEST_DERIVED_TOPOLOGY_WORK_EVIDENCE=";
+
+#[derive(Debug, Default)]
+struct DerivedTopologyCommunityEdgeMetrics {
+    internal_edge_count: usize,
+    external_edge_count: usize,
+    internal_weight: f64,
+    external_weight: f64,
+    relationship_kinds: BTreeMap<DerivedRelationshipKind, usize>,
+}
+
+impl DerivedTopologyCommunityEdgeMetrics {
+    fn record_internal(&mut self, edge: &ReferenceEdgeInput) {
+        self.internal_edge_count += 1;
+        self.internal_weight += edge.normalized_weight;
+        self.record_relationship(edge);
+    }
+
+    fn record_external(&mut self, edge: &ReferenceEdgeInput) {
+        self.external_edge_count += 1;
+        self.external_weight += edge.normalized_weight;
+        self.record_relationship(edge);
+    }
+
+    fn record_relationship(&mut self, edge: &ReferenceEdgeInput) {
+        *self.relationship_kinds.entry(edge.kind).or_default() += edge.occurrence_count;
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DerivedTopologyProjectionWork {
+    node_count: usize,
+    edge_count: usize,
+    community_count: usize,
+    edge_visits: usize,
+}
+
+fn emit_derived_topology_work_evidence(work: DerivedTopologyProjectionWork) {
+    if cfg!(debug_assertions)
+        && std::env::var("KAST_TEST_DERIVED_TOPOLOGY_WORK_EVIDENCE").as_deref() == Ok("1")
+    {
+        eprintln!(
+            "{DERIVED_TOPOLOGY_WORK_EVIDENCE_PREFIX}{}",
+            serde_json::json!({
+                "nodeCount": work.node_count,
+                "edgeCount": work.edge_count,
+                "communityCount": work.community_count,
+                "edgeVisits": work.edge_visits,
+            })
+        );
+    }
+}

--- a/cli-rs/tests/agent/public/derived_topology_cli/coverage.rs
+++ b/cli-rs/tests/agent/public/derived_topology_cli/coverage.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "scaling.rs"]
+mod scaling;
+
 impl ReferenceFixture {
     fn install_repository_base(&self) -> PathBuf {
         let database = self.database();

--- a/cli-rs/tests/agent/public/derived_topology_cli/scaling.rs
+++ b/cli-rs/tests/agent/public/derived_topology_cli/scaling.rs
@@ -1,0 +1,123 @@
+use super::*;
+
+const LARGE_FIXTURE_COMMUNITY_COUNT: usize = 96;
+const WORK_EVIDENCE_PREFIX: &str = "KAST_TEST_DERIVED_TOPOLOGY_WORK_EVIDENCE=";
+
+impl ReferenceFixture {
+    fn replace_with_disconnected_pairs(&self, community_count: usize) {
+        let node_count = community_count.checked_mul(2).expect("fixture node count");
+        self.index
+            .connection()
+            .execute_batch(
+                "DELETE FROM symbol_references;
+                 DELETE FROM declarations;
+                 DELETE FROM file_gradle_source_sets;
+                 DELETE FROM file_gradle_projects;
+                 DELETE FROM file_metadata;
+                 DELETE FROM file_stage_outcomes;
+                 DELETE FROM file_manifest;
+                 DELETE FROM fq_names WHERE fq_id >= 2;",
+            )
+            .expect("clear small reference graph fixture");
+        self.index.seed_high_cardinality_sources(node_count);
+
+        let mut connection = self.index.connection();
+        let transaction = connection
+            .transaction()
+            .expect("large reference graph transaction");
+        for index in 0..node_count {
+            let fq_id = i64::try_from(index + 2).expect("fixture fq id");
+            let fq_name = format!("large.Component{index:04}");
+            let filename = format!("Source{index:04}.kt");
+            transaction
+                .execute(
+                    "INSERT INTO fq_names(fq_id, fq_name) VALUES (?, ?)",
+                    rusqlite::params![fq_id, fq_name],
+                )
+                .expect("large fixture fq name");
+            transaction
+                .execute(
+                    "INSERT INTO declarations VALUES (?, 'CLASS', 'PUBLIC', 1, ?, 1, ':app', 'main')",
+                    rusqlite::params![fq_id, filename],
+                )
+                .expect("large fixture declaration");
+        }
+        for community in 0..community_count {
+            let source_index = community * 2;
+            let source_fq_id = i64::try_from(source_index + 2).expect("source fq id");
+            let target_fq_id = source_fq_id + 1;
+            let source_filename = format!("Source{source_index:04}.kt");
+            let target_filename = format!("Source{:04}.kt", source_index + 1);
+            transaction
+                .execute(
+                    "INSERT INTO symbol_references VALUES (1, ?, 10, ?, ?, 1, ?, 1, 'CALL')",
+                    rusqlite::params![source_filename, source_fq_id, target_fq_id, target_filename],
+                )
+                .expect("large fixture reference edge");
+        }
+        transaction.commit().expect("large reference graph commit");
+    }
+
+    fn derive_with_work_evidence(&self, output: &str) -> Output {
+        let arguments = [
+            "graph",
+            "derive",
+            "--experimental-derived-topology",
+            "--out",
+            output,
+        ];
+        let home = self
+            .workspace
+            .parent()
+            .expect("fixture parent")
+            .join("home");
+        let config_home = self._temp.path().join("config");
+        let mut command = Command::new(env!("CARGO_BIN_EXE_kast"));
+        command
+            .arg0("kast")
+            .current_dir(&self.workspace)
+            .env("HOME", &home)
+            .env("KAST_HOME", home.join(".local/share/kast"))
+            .env("KAST_CONFIG_HOME", &config_home)
+            .env("KAST_TEST_DERIVED_TOPOLOGY_WORK_EVIDENCE", "1");
+        published_semantic_command_for_reads(command, &home, &config_home, &self.workspace, 1)
+            .args(arguments)
+            .output()
+            .expect("run instrumented derived topology command")
+    }
+}
+
+#[test]
+fn derive_visits_each_edge_once_while_preserving_deterministic_output() {
+    let fixture = ReferenceFixture::new();
+    fixture.replace_with_disconnected_pairs(LARGE_FIXTURE_COMMUNITY_COUNT);
+
+    let minimally_instrumented = fixture.derive("minimal.json", None);
+    let instrumented = fixture.derive_with_work_evidence("instrumented.json");
+    assert_success(&minimally_instrumented);
+    assert_success(&instrumented);
+    assert_eq!(
+        fixture.artifact("minimal.json"),
+        fixture.artifact("instrumented.json"),
+        "work instrumentation must preserve the golden derived topology bytes"
+    );
+
+    let stderr = String::from_utf8(instrumented.stderr).expect("UTF-8 work evidence");
+    let evidence = stderr
+        .lines()
+        .find_map(|line| line.strip_prefix(WORK_EVIDENCE_PREFIX))
+        .map(|value| serde_json::from_str::<serde_json::Value>(value).expect("work evidence JSON"))
+        .expect("derived topology work evidence");
+    let edge_count = evidence["edgeCount"].as_u64().expect("edge count");
+    let community_count = evidence["communityCount"]
+        .as_u64()
+        .expect("community count");
+    let edge_visits = evidence["edgeVisits"].as_u64().expect("edge visits");
+
+    assert_eq!(edge_count, LARGE_FIXTURE_COMMUNITY_COUNT as u64);
+    assert_eq!(community_count, LARGE_FIXTURE_COMMUNITY_COUNT as u64);
+    assert!(
+        edge_visits <= edge_count,
+        "projection visited {edge_visits} edges for {edge_count} edges and {community_count} communities; work must be bounded by graph edges"
+    );
+}


### PR DESCRIPTION
Risk: community metrics now accumulate during the sole projection edge scan; deterministic golden-byte equivalence and graph regression coverage guard semantic drift.

## What
- aggregate internal/external community edge metrics in one graph-sized pass
- expose debug-only typed edge-visit evidence for the integration fixture
- add a 96-community deterministic scaling regression

## Why
Derived topology previously rescanned every edge once per community, producing community-count multiplied by edge-count work.

## Verification
- focused RED: 9,312 visits for 96 edges and 96 communities
- focused GREEN: 12/12 derived-topology tests
- regression: 8/8 graph tests plus 12/12 derived-topology tests
- offline format check and strict Clippy
- repository shape and diff hygiene

Closes #577