### PR TITLE
Fix release token handoff

### DIFF
--- a/.github/scripts/release/metadata/release-workflow-model.json
+++ b/.github/scripts/release/metadata/release-workflow-model.json
@@ -2,10 +2,10 @@
   "schemaVersion": 2,
   "evidenceMode": "structural-only",
   "provenance": {
-    "description": "Tag-only release topology for one retained indexer, four canonical setup bundles, one verified stable-versus-candidate bundle identity, and a required same-worker real-repository gate whose aggregate evidence is published with the release. Timing claims remain in benchmark evidence.",
+    "description": "Exact-tag release topology callable from the manual cut workflow or a tag push, with one retained indexer, four canonical setup bundles, one verified stable-versus-candidate bundle identity, and a required same-worker real-repository gate whose aggregate evidence is published with the release. Timing claims remain in benchmark evidence.",
     "observedAt": "2026-08-09",
     "source": ".github/workflows/release.yml",
-    "sourceSha256": "ccc55d97396fc4d3b445b7017b60f578d2da31d17ad083795b7e9c531ca651b6"
+    "sourceSha256": "d20dd730cd91310b8acc1caaee03c0a3a50b9ae432bea682da45d6810cac917a"
   },
   "tasks": [
     {

--- a/.github/scripts/release/test-release-workflow-contract.sh
+++ b/.github/scripts/release/test-release-workflow-contract.sh
@@ -42,7 +42,7 @@ workflow_jobs() {
 }
 
 cut_release_jobs="$(workflow_jobs "$cut_release")"
-expected_cut_release_jobs="$(printf '%s\n' cut-release release-preflight | sort)"
+expected_cut_release_jobs="$(printf '%s\n' cut-release publish-release release-preflight | sort)"
 [[ "$cut_release_jobs" == "$expected_cut_release_jobs" ]] \
   || die "unexpected cut release job inventory: ${cut_release_jobs//$'\n'/, }"
 
@@ -80,18 +80,41 @@ require "$release" '  push:' \
   "release publication must run for tag pushes"
 require "$release" '      - "v*.*.*"' \
   "release publication must remain tag scoped"
-reject "$release" '  workflow_dispatch:' \
-  "release publication must not instantiate on manual tag-cutting runs"
+require "$release" '  workflow_call:' \
+  "manual tag cutting must invoke publication as a reusable workflow"
 reject "$release" 'inputs.release_type' \
   "release publication must not contain tag-cutting inputs"
 
 for cut_evidence in \
   'release_type="${{ inputs.release_type }}"' \
-  'token: ${{ secrets.RELEASE_GITHUB_TOKEN }}' \
+  'token: ${{ github.token }}' \
   'git tag "$new_tag"' \
-  'git push origin "$new_tag"'; do
+  'git push origin "$new_tag"' \
+  'release_tag: ${{ steps.release-tag.outputs.value }}' \
+  'release_sha: ${{ steps.release-tag.outputs.sha }}' \
+  'uses: ./.github/workflows/release.yml' \
+  'release_tag: ${{ needs.cut-release.outputs.release_tag }}' \
+  'release_sha: ${{ needs.cut-release.outputs.release_sha }}' \
+  'secrets: inherit'; do
   require "$cut_release" "$cut_evidence" \
     "cut release must retain tag-cutting evidence: ${cut_evidence}"
+done
+
+for release_identity_evidence in \
+  'release_tag:' \
+  'release_sha:' \
+  'RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}' \
+  'RELEASE_SHA: ${{ inputs.release_sha || github.sha }}' \
+  'tag="${RELEASE_TAG}"' \
+  'git rev-parse "${tag}^{commit}"' \
+  '[[ "$tag_sha" == "$RELEASE_SHA" ]]'; do
+  require "$release" "$release_identity_evidence" \
+    "release publication must preserve exact reusable identity: ${release_identity_evidence}"
+done
+
+for tokenless_surface in "$cut_release" "$release"; do
+  reject "$tokenless_surface" 'RELEASE_GITHUB_TOKEN' \
+    "release automation must not depend on a long-lived GitHub token"
 done
 
 reject "$release" 'CI_AUX_' "release must not depend on mutable auxiliary flags"

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -93,13 +93,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      release_tag: ${{ steps.release-tag.outputs.value }}
+      release_sha: ${{ steps.release-tag.outputs.sha }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Compute next semver tag and push
+        id: release-tag
         shell: bash
         run: |
           set -euo pipefail
@@ -146,3 +150,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "$new_tag"
           git push origin "$new_tag"
+          printf 'value=%s\n' "$new_tag" >> "$GITHUB_OUTPUT"
+          printf 'sha=%s\n' "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
+  publish-release:
+    name: Publish ${{ needs.cut-release.outputs.release_tag }}
+    needs: [cut-release]
+    permissions:
+      actions: write
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      release_tag: ${{ needs.cut-release.outputs.release_tag }}
+      release_sha: ${{ needs.cut-release.outputs.release_sha }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,31 @@
 name: Release
-run-name: Release ${{ github.ref_name }}
+run-name: Release ${{ inputs.release_tag || github.ref_name }}
 
 on:
   push:
     tags:
       - "v*.*.*"
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Exact tag created by the cut-release job.
+        required: true
+        type: string
+      release_sha:
+        description: Exact source commit admitted by release preflight.
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+  RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.release_tag || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -34,6 +46,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "$GITHUB_SHA" != "$RELEASE_SHA" ]]; then
+            printf 'error: release source %s does not match workflow source %s\n' \
+              "$RELEASE_SHA" "$GITHUB_SHA" >&2
+            exit 1
+          fi
           ci_runs="$(gh api --method GET \
             "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
             -f branch=main \
@@ -89,19 +106,25 @@ jobs:
       source_ci_run_id: ${{ needs.release-preflight.outputs.run_id }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
       - name: Resolve release tag
         id: release-tag
         shell: bash
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${RELEASE_TAG}"
           [[ "$tag" == v* ]] || { echo "release tag must start with v: $tag" >&2; exit 1; }
+          tag_sha="$(git rev-parse "${tag}^{commit}")"
+          [[ "$tag_sha" == "$RELEASE_SHA" ]] \
+            || { printf 'release tag %s resolves to %s, expected %s\n' "$tag" "$tag_sha" "$RELEASE_SHA" >&2; exit 1; }
           printf 'value=%s\n' "$tag" >> "$GITHUB_OUTPUT"
           printf 'version=%s\n' "${tag#v}" >> "$GITHUB_OUTPUT"
 
       - name: Ensure draft release exists
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -161,7 +184,7 @@ jobs:
               "runNumber": os.environ["GITHUB_RUN_NUMBER"],
               "runAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
               "sha": os.environ["GITHUB_SHA"],
-              "ref": os.environ["GITHUB_REF"],
+              "ref": "refs/tags/" + os.environ["RELEASE_TAG"],
               "workflowRef": os.environ["GITHUB_WORKFLOW_REF"],
               "actor": os.environ["GITHUB_ACTOR"],
               "platformId": "openapi",
@@ -220,7 +243,7 @@ jobs:
 
       - name: Verify and publish retained OpenAPI asset
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -553,7 +576,7 @@ jobs:
 
       - name: Verify and publish retained agent resource assets
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -866,7 +889,7 @@ jobs:
           ref: ${{ needs.prepare-release.outputs.release_tag }}
       - uses: ./.github/scripts/release/actions/publish-setup-bundle
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         with:
           platform: ${{ matrix.platform }}
           tag: ${{ needs.prepare-release.outputs.release_tag }}
@@ -1154,7 +1177,7 @@ jobs:
 
       - name: Generate SHA256SUMS
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1225,7 +1248,7 @@ jobs:
 
       - name: Upload retained release metadata
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1239,7 +1262,7 @@ jobs:
 
       - name: Publish draft release with provenance annotation
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1277,7 +1300,7 @@ jobs:
 
       - name: Verify published release state
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- cut the release tag with the short-lived repository token
- invoke the complete release workflow as a reusable job in the same manual run
- carry and validate the exact tag and source SHA before publication
- remove release operations' dependency on the stale `RELEASE_GITHUB_TOKEN`

## Validation

- `.github/scripts/release/test-release-workflow-contract.sh`
- `.github/scripts/test-release-indexing-benchmark-contract.sh`
- `.github/scripts/ci/test-ci-workflow-model.sh`
- `actionlint .github/workflows/cut-release.yml .github/workflows/release.yml`