### PR TITLE
fix: report observed runtime stop state

### DIFF
--- a/cli-rs/src/execution/runtime/backend/indexer_authority/ownership/stop_evidence.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/ownership/stop_evidence.rs
@@ -68,3 +68,227 @@ fn signal_exact_observed_process(
     verify_socket_snapshot(socket, expected.identity.owner_uid)?;
     signal_process(&expected.identity, force)
 }
+
+#[derive(Clone, Copy)]
+enum ExpectedStopTerminal<'a> {
+    Service(&'a ServiceOwnedRuntime),
+    Legacy(&'a LegacyOwnedRuntime),
+}
+
+impl ExpectedStopTerminal<'_> {
+    fn workspace_root(&self) -> &Path {
+        match self {
+            Self::Service(owned) => &owned.workspace_root,
+            Self::Legacy(owned) => &owned.workspace_root,
+        }
+    }
+
+    fn process(&self) -> &super::process::ObservedProcess {
+        match self {
+            Self::Service(owned) => &owned.process,
+            Self::Legacy(owned) => &owned.process,
+        }
+    }
+
+    fn socket(&self) -> &SocketObservation {
+        match self {
+            Self::Service(owned) => &owned.socket,
+            Self::Legacy(owned) => &owned.socket,
+        }
+    }
+
+    fn graceful_timeout(&self) -> Duration {
+        match self {
+            Self::Service(_) => Duration::from_secs(10),
+            Self::Legacy(_) => Duration::from_secs(5),
+        }
+    }
+
+    fn stop_failed(&self) -> CliError {
+        let message = match self {
+            Self::Service(_) => "The exact registered runtime did not stop.",
+            Self::Legacy(_) => "The exact legacy Kast runtime did not stop.",
+        };
+        CliError::new("RUNTIME_STOP_FAILED", message)
+    }
+}
+
+struct ProvenGoneRuntime<'a> {
+    expected: ExpectedStopTerminal<'a>,
+    forced: bool,
+}
+
+fn prove_runtime_gone(expected: ExpectedStopTerminal<'_>) -> Result<ProvenGoneRuntime<'_>> {
+    signal_exact_observed_process(expected.process(), expected.socket(), false)?;
+    let mut forced = false;
+    if !wait_until_gone(
+        &expected.process().identity,
+        expected.graceful_timeout(),
+    )? {
+        signal_exact_observed_process(expected.process(), expected.socket(), true)?;
+        forced = true;
+        if !wait_until_gone(&expected.process().identity, Duration::from_secs(5))? {
+            return Err(expected.stop_failed());
+        }
+    }
+    Ok(ProvenGoneRuntime { expected, forced })
+}
+
+enum ObservedStopTerminalState {
+    Absent,
+    Service(Box<DeadServiceRuntime>),
+    Legacy(Box<DeadLegacyRuntime>),
+}
+
+impl ObservedStopTerminalState {
+    fn admit(
+        gone: &ProvenGoneRuntime<'_>,
+        snapshot: RuntimeOwnershipSnapshot,
+    ) -> std::result::Result<Self, StopTerminalFailure> {
+        match (gone.expected, snapshot) {
+            (expected, RuntimeOwnershipSnapshot::Absent(absent))
+                if absent.workspace_root == expected.workspace_root() =>
+            {
+                Ok(Self::Absent)
+            }
+            (ExpectedStopTerminal::Service(expected), RuntimeOwnershipSnapshot::ProvenDead(dead)) => {
+                admit_dead_service(expected, dead).map(|dead| Self::Service(Box::new(dead)))
+            }
+            (ExpectedStopTerminal::Legacy(expected), RuntimeOwnershipSnapshot::ProvenDead(dead)) => {
+                admit_dead_legacy(expected, dead).map(|dead| Self::Legacy(Box::new(dead)))
+            }
+            (_, RuntimeOwnershipSnapshot::ServiceOwned(_)) => {
+                Err(StopTerminalFailure::ServiceStillLive)
+            }
+            (_, RuntimeOwnershipSnapshot::LegacyOwned(_)) => {
+                Err(StopTerminalFailure::LegacyStillLive)
+            }
+            (_, RuntimeOwnershipSnapshot::Conflict(conflict)) => Err(
+                StopTerminalFailure::Conflict(conflict.runtime_instance_ids),
+            ),
+            (_, RuntimeOwnershipSnapshot::Ambiguous(ambiguity)) => {
+                Err(StopTerminalFailure::Ambiguous(ambiguity.reason))
+            }
+            _ => Err(StopTerminalFailure::OwnershipChanged),
+        }
+    }
+
+    fn cleanup(self, config: &KastConfig) -> Result<()> {
+        match self {
+            Self::Absent => Ok(()),
+            Self::Service(dead) => cleanup_dead_registration(config, &dead),
+            Self::Legacy(dead) => cleanup_dead_legacy(config, &dead),
+        }
+    }
+}
+
+enum StopTerminalFailure {
+    ServiceStillLive,
+    LegacyStillLive,
+    OwnershipChanged,
+    Conflict(Vec<String>),
+    Ambiguous(String),
+}
+
+impl From<StopTerminalFailure> for CliError {
+    fn from(failure: StopTerminalFailure) -> Self {
+        let message = match failure {
+            StopTerminalFailure::ServiceStillLive => {
+                "The exact registered runtime remained live after stop.".to_string()
+            }
+            StopTerminalFailure::LegacyStillLive => {
+                "The exact legacy runtime remained live after stop.".to_string()
+            }
+            StopTerminalFailure::OwnershipChanged => {
+                "Runtime ownership changed before terminal cleanup.".to_string()
+            }
+            StopTerminalFailure::Conflict(ids) => format!(
+                "Runtime ownership became conflicting before terminal cleanup: {}.",
+                ids.join(", ")
+            ),
+            StopTerminalFailure::Ambiguous(reason) => format!(
+                "Runtime ownership became ambiguous before terminal cleanup: {reason}"
+            ),
+        };
+        CliError::new("RUNTIME_OWNERSHIP_CHANGED", message)
+    }
+}
+
+fn observe_stop_terminal_state(
+    config: &KastConfig,
+    gone: &ProvenGoneRuntime<'_>,
+) -> Result<ObservedStopTerminalState> {
+    let snapshot = reconcile_runtime_ownership(config, gone.expected.workspace_root())?;
+    ObservedStopTerminalState::admit(gone, snapshot).map_err(Into::into)
+}
+
+fn admit_dead_service(
+    expected: &ServiceOwnedRuntime,
+    mut dead: super::ownership::ProvenDeadRuntimeOwnership,
+) -> std::result::Result<DeadServiceRuntime, StopTerminalFailure> {
+    if !dead.legacy.is_empty() || dead.services.len() != 1 {
+        return Err(StopTerminalFailure::OwnershipChanged);
+    }
+    let current = dead.services.pop().expect("one dead service was proven");
+    let descriptor_matches = current.descriptor.as_ref().is_none_or(|current| {
+        expected.descriptor.as_ref().is_some_and(|expected| {
+            current.id == expected.id && current.descriptor == expected.descriptor
+        })
+    });
+    let process_matches = current
+        .process_claim
+        .as_ref()
+        .is_none_or(|claim| claim.process == expected.process.identity);
+    let active_matches = current.active.as_ref().is_none_or(|active| {
+        active.runtime_instance_id == expected.registration.receipt.runtime_instance_id
+            && active.receipt_sha256 == expected.registration.receipt_sha256
+    });
+    if current.registration.receipt_sha256 != expected.registration.receipt_sha256
+        || current.registration.receipt != expected.registration.receipt
+        || current.registration.launch != expected.registration.launch
+        || !descriptor_matches
+        || !process_matches
+        || !active_matches
+        || !terminal_socket_matches(
+            &current.socket,
+            &expected.socket,
+            Path::new(&expected.registration.launch.socket_path),
+        )
+    {
+        return Err(StopTerminalFailure::OwnershipChanged);
+    }
+    Ok(current)
+}
+
+fn admit_dead_legacy(
+    expected: &LegacyOwnedRuntime,
+    mut dead: super::ownership::ProvenDeadRuntimeOwnership,
+) -> std::result::Result<DeadLegacyRuntime, StopTerminalFailure> {
+    if !dead.services.is_empty() || dead.legacy.len() != 1 {
+        return Err(StopTerminalFailure::OwnershipChanged);
+    }
+    let current = dead.legacy.pop().expect("one dead legacy runtime was proven");
+    if current.descriptor.id != expected.descriptor.id
+        || current.descriptor.descriptor != expected.descriptor.descriptor
+        || current.owner_uid != expected.process.identity.owner_uid
+        || !terminal_socket_matches(
+            &current.socket,
+            &expected.socket,
+            Path::new(&expected.descriptor.descriptor.socket_path),
+        )
+    {
+        return Err(StopTerminalFailure::OwnershipChanged);
+    }
+    Ok(current)
+}
+
+fn terminal_socket_matches(
+    current: &SocketObservation,
+    expected: &SocketObservation,
+    expected_path: &Path,
+) -> bool {
+    match current {
+        SocketObservation::Absent { path } => path == expected_path,
+        _ => current == expected,
+    }
+}

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/repair.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/repair.rs
@@ -280,38 +280,10 @@ pub(super) fn stop_service_runtime(
     owned: ServiceOwnedRuntime,
 ) -> Result<DaemonStopResult> {
     let owned = revalidate_service_runtime(config, &owned)?;
-    signal_exact_observed_process(&owned.process, &owned.socket, false)?;
-    let mut forced = false;
-    if !wait_until_gone(&owned.process.identity, Duration::from_secs(10))? {
-        signal_exact_observed_process(&owned.process, &owned.socket, true)?;
-        forced = true;
-        if !wait_until_gone(&owned.process.identity, Duration::from_secs(5))? {
-            return Err(CliError::new(
-                "RUNTIME_STOP_FAILED",
-                "The exact registered runtime did not stop.",
-            ));
-        }
-    }
     let descriptor = owned.descriptor.clone();
-    let process_claim = super::registration::read_process_claim(&owned.registration.directory)?;
-    let active = super::registration::read_active_registration(
-        &owned
-            .registration
-            .directory
-            .parent()
-            .ok_or_else(runtime_identity_mismatch)?
-            .join("active.json"),
-    )?;
-    cleanup_dead_registration(
-        config,
-        &DeadServiceRuntime {
-            registration: owned.registration,
-            process_claim,
-            active,
-            descriptor: descriptor.clone(),
-            socket: owned.socket,
-        },
-    )?;
+    let gone = prove_runtime_gone(ExpectedStopTerminal::Service(&owned))?;
+    let forced = gone.forced;
+    observe_stop_terminal_state(config, &gone)?.cleanup(config)?;
     Ok(stop_result(
         &owned.workspace_root,
         descriptor.as_ref(),
@@ -325,20 +297,9 @@ pub(super) fn stop_legacy_runtime(
     owned: LegacyOwnedRuntime,
 ) -> Result<DaemonStopResult> {
     let owned = revalidate_legacy_runtime(config, &owned)?;
-    signal_exact_observed_process(&owned.process, &owned.socket, false)?;
-    let mut forced = false;
-    if !wait_until_gone(&owned.process.identity, Duration::from_secs(5))? {
-        signal_exact_observed_process(&owned.process, &owned.socket, true)?;
-        forced = true;
-        if !wait_until_gone(&owned.process.identity, Duration::from_secs(5))? {
-            return Err(CliError::new(
-                "RUNTIME_STOP_FAILED",
-                "The exact legacy Kast runtime did not stop.",
-            ));
-        }
-    }
-    delete_descriptor(&config.paths.descriptor_dir, &owned.descriptor.descriptor)?;
-    remove_exact_socket(&owned.socket, owned.process.identity.owner_uid)?;
+    let gone = prove_runtime_gone(ExpectedStopTerminal::Legacy(&owned))?;
+    let forced = gone.forced;
+    observe_stop_terminal_state(config, &gone)?.cleanup(config)?;
     Ok(stop_result(
         &owned.workspace_root,
         Some(&owned.descriptor),
@@ -360,7 +321,7 @@ fn stop_result(
         backend_name: BackendName::Indexer.canonical().to_string(),
         descriptor_path: value.id.clone(),
         pid,
-        pid_alive: true,
+        pid_alive: false,
         reachable: false,
         lifecycle_accepted: true,
         lifecycle_method: Some("OWNERSHIP_SNAPSHOT".to_string()),

--- a/cli-rs/tests/runtime/durable_ownership/fixture.rs
+++ b/cli-rs/tests/runtime/durable_ownership/fixture.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+pub(super) enum RuntimeTerminalBehavior {
+    RetainArtifacts,
+    RemoveOwnedArtifacts,
+    LeaveIncompleteCleanup,
+}
+
 pub(super) struct RuntimeServiceFixture {
     _temp: tempfile::TempDir,
     home: PathBuf,
@@ -15,14 +21,18 @@ pub(super) struct RuntimeServiceFixture {
 
 impl RuntimeServiceFixture {
     pub(super) fn new() -> Self {
-        Self::with_persisted_descriptor_directory(false)
+        Self::with_options(false, RuntimeTerminalBehavior::RetainArtifacts)
     }
 
     pub(super) fn new_with_persisted_descriptor_directory() -> Self {
-        Self::with_persisted_descriptor_directory(true)
+        Self::with_options(true, RuntimeTerminalBehavior::RetainArtifacts)
     }
 
-    fn with_persisted_descriptor_directory(use_alternate_directory: bool) -> Self {
+    pub(super) fn new_with_terminal_behavior(terminal: RuntimeTerminalBehavior) -> Self {
+        Self::with_options(false, terminal)
+    }
+
+    fn with_options(use_alternate_directory: bool, terminal: RuntimeTerminalBehavior) -> Self {
         let temp = tempfile::tempdir().expect("runtime service fixture");
         let home = temp.path().join("home");
         let config_home = temp.path().join("config");
@@ -34,15 +44,6 @@ impl RuntimeServiceFixture {
         let workspace = std::fs::canonicalize(workspace).expect("canonical workspace");
         let listener = UnixListener::bind(&socket_path).expect("unservable endpoint");
         let runtime_instance_id = uuid::Uuid::new_v4();
-        let runtime_command =
-            registered_test_command(&workspace, &socket_path, runtime_instance_id);
-        let runtime = Command::new(&runtime_command[0])
-            .args(&runtime_command[1..])
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .expect("registered process");
         let install_root = default_install_root(&home);
         let runtime_dir = install_root.join("state/runtime");
         let descriptor_directory = if use_alternate_directory {
@@ -56,20 +57,37 @@ impl RuntimeServiceFixture {
             .join("services")
             .join(&workspace_key)
             .join(runtime_instance_id.to_string());
+        let runtime_command = registered_test_command(
+            &workspace,
+            &socket_path,
+            runtime_instance_id,
+            &terminal,
+            &descriptor_registry,
+            &registration,
+        );
+        let runtime = Command::new(&runtime_command[0])
+            .args(&runtime_command[1..])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("registered process");
         let manager_root = temp.path().join("test-manager");
         std::fs::create_dir_all(&manager_root).expect("manager root");
         let manager_state = manager_root.join(format!("{runtime_instance_id}.json"));
         make_private_directory(&registration);
         let registration = std::fs::canonicalize(registration).expect("canonical registration");
-        write_registration(
-            &registration,
-            runtime_instance_id,
-            &workspace,
-            &descriptor_directory,
-            &socket_path,
-            &manager_state,
-            temp.path(),
-        );
+        write_registration(RegistrationFixtureInput {
+            registration: &registration,
+            id: runtime_instance_id,
+            workspace: &workspace,
+            descriptor_directory: &descriptor_directory,
+            socket_path: &socket_path,
+            manager_state: &manager_state,
+            temp: temp.path(),
+            terminal: &terminal,
+            descriptor_registry: &descriptor_registry,
+        });
         let receipt_bytes = std::fs::read(registration.join("receipt.json")).expect("receipt");
         write_private(
             &registration
@@ -128,16 +146,17 @@ impl RuntimeServiceFixture {
         make_private_directory(&registration);
         let registration = std::fs::canonicalize(registration).expect("canonical registration");
         let runtime_dir = default_install_root(&self.home).join("state/runtime");
-        let manager_state = self.manager_root.join(format!("{id}.json"));
-        write_registration(
-            &registration,
+        write_registration(RegistrationFixtureInput {
+            registration: &registration,
             id,
-            &self.workspace,
-            &runtime_dir.join("daemons"),
-            &self.socket_path,
-            &manager_state,
-            self._temp.path(),
-        );
+            workspace: &self.workspace,
+            descriptor_directory: &runtime_dir.join("daemons"),
+            socket_path: &self.socket_path,
+            manager_state: &self.manager_root.join(format!("{id}.json")),
+            temp: self._temp.path(),
+            terminal: &RuntimeTerminalBehavior::RetainArtifacts,
+            descriptor_registry: &runtime_dir.join("daemons/daemons.json"),
+        });
         registration
     }
 
@@ -257,18 +276,21 @@ impl Drop for RuntimeServiceFixture {
     }
 }
 
-fn write_registration(
-    registration: &Path,
+struct RegistrationFixtureInput<'a> {
+    registration: &'a Path,
     id: uuid::Uuid,
-    workspace: &Path,
-    descriptor_directory: &Path,
-    socket_path: &Path,
-    manager_state: &Path,
-    temp: &Path,
-) {
-    let runtime_config = registration.join("runtime-config.json");
+    workspace: &'a Path,
+    descriptor_directory: &'a Path,
+    socket_path: &'a Path,
+    manager_state: &'a Path,
+    temp: &'a Path,
+    terminal: &'a RuntimeTerminalBehavior,
+    descriptor_registry: &'a Path,
+}
+fn write_registration(input: RegistrationFixtureInput<'_>) {
+    let runtime_config = input.registration.join("runtime-config.json");
     write_private(&runtime_config, b"{}");
-    let launcher = temp.join("test-kastctl");
+    let launcher = input.temp.join("test-kastctl");
     if !launcher.exists() {
         std::fs::write(&launcher, "#!/bin/sh\nexit 0\n").expect("test launcher");
         std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o700))
@@ -277,16 +299,23 @@ fn write_registration(
     let launcher = std::fs::canonicalize(launcher).expect("canonical test launcher");
     let launch = serde_json::json!({
         "schemaVersion": 1,
-        "workspaceRoot": workspace.display().to_string(),
-        "workspaceKey": sha256(workspace.to_string_lossy().as_bytes()),
-        "runtimeInstanceId": id,
+        "workspaceRoot": input.workspace.display().to_string(),
+        "workspaceKey": sha256(input.workspace.to_string_lossy().as_bytes()),
+        "runtimeInstanceId": input.id,
         "ownerUid": u64::from(unsafe { libc::geteuid() }),
-        "workingDirectory": workspace.display().to_string(),
-        "command": registered_test_command(workspace, socket_path, id),
+        "workingDirectory": input.workspace.display().to_string(),
+        "command": registered_test_command(
+            input.workspace,
+            input.socket_path,
+            input.id,
+            input.terminal,
+            input.descriptor_registry,
+            input.registration,
+        ),
         "environment": {},
-        "logFile": temp.join("runtime.log").display().to_string(),
-        "descriptorDirectory": descriptor_directory.display().to_string(),
-        "socketPath": socket_path.display().to_string(),
+        "logFile": input.temp.join("runtime.log").display().to_string(),
+        "descriptorDirectory": input.descriptor_directory.display().to_string(),
+        "socketPath": input.socket_path.display().to_string(),
         "launcherPath": launcher.display().to_string(),
         "launcherSha256": sha256(&std::fs::read(&launcher).expect("launcher bytes")),
         "runtimeConfigPath": runtime_config.display().to_string(),
@@ -294,9 +323,9 @@ fn write_registration(
     });
     let launch_bytes = serde_json::to_vec_pretty(&launch).expect("launch JSON");
     let launch_sha256 = sha256(&launch_bytes);
-    let launch_path = registration.join("launch.json");
+    let launch_path = input.registration.join("launch.json");
     write_private(&launch_path, &launch_bytes);
-    let definition_path = registration.join("service.test.json");
+    let definition_path = input.registration.join("service.test.json");
     let definition = serde_json::to_vec_pretty(&serde_json::json!({
         "launcher": launcher,
         "registration": launch_path,
@@ -306,20 +335,20 @@ fn write_registration(
     write_private(&definition_path, &definition);
     let receipt = serde_json::json!({
         "schemaVersion": 1,
-        "workspaceRoot": workspace.display().to_string(),
-        "workspaceKey": sha256(workspace.to_string_lossy().as_bytes()),
-        "runtimeInstanceId": id,
+        "workspaceRoot": input.workspace.display().to_string(),
+        "workspaceKey": sha256(input.workspace.to_string_lossy().as_bytes()),
+        "runtimeInstanceId": input.id,
         "launchPath": launch_path.display().to_string(),
         "launchSha256": launch_sha256,
         "definitionSha256": sha256(&definition),
         "manager": {
             "kind": "TEST",
-            "state_path": manager_state.display().to_string(),
+            "state_path": input.manager_state.display().to_string(),
             "definition_path": definition_path.display().to_string()
         }
     });
     write_private(
-        &registration.join("receipt.json"),
+        &input.registration.join("receipt.json"),
         &serde_json::to_vec_pretty(&receipt).expect("receipt JSON"),
     );
 }
@@ -328,15 +357,28 @@ fn registered_test_command(
     workspace: &Path,
     socket_path: &Path,
     runtime_instance_id: uuid::Uuid,
+    terminal: &RuntimeTerminalBehavior,
+    descriptor_registry: &Path,
+    registration: &Path,
 ) -> Vec<String> {
+    let script = match terminal {
+        RuntimeTerminalBehavior::RetainArtifacts => "trap 'exit 0' TERM; read fixture_value",
+        RuntimeTerminalBehavior::RemoveOwnedArtifacts => {
+            "trap 'rm -f \"$4\" \"$5\";exit' TERM;read x"
+        }
+        RuntimeTerminalBehavior::LeaveIncompleteCleanup => "trap 'touch \"$6/x\";exit' TERM;read x",
+    };
     vec![
         "/bin/sh".to_string(),
         "-c".to_string(),
-        "trap 'exit 0' TERM; read fixture_value".to_string(),
+        script.to_string(),
         "kast-indexer".to_string(),
         format!("--workspace-root={}", workspace.display()),
         format!("--socket-path={}", socket_path.display()),
         format!("--runtime-instance-id={runtime_instance_id}"),
+        descriptor_registry.display().to_string(),
+        socket_path.display().to_string(),
+        registration.display().to_string(),
     ]
 }
 

--- a/cli-rs/tests/runtime/durable_ownership/review_regressions.rs
+++ b/cli-rs/tests/runtime/durable_ownership/review_regressions.rs
@@ -1,4 +1,85 @@
+use super::fixture::RuntimeTerminalBehavior;
 use super::*;
+
+#[test]
+fn stop_reports_observed_terminal_state_and_is_idempotent() {
+    let fixture = RuntimeServiceFixture::new_with_terminal_behavior(
+        RuntimeTerminalBehavior::RemoveOwnedArtifacts,
+    );
+    let pid = fixture.runtime.id();
+
+    let stop = fixture
+        .command()
+        .arg("stop")
+        .args([
+            "--workspace-root",
+            fixture.workspace.to_str().expect("workspace path"),
+        ])
+        .output()
+        .expect("runtime stop");
+
+    assert_success(&stop, "terminal-state stop");
+    let stop = output_json(&stop);
+    assert_eq!(stop["stopped"], true);
+    assert_eq!(stop["stoppedCount"], 1);
+    assert_eq!(stop["pid"], u64::from(pid));
+    assert_eq!(stop["candidates"][0]["pidAlive"], false);
+    assert_eq!(stop["candidates"][0]["terminated"], true);
+    assert_eq!(stop["candidates"][0]["descriptorDeleted"], true);
+    assert!(!fixture.registration.exists(), "registration remains");
+    assert!(!fixture.descriptor_registry.exists(), "descriptor remains");
+    assert!(!fixture.socket_path.exists(), "socket remains");
+
+    let repeated = fixture
+        .command()
+        .arg("stop")
+        .args([
+            "--workspace-root",
+            fixture.workspace.to_str().expect("workspace path"),
+        ])
+        .output()
+        .expect("repeated runtime stop");
+
+    assert_success(&repeated, "repeated terminal-state stop");
+    let repeated = output_json(&repeated);
+    assert_eq!(repeated["stopped"], false);
+    assert_eq!(repeated["stoppedCount"], 0);
+    assert!(repeated.get("pid").is_none());
+    assert_eq!(repeated["candidates"].as_array().map(Vec::len), None);
+}
+
+#[test]
+fn stop_retains_typed_evidence_when_terminal_cleanup_is_incomplete() {
+    let mut fixture = RuntimeServiceFixture::new_with_terminal_behavior(
+        RuntimeTerminalBehavior::LeaveIncompleteCleanup,
+    );
+
+    let stop = fixture
+        .command()
+        .arg("stop")
+        .args([
+            "--workspace-root",
+            fixture.workspace.to_str().expect("workspace path"),
+        ])
+        .output()
+        .expect("runtime stop");
+
+    assert_error(&stop, "RUNTIME_OWNERSHIP_CHANGED");
+    assert!(
+        wait_until(Duration::from_secs(1), || fixture
+            .runtime
+            .try_wait()
+            .expect("runtime status")
+            .is_some()),
+        "registered runtime did not terminate"
+    );
+    assert!(fixture.registration.exists(), "registration was removed");
+    assert!(
+        fixture.descriptor_registry.exists(),
+        "descriptor was removed"
+    );
+    assert!(fixture.socket_path.exists(), "socket was removed");
+}
 
 #[test]
 fn deleted_workspace_registration_is_repaired_deleted_workspace_registration_review_regression() {


### PR DESCRIPTION
Risk: terminal reconciliation remains deliberately fail-closed; this does not relax runtime identity or permit PID-only signaling.

Summary:
- Preserve the admitted exact owned runtime through stop and terminal observation.
- Report success when that runtime is proven absent, including descriptor/socket self-removal and repeated stop.
- Retain typed RUNTIME_OWNERSHIP_CHANGED failures for incomplete cleanup, replacement, conflict, or ambiguity.

Proof:
- Fresh current-main baseline: 20/20 passed.
- RED checkpoint cdfe4350d: the terminal-state regression reached the intended IO_ERROR assertion.
- Identical GREEN: 22/22 passed.
- Affected regression: runtime backend, durable ownership 22/22, and workspace lease 6/6 passed after one qualified macOS process-info EPERM infrastructure retry.
- Format, strict all-target/all-feature Clippy, repository shape, diff hygiene, exact scope, and typed-contract audits passed.

Closes #579.