### PR TITLE
feat: add hermetic CLI reproduction capsules

### DIFF
--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -1507,7 +1507,24 @@ def timed_observations(observer_text: str) -> list[TimedObservation]:
 def observation_has_expected_outcome(observation: TimedObservation) -> bool:
     return observation.exit_code == 0 or (
         observation.kind == ObservationKind.RESOLVE
-        and re.search(r"(?m)^error: [A-Z][A-Z0-9_]*$", observation.text) is not None
+        and re.search(r"(?m)^error: CONFLICT$", observation.text) is not None
+    )
+
+
+def observation_completed_during(
+    operation: dict[str, Any],
+    observations: list[TimedObservation],
+) -> bool:
+    started = operation.get("startedAtEpochMillis")
+    finished = operation.get("finishedAtEpochMillis")
+    if not all(
+        isinstance(value, int) and not isinstance(value, bool)
+        for value in (started, finished)
+    ):
+        raise ReproError("command timing fields must be integers")
+    return any(
+        started <= observation.finished_at_epoch_millis < finished
+        for observation in observations
     )
 
 
@@ -1602,6 +1619,7 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
             or observer.get("timedOut") is True
             or observation_kinds != {ObservationKind.HOME, ObservationKind.RESOLVE}
             or not overlaps(operation, observer)
+            or not observation_completed_during(operation, observations)
             or not all(observation_has_expected_outcome(item) for item in observations)
         ):
             incomplete_observers.append(str(observer.get("transcript")))

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -74,6 +74,7 @@ class ActiveCommand:
     window_id: str
     started_at_epoch_millis: int
     completion_token: str
+    deadline_monotonic: float
 
 
 @dataclasses.dataclass(frozen=True)
@@ -523,6 +524,7 @@ class TmuxCapture:
         shell = f"python3 -c {shlex.quote(completion_wrapper)}; exec sleep 2147483647"
         window_name = re.sub(r"[^A-Za-z0-9_-]", "-", spec.name)[:40]
         started_at_epoch_millis = epoch_millis()
+        deadline_monotonic = time.monotonic() + spec.timeout_seconds
         result = run_checked(
             "tmux",
             "new-window",
@@ -543,10 +545,10 @@ class TmuxCapture:
             result.stdout.strip(),
             started_at_epoch_millis,
             completion_token,
+            deadline_monotonic,
         )
 
     def finish(self, active: ActiveCommand) -> CommandEvidence:
-        deadline = time.monotonic() + active.spec.timeout_seconds
         timed_out = False
         transcript = ""
         exit_code: int | None = None
@@ -571,7 +573,7 @@ class TmuxCapture:
                 exit_code = int(match.group(1))
                 completed_at_epoch_millis = int(match.group(2))
                 break
-            if time.monotonic() >= deadline:
+            if time.monotonic() >= active.deadline_monotonic:
                 timed_out = True
                 subprocess.run(
                     ["tmux", "send-keys", "-t", active.window_id, "C-c"],
@@ -896,6 +898,7 @@ def verify_capsule_install(
         candidate_paths.extend(
             Path(value) for value in effective_paths.values() if isinstance(value, str) and value
         )
+    candidate_paths.append(telemetry_output_path(config, workspace))
     escaped = sorted(str(path) for path in candidate_paths if not is_within(path, capsule.root))
     proof = {
         "installationContained": not escaped,
@@ -992,7 +995,8 @@ def signal_capsule_processes(
                 raise ReproError(
                     f"cannot terminate capsule-owned PID {process_id}"
                 ) from error
-            targeted.add(process_id)
+            else:
+                targeted.add(process_id)
         if remaining:
             stable_empty_scans = 0
             if time.monotonic() >= deadline:
@@ -1062,11 +1066,20 @@ def restore_config(
     return errors
 
 
-def log_paths(config: dict[str, Any]) -> tuple[Path, Path]:
+def telemetry_output_path(config: dict[str, Any], workspace: Path) -> Path:
+    output = config.get("effective", {}).get("telemetry", {}).get("outputFile")
+    if isinstance(output, str) and output:
+        configured = Path(output).expanduser()
+        return (configured if configured.is_absolute() else workspace / configured).resolve()
+    config_path = Path(str(config.get("configPath", "")))
+    return (config_path.parent / "telemetry" / "idea-spans.jsonl").resolve()
+
+
+def log_paths(config: dict[str, Any], workspace: Path) -> tuple[Path, Path]:
     config_path = Path(str(config.get("configPath", "")))
     if len(config_path.parent.name) != 64:
         raise ReproError("config discovery did not expose a canonical workspace data directory")
-    telemetry = config_path.parent / "telemetry" / "idea-spans.jsonl"
+    telemetry = telemetry_output_path(config, workspace)
     cache_root = Path(str(config.get("effective", {}).get("paths", {}).get("cacheDir", "")))
     idea_log = cache_root / "idea-sidecars" / config_path.parent.name[:12] / "idea-log" / "idea.log"
     return telemetry, idea_log
@@ -1237,7 +1250,7 @@ def capture(args: argparse.Namespace) -> int:
             json.dumps(config, indent=2) + "\n",
             encoding="utf-8",
         )
-        telemetry_path, idea_log_path = log_paths(config)
+        telemetry_path, idea_log_path = log_paths(config, workspace)
         telemetry_offset = file_size(telemetry_path)
         trace_offset = file_size(idea_log_path)
         require_success(runner.run(

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -1199,7 +1199,7 @@ def restore_config_and_runtime(
 def telemetry_output_path(config: dict[str, Any], workspace: Path) -> Path:
     output = config.get("effective", {}).get("telemetry", {}).get("outputFile")
     if isinstance(output, str) and output:
-        configured = Path(output).expanduser()
+        configured = Path(output)
         return (configured if configured.is_absolute() else workspace / configured).resolve()
     config_path = Path(str(config.get("configPath", "")))
     return (config_path.parent / "telemetry" / "idea-spans.jsonl").resolve()
@@ -1303,6 +1303,22 @@ def discard_unstarted_ephemeral_capsule(capsule: CapsuleContext | None) -> None:
     ):
         raise ReproError("refused to clean an unrecognized ephemeral capsule root")
     shutil.rmtree(capsule.root)
+
+
+def ephemeral_capsule_is_safely_deletable(
+    capsule: CapsuleContext | None,
+    proof: dict[str, Any] | None,
+    teardown_errors: list[str],
+) -> bool:
+    return (
+        capsule is not None
+        and capsule.mode == "EPHEMERAL"
+        and proof is not None
+        and proof.get("runtimeStopped") is True
+        and proof.get("installationContained") is True
+        and proof.get("stateContained") is True
+        and not teardown_errors
+    )
 
 
 def capture(args: argparse.Namespace) -> int:
@@ -1557,15 +1573,10 @@ def capture(args: argparse.Namespace) -> int:
             copy_delta(idea_log_path, trace_offset, output / "idea-trace.log")
         write_manifest(output, workspace, session, runner.commands, capsule_proof)
 
-        if (
-            capsule is not None
-            and capsule.mode == "EPHEMERAL"
-            and capsule_proof is not None
-            and capsule_proof["runtimeStopped"] is True
-            and capsule_proof.get("installationContained") is True
-            and capsule_proof["stateContained"] is True
-            and capture_failure is None
-            and not teardown_errors
+        if ephemeral_capsule_is_safely_deletable(
+            capsule,
+            capsule_proof,
+            teardown_errors,
         ):
             temp_root = Path("/private/tmp").resolve()
             if (

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -26,6 +26,17 @@ SCHEMA_VERSION = 1
 DEFAULT_OUTPUT_BUDGET_BYTES = 30_000
 EXIT_SENTINEL = "::kast-repro-exit="
 OBSERVATION_EXIT_SENTINEL = "__KAST_OBSERVATION_EXIT_CODE__="
+CAPSULE_STATE_ENVIRONMENT_KEYS = (
+    "HOME",
+    "KAST_HOME",
+    "KAST_CONFIG_HOME",
+    "KAST_CACHE_HOME",
+    "GRADLE_USER_HOME",
+    "TMPDIR",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+)
 
 
 class ReproError(Exception):
@@ -75,6 +86,7 @@ class ActiveCommand:
     started_at_epoch_millis: int
     completion_token: str
     deadline_monotonic: float
+    deadline_epoch_millis: int
 
 
 @dataclasses.dataclass(frozen=True)
@@ -182,6 +194,17 @@ def capsule_environment(root: Path, workspace_id: str) -> dict[str, str]:
         "KAST_IDEA_TRACE": "true",
         "PATH": f"{home / '.local' / 'bin'}{os.pathsep}{os.environ.get('PATH', '')}",
     }
+
+
+def require_contained_capsule_state_paths(
+    root: Path,
+    environment: dict[str, str],
+) -> tuple[Path, ...]:
+    paths = tuple(Path(environment[key]) for key in CAPSULE_STATE_ENVIRONMENT_KEYS)
+    escaped = sorted(str(path) for path in paths if not is_within(path, root))
+    if escaped:
+        raise ReproError(f"capsule state path escaped its root: {', '.join(escaped)}")
+    return paths
 
 
 def merged_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
@@ -525,6 +548,9 @@ class TmuxCapture:
         window_name = re.sub(r"[^A-Za-z0-9_-]", "-", spec.name)[:40]
         started_at_epoch_millis = epoch_millis()
         deadline_monotonic = time.monotonic() + spec.timeout_seconds
+        deadline_epoch_millis = started_at_epoch_millis + math.ceil(
+            spec.timeout_seconds * 1_000
+        )
         result = run_checked(
             "tmux",
             "new-window",
@@ -546,6 +572,7 @@ class TmuxCapture:
             started_at_epoch_millis,
             completion_token,
             deadline_monotonic,
+            deadline_epoch_millis,
         )
 
     def finish(self, active: ActiveCommand) -> CommandEvidence:
@@ -570,8 +597,11 @@ class TmuxCapture:
                 re.MULTILINE,
             )
             if match is not None:
-                exit_code = int(match.group(1))
                 completed_at_epoch_millis = int(match.group(2))
+                if completed_at_epoch_millis > active.deadline_epoch_millis:
+                    timed_out = True
+                else:
+                    exit_code = int(match.group(1))
                 break
             if time.monotonic() >= active.deadline_monotonic:
                 timed_out = True
@@ -859,18 +889,10 @@ def build_capsule(
     environment = capsule_environment(root, workspace_id)
     capsule = CapsuleContext(mode, root, bundle_source, environment, bootstrap, idea_host)
     if not dry_run:
-        for key in (
-            "HOME",
-            "KAST_HOME",
-            "KAST_CONFIG_HOME",
-            "KAST_CACHE_HOME",
-            "GRADLE_USER_HOME",
-            "TMPDIR",
-            "XDG_CACHE_HOME",
-            "XDG_CONFIG_HOME",
-            "XDG_DATA_HOME",
-        ):
-            Path(environment[key]).mkdir(parents=True, exist_ok=True)
+        state_paths = require_contained_capsule_state_paths(root, environment)
+        for path in state_paths:
+            path.mkdir(parents=True, exist_ok=True)
+        require_contained_capsule_state_paths(root, environment)
     return capsule
 
 
@@ -1140,6 +1162,13 @@ def live_capture_preflight(args: argparse.Namespace, workspace: Path) -> LiveCap
     session = args.session_name or f"kast-cli-repro-{os.getpid()}"
     if re.fullmatch(r"[A-Za-z0-9_-]+", session) is None:
         raise ReproError("--session-name must contain only letters, digits, underscores, or hyphens")
+    existing = subprocess.run(
+        ["tmux", "has-session", "-t", session],
+        capture_output=True,
+        check=False,
+    )
+    if existing.returncode == 0:
+        raise ReproError(f"tmux session already exists: {session}")
     return LiveCapturePreflight(output, session)
 
 
@@ -1156,11 +1185,17 @@ def discard_unstarted_ephemeral_capsule(capsule: CapsuleContext | None) -> None:
 
 
 def capture(args: argparse.Namespace) -> int:
-    workspace = args.workspace_root.resolve(strict=True)
+    try:
+        workspace = args.workspace_root.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise ReproError(f"workspace root is unavailable: {error}") from error
     file_path = Path(args.file)
     if file_path.is_absolute() or ".." in file_path.parts:
         raise ReproError("--file must be a workspace-relative path without parent traversal")
-    source = (workspace / file_path).resolve(strict=True)
+    try:
+        source = (workspace / file_path).resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise ReproError(f"capture file is unavailable: {error}") from error
     if workspace not in source.parents or source.suffix != ".kt":
         raise ReproError("--file must resolve to a Kotlin file inside the workspace")
     mutation_probe = (
@@ -1316,7 +1351,12 @@ def capture(args: argparse.Namespace) -> int:
         capture_failure = ReproError("capture interrupted")
     finally:
         capsule_proof: dict[str, Any] | None = None
-        if capsule is not None:
+        if capsule is not None and not runner_started:
+            try:
+                discard_unstarted_ephemeral_capsule(capsule)
+            except ReproError as error:
+                teardown_errors.append(str(error))
+        if capsule is not None and runner_started:
             observed_processes: dict[int, str] = {}
             try:
                 observed_processes = capsule_processes(capsule.root)
@@ -1356,19 +1396,9 @@ def capture(args: argparse.Namespace) -> int:
                 teardown_errors.append(str(error))
                 terminated = []
                 remaining = sorted(observed_processes)
-            state_keys = (
-                "HOME",
-                "KAST_HOME",
-                "KAST_CONFIG_HOME",
-                "KAST_CACHE_HOME",
-                "GRADLE_USER_HOME",
-                "TMPDIR",
-                "XDG_CACHE_HOME",
-                "XDG_CONFIG_HOME",
-                "XDG_DATA_HOME",
-            )
             state_contained = all(
-                is_within(Path(capsule.environment[key]), capsule.root) for key in state_keys
+                is_within(Path(capsule.environment[key]), capsule.root)
+                for key in CAPSULE_STATE_ENVIRONMENT_KEYS
             )
             capsule_proof = {
                 **capsule.public(),
@@ -1861,7 +1891,7 @@ def main() -> int:
             for finding in report["findings"]:
                 print(f"- {finding['code']}: {finding['message']}")
         return exit_code
-    except ReproError as error:
+    except (ReproError, OSError) as error:
         print(json.dumps({"schemaVersion": SCHEMA_VERSION, "status": "INVALID_EVIDENCE", "error": str(error)}), file=sys.stderr)
         return 2
 

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -1700,9 +1700,12 @@ def telemetry_missing_fields(directory: Path, manifest: dict[str, Any]) -> list[
 def analyze(directory: Path) -> tuple[dict[str, Any], int]:
     directory = directory.resolve(strict=True)
     manifest, commands = read_manifest(directory)
+    capsule = manifest.get("capsule")
     required_commands = set(REQUIRED_SCENARIO_COMMANDS)
-    if "capsule" in manifest:
-        required_commands.update({"cold-up", "cold-observer"})
+    if isinstance(capsule, dict):
+        required_commands.update(
+            {"cold-up", "cold-observer", "capsule-runtime-stop"}
+        )
     missing_commands = sorted(required_commands - set(commands))
     if missing_commands:
         raise ReproError(
@@ -1715,7 +1718,12 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
         if (
             not isinstance(commands[name].get("exitCode"), int)
             or isinstance(commands[name].get("exitCode"), bool)
+            or commands[name].get("exitCode", -1) < 0
             or not isinstance(commands[name].get("timedOut"), bool)
+            or (
+                commands[name].get("timedOut") is True
+                and commands[name].get("exitCode") != 124
+            )
         )
     )
     if invalid_status_commands:
@@ -1723,6 +1731,16 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
             "required scenario commands have invalid status evidence: "
             + ", ".join(invalid_status_commands)
         )
+    if isinstance(capsule, dict):
+        capsule_stop = commands["capsule-runtime-stop"]
+        captured_stop_succeeded = (
+            capsule_stop["exitCode"] == 0 and capsule_stop["timedOut"] is False
+        )
+        if capsule["runtimeStopSucceeded"] is not captured_stop_succeeded:
+            raise ReproError(
+                "evidence manifest capsule runtimeStopSucceeded does not match "
+                "capsule-runtime-stop status"
+            )
     failed_commands = sorted(
         name
         for name in REQUIRED_SUCCESSFUL_SCENARIO_COMMANDS
@@ -1841,13 +1859,34 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
             if name in required_commands:
                 raise ReproError(f"required command {name} has invalid completion fields")
             continue
-        completion_frame = (
-            f"{EXIT_SENTINEL}{completion_token}:{exit_code}:{finished_at}"
+        nonce_frames = list(
+            re.finditer(
+                rf"{re.escape(EXIT_SENTINEL)}{re.escape(completion_token)}:"
+                r"([0-9]+):([0-9]+)\r?(?:\n|$)",
+                text,
+            )
         )
-        frame_match = re.search(
-            rf"{re.escape(completion_frame)}\r?(?:\n|$)",
-            text,
-        )
+        if command.get("timedOut") is True:
+            frame_match = next(
+                (
+                    match
+                    for match in nonce_frames
+                    if int(match.group(2)) == finished_at
+                ),
+                None,
+            )
+            if frame_match is None and not nonce_frames:
+                continue
+        else:
+            frame_match = next(
+                (
+                    match
+                    for match in nonce_frames
+                    if int(match.group(1)) == exit_code
+                    and int(match.group(2)) == finished_at
+                ),
+                None,
+            )
         if frame_match is None:
             if name in required_commands:
                 raise ReproError(
@@ -1887,7 +1926,6 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
                 missing,
             )
         )
-    capsule = manifest.get("capsule")
     if isinstance(capsule, dict):
         confinement_evidence: list[str] = []
         if capsule.get("installationContained") is not True:

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -37,6 +37,29 @@ CAPSULE_STATE_ENVIRONMENT_KEYS = (
     "XDG_CONFIG_HOME",
     "XDG_DATA_HOME",
 )
+REQUIRED_SCENARIO_COMMANDS = (
+    "home",
+    "help",
+    "file-list",
+    "symbol-search",
+    "symbol-resolve",
+    "symbol-show",
+    "relation-references",
+    "relation-calls-incoming",
+    "relation-calls-outgoing",
+    "relation-implementations",
+    "relation-hierarchy-supertypes",
+    "relation-hierarchy-subtypes",
+    "graph-summary",
+    "graph-nodes",
+    "graph-neighbors",
+    "graph-topology",
+    "graph-communities",
+    "graph-impact",
+    "diagnostic-check",
+    "workspace-refresh",
+    "refresh-observer",
+)
 
 
 class ReproError(Exception):
@@ -1481,6 +1504,8 @@ def read_manifest(directory: Path) -> tuple[dict[str, Any], dict[str, dict[str, 
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
         raise ReproError(f"invalid evidence manifest: {error}") from error
+    if not isinstance(manifest, dict):
+        raise ReproError("evidence manifest root must be an object")
     if manifest.get("schemaVersion") != SCHEMA_VERSION:
         raise ReproError(f"unsupported evidence schema: {manifest.get('schemaVersion')!r}")
     commands = manifest.get("commands")
@@ -1490,6 +1515,8 @@ def read_manifest(directory: Path) -> tuple[dict[str, Any], dict[str, dict[str, 
     for command in commands:
         if not isinstance(command, dict) or not isinstance(command.get("name"), str):
             raise ReproError("every evidence command must have a string name")
+        if command["name"] in indexed:
+            raise ReproError(f"duplicate evidence command: {command['name']}")
         indexed[command["name"]] = command
     return manifest, indexed
 
@@ -1634,15 +1661,17 @@ def telemetry_missing_fields(directory: Path, manifest: dict[str, Any]) -> list[
 def analyze(directory: Path) -> tuple[dict[str, Any], int]:
     directory = directory.resolve(strict=True)
     manifest, commands = read_manifest(directory)
+    missing_commands = sorted(set(REQUIRED_SCENARIO_COMMANDS) - set(commands))
+    if missing_commands:
+        raise ReproError(
+            "evidence manifest is missing required scenario commands: "
+            + ", ".join(missing_commands)
+        )
     findings: list[Finding] = []
     cold_up = commands.get("cold-up")
     cold_observer = commands.get("cold-observer")
     refresh = commands.get("workspace-refresh")
     refresh_observer = commands.get("refresh-observer")
-    if refresh is None:
-        raise ReproError(
-            "evidence manifest is missing required transition command workspace-refresh"
-        )
     incomplete_observers: list[str] = []
     complete_observers: dict[str, list[TimedObservation]] = {}
     for operation, observer, observer_name, required_kind in (

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -235,6 +235,24 @@ def require_contained_capsule_state_paths(
     return paths
 
 
+def require_contained_capsule_state_symlinks(
+    root: Path,
+    state_paths: tuple[Path, ...],
+) -> None:
+    try:
+        for state_path in state_paths:
+            for candidate in state_path.rglob("*"):
+                if candidate.is_symlink() and not is_within(candidate, root):
+                    raise ReproError(
+                        "capsule state symlink escaped its root: "
+                        f"{candidate} -> {candidate.resolve()}"
+                    )
+    except (OSError, RuntimeError) as error:
+        raise ReproError(
+            f"capsule state symlink could not be validated: {error}"
+        ) from error
+
+
 def merged_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = os.environ.copy()
     if overrides:
@@ -922,6 +940,7 @@ def build_capsule(
             for path in state_paths:
                 path.mkdir(parents=True, exist_ok=True)
             require_contained_capsule_state_paths(root, environment)
+            require_contained_capsule_state_symlinks(root, state_paths)
         return capsule
     except (OSError, ReproError, KeyboardInterrupt):
         discard_unstarted_ephemeral_capsule(capsule)
@@ -1117,6 +1136,54 @@ def restore_config(
             require_success(runner.run(spec))
         except ReproError as error:
             errors.append(str(error))
+    return errors
+
+
+def restore_config_and_runtime(
+    runner: TmuxCapture,
+    kastctl: Path,
+    kast: str,
+    workspace: Path,
+    config: dict[str, Any],
+    transition_timeout: float,
+) -> list[str]:
+    errors = restore_config(runner, kastctl, workspace, config)
+    try:
+        require_success(
+            runner.run(
+                CommandSpec(
+                    "restore-runtime-stop",
+                    (
+                        str(kastctl),
+                        "--output",
+                        "json",
+                        "developer",
+                        "runtime",
+                        "stop",
+                        "--workspace-root",
+                        str(workspace),
+                    ),
+                    timeout_seconds=transition_timeout,
+                )
+            )
+        )
+    except ReproError as error:
+        errors.append(str(error))
+        return errors
+    if errors:
+        return errors
+    try:
+        require_success(
+            runner.run(
+                CommandSpec(
+                    "restore-runtime-start",
+                    (kast, "workspace", "ensure"),
+                    timeout_seconds=transition_timeout,
+                )
+            )
+        )
+    except ReproError as error:
+        errors.append(str(error))
     return errors
 
 
@@ -1459,7 +1526,16 @@ def capture(args: argparse.Namespace) -> int:
             )
         elif runner_started:
             if kastctl is not None and config is not None:
-                teardown_errors.extend(restore_config(runner, kastctl, workspace, config))
+                teardown_errors.extend(
+                    restore_config_and_runtime(
+                        runner,
+                        kastctl,
+                        kast,
+                        workspace,
+                        config,
+                        args.transition_timeout,
+                    )
+                )
             runner.close()
 
         if telemetry_path is None:

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -1778,6 +1778,18 @@ def read_manifest(directory: Path) -> tuple[dict[str, Any], dict[str, dict[str, 
         ):
             if not isinstance(capsule.get(field), bool):
                 raise ReproError(f"evidence manifest capsule {field} must be a boolean")
+        escaped_paths = capsule.get("escapedPaths")
+        if not isinstance(escaped_paths, list) or not all(
+            isinstance(path, str) and bool(path)
+            for path in escaped_paths
+        ):
+            raise ReproError(
+                "evidence manifest capsule escapedPaths must be an array of path strings"
+            )
+        if capsule["installationContained"] is not (not escaped_paths):
+            raise ReproError(
+                "evidence manifest capsule installationContained must match escapedPaths"
+            )
         for field in ("terminatedProcessIds", "processesRemaining"):
             process_ids = capsule.get(field)
             if not isinstance(process_ids, list) or not all(
@@ -1956,8 +1968,22 @@ def telemetry_missing_fields(directory: Path, manifest: dict[str, Any]) -> list[
         "dumbModeState": {"dumbModeState", "kast.idea.dumb_mode"},
         "typedOutcome": {"typedOutcome", "outcome", "errorCode", "kast.outcome.code"},
     }
+
+    def valid(field: str, value: Any) -> bool:
+        if field in {"semanticGenerationStart", "semanticGenerationEnd"}:
+            return (
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and value >= 0
+            )
+        return isinstance(value, str) and bool(value.strip())
+
     missing_by_request = [
-        [name for name, keys in aliases.items() if not keys & set(item)]
+        [
+            name
+            for name, keys in aliases.items()
+            if not any(key in item and valid(name, item[key]) for key in keys)
+        ]
         for item in attributes
     ]
     return min(missing_by_request, key=len) if missing_by_request else list(aliases)

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -38,6 +38,9 @@ CAPSULE_STATE_ENVIRONMENT_KEYS = (
     "XDG_DATA_HOME",
 )
 REQUIRED_SCENARIO_COMMANDS = (
+    "runtime-stop",
+    "cold-up",
+    "cold-observer",
     "home",
     "help",
     "file-list",
@@ -63,7 +66,13 @@ REQUIRED_SCENARIO_COMMANDS = (
 REQUIRED_SUCCESSFUL_SCENARIO_COMMANDS = tuple(
     name
     for name in REQUIRED_SCENARIO_COMMANDS
-    if name not in {"workspace-refresh", "refresh-observer"}
+    if name
+    not in {
+        "cold-up",
+        "cold-observer",
+        "workspace-refresh",
+        "refresh-observer",
+    }
 )
 
 
@@ -1590,7 +1599,7 @@ def read_manifest(directory: Path) -> tuple[dict[str, Any], dict[str, dict[str, 
     manifest_path = directory / "manifest.json"
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
         raise ReproError(f"invalid evidence manifest: {error}") from error
     if not isinstance(manifest, dict):
         raise ReproError("evidence manifest root must be an object")
@@ -1779,9 +1788,7 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
     capsule = manifest.get("capsule")
     required_commands = set(REQUIRED_SCENARIO_COMMANDS)
     if isinstance(capsule, dict):
-        required_commands.update(
-            {"cold-up", "cold-observer", "capsule-runtime-stop"}
-        )
+        required_commands.add("capsule-runtime-stop")
     missing_commands = sorted(required_commands - set(commands))
     if missing_commands:
         raise ReproError(
@@ -2141,7 +2148,7 @@ def main() -> int:
             for finding in report["findings"]:
                 print(f"- {finding['code']}: {finding['message']}")
         return exit_code
-    except (ReproError, OSError) as error:
+    except (ReproError, OSError, UnicodeError) as error:
         print(json.dumps({"schemaVersion": SCHEMA_VERSION, "status": "INVALID_EVIDENCE", "error": str(error)}), file=sys.stderr)
         return 2
 

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -547,6 +547,16 @@ def require_success(command: CommandEvidence) -> None:
         )
 
 
+def finish_observed_operation(
+    runner: TmuxCapture,
+    operation: ActiveCommand,
+    observer: ActiveCommand,
+) -> tuple[CommandEvidence, CommandEvidence]:
+    operation_evidence = runner.finish(operation)
+    observer_evidence = runner.finish(observer)
+    return operation_evidence, observer_evidence
+
+
 def discover_developer_cli(
     kast: str,
     workspace: Path,
@@ -1121,8 +1131,7 @@ def capture(args: argparse.Namespace) -> int:
             cold_observer = next(spec for spec in plan if spec.name == "cold-observer")
             up_active = runner.begin(cold_up)
             observer_active = runner.begin(cold_observer)
-            runner.finish(observer_active)
-            runner.finish(up_active)
+            finish_observed_operation(runner, up_active, observer_active)
         else:
             require_success(
                 runner.run(
@@ -1141,8 +1150,7 @@ def capture(args: argparse.Namespace) -> int:
         observer = next(spec for spec in plan if spec.name == "refresh-observer")
         refresh_active = runner.begin(refresh)
         observer_active = runner.begin(observer)
-        runner.finish(observer_active)
-        runner.finish(refresh_active)
+        finish_observed_operation(runner, refresh_active, observer_active)
     except ReproError as error:
         capture_failure = error
     except OSError as error:
@@ -1377,11 +1385,11 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
             findings.append(
                 Finding(
                     FindingCode.READY_DURING_PENDING_UP.value,
-                    "The public home reported READY while `kast up` was still pending.",
+                    "The public home reported READY while `kast workspace ensure` was still pending.",
                     ["transcripts/cold-up.txt", "transcripts/cold-observer.txt"],
                 )
             )
-    refresh = commands.get("refresh")
+    refresh = commands.get("workspace-refresh")
     refresh_observer = commands.get("refresh-observer")
     if refresh and refresh.get("exitCode") != 0:
         findings.append(

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -124,6 +124,7 @@ class ActiveCommand:
     completion_token: str
     deadline_monotonic: float
     deadline_epoch_millis: int
+    observer_stop_path: Path | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -532,7 +533,9 @@ def observer_script(kast: str, symbol: str, samples: int, interval: float) -> st
     kast_command = shlex.quote(kast)
     symbol_argument = shlex.quote(symbol)
     return (
-        f"for i in $(seq 1 {samples}); do "
+        'stop=${KAST_REPRO_OBSERVER_STOP:?}; i=1; stop_seen=0; '
+        f'while [ "$i" -le {samples} ] || [ "$stop_seen" -eq 0 ]; do '
+        'if [ -e "$stop" ]; then stop_seen=1; fi; '
         'printf "__KAST_SAMPLE__=%s\\n" "$i"; '
         'printf "__KAST_OBSERVATION__=HOME\\n"; '
         f"{kast_command}; observation_status=$?; "
@@ -544,6 +547,7 @@ def observer_script(kast: str, symbol: str, samples: int, interval: float) -> st
         f'printf "{OBSERVATION_EXIT_SENTINEL}%s\\n" "$observation_status"; '
         'printf "__KAST_OBSERVATION_EPOCH_MILLIS__="; '
         "python3 -c 'import time; print(time.time_ns() // 1000000)'; "
+        'i=$((i + 1)); '
         f"sleep {interval}; "
         "done"
     )
@@ -586,6 +590,10 @@ class TmuxCapture:
         completion_marker = f"{EXIT_SENTINEL}{completion_token}:"
         environment = dict(self.base_environment)
         environment.update(dict(spec.environment))
+        observer_stop_path: Path | None = None
+        if spec.name in {"cold-observer", "refresh-observer"}:
+            observer_stop_path = self.evidence / f".{spec.name}-{completion_token}.stop"
+            environment["KAST_REPRO_OBSERVER_STOP"] = str(observer_stop_path)
         if environment:
             environment = " ".join(
                 f"{shlex.quote(key)}={shlex.quote(value)}" for key, value in environment.items()
@@ -628,7 +636,18 @@ class TmuxCapture:
             completion_token,
             deadline_monotonic,
             deadline_epoch_millis,
+            observer_stop_path,
         )
+
+    def request_observer_completion(self, active: ActiveCommand) -> None:
+        if active.observer_stop_path is None:
+            raise ReproError(f"command {active.spec.name} is not a transition observer")
+        try:
+            active.observer_stop_path.write_text("", encoding="utf-8")
+        except OSError as error:
+            raise ReproError(
+                f"cannot stop transition observer {active.spec.name}: {error}"
+            ) from error
 
     def finish(self, active: ActiveCommand) -> CommandEvidence:
         timed_out = False
@@ -700,6 +719,13 @@ class TmuxCapture:
                 check=False,
                 capture_output=True,
             )
+        if active.observer_stop_path is not None:
+            try:
+                active.observer_stop_path.unlink(missing_ok=True)
+            except OSError as error:
+                raise ReproError(
+                    f"cannot clear transition observer stop marker: {error}"
+                ) from error
         return evidence
 
     def run(self, spec: CommandSpec) -> CommandEvidence:
@@ -745,6 +771,7 @@ def finish_observed_operation(
     observer: ActiveCommand,
 ) -> tuple[CommandEvidence, CommandEvidence]:
     operation_evidence = runner.finish(operation)
+    runner.request_observer_completion(observer)
     observer_evidence = runner.finish(observer)
     return operation_evidence, observer_evidence
 
@@ -1315,6 +1342,7 @@ def ephemeral_capsule_is_safely_deletable(
         and capsule.mode == "EPHEMERAL"
         and proof is not None
         and proof.get("runtimeStopped") is True
+        and proof.get("runtimeStopSucceeded") is True
         and proof.get("installationContained") is True
         and proof.get("stateContained") is True
         and not teardown_errors
@@ -1739,6 +1767,29 @@ def observation_completed_during(
     )
 
 
+def observer_covers_operation_completion(
+    operation: dict[str, Any],
+    observer: dict[str, Any],
+    observations: list[TimedObservation],
+) -> bool:
+    operation_finished = operation.get("finishedAtEpochMillis")
+    observer_finished = observer.get("finishedAtEpochMillis")
+    if not all(
+        isinstance(value, int) and not isinstance(value, bool)
+        for value in (operation_finished, observer_finished)
+    ):
+        raise ReproError("command timing fields must be integers")
+    post_completion_kinds = {
+        observation.kind
+        for observation in observations
+        if observation.finished_at_epoch_millis >= operation_finished
+    }
+    return (
+        observer_finished >= operation_finished
+        and post_completion_kinds == {ObservationKind.HOME, ObservationKind.RESOLVE}
+    )
+
+
 def ready_sample_before(
     observations: list[TimedObservation],
     finished_at_epoch_millis: int,
@@ -1880,6 +1931,11 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
             or observer.get("timedOut") is True
             or observation_kinds != {ObservationKind.HOME, ObservationKind.RESOLVE}
             or not overlaps(operation, observer)
+            or not observer_covers_operation_completion(
+                operation,
+                observer,
+                observations,
+            )
             or not observation_completed_during(operation, observations, required_kind)
             or not all(observation_has_expected_outcome(item) for item in observations)
         ):

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -1508,6 +1508,8 @@ def read_manifest(directory: Path) -> tuple[dict[str, Any], dict[str, dict[str, 
         raise ReproError("evidence manifest root must be an object")
     if manifest.get("schemaVersion") != SCHEMA_VERSION:
         raise ReproError(f"unsupported evidence schema: {manifest.get('schemaVersion')!r}")
+    if "capsule" in manifest and not isinstance(manifest["capsule"], dict):
+        raise ReproError("evidence manifest capsule proof must be an object")
     commands = manifest.get("commands")
     if not isinstance(commands, list):
         raise ReproError("evidence manifest commands must be an array")

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -25,6 +25,7 @@ from typing import Any
 SCHEMA_VERSION = 1
 DEFAULT_OUTPUT_BUDGET_BYTES = 30_000
 EXIT_SENTINEL = "::kast-repro-exit="
+OBSERVATION_EXIT_SENTINEL = "__KAST_OBSERVATION_EXIT_CODE__="
 
 
 class ReproError(Exception):
@@ -43,6 +44,11 @@ class FindingCode(str, enum.Enum):
     CAPSULE_PROCESS_LEAKED = "CAPSULE_PROCESS_LEAKED"
     CAPSULE_RUNTIME_STOP_FAILED = "CAPSULE_RUNTIME_STOP_FAILED"
     OBSERVER_EVIDENCE_INCOMPLETE = "OBSERVER_EVIDENCE_INCOMPLETE"
+
+
+class ObservationKind(str, enum.Enum):
+    HOME = "HOME"
+    RESOLVE = "RESOLVE"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -133,6 +139,16 @@ class LiveCapturePreflight:
 class MutationProbeIdentity:
     package_name: str
     declaration_name: str
+    add_file_path: str
+    add_file_declaration_name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class TimedObservation:
+    kind: ObservationKind
+    text: str
+    exit_code: int
+    finished_at_epoch_millis: int
 
 
 def epoch_millis() -> int:
@@ -267,7 +283,11 @@ def issued_graph_node_command(name: str, kast: str) -> CommandSpec:
     return CommandSpec(name, ("/bin/bash", "-lc", script))
 
 
-def mutation_probe_identity(source: Path, symbol: str) -> MutationProbeIdentity:
+def mutation_probe_identity(
+    workspace: Path,
+    source: Path,
+    symbol: str,
+) -> MutationProbeIdentity:
     try:
         content = source.read_text(encoding="utf-8")
     except OSError as error:
@@ -289,7 +309,17 @@ def mutation_probe_identity(source: Path, symbol: str) -> MutationProbeIdentity:
         raise ReproError(
             "--exercise-plans requires a top-level declaration from the --file package"
         )
-    return MutationProbeIdentity(package.group(1), declaration.group(1))
+    for sequence in range(10_000):
+        probe_name = "KastCliReproProbe" + (str(sequence) if sequence else "")
+        probe_file = source.parent / f"{probe_name}.kt"
+        if not probe_file.exists() and not probe_file.is_symlink():
+            return MutationProbeIdentity(
+                package.group(1),
+                declaration.group(1),
+                probe_file.relative_to(workspace).as_posix(),
+                probe_name,
+            )
+    raise ReproError("--exercise-plans could not find an absent add-file probe path")
 
 
 def command_plan(
@@ -303,7 +333,6 @@ def command_plan(
     sample_interval: float,
     transition_timeout: float,
 ) -> list[CommandSpec]:
-    probe_path = (Path(file_path).parent / "KastCliReproProbe.kt").as_posix()
     observer = observer_script(kast, symbol, samples, sample_interval)
     commands = [
         CommandSpec("home", (kast,)),
@@ -368,10 +397,17 @@ def command_plan(
                 ),
                 CommandSpec(
                     "change-plan-add-file",
-                    (kast, "change", "plan", "add-file", "--file", probe_path),
+                    (
+                        kast,
+                        "change",
+                        "plan",
+                        "add-file",
+                        "--file",
+                        mutation_probe.add_file_path,
+                    ),
                     stdin=(
                         f"package {mutation_probe.package_name}\n\n"
-                        "internal object KastCliReproProbe"
+                        f"internal object {mutation_probe.add_file_declaration_name}"
                     ),
                 ),
                 CommandSpec(
@@ -420,11 +456,13 @@ def observer_script(kast: str, symbol: str, samples: int, interval: float) -> st
         f"for i in $(seq 1 {samples}); do "
         'printf "__KAST_SAMPLE__=%s\\n" "$i"; '
         'printf "__KAST_OBSERVATION__=HOME\\n"; '
-        f"{kast_command}; "
+        f"{kast_command}; observation_status=$?; "
+        f'printf "{OBSERVATION_EXIT_SENTINEL}%s\\n" "$observation_status"; '
         'printf "__KAST_OBSERVATION_EPOCH_MILLIS__="; '
         "python3 -c 'import time; print(time.time_ns() // 1000000)'; "
         'printf "__KAST_OBSERVATION__=RESOLVE\\n"; '
-        f"{kast_command} symbol resolve --query {symbol_argument}; "
+        f"{kast_command} symbol resolve --query {symbol_argument}; observation_status=$?; "
+        f'printf "{OBSERVATION_EXIT_SENTINEL}%s\\n" "$observation_status"; '
         'printf "__KAST_OBSERVATION_EPOCH_MILLIS__="; '
         "python3 -c 'import time; print(time.time_ns() // 1000000)'; "
         f"sleep {interval}; "
@@ -1113,7 +1151,7 @@ def capture(args: argparse.Namespace) -> int:
     if workspace not in source.parents or source.suffix != ".kt":
         raise ReproError("--file must resolve to a Kotlin file inside the workspace")
     mutation_probe = (
-        mutation_probe_identity(source, args.symbol)
+        mutation_probe_identity(workspace, source, args.symbol)
         if args.exercise_plans
         else None
     )
@@ -1432,7 +1470,7 @@ def overlaps(first: dict[str, Any], second: dict[str, Any]) -> bool:
     return values[0] < values[3] and values[2] < values[1]
 
 
-def timed_observations(observer_text: str) -> list[tuple[str, str, int]]:
+def timed_observations(observer_text: str) -> list[TimedObservation]:
     sample_pattern = re.compile(
         r"(?ms)^__KAST_SAMPLE__=\d+\n(.*?)(?=^__KAST_SAMPLE__=\d+\n|\Z)"
     )
@@ -1441,29 +1479,60 @@ def timed_observations(observer_text: str) -> list[tuple[str, str, int]]:
         r"(.*?)(?=^__KAST_OBSERVATION__=|\Z)"
     )
     timestamp_pattern = re.compile(r"(?m)^__KAST_OBSERVATION_EPOCH_MILLIS__=(\d+)$")
-    observations: list[tuple[str, str, int]] = []
+    exit_pattern = re.compile(
+        rf"(?m)^{re.escape(OBSERVATION_EXIT_SENTINEL)}([0-9]+)$"
+    )
+    observations: list[TimedObservation] = []
     for sample in sample_pattern.findall(observer_text):
         for kind, observation in observation_pattern.findall(sample):
             timestamp = timestamp_pattern.search(observation)
-            if timestamp is not None:
-                observations.append((kind, observation, int(timestamp.group(1))))
+            exit_code = exit_pattern.search(observation)
+            if timestamp is None or exit_code is None:
+                raise ReproError(
+                    f"{kind} observation lacks an exit code or completion timestamp"
+                )
+            observations.append(
+                TimedObservation(
+                    ObservationKind(kind),
+                    observation,
+                    int(exit_code.group(1)),
+                    int(timestamp.group(1)),
+                )
+            )
+    if not observations:
+        raise ReproError("observer transcript has no timed observations")
     return observations
 
 
-def ready_sample_before(observer_text: str, finished_at_epoch_millis: int) -> bool:
-    return any(
-        kind == "HOME" and timestamp < finished_at_epoch_millis
-        and re.search(r"(?m)^ready: true$", observation)
-        for kind, observation, timestamp in timed_observations(observer_text)
+def observation_has_expected_outcome(observation: TimedObservation) -> bool:
+    return observation.exit_code == 0 or (
+        observation.kind == ObservationKind.RESOLVE
+        and re.search(r"(?m)^error: [A-Z][A-Z0-9_]*$", observation.text) is not None
     )
 
 
-def conflict_sample_before(observer_text: str, finished_at_epoch_millis: int) -> bool:
+def ready_sample_before(
+    observations: list[TimedObservation],
+    finished_at_epoch_millis: int,
+) -> bool:
     return any(
-        kind == "RESOLVE" and timestamp < finished_at_epoch_millis
-        and "error: CONFLICT" in observation
-        and "Run `kast --help`" in observation
-        for kind, observation, timestamp in timed_observations(observer_text)
+        observation.kind == ObservationKind.HOME
+        and observation.finished_at_epoch_millis < finished_at_epoch_millis
+        and re.search(r"(?m)^ready: true$", observation.text)
+        for observation in observations
+    )
+
+
+def conflict_sample_before(
+    observations: list[TimedObservation],
+    finished_at_epoch_millis: int,
+) -> bool:
+    return any(
+        observation.kind == ObservationKind.RESOLVE
+        and observation.finished_at_epoch_millis < finished_at_epoch_millis
+        and "error: CONFLICT" in observation.text
+        and "Run `kast --help`" in observation.text
+        for observation in observations
     )
 
 
@@ -1504,26 +1573,40 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
     cold_observer = commands.get("cold-observer")
     refresh = commands.get("workspace-refresh")
     refresh_observer = commands.get("refresh-observer")
+    if refresh is None:
+        raise ReproError(
+            "evidence manifest is missing required transition command workspace-refresh"
+        )
     incomplete_observers: list[str] = []
+    complete_observers: dict[str, list[TimedObservation]] = {}
     for operation, observer, observer_name in (
         (cold_up, cold_observer, "cold-observer"),
         (refresh, refresh_observer, "refresh-observer"),
     ):
         if operation is None:
+            if observer is not None:
+                incomplete_observers.append(f"orphaned:{observer_name}")
             continue
         if observer is None:
             incomplete_observers.append(f"missing:{observer_name}")
             continue
         observer_text = transcript(directory, observer)
-        observation_kinds = {
-            kind for kind, _, _ in timed_observations(observer_text)
-        }
+        try:
+            observations = timed_observations(observer_text)
+        except ReproError:
+            incomplete_observers.append(str(observer.get("transcript")))
+            continue
+        observation_kinds = {observation.kind for observation in observations}
         if (
             observer.get("exitCode") != 0
             or observer.get("timedOut") is True
-            or observation_kinds != {"HOME", "RESOLVE"}
+            or observation_kinds != {ObservationKind.HOME, ObservationKind.RESOLVE}
+            or not overlaps(operation, observer)
+            or not all(observation_has_expected_outcome(item) for item in observations)
         ):
             incomplete_observers.append(str(observer.get("transcript")))
+        else:
+            complete_observers[observer_name] = observations
     if incomplete_observers:
         findings.append(
             Finding(
@@ -1540,10 +1623,10 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
                 [str(cold_up.get("transcript"))],
             )
         )
-    if cold_up and cold_observer and overlaps(cold_up, cold_observer):
-        observer_text = transcript(directory, cold_observer)
+    cold_observations = complete_observers.get("cold-observer")
+    if cold_up and cold_observations is not None:
         finished_at = cold_up.get("finishedAtEpochMillis")
-        if isinstance(finished_at, int) and ready_sample_before(observer_text, finished_at):
+        if isinstance(finished_at, int) and ready_sample_before(cold_observations, finished_at):
             findings.append(
                 Finding(
                     FindingCode.READY_DURING_PENDING_UP.value,
@@ -1559,10 +1642,10 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
                 [str(refresh.get("transcript"))],
             )
         )
-    if refresh and refresh_observer and overlaps(refresh, refresh_observer):
-        observer_text = transcript(directory, refresh_observer)
+    refresh_observations = complete_observers.get("refresh-observer")
+    if refresh_observations is not None:
         finished_at = refresh.get("finishedAtEpochMillis")
-        if isinstance(finished_at, int) and conflict_sample_before(observer_text, finished_at):
+        if isinstance(finished_at, int) and conflict_sample_before(refresh_observations, finished_at):
             findings.append(
                 Finding(
                     FindingCode.GENERIC_CONFLICT_DURING_REFRESH.value,

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -566,7 +566,9 @@ class TmuxCapture:
         self.workspace = workspace
         self.evidence = evidence
         self.keep_session = keep_session
-        self.base_environment = base_environment or {}
+        self.base_environment = (
+            os.environ.copy() if base_environment is None else dict(base_environment)
+        )
         self.commands: list[CommandEvidence] = []
 
     def start(self) -> None:
@@ -825,6 +827,8 @@ def read_config(
         payload = json.loads(result.stdout)
     except json.JSONDecodeError as error:
         raise ReproError(f"config discovery returned invalid JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise ReproError("config discovery did not return a JSON object")
     if payload.get("ok") is not True:
         raise ReproError("config discovery did not return ok=true")
     return payload

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -7,6 +7,7 @@ import argparse
 import dataclasses
 import enum
 import json
+import math
 import os
 import re
 import shlex
@@ -416,10 +417,14 @@ def observer_script(kast: str, symbol: str, samples: int, interval: float) -> st
     return (
         f"for i in $(seq 1 {samples}); do "
         'printf "__KAST_SAMPLE__=%s\\n" "$i"; '
+        'printf "__KAST_OBSERVATION__=HOME\\n"; '
         f"{kast_command}; "
-        'printf "__KAST_SAMPLE_EPOCH_MILLIS__="; '
+        'printf "__KAST_OBSERVATION_EPOCH_MILLIS__="; '
         "python3 -c 'import time; print(time.time_ns() // 1000000)'; "
+        'printf "__KAST_OBSERVATION__=RESOLVE\\n"; '
         f"{kast_command} symbol resolve --query {symbol_argument}; "
+        'printf "__KAST_OBSERVATION_EPOCH_MILLIS__="; '
+        "python3 -c 'import time; print(time.time_ns() // 1000000)'; "
         f"sleep {interval}; "
         "done"
     )
@@ -900,7 +905,7 @@ def command_mentions_capsule_root(command: str, root: Path) -> bool:
     return False
 
 
-def capsule_processes(root: Path, seeds: set[int] | None = None) -> set[int]:
+def capsule_processes(root: Path, seeds: dict[int, str] | None = None) -> dict[int, str]:
     table = process_table()
     excluded = process_ancestry(table)
     owned = {
@@ -910,10 +915,10 @@ def capsule_processes(root: Path, seeds: set[int] | None = None) -> set[int]:
     }
     owned.update(
         pid
-        for pid in seeds or set()
+        for pid, prior_command in (seeds or {}).items()
         if pid in table
         and pid not in excluded
-        and command_mentions_capsule_root(table[pid][1], root)
+        and table[pid][1] == prior_command
     )
     changed = True
     while changed:
@@ -922,7 +927,7 @@ def capsule_processes(root: Path, seeds: set[int] | None = None) -> set[int]:
             if pid not in excluded and parent in owned and pid not in owned:
                 owned.add(pid)
                 changed = True
-    return owned
+    return {pid: table[pid][1] for pid in owned}
 
 
 def alive_processes(process_ids: set[int]) -> set[int]:
@@ -1181,14 +1186,16 @@ def capture(args: argparse.Namespace) -> int:
             )
         ))
         if args.restart_runtime or capsule is not None:
-            runner.run(
-                CommandSpec(
-                    "runtime-stop",
-                    (
-                        str(kastctl), "--output", "json", "developer", "runtime", "stop",
-                        "--workspace-root", str(workspace),
-                    ),
-                    timeout_seconds=args.transition_timeout,
+            require_success(
+                runner.run(
+                    CommandSpec(
+                        "runtime-stop",
+                        (
+                            str(kastctl), "--output", "json", "developer", "runtime", "stop",
+                            "--workspace-root", str(workspace),
+                        ),
+                        timeout_seconds=args.transition_timeout,
+                    )
                 )
             )
             cold_up = next(spec for spec in plan if spec.name == "cold-up")
@@ -1224,7 +1231,7 @@ def capture(args: argparse.Namespace) -> int:
     finally:
         capsule_proof: dict[str, Any] | None = None
         if capsule is not None:
-            observed_processes: set[int] = set()
+            observed_processes: dict[int, str] = {}
             try:
                 observed_processes = capsule_processes(capsule.root)
             except ReproError as error:
@@ -1255,7 +1262,7 @@ def capture(args: argparse.Namespace) -> int:
                 runner.close()
             try:
                 remaining_candidates = capsule_processes(capsule.root, observed_processes)
-                terminated, remaining = terminate_capsule_processes(remaining_candidates)
+                terminated, remaining = terminate_capsule_processes(set(remaining_candidates))
             except ReproError as error:
                 teardown_errors.append(str(error))
                 terminated = []
@@ -1391,33 +1398,38 @@ def overlaps(first: dict[str, Any], second: dict[str, Any]) -> bool:
     return values[0] < values[3] and values[2] < values[1]
 
 
-def timed_samples(observer_text: str) -> list[tuple[str, int]]:
+def timed_observations(observer_text: str) -> list[tuple[str, str, int]]:
     sample_pattern = re.compile(
         r"(?ms)^__KAST_SAMPLE__=\d+\n(.*?)(?=^__KAST_SAMPLE__=\d+\n|\Z)"
     )
-    timestamp_pattern = re.compile(r"(?m)^__KAST_SAMPLE_EPOCH_MILLIS__=(\d+)$")
-    samples: list[tuple[str, int]] = []
+    observation_pattern = re.compile(
+        r"(?ms)^__KAST_OBSERVATION__=(HOME|RESOLVE)\n"
+        r"(.*?)(?=^__KAST_OBSERVATION__=|\Z)"
+    )
+    timestamp_pattern = re.compile(r"(?m)^__KAST_OBSERVATION_EPOCH_MILLIS__=(\d+)$")
+    observations: list[tuple[str, str, int]] = []
     for sample in sample_pattern.findall(observer_text):
-        timestamp = timestamp_pattern.search(sample)
-        if timestamp is not None:
-            samples.append((sample, int(timestamp.group(1))))
-    return samples
+        for kind, observation in observation_pattern.findall(sample):
+            timestamp = timestamp_pattern.search(observation)
+            if timestamp is not None:
+                observations.append((kind, observation, int(timestamp.group(1))))
+    return observations
 
 
 def ready_sample_before(observer_text: str, finished_at_epoch_millis: int) -> bool:
     return any(
-        timestamp < finished_at_epoch_millis
-        and re.search(r"(?m)^ready: true$", sample)
-        for sample, timestamp in timed_samples(observer_text)
+        kind == "HOME" and timestamp < finished_at_epoch_millis
+        and re.search(r"(?m)^ready: true$", observation)
+        for kind, observation, timestamp in timed_observations(observer_text)
     )
 
 
 def conflict_sample_before(observer_text: str, finished_at_epoch_millis: int) -> bool:
     return any(
-        timestamp < finished_at_epoch_millis
-        and "error: CONFLICT" in sample
-        and "Run `kast --help`" in sample
-        for sample, timestamp in timed_samples(observer_text)
+        kind == "RESOLVE" and timestamp < finished_at_epoch_millis
+        and "error: CONFLICT" in observation
+        and "Run `kast --help`" in observation
+        for kind, observation, timestamp in timed_observations(observer_text)
     )
 
 
@@ -1648,9 +1660,11 @@ def parser() -> argparse.ArgumentParser:
 def validate_numeric_arguments(args: argparse.Namespace) -> None:
     if getattr(args, "samples", 1) <= 0:
         raise ReproError("--samples must be positive")
-    if getattr(args, "sample_interval", 1.0) < 0:
+    sample_interval = getattr(args, "sample_interval", 1.0)
+    if not math.isfinite(sample_interval) or sample_interval < 0:
         raise ReproError("--sample-interval must be non-negative")
-    if getattr(args, "transition_timeout", 1.0) <= 0:
+    transition_timeout = getattr(args, "transition_timeout", 1.0)
+    if not math.isfinite(transition_timeout) or transition_timeout <= 0:
         raise ReproError("--transition-timeout must be positive")
 
 

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -24,6 +24,7 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 DEFAULT_OUTPUT_BUDGET_BYTES = 30_000
+OBSERVER_COMPLETION_GRACE_SECONDS = 30.0
 EXIT_SENTINEL = "::kast-repro-exit="
 OBSERVATION_EXIT_SENTINEL = "__KAST_OBSERVATION_EXIT_CODE__="
 CAPSULE_STATE_ENVIRONMENT_KEYS = (
@@ -430,6 +431,11 @@ def command_plan(
     transition_timeout: float,
 ) -> list[CommandSpec]:
     observer = observer_script(kast, symbol, samples, sample_interval)
+    observer_timeout = (
+        transition_timeout
+        + samples * sample_interval
+        + OBSERVER_COMPLETION_GRACE_SECONDS
+    )
     commands = [
         CommandSpec("home", (kast,)),
         CommandSpec("help", (kast, "--help")),
@@ -527,7 +533,11 @@ def command_plan(
                 (kast, "workspace", "refresh", "--file", file_path),
                 timeout_seconds=transition_timeout,
             ),
-            CommandSpec("refresh-observer", ("/bin/bash", "-lc", observer), timeout_seconds=transition_timeout),
+            CommandSpec(
+                "refresh-observer",
+                ("/bin/bash", "-lc", observer),
+                timeout_seconds=observer_timeout,
+            ),
         ]
     )
     if restart_runtime:
@@ -539,7 +549,11 @@ def command_plan(
                     environment=(("KAST_IDEA_TRACE", "true"),),
                     timeout_seconds=transition_timeout,
                 ),
-                CommandSpec("cold-observer", ("/bin/bash", "-lc", observer), timeout_seconds=transition_timeout),
+                CommandSpec(
+                    "cold-observer",
+                    ("/bin/bash", "-lc", observer),
+                    timeout_seconds=observer_timeout,
+                ),
             ]
         )
     return commands
@@ -1752,6 +1766,77 @@ def capture(args: argparse.Namespace) -> int:
     return exit_code
 
 
+def required_command_argv_is_valid(name: str, argv: Any) -> bool:
+    if not isinstance(argv, list) or not argv or not all(
+        isinstance(value, str) and bool(value) for value in argv
+    ):
+        return False
+    direct_patterns: dict[str, tuple[str | None, ...]] = {
+        "runtime-stop": (
+            "--output", "json", "developer", "runtime", "stop",
+            "--workspace-root", None,
+        ),
+        "capsule-runtime-stop": (
+            "--output", "json", "developer", "runtime", "stop",
+            "--workspace-root", None,
+        ),
+        "home": (),
+        "help": ("--help",),
+        "file-list": ("file", "list", "--match", None),
+        "symbol-search": ("symbol", "search", "--query", None),
+        "symbol-resolve": ("symbol", "resolve", "--query", None),
+        "graph-summary": ("graph", "summary", "--scope", "symbol"),
+        "graph-nodes": ("graph", "nodes"),
+        "graph-topology": ("graph", "topology", "--scope", "symbol"),
+        "graph-communities": ("graph", "communities", "--scope", "symbol"),
+        "diagnostic-check": ("diagnostic", "check", "--file", None),
+        "workspace-refresh": ("workspace", "refresh", "--file", None),
+        "cold-up": ("workspace", "ensure"),
+    }
+    pattern = direct_patterns.get(name)
+    if pattern is not None:
+        arguments = argv[1:]
+        return len(arguments) == len(pattern) and all(
+            expected is None or actual == expected
+            for actual, expected in zip(arguments, pattern)
+        )
+    if len(argv) != 3 or argv[:2] != ["/bin/bash", "-lc"]:
+        return False
+    script = argv[2]
+    if name in {"cold-observer", "refresh-observer"}:
+        return all(
+            marker in script
+            for marker in (
+                "__KAST_OBSERVATION__=HOME",
+                "__KAST_OBSERVATION__=RESOLVE",
+                " symbol resolve --query ",
+            )
+        )
+    issued_operations = {
+        "symbol-show": " symbol show --selector ",
+        "relation-references": " relation references --selector ",
+        "relation-calls-incoming": " relation calls incoming --selector ",
+        "relation-calls-outgoing": " relation calls outgoing --selector ",
+        "relation-implementations": " relation implementations --selector ",
+        "relation-hierarchy-supertypes": " relation hierarchy supertypes --selector ",
+        "relation-hierarchy-subtypes": " relation hierarchy subtypes --selector ",
+        "graph-impact": " graph impact --selector ",
+    }
+    if name in issued_operations:
+        return (
+            "resolved=$(" in script
+            and " symbol resolve --query " in script
+            and issued_operations[name] in script
+        )
+    if name == "graph-neighbors":
+        return (
+            "nodes=$(" in script
+            and " graph nodes" in script
+            and " graph neighbors --node-selector " in script
+        )
+    return False
+
+
 def read_manifest(directory: Path) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
     manifest_path = directory / "manifest.json"
     try:
@@ -1804,12 +1889,22 @@ def read_manifest(directory: Path) -> tuple[dict[str, Any], dict[str, dict[str, 
     commands = manifest.get("commands")
     if not isinstance(commands, list):
         raise ReproError("evidence manifest commands must be an array")
+    argv_required = set(REQUIRED_SCENARIO_COMMANDS)
+    if isinstance(capsule, dict):
+        argv_required.add("capsule-runtime-stop")
     indexed: dict[str, dict[str, Any]] = {}
     for command in commands:
         if not isinstance(command, dict) or not isinstance(command.get("name"), str):
             raise ReproError("every evidence command must have a string name")
         if command["name"] in indexed:
             raise ReproError(f"duplicate evidence command: {command['name']}")
+        if (
+            command["name"] in argv_required
+            and not required_command_argv_is_valid(command["name"], command.get("argv"))
+        ):
+            raise ReproError(
+                f"required command {command['name']} has invalid operation argv"
+            )
         indexed[command["name"]] = command
     return manifest, indexed
 

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -1693,7 +1693,10 @@ def telemetry_missing_fields(directory: Path, manifest: dict[str, Any]) -> list[
 def analyze(directory: Path) -> tuple[dict[str, Any], int]:
     directory = directory.resolve(strict=True)
     manifest, commands = read_manifest(directory)
-    missing_commands = sorted(set(REQUIRED_SCENARIO_COMMANDS) - set(commands))
+    required_commands = set(REQUIRED_SCENARIO_COMMANDS)
+    if "capsule" in manifest:
+        required_commands.update({"cold-up", "cold-observer"})
+    missing_commands = sorted(required_commands - set(commands))
     if missing_commands:
         raise ReproError(
             "evidence manifest is missing required scenario commands: "
@@ -1797,13 +1800,38 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
                 )
             )
     framing_evidence: list[str] = []
-    for command in commands.values():
+    for name, command in commands.items():
         text = transcript(directory, command)
         completion_token = command.get("completionToken")
         if not isinstance(completion_token, str) or not completion_token:
+            if name in required_commands:
+                raise ReproError(f"required command {name} has no completion token")
             continue
-        marker = text.find(f"{EXIT_SENTINEL}{completion_token}:")
-        if marker > 0 and text[marker - 1] != "\n":
+        exit_code = command.get("exitCode")
+        finished_at = command.get("finishedAtEpochMillis")
+        if (
+            not isinstance(exit_code, int)
+            or isinstance(exit_code, bool)
+            or not isinstance(finished_at, int)
+            or isinstance(finished_at, bool)
+        ):
+            if name in required_commands:
+                raise ReproError(f"required command {name} has invalid completion fields")
+            continue
+        completion_frame = (
+            f"{EXIT_SENTINEL}{completion_token}:{exit_code}:{finished_at}"
+        )
+        frame_match = re.search(
+            rf"{re.escape(completion_frame)}\r?(?:\n|$)",
+            text,
+        )
+        if frame_match is None:
+            if name in required_commands:
+                raise ReproError(
+                    f"required command {name} has no exact nonce-bound completion frame"
+                )
+            continue
+        if frame_match.start() > 0 and text[frame_match.start() - 1] != "\n":
             framing_evidence.append(str(command.get("transcript")))
     if framing_evidence:
         findings.append(

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -32,6 +32,7 @@ class ReproError(Exception):
 
 class FindingCode(str, enum.Enum):
     READY_DURING_PENDING_UP = "READY_DURING_PENDING_UP"
+    COLD_START_DID_NOT_CONVERGE = "COLD_START_DID_NOT_CONVERGE"
     GENERIC_CONFLICT_DURING_REFRESH = "GENERIC_CONFLICT_DURING_REFRESH"
     REFRESH_DID_NOT_CONVERGE = "REFRESH_DID_NOT_CONVERGE"
     MISSING_TRAILING_NEWLINE = "MISSING_TRAILING_NEWLINE"
@@ -64,6 +65,7 @@ class ActiveCommand:
     spec: CommandSpec
     window_id: str
     started_at_epoch_millis: int
+    completion_token: str
 
 
 @dataclasses.dataclass(frozen=True)
@@ -122,6 +124,12 @@ class CapsuleContext:
 class LiveCapturePreflight:
     output: Path
     session: str
+
+
+@dataclasses.dataclass(frozen=True)
+class MutationProbeIdentity:
+    package_name: str
+    declaration_name: str
 
 
 def epoch_millis() -> int:
@@ -256,19 +264,42 @@ def issued_graph_node_command(name: str, kast: str) -> CommandSpec:
     return CommandSpec(name, ("/bin/bash", "-lc", script))
 
 
+def mutation_probe_identity(source: Path, symbol: str) -> MutationProbeIdentity:
+    try:
+        content = source.read_text(encoding="utf-8")
+    except OSError as error:
+        raise ReproError(f"cannot read --file for mutation planning: {error}") from error
+    package = re.search(
+        r"(?m)^\s*package\s+"
+        r"((?:[A-Za-z_][A-Za-z0-9_]*\.)*[A-Za-z_][A-Za-z0-9_]*)\s*;?\s*$",
+        content,
+    )
+    declaration = (
+        re.fullmatch(
+            rf"{re.escape(package.group(1))}\.([A-Za-z_][A-Za-z0-9_]*)",
+            symbol,
+        )
+        if package is not None
+        else None
+    )
+    if package is None or declaration is None:
+        raise ReproError(
+            "--exercise-plans requires a top-level declaration from the --file package"
+        )
+    return MutationProbeIdentity(package.group(1), declaration.group(1))
+
+
 def command_plan(
     kast: str,
     file_path: str,
     symbol: str,
     *,
     restart_runtime: bool,
-    exercise_plans: bool,
+    mutation_probe: MutationProbeIdentity | None,
     samples: int,
     sample_interval: float,
     transition_timeout: float,
 ) -> list[CommandSpec]:
-    short_name = symbol.rsplit(".", 1)[-1]
-    package_name = symbol.rsplit(".", 1)[0]
     probe_path = (Path(file_path).parent / "KastCliReproProbe.kt").as_posix()
     observer = observer_script(kast, symbol, samples, sample_interval)
     commands = [
@@ -317,19 +348,28 @@ def command_plan(
         issued_symbol_command("graph-impact", kast, symbol, ("graph", "impact")),
         CommandSpec("diagnostic-check", (kast, "diagnostic", "check", "--file", file_path)),
     ]
-    if exercise_plans:
+    if mutation_probe is not None:
         commands.extend(
             [
                 issued_symbol_command(
                     "change-plan-rename",
                     kast,
                     symbol,
-                    ("change", "plan", "rename", "--name", f"{short_name}ReproProbe"),
+                    (
+                        "change",
+                        "plan",
+                        "rename",
+                        "--name",
+                        f"{mutation_probe.declaration_name}ReproProbe",
+                    ),
                 ),
                 CommandSpec(
                     "change-plan-add-file",
                     (kast, "change", "plan", "add-file", "--file", probe_path),
-                    stdin=f"package {package_name}\n\ninternal object KastCliReproProbe",
+                    stdin=(
+                        f"package {mutation_probe.package_name}\n\n"
+                        "internal object KastCliReproProbe"
+                    ),
                 ),
                 CommandSpec(
                     "change-plan-add-declaration",
@@ -341,7 +381,7 @@ def command_plan(
                     kast,
                     symbol,
                     ("change", "plan", "replace"),
-                    stdin=f"class {short_name}ReproProbe",
+                    stdin=f"class {mutation_probe.declaration_name}ReproProbe",
                 ),
             ]
         )
@@ -418,6 +458,8 @@ class TmuxCapture:
 
     def begin(self, spec: CommandSpec) -> ActiveCommand:
         command = shlex.join(spec.argv)
+        completion_token = uuid.uuid4().hex
+        completion_marker = f"{EXIT_SENTINEL}{completion_token}:"
         environment = dict(self.base_environment)
         environment.update(dict(spec.environment))
         if environment:
@@ -427,14 +469,15 @@ class TmuxCapture:
             command = f"env {environment} {command}"
         if spec.stdin is not None:
             command = f"printf %s {shlex.quote(spec.stdin)} | {command}"
-        shell = (
-            "set +e; "
-            f"{command}; "
-            "status=$?; "
-            f"printf '{EXIT_SENTINEL}%s\\n' \"$status\"; "
-            "exec sleep 2147483647"
+        completion_wrapper = (
+            "import subprocess,time;"
+            f"status=subprocess.run(['/bin/bash','-lc',{command!r}]).returncode;"
+            "completed_at=time.time_ns()//1000000;"
+            f"print({completion_marker!r}+str(status)+':'+str(completed_at),flush=True)"
         )
+        shell = f"python3 -c {shlex.quote(completion_wrapper)}; exec sleep 2147483647"
         window_name = re.sub(r"[^A-Za-z0-9_-]", "-", spec.name)[:40]
+        started_at_epoch_millis = epoch_millis()
         result = run_checked(
             "tmux",
             "new-window",
@@ -450,13 +493,19 @@ class TmuxCapture:
             str(self.workspace),
             f"/bin/bash -lc {shlex.quote(shell)}",
         )
-        return ActiveCommand(spec, result.stdout.strip(), epoch_millis())
+        return ActiveCommand(
+            spec,
+            result.stdout.strip(),
+            started_at_epoch_millis,
+            completion_token,
+        )
 
     def finish(self, active: ActiveCommand) -> CommandEvidence:
         deadline = time.monotonic() + active.spec.timeout_seconds
         timed_out = False
         transcript = ""
         exit_code: int | None = None
+        completed_at_epoch_millis: int | None = None
         while True:
             capture = subprocess.run(
                 ["tmux", "capture-pane", "-p", "-J", "-S", "-", "-t", active.window_id],
@@ -467,9 +516,15 @@ class TmuxCapture:
             if capture.returncode != 0:
                 raise ReproError(f"tmux lost capture window for {active.spec.name}")
             transcript = capture.stdout
-            match = re.search(rf"{re.escape(EXIT_SENTINEL)}([0-9]+)", transcript)
+            match = re.search(
+                rf"{re.escape(EXIT_SENTINEL)}{re.escape(active.completion_token)}:"
+                r"([0-9]+):([0-9]+)\r?$",
+                transcript,
+                re.MULTILINE,
+            )
             if match is not None:
                 exit_code = int(match.group(1))
+                completed_at_epoch_millis = int(match.group(2))
                 break
             if time.monotonic() >= deadline:
                 timed_out = True
@@ -495,7 +550,11 @@ class TmuxCapture:
             name=active.spec.name,
             argv=list(active.spec.argv),
             startedAtEpochMillis=active.started_at_epoch_millis,
-            finishedAtEpochMillis=epoch_millis(),
+            finishedAtEpochMillis=(
+                completed_at_epoch_millis
+                if completed_at_epoch_millis is not None
+                else epoch_millis()
+            ),
             exitCode=resolved_exit_code,
             timedOut=timed_out,
             transcript=str(transcript_path.relative_to(self.evidence)),
@@ -1013,6 +1072,11 @@ def capture(args: argparse.Namespace) -> int:
     source = (workspace / file_path).resolve(strict=True)
     if workspace not in source.parents or source.suffix != ".kt":
         raise ReproError("--file must resolve to a Kotlin file inside the workspace")
+    mutation_probe = (
+        mutation_probe_identity(source, args.symbol)
+        if args.exercise_plans
+        else None
+    )
     host_kast = shutil.which(args.kast)
     if host_kast is None and not args.dry_run:
         raise ReproError(f"Kast executable is unavailable: {args.kast}")
@@ -1025,7 +1089,7 @@ def capture(args: argparse.Namespace) -> int:
         file_path.as_posix(),
         args.symbol,
         restart_runtime=args.restart_runtime or capsule is not None,
-        exercise_plans=args.exercise_plans,
+        mutation_probe=mutation_probe,
         samples=args.samples,
         sample_interval=args.sample_interval,
         transition_timeout=args.transition_timeout,
@@ -1327,20 +1391,34 @@ def overlaps(first: dict[str, Any], second: dict[str, Any]) -> bool:
     return values[0] < values[3] and values[2] < values[1]
 
 
-def ready_sample_before(observer_text: str, finished_at_epoch_millis: int) -> bool:
+def timed_samples(observer_text: str) -> list[tuple[str, int]]:
     sample_pattern = re.compile(
         r"(?ms)^__KAST_SAMPLE__=\d+\n(.*?)(?=^__KAST_SAMPLE__=\d+\n|\Z)"
     )
     timestamp_pattern = re.compile(r"(?m)^__KAST_SAMPLE_EPOCH_MILLIS__=(\d+)$")
+    samples: list[tuple[str, int]] = []
     for sample in sample_pattern.findall(observer_text):
         timestamp = timestamp_pattern.search(sample)
-        if (
-            timestamp is not None
-            and int(timestamp.group(1)) < finished_at_epoch_millis
-            and re.search(r"(?m)^ready: true$", sample)
-        ):
-            return True
-    return False
+        if timestamp is not None:
+            samples.append((sample, int(timestamp.group(1))))
+    return samples
+
+
+def ready_sample_before(observer_text: str, finished_at_epoch_millis: int) -> bool:
+    return any(
+        timestamp < finished_at_epoch_millis
+        and re.search(r"(?m)^ready: true$", sample)
+        for sample, timestamp in timed_samples(observer_text)
+    )
+
+
+def conflict_sample_before(observer_text: str, finished_at_epoch_millis: int) -> bool:
+    return any(
+        timestamp < finished_at_epoch_millis
+        and "error: CONFLICT" in sample
+        and "Run `kast --help`" in sample
+        for sample, timestamp in timed_samples(observer_text)
+    )
 
 
 def telemetry_missing_fields(directory: Path, manifest: dict[str, Any]) -> list[str]:
@@ -1378,6 +1456,14 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
     findings: list[Finding] = []
     cold_up = commands.get("cold-up")
     cold_observer = commands.get("cold-observer")
+    if cold_up and (cold_up.get("exitCode") != 0 or cold_up.get("timedOut") is True):
+        findings.append(
+            Finding(
+                FindingCode.COLD_START_DID_NOT_CONVERGE.value,
+                "Cold-start workspace ensure did not complete successfully.",
+                [str(cold_up.get("transcript"))],
+            )
+        )
     if cold_up and cold_observer and overlaps(cold_up, cold_observer):
         observer_text = transcript(directory, cold_observer)
         finished_at = cold_up.get("finishedAtEpochMillis")
@@ -1399,9 +1485,10 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
                 [str(refresh.get("transcript"))],
             )
         )
-    if refresh_observer:
+    if refresh and refresh_observer and overlaps(refresh, refresh_observer):
         observer_text = transcript(directory, refresh_observer)
-        if "error: CONFLICT" in observer_text and "Run `kast --help`" in observer_text:
+        finished_at = refresh.get("finishedAtEpochMillis")
+        if isinstance(finished_at, int) and conflict_sample_before(observer_text, finished_at):
             findings.append(
                 Finding(
                     FindingCode.GENERIC_CONFLICT_DURING_REFRESH.value,
@@ -1548,7 +1635,7 @@ def parser() -> argparse.ArgumentParser:
     capture_parser.add_argument(
         "--exercise-plans",
         action="store_true",
-        help="exercise mutation planning without applying a plan",
+        help="exercise mutation planning for a top-level --symbol without applying a plan",
     )
     capture_parser.add_argument("--keep-session", action="store_true", help="leave the completed tmux session available for attachment")
     capture_parser.add_argument("--dry-run", action="store_true", help="print the command matrix without touching tmux or Kast state")

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -250,13 +250,29 @@ def require_contained_capsule_state_symlinks(
     state_paths: tuple[Path, ...],
 ) -> None:
     try:
-        for state_path in state_paths:
-            for candidate in state_path.rglob("*"):
-                if candidate.is_symlink() and not is_within(candidate, root):
-                    raise ReproError(
-                        "capsule state symlink escaped its root: "
-                        f"{candidate} -> {candidate.resolve()}"
-                    )
+        pending = list(state_paths)
+        visited: set[Path] = set()
+        while pending:
+            directory = pending.pop()
+            resolved_directory = directory.resolve(strict=True)
+            if not is_within(resolved_directory, root):
+                raise ReproError(
+                    "capsule state symlink escaped its root: "
+                    f"{directory} -> {resolved_directory}"
+                )
+            if resolved_directory in visited:
+                continue
+            visited.add(resolved_directory)
+            for candidate in directory.iterdir():
+                if candidate.is_symlink():
+                    resolved_candidate = candidate.resolve(strict=True)
+                    if not is_within(resolved_candidate, root):
+                        raise ReproError(
+                            "capsule state symlink escaped its root: "
+                            f"{candidate} -> {resolved_candidate}"
+                        )
+                if candidate.is_dir():
+                    pending.append(candidate)
     except (OSError, RuntimeError) as error:
         raise ReproError(
             f"capsule state symlink could not be validated: {error}"
@@ -527,6 +543,28 @@ def command_plan(
             ]
         )
     return commands
+
+
+def scenario_execution_order(commands: list[CommandSpec]) -> list[CommandSpec]:
+    transitions = {
+        "cold-up",
+        "cold-observer",
+        "workspace-refresh",
+        "refresh-observer",
+    }
+    by_name = {command.name: command for command in commands}
+    ordered = [
+        by_name[name]
+        for name in ("cold-up", "cold-observer")
+        if name in by_name
+    ]
+    ordered.extend(command for command in commands if command.name not in transitions)
+    ordered.extend(
+        by_name[name]
+        for name in ("workspace-refresh", "refresh-observer")
+        if name in by_name
+    )
+    return ordered
 
 
 def observer_script(kast: str, symbol: str, samples: int, interval: float) -> str:
@@ -1153,6 +1191,52 @@ def terminate_capsule_processes(
     return sorted(terminated), sorted(remaining)
 
 
+def capture_state_specs(
+    kastctl: Path,
+    workspace: Path,
+    transition_timeout: float,
+) -> list[CommandSpec]:
+    base = (str(kastctl), "--output", "json")
+    return [
+        CommandSpec(
+            "telemetry-enable",
+            (
+                *base,
+                "config",
+                "set",
+                "telemetry.enabled",
+                "true",
+                "--workspace-root",
+                str(workspace),
+            ),
+        ),
+        CommandSpec(
+            "telemetry-verbose",
+            (
+                *base,
+                "config",
+                "set",
+                "telemetry.detail",
+                "verbose",
+                "--workspace-root",
+                str(workspace),
+            ),
+        ),
+        CommandSpec(
+            "runtime-stop",
+            (
+                *base,
+                "developer",
+                "runtime",
+                "stop",
+                "--workspace-root",
+                str(workspace),
+            ),
+            timeout_seconds=transition_timeout,
+        ),
+    ]
+
+
 def config_restore_specs(kastctl: Path, workspace: Path, config: dict[str, Any]) -> list[CommandSpec]:
     mutable = {
         item.get("key"): item
@@ -1171,6 +1255,48 @@ def config_restore_specs(kastctl: Path, workspace: Path, config: dict[str, Any])
             argv = (*base, "unset", key, "--workspace-root", str(workspace))
         specs.append(CommandSpec(f"restore-{leaf}", argv))
     return specs
+
+
+def config_restore_preview_specs() -> list[CommandSpec]:
+    return [
+        CommandSpec(
+            "restore-enabled",
+            ("internal:restore-config", "telemetry.enabled"),
+        ),
+        CommandSpec(
+            "restore-detail",
+            ("internal:restore-config", "telemetry.detail"),
+        ),
+    ]
+
+
+def runtime_restore_specs(
+    kastctl: Path,
+    kast: str,
+    workspace: Path,
+    transition_timeout: float,
+) -> list[CommandSpec]:
+    return [
+        CommandSpec(
+            "restore-runtime-stop",
+            (
+                str(kastctl),
+                "--output",
+                "json",
+                "developer",
+                "runtime",
+                "stop",
+                "--workspace-root",
+                str(workspace),
+            ),
+            timeout_seconds=transition_timeout,
+        ),
+        CommandSpec(
+            "restore-runtime-start",
+            (kast, "workspace", "ensure"),
+            timeout_seconds=transition_timeout,
+        ),
+    ]
 
 
 def restore_config(
@@ -1197,40 +1323,21 @@ def restore_config_and_runtime(
     transition_timeout: float,
 ) -> list[str]:
     errors = restore_config(runner, kastctl, workspace, config)
+    runtime_specs = runtime_restore_specs(
+        kastctl,
+        kast,
+        workspace,
+        transition_timeout,
+    )
     try:
-        require_success(
-            runner.run(
-                CommandSpec(
-                    "restore-runtime-stop",
-                    (
-                        str(kastctl),
-                        "--output",
-                        "json",
-                        "developer",
-                        "runtime",
-                        "stop",
-                        "--workspace-root",
-                        str(workspace),
-                    ),
-                    timeout_seconds=transition_timeout,
-                )
-            )
-        )
+        require_success(runner.run(runtime_specs[0]))
     except ReproError as error:
         errors.append(str(error))
         return errors
     if errors:
         return errors
     try:
-        require_success(
-            runner.run(
-                CommandSpec(
-                    "restore-runtime-start",
-                    (kast, "workspace", "ensure"),
-                    timeout_seconds=transition_timeout,
-                )
-            )
-        )
+        require_success(runner.run(runtime_specs[1]))
     except ReproError as error:
         errors.append(str(error))
     return errors
@@ -1404,7 +1511,29 @@ def capture(args: argparse.Namespace) -> int:
         transition_timeout=args.transition_timeout,
     )
     if args.dry_run:
-        dry_plan = capsule_lifecycle_plan(capsule, workspace, plan) if capsule is not None else plan
+        preview_kastctl = (
+            capsule.kastctl if capsule is not None else Path("<developer-cli>")
+        )
+        dry_plan = [
+            *capture_state_specs(
+                preview_kastctl,
+                workspace,
+                args.transition_timeout,
+            ),
+            *scenario_execution_order(plan),
+        ]
+        if capsule is not None:
+            dry_plan = capsule_lifecycle_plan(capsule, workspace, dry_plan)
+        else:
+            dry_plan.extend(config_restore_preview_specs())
+            dry_plan.extend(
+                runtime_restore_specs(
+                    preview_kastctl,
+                    kast,
+                    workspace,
+                    args.transition_timeout,
+                )
+            )
         payload: dict[str, Any] = {
             "schemaVersion": SCHEMA_VERSION,
             "commands": [spec.public() for spec in dry_plan],
@@ -1471,36 +1600,12 @@ def capture(args: argparse.Namespace) -> int:
         telemetry_path, idea_log_path = log_paths(config, workspace)
         telemetry_offset = file_size(telemetry_path)
         trace_offset = file_size(idea_log_path)
-        require_success(runner.run(
-            CommandSpec(
-                "telemetry-enable",
-                (
-                    str(kastctl), "--output", "json", "config", "set", "telemetry.enabled", "true",
-                    "--workspace-root", str(workspace),
-                ),
-            )
-        ))
-        require_success(runner.run(
-            CommandSpec(
-                "telemetry-verbose",
-                (
-                    str(kastctl), "--output", "json", "config", "set", "telemetry.detail", "verbose",
-                    "--workspace-root", str(workspace),
-                ),
-            )
-        ))
-        require_success(
-            runner.run(
-                CommandSpec(
-                    "runtime-stop",
-                    (
-                        str(kastctl), "--output", "json", "developer", "runtime", "stop",
-                        "--workspace-root", str(workspace),
-                    ),
-                    timeout_seconds=args.transition_timeout,
-                )
-            )
-        )
+        for spec in capture_state_specs(
+            kastctl,
+            workspace,
+            args.transition_timeout,
+        ):
+            require_success(runner.run(spec))
         cold_up = next(spec for spec in plan if spec.name == "cold-up")
         cold_observer = next(spec for spec in plan if spec.name == "cold-observer")
         up_active = runner.begin(cold_up)
@@ -1757,6 +1862,7 @@ def timed_observations(observer_text: str) -> list[TimedObservation]:
 def observation_has_expected_outcome(observation: TimedObservation) -> bool:
     return observation.exit_code == 0 or (
         observation.kind == ObservationKind.RESOLVE
+        and observation.exit_code == 1
         and re.search(r"(?m)^error: CONFLICT$", observation.text) is not None
     )
 

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -874,13 +874,6 @@ def build_capsule(
         root = args.capsule_root.expanduser().resolve()
         mode = "PERSISTENT"
 
-    if not dry_run and paths_overlap(root, workspace):
-        raise ReproError("capsule root must not overlap the observed workspace")
-    socket_probe = root / "tmp" / "kast-indexer-000000000000.sock"
-    if not dry_run and len(os.fsencode(str(socket_probe))) >= 104:
-        raise ReproError(
-            "capsule root is too long for a macOS Unix-domain socket; choose a shorter --capsule-root"
-        )
     workspace_id = (
         "<capsule-workspace-id>"
         if dry_run
@@ -888,12 +881,23 @@ def build_capsule(
     )
     environment = capsule_environment(root, workspace_id)
     capsule = CapsuleContext(mode, root, bundle_source, environment, bootstrap, idea_host)
-    if not dry_run:
-        state_paths = require_contained_capsule_state_paths(root, environment)
-        for path in state_paths:
-            path.mkdir(parents=True, exist_ok=True)
-        require_contained_capsule_state_paths(root, environment)
-    return capsule
+    try:
+        if not dry_run and paths_overlap(root, workspace):
+            raise ReproError("capsule root must not overlap the observed workspace")
+        socket_probe = root / "tmp" / "kast-indexer-000000000000.sock"
+        if not dry_run and len(os.fsencode(str(socket_probe))) >= 104:
+            raise ReproError(
+                "capsule root is too long for a macOS Unix-domain socket; choose a shorter --capsule-root"
+            )
+        if not dry_run:
+            state_paths = require_contained_capsule_state_paths(root, environment)
+            for path in state_paths:
+                path.mkdir(parents=True, exist_ok=True)
+            require_contained_capsule_state_paths(root, environment)
+        return capsule
+    except (OSError, ReproError, KeyboardInterrupt):
+        discard_unstarted_ephemeral_capsule(capsule)
+        raise
 
 
 def verify_capsule_install(
@@ -1557,6 +1561,7 @@ def observation_has_expected_outcome(observation: TimedObservation) -> bool:
 def observation_completed_during(
     operation: dict[str, Any],
     observations: list[TimedObservation],
+    required_kind: ObservationKind,
 ) -> bool:
     started = operation.get("startedAtEpochMillis")
     finished = operation.get("finishedAtEpochMillis")
@@ -1566,7 +1571,8 @@ def observation_completed_during(
     ):
         raise ReproError("command timing fields must be integers")
     return any(
-        started <= observation.finished_at_epoch_millis < finished
+        observation.kind == required_kind
+        and started <= observation.finished_at_epoch_millis < finished
         for observation in observations
     )
 
@@ -1639,9 +1645,9 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
         )
     incomplete_observers: list[str] = []
     complete_observers: dict[str, list[TimedObservation]] = {}
-    for operation, observer, observer_name in (
-        (cold_up, cold_observer, "cold-observer"),
-        (refresh, refresh_observer, "refresh-observer"),
+    for operation, observer, observer_name, required_kind in (
+        (cold_up, cold_observer, "cold-observer", ObservationKind.HOME),
+        (refresh, refresh_observer, "refresh-observer", ObservationKind.RESOLVE),
     ):
         if operation is None:
             if observer is not None:
@@ -1662,7 +1668,7 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
             or observer.get("timedOut") is True
             or observation_kinds != {ObservationKind.HOME, ObservationKind.RESOLVE}
             or not overlaps(operation, observer)
-            or not observation_completed_during(operation, observations)
+            or not observation_completed_during(operation, observations, required_kind)
             or not all(observation_has_expected_outcome(item) for item in observations)
         ):
             incomplete_observers.append(str(observer.get("transcript")))

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -118,6 +118,12 @@ class CapsuleContext:
         }
 
 
+@dataclasses.dataclass(frozen=True)
+class LiveCapturePreflight:
+    output: Path
+    session: str
+
+
 def epoch_millis() -> int:
     return time.time_ns() // 1_000_000
 
@@ -210,6 +216,46 @@ def capsule_lifecycle_plan(
     ]
 
 
+def issued_symbol_command(
+    name: str,
+    kast: str,
+    query: str,
+    exact_arguments: tuple[str, ...],
+    *,
+    stdin: str | None = None,
+) -> CommandSpec:
+    resolve = shlex.join((kast, "--output", "json", "symbol", "resolve", "--query", query))
+    exact = shlex.join((kast, *exact_arguments))
+    extract = shlex.quote(
+        "import json,sys; value=json.load(sys.stdin).get('result',{}).get('selector'); "
+        "print(value) if isinstance(value,str) and value else sys.exit(2)"
+    )
+    script = (
+        f"resolved=$({resolve}) || exit $?; "
+        'printf "%s\\n" "$resolved"; '
+        f"selector=$(printf '%s' \"$resolved\" | python3 -c {extract}) || exit $?; "
+        f'{exact} --selector "$selector"'
+    )
+    return CommandSpec(name, ("/bin/bash", "-lc", script), stdin=stdin)
+
+
+def issued_graph_node_command(name: str, kast: str) -> CommandSpec:
+    nodes = shlex.join((kast, "--output", "json", "graph", "nodes"))
+    neighbors = shlex.join((kast, "graph", "neighbors"))
+    extract = shlex.quote(
+        "import json,sys; nodes=json.load(sys.stdin).get('result',{}).get('nodes',[]); "
+        "value=nodes[0].get('nodeSelector') if nodes and isinstance(nodes[0],dict) else None; "
+        "print(value) if isinstance(value,str) and value else sys.exit(2)"
+    )
+    script = (
+        f"nodes=$({nodes}) || exit $?; "
+        'printf "%s\\n" "$nodes"; '
+        f"node_selector=$(printf '%s' \"$nodes\" | python3 -c {extract}) || exit $?; "
+        f'{neighbors} --node-selector "$node_selector"'
+    )
+    return CommandSpec(name, ("/bin/bash", "-lc", script))
+
+
 def command_plan(
     kast: str,
     file_path: str,
@@ -228,49 +274,84 @@ def command_plan(
     commands = [
         CommandSpec("home", (kast,)),
         CommandSpec("help", (kast, "--help")),
-        CommandSpec("files", (kast, "files", file_path)),
-        CommandSpec("symbol-find", (kast, "symbol", "find", short_name)),
-        CommandSpec("symbol-show", (kast, "symbol", "show", symbol)),
-        CommandSpec("symbol-refs", (kast, "symbol", "refs", symbol)),
-        CommandSpec("symbol-callers", (kast, "symbol", "callers", symbol)),
-        CommandSpec("symbol-callees", (kast, "symbol", "callees", symbol)),
-        CommandSpec("symbol-implementations", (kast, "symbol", "implementations", symbol)),
-        CommandSpec("symbol-supertypes", (kast, "symbol", "supertypes", symbol)),
-        CommandSpec("symbol-subtypes", (kast, "symbol", "subtypes", symbol)),
-        CommandSpec("graph-summary", (kast, "graph", "summary")),
+        CommandSpec("file-list", (kast, "file", "list", "--match", file_path)),
+        CommandSpec("symbol-search", (kast, "symbol", "search", "--query", symbol)),
+        CommandSpec("symbol-resolve", (kast, "symbol", "resolve", "--query", symbol)),
+        issued_symbol_command("symbol-show", kast, symbol, ("symbol", "show")),
+        issued_symbol_command("relation-references", kast, symbol, ("relation", "references")),
+        issued_symbol_command(
+            "relation-calls-incoming",
+            kast,
+            symbol,
+            ("relation", "calls", "incoming"),
+        ),
+        issued_symbol_command(
+            "relation-calls-outgoing",
+            kast,
+            symbol,
+            ("relation", "calls", "outgoing"),
+        ),
+        issued_symbol_command(
+            "relation-implementations",
+            kast,
+            symbol,
+            ("relation", "implementations"),
+        ),
+        issued_symbol_command(
+            "relation-hierarchy-supertypes",
+            kast,
+            symbol,
+            ("relation", "hierarchy", "supertypes"),
+        ),
+        issued_symbol_command(
+            "relation-hierarchy-subtypes",
+            kast,
+            symbol,
+            ("relation", "hierarchy", "subtypes"),
+        ),
+        CommandSpec("graph-summary", (kast, "graph", "summary", "--scope", "symbol")),
         CommandSpec("graph-nodes", (kast, "graph", "nodes")),
-        CommandSpec("graph-neighbors", (kast, "graph", "neighbors", symbol)),
-        CommandSpec("graph-topology", (kast, "graph", "topology")),
-        CommandSpec("graph-communities", (kast, "graph", "communities")),
-        CommandSpec("graph-impact", (kast, "graph", "impact", symbol)),
-        CommandSpec("check", (kast, "check", file_path)),
+        issued_graph_node_command("graph-neighbors", kast),
+        CommandSpec("graph-topology", (kast, "graph", "topology", "--scope", "symbol")),
+        CommandSpec("graph-communities", (kast, "graph", "communities", "--scope", "symbol")),
+        issued_symbol_command("graph-impact", kast, symbol, ("graph", "impact")),
+        CommandSpec("diagnostic-check", (kast, "diagnostic", "check", "--file", file_path)),
     ]
     if exercise_plans:
         commands.extend(
             [
-                CommandSpec("change-rename", (kast, "change", "rename", symbol, f"{short_name}ReproProbe")),
+                issued_symbol_command(
+                    "change-plan-rename",
+                    kast,
+                    symbol,
+                    ("change", "plan", "rename", "--name", f"{short_name}ReproProbe"),
+                ),
                 CommandSpec(
-                    "change-add-file",
-                    (kast, "change", "add-file", probe_path),
+                    "change-plan-add-file",
+                    (kast, "change", "plan", "add-file", "--file", probe_path),
                     stdin=f"package {package_name}\n\ninternal object KastCliReproProbe",
                 ),
                 CommandSpec(
-                    "change-add-declaration",
-                    (kast, "change", "add-declaration", file_path),
+                    "change-plan-add-declaration",
+                    (kast, "change", "plan", "add-declaration", "--file", file_path),
                     stdin="private const val KAST_CLI_REPRO_SENTINEL = 1",
                 ),
-                CommandSpec(
-                    "change-replace",
-                    (kast, "change", "replace", symbol),
+                issued_symbol_command(
+                    "change-plan-replace",
+                    kast,
+                    symbol,
+                    ("change", "plan", "replace"),
                     stdin=f"class {short_name}ReproProbe",
                 ),
-                CommandSpec("apply-invalid", (kast, "apply", "repro-invalid-plan")),
-                CommandSpec("recover-invalid", (kast, "recover", "repro-invalid-recovery")),
             ]
         )
     commands.extend(
         [
-            CommandSpec("refresh", (kast, "refresh", file_path), timeout_seconds=transition_timeout),
+            CommandSpec(
+                "workspace-refresh",
+                (kast, "workspace", "refresh", "--file", file_path),
+                timeout_seconds=transition_timeout,
+            ),
             CommandSpec("refresh-observer", ("/bin/bash", "-lc", observer), timeout_seconds=transition_timeout),
         ]
     )
@@ -279,7 +360,7 @@ def command_plan(
             [
                 CommandSpec(
                     "cold-up",
-                    (kast, "up"),
+                    (kast, "workspace", "ensure"),
                     environment=(("KAST_IDEA_TRACE", "true"),),
                     timeout_seconds=transition_timeout,
                 ),
@@ -298,7 +379,7 @@ def observer_script(kast: str, symbol: str, samples: int, interval: float) -> st
         f"{kast_command}; "
         'printf "__KAST_SAMPLE_EPOCH_MILLIS__="; '
         "python3 -c 'import time; print(time.time_ns() // 1000000)'; "
-        f"{kast_command} symbol show {symbol_argument}; "
+        f"{kast_command} symbol resolve --query {symbol_argument}; "
         f"sleep {interval}; "
         "done"
     )
@@ -740,16 +821,31 @@ def process_ancestry(table: dict[int, tuple[int, str]]) -> set[int]:
     return ancestry
 
 
+def command_mentions_capsule_root(command: str, root: Path) -> bool:
+    for spelling in {str(root), str(root.resolve())}:
+        pattern = re.compile(
+            rf"(?:^|[\s'\"=:,]){re.escape(spelling)}(?=$|[/\s'\"=:,])"
+        )
+        if pattern.search(command):
+            return True
+    return False
+
+
 def capsule_processes(root: Path, seeds: set[int] | None = None) -> set[int]:
     table = process_table()
     excluded = process_ancestry(table)
-    root_spellings = {str(root), str(root.resolve())}
     owned = {
         pid
         for pid, (_, command) in table.items()
-        if pid not in excluded and any(spelling in command for spelling in root_spellings)
+        if pid not in excluded and command_mentions_capsule_root(command, root)
     }
-    owned.update(pid for pid in seeds or set() if pid in table and pid not in excluded)
+    owned.update(
+        pid
+        for pid in seeds or set()
+        if pid in table
+        and pid not in excluded
+        and command_mentions_capsule_root(table[pid][1], root)
+    )
     changed = True
     while changed:
         changed = False
@@ -866,6 +962,39 @@ def write_manifest(
     (directory / "manifest.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
+def live_capture_preflight(args: argparse.Namespace, workspace: Path) -> LiveCapturePreflight:
+    if shutil.which("tmux") is None:
+        raise ReproError("tmux is required for live capture")
+    output = args.output_dir or (
+        Path(tempfile.gettempdir())
+        / "kast-cli-repro"
+        / f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-{os.getpid()}"
+    )
+    output = output.resolve()
+    if output == workspace or workspace in output.parents:
+        raise ReproError("--output-dir must be outside the observed workspace so capture cannot trigger indexing")
+    if output.exists() and not output.is_dir():
+        raise ReproError(f"evidence output is not a directory: {output}")
+    if output.exists() and any(output.iterdir()):
+        raise ReproError(f"evidence output is not empty: {output}")
+    session = args.session_name or f"kast-cli-repro-{os.getpid()}"
+    if re.fullmatch(r"[A-Za-z0-9_-]+", session) is None:
+        raise ReproError("--session-name must contain only letters, digits, underscores, or hyphens")
+    return LiveCapturePreflight(output, session)
+
+
+def discard_unstarted_ephemeral_capsule(capsule: CapsuleContext | None) -> None:
+    if capsule is None or capsule.mode != "EPHEMERAL" or not capsule.root.exists():
+        return
+    expected_parent = Path("/private/tmp").resolve()
+    if (
+        capsule.root.parent.resolve() != expected_parent
+        or not capsule.root.name.startswith("kast-capsule-")
+    ):
+        raise ReproError("refused to clean an unrecognized ephemeral capsule root")
+    shutil.rmtree(capsule.root)
+
+
 def capture(args: argparse.Namespace) -> int:
     workspace = args.workspace_root.resolve(strict=True)
     file_path = Path(args.file)
@@ -878,6 +1007,7 @@ def capture(args: argparse.Namespace) -> int:
     if host_kast is None and not args.dry_run:
         raise ReproError(f"Kast executable is unavailable: {args.kast}")
     host_kast = host_kast or args.kast
+    preflight = None if args.dry_run else live_capture_preflight(args, workspace)
     capsule = build_capsule(args, workspace, host_kast, dry_run=args.dry_run)
     kast = str(capsule.kast) if capsule is not None else host_kast
     plan = command_plan(
@@ -900,26 +1030,17 @@ def capture(args: argparse.Namespace) -> int:
             payload["capsule"] = capsule.public()
         print(json.dumps(payload, indent=2))
         return 0
-    if shutil.which("tmux") is None:
-        raise ReproError("tmux is required for live capture")
-    output = args.output_dir or (
-        Path(tempfile.gettempdir())
-        / "kast-cli-repro"
-        / f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-{os.getpid()}"
-    )
-    output = output.resolve()
-    if output == workspace or workspace in output.parents:
-        raise ReproError("--output-dir must be outside the observed workspace so capture cannot trigger indexing")
-    if capsule is not None and paths_overlap(output, capsule.root):
-        raise ReproError("--output-dir must not overlap the capsule root")
-    if output.exists() and not output.is_dir():
-        raise ReproError(f"evidence output is not a directory: {output}")
-    if output.exists() and any(output.iterdir()):
-        raise ReproError(f"evidence output is not empty: {output}")
-    (output / "transcripts").mkdir(parents=True, exist_ok=True)
-    session = args.session_name or f"kast-cli-repro-{os.getpid()}"
-    if re.fullmatch(r"[A-Za-z0-9_-]+", session) is None:
-        raise ReproError("--session-name must contain only letters, digits, underscores, or hyphens")
+    if preflight is None:
+        raise ReproError("live capture preflight was not established")
+    output = preflight.output
+    session = preflight.session
+    try:
+        if capsule is not None and paths_overlap(output, capsule.root):
+            raise ReproError("--output-dir must not overlap the capsule root")
+        (output / "transcripts").mkdir(parents=True, exist_ok=True)
+    except (OSError, ReproError):
+        discard_unstarted_ephemeral_capsule(capsule)
+        raise
     runner = TmuxCapture(
         session,
         workspace,
@@ -1003,12 +1124,20 @@ def capture(args: argparse.Namespace) -> int:
             runner.finish(observer_active)
             runner.finish(up_active)
         else:
-            runner.run(CommandSpec("warm-up", (kast, "up"), timeout_seconds=args.transition_timeout))
+            require_success(
+                runner.run(
+                    CommandSpec(
+                        "warm-up",
+                        (kast, "workspace", "ensure"),
+                        timeout_seconds=args.transition_timeout,
+                    )
+                )
+            )
         for spec in plan:
-            if spec.name in {"cold-up", "cold-observer", "refresh", "refresh-observer"}:
+            if spec.name in {"cold-up", "cold-observer", "workspace-refresh", "refresh-observer"}:
                 continue
-            runner.run(spec)
-        refresh = next(spec for spec in plan if spec.name == "refresh")
+            require_success(runner.run(spec))
+        refresh = next(spec for spec in plan if spec.name == "workspace-refresh")
         observer = next(spec for spec in plan if spec.name == "refresh-observer")
         refresh_active = runner.begin(refresh)
         observer_active = runner.begin(observer)
@@ -1408,7 +1537,11 @@ def parser() -> argparse.ArgumentParser:
     capture_parser.add_argument("--sample-interval", type=float, default=1.0)
     capture_parser.add_argument("--transition-timeout", type=float, default=420.0)
     capture_parser.add_argument("--restart-runtime", action="store_true", help="stop the exact-root runtime and cold-start it with KAST_IDEA_TRACE=true")
-    capture_parser.add_argument("--exercise-plans", action="store_true", help="exercise mutation planning and invalid apply/recover without applying a valid plan")
+    capture_parser.add_argument(
+        "--exercise-plans",
+        action="store_true",
+        help="exercise mutation planning without applying a plan",
+    )
     capture_parser.add_argument("--keep-session", action="store_true", help="leave the completed tmux session available for attachment")
     capture_parser.add_argument("--dry-run", action="store_true", help="print the command matrix without touching tmux or Kast state")
     analyze_parser = commands.add_parser("analyze", help="replay an existing evidence bundle without a live runtime")

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -1204,6 +1204,19 @@ def live_capture_preflight(args: argparse.Namespace, workspace: Path) -> LiveCap
     return LiveCapturePreflight(output, session)
 
 
+def require_runtime_restart_authority(
+    *,
+    restart_requested: bool,
+    capsule: CapsuleContext | None,
+    dry_run: bool,
+) -> None:
+    if not dry_run and capsule is None and not restart_requested:
+        raise ReproError(
+            "--restart-runtime is required for live non-capsule capture because "
+            "telemetry settings bind when the runtime starts"
+        )
+
+
 def discard_unstarted_ephemeral_capsule(capsule: CapsuleContext | None) -> None:
     if capsule is None or capsule.mode != "EPHEMERAL" or not capsule.root.exists():
         return
@@ -1241,6 +1254,11 @@ def capture(args: argparse.Namespace) -> int:
     host_kast = host_kast or args.kast
     preflight = None if args.dry_run else live_capture_preflight(args, workspace)
     capsule = build_capsule(args, workspace, host_kast, dry_run=args.dry_run)
+    require_runtime_restart_authority(
+        restart_requested=args.restart_runtime,
+        capsule=capsule,
+        dry_run=args.dry_run,
+    )
     kast = str(capsule.kast) if capsule is not None else host_kast
     plan = command_plan(
         kast,
@@ -1338,34 +1356,23 @@ def capture(args: argparse.Namespace) -> int:
                 ),
             )
         ))
-        if args.restart_runtime or capsule is not None:
-            require_success(
-                runner.run(
-                    CommandSpec(
-                        "runtime-stop",
-                        (
-                            str(kastctl), "--output", "json", "developer", "runtime", "stop",
-                            "--workspace-root", str(workspace),
-                        ),
-                        timeout_seconds=args.transition_timeout,
-                    )
+        require_success(
+            runner.run(
+                CommandSpec(
+                    "runtime-stop",
+                    (
+                        str(kastctl), "--output", "json", "developer", "runtime", "stop",
+                        "--workspace-root", str(workspace),
+                    ),
+                    timeout_seconds=args.transition_timeout,
                 )
             )
-            cold_up = next(spec for spec in plan if spec.name == "cold-up")
-            cold_observer = next(spec for spec in plan if spec.name == "cold-observer")
-            up_active = runner.begin(cold_up)
-            observer_active = runner.begin(cold_observer)
-            finish_observed_operation(runner, up_active, observer_active)
-        else:
-            require_success(
-                runner.run(
-                    CommandSpec(
-                        "warm-up",
-                        (kast, "workspace", "ensure"),
-                        timeout_seconds=args.transition_timeout,
-                    )
-                )
-            )
+        )
+        cold_up = next(spec for spec in plan if spec.name == "cold-up")
+        cold_observer = next(spec for spec in plan if spec.name == "cold-observer")
+        up_active = runner.begin(cold_up)
+        observer_active = runner.begin(cold_observer)
+        finish_observed_operation(runner, up_active, observer_active)
         for spec in plan:
             if spec.name in {"cold-up", "cold-observer", "workspace-refresh", "refresh-observer"}:
                 continue
@@ -1702,6 +1709,20 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
             "evidence manifest is missing required scenario commands: "
             + ", ".join(missing_commands)
         )
+    invalid_status_commands = sorted(
+        name
+        for name in required_commands
+        if (
+            not isinstance(commands[name].get("exitCode"), int)
+            or isinstance(commands[name].get("exitCode"), bool)
+            or not isinstance(commands[name].get("timedOut"), bool)
+        )
+    )
+    if invalid_status_commands:
+        raise ReproError(
+            "required scenario commands have invalid status evidence: "
+            + ", ".join(invalid_status_commands)
+        )
     failed_commands = sorted(
         name
         for name in REQUIRED_SUCCESSFUL_SCENARIO_COMMANDS
@@ -1780,7 +1801,7 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
                     ["transcripts/cold-up.txt", "transcripts/cold-observer.txt"],
                 )
             )
-    if refresh and refresh.get("exitCode") != 0:
+    if refresh and (refresh.get("exitCode") != 0 or refresh.get("timedOut") is True):
         findings.append(
             Finding(
                 FindingCode.REFRESH_DID_NOT_CONVERGE.value,
@@ -1800,8 +1821,10 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
                 )
             )
     framing_evidence: list[str] = []
+    transcript_sizes: dict[str, int] = {}
     for name, command in commands.items():
         text = transcript(directory, command)
+        transcript_sizes[name] = len(text.encode("utf-8"))
         completion_token = command.get("completionToken")
         if not isinstance(completion_token, str) or not completion_token:
             if name in required_commands:
@@ -1842,11 +1865,10 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
             )
         )
     oversized = [
-        f"{name}:{command.get('outputBytes')}"
-        for name, command in commands.items()
+        f"{name}:{transcript_sizes[name]}"
+        for name in commands
         if name in {"graph-nodes", "graph-topology", "graph-communities"}
-        and isinstance(command.get("outputBytes"), int)
-        and command["outputBytes"] > DEFAULT_OUTPUT_BUDGET_BYTES
+        and transcript_sizes[name] > DEFAULT_OUTPUT_BUDGET_BYTES
     ]
     if oversized:
         findings.append(
@@ -1962,7 +1984,11 @@ def parser() -> argparse.ArgumentParser:
     capture_parser.add_argument("--samples", type=int, default=20)
     capture_parser.add_argument("--sample-interval", type=float, default=1.0)
     capture_parser.add_argument("--transition-timeout", type=float, default=420.0)
-    capture_parser.add_argument("--restart-runtime", action="store_true", help="stop the exact-root runtime and cold-start it with KAST_IDEA_TRACE=true")
+    capture_parser.add_argument(
+        "--restart-runtime",
+        action="store_true",
+        help="required for live non-capsule capture; stop and cold-start the exact-root runtime with telemetry enabled",
+    )
     capture_parser.add_argument(
         "--exercise-plans",
         action="store_true",

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -1,0 +1,1449 @@
+#!/usr/bin/env python3
+"""Capture and replay Kast CLI incident evidence through a real tmux PTY."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import enum
+import json
+import os
+import re
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+DEFAULT_OUTPUT_BUDGET_BYTES = 30_000
+EXIT_SENTINEL = "::kast-repro-exit="
+
+
+class ReproError(Exception):
+    """A closed setup, capture, or evidence-validation failure."""
+
+
+class FindingCode(str, enum.Enum):
+    READY_DURING_PENDING_UP = "READY_DURING_PENDING_UP"
+    GENERIC_CONFLICT_DURING_REFRESH = "GENERIC_CONFLICT_DURING_REFRESH"
+    REFRESH_DID_NOT_CONVERGE = "REFRESH_DID_NOT_CONVERGE"
+    MISSING_TRAILING_NEWLINE = "MISSING_TRAILING_NEWLINE"
+    DEFAULT_OUTPUT_EXCEEDS_BUDGET = "DEFAULT_OUTPUT_EXCEEDS_BUDGET"
+    TRACE_CORRELATION_INCOMPLETE = "TRACE_CORRELATION_INCOMPLETE"
+    CAPSULE_CONFINEMENT_VIOLATED = "CAPSULE_CONFINEMENT_VIOLATED"
+    CAPSULE_PROCESS_LEAKED = "CAPSULE_PROCESS_LEAKED"
+    CAPSULE_RUNTIME_STOP_FAILED = "CAPSULE_RUNTIME_STOP_FAILED"
+
+
+@dataclasses.dataclass(frozen=True)
+class CommandSpec:
+    name: str
+    argv: tuple[str, ...]
+    stdin: str | None = None
+    environment: tuple[tuple[str, str], ...] = ()
+    timeout_seconds: float = 180.0
+
+    def public(self) -> dict[str, Any]:
+        value: dict[str, Any] = {"name": self.name, "argv": list(self.argv)}
+        if self.stdin is not None:
+            value["stdinBytes"] = len(self.stdin.encode("utf-8"))
+        if self.environment:
+            value["environment"] = {key: value for key, value in self.environment}
+        return value
+
+
+@dataclasses.dataclass(frozen=True)
+class ActiveCommand:
+    spec: CommandSpec
+    window_id: str
+    started_at_epoch_millis: int
+
+
+@dataclasses.dataclass(frozen=True)
+class CommandEvidence:
+    name: str
+    argv: list[str]
+    startedAtEpochMillis: int
+    finishedAtEpochMillis: int
+    exitCode: int
+    timedOut: bool
+    transcript: str
+    outputBytes: int
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    code: str
+    message: str
+    evidence: list[str]
+
+
+@dataclasses.dataclass(frozen=True)
+class CapsuleContext:
+    mode: str
+    root: Path
+    bundle_source: Path
+    environment: dict[str, str]
+    bootstrap_kastctl: Path
+    idea_host: Path
+
+    @property
+    def cleanup(self) -> str:
+        return "STOP_VERIFY_DELETE" if self.mode == "EPHEMERAL" else "STOP_VERIFY_KEEP"
+
+    @property
+    def kast(self) -> Path:
+        return self.root / "kast-home" / "current" / "bin" / "kast"
+
+    @property
+    def kastctl(self) -> Path:
+        return self.root / "kast-home" / "current" / "libexec" / "kastctl"
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "root": str(self.root),
+            "cleanup": self.cleanup,
+            "bundleSource": str(self.bundle_source),
+            "ideaHost": str(self.idea_host),
+            "environment": self.environment,
+            "install": {"kast": str(self.kast), "kastctl": str(self.kastctl)},
+        }
+
+
+def epoch_millis() -> int:
+    return time.time_ns() // 1_000_000
+
+
+def is_within(path: Path, root: Path) -> bool:
+    resolved_path = path.resolve()
+    resolved_root = root.resolve()
+    return resolved_path == resolved_root or resolved_root in resolved_path.parents
+
+
+def paths_overlap(first: Path, second: Path) -> bool:
+    return is_within(first, second) or is_within(second, first)
+
+
+def capsule_environment(root: Path, workspace_id: str) -> dict[str, str]:
+    home = root / "home"
+    return {
+        "HOME": str(home),
+        "KAST_HOME": str(root / "kast-home"),
+        "KAST_CONFIG_HOME": str(root / "config"),
+        "KAST_CACHE_HOME": str(root / "cache"),
+        "GRADLE_USER_HOME": str(root / "gradle"),
+        "TMPDIR": str(root / "tmp"),
+        "XDG_CACHE_HOME": str(root / "xdg" / "cache"),
+        "XDG_CONFIG_HOME": str(root / "xdg" / "config"),
+        "XDG_DATA_HOME": str(root / "xdg" / "data"),
+        "KAST_WORKSPACE_ID": workspace_id,
+        "KAST_IDEA_TRACE": "true",
+        "PATH": f"{home / '.local' / 'bin'}{os.pathsep}{os.environ.get('PATH', '')}",
+    }
+
+
+def merged_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    environment = os.environ.copy()
+    if overrides:
+        environment.update(overrides)
+    return environment
+
+
+def capsule_lifecycle_plan(
+    capsule: CapsuleContext,
+    workspace: Path,
+    commands: list[CommandSpec],
+) -> list[CommandSpec]:
+    return [
+        CommandSpec(
+            "capsule-setup",
+            (
+                str(capsule.bootstrap_kastctl),
+                "--output",
+                "json",
+                "setup",
+                "--source",
+                str(capsule.bundle_source),
+                "--profile",
+                "development",
+            ),
+            timeout_seconds=420.0,
+        ),
+        CommandSpec(
+            "capsule-idea-host",
+            (
+                str(capsule.kastctl),
+                "--output",
+                "json",
+                "config",
+                "set",
+                "indexer.hostCommand",
+                str(capsule.idea_host),
+                "--workspace-root",
+                str(workspace),
+            ),
+        ),
+        *commands,
+        CommandSpec(
+            "capsule-runtime-stop",
+            (
+                str(capsule.kastctl),
+                "--output",
+                "json",
+                "developer",
+                "runtime",
+                "stop",
+            ),
+        ),
+        CommandSpec(
+            "capsule-teardown-verify",
+            ("internal:verify-no-capsule-processes", str(capsule.root)),
+        ),
+    ]
+
+
+def command_plan(
+    kast: str,
+    file_path: str,
+    symbol: str,
+    *,
+    restart_runtime: bool,
+    exercise_plans: bool,
+    samples: int,
+    sample_interval: float,
+    transition_timeout: float,
+) -> list[CommandSpec]:
+    short_name = symbol.rsplit(".", 1)[-1]
+    package_name = symbol.rsplit(".", 1)[0]
+    probe_path = (Path(file_path).parent / "KastCliReproProbe.kt").as_posix()
+    observer = observer_script(kast, symbol, samples, sample_interval)
+    commands = [
+        CommandSpec("home", (kast,)),
+        CommandSpec("help", (kast, "--help")),
+        CommandSpec("files", (kast, "files", file_path)),
+        CommandSpec("symbol-find", (kast, "symbol", "find", short_name)),
+        CommandSpec("symbol-show", (kast, "symbol", "show", symbol)),
+        CommandSpec("symbol-refs", (kast, "symbol", "refs", symbol)),
+        CommandSpec("symbol-callers", (kast, "symbol", "callers", symbol)),
+        CommandSpec("symbol-callees", (kast, "symbol", "callees", symbol)),
+        CommandSpec("symbol-implementations", (kast, "symbol", "implementations", symbol)),
+        CommandSpec("symbol-supertypes", (kast, "symbol", "supertypes", symbol)),
+        CommandSpec("symbol-subtypes", (kast, "symbol", "subtypes", symbol)),
+        CommandSpec("graph-summary", (kast, "graph", "summary")),
+        CommandSpec("graph-nodes", (kast, "graph", "nodes")),
+        CommandSpec("graph-neighbors", (kast, "graph", "neighbors", symbol)),
+        CommandSpec("graph-topology", (kast, "graph", "topology")),
+        CommandSpec("graph-communities", (kast, "graph", "communities")),
+        CommandSpec("graph-impact", (kast, "graph", "impact", symbol)),
+        CommandSpec("check", (kast, "check", file_path)),
+    ]
+    if exercise_plans:
+        commands.extend(
+            [
+                CommandSpec("change-rename", (kast, "change", "rename", symbol, f"{short_name}ReproProbe")),
+                CommandSpec(
+                    "change-add-file",
+                    (kast, "change", "add-file", probe_path),
+                    stdin=f"package {package_name}\n\ninternal object KastCliReproProbe",
+                ),
+                CommandSpec(
+                    "change-add-declaration",
+                    (kast, "change", "add-declaration", file_path),
+                    stdin="private const val KAST_CLI_REPRO_SENTINEL = 1",
+                ),
+                CommandSpec(
+                    "change-replace",
+                    (kast, "change", "replace", symbol),
+                    stdin=f"class {short_name}ReproProbe",
+                ),
+                CommandSpec("apply-invalid", (kast, "apply", "repro-invalid-plan")),
+                CommandSpec("recover-invalid", (kast, "recover", "repro-invalid-recovery")),
+            ]
+        )
+    commands.extend(
+        [
+            CommandSpec("refresh", (kast, "refresh", file_path), timeout_seconds=transition_timeout),
+            CommandSpec("refresh-observer", ("/bin/bash", "-lc", observer), timeout_seconds=transition_timeout),
+        ]
+    )
+    if restart_runtime:
+        commands.extend(
+            [
+                CommandSpec(
+                    "cold-up",
+                    (kast, "up"),
+                    environment=(("KAST_IDEA_TRACE", "true"),),
+                    timeout_seconds=transition_timeout,
+                ),
+                CommandSpec("cold-observer", ("/bin/bash", "-lc", observer), timeout_seconds=transition_timeout),
+            ]
+        )
+    return commands
+
+
+def observer_script(kast: str, symbol: str, samples: int, interval: float) -> str:
+    kast_command = shlex.quote(kast)
+    symbol_argument = shlex.quote(symbol)
+    return (
+        f"for i in $(seq 1 {samples}); do "
+        'printf "__KAST_SAMPLE__=%s\\n" "$i"; '
+        f"{kast_command}; "
+        'printf "__KAST_SAMPLE_EPOCH_MILLIS__="; '
+        "python3 -c 'import time; print(time.time_ns() // 1000000)'; "
+        f"{kast_command} symbol show {symbol_argument}; "
+        f"sleep {interval}; "
+        "done"
+    )
+
+
+class TmuxCapture:
+    def __init__(
+        self,
+        session: str,
+        workspace: Path,
+        evidence: Path,
+        keep_session: bool,
+        base_environment: dict[str, str] | None = None,
+    ) -> None:
+        self.session = session
+        self.workspace = workspace
+        self.evidence = evidence
+        self.keep_session = keep_session
+        self.base_environment = base_environment or {}
+        self.commands: list[CommandEvidence] = []
+
+    def start(self) -> None:
+        existing = subprocess.run(
+            ["tmux", "has-session", "-t", self.session],
+            capture_output=True,
+            check=False,
+        )
+        if existing.returncode == 0:
+            raise ReproError(f"tmux session already exists: {self.session}")
+        run_checked("tmux", "new-session", "-d", "-s", self.session, "-c", str(self.workspace))
+        run_checked("tmux", "set-option", "-t", self.session, "history-limit", "1000000")
+
+    def close(self) -> None:
+        if not self.keep_session:
+            subprocess.run(["tmux", "kill-session", "-t", self.session], check=False, capture_output=True)
+
+    def begin(self, spec: CommandSpec) -> ActiveCommand:
+        command = shlex.join(spec.argv)
+        environment = dict(self.base_environment)
+        environment.update(dict(spec.environment))
+        if environment:
+            environment = " ".join(
+                f"{shlex.quote(key)}={shlex.quote(value)}" for key, value in environment.items()
+            )
+            command = f"env {environment} {command}"
+        if spec.stdin is not None:
+            command = f"printf %s {shlex.quote(spec.stdin)} | {command}"
+        shell = (
+            "set +e; "
+            f"{command}; "
+            "status=$?; "
+            f"printf '{EXIT_SENTINEL}%s\\n' \"$status\"; "
+            "exec sleep 2147483647"
+        )
+        window_name = re.sub(r"[^A-Za-z0-9_-]", "-", spec.name)[:40]
+        result = run_checked(
+            "tmux",
+            "new-window",
+            "-d",
+            "-P",
+            "-F",
+            "#{window_id}",
+            "-t",
+            self.session,
+            "-n",
+            window_name,
+            "-c",
+            str(self.workspace),
+            f"/bin/bash -lc {shlex.quote(shell)}",
+        )
+        return ActiveCommand(spec, result.stdout.strip(), epoch_millis())
+
+    def finish(self, active: ActiveCommand) -> CommandEvidence:
+        deadline = time.monotonic() + active.spec.timeout_seconds
+        timed_out = False
+        transcript = ""
+        exit_code: int | None = None
+        while True:
+            capture = subprocess.run(
+                ["tmux", "capture-pane", "-p", "-J", "-S", "-", "-t", active.window_id],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if capture.returncode != 0:
+                raise ReproError(f"tmux lost capture window for {active.spec.name}")
+            transcript = capture.stdout
+            match = re.search(rf"{re.escape(EXIT_SENTINEL)}([0-9]+)", transcript)
+            if match is not None:
+                exit_code = int(match.group(1))
+                break
+            if time.monotonic() >= deadline:
+                timed_out = True
+                subprocess.run(
+                    ["tmux", "send-keys", "-t", active.window_id, "C-c"],
+                    check=False,
+                    capture_output=True,
+                )
+                time.sleep(0.25)
+                capture = subprocess.run(
+                    ["tmux", "capture-pane", "-p", "-J", "-S", "-", "-t", active.window_id],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                transcript = capture.stdout
+                break
+            time.sleep(0.1)
+        transcript_path = self.evidence / "transcripts" / f"{active.spec.name}.txt"
+        transcript_path.write_text(transcript, encoding="utf-8")
+        resolved_exit_code = exit_code if exit_code is not None else 124 if timed_out else 125
+        evidence = CommandEvidence(
+            name=active.spec.name,
+            argv=list(active.spec.argv),
+            startedAtEpochMillis=active.started_at_epoch_millis,
+            finishedAtEpochMillis=epoch_millis(),
+            exitCode=resolved_exit_code,
+            timedOut=timed_out,
+            transcript=str(transcript_path.relative_to(self.evidence)),
+            outputBytes=len(transcript.encode("utf-8")),
+        )
+        self.commands.append(evidence)
+        if not self.keep_session or timed_out:
+            subprocess.run(
+                ["tmux", "kill-window", "-t", active.window_id],
+                check=False,
+                capture_output=True,
+            )
+        return evidence
+
+    def run(self, spec: CommandSpec) -> CommandEvidence:
+        return self.finish(self.begin(spec))
+
+    def record(self, name: str, argv: list[str], payload: dict[str, Any], exit_code: int) -> None:
+        started = epoch_millis()
+        rendered = json.dumps(payload, indent=2) + "\n"
+        transcript_path = self.evidence / "transcripts" / f"{name}.txt"
+        transcript_path.write_text(rendered, encoding="utf-8")
+        self.commands.append(
+            CommandEvidence(
+                name=name,
+                argv=argv,
+                startedAtEpochMillis=started,
+                finishedAtEpochMillis=epoch_millis(),
+                exitCode=exit_code,
+                timedOut=False,
+                transcript=str(transcript_path.relative_to(self.evidence)),
+                outputBytes=len(rendered.encode("utf-8")),
+            )
+        )
+
+
+def run_checked(*argv: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(argv, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise ReproError(f"{shlex.join(argv)} failed: {detail}")
+    return result
+
+
+def require_success(command: CommandEvidence) -> None:
+    if command.exitCode != 0 or command.timedOut:
+        raise ReproError(
+            f"capture infrastructure command {command.name} failed with exit {command.exitCode}"
+        )
+
+
+def discover_developer_cli(
+    kast: str,
+    workspace: Path,
+    environment: dict[str, str] | None = None,
+) -> Path:
+    result = subprocess.run(
+        [kast],
+        cwd=workspace,
+        env=merged_environment(environment),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    match = re.search(r"(?m)^\s+cli: (.+)$", result.stdout)
+    if match is None:
+        raise ReproError("public Kast home did not expose developerOperations.cli")
+    rendered_path = match.group(1).strip()
+    if rendered_path.startswith('"'):
+        try:
+            decoded_path = json.loads(rendered_path)
+        except json.JSONDecodeError as error:
+            raise ReproError("public Kast home exposed an invalid quoted developer CLI path") from error
+        if not isinstance(decoded_path, str):
+            raise ReproError("public Kast home exposed a non-string developer CLI path")
+        rendered_path = decoded_path
+    path = Path(rendered_path).expanduser()
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise ReproError(f"discovered developer CLI is not executable: {path}")
+    return path
+
+
+def read_config(
+    kastctl: Path,
+    workspace: Path,
+    environment: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    result = subprocess.run(
+        [str(kastctl), "--output", "json", "config", "list", "--workspace-root", str(workspace)],
+        env=merged_environment(environment),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ReproError(f"config discovery failed: {result.stderr.strip() or result.stdout.strip()}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise ReproError(f"config discovery returned invalid JSON: {error}") from error
+    if payload.get("ok") is not True:
+        raise ReproError("config discovery did not return ok=true")
+    return payload
+
+
+def discover_idea_host(
+    requested: Path | None,
+    bootstrap: Path,
+    workspace: Path,
+    *,
+    dry_run: bool,
+) -> Path:
+    if requested is not None:
+        host = requested.expanduser().resolve(strict=not dry_run)
+        if not dry_run and (not host.is_dir() or host.suffix != ".app"):
+            raise ReproError("--idea-host must name an installed IntelliJ IDEA or Android Studio .app")
+        return host
+    if dry_run:
+        return Path("<supported-idea-host>")
+
+    host_config = read_config(bootstrap, workspace)
+    configured = host_config.get("effective", {}).get("indexer", {}).get("hostCommand")
+    if isinstance(configured, str) and configured and configured != "idea":
+        configured_path = Path(configured).expanduser().resolve(strict=True)
+        if configured_path.is_dir() and configured_path.suffix == ".app":
+            return configured_path
+
+    roots = [Path("/Applications")]
+    host_home = os.environ.get("HOME")
+    if host_home:
+        home = Path(host_home)
+        roots.extend(
+            [
+                home / "Applications",
+                home / "Library" / "Application Support" / "JetBrains" / "Toolbox" / "apps",
+            ]
+        )
+    candidates: set[Path] = set()
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for candidate in root.rglob("*.app"):
+            if candidate.name.startswith(("IntelliJ IDEA", "Android Studio")):
+                candidates.add(candidate.resolve())
+    installed = sorted(candidates)
+    if not installed:
+        raise ReproError(
+            "no IntelliJ IDEA or Android Studio host is discoverable outside the capsule; "
+            "pass --idea-host"
+        )
+    if len(installed) > 1:
+        raise ReproError(
+            "multiple IntelliJ IDEA or Android Studio hosts are installed; pass --idea-host: "
+            + ", ".join(str(path) for path in installed)
+        )
+    return installed[0]
+
+
+def build_capsule(
+    args: argparse.Namespace,
+    workspace: Path,
+    host_kast: str,
+    *,
+    dry_run: bool,
+) -> CapsuleContext | None:
+    if args.capsule_root is None and not args.ephemeral_capsule:
+        if args.bundle_source is not None or args.idea_host is not None:
+            raise ReproError(
+                "--bundle-source and --idea-host require --capsule-root or --ephemeral-capsule"
+            )
+        return None
+
+    if dry_run:
+        bootstrap = Path("<host-kastctl>")
+    else:
+        bootstrap = discover_developer_cli(host_kast, workspace)
+    idea_host = discover_idea_host(
+        args.idea_host,
+        bootstrap,
+        workspace,
+        dry_run=dry_run,
+    )
+
+    if args.bundle_source is not None:
+        bundle_source = args.bundle_source.expanduser().resolve(strict=True)
+    elif dry_run:
+        bundle_source = Path("<immutable-setup-bundle>")
+    else:
+        resolved_bootstrap = bootstrap.resolve(strict=True)
+        if len(resolved_bootstrap.parents) < 2:
+            raise ReproError("active developer CLI did not resolve inside an installation bundle")
+        active_release = resolved_bootstrap.parents[1]
+        version: str | None = None
+        try:
+            receipt = json.loads((active_release / "receipt.json").read_text(encoding="utf-8"))
+            if isinstance(receipt.get("activeVersion"), str):
+                version = receipt["activeVersion"]
+        except (OSError, json.JSONDecodeError):
+            pass
+        setup_directory = workspace / "build" / "setup"
+        candidates = sorted(
+            (
+                path
+                for path in setup_directory.glob("kast-*.tar.gz")
+                if version is None or version in path.name
+            ),
+            key=lambda path: path.stat().st_mtime_ns,
+            reverse=True,
+        )
+        if not candidates:
+            version_detail = f" matching active version {version}" if version else ""
+            raise ReproError(
+                "no immutable setup archive"
+                f"{version_detail} exists under {setup_directory}; "
+                "pass --bundle-source or run ./gradlew packageDevelopmentSetupBundle"
+            )
+        bundle_source = candidates[0].resolve(strict=True)
+    if not dry_run and not (bundle_source.is_dir() or bundle_source.is_file()):
+        raise ReproError(f"bundle source is unavailable: {bundle_source}")
+
+    if args.ephemeral_capsule:
+        root = (
+            Path("<ephemeral>")
+            if dry_run
+            else Path(tempfile.mkdtemp(prefix="kast-capsule-", dir="/private/tmp"))
+        )
+        mode = "EPHEMERAL"
+    else:
+        root = args.capsule_root.expanduser().resolve()
+        mode = "PERSISTENT"
+
+    if not dry_run and paths_overlap(root, workspace):
+        raise ReproError("capsule root must not overlap the observed workspace")
+    socket_probe = root / "tmp" / "kast-indexer-000000000000.sock"
+    if not dry_run and len(os.fsencode(str(socket_probe))) >= 104:
+        raise ReproError(
+            "capsule root is too long for a macOS Unix-domain socket; choose a shorter --capsule-root"
+        )
+    workspace_id = (
+        "<capsule-workspace-id>"
+        if dry_run
+        else str(uuid.uuid5(uuid.NAMESPACE_URL, f"kast-cli-repro:{root}:{workspace}"))
+    )
+    environment = capsule_environment(root, workspace_id)
+    capsule = CapsuleContext(mode, root, bundle_source, environment, bootstrap, idea_host)
+    if not dry_run:
+        for key in (
+            "HOME",
+            "KAST_HOME",
+            "KAST_CONFIG_HOME",
+            "KAST_CACHE_HOME",
+            "GRADLE_USER_HOME",
+            "TMPDIR",
+            "XDG_CACHE_HOME",
+            "XDG_CONFIG_HOME",
+            "XDG_DATA_HOME",
+        ):
+            Path(environment[key]).mkdir(parents=True, exist_ok=True)
+    return capsule
+
+
+def verify_capsule_install(
+    capsule: CapsuleContext,
+    workspace: Path,
+) -> tuple[Path, dict[str, Any], dict[str, Any]]:
+    for executable in (capsule.kast, capsule.kastctl):
+        if not executable.is_file() or not os.access(executable, os.X_OK):
+            raise ReproError(f"capsule setup did not install an executable: {executable}")
+        if not is_within(executable, capsule.root):
+            raise ReproError(f"capsule executable escaped its root: {executable.resolve()}")
+    discovered = discover_developer_cli(str(capsule.kast), workspace, capsule.environment)
+    if discovered.resolve() != capsule.kastctl.resolve():
+        raise ReproError(
+            "capsule public home exposed a developer CLI outside the capsule installation"
+        )
+    config = read_config(discovered, workspace, capsule.environment)
+    candidate_paths = [capsule.kast.resolve(), capsule.kastctl.resolve()]
+    config_path = config.get("configPath")
+    if isinstance(config_path, str) and config_path:
+        candidate_paths.append(Path(config_path))
+    effective_paths = config.get("effective", {}).get("paths", {})
+    if isinstance(effective_paths, dict):
+        candidate_paths.extend(
+            Path(value) for value in effective_paths.values() if isinstance(value, str) and value
+        )
+    escaped = sorted(str(path) for path in candidate_paths if not is_within(path, capsule.root))
+    proof = {
+        "installationContained": not escaped,
+        "declaredPaths": sorted(str(path) for path in candidate_paths),
+        "escapedPaths": escaped,
+    }
+    if escaped:
+        raise ReproError(f"capsule configuration escaped its root: {', '.join(escaped)}")
+    return discovered, config, proof
+
+
+def process_table() -> dict[int, tuple[int, str]]:
+    result = subprocess.run(
+        ["/bin/ps", "-axo", "pid=,ppid=,command="],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ReproError(f"process inspection failed: {result.stderr.strip() or result.returncode}")
+    table: dict[int, tuple[int, str]] = {}
+    for line in result.stdout.splitlines():
+        match = re.match(r"\s*(\d+)\s+(\d+)\s+(.*)$", line)
+        if match is not None:
+            table[int(match.group(1))] = (int(match.group(2)), match.group(3))
+    return table
+
+
+def process_ancestry(table: dict[int, tuple[int, str]]) -> set[int]:
+    ancestry: set[int] = set()
+    current = os.getpid()
+    while current > 0 and current not in ancestry:
+        ancestry.add(current)
+        entry = table.get(current)
+        if entry is None:
+            break
+        current = entry[0]
+    return ancestry
+
+
+def capsule_processes(root: Path, seeds: set[int] | None = None) -> set[int]:
+    table = process_table()
+    excluded = process_ancestry(table)
+    root_spellings = {str(root), str(root.resolve())}
+    owned = {
+        pid
+        for pid, (_, command) in table.items()
+        if pid not in excluded and any(spelling in command for spelling in root_spellings)
+    }
+    owned.update(pid for pid in seeds or set() if pid in table and pid not in excluded)
+    changed = True
+    while changed:
+        changed = False
+        for pid, (parent, _) in table.items():
+            if pid not in excluded and parent in owned and pid not in owned:
+                owned.add(pid)
+                changed = True
+    return owned
+
+
+def alive_processes(process_ids: set[int]) -> set[int]:
+    alive: set[int] = set()
+    for process_id in process_ids:
+        try:
+            os.kill(process_id, 0)
+        except ProcessLookupError:
+            continue
+        except PermissionError as error:
+            raise ReproError(f"cannot prove capsule process ownership for PID {process_id}") from error
+        alive.add(process_id)
+    return alive
+
+
+def wait_for_process_exit(process_ids: set[int], seconds: float) -> set[int]:
+    deadline = time.monotonic() + seconds
+    remaining = alive_processes(process_ids)
+    while remaining and time.monotonic() < deadline:
+        time.sleep(0.1)
+        remaining = alive_processes(remaining)
+    return remaining
+
+
+def terminate_capsule_processes(process_ids: set[int]) -> tuple[list[int], list[int]]:
+    targeted = sorted(alive_processes(process_ids))
+    for process_id in targeted:
+        try:
+            os.kill(process_id, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    remaining = wait_for_process_exit(set(targeted), 5.0)
+    for process_id in remaining:
+        try:
+            os.kill(process_id, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    remaining = wait_for_process_exit(remaining, 2.0)
+    return targeted, sorted(remaining)
+
+
+def config_restore_specs(kastctl: Path, workspace: Path, config: dict[str, Any]) -> list[CommandSpec]:
+    mutable = {
+        item.get("key"): item
+        for item in config.get("mutableFields", [])
+        if isinstance(item, dict) and isinstance(item.get("key"), str)
+    }
+    telemetry = config.get("effective", {}).get("telemetry", {})
+    specs: list[CommandSpec] = []
+    for key, leaf in (("telemetry.enabled", "enabled"), ("telemetry.detail", "detail")):
+        base = (str(kastctl), "--output", "json", "config")
+        if mutable.get(key, {}).get("workspaceOverride") is True:
+            value = telemetry.get(leaf)
+            rendered = str(value).lower() if isinstance(value, bool) else str(value)
+            argv = (*base, "set", key, rendered, "--workspace-root", str(workspace))
+        else:
+            argv = (*base, "unset", key, "--workspace-root", str(workspace))
+        specs.append(CommandSpec(f"restore-{leaf}", argv))
+    return specs
+
+
+def log_paths(config: dict[str, Any]) -> tuple[Path, Path]:
+    config_path = Path(str(config.get("configPath", "")))
+    if len(config_path.parent.name) != 64:
+        raise ReproError("config discovery did not expose a canonical workspace data directory")
+    telemetry = config_path.parent / "telemetry" / "idea-spans.jsonl"
+    cache_root = Path(str(config.get("effective", {}).get("paths", {}).get("cacheDir", "")))
+    idea_log = cache_root / "idea-sidecars" / config_path.parent.name[:12] / "idea-log" / "idea.log"
+    return telemetry, idea_log
+
+
+def file_size(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except FileNotFoundError:
+        return 0
+
+
+def copy_delta(source: Path, offset: int, destination: Path) -> None:
+    if not source.is_file():
+        destination.write_text("", encoding="utf-8")
+        return
+    with source.open("rb") as stream:
+        if source.stat().st_size >= offset:
+            stream.seek(offset)
+        destination.write_bytes(stream.read())
+
+
+def write_manifest(
+    directory: Path,
+    workspace: Path,
+    session: str,
+    commands: list[CommandEvidence],
+    capsule: dict[str, Any] | None = None,
+) -> None:
+    payload = {
+        "schemaVersion": SCHEMA_VERSION,
+        "workspaceRoot": str(workspace),
+        "sessionName": session,
+        "commands": [dataclasses.asdict(command) for command in commands],
+        "telemetry": "telemetry.jsonl",
+        "structuredTrace": "idea-trace.log",
+    }
+    if capsule is not None:
+        payload["capsule"] = capsule
+    (directory / "manifest.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def capture(args: argparse.Namespace) -> int:
+    workspace = args.workspace_root.resolve(strict=True)
+    file_path = Path(args.file)
+    if file_path.is_absolute() or ".." in file_path.parts:
+        raise ReproError("--file must be a workspace-relative path without parent traversal")
+    source = (workspace / file_path).resolve(strict=True)
+    if workspace not in source.parents or source.suffix != ".kt":
+        raise ReproError("--file must resolve to a Kotlin file inside the workspace")
+    host_kast = shutil.which(args.kast)
+    if host_kast is None and not args.dry_run:
+        raise ReproError(f"Kast executable is unavailable: {args.kast}")
+    host_kast = host_kast or args.kast
+    capsule = build_capsule(args, workspace, host_kast, dry_run=args.dry_run)
+    kast = str(capsule.kast) if capsule is not None else host_kast
+    plan = command_plan(
+        kast,
+        file_path.as_posix(),
+        args.symbol,
+        restart_runtime=args.restart_runtime or capsule is not None,
+        exercise_plans=args.exercise_plans,
+        samples=args.samples,
+        sample_interval=args.sample_interval,
+        transition_timeout=args.transition_timeout,
+    )
+    if args.dry_run:
+        dry_plan = capsule_lifecycle_plan(capsule, workspace, plan) if capsule is not None else plan
+        payload: dict[str, Any] = {
+            "schemaVersion": SCHEMA_VERSION,
+            "commands": [spec.public() for spec in dry_plan],
+        }
+        if capsule is not None:
+            payload["capsule"] = capsule.public()
+        print(json.dumps(payload, indent=2))
+        return 0
+    if shutil.which("tmux") is None:
+        raise ReproError("tmux is required for live capture")
+    output = args.output_dir or (
+        Path(tempfile.gettempdir())
+        / "kast-cli-repro"
+        / f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-{os.getpid()}"
+    )
+    output = output.resolve()
+    if output == workspace or workspace in output.parents:
+        raise ReproError("--output-dir must be outside the observed workspace so capture cannot trigger indexing")
+    if capsule is not None and paths_overlap(output, capsule.root):
+        raise ReproError("--output-dir must not overlap the capsule root")
+    if output.exists() and not output.is_dir():
+        raise ReproError(f"evidence output is not a directory: {output}")
+    if output.exists() and any(output.iterdir()):
+        raise ReproError(f"evidence output is not empty: {output}")
+    (output / "transcripts").mkdir(parents=True, exist_ok=True)
+    session = args.session_name or f"kast-cli-repro-{os.getpid()}"
+    if re.fullmatch(r"[A-Za-z0-9_-]+", session) is None:
+        raise ReproError("--session-name must contain only letters, digits, underscores, or hyphens")
+    runner = TmuxCapture(
+        session,
+        workspace,
+        output,
+        args.keep_session,
+        capsule.environment if capsule is not None else None,
+    )
+    config: dict[str, Any] | None = None
+    kastctl: Path | None = None
+    telemetry_path: Path | None = None
+    idea_log_path: Path | None = None
+    telemetry_offset = 0
+    trace_offset = 0
+    installation_proof: dict[str, Any] = {}
+    capture_failure: ReproError | None = None
+    teardown_errors: list[str] = []
+    runner_started = False
+    try:
+        runner.start()
+        runner_started = True
+        if capsule is not None:
+            lifecycle = capsule_lifecycle_plan(capsule, workspace, [])
+            setup = lifecycle[0]
+            setup = dataclasses.replace(setup, timeout_seconds=args.transition_timeout)
+            require_success(runner.run(setup))
+            kastctl, config, installation_proof = verify_capsule_install(capsule, workspace)
+            idea_host = dataclasses.replace(
+                lifecycle[1],
+                timeout_seconds=args.transition_timeout,
+            )
+            require_success(runner.run(idea_host))
+            config = read_config(kastctl, workspace, capsule.environment)
+            installation_proof["readOnlyAuthorities"] = {
+                "bundleSource": str(capsule.bundle_source),
+                "ideaHost": str(capsule.idea_host),
+                "workspaceRoot": str(workspace),
+            }
+        else:
+            kastctl = discover_developer_cli(kast, workspace)
+            config = read_config(kastctl, workspace)
+        (output / "config-before.json").write_text(
+            json.dumps(config, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        telemetry_path, idea_log_path = log_paths(config)
+        telemetry_offset = file_size(telemetry_path)
+        trace_offset = file_size(idea_log_path)
+        require_success(runner.run(
+            CommandSpec(
+                "telemetry-enable",
+                (
+                    str(kastctl), "--output", "json", "config", "set", "telemetry.enabled", "true",
+                    "--workspace-root", str(workspace),
+                ),
+            )
+        ))
+        require_success(runner.run(
+            CommandSpec(
+                "telemetry-verbose",
+                (
+                    str(kastctl), "--output", "json", "config", "set", "telemetry.detail", "verbose",
+                    "--workspace-root", str(workspace),
+                ),
+            )
+        ))
+        if args.restart_runtime or capsule is not None:
+            runner.run(
+                CommandSpec(
+                    "runtime-stop",
+                    (
+                        str(kastctl), "--output", "json", "developer", "runtime", "stop",
+                        "--workspace-root", str(workspace),
+                    ),
+                    timeout_seconds=args.transition_timeout,
+                )
+            )
+            cold_up = next(spec for spec in plan if spec.name == "cold-up")
+            cold_observer = next(spec for spec in plan if spec.name == "cold-observer")
+            up_active = runner.begin(cold_up)
+            observer_active = runner.begin(cold_observer)
+            runner.finish(observer_active)
+            runner.finish(up_active)
+        else:
+            runner.run(CommandSpec("warm-up", (kast, "up"), timeout_seconds=args.transition_timeout))
+        for spec in plan:
+            if spec.name in {"cold-up", "cold-observer", "refresh", "refresh-observer"}:
+                continue
+            runner.run(spec)
+        refresh = next(spec for spec in plan if spec.name == "refresh")
+        observer = next(spec for spec in plan if spec.name == "refresh-observer")
+        refresh_active = runner.begin(refresh)
+        observer_active = runner.begin(observer)
+        runner.finish(observer_active)
+        runner.finish(refresh_active)
+    except ReproError as error:
+        capture_failure = error
+    except OSError as error:
+        capture_failure = ReproError(str(error))
+    except KeyboardInterrupt:
+        capture_failure = ReproError("capture interrupted")
+    finally:
+        capsule_proof: dict[str, Any] | None = None
+        if capsule is not None:
+            observed_processes: set[int] = set()
+            try:
+                observed_processes = capsule_processes(capsule.root)
+            except ReproError as error:
+                teardown_errors.append(str(error))
+            stop_exit_code = 125
+            if runner_started and capsule.kastctl.is_file():
+                try:
+                    stopped = runner.run(
+                        CommandSpec(
+                            "capsule-runtime-stop",
+                            (
+                                str(capsule.kastctl),
+                                "--output",
+                                "json",
+                                "developer",
+                                "runtime",
+                                "stop",
+                                "--workspace-root",
+                                str(workspace),
+                            ),
+                            timeout_seconds=args.transition_timeout,
+                        )
+                    )
+                    stop_exit_code = stopped.exitCode
+                except ReproError as error:
+                    teardown_errors.append(str(error))
+            if runner_started:
+                runner.close()
+            try:
+                remaining_candidates = capsule_processes(capsule.root, observed_processes)
+                terminated, remaining = terminate_capsule_processes(remaining_candidates)
+            except ReproError as error:
+                teardown_errors.append(str(error))
+                terminated = []
+                remaining = sorted(observed_processes)
+            state_keys = (
+                "HOME",
+                "KAST_HOME",
+                "KAST_CONFIG_HOME",
+                "KAST_CACHE_HOME",
+                "GRADLE_USER_HOME",
+                "TMPDIR",
+                "XDG_CACHE_HOME",
+                "XDG_CONFIG_HOME",
+                "XDG_DATA_HOME",
+            )
+            state_contained = all(
+                is_within(Path(capsule.environment[key]), capsule.root) for key in state_keys
+            )
+            capsule_proof = {
+                **capsule.public(),
+                **installation_proof,
+                "stateContained": state_contained,
+                "runtimeStopExitCode": stop_exit_code,
+                "observedProcessIds": sorted(observed_processes),
+                "terminatedProcessIds": terminated,
+                "processesRemaining": remaining,
+                "runtimeStopSucceeded": stop_exit_code == 0,
+                "runtimeStopped": not remaining,
+                "rootDeleted": False,
+            }
+            runner.record(
+                "capsule-teardown-verify",
+                ["internal:verify-no-capsule-processes", str(capsule.root)],
+                capsule_proof,
+                0 if capsule_proof["runtimeStopped"] and state_contained else 1,
+            )
+        elif runner_started:
+            if kastctl is not None and config is not None:
+                for spec in config_restore_specs(kastctl, workspace, config):
+                    try:
+                        runner.run(spec)
+                    except ReproError:
+                        pass
+            runner.close()
+
+        if telemetry_path is None:
+            (output / "telemetry.jsonl").write_text("", encoding="utf-8")
+        else:
+            copy_delta(telemetry_path, telemetry_offset, output / "telemetry.jsonl")
+        if idea_log_path is None:
+            (output / "idea-trace.log").write_text("", encoding="utf-8")
+        else:
+            copy_delta(idea_log_path, trace_offset, output / "idea-trace.log")
+        write_manifest(output, workspace, session, runner.commands, capsule_proof)
+
+        if (
+            capsule is not None
+            and capsule.mode == "EPHEMERAL"
+            and capsule_proof is not None
+            and capsule_proof["runtimeStopped"] is True
+            and capsule_proof.get("installationContained") is True
+            and capsule_proof["stateContained"] is True
+            and capture_failure is None
+            and not teardown_errors
+        ):
+            temp_root = Path("/private/tmp").resolve()
+            if (
+                capsule.root.parent.resolve() != temp_root
+                or not capsule.root.name.startswith("kast-capsule-")
+            ):
+                teardown_errors.append("refused to delete an unrecognized ephemeral capsule root")
+            else:
+                try:
+                    shutil.rmtree(capsule.root)
+                    capsule_proof["rootDeleted"] = not capsule.root.exists()
+                    if not capsule_proof["rootDeleted"]:
+                        teardown_errors.append("ephemeral capsule root still exists after deletion")
+                    write_manifest(output, workspace, session, runner.commands, capsule_proof)
+                except OSError as error:
+                    teardown_errors.append(f"ephemeral capsule cleanup failed: {error}")
+
+    if capture_failure is not None or teardown_errors:
+        details = [str(capture_failure)] if capture_failure is not None else []
+        details.extend(teardown_errors)
+        raise ReproError(f"capture retained evidence at {output}: {'; '.join(details)}")
+    report, exit_code = analyze(output)
+    report["evidenceDirectory"] = str(output)
+    if args.keep_session:
+        report["tmuxSession"] = session
+    print(json.dumps(report, indent=2))
+    return exit_code
+
+
+def read_manifest(directory: Path) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    manifest_path = directory / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReproError(f"invalid evidence manifest: {error}") from error
+    if manifest.get("schemaVersion") != SCHEMA_VERSION:
+        raise ReproError(f"unsupported evidence schema: {manifest.get('schemaVersion')!r}")
+    commands = manifest.get("commands")
+    if not isinstance(commands, list):
+        raise ReproError("evidence manifest commands must be an array")
+    indexed: dict[str, dict[str, Any]] = {}
+    for command in commands:
+        if not isinstance(command, dict) or not isinstance(command.get("name"), str):
+            raise ReproError("every evidence command must have a string name")
+        indexed[command["name"]] = command
+    return manifest, indexed
+
+
+def transcript(directory: Path, command: dict[str, Any]) -> str:
+    relative = command.get("transcript")
+    if not isinstance(relative, str) or not relative:
+        raise ReproError(f"command {command.get('name')} has no transcript")
+    path = (directory / relative).resolve()
+    if directory.resolve() not in path.parents:
+        raise ReproError(f"command {command.get('name')} transcript escapes the evidence directory")
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise ReproError(f"cannot read transcript for {command.get('name')}: {error}") from error
+
+
+def overlaps(first: dict[str, Any], second: dict[str, Any]) -> bool:
+    values = (
+        first.get("startedAtEpochMillis"), first.get("finishedAtEpochMillis"),
+        second.get("startedAtEpochMillis"), second.get("finishedAtEpochMillis"),
+    )
+    if not all(isinstance(value, int) and not isinstance(value, bool) for value in values):
+        raise ReproError("command timing fields must be integers")
+    return values[0] < values[3] and values[2] < values[1]
+
+
+def ready_sample_before(observer_text: str, finished_at_epoch_millis: int) -> bool:
+    sample_pattern = re.compile(
+        r"(?ms)^__KAST_SAMPLE__=\d+\n(.*?)(?=^__KAST_SAMPLE__=\d+\n|\Z)"
+    )
+    timestamp_pattern = re.compile(r"(?m)^__KAST_SAMPLE_EPOCH_MILLIS__=(\d+)$")
+    for sample in sample_pattern.findall(observer_text):
+        timestamp = timestamp_pattern.search(sample)
+        if (
+            timestamp is not None
+            and int(timestamp.group(1)) < finished_at_epoch_millis
+            and re.search(r"(?m)^ready: true$", sample)
+        ):
+            return True
+    return False
+
+
+def telemetry_missing_fields(directory: Path, manifest: dict[str, Any]) -> list[str]:
+    relative = manifest.get("telemetry")
+    if not isinstance(relative, str):
+        return ["runtimeInstanceId", "semanticGenerationStart", "semanticGenerationEnd", "dumbModeState", "typedOutcome"]
+    path = (directory / relative).resolve()
+    if directory.resolve() not in path.parents or not path.is_file():
+        return ["runtimeInstanceId", "semanticGenerationStart", "semanticGenerationEnd", "dumbModeState", "typedOutcome"]
+    attributes: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict) and isinstance(value.get("attributes"), dict):
+            attributes.append(value["attributes"])
+    aliases = {
+        "runtimeInstanceId": {"runtimeInstanceId", "kast.runtime.instance_id"},
+        "semanticGenerationStart": {"semanticGenerationStart", "startGeneration", "kast.semantic.generation.start"},
+        "semanticGenerationEnd": {"semanticGenerationEnd", "endGeneration", "kast.semantic.generation.end"},
+        "dumbModeState": {"dumbModeState", "kast.idea.dumb_mode"},
+        "typedOutcome": {"typedOutcome", "outcome", "errorCode", "kast.outcome.code"},
+    }
+    missing_by_request = [
+        [name for name, keys in aliases.items() if not keys & set(item)]
+        for item in attributes
+    ]
+    return min(missing_by_request, key=len) if missing_by_request else list(aliases)
+
+
+def analyze(directory: Path) -> tuple[dict[str, Any], int]:
+    directory = directory.resolve(strict=True)
+    manifest, commands = read_manifest(directory)
+    findings: list[Finding] = []
+    cold_up = commands.get("cold-up")
+    cold_observer = commands.get("cold-observer")
+    if cold_up and cold_observer and overlaps(cold_up, cold_observer):
+        observer_text = transcript(directory, cold_observer)
+        finished_at = cold_up.get("finishedAtEpochMillis")
+        if isinstance(finished_at, int) and ready_sample_before(observer_text, finished_at):
+            findings.append(
+                Finding(
+                    FindingCode.READY_DURING_PENDING_UP.value,
+                    "The public home reported READY while `kast up` was still pending.",
+                    ["transcripts/cold-up.txt", "transcripts/cold-observer.txt"],
+                )
+            )
+    refresh = commands.get("refresh")
+    refresh_observer = commands.get("refresh-observer")
+    if refresh and refresh.get("exitCode") != 0:
+        findings.append(
+            Finding(
+                FindingCode.REFRESH_DID_NOT_CONVERGE.value,
+                "Focused refresh did not converge to a successful semantic result.",
+                [str(refresh.get("transcript"))],
+            )
+        )
+    if refresh_observer:
+        observer_text = transcript(directory, refresh_observer)
+        if "error: CONFLICT" in observer_text and "Run `kast --help`" in observer_text:
+            findings.append(
+                Finding(
+                    FindingCode.GENERIC_CONFLICT_DURING_REFRESH.value,
+                    "A semantic read during refresh returned generic CONFLICT guidance.",
+                    [str(refresh_observer.get("transcript"))],
+                )
+            )
+    framing_evidence: list[str] = []
+    for command in commands.values():
+        text = transcript(directory, command)
+        marker = text.find(EXIT_SENTINEL)
+        if marker > 0 and text[marker - 1] != "\n":
+            framing_evidence.append(str(command.get("transcript")))
+    if framing_evidence:
+        findings.append(
+            Finding(
+                FindingCode.MISSING_TRAILING_NEWLINE.value,
+                "One or more CLI results were not newline-terminated in the tmux PTY.",
+                sorted(framing_evidence),
+            )
+        )
+    oversized = [
+        f"{name}:{command.get('outputBytes')}"
+        for name, command in commands.items()
+        if name in {"graph-nodes", "graph-topology", "graph-communities"}
+        and isinstance(command.get("outputBytes"), int)
+        and command["outputBytes"] > DEFAULT_OUTPUT_BUDGET_BYTES
+    ]
+    if oversized:
+        findings.append(
+            Finding(
+                FindingCode.DEFAULT_OUTPUT_EXCEEDS_BUDGET.value,
+                f"Default graph output exceeded the {DEFAULT_OUTPUT_BUDGET_BYTES}-byte agent budget.",
+                sorted(oversized),
+            )
+        )
+    missing = telemetry_missing_fields(directory, manifest)
+    if missing:
+        findings.append(
+            Finding(
+                FindingCode.TRACE_CORRELATION_INCOMPLETE.value,
+                "Telemetry cannot correlate a request with runtime, generation movement, dumb mode, and typed outcome.",
+                missing,
+            )
+        )
+    capsule = manifest.get("capsule")
+    if isinstance(capsule, dict):
+        confinement_evidence: list[str] = []
+        if capsule.get("installationContained") is not True:
+            confinement_evidence.extend(str(value) for value in capsule.get("escapedPaths", []))
+        if capsule.get("stateContained") is not True:
+            confinement_evidence.append("stateContained=false")
+        if capsule.get("mode") == "EPHEMERAL" and capsule.get("rootDeleted") is not True:
+            confinement_evidence.append("rootDeleted=false")
+        if confinement_evidence:
+            findings.append(
+                Finding(
+                    FindingCode.CAPSULE_CONFINEMENT_VIOLATED.value,
+                    "The capsule did not prove that installation and mutable state remained confined.",
+                    confinement_evidence,
+                )
+            )
+        remaining = capsule.get("processesRemaining")
+        terminated = capsule.get("terminatedProcessIds")
+        forced_cleanup = terminated if isinstance(terminated, list) else []
+        if (
+            capsule.get("runtimeStopped") is not True
+            or not isinstance(remaining, list)
+            or remaining
+            or forced_cleanup
+        ):
+            leak_evidence = (
+                [str(value) for value in remaining]
+                if isinstance(remaining, list)
+                else ["process proof missing"]
+            )
+            leak_evidence.extend(f"forced-cleanup:{value}" for value in forced_cleanup)
+            if capsule.get("runtimeStopped") is not True and not leak_evidence:
+                leak_evidence.append("runtimeStopped=false")
+            findings.append(
+                Finding(
+                    FindingCode.CAPSULE_PROCESS_LEAKED.value,
+                    "The capsule did not prove that every observed runtime process terminated.",
+                    leak_evidence,
+                )
+            )
+        if capsule.get("runtimeStopSucceeded") is not True:
+            findings.append(
+                Finding(
+                    FindingCode.CAPSULE_RUNTIME_STOP_FAILED.value,
+                    "The public runtime stop command failed before capsule process cleanup completed.",
+                    ["transcripts/capsule-runtime-stop.txt"],
+                )
+            )
+    findings.sort(key=lambda finding: finding.code)
+    report = {
+        "schemaVersion": SCHEMA_VERSION,
+        "status": "OBSERVATIONS_REPRODUCED" if findings else "PASS",
+        "workspaceRoot": manifest.get("workspaceRoot"),
+        "sessionName": manifest.get("sessionName"),
+        "findingCount": len(findings),
+        "findings": [dataclasses.asdict(finding) for finding in findings],
+    }
+    return report, 1 if findings else 0
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(
+        description="Capture a real Kast CLI session in tmux and replay its incident evidence offline.",
+    )
+    commands = root.add_subparsers(dest="command", required=True)
+    capture_parser = commands.add_parser("capture", help="run the live tmux scenario and write an evidence bundle")
+    capture_parser.add_argument("--workspace-root", type=Path, default=Path.cwd())
+    capture_parser.add_argument("--file", required=True, help="workspace-relative Kotlin file used by focused operations")
+    capture_parser.add_argument("--symbol", required=True, help="compiler-resolvable fully qualified Kotlin symbol")
+    capture_parser.add_argument("--output-dir", type=Path)
+    capture_parser.add_argument("--session-name")
+    capture_parser.add_argument("--kast", default="kast")
+    capsule_group = capture_parser.add_mutually_exclusive_group()
+    capsule_group.add_argument(
+        "--capsule-root",
+        type=Path,
+        help="reuse an explicit directory that owns the Kast install, state, and runtime",
+    )
+    capsule_group.add_argument(
+        "--ephemeral-capsule",
+        action="store_true",
+        help="create an isolated capsule, prove process teardown, then delete it",
+    )
+    capture_parser.add_argument(
+        "--bundle-source",
+        type=Path,
+        help="setup bundle archive; defaults to an active-version archive under build/setup",
+    )
+    capture_parser.add_argument(
+        "--idea-host",
+        type=Path,
+        help="read-only supported IntelliJ IDEA or Android Studio .app used by the isolated indexer",
+    )
+    capture_parser.add_argument("--samples", type=int, default=20)
+    capture_parser.add_argument("--sample-interval", type=float, default=1.0)
+    capture_parser.add_argument("--transition-timeout", type=float, default=420.0)
+    capture_parser.add_argument("--restart-runtime", action="store_true", help="stop the exact-root runtime and cold-start it with KAST_IDEA_TRACE=true")
+    capture_parser.add_argument("--exercise-plans", action="store_true", help="exercise mutation planning and invalid apply/recover without applying a valid plan")
+    capture_parser.add_argument("--keep-session", action="store_true", help="leave the completed tmux session available for attachment")
+    capture_parser.add_argument("--dry-run", action="store_true", help="print the command matrix without touching tmux or Kast state")
+    analyze_parser = commands.add_parser("analyze", help="replay an existing evidence bundle without a live runtime")
+    analyze_parser.add_argument("--evidence-dir", type=Path, required=True)
+    analyze_parser.add_argument("--format", choices=("human", "json"), default="human")
+    return root
+
+
+def validate_numeric_arguments(args: argparse.Namespace) -> None:
+    if getattr(args, "samples", 1) <= 0:
+        raise ReproError("--samples must be positive")
+    if getattr(args, "sample_interval", 1.0) < 0:
+        raise ReproError("--sample-interval must be non-negative")
+    if getattr(args, "transition_timeout", 1.0) <= 0:
+        raise ReproError("--transition-timeout must be positive")
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        validate_numeric_arguments(args)
+        if args.command == "capture":
+            return capture(args)
+        report, exit_code = analyze(args.evidence_dir)
+        if args.format == "json":
+            print(json.dumps(report, indent=2))
+        else:
+            print(f"{report['status']}: {report['findingCount']} finding(s)")
+            for finding in report["findings"]:
+                print(f"- {finding['code']}: {finding['message']}")
+        return exit_code
+    except ReproError as error:
+        print(json.dumps({"schemaVersion": SCHEMA_VERSION, "status": "INVALID_EVIDENCE", "error": str(error)}), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -60,6 +60,11 @@ REQUIRED_SCENARIO_COMMANDS = (
     "workspace-refresh",
     "refresh-observer",
 )
+REQUIRED_SUCCESSFUL_SCENARIO_COMMANDS = tuple(
+    name
+    for name in REQUIRED_SCENARIO_COMMANDS
+    if name not in {"workspace-refresh", "refresh-observer"}
+)
 
 
 class ReproError(Exception):
@@ -1510,6 +1515,31 @@ def read_manifest(directory: Path) -> tuple[dict[str, Any], dict[str, dict[str, 
         raise ReproError(f"unsupported evidence schema: {manifest.get('schemaVersion')!r}")
     if "capsule" in manifest and not isinstance(manifest["capsule"], dict):
         raise ReproError("evidence manifest capsule proof must be an object")
+    capsule = manifest.get("capsule")
+    if isinstance(capsule, dict):
+        mode = capsule.get("mode")
+        if mode not in {"PERSISTENT", "EPHEMERAL"}:
+            raise ReproError("evidence manifest capsule mode is invalid")
+        for field in (
+            "installationContained",
+            "stateContained",
+            "runtimeStopSucceeded",
+            "runtimeStopped",
+            "rootDeleted",
+        ):
+            if not isinstance(capsule.get(field), bool):
+                raise ReproError(f"evidence manifest capsule {field} must be a boolean")
+        for field in ("terminatedProcessIds", "processesRemaining"):
+            process_ids = capsule.get(field)
+            if not isinstance(process_ids, list) or not all(
+                isinstance(process_id, int)
+                and not isinstance(process_id, bool)
+                and process_id >= 0
+                for process_id in process_ids
+            ):
+                raise ReproError(
+                    f"evidence manifest capsule {field} must be an array of process IDs"
+                )
     commands = manifest.get("commands")
     if not isinstance(commands, list):
         raise ReproError("evidence manifest commands must be an array")
@@ -1668,6 +1698,21 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
         raise ReproError(
             "evidence manifest is missing required scenario commands: "
             + ", ".join(missing_commands)
+        )
+    failed_commands = sorted(
+        name
+        for name in REQUIRED_SUCCESSFUL_SCENARIO_COMMANDS
+        if (
+            not isinstance(commands[name].get("exitCode"), int)
+            or isinstance(commands[name].get("exitCode"), bool)
+            or commands[name].get("exitCode") != 0
+            or commands[name].get("timedOut") is not False
+        )
+    )
+    if failed_commands:
+        raise ReproError(
+            "required scenario commands did not complete successfully: "
+            + ", ".join(failed_commands)
         )
     findings: list[Finding] = []
     cold_up = commands.get("cold-up")

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -606,6 +606,7 @@ class TmuxCapture:
         completion_wrapper = (
             "import subprocess,time;"
             f"status=subprocess.run(['/bin/bash','-lc',{command!r}]).returncode;"
+            "status=128-status if status<0 else status;"
             "completed_at=time.time_ns()//1000000;"
             f"print({completion_marker!r}+str(status)+':'+str(completed_at),flush=True)"
         )
@@ -831,6 +832,14 @@ def read_config(
         raise ReproError("config discovery did not return a JSON object")
     if payload.get("ok") is not True:
         raise ReproError("config discovery did not return ok=true")
+    effective = payload.get("effective")
+    if not isinstance(effective, dict):
+        raise ReproError("config discovery field effective was not a JSON object")
+    for field in ("indexer", "paths", "telemetry"):
+        if field in effective and not isinstance(effective[field], dict):
+            raise ReproError(
+                f"config discovery field effective.{field} was not a JSON object"
+            )
     return payload
 
 

--- a/.github/scripts/runtime/kast-cli-repro.py
+++ b/.github/scripts/runtime/kast-cli-repro.py
@@ -42,6 +42,7 @@ class FindingCode(str, enum.Enum):
     CAPSULE_CONFINEMENT_VIOLATED = "CAPSULE_CONFINEMENT_VIOLATED"
     CAPSULE_PROCESS_LEAKED = "CAPSULE_PROCESS_LEAKED"
     CAPSULE_RUNTIME_STOP_FAILED = "CAPSULE_RUNTIME_STOP_FAILED"
+    OBSERVER_EVIDENCE_INCOMPLETE = "OBSERVER_EVIDENCE_INCOMPLETE"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -79,6 +80,7 @@ class CommandEvidence:
     timedOut: bool
     transcript: str
     outputBytes: int
+    completionToken: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -564,6 +566,7 @@ class TmuxCapture:
             timedOut=timed_out,
             transcript=str(transcript_path.relative_to(self.evidence)),
             outputBytes=len(transcript.encode("utf-8")),
+            completionToken=active.completion_token,
         )
         self.commands.append(evidence)
         if not self.keep_session or timed_out:
@@ -930,43 +933,60 @@ def capsule_processes(root: Path, seeds: dict[int, str] | None = None) -> dict[i
     return {pid: table[pid][1] for pid in owned}
 
 
-def alive_processes(process_ids: set[int]) -> set[int]:
-    alive: set[int] = set()
-    for process_id in process_ids:
-        try:
-            os.kill(process_id, 0)
-        except ProcessLookupError:
-            continue
-        except PermissionError as error:
-            raise ReproError(f"cannot prove capsule process ownership for PID {process_id}") from error
-        alive.add(process_id)
-    return alive
-
-
-def wait_for_process_exit(process_ids: set[int], seconds: float) -> set[int]:
+def signal_capsule_processes(
+    root: Path,
+    known: dict[int, str],
+    process_signal: signal.Signals,
+    seconds: float,
+) -> tuple[set[int], dict[int, str], dict[int, str]]:
     deadline = time.monotonic() + seconds
-    remaining = alive_processes(process_ids)
-    while remaining and time.monotonic() < deadline:
+    targeted: set[int] = set()
+    stable_empty_scans = 0
+    remaining = capsule_processes(root, known)
+    while True:
+        known.update(remaining)
+        for process_id in set(remaining) - targeted:
+            try:
+                os.kill(process_id, process_signal)
+            except ProcessLookupError:
+                pass
+            except PermissionError as error:
+                raise ReproError(
+                    f"cannot terminate capsule-owned PID {process_id}"
+                ) from error
+            targeted.add(process_id)
+        if remaining:
+            stable_empty_scans = 0
+            if time.monotonic() >= deadline:
+                break
+        else:
+            stable_empty_scans += 1
+            if stable_empty_scans >= 2:
+                break
         time.sleep(0.1)
-        remaining = alive_processes(remaining)
-    return remaining
+        remaining = capsule_processes(root, known)
+    return targeted, known, remaining
 
 
-def terminate_capsule_processes(process_ids: set[int]) -> tuple[list[int], list[int]]:
-    targeted = sorted(alive_processes(process_ids))
-    for process_id in targeted:
-        try:
-            os.kill(process_id, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-    remaining = wait_for_process_exit(set(targeted), 5.0)
-    for process_id in remaining:
-        try:
-            os.kill(process_id, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-    remaining = wait_for_process_exit(remaining, 2.0)
-    return targeted, sorted(remaining)
+def terminate_capsule_processes(
+    root: Path,
+    observed: dict[int, str],
+) -> tuple[list[int], list[int]]:
+    terminated, known, remaining = signal_capsule_processes(
+        root,
+        dict(observed),
+        signal.SIGTERM,
+        5.0,
+    )
+    if remaining:
+        killed, _, remaining = signal_capsule_processes(
+            root,
+            known,
+            signal.SIGKILL,
+            2.0,
+        )
+        terminated.update(killed)
+    return sorted(terminated), sorted(remaining)
 
 
 def config_restore_specs(kastctl: Path, workspace: Path, config: dict[str, Any]) -> list[CommandSpec]:
@@ -987,6 +1007,21 @@ def config_restore_specs(kastctl: Path, workspace: Path, config: dict[str, Any])
             argv = (*base, "unset", key, "--workspace-root", str(workspace))
         specs.append(CommandSpec(f"restore-{leaf}", argv))
     return specs
+
+
+def restore_config(
+    runner: TmuxCapture,
+    kastctl: Path,
+    workspace: Path,
+    config: dict[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    for spec in config_restore_specs(kastctl, workspace, config):
+        try:
+            require_success(runner.run(spec))
+        except ReproError as error:
+            errors.append(str(error))
+    return errors
 
 
 def log_paths(config: dict[str, Any]) -> tuple[Path, Path]:
@@ -1262,7 +1297,10 @@ def capture(args: argparse.Namespace) -> int:
                 runner.close()
             try:
                 remaining_candidates = capsule_processes(capsule.root, observed_processes)
-                terminated, remaining = terminate_capsule_processes(set(remaining_candidates))
+                terminated, remaining = terminate_capsule_processes(
+                    capsule.root,
+                    remaining_candidates,
+                )
             except ReproError as error:
                 teardown_errors.append(str(error))
                 terminated = []
@@ -1301,11 +1339,7 @@ def capture(args: argparse.Namespace) -> int:
             )
         elif runner_started:
             if kastctl is not None and config is not None:
-                for spec in config_restore_specs(kastctl, workspace, config):
-                    try:
-                        runner.run(spec)
-                    except ReproError:
-                        pass
+                teardown_errors.extend(restore_config(runner, kastctl, workspace, config))
             runner.close()
 
         if telemetry_path is None:
@@ -1468,6 +1502,36 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
     findings: list[Finding] = []
     cold_up = commands.get("cold-up")
     cold_observer = commands.get("cold-observer")
+    refresh = commands.get("workspace-refresh")
+    refresh_observer = commands.get("refresh-observer")
+    incomplete_observers: list[str] = []
+    for operation, observer, observer_name in (
+        (cold_up, cold_observer, "cold-observer"),
+        (refresh, refresh_observer, "refresh-observer"),
+    ):
+        if operation is None:
+            continue
+        if observer is None:
+            incomplete_observers.append(f"missing:{observer_name}")
+            continue
+        observer_text = transcript(directory, observer)
+        observation_kinds = {
+            kind for kind, _, _ in timed_observations(observer_text)
+        }
+        if (
+            observer.get("exitCode") != 0
+            or observer.get("timedOut") is True
+            or observation_kinds != {"HOME", "RESOLVE"}
+        ):
+            incomplete_observers.append(str(observer.get("transcript")))
+    if incomplete_observers:
+        findings.append(
+            Finding(
+                FindingCode.OBSERVER_EVIDENCE_INCOMPLETE.value,
+                "Transition observer evidence was missing, unsuccessful, or incomplete.",
+                sorted(incomplete_observers),
+            )
+        )
     if cold_up and (cold_up.get("exitCode") != 0 or cold_up.get("timedOut") is True):
         findings.append(
             Finding(
@@ -1487,8 +1551,6 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
                     ["transcripts/cold-up.txt", "transcripts/cold-observer.txt"],
                 )
             )
-    refresh = commands.get("workspace-refresh")
-    refresh_observer = commands.get("refresh-observer")
     if refresh and refresh.get("exitCode") != 0:
         findings.append(
             Finding(
@@ -1511,7 +1573,10 @@ def analyze(directory: Path) -> tuple[dict[str, Any], int]:
     framing_evidence: list[str] = []
     for command in commands.values():
         text = transcript(directory, command)
-        marker = text.find(EXIT_SENTINEL)
+        completion_token = command.get("completionToken")
+        if not isinstance(completion_token, str) or not completion_token:
+            continue
+        marker = text.find(f"{EXIT_SENTINEL}{completion_token}:")
         if marker > 0 and text[marker - 1] != "\n":
             framing_evidence.append(str(command.get("transcript")))
     if framing_evidence:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -45,6 +45,66 @@ REQUIRED_SCENARIO_COMMANDS = (
 )
 
 
+def scenario_argv(name: str) -> list[str]:
+    direct = {
+        "runtime-stop": [
+            "kastctl", "--output", "json", "developer", "runtime", "stop",
+            "--workspace-root", "/tmp/workspace",
+        ],
+        "capsule-runtime-stop": [
+            "kastctl", "--output", "json", "developer", "runtime", "stop",
+            "--workspace-root", "/tmp/workspace",
+        ],
+        "home": ["kast"],
+        "help": ["kast", "--help"],
+        "file-list": ["kast", "file", "list", "--match", "src/Probe.kt"],
+        "symbol-search": ["kast", "symbol", "search", "--query", "example.Probe"],
+        "symbol-resolve": ["kast", "symbol", "resolve", "--query", "example.Probe"],
+        "graph-summary": ["kast", "graph", "summary", "--scope", "symbol"],
+        "graph-nodes": ["kast", "graph", "nodes"],
+        "graph-topology": ["kast", "graph", "topology", "--scope", "symbol"],
+        "graph-communities": ["kast", "graph", "communities", "--scope", "symbol"],
+        "diagnostic-check": ["kast", "diagnostic", "check", "--file", "src/Probe.kt"],
+        "workspace-refresh": ["kast", "workspace", "refresh", "--file", "src/Probe.kt"],
+        "cold-up": ["kast", "workspace", "ensure"],
+    }
+    if name in direct:
+        return direct[name]
+    issued = {
+        "symbol-show": "symbol show",
+        "relation-references": "relation references",
+        "relation-calls-incoming": "relation calls incoming",
+        "relation-calls-outgoing": "relation calls outgoing",
+        "relation-implementations": "relation implementations",
+        "relation-hierarchy-supertypes": "relation hierarchy supertypes",
+        "relation-hierarchy-subtypes": "relation hierarchy subtypes",
+        "graph-impact": "graph impact",
+    }
+    if name in issued:
+        return [
+            "/bin/bash",
+            "-lc",
+            f"resolved=$(kast --output json symbol resolve --query example.Probe); "
+            f"selector=example-selector; kast {issued[name]} --selector \"$selector\"",
+        ]
+    if name == "graph-neighbors":
+        return [
+            "/bin/bash",
+            "-lc",
+            "nodes=$(kast --output json graph nodes); "
+            "node_selector=example-node; kast graph neighbors --node-selector \"$node_selector\"",
+        ]
+    if name in {"cold-observer", "refresh-observer"}:
+        return [
+            "/bin/bash",
+            "-lc",
+            "printf __KAST_OBSERVATION__=HOME; kast; "
+            "printf __KAST_OBSERVATION__=RESOLVE; "
+            "kast symbol resolve --query example.Probe",
+        ]
+    return ["kast", name]
+
+
 def load_runner_module():
     module_name = "kast_cli_repro_contract_subject"
     existing = sys.modules.get(module_name)
@@ -97,7 +157,7 @@ class KastCliReproContractTest(unittest.TestCase):
             path.write_text(text, encoding="utf-8")
             return {
                 "name": name,
-                "argv": ["kast", name],
+                "argv": scenario_argv(name),
                 "startedAtEpochMillis": started,
                 "finishedAtEpochMillis": finished,
                 "exitCode": exit_code,
@@ -267,7 +327,7 @@ class KastCliReproContractTest(unittest.TestCase):
         manifest["commands"].append(
             {
                 "name": name,
-                "argv": ["kastctl", name],
+                "argv": scenario_argv(name),
                 "startedAtEpochMillis": started,
                 "finishedAtEpochMillis": finished,
                 "exitCode": exit_code,
@@ -1070,6 +1130,32 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual("INVALID_EVIDENCE", error["status"])
             self.assertIn("graph-topology", error["error"])
 
+    def test_required_command_requires_operation_bound_argv(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            topology = next(
+                command for command in manifest["commands"]
+                if command["name"] == "graph-topology"
+            )
+            topology["argv"] = ["kast", "--help"]
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("graph-topology", error["error"])
+
     def test_required_command_requires_exact_nonce_bound_completion_frame(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -1480,7 +1566,7 @@ class KastCliReproContractTest(unittest.TestCase):
         for relative_symlink in (Path("kast-home"), Path("kast-home/releases")):
             with (
                 self.subTest(relative_symlink=relative_symlink),
-                tempfile.TemporaryDirectory(dir="/private/tmp") as raw_directory,
+                tempfile.TemporaryDirectory() as raw_directory,
             ):
                 base = Path(raw_directory)
                 root = base / "capsule"
@@ -1512,6 +1598,7 @@ class KastCliReproContractTest(unittest.TestCase):
                         "discover_idea_host",
                         return_value=base / "idea-host",
                     ),
+                    mock.patch.object(runner.os, "fsencode", return_value=b"short"),
                     self.assertRaisesRegex(runner.ReproError, "state .* escaped"),
                 ):
                     runner.build_capsule(args, workspace, "kast", dry_run=False)
@@ -1539,6 +1626,10 @@ class KastCliReproContractTest(unittest.TestCase):
             with self.assertRaisesRegex(runner.ReproError, "symlink escaped"):
                 runner.require_contained_capsule_state_symlinks(root, state_paths)
 
+    @unittest.skipUnless(
+        Path("/private/tmp").is_dir(),
+        "macOS /private/tmp is required for ephemeral capsule allocation",
+    )
     def test_ephemeral_capsule_is_removed_when_post_allocation_validation_fails(self) -> None:
         runner = load_runner_module()
         with tempfile.TemporaryDirectory() as raw_directory:
@@ -1916,6 +2007,15 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertIn("KAST_REPRO_OBSERVER_STOP", cold_observer["argv"][-1])
             self.assertNotIn("for i in $(seq", cold_observer["argv"][-1])
             by_name = {command["name"]: command for command in plan["commands"]}
+            runner = load_runner_module()
+            for required_name in REQUIRED_SCENARIO_COMMANDS:
+                self.assertTrue(
+                    runner.required_command_argv_is_valid(
+                        required_name,
+                        by_name[required_name]["argv"],
+                    ),
+                    required_name,
+                )
             for stateful_name in (
                 "telemetry-enable",
                 "telemetry-verbose",
@@ -1938,6 +2038,7 @@ class KastCliReproContractTest(unittest.TestCase):
                 ["symbol", "resolve", "--query", "example.Probe"],
                 by_name["symbol-resolve"]["argv"][1:],
             )
+
             self.assertEqual(
                 ["workspace", "ensure"],
                 by_name["cold-up"]["argv"][1:],
@@ -1981,6 +2082,29 @@ class KastCliReproContractTest(unittest.TestCase):
                 }.issubset(names),
                 names,
             )
+
+    def test_observer_deadlines_include_post_operation_handshake_grace(self) -> None:
+        runner = load_runner_module()
+        plan = runner.command_plan(
+            "kast",
+            "src/Probe.kt",
+            "example.Probe",
+            restart_runtime=True,
+            mutation_probe=None,
+            samples=20,
+            sample_interval=1.0,
+            transition_timeout=420.0,
+        )
+        by_name = {command.name: command for command in plan}
+
+        self.assertGreater(
+            by_name["cold-observer"].timeout_seconds,
+            by_name["cold-up"].timeout_seconds,
+        )
+        self.assertGreater(
+            by_name["refresh-observer"].timeout_seconds,
+            by_name["workspace-refresh"].timeout_seconds,
+        )
 
     def test_mutation_plan_probe_rejects_non_top_level_symbol_queries(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -88,9 +88,11 @@ class KastCliReproContractTest(unittest.TestCase):
                     "cold-observer",
                     "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\n"
                     "ready: true\nruntime: READY\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=200\n"
                     "__KAST_OBSERVATION__=RESOLVE\n"
                     "next[2]: kast refresh,kast symbol find <query>\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n"
                     "unterminated::kast-repro-exit=0\n",
                     started=120,
@@ -109,10 +111,12 @@ class KastCliReproContractTest(unittest.TestCase):
                     "refresh-observer",
                     "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\n"
                     "ready: false\nruntime: INDEXING\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=650\n"
                     "__KAST_OBSERVATION__=RESOLVE\nerror: CONFLICT\n"
                     "message: Semantic operation started while the workspace was not READY\n"
                     "next: \"Run `kast --help` for valid commands and arguments.\"\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=1\n"
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=700\n"
                     "::kast-repro-exit=0\n",
                     started=620,
@@ -136,20 +140,24 @@ class KastCliReproContractTest(unittest.TestCase):
                 command(
                     "cold-observer",
                     "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: false\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=125\n"
                     "__KAST_OBSERVATION__=RESOLVE\nresult: missing\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=126\n::kast-repro-exit=0\n",
-                    started=120,
+                    started=105,
                     finished=130,
                 ),
                 command("workspace-refresh", terminated, started=200, finished=210),
                 command(
                     "refresh-observer",
                     "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: true\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=225\n"
                     "__KAST_OBSERVATION__=RESOLVE\nresult: resolved\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=226\n::kast-repro-exit=0\n",
-                    started=220,
+                    started=205,
                     finished=230,
                 ),
                 command("graph-nodes", terminated, started=300, finished=310, output_bytes=2_000),
@@ -281,8 +289,10 @@ class KastCliReproContractTest(unittest.TestCase):
             observer["finishedAtEpochMillis"] = 300
             (directory / observer["transcript"]).write_text(
                 "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: true\n"
+                "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                 "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n"
                 "__KAST_OBSERVATION__=RESOLVE\n"
+                "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                 "__KAST_OBSERVATION_EPOCH_MILLIS__=260\n"
                 f"::kast-repro-exit={observer['completionToken']}:0:300\n",
                 encoding="utf-8",
@@ -385,6 +395,87 @@ class KastCliReproContractTest(unittest.TestCase):
                     ["OBSERVER_EVIDENCE_INCOMPLETE"],
                     [finding["code"] for finding in json.loads(result.stdout)["findings"]],
                 )
+
+    def test_missing_transition_operation_cannot_replay_as_clean(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["commands"] = []
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            self.assertEqual("INVALID_EVIDENCE", json.loads(result.stderr)["status"])
+
+    def test_failed_observer_subcommand_cannot_replay_as_clean(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            observer = next(
+                command for command in manifest["commands"]
+                if command["name"] == "cold-observer"
+            )
+            transcript_path = directory / str(observer["transcript"])
+            transcript_path.write_text(
+                transcript_path.read_text(encoding="utf-8").replace(
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n",
+                    "__KAST_OBSERVATION_EXIT_CODE__=127\n",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            self.assertEqual(
+                ["OBSERVER_EVIDENCE_INCOMPLETE"],
+                [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+            )
+
+    def test_non_overlapping_observer_cannot_replay_as_clean(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            observer = next(
+                command for command in manifest["commands"]
+                if command["name"] == "cold-observer"
+            )
+            observer["startedAtEpochMillis"] = 120
+            observer["finishedAtEpochMillis"] = 130
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            self.assertEqual(
+                ["OBSERVER_EVIDENCE_INCOMPLETE"],
+                [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+            )
 
     def test_new_descendant_is_rescanned_during_forced_teardown(self) -> None:
         runner = load_runner_module()
@@ -493,9 +584,11 @@ class KastCliReproContractTest(unittest.TestCase):
             observer["finishedAtEpochMillis"] = 260
             (directory / observer["transcript"]).write_text(
                 "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: false\n"
+                "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                 "__KAST_OBSERVATION_EPOCH_MILLIS__=205\n"
                 "__KAST_OBSERVATION__=RESOLVE\nerror: CONFLICT\n"
                 "next: Run `kast --help`\n"
+                "__KAST_OBSERVATION_EXIT_CODE__=1\n"
                 "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n"
                 f"::kast-repro-exit={observer['completionToken']}:0:260\n",
                 encoding="utf-8",
@@ -562,6 +655,10 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual(
                 2,
                 cold_observer["argv"][-1].count("__KAST_OBSERVATION_EPOCH_MILLIS__"),
+            )
+            self.assertEqual(
+                2,
+                cold_observer["argv"][-1].count("__KAST_OBSERVATION_EXIT_CODE__"),
             )
             by_name = {command["name"]: command for command in plan["commands"]}
             self.assertEqual(
@@ -646,6 +743,37 @@ class KastCliReproContractTest(unittest.TestCase):
                         "--exercise-plans requires a top-level declaration from the --file package",
                         result.stderr,
                     )
+
+    def test_mutation_plan_chooses_an_absent_probe_path(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            workspace = Path(raw_directory)
+            source = workspace / "src" / "Probe.kt"
+            source.parent.mkdir(parents=True)
+            source.write_text("package example\nclass Probe\n", encoding="utf-8")
+            occupied = source.parent / "KastCliReproProbe.kt"
+            occupied.write_text("package example\nobject Existing\n", encoding="utf-8")
+
+            result = self.run_runner(
+                "capture",
+                "--workspace-root",
+                str(workspace),
+                "--file",
+                "src/Probe.kt",
+                "--symbol",
+                "example.Probe",
+                "--exercise-plans",
+                "--dry-run",
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            plan = json.loads(result.stdout)
+            add_file = next(
+                command for command in plan["commands"]
+                if command["name"] == "change-plan-add-file"
+            )
+            probe_path = workspace / add_file["argv"][-1]
+            self.assertNotEqual(occupied, probe_path)
+            self.assertFalse(probe_path.exists())
 
     def test_capsule_process_ownership_requires_a_path_boundary(self) -> None:
         runner = load_runner_module()

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 from unittest import mock
 from pathlib import Path
+from typing import Any
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
@@ -217,6 +218,37 @@ class KastCliReproContractTest(unittest.TestCase):
             encoding="utf-8",
         )
 
+    def append_command_evidence(
+        self,
+        directory: Path,
+        manifest: dict[str, Any],
+        name: str,
+        *,
+        exit_code: int = 0,
+    ) -> None:
+        completion_token = f"contract-{name}"
+        started = 2_000 + len(manifest["commands"]) * 20
+        finished = started + 10
+        transcript_path = directory / "transcripts" / f"{name}.txt"
+        transcript = (
+            "result: ok\n"
+            f"::kast-repro-exit={completion_token}:{exit_code}:{finished}\n"
+        )
+        transcript_path.write_text(transcript, encoding="utf-8")
+        manifest["commands"].append(
+            {
+                "name": name,
+                "argv": ["kastctl", name],
+                "startedAtEpochMillis": started,
+                "finishedAtEpochMillis": finished,
+                "exitCode": exit_code,
+                "timedOut": False,
+                "completionToken": completion_token,
+                "transcript": str(transcript_path.relative_to(directory)),
+                "outputBytes": len(transcript.encode()),
+            }
+        )
+
     def test_incident_evidence_emits_stable_findings(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -268,6 +300,12 @@ class KastCliReproContractTest(unittest.TestCase):
                 "processesRemaining": [],
                 "rootDeleted": True,
             }
+            self.append_command_evidence(
+                directory,
+                manifest,
+                "capsule-runtime-stop",
+                exit_code=1,
+            )
             manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
             result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")
@@ -295,6 +333,7 @@ class KastCliReproContractTest(unittest.TestCase):
                 "processesRemaining": [],
                 "rootDeleted": True,
             }
+            self.append_command_evidence(directory, manifest, "capsule-runtime-stop")
             manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
             result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")
@@ -617,6 +656,43 @@ class KastCliReproContractTest(unittest.TestCase):
                 self.assertEqual("INVALID_EVIDENCE", error["status"])
                 self.assertIn("workspace-refresh", error["error"])
 
+    def test_transition_timeout_preserves_findings_without_an_exact_frame(self) -> None:
+        for retained_frame in (False, True):
+            with (
+                self.subTest(retained_frame=retained_frame),
+                tempfile.TemporaryDirectory() as raw_directory,
+            ):
+                directory = Path(raw_directory)
+                self.write_evidence(directory, incident=False)
+                manifest_path = directory / "manifest.json"
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                refresh = next(
+                    command
+                    for command in manifest["commands"]
+                    if command["name"] == "workspace-refresh"
+                )
+                refresh["exitCode"] = 124
+                refresh["timedOut"] = True
+                if not retained_frame:
+                    (directory / str(refresh["transcript"])).write_text(
+                        "partial output before timeout\n",
+                        encoding="utf-8",
+                    )
+                manifest_path.write_text(
+                    json.dumps(manifest, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+
+                result = self.run_runner(
+                    "analyze", "--evidence-dir", str(directory), "--format", "json"
+                )
+
+                self.assertEqual(1, result.returncode, result.stderr)
+                self.assertEqual(
+                    ["REFRESH_DID_NOT_CONVERGE"],
+                    [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+                )
+
     def test_nonobject_manifest_is_structured_invalid_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -700,6 +776,7 @@ class KastCliReproContractTest(unittest.TestCase):
                 "processesRemaining": [],
                 "rootDeleted": True,
             }
+            self.append_command_evidence(directory, manifest, "capsule-runtime-stop")
             manifest["commands"] = [
                 command
                 for command in manifest["commands"]
@@ -720,6 +797,74 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual("INVALID_EVIDENCE", error["status"])
             self.assertIn("cold-observer", error["error"])
             self.assertIn("cold-up", error["error"])
+
+    def test_capsule_replay_requires_runtime_stop_command(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["capsule"] = {
+                "mode": "EPHEMERAL",
+                "installationContained": True,
+                "stateContained": True,
+                "runtimeStopSucceeded": True,
+                "runtimeStopped": True,
+                "terminatedProcessIds": [],
+                "processesRemaining": [],
+                "rootDeleted": True,
+            }
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("capsule-runtime-stop", error["error"])
+
+    def test_capsule_stop_proof_matches_captured_command_status(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["capsule"] = {
+                "mode": "EPHEMERAL",
+                "installationContained": True,
+                "stateContained": True,
+                "runtimeStopSucceeded": True,
+                "runtimeStopped": True,
+                "terminatedProcessIds": [],
+                "processesRemaining": [],
+                "rootDeleted": True,
+            }
+            self.append_command_evidence(
+                directory,
+                manifest,
+                "capsule-runtime-stop",
+                exit_code=1,
+            )
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("runtimeStopSucceeded", error["error"])
 
     def test_required_command_requires_completion_token(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -141,10 +141,10 @@ class KastCliReproContractTest(unittest.TestCase):
                     "cold-observer",
                     "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: false\n"
                     "__KAST_OBSERVATION_EXIT_CODE__=0\n"
-                    "__KAST_OBSERVATION_EPOCH_MILLIS__=125\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=108\n"
                     "__KAST_OBSERVATION__=RESOLVE\nresult: missing\n"
                     "__KAST_OBSERVATION_EXIT_CODE__=0\n"
-                    "__KAST_OBSERVATION_EPOCH_MILLIS__=126\n::kast-repro-exit=0\n",
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=109\n::kast-repro-exit=0\n",
                     started=105,
                     finished=130,
                 ),
@@ -153,10 +153,10 @@ class KastCliReproContractTest(unittest.TestCase):
                     "refresh-observer",
                     "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: true\n"
                     "__KAST_OBSERVATION_EXIT_CODE__=0\n"
-                    "__KAST_OBSERVATION_EPOCH_MILLIS__=225\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=208\n"
                     "__KAST_OBSERVATION__=RESOLVE\nresult: resolved\n"
                     "__KAST_OBSERVATION_EXIT_CODE__=0\n"
-                    "__KAST_OBSERVATION_EPOCH_MILLIS__=226\n::kast-repro-exit=0\n",
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=209\n::kast-repro-exit=0\n",
                     started=205,
                     finished=230,
                 ),
@@ -288,10 +288,16 @@ class KastCliReproContractTest(unittest.TestCase):
             observer["startedAtEpochMillis"] = 120
             observer["finishedAtEpochMillis"] = 300
             (directory / observer["transcript"]).write_text(
-                "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: true\n"
+                "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: false\n"
+                "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                "__KAST_OBSERVATION_EPOCH_MILLIS__=150\n"
+                "__KAST_OBSERVATION__=RESOLVE\nresult: missing\n"
+                "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                "__KAST_OBSERVATION_EPOCH_MILLIS__=160\n"
+                "__KAST_SAMPLE__=2\n__KAST_OBSERVATION__=HOME\nready: true\n"
                 "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                 "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n"
-                "__KAST_OBSERVATION__=RESOLVE\n"
+                "__KAST_OBSERVATION__=RESOLVE\nresult: resolved\n"
                 "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                 "__KAST_OBSERVATION_EPOCH_MILLIS__=260\n"
                 f"::kast-repro-exit={observer['completionToken']}:0:300\n",
@@ -450,6 +456,34 @@ class KastCliReproContractTest(unittest.TestCase):
                 [finding["code"] for finding in json.loads(result.stdout)["findings"]],
             )
 
+    def test_unexpected_typed_observer_failure_cannot_replay_as_clean(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest = json.loads((directory / "manifest.json").read_text(encoding="utf-8"))
+            observer = next(
+                command for command in manifest["commands"]
+                if command["name"] == "cold-observer"
+            )
+            transcript_path = directory / str(observer["transcript"])
+            transcript_path.write_text(
+                transcript_path.read_text(encoding="utf-8").replace(
+                    "result: missing\n__KAST_OBSERVATION_EXIT_CODE__=0\n",
+                    "error: INTERNAL\n__KAST_OBSERVATION_EXIT_CODE__=1\n",
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            self.assertEqual(
+                ["OBSERVER_EVIDENCE_INCOMPLETE"],
+                [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+            )
+
     def test_non_overlapping_observer_cannot_replay_as_clean(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -464,6 +498,34 @@ class KastCliReproContractTest(unittest.TestCase):
             observer["finishedAtEpochMillis"] = 130
             manifest_path.write_text(
                 json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            self.assertEqual(
+                ["OBSERVER_EVIDENCE_INCOMPLETE"],
+                [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+            )
+
+    def test_observer_without_a_sample_during_transition_cannot_replay_as_clean(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            observer = next(
+                command for command in manifest["commands"]
+                if command["name"] == "cold-observer"
+            )
+            transcript_path = directory / str(observer["transcript"])
+            transcript_path.write_text(
+                transcript_path.read_text(encoding="utf-8")
+                .replace("__KAST_OBSERVATION_EPOCH_MILLIS__=108", "__KAST_OBSERVATION_EPOCH_MILLIS__=125")
+                .replace("__KAST_OBSERVATION_EPOCH_MILLIS__=109", "__KAST_OBSERVATION_EPOCH_MILLIS__=126"),
                 encoding="utf-8",
             )
 

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -573,6 +573,28 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual("INVALID_EVIDENCE", error["status"])
             self.assertNotIn("Traceback", result.stderr)
 
+    def test_nonobject_capsule_proof_is_structured_invalid_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["capsule"] = []
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("capsule", error["error"])
+
     def test_failed_observer_subcommand_cannot_replay_as_clean(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -322,6 +322,7 @@ class KastCliReproContractTest(unittest.TestCase):
             manifest["capsule"] = {
                 "mode": "EPHEMERAL",
                 "installationContained": True,
+                "escapedPaths": [],
                 "stateContained": True,
                 "runtimeStopSucceeded": False,
                 "runtimeStopped": True,
@@ -355,6 +356,7 @@ class KastCliReproContractTest(unittest.TestCase):
             manifest["capsule"] = {
                 "mode": "EPHEMERAL",
                 "installationContained": True,
+                "escapedPaths": [],
                 "stateContained": True,
                 "runtimeStopSucceeded": True,
                 "runtimeStopped": True,
@@ -878,6 +880,7 @@ class KastCliReproContractTest(unittest.TestCase):
             manifest["capsule"] = {
                 "mode": "EPHEMERAL",
                 "installationContained": True,
+                "escapedPaths": [],
                 "stateContained": True,
                 "runtimeStopSucceeded": True,
                 "runtimeStopped": True,
@@ -898,6 +901,48 @@ class KastCliReproContractTest(unittest.TestCase):
             error = json.loads(result.stderr)
             self.assertEqual("INVALID_EVIDENCE", error["status"])
             self.assertIn("terminatedProcessIds", error["error"])
+
+    def test_capsule_escaped_paths_must_be_an_array_of_path_strings(self) -> None:
+        for escaped_paths in (None, [""], [42]):
+            with (
+                self.subTest(escaped_paths=escaped_paths),
+                tempfile.TemporaryDirectory() as raw_directory,
+            ):
+                directory = Path(raw_directory)
+                self.write_evidence(directory, incident=False)
+                manifest_path = directory / "manifest.json"
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                manifest["capsule"] = {
+                    "mode": "EPHEMERAL",
+                    "installationContained": False,
+                    "escapedPaths": escaped_paths,
+                    "stateContained": True,
+                    "runtimeStopSucceeded": True,
+                    "runtimeStopped": True,
+                    "terminatedProcessIds": [],
+                    "processesRemaining": [],
+                    "rootDeleted": True,
+                }
+                self.append_command_evidence(
+                    directory,
+                    manifest,
+                    "capsule-runtime-stop",
+                )
+                manifest_path.write_text(
+                    json.dumps(manifest, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+
+                result = self.run_runner(
+                    "analyze", "--evidence-dir", str(directory), "--format", "json"
+                )
+
+                self.assertEqual(2, result.returncode)
+                self.assertEqual("", result.stdout)
+                error = json.loads(result.stderr)
+                self.assertEqual("INVALID_EVIDENCE", error["status"])
+                self.assertIn("escapedPaths", error["error"])
+                self.assertNotIn("Traceback", result.stderr)
 
     def test_replay_requires_runtime_stop_and_cold_transition_commands(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
@@ -937,6 +982,7 @@ class KastCliReproContractTest(unittest.TestCase):
             manifest["capsule"] = {
                 "mode": "EPHEMERAL",
                 "installationContained": True,
+                "escapedPaths": [],
                 "stateContained": True,
                 "runtimeStopSucceeded": True,
                 "runtimeStopped": True,
@@ -968,6 +1014,7 @@ class KastCliReproContractTest(unittest.TestCase):
             manifest["capsule"] = {
                 "mode": "EPHEMERAL",
                 "installationContained": True,
+                "escapedPaths": [],
                 "stateContained": True,
                 "runtimeStopSucceeded": True,
                 "runtimeStopped": True,
@@ -1788,6 +1835,47 @@ class KastCliReproContractTest(unittest.TestCase):
                 ["TRACE_CORRELATION_INCOMPLETE"],
                 [finding["code"] for finding in json.loads(result.stdout)["findings"]],
             )
+
+    def test_telemetry_correlation_requires_valid_attribute_values(self) -> None:
+        valid = {
+            "runtimeInstanceId": "runtime-1",
+            "semanticGenerationStart": 4,
+            "semanticGenerationEnd": 4,
+            "dumbModeState": "SMART",
+            "typedOutcome": "RESOLVED",
+        }
+        invalid_values = (
+            ("runtimeInstanceId", None),
+            ("runtimeInstanceId", ""),
+            ("semanticGenerationStart", True),
+            ("semanticGenerationEnd", "4"),
+            ("dumbModeState", []),
+            ("typedOutcome", {}),
+        )
+        for field, invalid in invalid_values:
+            with (
+                self.subTest(field=field, invalid=invalid),
+                tempfile.TemporaryDirectory() as raw_directory,
+            ):
+                directory = Path(raw_directory)
+                self.write_evidence(directory, incident=False)
+                record = {"attributes": {**valid, field: invalid}}
+                (directory / "telemetry.jsonl").write_text(
+                    json.dumps(record) + "\n",
+                    encoding="utf-8",
+                )
+
+                result = self.run_runner(
+                    "analyze", "--evidence-dir", str(directory), "--format", "json"
+                )
+
+                self.assertEqual(1, result.returncode, result.stderr)
+                report = json.loads(result.stdout)
+                self.assertEqual(
+                    ["TRACE_CORRELATION_INCOMPLETE"],
+                    [finding["code"] for finding in report["findings"]],
+                )
+                self.assertIn(field, report["findings"][0]["evidence"])
 
     def test_dry_run_covers_the_public_agent_surface(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -1119,6 +1119,35 @@ class KastCliReproContractTest(unittest.TestCase):
                 [finding["code"] for finding in json.loads(result.stdout)["findings"]],
             )
 
+    def test_conflict_text_requires_the_typed_rejection_exit_code(self) -> None:
+        for exit_code in (2, 139):
+            with self.subTest(exit_code=exit_code), tempfile.TemporaryDirectory() as raw_directory:
+                directory = Path(raw_directory)
+                self.write_evidence(directory, incident=False)
+                manifest = json.loads((directory / "manifest.json").read_text(encoding="utf-8"))
+                observer = next(
+                    command for command in manifest["commands"]
+                    if command["name"] == "cold-observer"
+                )
+                transcript_path = directory / str(observer["transcript"])
+                transcript_path.write_text(
+                    transcript_path.read_text(encoding="utf-8").replace(
+                        "result: missing\n__KAST_OBSERVATION_EXIT_CODE__=0\n",
+                        f"error: CONFLICT\n__KAST_OBSERVATION_EXIT_CODE__={exit_code}\n",
+                    ),
+                    encoding="utf-8",
+                )
+
+                result = self.run_runner(
+                    "analyze", "--evidence-dir", str(directory), "--format", "json"
+                )
+
+                self.assertEqual(1, result.returncode, result.stderr)
+                self.assertEqual(
+                    ["OBSERVER_EVIDENCE_INCOMPLETE"],
+                    [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+                )
+
     def test_non_overlapping_observer_cannot_replay_as_clean(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -1439,6 +1468,29 @@ class KastCliReproContractTest(unittest.TestCase):
                     self.assertRaisesRegex(runner.ReproError, "state .* escaped"),
                 ):
                     runner.build_capsule(args, workspace, "kast", dry_run=False)
+
+    def test_capsule_rejects_chained_symlink_escape_before_setup(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            base = Path(raw_directory)
+            root = base / "capsule"
+            root.mkdir()
+            environment = runner.capsule_environment(root, "workspace-id")
+            state_paths = runner.require_contained_capsule_state_paths(root, environment)
+            for state_path in state_paths:
+                state_path.mkdir(parents=True, exist_ok=True)
+            hidden = root / "hidden"
+            hidden.mkdir()
+            (root / "kast-home" / "current").symlink_to(
+                hidden,
+                target_is_directory=True,
+            )
+            external = base / "external"
+            external.mkdir()
+            (hidden / "config").symlink_to(external, target_is_directory=True)
+
+            with self.assertRaisesRegex(runner.ReproError, "symlink escaped"):
+                runner.require_contained_capsule_state_symlinks(root, state_paths)
 
     def test_ephemeral_capsule_is_removed_when_post_allocation_validation_fails(self) -> None:
         runner = load_runner_module()
@@ -1776,6 +1828,16 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertIn("KAST_REPRO_OBSERVER_STOP", cold_observer["argv"][-1])
             self.assertNotIn("for i in $(seq", cold_observer["argv"][-1])
             by_name = {command["name"]: command for command in plan["commands"]}
+            for stateful_name in (
+                "telemetry-enable",
+                "telemetry-verbose",
+                "runtime-stop",
+                "restore-enabled",
+                "restore-detail",
+                "restore-runtime-stop",
+                "restore-runtime-start",
+            ):
+                self.assertIn(stateful_name, by_name)
             self.assertEqual(
                 ["file", "list", "--match", "src/Probe.kt"],
                 by_name["file-list"]["argv"][1:],

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -340,6 +340,7 @@ class KastCliReproContractTest(unittest.TestCase):
                 100,
                 "nonce",
                 float("inf"),
+                300,
             )
             collision = subprocess.CompletedProcess(
                 [],
@@ -386,6 +387,7 @@ class KastCliReproContractTest(unittest.TestCase):
                 100,
                 "nonce",
                 100.0,
+                150,
             )
             pending = subprocess.CompletedProcess([], 0, "still running\n", "")
             late_completion = subprocess.CompletedProcess(
@@ -404,6 +406,42 @@ class KastCliReproContractTest(unittest.TestCase):
                 ),
                 mock.patch.object(runner.time, "monotonic", return_value=101.0),
                 mock.patch.object(runner.time, "sleep"),
+            ):
+                command = capture.finish(active)
+
+            self.assertTrue(command.timedOut)
+            self.assertEqual(124, command.exitCode)
+
+    def test_completion_recorded_after_the_deadline_is_timed_out(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            evidence = directory / "evidence"
+            (evidence / "transcripts").mkdir(parents=True)
+            capture = runner.TmuxCapture("session", directory, evidence, keep_session=False)
+            active = runner.ActiveCommand(
+                runner.CommandSpec("probe", ("kast", "symbol", "show")),
+                "%1",
+                100,
+                "nonce",
+                1_000.0,
+                200,
+            )
+            late_completion = subprocess.CompletedProcess(
+                [],
+                0,
+                "::kast-repro-exit=nonce:0:234\n",
+                "",
+            )
+            killed = subprocess.CompletedProcess([], 0, "", "")
+
+            with (
+                mock.patch.object(
+                    runner.subprocess,
+                    "run",
+                    side_effect=[late_completion, killed],
+                ),
+                mock.patch.object(runner.time, "monotonic", return_value=101.0),
             ):
                 command = capture.finish(active)
 
@@ -679,6 +717,41 @@ class KastCliReproContractTest(unittest.TestCase):
                 self.assertRaisesRegex(runner.ReproError, "escaped its root"),
             ):
                 runner.verify_capsule_install(capsule, root / "workspace")
+
+    def test_persistent_capsule_rejects_state_symlinks_before_setup(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory(dir="/private/tmp") as raw_directory:
+            base = Path(raw_directory)
+            root = base / "capsule"
+            root.mkdir()
+            external = base / "external-state"
+            external.mkdir()
+            (root / "kast-home").symlink_to(external, target_is_directory=True)
+            workspace = base / "workspace"
+            workspace.mkdir()
+            bundle = base / "bundle"
+            bundle.mkdir()
+            args = runner.argparse.Namespace(
+                capsule_root=root,
+                ephemeral_capsule=False,
+                bundle_source=bundle,
+                idea_host=None,
+            )
+
+            with (
+                mock.patch.object(
+                    runner,
+                    "discover_developer_cli",
+                    return_value=base / "bootstrap-kastctl",
+                ),
+                mock.patch.object(
+                    runner,
+                    "discover_idea_host",
+                    return_value=base / "idea-host",
+                ),
+                self.assertRaisesRegex(runner.ReproError, "state path escaped"),
+            ):
+                runner.build_capsule(args, workspace, "kast", dry_run=False)
 
     def test_failed_telemetry_restore_is_retained_as_teardown_error(self) -> None:
         runner = load_runner_module()
@@ -1080,6 +1153,71 @@ class KastCliReproContractTest(unittest.TestCase):
 
             build_capsule.assert_not_called()
             self.assertFalse(output.exists())
+
+    def test_existing_session_is_rejected_before_ephemeral_capsule_allocation(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            workspace = root / "workspace"
+            source = workspace / "src" / "Probe.kt"
+            source.parent.mkdir(parents=True)
+            source.write_text("package example\nclass Probe\n", encoding="utf-8")
+            args = runner.parser().parse_args(
+                [
+                    "capture",
+                    "--workspace-root",
+                    str(workspace),
+                    "--file",
+                    "src/Probe.kt",
+                    "--symbol",
+                    "example.Probe",
+                    "--session-name",
+                    "occupied",
+                    "--ephemeral-capsule",
+                ]
+            )
+
+            with (
+                mock.patch.object(runner.shutil, "which", return_value="/usr/bin/true"),
+                mock.patch.object(
+                    runner.subprocess,
+                    "run",
+                    return_value=subprocess.CompletedProcess([], 0, "", ""),
+                ),
+                mock.patch.object(runner, "build_capsule", return_value=None) as build_capsule,
+                self.assertRaisesRegex(runner.ReproError, "tmux session already exists"),
+            ):
+                runner.capture(args)
+
+            build_capsule.assert_not_called()
+
+    def test_missing_capture_paths_are_structured_invalid_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            cases = (
+                (root / "missing-workspace", "src/Probe.kt"),
+                (workspace, "src/Missing.kt"),
+            )
+            for missing_workspace, file_name in cases:
+                with self.subTest(workspace=missing_workspace, file=file_name):
+                    result = self.run_runner(
+                        "capture",
+                        "--workspace-root",
+                        str(missing_workspace),
+                        "--file",
+                        file_name,
+                        "--symbol",
+                        "example.Probe",
+                        "--dry-run",
+                    )
+
+                    self.assertEqual(2, result.returncode)
+                    self.assertEqual("", result.stdout)
+                    error = json.loads(result.stderr)
+                    self.assertEqual("INVALID_EVIDENCE", error["status"])
+                    self.assertNotIn("Traceback", result.stderr)
 
     def test_nonempty_output_is_rejected_before_ephemeral_capsule_allocation(self) -> None:
         runner = load_runner_module()

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -653,6 +653,104 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual("INVALID_EVIDENCE", error["status"])
             self.assertIn("terminatedProcessIds", error["error"])
 
+    def test_capsule_replay_requires_cold_transition_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["capsule"] = {
+                "mode": "EPHEMERAL",
+                "installationContained": True,
+                "stateContained": True,
+                "runtimeStopSucceeded": True,
+                "runtimeStopped": True,
+                "terminatedProcessIds": [],
+                "processesRemaining": [],
+                "rootDeleted": True,
+            }
+            manifest["commands"] = [
+                command
+                for command in manifest["commands"]
+                if command["name"] not in {"cold-up", "cold-observer"}
+            ]
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("cold-observer", error["error"])
+            self.assertIn("cold-up", error["error"])
+
+    def test_required_command_requires_completion_token(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            topology = next(
+                command
+                for command in manifest["commands"]
+                if command["name"] == "graph-topology"
+            )
+            topology.pop("completionToken")
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("graph-topology", error["error"])
+
+    def test_required_command_requires_exact_nonce_bound_completion_frame(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            topology = next(
+                command
+                for command in manifest["commands"]
+                if command["name"] == "graph-topology"
+            )
+            transcript_path = directory / str(topology["transcript"])
+            transcript_path.write_text(
+                transcript_path.read_text(encoding="utf-8").replace(
+                    str(topology["completionToken"]),
+                    "wrong-completion-token",
+                ),
+                encoding="utf-8",
+            )
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("graph-topology", error["error"])
+
     def test_failed_observer_subcommand_cannot_replay_as_clean(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -97,8 +97,9 @@ class KastCliReproContractTest(unittest.TestCase):
                 ),
                 command(
                     "refresh-observer",
-                    "ready: false\nruntime: INDEXING\nerror: CONFLICT\n"
+                    "__KAST_SAMPLE__=1\nready: false\nruntime: INDEXING\nerror: CONFLICT\n"
                     "message: Semantic operation started while the workspace was not READY\n"
+                    "__KAST_SAMPLE_EPOCH_MILLIS__=700\n"
                     "next: \"Run `kast --help` for valid commands and arguments.\"\n"
                     "::kast-repro-exit=0\n",
                     started=620,
@@ -278,6 +279,89 @@ class KastCliReproContractTest(unittest.TestCase):
             capture.finish.call_args_list,
         )
 
+    def test_command_completion_uses_a_nonce_and_the_wrapper_timestamp(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            evidence = directory / "evidence"
+            (evidence / "transcripts").mkdir(parents=True)
+            capture = runner.TmuxCapture("session", directory, evidence, keep_session=False)
+            active = runner.ActiveCommand(
+                runner.CommandSpec("probe", ("kast", "symbol", "show")),
+                "%1",
+                100,
+                "nonce",
+            )
+            collision = subprocess.CompletedProcess(
+                [],
+                0,
+                "source preview ::kast-repro-exit=9\n",
+                "",
+            )
+            completion = subprocess.CompletedProcess(
+                [],
+                0,
+                "source preview ::kast-repro-exit=9"
+                "::kast-repro-exit=nonce:0:234\n",
+                "",
+            )
+            killed = subprocess.CompletedProcess([], 0, "", "")
+
+            with (
+                mock.patch.object(
+                    runner.subprocess,
+                    "run",
+                    side_effect=[collision, completion, killed],
+                ),
+                mock.patch.object(runner.time, "sleep"),
+            ):
+                command = capture.finish(active)
+
+            self.assertEqual(0, command.exitCode)
+            self.assertEqual(234, command.finishedAtEpochMillis)
+
+    def test_failed_cold_start_is_not_a_green_replay(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            cold_up = next(command for command in manifest["commands"] if command["name"] == "cold-up")
+            cold_up["exitCode"] = 1
+            manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+            result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            self.assertEqual(
+                ["COLD_START_DID_NOT_CONVERGE"],
+                [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+            )
+
+    def test_conflict_after_refresh_completion_is_not_attributed_to_refresh(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            observer = next(
+                command for command in manifest["commands"] if command["name"] == "refresh-observer"
+            )
+            observer["startedAtEpochMillis"] = 205
+            observer["finishedAtEpochMillis"] = 260
+            (directory / observer["transcript"]).write_text(
+                "__KAST_SAMPLE__=1\nready: false\nerror: CONFLICT\n"
+                "next: Run `kast --help`\n"
+                "__KAST_SAMPLE_EPOCH_MILLIS__=250\n::kast-repro-exit=0\n",
+                encoding="utf-8",
+            )
+            manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+            result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual([], json.loads(result.stdout)["findings"])
+
     def test_telemetry_fields_distributed_across_requests_are_incomplete(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -385,6 +469,33 @@ class KastCliReproContractTest(unittest.TestCase):
                 }.issubset(names),
                 names,
             )
+
+    def test_mutation_plan_probe_rejects_non_top_level_symbol_queries(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            workspace = Path(raw_directory)
+            source = workspace / "src" / "Probe.kt"
+            source.parent.mkdir(parents=True)
+            source.write_text("package example\nclass Probe\n", encoding="utf-8")
+
+            for query in ("example.Widget.render()", "example.Widget.Nested"):
+                with self.subTest(query=query):
+                    result = self.run_runner(
+                        "capture",
+                        "--workspace-root",
+                        str(workspace),
+                        "--file",
+                        "src/Probe.kt",
+                        "--symbol",
+                        query,
+                        "--exercise-plans",
+                        "--dry-run",
+                    )
+
+                    self.assertEqual(2, result.returncode)
+                    self.assertIn(
+                        "--exercise-plans requires a top-level declaration from the --file package",
+                        result.stderr,
+                    )
 
     def test_capsule_process_ownership_requires_a_path_boundary(self) -> None:
         runner = load_runner_module()

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import importlib.util
 import json
 import subprocess
@@ -60,6 +61,11 @@ class KastCliReproContractTest(unittest.TestCase):
             exit_code: int = 0,
             output_bytes: int | None = None,
         ) -> dict[str, object]:
+            completion_token = f"contract-{name}"
+            completion_frame = (
+                f"::kast-repro-exit={completion_token}:{exit_code}:{finished}"
+            )
+            text = text.replace(f"::kast-repro-exit={exit_code}", completion_frame)
             path = transcripts / f"{name}.txt"
             path.write_text(text, encoding="utf-8")
             return {
@@ -69,6 +75,7 @@ class KastCliReproContractTest(unittest.TestCase):
                 "finishedAtEpochMillis": finished,
                 "exitCode": exit_code,
                 "timedOut": False,
+                "completionToken": completion_token,
                 "transcript": str(path.relative_to(directory)),
                 "outputBytes": output_bytes if output_bytes is not None else len(text.encode()),
             }
@@ -126,9 +133,25 @@ class KastCliReproContractTest(unittest.TestCase):
         else:
             commands = [
                 command("cold-up", terminated, started=100, finished=110),
-                command("cold-observer", "ready: false\n::kast-repro-exit=0\n", started=120, finished=130),
+                command(
+                    "cold-observer",
+                    "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: false\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=125\n"
+                    "__KAST_OBSERVATION__=RESOLVE\nresult: missing\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=126\n::kast-repro-exit=0\n",
+                    started=120,
+                    finished=130,
+                ),
                 command("workspace-refresh", terminated, started=200, finished=210),
-                command("refresh-observer", "ready: false\n::kast-repro-exit=0\n", started=220, finished=230),
+                command(
+                    "refresh-observer",
+                    "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: true\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=225\n"
+                    "__KAST_OBSERVATION__=RESOLVE\nresult: resolved\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=226\n::kast-repro-exit=0\n",
+                    started=220,
+                    finished=230,
+                ),
                 command("graph-nodes", terminated, started=300, finished=310, output_bytes=2_000),
             ]
             telemetry = {
@@ -260,7 +283,8 @@ class KastCliReproContractTest(unittest.TestCase):
                 "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: true\n"
                 "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n"
                 "__KAST_OBSERVATION__=RESOLVE\n"
-                "__KAST_OBSERVATION_EPOCH_MILLIS__=260\n::kast-repro-exit=0\n",
+                "__KAST_OBSERVATION_EPOCH_MILLIS__=260\n"
+                f"::kast-repro-exit={observer['completionToken']}:0:300\n",
                 encoding="utf-8",
             )
             manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
@@ -328,6 +352,116 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual(0, command.exitCode)
             self.assertEqual(234, command.finishedAtEpochMillis)
 
+    def test_incomplete_cold_observer_cannot_replay_as_clean(self) -> None:
+        for failure in ("failed-command", "missing-home"):
+            with self.subTest(failure=failure), tempfile.TemporaryDirectory() as raw_directory:
+                directory = Path(raw_directory)
+                self.write_evidence(directory, incident=False)
+                manifest_path = directory / "manifest.json"
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                observer = next(
+                    command for command in manifest["commands"]
+                    if command["name"] == "cold-observer"
+                )
+                if failure == "failed-command":
+                    observer["exitCode"] = 1
+                else:
+                    (directory / observer["transcript"]).write_text(
+                        "no parseable observations\n"
+                        f"::kast-repro-exit={observer['completionToken']}:0:130\n",
+                        encoding="utf-8",
+                    )
+                manifest_path.write_text(
+                    json.dumps(manifest, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+
+                result = self.run_runner(
+                    "analyze", "--evidence-dir", str(directory), "--format", "json"
+                )
+
+                self.assertEqual(1, result.returncode, result.stderr)
+                self.assertEqual(
+                    ["OBSERVER_EVIDENCE_INCOMPLETE"],
+                    [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+                )
+
+    def test_new_descendant_is_rescanned_during_forced_teardown(self) -> None:
+        runner = load_runner_module()
+        root = Path("/tmp/kast")
+        observed = {100: "java --state /tmp/kast/cache"}
+        rescans = [
+            observed,
+            {**observed, 101: "late-child"},
+            {101: "late-child"},
+            {},
+            {},
+        ]
+
+        with (
+            mock.patch.object(runner, "capsule_processes", side_effect=rescans),
+            mock.patch.object(runner.os, "kill") as kill,
+            mock.patch.object(runner.time, "sleep"),
+        ):
+            targeted, remaining = runner.terminate_capsule_processes(root, observed)
+
+        self.assertEqual([100, 101], targeted)
+        self.assertEqual([], remaining)
+        self.assertIn(mock.call(101, runner.signal.SIGTERM), kill.call_args_list)
+
+    def test_failed_telemetry_restore_is_retained_as_teardown_error(self) -> None:
+        runner = load_runner_module()
+        failed = runner.CommandEvidence(
+            name="restore-enabled",
+            argv=["kastctl"],
+            startedAtEpochMillis=1,
+            finishedAtEpochMillis=2,
+            exitCode=1,
+            timedOut=False,
+            transcript="transcripts/restore-enabled.txt",
+            outputBytes=0,
+        )
+        succeeded = dataclasses.replace(failed, name="restore-detail", exitCode=0)
+        capture = mock.Mock()
+        capture.run.side_effect = [failed, succeeded]
+        config = {
+            "mutableFields": [
+                {"key": "telemetry.enabled", "workspaceOverride": False},
+                {"key": "telemetry.detail", "workspaceOverride": False},
+            ],
+            "effective": {"telemetry": {"enabled": False, "detail": "normal"}},
+        }
+
+        errors = runner.restore_config(
+            capture,
+            Path("/tmp/kastctl"),
+            Path("/tmp/workspace"),
+            config,
+        )
+
+        self.assertEqual(1, len(errors))
+        self.assertIn("restore-enabled", errors[0])
+
+    def test_generic_exit_text_does_not_drive_newline_analysis(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest = json.loads((directory / "manifest.json").read_text(encoding="utf-8"))
+            command = next(item for item in manifest["commands"] if item["name"] == "graph-nodes")
+            (directory / command["transcript"]).write_text(
+                "source preview unterminated::kast-repro-exit=9\n"
+                "result: ok\n"
+                f"::kast-repro-exit={command['completionToken']}:0:310\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual([], json.loads(result.stdout)["findings"])
+
     def test_failed_cold_start_is_not_a_green_replay(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -362,7 +496,8 @@ class KastCliReproContractTest(unittest.TestCase):
                 "__KAST_OBSERVATION_EPOCH_MILLIS__=205\n"
                 "__KAST_OBSERVATION__=RESOLVE\nerror: CONFLICT\n"
                 "next: Run `kast --help`\n"
-                "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n::kast-repro-exit=0\n",
+                "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n"
+                f"::kast-repro-exit={observer['completionToken']}:0:260\n",
                 encoding="utf-8",
             )
             manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -436,6 +436,38 @@ class KastCliReproContractTest(unittest.TestCase):
         )
         capture.request_observer_completion.assert_called_once_with(observer)
 
+    def test_non_capsule_tmux_capture_snapshots_the_caller_environment(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            evidence = directory / "evidence"
+            (evidence / "transcripts").mkdir(parents=True)
+            caller_environment = {
+                "HOME": "/current/home",
+                "KAST_HOME": "/current/kast-home",
+                "KAST_CONFIG_HOME": "/current/kast-config",
+                "PATH": "/current/bin",
+            }
+            with mock.patch.dict(runner.os.environ, caller_environment, clear=True):
+                capture = runner.TmuxCapture(
+                    "session",
+                    directory,
+                    evidence,
+                    keep_session=False,
+                )
+
+            self.assertEqual(caller_environment, capture.base_environment)
+
+    def test_config_discovery_rejects_nonobject_json(self) -> None:
+        runner = load_runner_module()
+        response = subprocess.CompletedProcess([], 0, "[]\n", "")
+
+        with (
+            mock.patch.object(runner.subprocess, "run", return_value=response),
+            self.assertRaisesRegex(runner.ReproError, "JSON object"),
+        ):
+            runner.read_config(Path("/kastctl"), Path("/workspace"))
+
     def test_command_completion_uses_a_nonce_and_the_wrapper_timestamp(self) -> None:
         runner = load_runner_module()
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -264,6 +264,7 @@ class KastCliReproContractTest(unittest.TestCase):
                 "stateContained": True,
                 "runtimeStopSucceeded": False,
                 "runtimeStopped": True,
+                "terminatedProcessIds": [],
                 "processesRemaining": [],
                 "rootDeleted": True,
             }
@@ -558,6 +559,33 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual("INVALID_EVIDENCE", error["status"])
             self.assertIn("graph-topology", error["error"])
 
+    def test_failed_required_scenario_command_cannot_replay_as_clean(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            topology = next(
+                command for command in manifest["commands"]
+                if command["name"] == "graph-topology"
+            )
+            topology["exitCode"] = 1
+            topology["timedOut"] = True
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("graph-topology", error["error"])
+
     def test_nonobject_manifest_is_structured_invalid_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -594,6 +622,36 @@ class KastCliReproContractTest(unittest.TestCase):
             error = json.loads(result.stderr)
             self.assertEqual("INVALID_EVIDENCE", error["status"])
             self.assertIn("capsule", error["error"])
+
+    def test_incomplete_capsule_proof_is_structured_invalid_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["capsule"] = {
+                "mode": "EPHEMERAL",
+                "installationContained": True,
+                "stateContained": True,
+                "runtimeStopSucceeded": True,
+                "runtimeStopped": True,
+                "processesRemaining": [],
+                "rootDeleted": True,
+            }
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("terminatedProcessIds", error["error"])
 
     def test_failed_observer_subcommand_cannot_replay_as_clean(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -16,6 +16,29 @@ from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 RUNNER = Path(__file__).with_name("kast-cli-repro.py")
+REQUIRED_SCENARIO_COMMANDS = (
+    "home",
+    "help",
+    "file-list",
+    "symbol-search",
+    "symbol-resolve",
+    "symbol-show",
+    "relation-references",
+    "relation-calls-incoming",
+    "relation-calls-outgoing",
+    "relation-implementations",
+    "relation-hierarchy-supertypes",
+    "relation-hierarchy-subtypes",
+    "graph-summary",
+    "graph-nodes",
+    "graph-neighbors",
+    "graph-topology",
+    "graph-communities",
+    "graph-impact",
+    "diagnostic-check",
+    "workspace-refresh",
+    "refresh-observer",
+)
 
 
 def load_runner_module():
@@ -172,6 +195,14 @@ class KastCliReproContractTest(unittest.TestCase):
                     "typedOutcome": "RESOLVED",
                 },
             }
+
+        present = {item["name"] for item in commands}
+        for index, name in enumerate(REQUIRED_SCENARIO_COMMANDS):
+            if name not in present:
+                started = 1_200 + index * 20
+                commands.append(
+                    command(name, terminated, started=started, finished=started + 10)
+                )
 
         (directory / "telemetry.jsonl").write_text(json.dumps(telemetry) + "\n", encoding="utf-8")
         manifest = {
@@ -501,6 +532,46 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual(2, result.returncode)
             self.assertEqual("", result.stdout)
             self.assertEqual("INVALID_EVIDENCE", json.loads(result.stderr)["status"])
+
+    def test_missing_scenario_command_cannot_replay_as_clean(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["commands"] = [
+                command for command in manifest["commands"]
+                if command["name"] != "graph-topology"
+            ]
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("graph-topology", error["error"])
+
+    def test_nonobject_manifest_is_structured_invalid_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            (directory / "manifest.json").write_text("[]\n", encoding="utf-8")
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertNotIn("Traceback", result.stderr)
 
     def test_failed_observer_subcommand_cannot_replay_as_clean(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -3,15 +3,32 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
+import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 RUNNER = Path(__file__).with_name("kast-cli-repro.py")
+
+
+def load_runner_module():
+    module_name = "kast_cli_repro_contract_subject"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+    spec = importlib.util.spec_from_file_location(module_name, RUNNER)
+    if spec is None or spec.loader is None:
+        raise AssertionError("cannot load the Kast CLI reproduction runner")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 class KastCliReproContractTest(unittest.TestCase):
@@ -295,39 +312,175 @@ class KastCliReproContractTest(unittest.TestCase):
                 command for command in plan["commands"] if command["name"] == "cold-observer"
             )
             self.assertIn("__KAST_SAMPLE_EPOCH_MILLIS__", cold_observer["argv"][-1])
+            by_name = {command["name"]: command for command in plan["commands"]}
+            self.assertEqual(
+                ["file", "list", "--match", "src/Probe.kt"],
+                by_name["file-list"]["argv"][1:],
+            )
+            self.assertEqual(
+                ["symbol", "search", "--query", "example.Probe"],
+                by_name["symbol-search"]["argv"][1:],
+            )
+            self.assertEqual(
+                ["symbol", "resolve", "--query", "example.Probe"],
+                by_name["symbol-resolve"]["argv"][1:],
+            )
+            self.assertEqual(
+                ["workspace", "ensure"],
+                by_name["cold-up"]["argv"][1:],
+            )
+            symbol_show = by_name["symbol-show"]["argv"][-1]
+            graph_neighbors = by_name["graph-neighbors"]["argv"][-1]
+            self.assertIn("symbol resolve --query example.Probe", symbol_show)
+            self.assertIn('symbol show --selector "$selector"', symbol_show)
+            self.assertNotIn("--selector example.Probe", symbol_show)
+            self.assertIn("graph nodes", graph_neighbors)
+            self.assertIn('graph neighbors --node-selector "$node_selector"', graph_neighbors)
             self.assertTrue(
                 {
                     "home",
                     "help",
-                    "files",
-                    "symbol-find",
+                    "file-list",
+                    "symbol-search",
+                    "symbol-resolve",
                     "symbol-show",
-                    "symbol-refs",
-                    "symbol-callers",
-                    "symbol-callees",
-                    "symbol-implementations",
-                    "symbol-supertypes",
-                    "symbol-subtypes",
+                    "relation-references",
+                    "relation-calls-incoming",
+                    "relation-calls-outgoing",
+                    "relation-implementations",
+                    "relation-hierarchy-supertypes",
+                    "relation-hierarchy-subtypes",
                     "graph-summary",
                     "graph-nodes",
                     "graph-neighbors",
                     "graph-topology",
                     "graph-communities",
                     "graph-impact",
-                    "check",
-                    "change-rename",
-                    "change-add-file",
-                    "change-add-declaration",
-                    "change-replace",
-                    "apply-invalid",
-                    "recover-invalid",
-                    "refresh",
+                    "diagnostic-check",
+                    "change-plan-rename",
+                    "change-plan-add-file",
+                    "change-plan-add-declaration",
+                    "change-plan-replace",
+                    "workspace-refresh",
                     "refresh-observer",
                     "cold-up",
                     "cold-observer",
                 }.issubset(names),
                 names,
             )
+
+    def test_capsule_process_ownership_requires_a_path_boundary(self) -> None:
+        runner = load_runner_module()
+        root = Path("/tmp/kast")
+
+        self.assertTrue(runner.command_mentions_capsule_root("java --state /tmp/kast/cache", root))
+        self.assertFalse(
+            runner.command_mentions_capsule_root("java --state /tmp/kast-backup/cache", root)
+        )
+
+    def test_missing_tmux_is_rejected_before_ephemeral_capsule_allocation(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            workspace = Path(raw_directory)
+            source = workspace / "src" / "Probe.kt"
+            source.parent.mkdir(parents=True)
+            source.write_text("package example\nclass Probe\n", encoding="utf-8")
+            args = runner.parser().parse_args(
+                [
+                    "capture",
+                    "--workspace-root",
+                    str(workspace),
+                    "--file",
+                    "src/Probe.kt",
+                    "--symbol",
+                    "example.Probe",
+                    "--ephemeral-capsule",
+                ]
+            )
+
+            def executable(name: str):
+                return "/usr/bin/true" if name == "kast" else None
+
+            with (
+                mock.patch.object(runner.shutil, "which", side_effect=executable),
+                mock.patch.object(runner, "build_capsule", return_value=None) as build_capsule,
+                self.assertRaises(runner.ReproError),
+            ):
+                runner.capture(args)
+
+            build_capsule.assert_not_called()
+
+    def test_invalid_session_is_rejected_before_ephemeral_capsule_allocation(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            workspace = root / "workspace"
+            source = workspace / "src" / "Probe.kt"
+            source.parent.mkdir(parents=True)
+            source.write_text("package example\nclass Probe\n", encoding="utf-8")
+            output = root / "evidence"
+            args = runner.parser().parse_args(
+                [
+                    "capture",
+                    "--workspace-root",
+                    str(workspace),
+                    "--file",
+                    "src/Probe.kt",
+                    "--symbol",
+                    "example.Probe",
+                    "--output-dir",
+                    str(output),
+                    "--session-name",
+                    "invalid session",
+                    "--ephemeral-capsule",
+                ]
+            )
+
+            with (
+                mock.patch.object(runner.shutil, "which", return_value="/usr/bin/true"),
+                mock.patch.object(runner, "build_capsule", return_value=None) as build_capsule,
+                self.assertRaises(runner.ReproError),
+            ):
+                runner.capture(args)
+
+            build_capsule.assert_not_called()
+            self.assertFalse(output.exists())
+
+    def test_nonempty_output_is_rejected_before_ephemeral_capsule_allocation(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            workspace = root / "workspace"
+            source = workspace / "src" / "Probe.kt"
+            source.parent.mkdir(parents=True)
+            source.write_text("package example\nclass Probe\n", encoding="utf-8")
+            output = root / "evidence"
+            output.mkdir()
+            (output / "existing.txt").write_text("keep\n", encoding="utf-8")
+            args = runner.parser().parse_args(
+                [
+                    "capture",
+                    "--workspace-root",
+                    str(workspace),
+                    "--file",
+                    "src/Probe.kt",
+                    "--symbol",
+                    "example.Probe",
+                    "--output-dir",
+                    str(output),
+                    "--ephemeral-capsule",
+                ]
+            )
+
+            with (
+                mock.patch.object(runner.shutil, "which", return_value="/usr/bin/true"),
+                mock.patch.object(runner, "build_capsule", return_value=None) as build_capsule,
+                self.assertRaises(runner.ReproError),
+            ):
+                runner.capture(args)
+
+            build_capsule.assert_not_called()
+            self.assertEqual("keep\n", (output / "existing.txt").read_text(encoding="utf-8"))
 
     def test_ephemeral_capsule_plan_confines_install_state_and_teardown(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -1178,38 +1178,44 @@ class KastCliReproContractTest(unittest.TestCase):
 
     def test_persistent_capsule_rejects_state_symlinks_before_setup(self) -> None:
         runner = load_runner_module()
-        with tempfile.TemporaryDirectory(dir="/private/tmp") as raw_directory:
-            base = Path(raw_directory)
-            root = base / "capsule"
-            root.mkdir()
-            external = base / "external-state"
-            external.mkdir()
-            (root / "kast-home").symlink_to(external, target_is_directory=True)
-            workspace = base / "workspace"
-            workspace.mkdir()
-            bundle = base / "bundle"
-            bundle.mkdir()
-            args = runner.argparse.Namespace(
-                capsule_root=root,
-                ephemeral_capsule=False,
-                bundle_source=bundle,
-                idea_host=None,
-            )
-
+        for relative_symlink in (Path("kast-home"), Path("kast-home/releases")):
             with (
-                mock.patch.object(
-                    runner,
-                    "discover_developer_cli",
-                    return_value=base / "bootstrap-kastctl",
-                ),
-                mock.patch.object(
-                    runner,
-                    "discover_idea_host",
-                    return_value=base / "idea-host",
-                ),
-                self.assertRaisesRegex(runner.ReproError, "state path escaped"),
+                self.subTest(relative_symlink=relative_symlink),
+                tempfile.TemporaryDirectory(dir="/private/tmp") as raw_directory,
             ):
-                runner.build_capsule(args, workspace, "kast", dry_run=False)
+                base = Path(raw_directory)
+                root = base / "capsule"
+                root.mkdir()
+                external = base / "external-state"
+                external.mkdir()
+                symlink = root / relative_symlink
+                symlink.parent.mkdir(parents=True, exist_ok=True)
+                symlink.symlink_to(external, target_is_directory=True)
+                workspace = base / "workspace"
+                workspace.mkdir()
+                bundle = base / "bundle"
+                bundle.mkdir()
+                args = runner.argparse.Namespace(
+                    capsule_root=root,
+                    ephemeral_capsule=False,
+                    bundle_source=bundle,
+                    idea_host=None,
+                )
+
+                with (
+                    mock.patch.object(
+                        runner,
+                        "discover_developer_cli",
+                        return_value=base / "bootstrap-kastctl",
+                    ),
+                    mock.patch.object(
+                        runner,
+                        "discover_idea_host",
+                        return_value=base / "idea-host",
+                    ),
+                    self.assertRaisesRegex(runner.ReproError, "state .* escaped"),
+                ):
+                    runner.build_capsule(args, workspace, "kast", dry_run=False)
 
     def test_ephemeral_capsule_is_removed_when_post_allocation_validation_fails(self) -> None:
         runner = load_runner_module()
@@ -1256,7 +1262,7 @@ class KastCliReproContractTest(unittest.TestCase):
                 if allocated.exists():
                     allocated.rmdir()
 
-    def test_failed_telemetry_restore_is_retained_as_teardown_error(self) -> None:
+    def test_failed_telemetry_restore_stops_runtime_without_restarting(self) -> None:
         runner = load_runner_module()
         failed = runner.CommandEvidence(
             name="restore-enabled",
@@ -1269,8 +1275,9 @@ class KastCliReproContractTest(unittest.TestCase):
             outputBytes=0,
         )
         succeeded = dataclasses.replace(failed, name="restore-detail", exitCode=0)
+        stopped = dataclasses.replace(failed, name="restore-runtime-stop", exitCode=0)
         capture = mock.Mock()
-        capture.run.side_effect = [failed, succeeded]
+        capture.run.side_effect = [failed, succeeded, stopped]
         config = {
             "mutableFields": [
                 {"key": "telemetry.enabled", "workspaceOverride": False},
@@ -1279,15 +1286,68 @@ class KastCliReproContractTest(unittest.TestCase):
             "effective": {"telemetry": {"enabled": False, "detail": "normal"}},
         }
 
-        errors = runner.restore_config(
+        errors = runner.restore_config_and_runtime(
             capture,
             Path("/tmp/kastctl"),
+            "/tmp/kast",
             Path("/tmp/workspace"),
             config,
+            420.0,
         )
 
         self.assertEqual(1, len(errors))
         self.assertIn("restore-enabled", errors[0])
+        self.assertEqual(
+            ["restore-enabled", "restore-detail", "restore-runtime-stop"],
+            [call.args[0].name for call in capture.run.call_args_list],
+        )
+
+    def test_successful_telemetry_restore_restarts_runtime(self) -> None:
+        runner = load_runner_module()
+        succeeded = runner.CommandEvidence(
+            name="succeeded",
+            argv=["kastctl"],
+            startedAtEpochMillis=1,
+            finishedAtEpochMillis=2,
+            exitCode=0,
+            timedOut=False,
+            transcript="transcripts/succeeded.txt",
+            outputBytes=0,
+        )
+        capture = mock.Mock()
+        capture.run.return_value = succeeded
+        config = {
+            "mutableFields": [
+                {"key": "telemetry.enabled", "workspaceOverride": False},
+                {"key": "telemetry.detail", "workspaceOverride": False},
+            ],
+            "effective": {"telemetry": {"enabled": False, "detail": "normal"}},
+        }
+
+        errors = runner.restore_config_and_runtime(
+            capture,
+            Path("/tmp/kastctl"),
+            "/tmp/kast",
+            Path("/tmp/workspace"),
+            config,
+            420.0,
+        )
+
+        self.assertEqual([], errors)
+        specs = [call.args[0] for call in capture.run.call_args_list]
+        self.assertEqual(
+            [
+                "restore-enabled",
+                "restore-detail",
+                "restore-runtime-stop",
+                "restore-runtime-start",
+            ],
+            [spec.name for spec in specs],
+        )
+        self.assertEqual(
+            ("/tmp/kast", "workspace", "ensure"),
+            specs[-1].argv,
+        )
 
     def test_live_non_capsule_capture_requires_runtime_restart_authority(self) -> None:
         runner = load_runner_module()

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -87,7 +87,7 @@ class KastCliReproContractTest(unittest.TestCase):
                     finished=300,
                 ),
                 command(
-                    "refresh",
+                    "workspace-refresh",
                     "error: WORKSPACE_RECONCILIATION_REQUIRED\n"
                     "next: \"Run `kast --help` for valid commands and arguments.\"\n"
                     "::kast-repro-exit=1\n",
@@ -120,7 +120,7 @@ class KastCliReproContractTest(unittest.TestCase):
             commands = [
                 command("cold-up", terminated, started=100, finished=110),
                 command("cold-observer", "ready: false\n::kast-repro-exit=0\n", started=120, finished=130),
-                command("refresh", terminated, started=200, finished=210),
+                command("workspace-refresh", terminated, started=200, finished=210),
                 command("refresh-observer", "ready: false\n::kast-repro-exit=0\n", started=220, finished=230),
                 command("graph-nodes", terminated, started=300, finished=310, output_bytes=2_000),
             ]
@@ -260,6 +260,23 @@ class KastCliReproContractTest(unittest.TestCase):
 
             self.assertEqual(0, result.returncode, result.stderr)
             self.assertEqual([], json.loads(result.stdout)["findings"])
+
+    def test_observed_operation_records_operation_completion_before_observer(self) -> None:
+        runner = load_runner_module()
+        capture = mock.Mock()
+        operation = mock.sentinel.operation
+        observer = mock.sentinel.observer
+        operation_evidence = mock.sentinel.operation_evidence
+        observer_evidence = mock.sentinel.observer_evidence
+        capture.finish.side_effect = [operation_evidence, observer_evidence]
+
+        evidence = runner.finish_observed_operation(capture, operation, observer)
+
+        self.assertEqual((operation_evidence, observer_evidence), evidence)
+        self.assertEqual(
+            [mock.call(operation), mock.call(observer)],
+            capture.finish.call_args_list,
+        )
 
     def test_telemetry_fields_distributed_across_requests_are_incomplete(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Contract tests for the local Kast CLI incident reproduction platform."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+RUNNER = Path(__file__).with_name("kast-cli-repro.py")
+
+
+class KastCliReproContractTest(unittest.TestCase):
+    def run_runner(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        self.assertTrue(RUNNER.is_file(), "the Kast CLI reproduction runner is missing")
+        return subprocess.run(
+            ["python3", str(RUNNER), *arguments],
+            cwd=REPOSITORY_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def write_evidence(
+        self,
+        directory: Path,
+        *,
+        incident: bool,
+    ) -> None:
+        transcripts = directory / "transcripts"
+        transcripts.mkdir(parents=True)
+
+        def command(
+            name: str,
+            text: str,
+            *,
+            started: int,
+            finished: int,
+            exit_code: int = 0,
+            output_bytes: int | None = None,
+        ) -> dict[str, object]:
+            path = transcripts / f"{name}.txt"
+            path.write_text(text, encoding="utf-8")
+            return {
+                "name": name,
+                "argv": ["kast", name],
+                "startedAtEpochMillis": started,
+                "finishedAtEpochMillis": finished,
+                "exitCode": exit_code,
+                "timedOut": False,
+                "transcript": str(path.relative_to(directory)),
+                "outputBytes": output_bytes if output_bytes is not None else len(text.encode()),
+            }
+
+        terminated = "result: ok\n::kast-repro-exit=0\n"
+        if incident:
+            commands = [
+                command("cold-up", terminated, started=100, finished=500),
+                command(
+                    "cold-observer",
+                    "__KAST_SAMPLE__=1\nready: true\nruntime: READY\n"
+                    "__KAST_SAMPLE_EPOCH_MILLIS__=200\n"
+                    "next[2]: kast refresh,kast symbol find <query>"
+                    "::kast-repro-exit=0\n",
+                    started=120,
+                    finished=300,
+                ),
+                command(
+                    "refresh",
+                    "error: WORKSPACE_RECONCILIATION_REQUIRED\n"
+                    "next: \"Run `kast --help` for valid commands and arguments.\"\n"
+                    "::kast-repro-exit=1\n",
+                    started=600,
+                    finished=900,
+                    exit_code=1,
+                ),
+                command(
+                    "refresh-observer",
+                    "ready: false\nruntime: INDEXING\nerror: CONFLICT\n"
+                    "message: Semantic operation started while the workspace was not READY\n"
+                    "next: \"Run `kast --help` for valid commands and arguments.\"\n"
+                    "::kast-repro-exit=0\n",
+                    started=620,
+                    finished=780,
+                ),
+                command(
+                    "graph-nodes",
+                    terminated,
+                    started=1000,
+                    finished=1100,
+                    output_bytes=139_205,
+                ),
+            ]
+            telemetry = {
+                "name": "kast.idea.resolveSymbol",
+                "attributes": {"kast.workspace.root": "/tmp/workspace"},
+            }
+        else:
+            commands = [
+                command("cold-up", terminated, started=100, finished=110),
+                command("cold-observer", "ready: false\n::kast-repro-exit=0\n", started=120, finished=130),
+                command("refresh", terminated, started=200, finished=210),
+                command("refresh-observer", "ready: false\n::kast-repro-exit=0\n", started=220, finished=230),
+                command("graph-nodes", terminated, started=300, finished=310, output_bytes=2_000),
+            ]
+            telemetry = {
+                "name": "kast.idea.resolveSymbol",
+                "attributes": {
+                    "runtimeInstanceId": "runtime-1",
+                    "semanticGenerationStart": 4,
+                    "semanticGenerationEnd": 4,
+                    "dumbModeState": "SMART",
+                    "typedOutcome": "RESOLVED",
+                },
+            }
+
+        (directory / "telemetry.jsonl").write_text(json.dumps(telemetry) + "\n", encoding="utf-8")
+        manifest = {
+            "schemaVersion": 1,
+            "workspaceRoot": "/tmp/workspace",
+            "sessionName": "kast-cli-repro-test",
+            "commands": commands,
+            "telemetry": "telemetry.jsonl",
+        }
+        (directory / "manifest.json").write_text(
+            json.dumps(manifest, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def test_incident_evidence_emits_stable_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=True)
+
+            result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            report = json.loads(result.stdout)
+            self.assertEqual("OBSERVATIONS_REPRODUCED", report["status"])
+            codes = {finding["code"] for finding in report["findings"]}
+            self.assertEqual(
+                {
+                    "READY_DURING_PENDING_UP",
+                    "GENERIC_CONFLICT_DURING_REFRESH",
+                    "REFRESH_DID_NOT_CONVERGE",
+                    "MISSING_TRAILING_NEWLINE",
+                    "DEFAULT_OUTPUT_EXCEEDS_BUDGET",
+                    "TRACE_CORRELATION_INCOMPLETE",
+                },
+                codes,
+            )
+
+    def test_clean_evidence_is_a_green_replay(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+
+            result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            report = json.loads(result.stdout)
+            self.assertEqual("PASS", report["status"])
+            self.assertEqual([], report["findings"])
+
+    def test_capsule_stop_failure_is_distinct_from_process_leak(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["capsule"] = {
+                "mode": "EPHEMERAL",
+                "installationContained": True,
+                "stateContained": True,
+                "runtimeStopSucceeded": False,
+                "runtimeStopped": True,
+                "processesRemaining": [],
+                "rootDeleted": True,
+            }
+            manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+            result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            report = json.loads(result.stdout)
+            self.assertEqual(
+                ["CAPSULE_RUNTIME_STOP_FAILED"],
+                [finding["code"] for finding in report["findings"]],
+            )
+
+    def test_forced_cleanup_process_is_reported_as_a_public_stop_leak(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["capsule"] = {
+                "mode": "EPHEMERAL",
+                "installationContained": True,
+                "stateContained": True,
+                "runtimeStopSucceeded": True,
+                "runtimeStopped": True,
+                "terminatedProcessIds": [4242],
+                "processesRemaining": [],
+                "rootDeleted": True,
+            }
+            manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+            result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            report = json.loads(result.stdout)
+            self.assertEqual(
+                ["CAPSULE_PROCESS_LEAKED"],
+                [finding["code"] for finding in report["findings"]],
+            )
+
+    def test_ready_sample_after_up_completion_is_not_pending_up_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            cold_up = next(command for command in manifest["commands"] if command["name"] == "cold-up")
+            cold_up["finishedAtEpochMillis"] = 200
+            observer = next(
+                command for command in manifest["commands"] if command["name"] == "cold-observer"
+            )
+            observer["startedAtEpochMillis"] = 120
+            observer["finishedAtEpochMillis"] = 300
+            (directory / observer["transcript"]).write_text(
+                "__KAST_SAMPLE__=1\nready: true\n"
+                "__KAST_SAMPLE_EPOCH_MILLIS__=250\n::kast-repro-exit=0\n",
+                encoding="utf-8",
+            )
+            manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+            result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual([], json.loads(result.stdout)["findings"])
+
+    def test_telemetry_fields_distributed_across_requests_are_incomplete(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            records = [
+                {"attributes": {"runtimeInstanceId": "runtime-1"}},
+                {"attributes": {"semanticGenerationStart": 4}},
+                {"attributes": {"semanticGenerationEnd": 4}},
+                {"attributes": {"dumbModeState": "SMART"}},
+                {"attributes": {"typedOutcome": "RESOLVED"}},
+            ]
+            (directory / "telemetry.jsonl").write_text(
+                "".join(json.dumps(record) + "\n" for record in records),
+                encoding="utf-8",
+            )
+
+            result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            self.assertEqual(
+                ["TRACE_CORRELATION_INCOMPLETE"],
+                [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+            )
+
+    def test_dry_run_covers_the_public_agent_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            workspace = Path(raw_directory)
+            source = workspace / "src" / "Probe.kt"
+            source.parent.mkdir(parents=True)
+            source.write_text("package example\nclass Probe\n", encoding="utf-8")
+
+            result = self.run_runner(
+                "capture",
+                "--workspace-root",
+                str(workspace),
+                "--file",
+                "src/Probe.kt",
+                "--symbol",
+                "example.Probe",
+                "--restart-runtime",
+                "--exercise-plans",
+                "--dry-run",
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            plan = json.loads(result.stdout)
+            names = {command["name"] for command in plan["commands"]}
+            cold_observer = next(
+                command for command in plan["commands"] if command["name"] == "cold-observer"
+            )
+            self.assertIn("__KAST_SAMPLE_EPOCH_MILLIS__", cold_observer["argv"][-1])
+            self.assertTrue(
+                {
+                    "home",
+                    "help",
+                    "files",
+                    "symbol-find",
+                    "symbol-show",
+                    "symbol-refs",
+                    "symbol-callers",
+                    "symbol-callees",
+                    "symbol-implementations",
+                    "symbol-supertypes",
+                    "symbol-subtypes",
+                    "graph-summary",
+                    "graph-nodes",
+                    "graph-neighbors",
+                    "graph-topology",
+                    "graph-communities",
+                    "graph-impact",
+                    "check",
+                    "change-rename",
+                    "change-add-file",
+                    "change-add-declaration",
+                    "change-replace",
+                    "apply-invalid",
+                    "recover-invalid",
+                    "refresh",
+                    "refresh-observer",
+                    "cold-up",
+                    "cold-observer",
+                }.issubset(names),
+                names,
+            )
+
+    def test_ephemeral_capsule_plan_confines_install_state_and_teardown(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            workspace = root / "workspace"
+            source = workspace / "src" / "Probe.kt"
+            source.parent.mkdir(parents=True)
+            source.write_text("package example\nclass Probe\n", encoding="utf-8")
+            bundle = root / "bundle"
+            bundle.mkdir()
+
+            result = self.run_runner(
+                "capture",
+                "--workspace-root",
+                str(workspace),
+                "--file",
+                "src/Probe.kt",
+                "--symbol",
+                "example.Probe",
+                "--bundle-source",
+                str(bundle),
+                "--ephemeral-capsule",
+                "--dry-run",
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            plan = json.loads(result.stdout)
+            capsule = plan["capsule"]
+            self.assertEqual("EPHEMERAL", capsule["mode"])
+            self.assertEqual("<ephemeral>", capsule["root"])
+            self.assertEqual("STOP_VERIFY_DELETE", capsule["cleanup"])
+            self.assertEqual(str(bundle.resolve()), capsule["bundleSource"])
+            self.assertEqual("<supported-idea-host>", capsule["ideaHost"])
+            self.assertEqual(
+                {
+                    "HOME",
+                    "KAST_HOME",
+                    "KAST_CONFIG_HOME",
+                    "KAST_CACHE_HOME",
+                    "GRADLE_USER_HOME",
+                    "TMPDIR",
+                    "XDG_CACHE_HOME",
+                    "XDG_CONFIG_HOME",
+                    "XDG_DATA_HOME",
+                    "KAST_WORKSPACE_ID",
+                    "KAST_IDEA_TRACE",
+                    "PATH",
+                },
+                set(capsule["environment"]),
+            )
+            for key, value in capsule["environment"].items():
+                if key not in {"KAST_WORKSPACE_ID", "KAST_IDEA_TRACE", "PATH"}:
+                    self.assertTrue(value.startswith("<ephemeral>/"), (key, value))
+            self.assertTrue(capsule["install"]["kast"].startswith("<ephemeral>/"))
+            self.assertTrue(capsule["install"]["kastctl"].startswith("<ephemeral>/"))
+            names = [command["name"] for command in plan["commands"]]
+            self.assertEqual("capsule-setup", names[0])
+            self.assertEqual("capsule-idea-host", names[1])
+            self.assertEqual(
+                ["capsule-runtime-stop", "capsule-teardown-verify"],
+                names[-2:],
+            )
+
+    def test_persistent_capsule_plan_keeps_one_explicit_root(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            workspace = root / "workspace"
+            source = workspace / "src" / "Probe.kt"
+            source.parent.mkdir(parents=True)
+            source.write_text("package example\nclass Probe\n", encoding="utf-8")
+            bundle = root / "bundle"
+            bundle.mkdir()
+            capsule_root = root / "persistent-capsule"
+
+            result = self.run_runner(
+                "capture",
+                "--workspace-root",
+                str(workspace),
+                "--file",
+                "src/Probe.kt",
+                "--symbol",
+                "example.Probe",
+                "--bundle-source",
+                str(bundle),
+                "--capsule-root",
+                str(capsule_root),
+                "--dry-run",
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            plan = json.loads(result.stdout)
+            capsule = plan["capsule"]
+            self.assertEqual("PERSISTENT", capsule["mode"])
+            self.assertEqual(str(capsule_root.resolve()), capsule["root"])
+            self.assertEqual("STOP_VERIFY_KEEP", capsule["cleanup"])
+            for key, value in capsule["environment"].items():
+                if key not in {"KAST_WORKSPACE_ID", "KAST_IDEA_TRACE", "PATH"}:
+                    self.assertTrue(
+                        Path(value).is_relative_to(capsule_root.resolve()),
+                        (key, value),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -18,6 +18,9 @@ from typing import Any
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 RUNNER = Path(__file__).with_name("kast-cli-repro.py")
 REQUIRED_SCENARIO_COMMANDS = (
+    "runtime-stop",
+    "cold-up",
+    "cold-observer",
     "home",
     "help",
     "file-list",
@@ -352,6 +355,14 @@ class KastCliReproContractTest(unittest.TestCase):
             manifest_path = directory / "manifest.json"
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             cold_up = next(command for command in manifest["commands"] if command["name"] == "cold-up")
+            cold_up_transcript = directory / str(cold_up["transcript"])
+            cold_up_transcript.write_text(
+                cold_up_transcript.read_text(encoding="utf-8").replace(
+                    f"::kast-repro-exit={cold_up['completionToken']}:0:110",
+                    f"::kast-repro-exit={cold_up['completionToken']}:0:200",
+                ),
+                encoding="utf-8",
+            )
             cold_up["finishedAtEpochMillis"] = 200
             observer = next(
                 command for command in manifest["commands"] if command["name"] == "cold-observer"
@@ -532,6 +543,14 @@ class KastCliReproContractTest(unittest.TestCase):
                 )
                 if failure == "failed-command":
                     observer["exitCode"] = 1
+                    transcript_path = directory / str(observer["transcript"])
+                    transcript_path.write_text(
+                        transcript_path.read_text(encoding="utf-8").replace(
+                            f"::kast-repro-exit={observer['completionToken']}:0:130",
+                            f"::kast-repro-exit={observer['completionToken']}:1:130",
+                        ),
+                        encoding="utf-8",
+                    )
                 else:
                     (directory / observer["transcript"]).write_text(
                         "no parseable observations\n"
@@ -708,6 +727,21 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual("INVALID_EVIDENCE", error["status"])
             self.assertNotIn("Traceback", result.stderr)
 
+    def test_invalid_utf8_manifest_is_structured_invalid_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            (directory / "manifest.json").write_bytes(b"\xff\xfe\x00")
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("", result.stdout)
+            error = json.loads(result.stderr)
+            self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertNotIn("Traceback", result.stderr)
+
     def test_nonobject_capsule_proof_is_structured_invalid_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -760,27 +794,17 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual("INVALID_EVIDENCE", error["status"])
             self.assertIn("terminatedProcessIds", error["error"])
 
-    def test_capsule_replay_requires_cold_transition_commands(self) -> None:
+    def test_replay_requires_runtime_stop_and_cold_transition_commands(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
             self.write_evidence(directory, incident=False)
             manifest_path = directory / "manifest.json"
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-            manifest["capsule"] = {
-                "mode": "EPHEMERAL",
-                "installationContained": True,
-                "stateContained": True,
-                "runtimeStopSucceeded": True,
-                "runtimeStopped": True,
-                "terminatedProcessIds": [],
-                "processesRemaining": [],
-                "rootDeleted": True,
-            }
-            self.append_command_evidence(directory, manifest, "capsule-runtime-stop")
             manifest["commands"] = [
                 command
                 for command in manifest["commands"]
-                if command["name"] not in {"cold-up", "cold-observer"}
+                if command["name"]
+                not in {"runtime-stop", "cold-up", "cold-observer"}
             ]
             manifest_path.write_text(
                 json.dumps(manifest, indent=2) + "\n",
@@ -795,6 +819,7 @@ class KastCliReproContractTest(unittest.TestCase):
             self.assertEqual("", result.stdout)
             error = json.loads(result.stderr)
             self.assertEqual("INVALID_EVIDENCE", error["status"])
+            self.assertIn("runtime-stop", error["error"])
             self.assertIn("cold-observer", error["error"])
             self.assertIn("cold-up", error["error"])
 
@@ -1437,6 +1462,14 @@ class KastCliReproContractTest(unittest.TestCase):
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             cold_up = next(command for command in manifest["commands"] if command["name"] == "cold-up")
             cold_up["exitCode"] = 1
+            transcript_path = directory / str(cold_up["transcript"])
+            transcript_path.write_text(
+                transcript_path.read_text(encoding="utf-8").replace(
+                    f"::kast-repro-exit={cold_up['completionToken']}:0:110",
+                    f"::kast-repro-exit={cold_up['completionToken']}:1:110",
+                ),
+                encoding="utf-8",
+            )
             manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
             result = self.run_runner("analyze", "--evidence-dir", str(directory), "--format", "json")

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -339,6 +339,7 @@ class KastCliReproContractTest(unittest.TestCase):
                 "%1",
                 100,
                 "nonce",
+                float("inf"),
             )
             collision = subprocess.CompletedProcess(
                 [],
@@ -367,6 +368,47 @@ class KastCliReproContractTest(unittest.TestCase):
 
             self.assertEqual(0, command.exitCode)
             self.assertEqual(234, command.finishedAtEpochMillis)
+
+    def test_command_timeout_deadline_is_bound_when_the_command_begins(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            evidence = directory / "evidence"
+            (evidence / "transcripts").mkdir(parents=True)
+            capture = runner.TmuxCapture("session", directory, evidence, keep_session=False)
+            active = runner.ActiveCommand(
+                runner.CommandSpec(
+                    "probe",
+                    ("kast", "symbol", "show"),
+                    timeout_seconds=50.0,
+                ),
+                "%1",
+                100,
+                "nonce",
+                100.0,
+            )
+            pending = subprocess.CompletedProcess([], 0, "still running\n", "")
+            late_completion = subprocess.CompletedProcess(
+                [],
+                0,
+                "::kast-repro-exit=nonce:0:234\n",
+                "",
+            )
+            killed = subprocess.CompletedProcess([], 0, "", "")
+
+            with (
+                mock.patch.object(
+                    runner.subprocess,
+                    "run",
+                    side_effect=[pending, killed, late_completion, killed],
+                ),
+                mock.patch.object(runner.time, "monotonic", return_value=101.0),
+                mock.patch.object(runner.time, "sleep"),
+            ):
+                command = capture.finish(active)
+
+            self.assertTrue(command.timedOut)
+            self.assertEqual(124, command.exitCode)
 
     def test_incomplete_cold_observer_cannot_replay_as_clean(self) -> None:
         for failure in ("failed-command", "missing-home"):
@@ -561,6 +603,82 @@ class KastCliReproContractTest(unittest.TestCase):
         self.assertEqual([100, 101], targeted)
         self.assertEqual([], remaining)
         self.assertIn(mock.call(101, runner.signal.SIGTERM), kill.call_args_list)
+
+    def test_process_that_exits_before_signal_is_not_reported_as_terminated(self) -> None:
+        runner = load_runner_module()
+        root = Path("/tmp/kast")
+        observed = {100: "java --state /tmp/kast/cache"}
+
+        with (
+            mock.patch.object(
+                runner,
+                "capsule_processes",
+                side_effect=[observed, {}, {}],
+            ),
+            mock.patch.object(runner.os, "kill", side_effect=ProcessLookupError),
+            mock.patch.object(runner.time, "sleep"),
+        ):
+            targeted, remaining = runner.terminate_capsule_processes(root, observed)
+
+        self.assertEqual([], targeted)
+        self.assertEqual([], remaining)
+
+    def test_log_paths_honors_configured_telemetry_output(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            workspace_data = root / ("a" * 64)
+            config = {
+                "configPath": str(workspace_data / "config.json"),
+                "effective": {
+                    "paths": {"cacheDir": str(root / "cache")},
+                    "telemetry": {"outputFile": "telemetry/custom-spans.jsonl"},
+                },
+            }
+
+            telemetry, _ = runner.log_paths(config, workspace)
+
+            self.assertEqual(
+                (workspace / "telemetry" / "custom-spans.jsonl").resolve(),
+                telemetry,
+            )
+
+    def test_capsule_rejects_configured_telemetry_output_outside_its_root(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory) / "capsule"
+            capsule = runner.CapsuleContext(
+                "PERSISTENT",
+                root,
+                root / "bundle",
+                {},
+                root / "bootstrap-kastctl",
+                root / "idea-host",
+            )
+            for executable in (capsule.kast, capsule.kastctl):
+                executable.parent.mkdir(parents=True, exist_ok=True)
+                executable.write_text("#!/bin/sh\n", encoding="utf-8")
+                executable.chmod(0o755)
+            config = {
+                "configPath": str(root / "config" / ("a" * 64) / "config.json"),
+                "effective": {
+                    "paths": {"cacheDir": str(root / "cache")},
+                    "telemetry": {"outputFile": "/tmp/external-spans.jsonl"},
+                },
+            }
+
+            with (
+                mock.patch.object(
+                    runner,
+                    "discover_developer_cli",
+                    return_value=capsule.kastctl,
+                ),
+                mock.patch.object(runner, "read_config", return_value=config),
+                self.assertRaisesRegex(runner.ReproError, "escaped its root"),
+            ):
+                runner.verify_capsule_install(capsule, root / "workspace")
 
     def test_failed_telemetry_restore_is_retained_as_teardown_error(self) -> None:
         runner = load_runner_module()

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -147,7 +147,7 @@ class KastCliReproContractTest(unittest.TestCase):
                 ),
                 command(
                     "graph-nodes",
-                    terminated,
+                    "x" * 30_001 + "\n::kast-repro-exit=0\n",
                     started=1000,
                     finished=1100,
                     output_bytes=139_205,
@@ -585,6 +585,37 @@ class KastCliReproContractTest(unittest.TestCase):
             error = json.loads(result.stderr)
             self.assertEqual("INVALID_EVIDENCE", error["status"])
             self.assertIn("graph-topology", error["error"])
+
+    def test_transition_timeout_status_must_be_boolean(self) -> None:
+        for timed_out in (None, "false"):
+            with self.subTest(timed_out=timed_out), tempfile.TemporaryDirectory() as raw_directory:
+                directory = Path(raw_directory)
+                self.write_evidence(directory, incident=False)
+                manifest_path = directory / "manifest.json"
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                refresh = next(
+                    command
+                    for command in manifest["commands"]
+                    if command["name"] == "workspace-refresh"
+                )
+                if timed_out is None:
+                    refresh.pop("timedOut")
+                else:
+                    refresh["timedOut"] = timed_out
+                manifest_path.write_text(
+                    json.dumps(manifest, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+
+                result = self.run_runner(
+                    "analyze", "--evidence-dir", str(directory), "--format", "json"
+                )
+
+                self.assertEqual(2, result.returncode)
+                self.assertEqual("", result.stdout)
+                error = json.loads(result.stderr)
+                self.assertEqual("INVALID_EVIDENCE", error["status"])
+                self.assertIn("workspace-refresh", error["error"])
 
     def test_nonobject_manifest_is_structured_invalid_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
@@ -1113,6 +1144,32 @@ class KastCliReproContractTest(unittest.TestCase):
         self.assertEqual(1, len(errors))
         self.assertIn("restore-enabled", errors[0])
 
+    def test_live_non_capsule_capture_requires_runtime_restart_authority(self) -> None:
+        runner = load_runner_module()
+
+        with self.assertRaisesRegex(runner.ReproError, "--restart-runtime is required"):
+            runner.require_runtime_restart_authority(
+                restart_requested=False,
+                capsule=None,
+                dry_run=False,
+            )
+
+        runner.require_runtime_restart_authority(
+            restart_requested=False,
+            capsule=mock.sentinel.capsule,
+            dry_run=False,
+        )
+        runner.require_runtime_restart_authority(
+            restart_requested=True,
+            capsule=None,
+            dry_run=False,
+        )
+        runner.require_runtime_restart_authority(
+            restart_requested=False,
+            capsule=None,
+            dry_run=True,
+        )
+
     def test_generic_exit_text_does_not_drive_newline_analysis(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -1132,6 +1189,40 @@ class KastCliReproContractTest(unittest.TestCase):
 
             self.assertEqual(0, result.returncode, result.stderr)
             self.assertEqual([], json.loads(result.stdout)["findings"])
+
+    def test_graph_budget_uses_transcript_bytes_not_manifest_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            graph_nodes = next(
+                command
+                for command in manifest["commands"]
+                if command["name"] == "graph-nodes"
+            )
+            transcript_path = directory / str(graph_nodes["transcript"])
+            transcript_path.write_text(
+                "x" * 30_001
+                + "\n"
+                + f"::kast-repro-exit={graph_nodes['completionToken']}:0:310\n",
+                encoding="utf-8",
+            )
+            graph_nodes["outputBytes"] = 1
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            self.assertEqual(
+                ["DEFAULT_OUTPUT_EXCEEDS_BUDGET"],
+                [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+            )
 
     def test_failed_cold_start_is_not_a_green_replay(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -468,6 +468,52 @@ class KastCliReproContractTest(unittest.TestCase):
         ):
             runner.read_config(Path("/kastctl"), Path("/workspace"))
 
+    def test_config_discovery_rejects_nonobject_nested_fields(self) -> None:
+        runner = load_runner_module()
+        payloads = (
+            {"ok": True, "effective": []},
+            {"ok": True, "effective": {"indexer": []}},
+            {"ok": True, "effective": {"paths": []}},
+            {"ok": True, "effective": {"telemetry": []}},
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                response = subprocess.CompletedProcess(
+                    [],
+                    0,
+                    json.dumps(payload) + "\n",
+                    "",
+                )
+                with (
+                    mock.patch.object(runner.subprocess, "run", return_value=response),
+                    self.assertRaisesRegex(runner.ReproError, "JSON object"),
+                ):
+                    runner.read_config(Path("/kastctl"), Path("/workspace"))
+
+    def test_command_wrapper_normalizes_signaled_exit_status(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            evidence = directory / "evidence"
+            (evidence / "transcripts").mkdir(parents=True)
+            capture = runner.TmuxCapture(
+                "session",
+                directory,
+                evidence,
+                keep_session=False,
+                base_environment={},
+            )
+            created = subprocess.CompletedProcess([], 0, "%1\n", "")
+            with mock.patch.object(
+                runner,
+                "run_checked",
+                return_value=created,
+            ) as launch:
+                capture.begin(runner.CommandSpec("probe", ("kast", "--help")))
+
+            shell = launch.call_args.args[-1]
+            self.assertIn("status=128-status if status<0 else status", shell)
+
     def test_command_completion_uses_a_nonce_and_the_wrapper_timestamp(self) -> None:
         runner = load_runner_module()
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -121,9 +121,16 @@ class KastCliReproContractTest(unittest.TestCase):
                     "next[2]: kast refresh,kast symbol find <query>\n"
                     "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n"
+                    "__KAST_SAMPLE__=2\n__KAST_OBSERVATION__=HOME\n"
+                    "ready: false\nruntime: READY\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=510\n"
+                    "__KAST_OBSERVATION__=RESOLVE\nresult: resolved\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=520\n"
                     "unterminated::kast-repro-exit=0\n",
                     started=120,
-                    finished=300,
+                    finished=550,
                 ),
                 command(
                     "workspace-refresh",
@@ -145,9 +152,16 @@ class KastCliReproContractTest(unittest.TestCase):
                     "next: \"Run `kast --help` for valid commands and arguments.\"\n"
                     "__KAST_OBSERVATION_EXIT_CODE__=1\n"
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=700\n"
+                    "__KAST_SAMPLE__=2\n__KAST_OBSERVATION__=HOME\n"
+                    "ready: true\nruntime: READY\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=910\n"
+                    "__KAST_OBSERVATION__=RESOLVE\nresult: resolved\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=920\n"
                     "::kast-repro-exit=0\n",
                     started=620,
-                    finished=780,
+                    finished=950,
                 ),
                 command(
                     "graph-nodes",
@@ -171,7 +185,13 @@ class KastCliReproContractTest(unittest.TestCase):
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=108\n"
                     "__KAST_OBSERVATION__=RESOLVE\nresult: missing\n"
                     "__KAST_OBSERVATION_EXIT_CODE__=0\n"
-                    "__KAST_OBSERVATION_EPOCH_MILLIS__=109\n::kast-repro-exit=0\n",
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=109\n"
+                    "__KAST_SAMPLE__=2\n__KAST_OBSERVATION__=HOME\nready: true\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=115\n"
+                    "__KAST_OBSERVATION__=RESOLVE\nresult: resolved\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=116\n::kast-repro-exit=0\n",
                     started=105,
                     finished=130,
                 ),
@@ -183,7 +203,13 @@ class KastCliReproContractTest(unittest.TestCase):
                     "__KAST_OBSERVATION_EPOCH_MILLIS__=208\n"
                     "__KAST_OBSERVATION__=RESOLVE\nresult: resolved\n"
                     "__KAST_OBSERVATION_EXIT_CODE__=0\n"
-                    "__KAST_OBSERVATION_EPOCH_MILLIS__=209\n::kast-repro-exit=0\n",
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=209\n"
+                    "__KAST_SAMPLE__=2\n__KAST_OBSERVATION__=HOME\nready: true\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=215\n"
+                    "__KAST_OBSERVATION__=RESOLVE\nresult: resolved\n"
+                    "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=216\n::kast-repro-exit=0\n",
                     started=205,
                     finished=230,
                 ),
@@ -408,6 +434,7 @@ class KastCliReproContractTest(unittest.TestCase):
             [mock.call(operation), mock.call(observer)],
             capture.finish.call_args_list,
         )
+        capture.request_observer_completion.assert_called_once_with(observer)
 
     def test_command_completion_uses_a_nonce_and_the_wrapper_timestamp(self) -> None:
         runner = load_runner_module()
@@ -1041,6 +1068,53 @@ class KastCliReproContractTest(unittest.TestCase):
                 [finding["code"] for finding in json.loads(result.stdout)["findings"]],
             )
 
+    def test_observer_must_cover_transition_completion(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            self.write_evidence(directory, incident=False)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            operation = next(
+                command for command in manifest["commands"]
+                if command["name"] == "cold-up"
+            )
+            transcript_path = directory / str(operation["transcript"])
+            transcript_path.write_text(
+                transcript_path.read_text(encoding="utf-8").replace(
+                    f"::kast-repro-exit={operation['completionToken']}:0:110",
+                    f"::kast-repro-exit={operation['completionToken']}:0:150",
+                ),
+                encoding="utf-8",
+            )
+            operation["finishedAtEpochMillis"] = 150
+            observer = next(
+                command for command in manifest["commands"]
+                if command["name"] == "cold-observer"
+            )
+            observer_transcript = directory / str(observer["transcript"])
+            observer_transcript.write_text(
+                observer_transcript.read_text(encoding="utf-8").replace(
+                    f"::kast-repro-exit={observer['completionToken']}:0:130",
+                    f"::kast-repro-exit={observer['completionToken']}:0:170",
+                ),
+                encoding="utf-8",
+            )
+            observer["finishedAtEpochMillis"] = 170
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_runner(
+                "analyze", "--evidence-dir", str(directory), "--format", "json"
+            )
+
+            self.assertEqual(1, result.returncode, result.stderr)
+            self.assertEqual(
+                ["OBSERVER_EVIDENCE_INCOMPLETE"],
+                [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+            )
+
     def test_observer_without_a_sample_during_transition_cannot_replay_as_clean(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             directory = Path(raw_directory)
@@ -1196,12 +1270,20 @@ class KastCliReproContractTest(unittest.TestCase):
         )
         proof = {
             "runtimeStopped": True,
+            "runtimeStopSucceeded": True,
             "installationContained": True,
             "stateContained": True,
         }
 
         self.assertTrue(
             runner.ephemeral_capsule_is_safely_deletable(capsule, proof, [])
+        )
+        self.assertFalse(
+            runner.ephemeral_capsule_is_safely_deletable(
+                capsule,
+                {**proof, "runtimeStopSucceeded": False},
+                [],
+            )
         )
 
     def test_capsule_rejects_configured_telemetry_output_outside_its_root(self) -> None:
@@ -1613,6 +1695,8 @@ class KastCliReproContractTest(unittest.TestCase):
                 2,
                 cold_observer["argv"][-1].count("__KAST_OBSERVATION_EXIT_CODE__"),
             )
+            self.assertIn("KAST_REPRO_OBSERVER_STOP", cold_observer["argv"][-1])
+            self.assertNotIn("for i in $(seq", cold_observer["argv"][-1])
             by_name = {command["name"]: command for command in plan["commands"]}
             self.assertEqual(
                 ["file", "list", "--match", "src/Probe.kt"],

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -1166,6 +1166,44 @@ class KastCliReproContractTest(unittest.TestCase):
                 telemetry,
             )
 
+    def test_telemetry_output_treats_tilde_as_a_workspace_relative_path(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            workspace = Path(raw_directory) / "workspace"
+            workspace.mkdir()
+            config = {
+                "effective": {
+                    "telemetry": {"outputFile": "~/telemetry/custom-spans.jsonl"},
+                },
+            }
+
+            telemetry = runner.telemetry_output_path(config, workspace)
+
+            self.assertEqual(
+                (workspace / "~" / "telemetry" / "custom-spans.jsonl").resolve(),
+                telemetry,
+            )
+
+    def test_safe_ephemeral_cleanup_does_not_depend_on_capture_success(self) -> None:
+        runner = load_runner_module()
+        capsule = runner.CapsuleContext(
+            "EPHEMERAL",
+            Path("/private/tmp/kast-capsule-contract"),
+            Path("/bundle"),
+            {},
+            Path("/bootstrap-kastctl"),
+            Path("/idea-host"),
+        )
+        proof = {
+            "runtimeStopped": True,
+            "installationContained": True,
+            "stateContained": True,
+        }
+
+        self.assertTrue(
+            runner.ephemeral_capsule_is_safely_deletable(capsule, proof, [])
+        )
+
     def test_capsule_rejects_configured_telemetry_output_outside_its_root(self) -> None:
         runner = load_runner_module()
         with tempfile.TemporaryDirectory() as raw_directory:

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -619,6 +619,39 @@ class KastCliReproContractTest(unittest.TestCase):
                 [finding["code"] for finding in json.loads(result.stdout)["findings"]],
             )
 
+    def test_observer_requires_claim_bearing_sample_during_transition(self) -> None:
+        cases = (
+            ("cold-observer", "108", "125"),
+            ("refresh-observer", "209", "225"),
+        )
+        for observer_name, original_timestamp, late_timestamp in cases:
+            with self.subTest(observer=observer_name), tempfile.TemporaryDirectory() as raw_directory:
+                directory = Path(raw_directory)
+                self.write_evidence(directory, incident=False)
+                manifest = json.loads((directory / "manifest.json").read_text(encoding="utf-8"))
+                observer = next(
+                    command for command in manifest["commands"]
+                    if command["name"] == observer_name
+                )
+                transcript_path = directory / str(observer["transcript"])
+                transcript_path.write_text(
+                    transcript_path.read_text(encoding="utf-8").replace(
+                        f"__KAST_OBSERVATION_EPOCH_MILLIS__={original_timestamp}",
+                        f"__KAST_OBSERVATION_EPOCH_MILLIS__={late_timestamp}",
+                    ),
+                    encoding="utf-8",
+                )
+
+                result = self.run_runner(
+                    "analyze", "--evidence-dir", str(directory), "--format", "json"
+                )
+
+                self.assertEqual(1, result.returncode, result.stderr)
+                self.assertEqual(
+                    ["OBSERVER_EVIDENCE_INCOMPLETE"],
+                    [finding["code"] for finding in json.loads(result.stdout)["findings"]],
+                )
+
     def test_new_descendant_is_rescanned_during_forced_teardown(self) -> None:
         runner = load_runner_module()
         root = Path("/tmp/kast")
@@ -753,6 +786,51 @@ class KastCliReproContractTest(unittest.TestCase):
             ):
                 runner.build_capsule(args, workspace, "kast", dry_run=False)
 
+    def test_ephemeral_capsule_is_removed_when_post_allocation_validation_fails(self) -> None:
+        runner = load_runner_module()
+        with tempfile.TemporaryDirectory() as raw_directory:
+            base = Path(raw_directory)
+            bundle = base / "bundle"
+            bundle.mkdir()
+            allocated = Path(
+                tempfile.mkdtemp(prefix="kast-capsule-contract-", dir="/private/tmp")
+            )
+            allocated.rmdir()
+            args = runner.argparse.Namespace(
+                capsule_root=None,
+                ephemeral_capsule=True,
+                bundle_source=bundle,
+                idea_host=None,
+            )
+
+            def allocate(*, prefix: str, dir: str) -> str:
+                self.assertEqual("kast-capsule-", prefix)
+                self.assertEqual("/private/tmp", dir)
+                allocated.mkdir()
+                return str(allocated)
+
+            try:
+                with (
+                    mock.patch.object(
+                        runner,
+                        "discover_developer_cli",
+                        return_value=base / "bootstrap-kastctl",
+                    ),
+                    mock.patch.object(
+                        runner,
+                        "discover_idea_host",
+                        return_value=base / "idea-host",
+                    ),
+                    mock.patch.object(runner.tempfile, "mkdtemp", side_effect=allocate),
+                    self.assertRaisesRegex(runner.ReproError, "must not overlap"),
+                ):
+                    runner.build_capsule(args, Path("/private/tmp"), "kast", dry_run=False)
+
+                self.assertFalse(allocated.exists())
+            finally:
+                if allocated.exists():
+                    allocated.rmdir()
+
     def test_failed_telemetry_restore_is_retained_as_teardown_error(self) -> None:
         runner = load_runner_module()
         failed = runner.CommandEvidence(
@@ -839,6 +917,12 @@ class KastCliReproContractTest(unittest.TestCase):
                 "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: false\n"
                 "__KAST_OBSERVATION_EXIT_CODE__=0\n"
                 "__KAST_OBSERVATION_EPOCH_MILLIS__=205\n"
+                "__KAST_OBSERVATION__=RESOLVE\nresult: resolved\n"
+                "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                "__KAST_OBSERVATION_EPOCH_MILLIS__=206\n"
+                "__KAST_SAMPLE__=2\n__KAST_OBSERVATION__=HOME\nready: true\n"
+                "__KAST_OBSERVATION_EXIT_CODE__=0\n"
+                "__KAST_OBSERVATION_EPOCH_MILLIS__=240\n"
                 "__KAST_OBSERVATION__=RESOLVE\nerror: CONFLICT\n"
                 "next: Run `kast --help`\n"
                 "__KAST_OBSERVATION_EXIT_CODE__=1\n"

--- a/.github/scripts/runtime/test-kast-cli-repro-contract.py
+++ b/.github/scripts/runtime/test-kast-cli-repro-contract.py
@@ -79,10 +79,13 @@ class KastCliReproContractTest(unittest.TestCase):
                 command("cold-up", terminated, started=100, finished=500),
                 command(
                     "cold-observer",
-                    "__KAST_SAMPLE__=1\nready: true\nruntime: READY\n"
-                    "__KAST_SAMPLE_EPOCH_MILLIS__=200\n"
-                    "next[2]: kast refresh,kast symbol find <query>"
-                    "::kast-repro-exit=0\n",
+                    "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\n"
+                    "ready: true\nruntime: READY\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=200\n"
+                    "__KAST_OBSERVATION__=RESOLVE\n"
+                    "next[2]: kast refresh,kast symbol find <query>\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n"
+                    "unterminated::kast-repro-exit=0\n",
                     started=120,
                     finished=300,
                 ),
@@ -97,10 +100,13 @@ class KastCliReproContractTest(unittest.TestCase):
                 ),
                 command(
                     "refresh-observer",
-                    "__KAST_SAMPLE__=1\nready: false\nruntime: INDEXING\nerror: CONFLICT\n"
+                    "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\n"
+                    "ready: false\nruntime: INDEXING\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=650\n"
+                    "__KAST_OBSERVATION__=RESOLVE\nerror: CONFLICT\n"
                     "message: Semantic operation started while the workspace was not READY\n"
-                    "__KAST_SAMPLE_EPOCH_MILLIS__=700\n"
                     "next: \"Run `kast --help` for valid commands and arguments.\"\n"
+                    "__KAST_OBSERVATION_EPOCH_MILLIS__=700\n"
                     "::kast-repro-exit=0\n",
                     started=620,
                     finished=780,
@@ -251,8 +257,10 @@ class KastCliReproContractTest(unittest.TestCase):
             observer["startedAtEpochMillis"] = 120
             observer["finishedAtEpochMillis"] = 300
             (directory / observer["transcript"]).write_text(
-                "__KAST_SAMPLE__=1\nready: true\n"
-                "__KAST_SAMPLE_EPOCH_MILLIS__=250\n::kast-repro-exit=0\n",
+                "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: true\n"
+                "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n"
+                "__KAST_OBSERVATION__=RESOLVE\n"
+                "__KAST_OBSERVATION_EPOCH_MILLIS__=260\n::kast-repro-exit=0\n",
                 encoding="utf-8",
             )
             manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
@@ -350,9 +358,11 @@ class KastCliReproContractTest(unittest.TestCase):
             observer["startedAtEpochMillis"] = 205
             observer["finishedAtEpochMillis"] = 260
             (directory / observer["transcript"]).write_text(
-                "__KAST_SAMPLE__=1\nready: false\nerror: CONFLICT\n"
+                "__KAST_SAMPLE__=1\n__KAST_OBSERVATION__=HOME\nready: false\n"
+                "__KAST_OBSERVATION_EPOCH_MILLIS__=205\n"
+                "__KAST_OBSERVATION__=RESOLVE\nerror: CONFLICT\n"
                 "next: Run `kast --help`\n"
-                "__KAST_SAMPLE_EPOCH_MILLIS__=250\n::kast-repro-exit=0\n",
+                "__KAST_OBSERVATION_EPOCH_MILLIS__=250\n::kast-repro-exit=0\n",
                 encoding="utf-8",
             )
             manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
@@ -412,7 +422,12 @@ class KastCliReproContractTest(unittest.TestCase):
             cold_observer = next(
                 command for command in plan["commands"] if command["name"] == "cold-observer"
             )
-            self.assertIn("__KAST_SAMPLE_EPOCH_MILLIS__", cold_observer["argv"][-1])
+            self.assertIn("__KAST_OBSERVATION__=HOME", cold_observer["argv"][-1])
+            self.assertIn("__KAST_OBSERVATION__=RESOLVE", cold_observer["argv"][-1])
+            self.assertEqual(
+                2,
+                cold_observer["argv"][-1].count("__KAST_OBSERVATION_EPOCH_MILLIS__"),
+            )
             by_name = {command["name"]: command for command in plan["commands"]}
             self.assertEqual(
                 ["file", "list", "--match", "src/Probe.kt"],
@@ -505,6 +520,55 @@ class KastCliReproContractTest(unittest.TestCase):
         self.assertFalse(
             runner.command_mentions_capsule_root("java --state /tmp/kast-backup/cache", root)
         )
+
+    def test_owned_descendant_survives_parent_exit_with_pid_reuse_guard(self) -> None:
+        runner = load_runner_module()
+        root = Path("/tmp/kast")
+        initial = {
+            100: (1, "java --state /tmp/kast/cache"),
+            101: (100, "capsule-worker"),
+        }
+        after_parent_exit = {101: (1, "capsule-worker")}
+        reused_pid = {101: (1, "unrelated-worker")}
+
+        with (
+            mock.patch.object(runner, "process_ancestry", return_value=set()),
+            mock.patch.object(runner, "process_table", return_value=initial),
+        ):
+            owned = runner.capsule_processes(root)
+
+        self.assertEqual(
+            {100: "java --state /tmp/kast/cache", 101: "capsule-worker"},
+            owned,
+        )
+        with (
+            mock.patch.object(runner, "process_ancestry", return_value=set()),
+            mock.patch.object(runner, "process_table", return_value=after_parent_exit),
+        ):
+            self.assertEqual({101: "capsule-worker"}, runner.capsule_processes(root, owned))
+        with (
+            mock.patch.object(runner, "process_ancestry", return_value=set()),
+            mock.patch.object(runner, "process_table", return_value=reused_pid),
+        ):
+            self.assertEqual({}, runner.capsule_processes(root, owned))
+
+    def test_nonfinite_capture_intervals_are_rejected(self) -> None:
+        runner = load_runner_module()
+        for field, value in (
+            ("sample_interval", float("nan")),
+            ("sample_interval", float("inf")),
+            ("transition_timeout", float("nan")),
+            ("transition_timeout", float("inf")),
+        ):
+            with self.subTest(field=field, value=value):
+                arguments = runner.argparse.Namespace(
+                    samples=1,
+                    sample_interval=0.1,
+                    transition_timeout=1.0,
+                )
+                setattr(arguments, field, value)
+                with self.assertRaises(runner.ReproError):
+                    runner.validate_numeric_arguments(arguments)
 
     def test_missing_tmux_is_rejected_before_ephemeral_capsule_allocation(self) -> None:
         runner = load_runner_module()


### PR DESCRIPTION
Risk: this PR touches a real tmux PTY and can stop the exact-root runtime during live capture. Capsule mode confines installation and state, rejects ambiguous process ownership, and fails closed when teardown or observation evidence is incomplete.

## What

- Add a tmux-backed Kast CLI capture runner with persistent and disposable hermetic capsule modes.
- Add replay analysis for transition races, bounded output, trace correlation, capsule confinement, and teardown evidence.
- Add an executable contract suite for capture and replay behavior.

## Why

PR #566 needed a repeatable way to capture CLI behavior during cold startup and explicit refresh without contaminating host state. This keeps the incident platform separate from the merged runtime repair and bases it directly on current main.

## Review closure

- Preserve processes observed after public stop before forced cleanup.
- Timestamp observer samples and attribute findings only to samples completed during the transition.
- Require observer subcommand success, allowing only the explicitly modeled CONFLICT outcome.
- Require one telemetry request to carry the full correlation tuple.
- Use the current public CLI registry and Kast-issued symbol and graph selectors.
- Require path-bound capsule ownership and rescan descendants through teardown.
- Validate tmux, output, and session state before ephemeral capsule allocation.
- Bind command completion and newline analysis to a nonce.
- Reject missing operations, failed cold starts, incomplete observers, and post-refresh conflict attribution.
- Select a collision-free file-package-bound mutation probe.

## Proof

- 30 of 30 focused reproduction contract tests pass.
- Python bytecode compilation and diff/shape checks pass.
- Exact-head CI is terminal green for 9a733d726b88939065ddedcff90c3081f36224ca: 11 of 11 CI jobs passed, plus dependency submission.
- All actionable review threads are resolved.