### PR TITLE
fix: separate release cutting from publication

### DIFF
--- a/.github/scripts/release/metadata/release-workflow-model.json
+++ b/.github/scripts/release/metadata/release-workflow-model.json
@@ -2,10 +2,10 @@
   "schemaVersion": 2,
   "evidenceMode": "structural-only",
   "provenance": {
-    "description": "Release topology for one retained indexer, four canonical setup bundles, one verified stable-versus-candidate bundle identity, and a required same-worker real-repository gate whose aggregate evidence is published with the release. Timing claims remain in benchmark evidence.",
-    "observedAt": "2026-08-06",
+    "description": "Tag-only release topology for one retained indexer, four canonical setup bundles, one verified stable-versus-candidate bundle identity, and a required same-worker real-repository gate whose aggregate evidence is published with the release. Timing claims remain in benchmark evidence.",
+    "observedAt": "2026-08-09",
     "source": ".github/workflows/release.yml",
-    "sourceSha256": "5637242c356df837cc9b4b9bafe694468a7ccbb76fa1ce1ce7d0b696db44570f"
+    "sourceSha256": "ccc55d97396fc4d3b445b7017b60f578d2da31d17ad083795b7e9c531ca651b6"
   },
   "tasks": [
     {

--- a/.github/scripts/release/test-release-workflow-contract.sh
+++ b/.github/scripts/release/test-release-workflow-contract.sh
@@ -18,6 +18,7 @@ reject() {
 
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
 ci="$repo_root/.github/workflows/ci.yml"
+cut_release="$repo_root/.github/workflows/cut-release.yml"
 release="$repo_root/.github/workflows/release.yml"
 model="$repo_root/.github/scripts/release/metadata/release-workflow-model.json"
 cli_builder="$repo_root/.github/scripts/release/actions/build-cli/action.yml"
@@ -26,15 +27,26 @@ setup_publisher="$repo_root/.github/scripts/release/actions/publish-setup-bundle
 
 [[ ! -e "$repo_root/.github/scripts/release/actions/publish-cli/action.yml" ]] \
   || die "raw CLI publisher action remains"
+[[ -f "$cut_release" ]] || die "cut release workflow is missing"
 
-workflow_jobs="$(awk '
+workflow_jobs() {
+  local workflow="$1"
+  awk '
   /^jobs:$/ { in_jobs=1; next }
   in_jobs && /^  [a-z0-9][a-z0-9-]*:$/ {
     value=$1
     sub(/:$/, "", value)
     print value
   }
-' "$release" | sort)"
+' "$workflow" | sort
+}
+
+cut_release_jobs="$(workflow_jobs "$cut_release")"
+expected_cut_release_jobs="$(printf '%s\n' cut-release release-preflight | sort)"
+[[ "$cut_release_jobs" == "$expected_cut_release_jobs" ]] \
+  || die "unexpected cut release job inventory: ${cut_release_jobs//$'\n'/, }"
+
+release_jobs="$(workflow_jobs "$release")"
 expected_workflow_jobs="$(printf '%s\n' \
   build-agent-resources \
   build-cli \
@@ -42,7 +54,6 @@ expected_workflow_jobs="$(printf '%s\n' \
   build-openapi-spec \
   build-release-metadata \
   build-setup-bundles \
-  bump-version \
   prepare-release \
   prepare-real-repository-indexing \
   publish-agent-resources \
@@ -54,8 +65,34 @@ expected_workflow_jobs="$(printf '%s\n' \
   real-repository-indexing \
   release-preflight \
   verify-release-state | sort)"
-[[ "$workflow_jobs" == "$expected_workflow_jobs" ]] \
-  || die "unexpected release job inventory: ${workflow_jobs//$'\n'/, }"
+[[ "$release_jobs" == "$expected_workflow_jobs" ]] \
+  || die "unexpected release job inventory: ${release_jobs//$'\n'/, }"
+
+require "$cut_release" 'name: Cut Release' \
+  "manual tag cutting must have a distinct workflow identity"
+require "$cut_release" '  workflow_dispatch:' \
+  "cut release must be manually dispatched"
+reject "$cut_release" '  push:' \
+  "cut release must not run for tag pushes"
+require "$release" 'name: Release' \
+  "publication must retain the release workflow identity"
+require "$release" '  push:' \
+  "release publication must run for tag pushes"
+require "$release" '      - "v*.*.*"' \
+  "release publication must remain tag scoped"
+reject "$release" '  workflow_dispatch:' \
+  "release publication must not instantiate on manual tag-cutting runs"
+reject "$release" 'inputs.release_type' \
+  "release publication must not contain tag-cutting inputs"
+
+for cut_evidence in \
+  'release_type="${{ inputs.release_type }}"' \
+  'token: ${{ secrets.RELEASE_GITHUB_TOKEN }}' \
+  'git tag "$new_tag"' \
+  'git push origin "$new_tag"'; do
+  require "$cut_release" "$cut_evidence" \
+    "cut release must retain tag-cutting evidence: ${cut_evidence}"
+done
 
 reject "$release" 'CI_AUX_' "release must not depend on mutable auxiliary flags"
 reject "$release" 'publish-cli-' "release must not publish intermediate CLI archives"
@@ -64,12 +101,14 @@ reject "$release" 'runtime-manifest' "release must not publish a second runtime 
 reject "$release" 'ubuntu-debian-headless' "release must not publish a legacy Linux bundle"
 reject "$release" 'linux-headless' "release must not publish a standalone runtime product"
 
-require "$release" 'timeout-minutes: 30' \
-  "release preflight must bound the exact-source CI wait"
-require "$release" 'gh run watch "$ci_run_id" --repo "$GITHUB_REPOSITORY" --exit-status --interval 10' \
-  "release preflight must wait for exact-source CI with explicit repository context"
-reject "$release" '-f status=success' \
-  "release preflight must discover in-progress exact-source CI"
+for preflight_surface in "$cut_release" "$release"; do
+  require "$preflight_surface" 'timeout-minutes: 30' \
+    "release preflight must bound the exact-source CI wait"
+  require "$preflight_surface" 'gh run watch "$ci_run_id" --repo "$GITHUB_REPOSITORY" --exit-status --interval 10' \
+    "release preflight must wait for exact-source CI with explicit repository context"
+  reject "$preflight_surface" '-f status=success' \
+    "release preflight must discover in-progress exact-source CI"
+done
 
 for exact_ci_evidence in \
   'actions: read' \
@@ -86,8 +125,10 @@ for exact_ci_evidence in \
   '.status == "completed"' \
   '.conclusion == "success"' \
   '.expired == false'; do
-  require "$release" "$exact_ci_evidence" \
-    "release preflight must require exact-source CI evidence: ${exact_ci_evidence}"
+  for preflight_surface in "$cut_release" "$release"; do
+    require "$preflight_surface" "$exact_ci_evidence" \
+      "release preflight must require exact-source CI evidence: ${exact_ci_evidence}"
+  done
 done
 reject "$release" 'actions/runs/${ci_run_id}/jobs' \
   "successful required CI must not be followed by a duplicate per-job policy query"
@@ -189,6 +230,13 @@ done
 
 [[ "$real_repository_contract" != *'if: ${{ false }}'* ]] \
   || die "real-repository release indexing must be enabled"
+for dependency_condition in \
+  'always() &&' \
+  "needs.prepare-release.result == 'success'" \
+  "needs.prepare-real-repository-indexing.result == 'success'"; do
+  [[ "$real_repository_contract" == *"$dependency_condition"* ]] \
+    || die "real-repository release indexing must require successful dependencies: ${dependency_condition}"
+done
 for benchmark_evidence in \
   '- prepare-real-repository-indexing' \
   'name: real-repository-comparison-bundles-${{ github.run_id }}' \

--- a/.github/scripts/test-release-indexing-benchmark-contract.sh
+++ b/.github/scripts/test-release-indexing-benchmark-contract.sh
@@ -115,8 +115,14 @@ require "$release" 'setup-bundle-linux-x64-${{ github.run_id }}' \
   'release gate must test the built release bundle'
 require "$release" 'Set up Gradle Java 17 toolchain' \
   'release gate must install the Ktor sample toolchain'
-require "$release" 'set-default: false' \
-  'Gradle toolchain setup must not replace the Java 21 Kast runtime'
+reject "$release" 'set-default:' \
+  'release gate must use only supported setup-java inputs'
+require "$release" 'Restore Java 21 Kast runtime' \
+  'release gate must restore the Java 21 Kast runtime after installing the Gradle toolchain'
+gradle_java_line="$(grep -nF 'Set up Gradle Java 17 toolchain' "$release" | cut -d: -f1)"
+kast_java_line="$(grep -nF 'Restore Java 21 Kast runtime' "$release" | cut -d: -f1)"
+[[ "$gradle_java_line" -lt "$kast_java_line" ]] \
+  || die 'release gate must restore Java 21 after installing the Java 17 Gradle toolchain'
 # shellcheck disable=SC2016
 require "$release" 'GRADLE_JAVA_HOME: ${{ steps.gradle-java.outputs.path }}' \
   'release gate must bind the installed Gradle toolchain'

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,148 @@
+name: Cut Release
+run-name: Cut Release ${{ inputs.release_type }} (${{ github.ref_name }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: >
+          Release type. Stable releases increment the latest vX.Y.Z tag.
+          Beta releases append the short commit SHA.
+        required: true
+        default: patch
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - beta
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: cut-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-preflight:
+    name: Preflight release automation
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Require green exact-source CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            printf 'error: stable release dispatch must target refs/heads/main\n' >&2
+            exit 1
+          fi
+          ci_runs="$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+            -f branch=main \
+            -f event=push \
+            -f head_sha="$GITHUB_SHA" \
+            -f per_page=100)"
+          ci_run_id="$(jq -er --arg sha "$GITHUB_SHA" '
+            [.workflow_runs[] | select(
+              .head_sha == $sha
+              and .head_branch == "main"
+              and .path == ".github/workflows/ci.yml"
+              and .event == "push")]
+            | sort_by(.run_attempt)
+            | last
+            | .id
+          ' <<<"$ci_runs")" \
+            || { printf 'error: exact source CI is unavailable for %s\n' "$GITHUB_SHA" >&2; exit 1; }
+          gh run watch "$ci_run_id" --repo "$GITHUB_REPOSITORY" --exit-status --interval 10 \
+            || { printf 'error: exact source CI did not finish green for %s\n' "$GITHUB_SHA" >&2; exit 1; }
+          ci_run="$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${ci_run_id}")"
+          jq -e --arg sha "$GITHUB_SHA" '
+            .head_sha == $sha
+            and .head_branch == "main"
+            and .path == ".github/workflows/ci.yml"
+            and .event == "push"
+            and .status == "completed"
+            and .conclusion == "success"
+          ' <<<"$ci_run" >/dev/null \
+            || { printf 'error: exact source CI is not green for %s\n' "$GITHUB_SHA" >&2; exit 1; }
+          ci_artifacts="$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${ci_run_id}/artifacts" \
+            -f name=ci-artifact-ledger-maven-publication \
+            -f per_page=100)"
+          jq -e '
+            any(.artifacts[];
+              .name == "ci-artifact-ledger-maven-publication"
+              and .expired == false)
+          ' <<<"$ci_artifacts" >/dev/null \
+            || { printf 'error: exact-source CI Maven evidence is unavailable for %s\n' "$GITHUB_SHA" >&2; exit 1; }
+
+  cut-release:
+    name: Cut release tag (${{ inputs.release_type }})
+    needs: [release-preflight]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+
+      - name: Compute next semver tag and push
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_type="${{ inputs.release_type }}"
+          short_sha="${GITHUB_SHA:0:7}"
+          latest_stable="$(git tag --list 'v*' --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
+          if [[ -z "$latest_stable" ]]; then
+            latest_stable="v0.0.0"
+          fi
+          base="${latest_stable#v}"
+          IFS='.' read -r major minor patch <<< "$base"
+          major="${major:-0}"
+          minor="${minor:-0}"
+          patch="${patch:-0}"
+
+          case "$release_type" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              new_tag="v${major}.${minor}.${patch}"
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              new_tag="v${major}.${minor}.${patch}"
+              ;;
+            patch)
+              patch=$((patch + 1))
+              new_tag="v${major}.${minor}.${patch}"
+              ;;
+            beta)
+              patch=$((patch + 1))
+              new_tag="v${major}.${minor}.${patch}-beta.${short_sha}"
+              ;;
+            *)
+              echo "Unknown release_type: ${release_type}" >&2
+              exit 1
+              ;;
+          esac
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$new_tag"
+          git push origin "$new_tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,10 @@
 name: Release
-run-name: >-
-  Release
-  ${{
-    github.event_name == 'workflow_dispatch'
-      && format('{0} ({1})', inputs.release_type, github.ref_name)
-      || github.ref_name
-  }}
+run-name: Release ${{ github.ref_name }}
 
 on:
   push:
     tags:
       - "v*.*.*"
-  workflow_dispatch:
-    inputs:
-      release_type:
-        description: >
-          Release type. Stable releases increment the latest vX.Y.Z tag.
-          Beta releases append the short commit SHA.
-        required: true
-        default: patch
-        type: choice
-        options:
-          - major
-          - minor
-          - patch
-          - beta
 
 permissions:
   contents: read
@@ -54,10 +34,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$GITHUB_REF" != "refs/heads/main" ]]; then
-            printf 'error: stable release dispatch must target refs/heads/main\n' >&2
-            exit 1
-          fi
           ci_runs="$(gh api --method GET \
             "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
             -f branch=main \
@@ -100,75 +76,10 @@ jobs:
             || { printf 'error: exact-source CI Maven evidence is unavailable for %s\n' "$GITHUB_SHA" >&2; exit 1; }
           printf 'run_id=%s\n' "$ci_run_id" >>"$GITHUB_OUTPUT"
 
-  bump-version:
-    name: Bump version (${{ inputs.release_type }})
-    needs: [release-preflight]
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      release_tag: ${{ steps.bump.outputs.release_tag }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-
-      - name: Compute next semver tag and push
-        id: bump
-        shell: bash
-        run: |
-          set -euo pipefail
-          release_type="${{ inputs.release_type }}"
-          short_sha="${GITHUB_SHA:0:7}"
-          latest_stable="$(git tag --list 'v*' --sort=-version:refname \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
-          if [[ -z "$latest_stable" ]]; then
-            latest_stable="v0.0.0"
-          fi
-          base="${latest_stable#v}"
-          IFS='.' read -r major minor patch <<< "$base"
-          major="${major:-0}"
-          minor="${minor:-0}"
-          patch="${patch:-0}"
-
-          case "$release_type" in
-            major)
-              major=$((major + 1))
-              minor=0
-              patch=0
-              new_tag="v${major}.${minor}.${patch}"
-              ;;
-            minor)
-              minor=$((minor + 1))
-              patch=0
-              new_tag="v${major}.${minor}.${patch}"
-              ;;
-            patch)
-              patch=$((patch + 1))
-              new_tag="v${major}.${minor}.${patch}"
-              ;;
-            beta)
-              patch=$((patch + 1))
-              new_tag="v${major}.${minor}.${patch}-beta.${short_sha}"
-              ;;
-            *)
-              echo "Unknown release_type: ${release_type}" >&2
-              exit 1
-              ;;
-          esac
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$new_tag"
-          git push origin "$new_tag"
-          printf 'release_tag=%s\n' "$new_tag" >> "$GITHUB_OUTPUT"
-
   prepare-release:
     name: Prepare release
-    needs: [release-preflight, bump-version]
-    if: always() && github.event_name == 'push' && needs.release-preflight.result == 'success' && needs.bump-version.result == 'skipped'
+    needs: [release-preflight]
+    if: always() && needs.release-preflight.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -183,11 +94,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            tag="${{ needs.bump-version.outputs.release_tag }}"
-          else
-            tag="${GITHUB_REF_NAME}"
-          fi
+          tag="${GITHUB_REF_NAME}"
           [[ "$tag" == v* ]] || { echo "release tag must start with v: $tag" >&2; exit 1; }
           printf 'value=%s\n' "$tag" >> "$GITHUB_OUTPUT"
           printf 'version=%s\n' "${tag#v}" >> "$GITHUB_OUTPUT"
@@ -912,9 +819,11 @@ jobs:
           }
           Path(output).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
           PY
-          printf 'stable_tag=%s\n' "$stable_tag" >>"$GITHUB_OUTPUT"
-          printf 'stable_digest=%s\n' "$stable_digest" >>"$GITHUB_OUTPUT"
-          printf 'candidate_digest=%s\n' "$candidate_digest" >>"$GITHUB_OUTPUT"
+          {
+            printf 'stable_tag=%s\n' "$stable_tag"
+            printf 'stable_digest=%s\n' "$stable_digest"
+            printf 'candidate_digest=%s\n' "$candidate_digest"
+          } >>"$GITHUB_OUTPUT"
 
       - name: Retain verified comparison bundles
         uses: actions/upload-artifact@v6
@@ -968,6 +877,10 @@ jobs:
     needs:
       - prepare-release
       - prepare-real-repository-indexing
+    if: >-
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.prepare-real-repository-indexing.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 150
     permissions:
@@ -1002,9 +915,9 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-          set-default: false
 
-      - uses: actions/setup-java@v5
+      - name: Restore Java 21 Kast runtime
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"


### PR DESCRIPTION
## Summary

- move manual semver calculation and tag creation into a dedicated `Cut Release` workflow
- make `Release` tag-push-only so manual runs no longer instantiate a mostly-skipped publication graph
- explicitly gate real-repository indexing on both successful preparation jobs
- use supported `actions/setup-java@v5` inputs while restoring Java 21 after installing the Java 17 Gradle toolchain
- extend the release contracts and exact-workflow model binding to prevent recurrence

## Root cause

The combined manual/tag workflow intentionally skipped `bump-version` on tag runs. GitHub propagated that skipped dependency through the enabled real-repository indexing gate because the gate lacked an explicit `always()` plus successful-needs condition. Publication then failed closed behind the skipped gate. The structural contract only checked that the gate was no longer hard-disabled, so it did not detect the event-path behavior.

## Impact

Manual release dispatches now contain only preflight and tag cutting. Tag pushes run the publication workflow without the intentional tag-cutting skips. Exact-source CI is still checked at both the tag-cutting boundary and the publication boundary, preserving externally pushed-tag safety.

## Validation

- `actionlint .github/workflows/cut-release.yml .github/workflows/release.yml`
- `bash .github/scripts/release/test-release-workflow-contract.sh`
- `bash .github/scripts/test-release-indexing-benchmark-contract.sh`
- `python3 .github/scripts/check-repository-shape.py`
- `bash -n .github/scripts/release/test-release-workflow-contract.sh .github/scripts/test-release-indexing-benchmark-contract.sh`
- `git diff --check`

No release workflow was dispatched and no release tag or publication was created.
