### PR TITLE
Bound graph output for agent consumption

### DIFF
--- a/cli-rs/src/agent/adapter/graph.rs
+++ b/cli-rs/src/agent/adapter/graph.rs
@@ -155,131 +155,19 @@ fn print_native_graph(
                     "The native graph node page returned the wrong generation.",
                 )
             })?;
-        let expected_after_id = page
-            .as_ref()
-            .map_or(0, agent::public_protocol::GraphNodesPageToken::after_id);
-        fields
-            .remove("afterId")
-            .and_then(|value| value.as_u64())
-            .filter(|after_id| *after_id == expected_after_id)
-            .ok_or_else(|| {
-                CliError::new(
-                    "KAST_INVALID_AGENT_RESULT",
-                    "The native graph node page returned the wrong prior node identity.",
-                )
-            })?;
-        let previously_returned = fields
-            .remove("previouslyReturned")
-            .and_then(|value| value.as_u64())
-            .ok_or_else(|| {
-                CliError::new(
-                    "KAST_INVALID_AGENT_RESULT",
-                    "The native graph node page returned no prior cardinality evidence.",
-                )
-            })?;
-        let nodes = fields
-            .get_mut("nodes")
-            .and_then(Value::as_array_mut)
-            .ok_or_else(|| {
-                CliError::new(
-                    "KAST_INVALID_AGENT_RESULT",
-                    "The native graph node page returned no node collection.",
-                )
-            })?;
-        for node in nodes.iter_mut() {
-            replace_public_path(&workspace_root, node, "path", "path")?;
-            let node_fields = node.as_object_mut().ok_or_else(|| {
-                CliError::new(
-                    "KAST_INVALID_AGENT_RESULT",
-                    "The native graph node page returned a non-object node.",
-                )
-            })?;
-            let node_id = node_fields.get("id").and_then(Value::as_u64).ok_or_else(|| {
-                CliError::new(
-                    "KAST_INVALID_AGENT_RESULT",
-                    "The native graph node page returned a node without a numeric identity.",
-                )
-            })?;
-            let stable_key = node_fields
-                .get("stableKey")
-                .and_then(Value::as_str)
-                .ok_or_else(|| {
-                    CliError::new(
-                        "KAST_INVALID_AGENT_RESULT",
-                        "The native graph node page returned a node without a stable key.",
-                    )
-                })?;
-            let selector = agent::public_protocol::issue_graph_node_selector(
-                &workspace_root,
-                generation,
-                node_id,
-                stable_key,
-            )
-            .map_err(|failure| CliError::new(failure.code(), failure.message()))?;
-            node_fields.insert(
-                "nodeSelector".to_string(),
-                Value::String(selector.as_str().to_string()),
-            );
+        if let Some(nodes) = fields.get_mut("nodes").and_then(Value::as_array_mut) {
+            for node in nodes {
+                replace_public_path(&workspace_root, node, "path", "path")?;
+            }
         }
-        let returned = u64::try_from(nodes.len()).map_err(|_| {
-            CliError::new(
-                "KAST_INVALID_AGENT_RESULT",
-                "The graph node page exceeded public cardinality.",
-            )
-        })?;
-        let cumulative_returned = previously_returned.checked_add(returned).ok_or_else(|| {
-            CliError::new(
-                "KAST_INVALID_AGENT_RESULT",
-                "The graph node continuation exceeded public cardinality.",
-            )
-        })?;
-        let next_after_id = fields.remove("nextAfterId").ok_or_else(|| {
-            CliError::new(
-                "KAST_INVALID_AGENT_RESULT",
-                "The native graph node page returned no continuation evidence.",
-            )
-        })?;
-        let truncated = !next_after_id.is_null();
-        let mut continuation = None;
-        if truncated {
-            let next_after_id = next_after_id.as_u64().ok_or_else(|| {
-                CliError::new(
-                    "KAST_INVALID_AGENT_RESULT",
-                    "The native graph node page returned an invalid continuation.",
-                )
-            })?;
-            let next_page = agent::public_protocol::GraphNodesPageToken::issue(
-                workspace_fingerprint,
-                admission.generation(),
-                next_after_id,
-            )
-            .ok_or_else(|| {
-                CliError::new(
-                    "KAST_INVALID_AGENT_RESULT",
-                    "The native graph node page returned a zero continuation.",
-                )
-            })?;
-            continuation = Some(next_page.canonical());
-        }
-        let cardinality = if truncated {
-            let known_minimum = cumulative_returned.checked_add(1).ok_or_else(|| {
-                CliError::new(
-                    "KAST_INVALID_AGENT_RESULT",
-                    "The graph node page exceeded public cardinality.",
-                )
-            })?;
-            json!({"type": "known-minimum", "count": known_minimum})
-        } else {
-            json!({"type": "exact", "count": cumulative_returned})
-        };
-        let mut page = json!({
-            "cardinality": cardinality,
-            "returned": returned,
-        });
-        if let Some(continuation) = continuation {
-            page["continuation"] = Value::String(continuation);
-        }
-        fields.insert("page".to_string(), page);
+        *fields = agent::public_protocol::GraphNodesPageToken::project_page(
+            &workspace_root,
+            generation,
+            page.as_ref(),
+            std::mem::take(fields),
+        )
+        .map_err(|failure| CliError::new("KAST_INVALID_AGENT_RESULT", failure.message()))?
+        .into_fields();
     }
     if let Some(selected_node) = selected_node
         && fields.get("key").and_then(Value::as_str) != Some(selected_node.stable_key())
@@ -292,14 +180,18 @@ fn print_native_graph(
             ),
         ));
     }
-    let backend_type = fields.remove("type").and_then(|value| value.as_str().map(str::to_string));
+    let backend_type = fields
+        .remove("type")
+        .and_then(|value| value.as_str().map(str::to_string));
     if backend_type.as_deref() != Some(native_graph_result_type(operation)) {
         return Err(CliError::new(
             "KAST_INVALID_AGENT_RESULT",
             "The native graph operation returned the wrong result type.",
         ));
     }
-    if fields.remove("schemaVersion").and_then(|value| value.as_u64())
+    if fields
+        .remove("schemaVersion")
+        .and_then(|value| value.as_u64())
         != Some(u64::from(crate::SCHEMA_VERSION))
     {
         return Err(CliError::new(
@@ -312,27 +204,140 @@ fn print_native_graph(
     } else {
         agent::public_protocol::OperationStatus::Complete
     };
-    print_protocol(
-        agent::public_protocol::ProtocolEnvelope::projected(
-            public_operation,
-            status,
-            fields.clone(),
-        ),
+    BoundedGraphResponse::print(
+        public_operation,
+        status,
+        operation,
+        std::mem::take(fields),
         output_format,
     )
 }
 
-fn public_graph_operation(
+const MAX_PUBLIC_GRAPH_RESPONSE_BYTES: usize = 64 * 1_024;
+
+struct BoundedGraphResponse(agent::public_protocol::ProtocolEnvelope);
+
+impl BoundedGraphResponse {
+    fn print(
+        public_operation: agent::public_protocol::OperationId,
+        status: agent::public_protocol::OperationStatus,
+        operation: NativeGraphOperation,
+        mut fields: serde_json::Map<String, Value>,
+        output_format: OutputFormat,
+    ) -> Result<i32> {
+        summarize_graph_projection(operation, &mut fields)?;
+        let envelope =
+            agent::public_protocol::ProtocolEnvelope::projected(public_operation, status, fields);
+        let bytes = output::render_structured_output(&envelope, output_format)?.len();
+        if bytes > MAX_PUBLIC_GRAPH_RESPONSE_BYTES {
+            return Err(CliError::new(
+                "KAST_GRAPH_RESPONSE_BUDGET_EXCEEDED",
+                format!(
+                    "The graph response required {bytes} bytes; the public bound is {MAX_PUBLIC_GRAPH_RESPONSE_BYTES}."
+                ),
+            ));
+        }
+        let response = Self(envelope);
+        print_protocol(response.0, output_format)
+    }
+}
+
+fn summarize_graph_projection(
     operation: NativeGraphOperation,
-) -> agent::public_protocol::OperationId {
+    fields: &mut serde_json::Map<String, Value>,
+) -> Result<()> {
+    let summary = match operation {
+        NativeGraphOperation::Summary | NativeGraphOperation::Nodes => return Ok(()),
+        NativeGraphOperation::Neighbors => json!({
+            "type": "bounded-summary",
+            "outgoingCount": take_graph_array(fields, "outgoing")?.len(),
+            "incomingCount": take_graph_array(fields, "incoming")?.len(),
+        }),
+        NativeGraphOperation::Topology => {
+            let nodes = take_graph_array(fields, "nodes")?;
+            let components = take_graph_array(fields, "components")?;
+            let strongly_connected = take_graph_array(fields, "stronglyConnectedComponents")?;
+            let topological = take_graph_array(fields, "condensationTopologicalOrder")?;
+            if components.len() != nodes.len() || strongly_connected.len() != nodes.len() {
+                return Err(invalid_graph_projection("topology cardinalities disagreed"));
+            }
+            let component_count = distinct_graph_ids(&components)?;
+            let strongly_connected_count = distinct_graph_ids(&strongly_connected)?;
+            if distinct_graph_ids(&topological)? != strongly_connected_count {
+                return Err(invalid_graph_projection(
+                    "topological components were incomplete",
+                ));
+            }
+            json!({
+                "type": "bounded-summary",
+                "nodeCount": nodes.len(),
+                "componentCount": component_count,
+                "stronglyConnectedComponentCount": strongly_connected_count,
+            })
+        }
+        NativeGraphOperation::Communities => {
+            let nodes = take_graph_array(fields, "nodes")?;
+            let mut communities = BTreeSet::new();
+            for node in &nodes {
+                let fields = node
+                    .as_object()
+                    .ok_or_else(|| invalid_graph_projection("community node was not an object"))?;
+                if fields.get("key").and_then(Value::as_str).is_none() {
+                    return Err(invalid_graph_projection("community node omitted its key"));
+                }
+                communities.insert(fields.get("community").and_then(Value::as_u64).ok_or_else(
+                    || invalid_graph_projection("community node omitted its identity"),
+                )?);
+            }
+            json!({
+                "type": "bounded-summary",
+                "nodeCount": nodes.len(),
+                "communityCount": communities.len()
+            })
+        }
+        NativeGraphOperation::Refresh => {
+            return Err(invalid_graph_projection(
+                "refresh reached the graph read projection",
+            ));
+        }
+    };
+    fields.insert("summary".to_string(), summary);
+    Ok(())
+}
+
+fn take_graph_array(
+    fields: &mut serde_json::Map<String, Value>,
+    name: &'static str,
+) -> Result<Vec<Value>> {
+    fields
+        .remove(name)
+        .and_then(|value| value.as_array().cloned())
+        .ok_or_else(|| invalid_graph_projection("graph summary omitted a required collection"))
+}
+
+fn distinct_graph_ids(values: &[Value]) -> Result<usize> {
+    values
+        .iter()
+        .map(|value| {
+            value.as_u64().ok_or_else(|| {
+                invalid_graph_projection("graph summary contained a non-numeric identity")
+            })
+        })
+        .collect::<Result<BTreeSet<_>>>()
+        .map(|ids| ids.len())
+}
+
+fn invalid_graph_projection(message: &'static str) -> CliError {
+    CliError::new("KAST_INVALID_AGENT_RESULT", message)
+}
+
+fn public_graph_operation(operation: NativeGraphOperation) -> agent::public_protocol::OperationId {
     match operation {
         NativeGraphOperation::Summary => agent::public_protocol::OperationId::GraphSummary,
         NativeGraphOperation::Nodes => agent::public_protocol::OperationId::GraphNodes,
         NativeGraphOperation::Neighbors => agent::public_protocol::OperationId::GraphNeighbors,
         NativeGraphOperation::Topology => agent::public_protocol::OperationId::GraphTopology,
-        NativeGraphOperation::Communities => {
-            agent::public_protocol::OperationId::GraphCommunities
-        }
+        NativeGraphOperation::Communities => agent::public_protocol::OperationId::GraphCommunities,
         NativeGraphOperation::Refresh => agent::public_protocol::OperationId::WorkspaceRefresh,
     }
 }
@@ -370,7 +375,8 @@ fn native_graph_command(
         symbol,
         generation,
         after_id,
-        limit: (operation == NativeGraphOperation::Nodes).then_some(500),
+        limit: (operation == NativeGraphOperation::Nodes)
+            .then_some(agent::public_protocol::GraphNodesPageToken::public_limit()),
         resolution: None,
     })
 }

--- a/cli-rs/src/agent/public_protocol/graph.rs
+++ b/cli-rs/src/agent/public_protocol/graph.rs
@@ -1,5 +1,6 @@
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::Serialize;
+use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 use std::num::NonZeroU64;
 use std::path::Path;
@@ -8,6 +9,7 @@ const GRAPH_NODE_SELECTOR_VERSION: &str = "kgns1";
 const GRAPH_NODES_PAGE_TOKEN_VERSION: &str = "kgn3";
 const MAX_GRAPH_NODE_SELECTOR_LENGTH: usize = 4_096;
 const MAX_GRAPH_NODES_PAGE_TOKEN_LENGTH: usize = 128;
+const PUBLIC_GRAPH_NODE_PAGE_LIMIT: usize = 64;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct GraphNodesPageToken {
@@ -71,6 +73,122 @@ impl GraphNodesPageToken {
             "{GRAPH_NODES_PAGE_TOKEN_VERSION}.{}.{}.{}",
             self.workspace_fingerprint, self.generation, self.after_id
         )
+    }
+
+    pub(crate) fn public_limit() -> u16 {
+        PUBLIC_GRAPH_NODE_PAGE_LIMIT as u16
+    }
+
+    pub(crate) fn project_page(
+        workspace_root: &Path,
+        expected_generation: u64,
+        prior: Option<&Self>,
+        mut fields: Map<String, Value>,
+    ) -> Result<ProjectedGraphNodesPage, GraphNodesPageProjectionFailure> {
+        if fields.get("generation").and_then(Value::as_u64) != Some(expected_generation) {
+            return Err(GraphNodesPageProjectionFailure::Generation);
+        }
+        let expected_after_id = prior.map_or(0, Self::after_id);
+        if fields.remove("afterId").and_then(|value| value.as_u64()) != Some(expected_after_id) {
+            return Err(GraphNodesPageProjectionFailure::PriorIdentity);
+        }
+        let previously_returned = fields
+            .remove("previouslyReturned")
+            .and_then(|value| value.as_u64())
+            .ok_or(GraphNodesPageProjectionFailure::Cardinality)?;
+        let nodes = fields
+            .get_mut("nodes")
+            .and_then(Value::as_array_mut)
+            .filter(|nodes| nodes.len() <= PUBLIC_GRAPH_NODE_PAGE_LIMIT)
+            .ok_or(GraphNodesPageProjectionFailure::Nodes)?;
+        let returned =
+            u64::try_from(nodes.len()).map_err(|_| GraphNodesPageProjectionFailure::Nodes)?;
+        for node in nodes {
+            let node = node
+                .as_object_mut()
+                .ok_or(GraphNodesPageProjectionFailure::Nodes)?;
+            let node_id = node
+                .get("id")
+                .and_then(Value::as_u64)
+                .ok_or(GraphNodesPageProjectionFailure::Nodes)?;
+            let stable_key = node
+                .get("stableKey")
+                .and_then(Value::as_str)
+                .ok_or(GraphNodesPageProjectionFailure::Nodes)?;
+            let selector = super::issue_graph_node_selector(
+                workspace_root,
+                expected_generation,
+                node_id,
+                stable_key,
+            )
+            .map_err(|_| GraphNodesPageProjectionFailure::Nodes)?;
+            node.insert(
+                "nodeSelector".to_string(),
+                Value::String(selector.as_str().to_string()),
+            );
+        }
+        let cumulative = previously_returned
+            .checked_add(returned)
+            .ok_or(GraphNodesPageProjectionFailure::Cardinality)?;
+        let next_after_id = fields
+            .remove("nextAfterId")
+            .ok_or(GraphNodesPageProjectionFailure::Continuation)?;
+        let continuation = if next_after_id.is_null() {
+            None
+        } else {
+            let after_id = next_after_id
+                .as_u64()
+                .ok_or(GraphNodesPageProjectionFailure::Continuation)?;
+            Some(
+                Self::issue(
+                    graph_workspace_fingerprint(workspace_root),
+                    expected_generation,
+                    after_id,
+                )
+                .ok_or(GraphNodesPageProjectionFailure::Continuation)?
+                .canonical(),
+            )
+        };
+        let cardinality = match continuation {
+            Some(_) => json!({"type": "known-minimum", "count": cumulative.checked_add(1)
+                .ok_or(GraphNodesPageProjectionFailure::Cardinality)?}),
+            None => json!({"type": "exact", "count": cumulative}),
+        };
+        let mut page = json!({"cardinality": cardinality, "returned": returned});
+        if let Some(continuation) = continuation {
+            page["continuation"] = Value::String(continuation);
+        }
+        fields.insert("page".to_string(), page);
+        Ok(ProjectedGraphNodesPage(fields))
+    }
+}
+
+pub(crate) struct ProjectedGraphNodesPage(Map<String, Value>);
+
+impl ProjectedGraphNodesPage {
+    pub(crate) fn into_fields(self) -> Map<String, Value> {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GraphNodesPageProjectionFailure {
+    Generation,
+    PriorIdentity,
+    Cardinality,
+    Nodes,
+    Continuation,
+}
+
+impl GraphNodesPageProjectionFailure {
+    pub(crate) fn message(self) -> &'static str {
+        match self {
+            Self::Generation => "The graph node page returned the wrong generation.",
+            Self::PriorIdentity => "The graph node page returned the wrong prior node identity.",
+            Self::Cardinality => "The graph node page returned invalid cardinality evidence.",
+            Self::Nodes => "The graph node page exceeded its public record bound.",
+            Self::Continuation => "The graph node page returned invalid continuation evidence.",
+        }
     }
 }
 

--- a/cli-rs/tests/agent/public/kast_agent_surface.rs
+++ b/cli-rs/tests/agent/public/kast_agent_surface.rs
@@ -226,8 +226,8 @@ fn public_graph_nodes_issue_distinct_node_selectors_and_opaque_continuations() {
     assert_eq!(first["operation"], "graph.nodes", "{first:#}");
     assert_eq!(first["status"], "complete", "{first:#}");
     assert_eq!(first["result"]["type"], "graph-nodes", "{first:#}");
-    assert_eq!(first["result"]["nodes"].as_array().map(Vec::len), Some(500));
-    assert_eq!(first["result"]["page"]["returned"], 500);
+    assert_eq!(first["result"]["nodes"].as_array().map(Vec::len), Some(64));
+    assert_eq!(first["result"]["page"]["returned"], 64);
     assert_eq!(
         first["result"]["page"]["cardinality"]["type"],
         "known-minimum"
@@ -295,18 +295,24 @@ fn public_graph_nodes_issue_distinct_node_selectors_and_opaque_continuations() {
             .trim(),
     )
     .expect("second graph page TOON");
-    assert_eq!(second["result"]["nodes"].as_array().map(Vec::len), Some(1));
-    assert_eq!(second["result"]["nodes"][0]["id"], 501);
+    assert_eq!(second["result"]["nodes"].as_array().map(Vec::len), Some(64));
+    assert_eq!(second["result"]["nodes"][0]["id"], 65);
     assert!(
         second["result"]["nodes"][0]["nodeSelector"]
             .as_str()
             .is_some_and(|selector| selector.starts_with("kgns1."))
     );
-    assert_eq!(second["result"]["page"]["returned"], 1);
-    assert_eq!(second["result"]["page"]["cardinality"]["type"], "exact");
-    assert_eq!(second["result"]["page"]["cardinality"]["count"], 501);
+    assert_eq!(second["result"]["page"]["returned"], 64);
+    assert_eq!(
+        second["result"]["page"]["cardinality"]["type"],
+        "known-minimum"
+    );
+    assert_eq!(second["result"]["page"]["cardinality"]["count"], 129);
     assert!(
-        second["result"]["page"].get("continuation").is_none(),
+        second["result"]["page"]
+            .get("continuation")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|continuation| continuation.starts_with("kgn3.")),
         "{second:#}"
     );
 

--- a/cli-rs/tests/agent/public/surface/graph_fixture_and_dispatch.rs
+++ b/cli-rs/tests/agent/public/surface/graph_fixture_and_dispatch.rs
@@ -76,10 +76,23 @@ fn seed_public_graph(workspace: &Path, stale: bool) -> WorkspaceIndexFixture {
 }
 
 fn seed_paged_public_graph(workspace: &Path) -> WorkspaceIndexFixture {
+    seed_public_graph_with_symbol_count(workspace, 501, false)
+}
+
+fn seed_large_public_graph(workspace: &Path) -> WorkspaceIndexFixture {
+    seed_public_graph_with_symbol_count(workspace, 2_049, true)
+}
+
+fn seed_public_graph_with_symbol_count(
+    workspace: &Path,
+    symbol_count: i64,
+    connect_to_source: bool,
+) -> WorkspaceIndexFixture {
     let index = seed_public_graph(workspace, false);
-    let connection = index.connection();
-    for id in 3_i64..=501 {
-        connection
+    let mut connection = index.connection();
+    let transaction = connection.transaction().expect("large graph transaction");
+    for id in 3_i64..=symbol_count {
+        transaction
             .execute(
                 "INSERT INTO semantic_symbols(id, stable_key, kind, name, file_id)
                  VALUES (?, ?, 'CLASS', ?, 1)",
@@ -90,7 +103,17 @@ fn seed_paged_public_graph(workspace: &Path) -> WorkspaceIndexFixture {
                 ],
             )
             .expect("graph symbol");
+        if connect_to_source {
+            transaction
+                .execute(
+                    "INSERT INTO semantic_edge_occurrences
+                     VALUES (?, 1, ?, 1, 'REFERENCE', 'TYPE')",
+                    params![id, id],
+                )
+                .expect("large graph edge");
+        }
     }
+    transaction.commit().expect("large graph commit");
     drop(connection);
     index
 }
@@ -183,12 +206,7 @@ fn public_read_commands_delegate_to_typed_operations() {
         &["file", "list", "--match", "src/**/*.kt"][..],
         &["symbol", "search", "--query", "Widget"][..],
         &["symbol", "show", "--selector", "sample.Widget"][..],
-        &[
-            "relation",
-            "references",
-            "--selector",
-            "sample.Widget",
-        ][..],
+        &["relation", "references", "--selector", "sample.Widget"][..],
         &[
             "relation",
             "calls",
@@ -203,12 +221,7 @@ fn public_read_commands_delegate_to_typed_operations() {
             "--selector",
             "sample.Widget.run",
         ][..],
-        &[
-            "relation",
-            "implementations",
-            "--selector",
-            "sample.Widget",
-        ][..],
+        &["relation", "implementations", "--selector", "sample.Widget"][..],
         &[
             "relation",
             "hierarchy",
@@ -233,12 +246,7 @@ fn public_read_commands_delegate_to_typed_operations() {
         &["graph", "topology"][..],
         &["graph", "communities"][..],
         &["graph", "impact", "--selector", "sample.Widget"][..],
-        &[
-            "diagnostic",
-            "check",
-            "--file",
-            "src/main/kotlin/App.kt",
-        ][..],
+        &["diagnostic", "check", "--file", "src/main/kotlin/App.kt"][..],
     ] {
         let output = named("kast")
             .current_dir(&workspace)

--- a/cli-rs/tests/agent/public/surface/typed_graph_protocol.rs
+++ b/cli-rs/tests/agent/public/surface/typed_graph_protocol.rs
@@ -1,5 +1,150 @@
 use super::*;
 
+const MAX_PUBLIC_GRAPH_RESPONSE_BYTES: usize = 64 * 1_024;
+
+#[test]
+fn large_graph_results_are_bounded_stable_and_snapshot_bound() {
+    let fixture = tempfile::tempdir().expect("temporary large graph fixture");
+    let home = fixture.path().join("home");
+    let config_home = fixture.path().join("config");
+    let workspace = fixture.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(workspace.join("settings.gradle.kts"), "").expect("Gradle marker");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let index = seed_large_public_graph(&workspace);
+
+    for (operation, expected_count_field) in
+        [("topology", "nodeCount"), ("communities", "nodeCount")]
+    {
+        let run = || {
+            published_public_kast(&home, &config_home, &workspace)
+                .current_dir(&workspace)
+                .args(["--output", "json", "graph", operation])
+                .output()
+                .unwrap_or_else(|error| panic!("run graph {operation}: {error}"))
+        };
+        let first = run();
+        assert!(first.status.success(), "{operation}: {first:?}");
+        assert!(
+            first.stdout.len() <= MAX_PUBLIC_GRAPH_RESPONSE_BYTES,
+            "graph {operation} emitted {} bytes",
+            first.stdout.len()
+        );
+        let first_value: serde_json::Value =
+            serde_json::from_slice(&first.stdout).expect("bounded graph summary JSON");
+        assert_eq!(
+            first_value["result"]["summary"]["type"], "bounded-summary",
+            "{first_value:#}"
+        );
+        assert_eq!(
+            first_value["result"]["summary"][expected_count_field], 2_049,
+            "{first_value:#}"
+        );
+
+        let second = run();
+        assert!(second.status.success(), "{operation}: {second:?}");
+        assert_eq!(
+            first.stdout, second.stdout,
+            "unstable graph {operation} summary"
+        );
+    }
+
+    let mut continuation = None;
+    let mut first_continuation = None;
+    let mut first_selector = None;
+    let mut observed_ids = Vec::new();
+    loop {
+        let mut command = published_public_kast(&home, &config_home, &workspace);
+        command
+            .current_dir(&workspace)
+            .args(["--output", "json", "graph", "nodes"]);
+        if let Some(token) = continuation.as_deref() {
+            command.args(["--continuation", token]);
+        }
+        let output = command.output().expect("bounded graph node page");
+        assert!(output.status.success(), "{output:?}");
+        assert!(
+            output.stdout.len() <= MAX_PUBLIC_GRAPH_RESPONSE_BYTES,
+            "graph nodes emitted {} bytes",
+            output.stdout.len()
+        );
+        let value: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("graph node page JSON");
+        let nodes = value["result"]["nodes"].as_array().expect("graph nodes");
+        if first_selector.is_none() {
+            first_selector = nodes[0]["nodeSelector"].as_str().map(str::to_string);
+        }
+        observed_ids.extend(
+            nodes
+                .iter()
+                .map(|node| node["id"].as_u64().expect("numeric graph node identity")),
+        );
+        continuation = value["result"]["page"]["continuation"]
+            .as_str()
+            .map(str::to_string);
+        first_continuation = first_continuation.or_else(|| continuation.clone());
+        if continuation.is_none() {
+            break;
+        }
+        assert!(observed_ids.len() <= 2_049, "graph continuation cycle");
+    }
+    assert_eq!(observed_ids, (1_u64..=2_049).collect::<Vec<_>>());
+
+    let neighbors = published_public_kast(&home, &config_home, &workspace)
+        .current_dir(&workspace)
+        .args([
+            "--output",
+            "json",
+            "graph",
+            "neighbors",
+            "--node-selector",
+            first_selector
+                .as_deref()
+                .expect("first graph node selector"),
+        ])
+        .output()
+        .expect("bounded graph neighbor summary");
+    assert!(neighbors.status.success(), "{neighbors:?}");
+    assert!(neighbors.stdout.len() <= MAX_PUBLIC_GRAPH_RESPONSE_BYTES);
+    let neighbors: serde_json::Value =
+        serde_json::from_slice(&neighbors.stdout).expect("graph neighbor summary JSON");
+    assert_eq!(
+        neighbors["result"]["summary"],
+        serde_json::json!({
+            "type": "bounded-summary",
+            "incomingCount": 0,
+            "outgoingCount": 2_049
+        }),
+        "{neighbors:#}"
+    );
+
+    index
+        .connection()
+        .execute("UPDATE schema_version SET generation = generation + 1", [])
+        .expect("advance graph snapshot");
+    let stale = published_public_kast(&home, &config_home, &workspace)
+        .current_dir(&workspace)
+        .args([
+            "--output",
+            "json",
+            "graph",
+            "nodes",
+            "--continuation",
+            first_continuation
+                .as_deref()
+                .expect("snapshot-bound continuation"),
+        ])
+        .output()
+        .expect("stale graph continuation");
+    assert_eq!(stale.status.code(), Some(1), "{stale:?}");
+    let stale: serde_json::Value =
+        serde_json::from_slice(&stale.stdout).expect("stale graph rejection JSON");
+    assert_eq!(
+        stale["result"]["failure"]["code"], "GRAPH_PAGE_EXPIRED",
+        "{stale:#}"
+    );
+}
+
 #[test]
 fn graph_continuations_reject_stale_generations() {
     let fixture = tempfile::tempdir().expect("temporary stale graph fixture");


### PR DESCRIPTION
Closes #578

## Summary

- cap public graph node pages at 64 records with snapshot-bound `kgn3` continuations
- project neighbor, topology, and community results into bounded typed summaries
- reject selected graph wire output above 65,536 bytes
- cover a deterministic 2,049-node workload, exact pagination, snapshot invalidation, and the public root harness

## Proof

- semantic RED: `cargo test --locked --manifest-path cli-rs/Cargo.toml --test kast_agent_surface typed_graph_protocol` failed because topology emitted 128,416 bytes
- identical GREEN: focused command passed both tests
- affected regression: 8 graph smoke + 33 public-surface tests passed
- full locked Rust suite passed
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- repository shape and diff hygiene passed