### PR TITLE
feat: emit runtime profiling artifacts

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/fields/profiling/ProfilingModes.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/fields/profiling/ProfilingModes.kt
@@ -7,24 +7,74 @@ data class ProfilingModes(
     override val key: String get() = "modes"
     override val default: ConfigurationDefault<String> get() = ConfigurationDefault("cpu")
 
-    fun parseModes(): Set<ProfilingMode> = value
-        .split(',')
-        .map(String::trim)
-        .filter(String::isNotEmpty)
-        .mapNotNull(ProfilingMode::parse)
-        .toSet()
+    /**
+     * Proof transition: `ProfilingModes -> ProfilingModeResolution`.
+     *
+     * Establishes a non-empty, canonical supported mode set or returns the
+     * closed [ProfilingModeFailure] that prevented admission. Raw comma-
+     * separated text is extracted only at the runtime configuration boundary.
+     */
+    fun resolve(): ProfilingModeResolution {
+        val requested = value.split(',').map(String::trim)
+        if (requested.any(String::isEmpty)) {
+            return ProfilingModeResolution.Rejected(ProfilingModeFailure.Empty)
+        }
+        val supported = linkedSetOf<ProfilingMode>()
+        val unsupported = linkedSetOf<String>()
+        requested.forEach { rawMode ->
+            val normalized = rawMode.lowercase()
+            val mode = ProfilingMode.entries.firstOrNull { normalized in it.aliases }
+            if (mode == null) unsupported += rawMode else supported += mode
+        }
+        return if (unsupported.isEmpty()) {
+            ProfilingModeResolution.Resolved(ProfilingModeSelection.of(supported))
+        } else {
+            ProfilingModeResolution.Rejected(ProfilingModeFailure.Unsupported(unsupported))
+        }
+    }
 }
 
-enum class ProfilingMode(private val aliases: Set<String>) {
-    CPU(setOf("cpu")),
-    ALLOCATION(setOf("alloc", "allocation")),
-    LOCK(setOf("lock")),
-    WALL(setOf("wall"));
+enum class ProfilingMode(
+    val wireName: String,
+    internal val aliases: Set<String>,
+) {
+    CPU("cpu", setOf("cpu")),
+    ALLOCATION("allocation", setOf("alloc", "allocation")),
+    LOCK("lock", setOf("lock")),
+    WALL("wall", setOf("wall")),
+}
+
+class ProfilingModeSelection private constructor(
+    val modes: Set<ProfilingMode>,
+) {
+    init {
+        require(modes.isNotEmpty()) { "Profiling mode selection must not be empty" }
+    }
 
     companion object {
-        fun parse(value: String): ProfilingMode? {
-            val normalized = value.trim().lowercase()
-            return entries.firstOrNull { normalized in it.aliases }
+        /**
+         * Proof transition: `Set<ProfilingMode> -> ProfilingModeSelection`.
+         *
+         * Preserves an already-admitted non-empty mode set in canonical order.
+         * Raw set extraction is permitted only at profiler configuration.
+         */
+        internal fun of(modes: Set<ProfilingMode>): ProfilingModeSelection =
+            ProfilingModeSelection(ProfilingMode.entries.filterTo(linkedSetOf()) { it in modes })
+    }
+}
+
+sealed interface ProfilingModeResolution {
+    data class Resolved(val selection: ProfilingModeSelection) : ProfilingModeResolution
+
+    data class Rejected(val failure: ProfilingModeFailure) : ProfilingModeResolution
+}
+
+sealed interface ProfilingModeFailure {
+    data object Empty : ProfilingModeFailure
+
+    data class Unsupported(val values: Set<String>) : ProfilingModeFailure {
+        init {
+            require(values.isNotEmpty()) { "Unsupported profiling modes must not be empty" }
         }
     }
 }

--- a/indexer/src/main/kotlin/io/github/amichne/kast/indexer/KastIndexerRuntime.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/indexer/KastIndexerRuntime.kt
@@ -3,15 +3,21 @@ package io.github.amichne.kast.indexer
 import com.intellij.openapi.project.Project
 import io.github.amichne.kast.api.client.KastConfig
 import io.github.amichne.kast.api.client.KastConfigOverride
+import io.github.amichne.kast.api.client.ProfilingConfig
+import io.github.amichne.kast.api.client.RuntimeInstanceId
 import io.github.amichne.kast.api.client.ServerLaunchOptions
+import io.github.amichne.kast.api.client.fields.ProfilingModeFailure
 import io.github.amichne.kast.api.contract.AnalysisTransport
+import io.github.amichne.kast.api.contract.compatibility.RuntimeImplementationVersion
 import io.github.amichne.kast.idea.IndexerServerRuntime
 import io.github.amichne.kast.idea.RunningIndexer
+import io.github.amichne.kast.idea.backend.KastIndexerBackend
 import io.github.amichne.kast.idea.transition.GitWorktreeRegistrationProof
 import io.github.amichne.kast.indexer.gradle.bootstrap.GradleProjectImportBridge
 import io.github.amichne.kast.indexer.project.ProjectOpener
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Path
+import java.time.Clock
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.exitProcess
 
@@ -57,14 +63,106 @@ data class IndexerServerOptions(
     }
 }
 
+internal data class RuntimeProfilingLaunch(
+    val config: ProfilingConfig,
+    val logsDirectory: Path,
+    val workspaceRoot: Path,
+    val runtimeVersion: RuntimeImplementationVersion,
+    val runtimeInstanceId: RuntimeInstanceId,
+    val clock: Clock = Clock.systemUTC(),
+)
+
+internal sealed interface RuntimeProfilingStart {
+    data object Disabled : RuntimeProfilingStart
+
+    data class Started(val ownership: RuntimeProfilingOwnership) : RuntimeProfilingStart
+
+    data class Rejected(val failure: RuntimeProfilingFailure) : RuntimeProfilingStart
+}
+
+internal sealed interface RuntimeProfilingOwnership {
+    /**
+     * Proof transition: `RuntimeProfilingOwnership -> RuntimeProfilingFinish`.
+     *
+     * Establishes that every owned recording is closed and each requested
+     * artifact is a non-empty regular file, or returns the closed finalization
+     * failure. Raw JFR resources remain confined to the JFR boundary.
+     */
+    fun finish(): RuntimeProfilingFinish
+
+    data object Disabled : RuntimeProfilingOwnership {
+        override fun finish(): RuntimeProfilingFinish = RuntimeProfilingFinish.Completed
+    }
+}
+
+internal sealed interface RuntimeProfilingFinish {
+    data object Completed : RuntimeProfilingFinish
+
+    data class Rejected(val failure: RuntimeProfilingFailure.FinalizationFailed) : RuntimeProfilingFinish
+}
+
+internal sealed interface RuntimeProfilingFailure {
+    data class InvalidModes(val failure: ProfilingModeFailure) : RuntimeProfilingFailure
+
+    data class InvalidDuration(val seconds: Long) : RuntimeProfilingFailure
+
+    data class InvalidOutputDirectory(val value: String) : RuntimeProfilingFailure
+
+    data class WorkspaceUnavailable(val path: Path, val reason: String) : RuntimeProfilingFailure
+
+    data class SourceHeadUnavailable(val workspace: Path, val reason: String) : RuntimeProfilingFailure
+
+    data class ArtifactPreparationFailed(val path: Path, val reason: String) : RuntimeProfilingFailure
+
+    data class RecorderStartFailed(val path: Path, val reason: String) : RuntimeProfilingFailure
+
+    data class FinalizationFailed(val artifacts: Set<Path>) : RuntimeProfilingFailure {
+        init {
+            require(artifacts.isNotEmpty()) { "Failed profiling artifacts must not be empty" }
+        }
+    }
+}
+
+internal class RuntimeProfilingBoundaryException(
+    val failure: RuntimeProfilingFailure,
+) : IllegalStateException(failure.message())
+
+private fun RuntimeProfilingFailure.message(): String = when (this) {
+    is RuntimeProfilingFailure.InvalidModes -> "Invalid profiling modes: $failure"
+    is RuntimeProfilingFailure.InvalidDuration -> "Profiling duration must be positive: $seconds"
+    is RuntimeProfilingFailure.InvalidOutputDirectory -> "Profiling output directory must be absolute: $value"
+    is RuntimeProfilingFailure.WorkspaceUnavailable -> "Profiling workspace is unavailable at $path: $reason"
+    is RuntimeProfilingFailure.SourceHeadUnavailable -> "Profiling source HEAD is unavailable at $workspace: $reason"
+    is RuntimeProfilingFailure.ArtifactPreparationFailed -> "Cannot prepare profiling artifacts at $path: $reason"
+    is RuntimeProfilingFailure.RecorderStartFailed -> "Cannot start runtime profiling at $path: $reason"
+    is RuntimeProfilingFailure.FinalizationFailed -> "Cannot finalize profiling artifacts: ${artifacts.joinToString()}"
+}
+
 class RunningKastIndexer internal constructor(
     val indexerRuntime: RunningIndexer,
+    private val profiling: RuntimeProfilingOwnership,
 ) : AutoCloseable {
     private val closed = AtomicBoolean(false)
 
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
-        indexerRuntime.close()
+        runCatching { indexerRuntime.close() }.fold(
+            onSuccess = {
+                when (val result = profiling.finish()) {
+                    RuntimeProfilingFinish.Completed -> Unit
+                    is RuntimeProfilingFinish.Rejected -> throw RuntimeProfilingBoundaryException(result.failure)
+                }
+            },
+            onFailure = { failure ->
+                when (val result = profiling.finish()) {
+                    RuntimeProfilingFinish.Completed -> Unit
+                    is RuntimeProfilingFinish.Rejected -> {
+                        failure.addSuppressed(RuntimeProfilingBoundaryException(result.failure))
+                    }
+                }
+                throw failure
+            },
+        )
     }
 
     fun await() {
@@ -92,28 +190,54 @@ object KastIndexerRuntime {
         configureSystemProperties()
         val serverOptions = options.serverOptions
         val workspaceRoot = serverOptions.workspaceRoot
-        val registrationProof = serverOptions.linkedWorktreeLaunchClaim?.let { claim ->
-            GitWorktreeRegistrationProof.capture(workspaceRoot, claim)
-        }
-        GradleProjectImportBridge.configureIndexerApplication()
-        val project = projectOpener.openProject(workspaceRoot)
         val config = options.runtimeConfig ?: KastConfig.load(
             workspaceRoot = workspaceRoot,
             overrides = KastConfigOverride(profiling = serverOptions.profilingOverride),
         )
-        val indexerRuntime = IndexerServerRuntime.startWithRegistrationProof(
-            project = project,
-            workspaceRoot = workspaceRoot,
-            transport = serverOptions.transport,
-            config = config,
-            registrationProof = registrationProof,
-            runtimeInstanceId = serverOptions.runtimeInstanceId,
-        )
-        val status = runBlocking { indexerRuntime.backend.runtimeStatus() }
-        check(status.backendName == "indexer") {
-            "Kast indexer started with unexpected runtime name: ${status.backendName}"
+        val registrationProof = serverOptions.linkedWorktreeLaunchClaim?.let { claim ->
+            GitWorktreeRegistrationProof.capture(workspaceRoot, claim)
         }
-        return RunningKastIndexer(indexerRuntime)
+        val runtimeInstanceId = serverOptions.runtimeInstanceId ?: RuntimeInstanceId.create()
+        val profiling = when (
+            val started = KastRuntimeProfiling.start(
+                RuntimeProfilingLaunch(
+                    config = config.profiling,
+                    logsDirectory = Path.of(config.paths.logsDir.value),
+                    workspaceRoot = workspaceRoot,
+                    runtimeVersion = RuntimeImplementationVersion(KastIndexerBackend.INDEXER_VERSION),
+                    runtimeInstanceId = runtimeInstanceId,
+                ),
+            )
+        ) {
+            RuntimeProfilingStart.Disabled -> RuntimeProfilingOwnership.Disabled
+            is RuntimeProfilingStart.Started -> started.ownership
+            is RuntimeProfilingStart.Rejected -> throw RuntimeProfilingBoundaryException(started.failure)
+        }
+        try {
+            GradleProjectImportBridge.configureIndexerApplication()
+            val project = projectOpener.openProject(workspaceRoot)
+            val indexerRuntime = IndexerServerRuntime.startWithRegistrationProof(
+                project = project,
+                workspaceRoot = workspaceRoot,
+                transport = serverOptions.transport,
+                config = config,
+                registrationProof = registrationProof,
+                runtimeInstanceId = runtimeInstanceId,
+            )
+            val status = runBlocking { indexerRuntime.backend.runtimeStatus() }
+            check(status.backendName == "indexer") {
+                "Kast indexer started with unexpected runtime name: ${status.backendName}"
+            }
+            return RunningKastIndexer(indexerRuntime, profiling)
+        } catch (failure: Throwable) {
+            when (val result = profiling.finish()) {
+                RuntimeProfilingFinish.Completed -> Unit
+                is RuntimeProfilingFinish.Rejected -> {
+                    failure.addSuppressed(RuntimeProfilingBoundaryException(result.failure))
+                }
+            }
+            throw failure
+        }
     }
 
     fun run(options: IndexerServerOptions) {

--- a/indexer/src/main/kotlin/io/github/amichne/kast/indexer/KastRuntimeProfiling.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/indexer/KastRuntimeProfiling.kt
@@ -1,0 +1,387 @@
+package io.github.amichne.kast.indexer
+
+import io.github.amichne.kast.api.client.fields.ProfilingMode
+import io.github.amichne.kast.api.client.fields.ProfilingModeResolution
+import io.github.amichne.kast.api.client.fields.ProfilingModeSelection
+import jdk.jfr.Recording
+import jdk.jfr.RecordingState
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.time.Duration
+
+internal object KastRuntimeProfiling {
+    /**
+     * Proof transition: `RuntimeProfilingLaunch -> RuntimeProfilingStart`.
+     *
+     * Establishes disabled ownership, or an active recording capability bound
+     * to one runtime instance, canonical workspace, exact Git source head,
+     * start time, duration, supported mode set, and owned artifact paths.
+     * Expected rejection is the closed [RuntimeProfilingFailure] family. Raw
+     * paths and serialized manifest primitives are extracted only at the Git,
+     * filesystem, JFR, and JSON adapter boundaries in this file.
+     */
+    fun start(launch: RuntimeProfilingLaunch): RuntimeProfilingStart {
+        if (!launch.config.enabled.value) return RuntimeProfilingStart.Disabled
+        val selection = when (val resolution = launch.config.modes.resolve()) {
+            is ProfilingModeResolution.Resolved -> resolution.selection
+            is ProfilingModeResolution.Rejected -> {
+                return RuntimeProfilingStart.Rejected(RuntimeProfilingFailure.InvalidModes(resolution.failure))
+            }
+        }
+        val duration = when (val resolution = RuntimeProfileDuration.resolve(launch.config.durationSeconds.value)) {
+            is RuntimeProfileDurationResolution.Resolved -> resolution.duration
+            is RuntimeProfileDurationResolution.Rejected -> return RuntimeProfilingStart.Rejected(resolution.failure)
+        }
+        val outputRoot = when (val resolution = RuntimeProfileOutputRoot.resolve(launch)) {
+            is RuntimeProfileOutputResolution.Resolved -> resolution.root
+            is RuntimeProfileOutputResolution.Rejected -> return RuntimeProfilingStart.Rejected(resolution.failure)
+        }
+        val workspace = runCatching { RuntimeProfileWorkspace(launch.workspaceRoot.toRealPath()) }
+            .getOrElse { failure ->
+                return RuntimeProfilingStart.Rejected(
+                    RuntimeProfilingFailure.WorkspaceUnavailable(launch.workspaceRoot, failure.failureText()),
+                )
+            }
+        val sourceHead = when (val resolution = GitSourceHeadResolver.resolve(workspace.path)) {
+            is RuntimeSourceHeadResolution.Resolved -> resolution.sourceHead
+            is RuntimeSourceHeadResolution.Rejected -> return RuntimeProfilingStart.Rejected(resolution.failure)
+        }
+        return startRecordings(
+            launch = launch,
+            selection = selection,
+            duration = duration,
+            outputRoot = outputRoot,
+            workspace = workspace,
+            sourceHead = sourceHead,
+        )
+    }
+
+    private fun startRecordings(
+        launch: RuntimeProfilingLaunch,
+        selection: ProfilingModeSelection,
+        duration: RuntimeProfileDuration,
+        outputRoot: RuntimeProfileOutputRoot,
+        workspace: RuntimeProfileWorkspace,
+        sourceHead: RuntimeProfileSourceHead,
+    ): RuntimeProfilingStart {
+        val startedAt = launch.clock.instant()
+        val sessionRoot = outputRoot.path.resolve("${sourceHead.value}-${launch.runtimeInstanceId.value}")
+        try {
+            Files.createDirectories(outputRoot.path)
+            Files.createDirectory(sessionRoot)
+        } catch (failure: Exception) {
+            return RuntimeProfilingStart.Rejected(
+                RuntimeProfilingFailure.ArtifactPreparationFailed(sessionRoot, failure.failureText()),
+            )
+        }
+        val recordings = mutableListOf<OwnedRuntimeRecording>()
+        try {
+            selection.modes.forEach { mode ->
+                val artifact = sessionRoot.resolve("${mode.wireName}.jfr")
+                val recording = OwnedRuntimeRecording(mode, artifact, Recording())
+                recordings += recording
+                recording.recording.apply {
+                    name = "kast-${mode.wireName}-${launch.runtimeInstanceId.value}"
+                    configure(mode)
+                    destination = artifact
+                    this.duration = duration.value
+                    start()
+                }
+            }
+            if (launch.config.emitManifest.value) {
+                writeManifest(
+                    path = sessionRoot.resolve(MANIFEST_FILE_NAME),
+                    manifest = RuntimeProfilingManifest(
+                        runtimeImplementationVersion = launch.runtimeVersion.value,
+                        runtimeInstanceId = launch.runtimeInstanceId.value,
+                        workspaceRoot = workspace.path.toString(),
+                        sourceHead = sourceHead.value,
+                        startedAt = startedAt.toString(),
+                        durationSeconds = duration.value.seconds,
+                        modes = selection.modes.map(ProfilingMode::wireName),
+                        artifacts = recordings.associate { it.mode.wireName to it.path.toString() },
+                    ),
+                )
+            }
+            return RuntimeProfilingStart.Started(RuntimeProfilingSession(recordings))
+        } catch (failure: Exception) {
+            recordings.closeAndDelete()
+            runCatching { Files.deleteIfExists(sessionRoot.resolve(MANIFEST_FILE_NAME)) }
+            sessionRoot.deleteIfEmpty()
+            return RuntimeProfilingStart.Rejected(
+                RuntimeProfilingFailure.RecorderStartFailed(sessionRoot, failure.failureText()),
+            )
+        }
+    }
+
+    private fun Recording.configure(mode: ProfilingMode) {
+        when (mode) {
+            ProfilingMode.CPU -> {
+                enable("jdk.ExecutionSample").withPeriod(SAMPLE_PERIOD)
+                enable("jdk.NativeMethodSample").withPeriod(SAMPLE_PERIOD)
+            }
+
+            ProfilingMode.ALLOCATION -> {
+                enable("jdk.ObjectAllocationSample").withPeriod(SAMPLE_PERIOD)
+                enable("jdk.ObjectAllocationInNewTLAB").withThreshold(Duration.ZERO)
+                enable("jdk.ObjectAllocationOutsideTLAB").withThreshold(Duration.ZERO)
+            }
+
+            ProfilingMode.LOCK -> {
+                enable("jdk.JavaMonitorEnter").withThreshold(Duration.ZERO)
+                enable("jdk.JavaMonitorWait").withThreshold(Duration.ZERO)
+                enable("jdk.ThreadPark").withThreshold(Duration.ZERO)
+            }
+
+            ProfilingMode.WALL -> {
+                enable("jdk.ExecutionSample").withPeriod(SAMPLE_PERIOD)
+                enable("jdk.ThreadSleep").withThreshold(Duration.ZERO)
+                enable("jdk.ThreadPark").withThreshold(Duration.ZERO)
+                enable("jdk.JavaMonitorWait").withThreshold(Duration.ZERO)
+            }
+        }
+    }
+
+    private fun writeManifest(path: Path, manifest: RuntimeProfilingManifest) {
+        val temporary = Files.createTempFile(path.parent, ".manifest-", ".json")
+        try {
+            Files.writeString(temporary, manifest.toJson().toString())
+            Files.move(temporary, path, StandardCopyOption.ATOMIC_MOVE)
+        } finally {
+            Files.deleteIfExists(temporary)
+        }
+    }
+
+    private val SAMPLE_PERIOD: Duration = Duration.ofMillis(20L)
+    private const val MANIFEST_FILE_NAME = "manifest.json"
+}
+
+@JvmInline
+private value class RuntimeProfileDuration private constructor(val value: Duration) {
+    companion object {
+        /**
+         * Proof transition: `Long -> RuntimeProfileDurationResolution`.
+         *
+         * Establishes a strictly positive recording duration. Non-positive
+         * values remain the closed `InvalidDuration` launch failure. Raw
+         * seconds are extracted only into JFR and manifest adapters.
+         */
+        fun resolve(seconds: Long): RuntimeProfileDurationResolution = if (seconds > 0L) {
+            RuntimeProfileDurationResolution.Resolved(RuntimeProfileDuration(Duration.ofSeconds(seconds)))
+        } else {
+            RuntimeProfileDurationResolution.Rejected(RuntimeProfilingFailure.InvalidDuration(seconds))
+        }
+    }
+}
+
+private sealed interface RuntimeProfileDurationResolution {
+    data class Resolved(val duration: RuntimeProfileDuration) : RuntimeProfileDurationResolution
+
+    data class Rejected(val failure: RuntimeProfilingFailure.InvalidDuration) : RuntimeProfileDurationResolution
+}
+
+@JvmInline
+private value class RuntimeProfileOutputRoot private constructor(val path: Path) {
+    companion object {
+        /**
+         * Proof transition: `RuntimeProfilingLaunch -> RuntimeProfileOutputResolution`.
+         *
+         * Establishes an absolute normalized artifact root after resolving the
+         * logs-directory token, or returns `InvalidOutputDirectory`. Raw path
+         * extraction occurs only at the filesystem boundary.
+         */
+        fun resolve(launch: RuntimeProfilingLaunch): RuntimeProfileOutputResolution {
+            val expanded = launch.config.outputDir.value.replace(LOGS_DIRECTORY_TOKEN, launch.logsDirectory.toString())
+            val boundaryPath = runCatching { Path.of(expanded) }
+                .getOrElse {
+                    return RuntimeProfileOutputResolution.Rejected(
+                        RuntimeProfilingFailure.InvalidOutputDirectory(launch.config.outputDir.value),
+                    )
+                }
+            return if (boundaryPath.isAbsolute) {
+                RuntimeProfileOutputResolution.Resolved(RuntimeProfileOutputRoot(boundaryPath.normalize()))
+            } else {
+                RuntimeProfileOutputResolution.Rejected(
+                    RuntimeProfilingFailure.InvalidOutputDirectory(launch.config.outputDir.value),
+                )
+            }
+        }
+
+        private const val LOGS_DIRECTORY_TOKEN = "{logsDir}"
+    }
+}
+
+private sealed interface RuntimeProfileOutputResolution {
+    data class Resolved(val root: RuntimeProfileOutputRoot) : RuntimeProfileOutputResolution
+
+    data class Rejected(val failure: RuntimeProfilingFailure.InvalidOutputDirectory) : RuntimeProfileOutputResolution
+}
+
+@JvmInline
+private value class RuntimeProfileWorkspace(val path: Path)
+
+@JvmInline
+private value class RuntimeProfileSourceHead private constructor(val value: String) {
+    companion object {
+        /**
+         * Proof transition: `String -> RuntimeSourceHeadResolution`.
+         *
+         * Establishes an exact lower-case SHA-1 or SHA-256 Git object identity,
+         * or returns `SourceHeadUnavailable`. Raw text is extracted only from
+         * the read-only Git process boundary.
+         */
+        fun resolve(workspace: Path, raw: String): RuntimeSourceHeadResolution {
+            val normalized = raw.trim().lowercase()
+            return if (SOURCE_HEAD.matches(normalized)) {
+                RuntimeSourceHeadResolution.Resolved(RuntimeProfileSourceHead(normalized))
+            } else {
+                RuntimeSourceHeadResolution.Rejected(
+                    RuntimeProfilingFailure.SourceHeadUnavailable(workspace, "Git HEAD was not an exact object ID"),
+                )
+            }
+        }
+
+        private val SOURCE_HEAD = Regex("[0-9a-f]{40}|[0-9a-f]{64}")
+    }
+}
+
+private sealed interface RuntimeSourceHeadResolution {
+    data class Resolved(val sourceHead: RuntimeProfileSourceHead) : RuntimeSourceHeadResolution
+
+    data class Rejected(val failure: RuntimeProfilingFailure.SourceHeadUnavailable) : RuntimeSourceHeadResolution
+}
+
+private object GitSourceHeadResolver {
+    /**
+     * Proof transition: `Path -> RuntimeSourceHeadResolution`.
+     *
+     * Establishes an exact Git source identity for the canonical workspace or
+     * returns the closed source-head failure. Raw process output is consumed
+     * only by [RuntimeProfileSourceHead.resolve].
+     */
+    fun resolve(workspace: Path): RuntimeSourceHeadResolution {
+        val builder = ProcessBuilder("git", "rev-parse", "--verify", "HEAD")
+            .directory(workspace.toFile())
+            .redirectErrorStream(true)
+        builder.environment().apply {
+            put("GIT_CONFIG_NOSYSTEM", "1")
+            put("GIT_OPTIONAL_LOCKS", "0")
+            remove("XDG_CONFIG_HOME")
+            keys.removeAll(GIT_REPOSITORY_SELECTORS)
+        }
+        return runCatching {
+            val process = builder.start()
+            val output = process.inputStream.bufferedReader().use { it.readText() }
+            if (process.waitFor() == 0) {
+                RuntimeProfileSourceHead.resolve(workspace, output)
+            } else {
+                RuntimeSourceHeadResolution.Rejected(
+                    RuntimeProfilingFailure.SourceHeadUnavailable(workspace, output.trim().ifBlank { "git failed" }),
+                )
+            }
+        }.getOrElse { failure ->
+            RuntimeSourceHeadResolution.Rejected(
+                RuntimeProfilingFailure.SourceHeadUnavailable(workspace, failure.failureText()),
+            )
+        }
+    }
+
+    private val GIT_REPOSITORY_SELECTORS = setOf(
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_COMMON_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    )
+}
+
+private data class OwnedRuntimeRecording(
+    val mode: ProfilingMode,
+    val path: Path,
+    val recording: Recording,
+)
+
+private class RuntimeProfilingSession(
+    recordings: List<OwnedRuntimeRecording>,
+) : RuntimeProfilingOwnership {
+    private var state: State = State.Open(recordings)
+
+    @Synchronized
+    override fun finish(): RuntimeProfilingFinish = when (val current = state) {
+        is State.Finished -> current.result
+        is State.Open -> current.recordings.finish().also { result -> state = State.Finished(result) }
+    }
+
+    private sealed interface State {
+        data class Open(val recordings: List<OwnedRuntimeRecording>) : State
+
+        data class Finished(val result: RuntimeProfilingFinish) : State
+    }
+}
+
+private fun List<OwnedRuntimeRecording>.finish(): RuntimeProfilingFinish {
+    val failed = linkedSetOf<Path>()
+    asReversed().forEach { owned ->
+        runCatching {
+            try {
+                if (owned.recording.state == RecordingState.RUNNING) owned.recording.stop()
+            } finally {
+                owned.recording.close()
+            }
+            check(Files.isRegularFile(owned.path) && Files.size(owned.path) > 0L)
+        }.onFailure { failed.add(owned.path) }
+    }
+    return if (failed.isEmpty()) {
+        RuntimeProfilingFinish.Completed
+    } else {
+        RuntimeProfilingFinish.Rejected(RuntimeProfilingFailure.FinalizationFailed(failed.toSet()))
+    }
+}
+
+private fun List<OwnedRuntimeRecording>.closeAndDelete() {
+    asReversed().forEach { owned ->
+        runCatching { if (owned.recording.state == RecordingState.RUNNING) owned.recording.stop() }
+        runCatching { owned.recording.close() }
+        runCatching { Files.deleteIfExists(owned.path) }
+    }
+}
+
+private fun Path.deleteIfEmpty() {
+    runCatching {
+        Files.newDirectoryStream(this).use { entries ->
+            if (!entries.iterator().hasNext()) Files.deleteIfExists(this)
+        }
+    }
+}
+
+private fun Throwable.failureText(): String = message?.takeIf(String::isNotBlank) ?: javaClass.name
+
+private data class RuntimeProfilingManifest(
+    val runtimeImplementationVersion: String,
+    val runtimeInstanceId: String,
+    val workspaceRoot: String,
+    val sourceHead: String,
+    val startedAt: String,
+    val durationSeconds: Long,
+    val modes: List<String>,
+    val artifacts: Map<String, String>,
+) {
+    fun toJson() = buildJsonObject {
+        put("runtimeImplementationVersion", runtimeImplementationVersion)
+        put("runtimeInstanceId", runtimeInstanceId)
+        put("workspaceRoot", workspaceRoot)
+        put("sourceHead", sourceHead)
+        put("startedAt", startedAt)
+        put("durationSeconds", durationSeconds)
+        put("modes", buildJsonArray { modes.forEach { mode -> add(mode) } })
+        put("artifacts", buildJsonObject { artifacts.forEach { (mode, path) -> put(mode, path) } })
+    }
+}

--- a/indexer/src/test/kotlin/io/github/amichne/kast/indexer/KastRuntimeProfilingTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/indexer/KastRuntimeProfilingTest.kt
@@ -138,8 +138,10 @@ class KastRuntimeProfilingTest {
         profiling: ProfilingConfig,
     ): IndexerServerOptions {
         val root = tempDir.resolve("runtime-${runtimeInstanceId.value}")
-        val socketRoot = Path.of(requireNotNull(System.getenv("TMPDIR")))
-            .toAbsolutePath()
+        val temporaryDirectory = System.getenv("TMPDIR")
+            ?.let(Path::of)
+            ?: Path.of(System.getProperty("java.io.tmpdir"))
+        val socketRoot = temporaryDirectory.toAbsolutePath()
             .normalize()
             .createDirectories()
         val config = hermeticConfig(root).copy(profiling = profiling)

--- a/indexer/src/test/kotlin/io/github/amichne/kast/indexer/KastRuntimeProfilingTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/indexer/KastRuntimeProfilingTest.kt
@@ -1,0 +1,296 @@
+package io.github.amichne.kast.indexer
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteIntentReadAction
+import com.intellij.openapi.project.ex.ProjectManagerEx
+import com.intellij.openapi.util.Disposer
+import com.intellij.testFramework.common.ThreadLeakTracker
+import com.intellij.testFramework.junit5.TestApplication
+import io.github.amichne.kast.api.client.KastConfig
+import io.github.amichne.kast.api.client.ProfilingConfig
+import io.github.amichne.kast.api.client.RuntimeInstanceId
+import io.github.amichne.kast.api.client.ServerLaunchOptions
+import io.github.amichne.kast.api.client.fields.CacheEnabled
+import io.github.amichne.kast.api.client.fields.CliBinaryPath
+import io.github.amichne.kast.api.client.fields.PathsBinDir
+import io.github.amichne.kast.api.client.fields.PathsCacheDir
+import io.github.amichne.kast.api.client.fields.PathsDescriptorDir
+import io.github.amichne.kast.api.client.fields.PathsInstallRoot
+import io.github.amichne.kast.api.client.fields.PathsLibDir
+import io.github.amichne.kast.api.client.fields.PathsLogsDir
+import io.github.amichne.kast.api.client.fields.PathsRuntimeDir
+import io.github.amichne.kast.api.client.fields.PathsSocketDir
+import io.github.amichne.kast.api.client.fields.ProfilingDurationSeconds
+import io.github.amichne.kast.api.client.fields.ProfilingEmitManifest
+import io.github.amichne.kast.api.client.fields.ProfilingEnabled
+import io.github.amichne.kast.api.client.fields.ProfilingModes
+import io.github.amichne.kast.api.client.fields.ProfilingOutputDir
+import io.github.amichne.kast.api.contract.AnalysisTransport
+import jdk.jfr.consumer.RecordingFile
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.writeText
+
+@TestApplication
+class KastRuntimeProfilingTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `enabled runtime emits readable identity-bound artifacts`() = withHermeticUserHome {
+        val workspace = gitWorkspace(tempDir.resolve("enabled-workspace"))
+        val profileRoot = tempDir.resolve("enabled-profiles")
+        val runtimeInstanceId = RuntimeInstanceId.parse("550e8400-e29b-41d4-a716-446655440000")
+        val options = options(
+            workspace = workspace.root,
+            runtimeInstanceId = runtimeInstanceId,
+            profiling = profiling(enabled = true, modes = "cpu,alloc,lock,wall", output = profileRoot),
+        )
+
+        val runtimeVersion = withProjectClosure(workspace.root) {
+            KastIndexerRuntime.start(options).use { runtime ->
+                runtime.indexerRuntime.server.descriptor?.backendVersion?.value
+                    ?: error("Launched runtime did not publish a descriptor")
+            }
+        }
+
+        val manifestPath = onlyManifest(profileRoot)
+        val manifest = Json.parseToJsonElement(Files.readString(manifestPath)).jsonObject
+        assertEquals(runtimeVersion, manifest.getValue("runtimeImplementationVersion").jsonPrimitive.content)
+        assertEquals(runtimeInstanceId.value, manifest.getValue("runtimeInstanceId").jsonPrimitive.content)
+        assertEquals(workspace.root.toRealPath().toString(), manifest.getValue("workspaceRoot").jsonPrimitive.content)
+        assertEquals(workspace.head, manifest.getValue("sourceHead").jsonPrimitive.content)
+        Instant.parse(manifest.getValue("startedAt").jsonPrimitive.content)
+        assertEquals(1L, manifest.getValue("durationSeconds").jsonPrimitive.content.toLong())
+        assertEquals(
+            setOf("cpu", "allocation", "lock", "wall"),
+            manifest.getValue("modes").jsonArray.map { it.jsonPrimitive.content }.toSet(),
+        )
+
+        val artifacts = manifest.getValue("artifacts").jsonObject
+            .mapValues { (_, encodedPath) -> Path.of(encodedPath.jsonPrimitive.content) }
+        assertEquals(setOf("cpu", "allocation", "lock", "wall"), artifacts.keys)
+        artifacts.values.forEach { artifact ->
+            assertTrue(artifact.isRegularFile(), "Missing profile artifact: $artifact")
+            assertTrue(Files.size(artifact) > 0L, "Empty profile artifact: $artifact")
+            RecordingFile(artifact).use { recording ->
+                while (recording.hasMoreEvents()) recording.readEvent()
+            }
+        }
+        retainProfilingEvidence(manifestPath, artifacts)
+    }
+
+    @Test
+    fun `disabled runtime emits no profiling output`() = withHermeticUserHome {
+        val workspace = gitWorkspace(tempDir.resolve("disabled-workspace"))
+        val profileRoot = tempDir.resolve("disabled-profiles")
+        val options = options(
+            workspace = workspace.root,
+            runtimeInstanceId = RuntimeInstanceId.parse("550e8400-e29b-41d4-a716-446655440001"),
+            profiling = profiling(enabled = false, modes = "cpu", output = profileRoot),
+        )
+
+        withProjectClosure(workspace.root) {
+            KastIndexerRuntime.start(options).use { }
+        }
+
+        assertFalse(profileRoot.exists(), "Disabled profiling created output at $profileRoot")
+    }
+
+    @Test
+    fun `unsupported mode fails before runtime admission`() = withHermeticUserHome {
+        val workspace = gitWorkspace(tempDir.resolve("unsupported-workspace"))
+        val profileRoot = tempDir.resolve("unsupported-profiles")
+        val options = options(
+            workspace = workspace.root,
+            runtimeInstanceId = RuntimeInstanceId.parse("550e8400-e29b-41d4-a716-446655440002"),
+            profiling = profiling(enabled = true, modes = "cpu,heap", output = profileRoot),
+        )
+
+        val result = runCatching {
+            withProjectClosure(workspace.root) {
+                KastIndexerRuntime.start(options).use { }
+            }
+        }
+
+        assertTrue(result.isFailure, "Unsupported profiling mode was silently admitted")
+        assertFalse(profileRoot.exists(), "Rejected profiling created output at $profileRoot")
+    }
+
+    private fun options(
+        workspace: Path,
+        runtimeInstanceId: RuntimeInstanceId,
+        profiling: ProfilingConfig,
+    ): IndexerServerOptions {
+        val root = tempDir.resolve("runtime-${runtimeInstanceId.value}")
+        val socketRoot = Path.of(requireNotNull(System.getenv("TMPDIR")))
+            .toAbsolutePath()
+            .normalize()
+            .createDirectories()
+        val config = hermeticConfig(root).copy(profiling = profiling)
+        return IndexerServerOptions(
+            serverOptions = ServerLaunchOptions(
+                workspaceRoot = workspace,
+                sourceRoots = emptyList(),
+                classpathRoots = emptyList(),
+                moduleName = "sources",
+                transport = AnalysisTransport.UnixDomainSocket(
+                    socketRoot.resolve("k573-${runtimeInstanceId.value.takeLast(4)}.sock"),
+                ),
+                runtimeInstanceId = runtimeInstanceId,
+                requestTimeoutMillis = config.server.requestTimeoutMillis.value,
+                maxResults = config.server.maxResults.value,
+                maxConcurrentRequests = config.server.maxConcurrentRequests.value,
+            ),
+            runtimeConfig = config,
+        )
+    }
+
+    private fun hermeticConfig(root: Path): KastConfig {
+        val install = root.resolve("install")
+        val runtime = root.resolve("runtime")
+        val defaults = KastConfig.defaults()
+        return defaults.copy(
+            cache = defaults.cache.copy(enabled = CacheEnabled(false)),
+            paths = defaults.paths.copy(
+                installRoot = PathsInstallRoot(install.toString()),
+                binDir = PathsBinDir(install.resolve("bin").toString()),
+                libDir = PathsLibDir(install.resolve("lib").toString()),
+                cacheDir = PathsCacheDir(root.resolve("cache").toString()),
+                logsDir = PathsLogsDir(root.resolve("logs").toString()),
+                runtimeDir = PathsRuntimeDir(runtime.toString()),
+                descriptorDir = PathsDescriptorDir(runtime.resolve("descriptors").toString()),
+                socketDir = PathsSocketDir(runtime.toString()),
+            ),
+            cli = defaults.cli.copy(binaryPath = CliBinaryPath(install.resolve("bin/kast").toString())),
+        )
+    }
+
+    private fun profiling(enabled: Boolean, modes: String, output: Path): ProfilingConfig =
+        KastConfig.defaults().profiling.copy(
+            enabled = ProfilingEnabled(enabled),
+            modes = ProfilingModes(modes),
+            durationSeconds = ProfilingDurationSeconds(1L),
+            outputDir = ProfilingOutputDir(output.toString()),
+            emitManifest = ProfilingEmitManifest(true),
+        )
+
+    private fun gitWorkspace(root: Path): GitFixture {
+        root.createDirectories()
+        root.resolve("README.md").writeText("profiling fixture\n")
+        git(root, "init", "--quiet")
+        git(root, "add", "README.md")
+        git(root, "-c", "user.name=Kast Test", "-c", "user.email=kast@example.invalid", "commit", "--quiet", "-m", "fixture")
+        return GitFixture(root.toRealPath(), git(root, "rev-parse", "HEAD").trim())
+    }
+
+    private fun git(root: Path, vararg arguments: String): String {
+        val processBuilder = ProcessBuilder(listOf("git") + arguments)
+            .directory(root.toFile())
+            .redirectErrorStream(true)
+        processBuilder.environment().apply {
+            put("HOME", tempDir.resolve("home").createDirectories().toString())
+            put("XDG_CONFIG_HOME", tempDir.resolve("config").createDirectories().toString())
+            put("GIT_CONFIG_NOSYSTEM", "1")
+            put("GIT_OPTIONAL_LOCKS", "0")
+            keys.removeAll(
+                setOf(
+                    "GIT_DIR",
+                    "GIT_WORK_TREE",
+                    "GIT_COMMON_DIR",
+                    "GIT_INDEX_FILE",
+                    "GIT_OBJECT_DIRECTORY",
+                    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+                ),
+            )
+        }
+        val process = processBuilder.start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        check(process.waitFor() == 0) { "git ${arguments.joinToString(" ")} failed: $output" }
+        return output
+    }
+
+    private fun onlyManifest(profileRoot: Path): Path = Files.walk(profileRoot).use { paths ->
+        paths.filter { it.fileName.toString() == "manifest.json" }.toList().single()
+    }
+
+    private fun retainProfilingEvidence(manifestPath: Path, artifacts: Map<String, Path>) {
+        val gradleHome = System.getenv("GRADLE_USER_HOME")
+            ?.let(Path::of)
+            ?.toAbsolutePath()
+            ?.normalize()
+            ?.takeIf { it.fileName.toString() == "gradle-home" }
+            ?: return
+        val evidenceRoot = gradleHome.parent.resolve("artifacts").createDirectories()
+        val retained = Files.createTempDirectory(evidenceRoot, "delivery-regression-")
+        Files.copy(manifestPath, retained.resolve("manifest.json"))
+        artifacts.forEach { (mode, artifact) ->
+            Files.copy(artifact, retained.resolve("$mode.jfr"))
+        }
+        println("Retained runtime profiling evidence at $retained")
+    }
+
+    private fun <T> withProjectClosure(workspaceRoot: Path, block: () -> T): T = try {
+        block()
+    } finally {
+        ApplicationManager.getApplication().invokeAndWait {
+            WriteIntentReadAction.run {
+                ProjectManagerEx.getInstanceEx().openProjects
+                    .filter { project -> project.basePath?.let(Path::of)?.toAbsolutePath()?.normalize() == workspaceRoot }
+                    .forEach { project -> ProjectManagerEx.getInstanceEx().forceCloseProject(project) }
+            }
+        }
+    }
+
+    private fun <T> withHermeticUserHome(block: () -> T): T {
+        val previous = System.getProperty("user.home")
+        val userHome = tempDir.resolve("home").createDirectories().toString()
+        return try {
+            System.setProperty("user.home", userHome)
+            block()
+        } finally {
+            System.setProperty("user.home", previous)
+        }
+    }
+
+    private data class GitFixture(
+        val root: Path,
+        val head: String,
+    )
+
+    companion object {
+        private val jfrDaemonWhitelist = Disposer.newDisposable("KastRuntimeProfilingTest JFR daemons")
+
+        @BeforeAll
+        @JvmStatic
+        fun allowJfrDaemonThreads() {
+            ThreadLeakTracker.longRunningThreadCreated(
+                jfrDaemonWhitelist,
+                "JFR Recording Scheduler",
+                "JFR Recorder Thread",
+                "JFR Periodic Tasks",
+            )
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun removeJfrDaemonThreads() {
+            Disposer.dispose(jfrDaemonWhitelist)
+        }
+    }
+}


### PR DESCRIPTION
Risk: Profiling uses JDK Flight Recorder and adds lifecycle-owned files only when explicitly enabled. Unsupported modes fail before runtime admission.

## What

- Resolve configured profiling modes into canonical supported selections or finite typed failures.
- Own CPU, allocation, lock, and wall recordings through indexer startup and shutdown.
- Emit a manifest bound to runtime version and instance, normalized workspace, Git source head, UTC start, duration, exact mode set, and artifact paths.
- Prove enabled, disabled, and unsupported behavior through a launched-runtime test.

## Why

Profiling settings were accepted but did not produce usable runtime evidence. This makes the existing configuration observable and fail-closed.

## Validation

- env HOME=/private/tmp/kast-573-hermetic/home GRADLE_USER_HOME=/private/tmp/kast-573-hermetic/gradle-home TMPDIR=/private/tmp/kast-573-hermetic/tmp ./gradlew :analysis-api:test :indexer:test
- env HOME=/private/tmp/kast-573-hermetic/home GRADLE_USER_HOME=/private/tmp/kast-573-hermetic/gradle-home TMPDIR=/private/tmp/kast-573-hermetic/tmp ./gradlew :analysis-api:compileKotlin :indexer:compileKotlin :indexer:compileTestKotlin
- bash .github/scripts/test-repository-shape-contract.sh
- python3 .github/scripts/check-repository-shape.py
- git diff --cached --check

Closes #573