### PR TITLE
fix: package development bundles for detected host

### DIFF
--- a/cli-rs/src/interface/cli/release_package_generate.rs
+++ b/cli-rs/src/interface/cli/release_package_generate.rs
@@ -1,3 +1,12 @@
+mod setup_bundle_platform {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/operations/parts/package/platform.rs"
+    ));
+}
+
+use setup_bundle_platform::SetupBundlePlatform;
+
 #[derive(Debug, Args, Clone)]
 pub struct ValidateArgs {
     /// Raw JSON-RPC request string.
@@ -47,12 +56,15 @@ pub struct SetupBundlePackageArgs {
     #[arg(long)]
     pub indexer_archive: PathBuf,
     /// Bundle platform id used in the archive name and manifest.
-    #[arg(long, default_value = "linux-x64")]
-    pub platform: String,
+    #[arg(
+        long,
+        default_value = setup_bundle_platform::native_default_value()
+    )]
+    pub(crate) platform: SetupBundlePlatform,
     /// Release tag or version for the generated bundle.
     #[arg(long)]
     pub version: String,
-    /// Output tar.gz path. Defaults to dist/kast-linux-x64-<version>.tar.gz.
+    /// Output tar.gz path. Defaults to dist/kast-<platform>-<version>.tar.gz.
     #[arg(long = "bundle-output")]
     pub bundle_output: Option<PathBuf>,
     /// Repository root containing install.sh, bundle resources, and LICENSE.

--- a/cli-rs/src/operations/parts/package/platform.rs
+++ b/cli-rs/src/operations/parts/package/platform.rs
@@ -1,0 +1,264 @@
+use std::env;
+use std::fmt;
+use std::ops::Deref;
+use std::str::FromStr;
+
+const ALLOW_TEST_HOST_EVIDENCE: &str = "KAST_TEST_ALLOW_PACKAGE_HOST_EVIDENCE";
+const TEST_HOST_OS: &str = "KAST_TEST_PACKAGE_HOST_OS";
+const TEST_HOST_ARCH: &str = "KAST_TEST_PACKAGE_HOST_ARCH";
+const UNSUPPORTED_NATIVE_HOST_DEFAULT: &str = "__kast_unsupported_native_package_host";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SetupBundlePlatform {
+    MacosArm64,
+    MacosX64,
+    LinuxX64,
+}
+
+impl SetupBundlePlatform {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::MacosArm64 => "macos-arm64",
+            Self::MacosX64 => "macos-x64",
+            Self::LinuxX64 => "linux-x64",
+        }
+    }
+
+    /// Canonical platform values contain no surrounding whitespace, so this
+    /// identity transition retains the admitted platform proof for packaging.
+    pub(crate) fn trim(&self) -> &Self {
+        self
+    }
+}
+
+impl Deref for SetupBundlePlatform {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for SetupBundlePlatform {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SetupBundlePlatform {
+    type Err = SetupBundlePlatformError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "macos-arm64" => Ok(Self::MacosArm64),
+            "macos-x64" => Ok(Self::MacosX64),
+            "linux-x64" => Ok(Self::LinuxX64),
+            UNSUPPORTED_NATIVE_HOST_DEFAULT => native_platform().and_then(|_| {
+                Err(SetupBundlePlatformError::UnsupportedTarget {
+                    observed: value.to_string(),
+                })
+            }),
+            _ => Err(SetupBundlePlatformError::UnsupportedTarget {
+                observed: value.to_string(),
+            }),
+        }
+    }
+}
+
+pub(super) fn native_default_value() -> &'static str {
+    native_platform()
+        .map(SetupBundlePlatform::as_str)
+        .unwrap_or(UNSUPPORTED_NATIVE_HOST_DEFAULT)
+}
+
+fn native_platform() -> Result<SetupBundlePlatform, SetupBundlePlatformError> {
+    SupportedHostPlatform::try_from(observed_host_evidence()?)
+        .map(SupportedHostPlatform::package_platform)
+}
+
+fn observed_host_evidence() -> Result<HostPlatformEvidence, SetupBundlePlatformError> {
+    if env::var(ALLOW_TEST_HOST_EVIDENCE).as_deref() == Ok("1") {
+        let os = env::var(TEST_HOST_OS).map_err(|_| {
+            SetupBundlePlatformError::IncompleteHostEvidence {
+                missing: HostEvidenceField::OperatingSystem,
+            }
+        })?;
+        let arch = env::var(TEST_HOST_ARCH).map_err(|_| {
+            SetupBundlePlatformError::IncompleteHostEvidence {
+                missing: HostEvidenceField::Architecture,
+            }
+        })?;
+        return HostPlatformEvidence::parse(&os, &arch);
+    }
+    HostPlatformEvidence::parse(env::consts::OS, env::consts::ARCH)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct HostPlatformEvidence {
+    operating_system: HostOperatingSystem,
+    architecture: HostArchitecture,
+}
+
+impl HostPlatformEvidence {
+    fn parse(os: &str, arch: &str) -> Result<Self, SetupBundlePlatformError> {
+        Ok(Self {
+            operating_system: HostOperatingSystem::parse(os)?,
+            architecture: HostArchitecture::parse(arch)?,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HostOperatingSystem {
+    Macos,
+    Linux,
+}
+
+impl HostOperatingSystem {
+    fn parse(value: &str) -> Result<Self, SetupBundlePlatformError> {
+        match value {
+            "macos" => Ok(Self::Macos),
+            "linux" => Ok(Self::Linux),
+            _ => Err(SetupBundlePlatformError::UnsupportedHostOperatingSystem {
+                observed: value.to_string(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for HostOperatingSystem {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Macos => "macos",
+            Self::Linux => "linux",
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HostArchitecture {
+    Arm64,
+    X64,
+}
+
+impl HostArchitecture {
+    fn parse(value: &str) -> Result<Self, SetupBundlePlatformError> {
+        match value {
+            "aarch64" => Ok(Self::Arm64),
+            "x86_64" => Ok(Self::X64),
+            _ => Err(SetupBundlePlatformError::UnsupportedHostArchitecture {
+                observed: value.to_string(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for HostArchitecture {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Arm64 => "aarch64",
+            Self::X64 => "x86_64",
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SupportedHostPlatform {
+    MacosArm64,
+    MacosX64,
+    LinuxX64,
+}
+
+impl SupportedHostPlatform {
+    fn package_platform(self) -> SetupBundlePlatform {
+        match self {
+            Self::MacosArm64 => SetupBundlePlatform::MacosArm64,
+            Self::MacosX64 => SetupBundlePlatform::MacosX64,
+            Self::LinuxX64 => SetupBundlePlatform::LinuxX64,
+        }
+    }
+}
+
+impl TryFrom<HostPlatformEvidence> for SupportedHostPlatform {
+    type Error = SetupBundlePlatformError;
+
+    fn try_from(evidence: HostPlatformEvidence) -> Result<Self, Self::Error> {
+        match (evidence.operating_system, evidence.architecture) {
+            (HostOperatingSystem::Macos, HostArchitecture::Arm64) => Ok(Self::MacosArm64),
+            (HostOperatingSystem::Macos, HostArchitecture::X64) => Ok(Self::MacosX64),
+            (HostOperatingSystem::Linux, HostArchitecture::X64) => Ok(Self::LinuxX64),
+            (operating_system, architecture) => {
+                Err(SetupBundlePlatformError::UnsupportedHostCombination {
+                    operating_system,
+                    architecture,
+                })
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HostEvidenceField {
+    OperatingSystem,
+    Architecture,
+}
+
+impl fmt::Display for HostEvidenceField {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::OperatingSystem => "operating system",
+            Self::Architecture => "architecture",
+        })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum SetupBundlePlatformError {
+    IncompleteHostEvidence {
+        missing: HostEvidenceField,
+    },
+    UnsupportedHostOperatingSystem {
+        observed: String,
+    },
+    UnsupportedHostArchitecture {
+        observed: String,
+    },
+    UnsupportedHostCombination {
+        operating_system: HostOperatingSystem,
+        architecture: HostArchitecture,
+    },
+    UnsupportedTarget {
+        observed: String,
+    },
+}
+
+impl fmt::Display for SetupBundlePlatformError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IncompleteHostEvidence { missing } => {
+                write!(formatter, "Package host evidence is missing {missing}.")
+            }
+            Self::UnsupportedHostOperatingSystem { observed } => write!(
+                formatter,
+                "Package host operating system `{observed}` is unsupported."
+            ),
+            Self::UnsupportedHostArchitecture { observed } => write!(
+                formatter,
+                "Package host architecture `{observed}` is unsupported."
+            ),
+            Self::UnsupportedHostCombination {
+                operating_system,
+                architecture,
+            } => write!(
+                formatter,
+                "Package host `{operating_system}/{architecture}` has no supported bundle target."
+            ),
+            Self::UnsupportedTarget { observed } => write!(
+                formatter,
+                "Package target `{observed}` is unsupported; expected macos-arm64, macos-x64, or linux-x64."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SetupBundlePlatformError {}

--- a/cli-rs/tests/surface/release_bundle.rs
+++ b/cli-rs/tests/surface/release_bundle.rs
@@ -3,6 +3,154 @@ mod support;
 
 use support::*;
 
+const ALLOW_TEST_HOST_EVIDENCE: &str = "KAST_TEST_ALLOW_PACKAGE_HOST_EVIDENCE";
+const TEST_HOST_OS: &str = "KAST_TEST_PACKAGE_HOST_OS";
+const TEST_HOST_ARCH: &str = "KAST_TEST_PACKAGE_HOST_ARCH";
+
+#[derive(Clone, Copy)]
+struct HostEvidenceFixture<'a> {
+    os: Option<&'a str>,
+    arch: Option<&'a str>,
+}
+
+fn run_package_for_platform(
+    host: HostEvidenceFixture<'_>,
+    platform_override: Option<&str>,
+) -> (tempfile::TempDir, std::process::Output) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let repo_root = temp.path().join("repo");
+    let output = temp.path().join("dist/bundle.tar.gz");
+    std::fs::create_dir_all(&repo_root).expect("repo root");
+    std::fs::write(repo_root.join("install.sh"), "#!/usr/bin/env bash\n")
+        .expect("bootstrap script");
+    set_executable_for_test(&repo_root.join("install.sh"));
+
+    let cli_archive = write_cli_archive(temp.path());
+    let indexer_archive = write_indexer_archive(temp.path(), "indexer", "v9.8.7");
+    let mut command = kast(&home, &config_home);
+    command
+        .env_remove(ALLOW_TEST_HOST_EVIDENCE)
+        .env_remove(TEST_HOST_OS)
+        .env_remove(TEST_HOST_ARCH)
+        .env(ALLOW_TEST_HOST_EVIDENCE, "1")
+        .args([
+            "--output",
+            "json",
+            "developer",
+            "release",
+            "package",
+            "setup-bundle",
+            "--repo-root",
+            repo_root.to_str().expect("repo root"),
+            "--cli-archive",
+            cli_archive.to_str().expect("cli archive"),
+            "--indexer-archive",
+            indexer_archive.to_str().expect("indexer archive"),
+            "--version",
+            "v9.8.7",
+            "--bundle-output",
+            output.to_str().expect("output"),
+        ]);
+    if let Some(os) = host.os {
+        command.env(TEST_HOST_OS, os);
+    }
+    if let Some(arch) = host.arch {
+        command.env(TEST_HOST_ARCH, arch);
+    }
+    if let Some(platform) = platform_override {
+        command.args(["--platform", platform]);
+    }
+
+    let package = command.output().expect("package setup bundle");
+    (temp, package)
+}
+
+#[test]
+fn package_setup_bundle_derives_each_supported_native_platform() {
+    for (os, arch, expected) in [
+        ("macos", "aarch64", "macos-arm64"),
+        ("macos", "x86_64", "macos-x64"),
+        ("linux", "x86_64", "linux-x64"),
+    ] {
+        let (_temp, package) = run_package_for_platform(
+            HostEvidenceFixture {
+                os: Some(os),
+                arch: Some(arch),
+            },
+            None,
+        );
+        assert!(
+            package.status.success(),
+            "{os}/{arch} package should succeed: stdout={}, stderr={}",
+            String::from_utf8_lossy(&package.stdout),
+            String::from_utf8_lossy(&package.stderr)
+        );
+        let stdout: serde_json::Value =
+            serde_json::from_slice(&package.stdout).expect("package json");
+        assert_eq!(stdout["platform"], expected, "host {os}/{arch}");
+    }
+}
+
+#[test]
+fn package_setup_bundle_honors_and_reports_supported_override() {
+    let (_temp, package) = run_package_for_platform(
+        HostEvidenceFixture {
+            os: Some("macos"),
+            arch: Some("aarch64"),
+        },
+        Some("linux-x64"),
+    );
+    assert!(
+        package.status.success(),
+        "override package should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&package.stdout),
+        String::from_utf8_lossy(&package.stderr)
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&package.stdout).expect("package json");
+    assert_eq!(stdout["platform"], "linux-x64");
+}
+
+#[test]
+fn package_setup_bundle_rejects_unsupported_or_incomplete_host_evidence() {
+    for host in [
+        HostEvidenceFixture {
+            os: Some("windows"),
+            arch: Some("x86_64"),
+        },
+        HostEvidenceFixture {
+            os: Some("macos"),
+            arch: None,
+        },
+    ] {
+        let (_temp, package) = run_package_for_platform(host, None);
+        assert!(
+            !package.status.success(),
+            "unsupported or incomplete host evidence must fail closed: stdout={}, stderr={}",
+            String::from_utf8_lossy(&package.stdout),
+            String::from_utf8_lossy(&package.stderr)
+        );
+    }
+}
+
+#[test]
+fn package_setup_bundle_rejects_unsupported_target_override() {
+    let (_temp, package) = run_package_for_platform(
+        HostEvidenceFixture {
+            os: Some("macos"),
+            arch: Some("aarch64"),
+        },
+        Some("windows-x64"),
+    );
+    assert!(
+        !package.status.success(),
+        "unsupported target must fail closed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&package.stdout),
+        String::from_utf8_lossy(&package.stderr)
+    );
+}
+
 #[test]
 fn package_setup_bundle_writes_manifest_projection() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -34,6 +182,8 @@ fn package_setup_bundle_writes_manifest_projection() {
             indexer_archive.to_str().expect("indexer archive"),
             "--version",
             "v9.8.7",
+            "--platform",
+            "linux-x64",
             "--bundle-output",
             output.to_str().expect("output"),
         ])


### PR DESCRIPTION
Fixes #582.

## What changed

- Development setup-bundle generation now selects `macos-arm64`, `macos-x64`, or `linux-x64` from the detected host when `--platform` is absent.
- Supported explicit platform overrides remain authoritative and are reported in package output.
- Unsupported or incomplete host evidence and unsupported targets fail closed.

## Verification

- Focused release-bundle surface suite: 5/5 passed with disposable Kast and Cargo roots.
- `packageDevelopmentSetupBundle`: passed hermetically and produced a `macos-arm64` archive root and manifest on the ARM macOS host.
- Rust format, strict all-target/all-feature Clippy, repository-shape, and diff-hygiene checks: passed.

Scope is limited to the setup-bundle platform contract and its surface tests.
