### PR TITLE
fix: support Linux ARM64 development bundles

### DIFF
--- a/cli-rs/src/operations/parts/package/platform.rs
+++ b/cli-rs/src/operations/parts/package/platform.rs
@@ -12,6 +12,7 @@ const UNSUPPORTED_NATIVE_HOST_DEFAULT: &str = "__kast_unsupported_native_package
 pub(crate) enum SetupBundlePlatform {
     MacosArm64,
     MacosX64,
+    LinuxArm64,
     LinuxX64,
 }
 
@@ -20,6 +21,7 @@ impl SetupBundlePlatform {
         match self {
             Self::MacosArm64 => "macos-arm64",
             Self::MacosX64 => "macos-x64",
+            Self::LinuxArm64 => "linux-arm64",
             Self::LinuxX64 => "linux-x64",
         }
     }
@@ -52,6 +54,7 @@ impl FromStr for SetupBundlePlatform {
         match value {
             "macos-arm64" => Ok(Self::MacosArm64),
             "macos-x64" => Ok(Self::MacosX64),
+            "linux-arm64" => Ok(Self::LinuxArm64),
             "linux-x64" => Ok(Self::LinuxX64),
             UNSUPPORTED_NATIVE_HOST_DEFAULT => native_platform().and_then(|_| {
                 Err(SetupBundlePlatformError::UnsupportedTarget {
@@ -72,8 +75,9 @@ pub(super) fn native_default_value() -> &'static str {
 }
 
 fn native_platform() -> Result<SetupBundlePlatform, SetupBundlePlatformError> {
-    SupportedHostPlatform::try_from(observed_host_evidence()?)
-        .map(SupportedHostPlatform::package_platform)
+    observed_host_evidence().map(|evidence| {
+        SupportedHostPlatform::from(evidence).package_platform()
+    })
 }
 
 fn observed_host_evidence() -> Result<HostPlatformEvidence, SetupBundlePlatformError> {
@@ -166,6 +170,7 @@ impl fmt::Display for HostArchitecture {
 enum SupportedHostPlatform {
     MacosArm64,
     MacosX64,
+    LinuxArm64,
     LinuxX64,
 }
 
@@ -174,25 +179,19 @@ impl SupportedHostPlatform {
         match self {
             Self::MacosArm64 => SetupBundlePlatform::MacosArm64,
             Self::MacosX64 => SetupBundlePlatform::MacosX64,
+            Self::LinuxArm64 => SetupBundlePlatform::LinuxArm64,
             Self::LinuxX64 => SetupBundlePlatform::LinuxX64,
         }
     }
 }
 
-impl TryFrom<HostPlatformEvidence> for SupportedHostPlatform {
-    type Error = SetupBundlePlatformError;
-
-    fn try_from(evidence: HostPlatformEvidence) -> Result<Self, Self::Error> {
+impl From<HostPlatformEvidence> for SupportedHostPlatform {
+    fn from(evidence: HostPlatformEvidence) -> Self {
         match (evidence.operating_system, evidence.architecture) {
-            (HostOperatingSystem::Macos, HostArchitecture::Arm64) => Ok(Self::MacosArm64),
-            (HostOperatingSystem::Macos, HostArchitecture::X64) => Ok(Self::MacosX64),
-            (HostOperatingSystem::Linux, HostArchitecture::X64) => Ok(Self::LinuxX64),
-            (operating_system, architecture) => {
-                Err(SetupBundlePlatformError::UnsupportedHostCombination {
-                    operating_system,
-                    architecture,
-                })
-            }
+            (HostOperatingSystem::Macos, HostArchitecture::Arm64) => Self::MacosArm64,
+            (HostOperatingSystem::Macos, HostArchitecture::X64) => Self::MacosX64,
+            (HostOperatingSystem::Linux, HostArchitecture::Arm64) => Self::LinuxArm64,
+            (HostOperatingSystem::Linux, HostArchitecture::X64) => Self::LinuxX64,
         }
     }
 }
@@ -223,10 +222,6 @@ pub(crate) enum SetupBundlePlatformError {
     UnsupportedHostArchitecture {
         observed: String,
     },
-    UnsupportedHostCombination {
-        operating_system: HostOperatingSystem,
-        architecture: HostArchitecture,
-    },
     UnsupportedTarget {
         observed: String,
     },
@@ -246,16 +241,9 @@ impl fmt::Display for SetupBundlePlatformError {
                 formatter,
                 "Package host architecture `{observed}` is unsupported."
             ),
-            Self::UnsupportedHostCombination {
-                operating_system,
-                architecture,
-            } => write!(
-                formatter,
-                "Package host `{operating_system}/{architecture}` has no supported bundle target."
-            ),
             Self::UnsupportedTarget { observed } => write!(
                 formatter,
-                "Package target `{observed}` is unsupported; expected macos-arm64, macos-x64, or linux-x64."
+                "Package target `{observed}` is unsupported; expected macos-arm64, macos-x64, linux-arm64, or linux-x64."
             ),
         }
     }

--- a/cli-rs/tests/surface/release_bundle.rs
+++ b/cli-rs/tests/surface/release_bundle.rs
@@ -72,6 +72,7 @@ fn package_setup_bundle_derives_each_supported_native_platform() {
     for (os, arch, expected) in [
         ("macos", "aarch64", "macos-arm64"),
         ("macos", "x86_64", "macos-x64"),
+        ("linux", "aarch64", "linux-arm64"),
         ("linux", "x86_64", "linux-x64"),
     ] {
         let (_temp, package) = run_package_for_platform(
@@ -91,6 +92,25 @@ fn package_setup_bundle_derives_each_supported_native_platform() {
             serde_json::from_slice(&package.stdout).expect("package json");
         assert_eq!(stdout["platform"], expected, "host {os}/{arch}");
     }
+}
+
+#[test]
+fn package_setup_bundle_supports_linux_arm64_target() {
+    let (_temp, package) = run_package_for_platform(
+        HostEvidenceFixture {
+            os: Some("macos"),
+            arch: Some("aarch64"),
+        },
+        Some("linux-arm64"),
+    );
+    assert!(
+        package.status.success(),
+        "Linux ARM64 package should succeed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&package.stdout),
+        String::from_utf8_lossy(&package.stderr)
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&package.stdout).expect("package json");
+    assert_eq!(stdout["platform"], "linux-arm64");
 }
 
 #[test]


### PR DESCRIPTION
Addresses #582.

Delivery note: this PR intentionally does not auto-close #582. The issue remains open for post-merge exact-main CI and successful snapshot publication verification.

## What changed

- Admit `linux-arm64` in the typed development setup-bundle platform contract.
- Derive `linux-arm64` from native Linux/aarch64 host evidence.
- Remove the now-impossible unsupported combination from the closed host-platform mapping.
- Cover the explicit Linux ARM64 target and all four repository matrix platforms through the real CLI surface.

This repairs the deterministic `CLI_USAGE` failure in [snapshot run 31284283383](https://github.com/amichne/kast/actions/runs/31284283383), where only the Linux ARM64 setup-bundle job failed.

## Verification

- Focused Linux ARM64 RED → identical GREEN: passed.
- `release_bundle_smoke`: 6/6 passed.
- Real development package task and explicit built `linux-arm64` package: passed; bundle sidecar verified.
- Release-workflow, snapshot-installer, and local-development refresh contracts: passed.
- Rust format, strict all-target/all-feature Clippy, repository-shape, and diff-hygiene checks: passed.

Scope is limited to the typed platform owner and release-bundle surface tests.
