### PR TITLE
Bound indexer resource pressure and recover after idle shutdown

### DIFF
--- a/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspacePathPolicy.kt
+++ b/analysis-api/src/main/kotlin/io/github/amichne/kast/api/client/WorkspacePathPolicy.kt
@@ -8,6 +8,12 @@ value class WorkspaceRelativePath private constructor(val value: String) {
     val path: Path get() = Path.of(value)
 
     companion object {
+        /**
+         * Proof transition: `Path -> WorkspaceRelativePath`.
+         *
+         * Establishes that the path is relative, normalized, and cannot escape through a parent
+         * component. Raw `Path` extraction is permitted only at filesystem and protocol boundaries.
+         */
         fun parse(path: Path): WorkspaceRelativePath {
             require(!path.isAbsolute) { "Workspace-relative paths must not be absolute: $path" }
             val normalized = path.normalize()
@@ -17,6 +23,13 @@ value class WorkspaceRelativePath private constructor(val value: String) {
             return WorkspaceRelativePath(normalized.toString().replace('\\', '/'))
         }
 
+        /**
+         * Proof transition: `(workspace root, candidate Path) -> WorkspaceRelativePath?`.
+         *
+         * Establishes that the normalized candidate is contained by the normalized workspace root.
+         * `null` reports the closed containment miss at this filesystem boundary; raw `Path`
+         * extraction is permitted only at filesystem and protocol boundaries.
+         */
         fun resolve(workspaceRoot: Path, candidate: Path): WorkspaceRelativePath? {
             val root = NormalizedPath.of(workspaceRoot).toJavaPath()
             val absoluteCandidate = if (candidate.isAbsolute) candidate else root.resolve(candidate)
@@ -28,7 +41,8 @@ value class WorkspaceRelativePath private constructor(val value: String) {
 }
 
 object WorkspacePathPolicy {
-    private val hardExcludedDirectoryNames = setOf(".gradle", ".idea", ".kotlin", "build", "out")
+    private val hardExcludedDirectoryNames =
+        setOf(".gradle", ".idea", ".kotlin", "build", "out", "target")
 
     fun isHardExcluded(path: Path): Boolean =
         isHardExcluded(WorkspaceRelativePath.parse(path))

--- a/analysis-api/src/test/kotlin/io/github/amichne/kast/api/config/WorkspacePathPolicyTest.kt
+++ b/analysis-api/src/test/kotlin/io/github/amichne/kast/api/config/WorkspacePathPolicyTest.kt
@@ -8,7 +8,13 @@ import java.nio.file.Path
 class WorkspacePathPolicyTest {
     @Test
     fun `hard output directories are excluded by path component`() {
-        for (path in listOf("build/generated/Foo.kt", ".gradle/cache/Foo.kt", "out/classes/Foo.kt", ".idea/Foo.kt")) {
+        for (path in listOf(
+            "build/generated/Foo.kt",
+            ".gradle/cache/Foo.kt",
+            "out/classes/Foo.kt",
+            "cli-rs/target/debug/deps/Foo.kt",
+            ".idea/Foo.kt",
+        )) {
             assertTrue(WorkspacePathPolicy.isHardExcluded(Path.of(path)), path)
         }
         assertFalse(WorkspacePathPolicy.isHardExcluded(Path.of("src/main/kotlin/Build.kt")))

--- a/cli-rs/src/agent/adapter/commands.rs
+++ b/cli-rs/src/agent/adapter/commands.rs
@@ -12,13 +12,13 @@ struct UpResult {
 }
 
 pub(crate) fn run_up(output_format: OutputFormat) -> Result<i32> {
-    let ready = runtime::demand_source_ready_runtime(None)?;
+    let ready = runtime::demand_reference_ready_runtime(None)?;
     let result = UpResult {
         root: ready.workspace_root().display().to_string(),
         ready: true,
         runtime: "READY",
         backend: ready.backend_name().to_string(),
-        reference_index_ready: ready.reference_index_ready(),
+        reference_index_ready: true,
         source_revision: ready.source_revision(),
         source_module_count: ready.source_module_count(),
         next: vec![

--- a/cli-rs/src/agent/navigation/native_graph/entrypoint.rs
+++ b/cli-rs/src/agent/navigation/native_graph/entrypoint.rs
@@ -36,7 +36,7 @@ fn execute_agent_native_graph(args: AgentNativeGraphArgs) -> AgentEnvelope {
         return execute_agent_native_graph_refresh(args);
     }
     let semantic_read = if args.database.is_none() {
-        match runtime::semantic_graph_workspace_read_ready(args.runtime.workspace_root.clone()) {
+        match runtime::semantic_graph_workspace_read(args.runtime.workspace_root.clone()) {
             Ok(read) => Some(read),
             Err(error) => {
                 return error_envelope(
@@ -236,7 +236,7 @@ fn execute_agent_native_graph_refresh(args: AgentNativeGraphArgs) -> AgentEnvelo
         params["expectedGeneration"] = json!(snapshot.generation);
     }
     let request = json_rpc_request("raw/semantic-graph", params);
-    let session = match runtime::raw_rpc_session_ready(args.runtime.workspace_root.clone()) {
+    let session = match runtime::raw_rpc_session(args.runtime.workspace_root.clone()) {
         Ok(session) => session,
         Err(error) => {
             return error_envelope(

--- a/cli-rs/src/agent/navigation/native_graph/graph/derived_topology/write.rs
+++ b/cli-rs/src/agent/navigation/native_graph/graph/derived_topology/write.rs
@@ -11,7 +11,7 @@ pub(crate) fn write_reference_derived_topology(
 ) -> Result<DerivedTopologyReceipt> {
     let output = NewDerivedTopologyPath::resolve(workspace_root, output)?;
     let semantic_read =
-        crate::runtime::semantic_graph_workspace_read_ready(Some(output.workspace_root.clone()))?;
+        crate::runtime::semantic_graph_workspace_read(Some(output.workspace_root.clone()))?;
     let previous = prior
         .map(|path| read_previous_topology(&output.workspace_root, path))
         .transpose()?;

--- a/cli-rs/src/agent/navigation/native_graph/source_scope.rs
+++ b/cli-rs/src/agent/navigation/native_graph/source_scope.rs
@@ -23,7 +23,7 @@ fn native_graph_refresh_scope_snapshot(
     args: &AgentNativeGraphArgs,
 ) -> std::result::Result<NativeGraphRefreshScopeSnapshot, AgentError> {
     let workspace_root = native_graph_workspace_root(args)?;
-    let semantic_read = runtime::semantic_workspace_read_ready(Some(workspace_root.clone()))
+    let semantic_read = runtime::semantic_workspace_read(Some(workspace_root.clone()))
         .map_err(AgentError::from_cli_error)?;
     let published = semantic_read.published();
     let database = native_graph_database_path(args, Some(published))?;

--- a/cli-rs/src/configuration/config/load.rs
+++ b/cli-rs/src/configuration/config/load.rs
@@ -131,8 +131,13 @@ impl KastConfig {
                 self.server.max_concurrent_requests = value;
             }
         }
-        if let Some(value) = partial.indexer.and_then(|indexer| indexer.host_command) {
-            self.indexer.host_command = value;
+        if let Some(indexer) = partial.indexer {
+            if let Some(value) = indexer.host_command {
+                self.indexer.host_command = value;
+            }
+            if let Some(value) = indexer.max_heap_megabytes {
+                self.indexer.max_heap_megabytes = value;
+            }
         }
         if let Some(hooks) = partial.codex.and_then(|codex| codex.hooks) {
             if let Some(value) = hooks.enabled {

--- a/cli-rs/src/configuration/config/model.rs
+++ b/cli-rs/src/configuration/config/model.rs
@@ -28,6 +28,23 @@ pub struct IndexerConfig {
     pub runtime_libs_dir: Option<PathBuf>,
     pub host_home: Option<PathBuf>,
     pub host_command: PathBuf,
+    pub max_heap_megabytes: IndexerMaxHeapMegabytes,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct IndexerMaxHeapMegabytes(NonZeroU32);
+
+impl IndexerMaxHeapMegabytes {
+    pub(crate) fn jvm_argument(self) -> String {
+        format!("-Xmx{}m", self.0)
+    }
+}
+
+impl Default for IndexerMaxHeapMegabytes {
+    fn default() -> Self {
+        Self(NonZeroU32::new(2_048).expect("default indexer heap is positive"))
+    }
 }
 
 impl Default for IndexerConfig {
@@ -36,6 +53,7 @@ impl Default for IndexerConfig {
             runtime_libs_dir: None,
             host_home: None,
             host_command: PathBuf::from("idea"),
+            max_heap_megabytes: IndexerMaxHeapMegabytes::default(),
         }
     }
 }

--- a/cli-rs/src/configuration/config/partial.rs
+++ b/cli-rs/src/configuration/config/partial.rs
@@ -25,6 +25,7 @@ struct PartialServer {
 #[serde(rename_all = "camelCase")]
 struct PartialIndexer {
     host_command: Option<PathBuf>,
+    max_heap_megabytes: Option<IndexerMaxHeapMegabytes>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/cli-rs/src/configuration/config/workspace/mutation.rs
+++ b/cli-rs/src/configuration/config/workspace/mutation.rs
@@ -73,6 +73,7 @@ const MUTABLE_CONFIG_FIELDS: &[ConfigFieldSpec] = &[
     ConfigFieldSpec::positive("server.requestTimeoutMillis"),
     ConfigFieldSpec::positive("server.maxConcurrentRequests"),
     ConfigFieldSpec::new("indexer.hostCommand", ConfigValueType::String),
+    ConfigFieldSpec::positive("indexer.maxHeapMegabytes"),
     ConfigFieldSpec::new("codex.hooks.enabled", ConfigValueType::Boolean),
     ConfigFieldSpec::new("codex.hooks.sessionStart", ConfigValueType::Boolean),
     ConfigFieldSpec::new("codex.hooks.postToolUse", ConfigValueType::Boolean),

--- a/cli-rs/src/execution/runtime/backend/indexer_authority.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority.rs
@@ -166,6 +166,7 @@ struct AdmittedIndexerCapabilities {
 pub(crate) enum SemanticRuntimeAvailability {
     ReuseOnly,
     StartIfMissing,
+    StartIfMissingOrAwaitCapability,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/ownership/admission.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/ownership/admission.rs
@@ -5,56 +5,134 @@ pub(super) fn admit_indexer_runtime<C: RequiredCapability>(
         Ok(candidate) => {
             construct_admitted_runtime(request, candidate, RuntimeAdmissionPath::Reused)
         }
-        Err(rejection)
-            if request.availability == SemanticRuntimeAvailability::StartIfMissing
-                && matches!(rejection.code, "NO_INDEXER_AVAILABLE" | "RUNTIME_NOT_READY") =>
+        Err(CandidateAdmissionRejection::Missing(_))
+            if matches!(
+                request.availability,
+                SemanticRuntimeAvailability::StartIfMissing
+                    | SemanticRuntimeAvailability::StartIfMissingOrAwaitCapability
+            ) =>
         {
             start_indexer_runtime(request)
         }
-        Err(rejection) => Err(rejection),
+        Err(CandidateAdmissionRejection::PresentButNotReady { candidate, .. })
+            if request.availability
+                == SemanticRuntimeAvailability::StartIfMissingOrAwaitCapability =>
+        {
+            await_observed_runtime(request, *candidate)
+        }
+        Err(rejection) => Err(rejection.into_runtime_rejection()),
+    }
+}
+
+enum CandidateAdmissionRejection {
+    Missing(SemanticRuntimeRejection),
+    PresentButNotReady {
+        candidate: Box<RuntimeCandidateStatus>,
+        rejection: SemanticRuntimeRejection,
+    },
+    Terminal(SemanticRuntimeRejection),
+}
+
+impl CandidateAdmissionRejection {
+    fn into_runtime_rejection(self) -> SemanticRuntimeRejection {
+        match self {
+            Self::Missing(rejection)
+            | Self::Terminal(rejection) => rejection,
+            Self::PresentButNotReady { rejection, .. } => rejection,
+        }
     }
 }
 
 fn admitted_candidate<C: RequiredCapability>(
     request: &SemanticRuntimeRequest<C>,
-) -> std::result::Result<RuntimeCandidateStatus, SemanticRuntimeRejection> {
+) -> std::result::Result<RuntimeCandidateStatus, CandidateAdmissionRejection> {
     let inspection = inspect_indexer_workspace_with_config(
         &request.workspace_root,
         &request.config,
         StaleDescriptorPolicy::Preserve,
     )
     .map_err(|error| {
-        runtime_cli_rejection(&request.workspace_root, request.workspace_kind, error)
+        CandidateAdmissionRejection::Terminal(runtime_cli_rejection(
+            &request.workspace_root,
+            request.workspace_kind,
+            error,
+        ))
     })?;
     let reachable_candidates = inspection
         .candidates
         .into_iter()
-        .filter(|candidate| candidate.runtime_status.as_ref().is_some_and(is_servable))
+        .filter(|candidate| candidate.reachable)
         .collect::<Vec<_>>();
     if reachable_candidates.len() > 1 {
-        return Err(indexer_conflict_rejection(
-            &request.workspace_root,
-            request.workspace_kind,
-            &reachable_candidates,
+        return Err(CandidateAdmissionRejection::Terminal(
+            indexer_conflict_rejection(
+                &request.workspace_root,
+                request.workspace_kind,
+                &reachable_candidates,
+            ),
         ));
     }
-    let candidate = reachable_candidates.into_iter().next().filter(|candidate| {
-        candidate.runtime_status.as_ref().is_some_and(|status| {
-            status
+    let Some(candidate) = reachable_candidates.into_iter().next() else {
+        return Err(CandidateAdmissionRejection::Missing(
+            unavailable_rejection(
+                &request.workspace_root,
+                request.workspace_kind,
+                request.accept_indexing,
+            ),
+        ));
+    };
+    if candidate.runtime_status.as_ref().is_some_and(|status| {
+        is_servable(status)
+            && status
                 .published_workspace_generation
                 .as_ref()
                 .is_some_and(|publication| {
                     require_capability_publication::<C>(status, publication).is_ok()
                 })
-        })
-    });
-    candidate.ok_or_else(|| {
-        unavailable_rejection(
+    }) {
+        return Ok(candidate);
+    }
+    Err(CandidateAdmissionRejection::PresentButNotReady {
+        candidate: Box::new(candidate),
+        rejection: unavailable_rejection(
             &request.workspace_root,
             request.workspace_kind,
-            request.accept_indexing,
-        )
+            false,
+        ),
     })
+}
+
+fn await_observed_runtime<C: RequiredCapability>(
+    request: SemanticRuntimeRequest<C>,
+    observed: RuntimeCandidateStatus,
+) -> std::result::Result<AdmittedIndexerRuntime<C>, SemanticRuntimeRejection> {
+    let expected_descriptor = observed.descriptor;
+    let started_at = Instant::now();
+    let candidate = poll_for_runtime_candidate(
+        request.wait_timeout_ms,
+        250,
+        || u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX),
+        || {
+            admitted_candidate(&request)
+                .ok()
+                .filter(|candidate| candidate.descriptor == expected_descriptor)
+        },
+        |duration_ms| thread::sleep(Duration::from_millis(duration_ms)),
+    )
+    .ok_or_else(|| {
+        runtime_cli_rejection(
+            &request.workspace_root,
+            request.workspace_kind,
+            CliError::new(
+                "RUNTIME_TIMEOUT",
+                format!(
+                    "Timed out waiting for the existing indexer for {}.",
+                    request.workspace_root.display()
+                ),
+            ),
+        )
+    })?;
+    construct_admitted_runtime(request, candidate, RuntimeAdmissionPath::Reused)
 }
 
 enum RuntimeAdmissionPath<C: RequiredCapability> {

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/registration/environment.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/registration/environment.rs
@@ -6,6 +6,9 @@ use std::collections::{BTreeMap, btree_map};
 use std::ffi::{OsStr, OsString};
 use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
 
+const IMPLICIT_JVM_OPTION_VARIABLES: [&str; 3] =
+    ["JAVA_TOOL_OPTIONS", "JDK_JAVA_OPTIONS", "_JAVA_OPTIONS"];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::runtime::indexer_authority) struct ServiceLaunchEnvironment {
     variables: BTreeMap<OsString, OsString>,
@@ -27,6 +30,9 @@ impl ServiceLaunchEnvironment {
         inherited: impl IntoIterator<Item = (OsString, OsString)>,
     ) -> std::result::Result<Self, &'static str> {
         let mut environment = Self::from_variables(inherited)?;
+        for variable in IMPLICIT_JVM_OPTION_VARIABLES {
+            environment.variables.remove(OsStr::new(variable));
+        }
         environment.variables.insert(
             OsString::from("KAST_HOME"),
             config.paths.install_root.as_os_str().to_os_string(),
@@ -186,6 +192,15 @@ mod tests {
                 OsString::from("HTTPS_PROXY"),
                 OsString::from("https://proxy.invalid"),
             ),
+            (
+                OsString::from("JAVA_TOOL_OPTIONS"),
+                OsString::from("-Xmx8192m"),
+            ),
+            (
+                OsString::from("JDK_JAVA_OPTIONS"),
+                OsString::from("-Xmx7168m"),
+            ),
+            (OsString::from("_JAVA_OPTIONS"), OsString::from("-Xmx6144m")),
             (OsString::from("KAST_HOME"), OsString::from("/poisoned")),
             (OsString::from("KAST_INDEXER"), OsString::from("false")),
             (
@@ -224,6 +239,9 @@ mod tests {
             environment.value(OsStr::new("HTTPS_PROXY")),
             Some(OsStr::new("https://proxy.invalid")),
         );
+        for variable in IMPLICIT_JVM_OPTION_VARIABLES {
+            assert_eq!(environment.value(OsStr::new(variable)), None);
+        }
         assert_eq!(
             environment.value(OsStr::new("KAST_HOME")),
             Some(config.paths.install_root.as_os_str()),

--- a/cli-rs/src/execution/runtime/backend/workspace_admission.rs
+++ b/cli-rs/src/execution/runtime/backend/workspace_admission.rs
@@ -92,30 +92,19 @@ pub(crate) enum SemanticWorkspaceRoute<C: lifecycle_typestate::RequiredCapabilit
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SourceReadyRuntime {
-    source: lifecycle_typestate::SourceReady<lifecycle_typestate::SourceCapability>,
+pub(crate) struct ReferenceReadyRuntime {
+    ready: lifecycle_typestate::ReferenceReady<lifecycle_typestate::ReferenceCapability>,
     backend_name: String,
-    references: ReferenceLaneEvidence,
     source_module_count: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReferenceLaneEvidence {
-    Ready,
-    Blocked,
-}
-
-impl SourceReadyRuntime {
+impl ReferenceReadyRuntime {
     pub(crate) fn workspace_root(&self) -> &Path {
-        self.source.runtime().root().as_path()
+        self.ready.source().runtime().root().as_path()
     }
 
     pub(crate) fn backend_name(&self) -> &str {
         &self.backend_name
-    }
-
-    pub(crate) fn reference_index_ready(&self) -> bool {
-        matches!(self.references, ReferenceLaneEvidence::Ready)
     }
 
     pub(crate) fn source_module_count(&self) -> usize {
@@ -123,64 +112,7 @@ impl SourceReadyRuntime {
     }
 
     pub(crate) fn source_revision(&self) -> u64 {
-        self.source.revision().value()
-    }
-}
-
-pub(crate) fn demand_source_ready_runtime(
-    requested_workspace_root: Option<PathBuf>,
-) -> Result<SourceReadyRuntime> {
-    let route = semantic_workspace_route_with_availability(
-        semantic_runtime_args(requested_workspace_root, false, false),
-        indexer_authority::SemanticRuntimeAvailability::StartIfMissing,
-        lifecycle_typestate::Demand::<lifecycle_typestate::SourceCapability>::new(),
-    )?;
-    let admission = match route {
-        SemanticWorkspaceRoute::Admitted(admission) => admission,
-        SemanticWorkspaceRoute::Rejected(rejection) => return Err(rejection.into_cli_error()),
-    };
-    let epoch = admission.validate_current()?;
-    let source = epoch.capability_ready()?;
-    let status = admission
-        .candidate()
-        .runtime_status
-        .as_ref()
-        .ok_or_else(|| {
-            CliError::new(
-                "SOURCE_READY_EVIDENCE_MISSING",
-                "Source-ready admission returned no runtime epoch evidence.",
-            )
-        })?;
-    if status.state != RuntimeState::Ready
-        || !status.active()
-        || status.indexing()
-        || status.source_module_names.is_empty()
-    {
-        return Err(CliError::new(
-            "SOURCE_READY_EVIDENCE_INVALID",
-            "Source-ready admission returned an epoch without committed source evidence.",
-        ));
-    }
-    Ok(SourceReadyRuntime {
-        source,
-        backend_name: status.backend_name.clone(),
-        references: if status.reference_index_ready() {
-            ReferenceLaneEvidence::Ready
-        } else {
-            ReferenceLaneEvidence::Blocked
-        },
-        source_module_count: status.source_module_names.len(),
-    })
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct ReferenceReadyRuntime {
-    ready: lifecycle_typestate::ReferenceReady<lifecycle_typestate::ReferenceCapability>,
-}
-
-impl ReferenceReadyRuntime {
-    pub(crate) fn workspace_root(&self) -> &Path {
-        self.ready.source().runtime().root().as_path()
+        self.ready.source().revision().value()
     }
 }
 
@@ -189,7 +121,7 @@ pub(crate) fn demand_reference_ready_runtime(
 ) -> Result<ReferenceReadyRuntime> {
     let route = semantic_workspace_route_with_availability(
         semantic_runtime_args(requested_workspace_root, false, false),
-        indexer_authority::SemanticRuntimeAvailability::StartIfMissing,
+        indexer_authority::SemanticRuntimeAvailability::StartIfMissingOrAwaitCapability,
         lifecycle_typestate::Demand::<lifecycle_typestate::ReferenceCapability>::new(),
     )?;
     let admission = match route {
@@ -197,7 +129,32 @@ pub(crate) fn demand_reference_ready_runtime(
         SemanticWorkspaceRoute::Rejected(rejection) => return Err(rejection.into_cli_error()),
     };
     let ready = admission.validate_current()?.capability_ready()?;
-    Ok(ReferenceReadyRuntime { ready })
+    let status = admission
+        .candidate()
+        .runtime_status
+        .as_ref()
+        .ok_or_else(|| {
+            CliError::new(
+                "REFERENCE_READY_EVIDENCE_MISSING",
+                "Reference-ready admission returned no runtime epoch evidence.",
+            )
+        })?;
+    if status.state != RuntimeState::Ready
+        || !status.active()
+        || status.indexing()
+        || status.source_module_names.is_empty()
+        || !status.reference_index_ready()
+    {
+        return Err(CliError::new(
+            "REFERENCE_READY_EVIDENCE_INVALID",
+            "Reference-ready admission returned an epoch without committed source and reference evidence.",
+        ));
+    }
+    Ok(ReferenceReadyRuntime {
+        ready,
+        backend_name: status.backend_name.clone(),
+        source_module_count: status.source_module_names.len(),
+    })
 }
 
 pub(crate) fn semantic_workspace_route(
@@ -205,7 +162,7 @@ pub(crate) fn semantic_workspace_route(
 ) -> Result<SemanticWorkspaceRoute> {
     semantic_workspace_route_with_availability(
         semantic_runtime_args(requested_workspace_root, true, false),
-        indexer_authority::SemanticRuntimeAvailability::StartIfMissing,
+        semantic_demand_availability(),
         lifecycle_typestate::Demand::<lifecycle_typestate::SourceCapability>::new(),
     )
 }
@@ -226,7 +183,7 @@ pub(crate) fn semantic_workspace_route_for_runtime(
     let availability = if args.no_auto_start.unwrap_or(false) {
         indexer_authority::SemanticRuntimeAvailability::ReuseOnly
     } else {
-        indexer_authority::SemanticRuntimeAvailability::StartIfMissing
+        indexer_authority::SemanticRuntimeAvailability::StartIfMissingOrAwaitCapability
     };
     semantic_workspace_route_with_availability(
         args,
@@ -245,14 +202,18 @@ pub(crate) fn semantic_workspace_route_ready(
     )
 }
 
-pub(crate) fn semantic_graph_workspace_route_ready(
+pub(crate) fn semantic_graph_workspace_route(
     requested_workspace_root: Option<PathBuf>,
 ) -> Result<SemanticWorkspaceRoute<lifecycle_typestate::GraphCapability>> {
     semantic_workspace_route_with_availability(
-        semantic_runtime_args(requested_workspace_root, false, true),
-        indexer_authority::SemanticRuntimeAvailability::ReuseOnly,
+        semantic_runtime_args(requested_workspace_root, false, false),
+        semantic_demand_availability(),
         lifecycle_typestate::Demand::<lifecycle_typestate::GraphCapability>::new(),
     )
+}
+
+const fn semantic_demand_availability() -> indexer_authority::SemanticRuntimeAvailability {
+    indexer_authority::SemanticRuntimeAvailability::StartIfMissing
 }
 
 fn semantic_workspace_route_with_availability<C: lifecycle_typestate::RequiredCapability>(

--- a/cli-rs/src/execution/runtime/control/inspect.rs
+++ b/cli-rs/src/execution/runtime/control/inspect.rs
@@ -90,16 +90,18 @@ fn inspect_descriptor(
     }
 
     let socket_path = Path::new(&registered.descriptor.socket_path);
-    let status_result = rpc::request::<RuntimeStatusResponse>(
+    let status_response = rpc::request::<RuntimeStatusResponse>(
         socket_path,
         "runtime/status",
         Value::Object(Default::default()),
-    )
-    .and_then(RuntimeStatusResponse::validate_protocol)
-    .and_then(|status| {
-        validate_runtime_status_identity(&registered.descriptor, &status)?;
-        Ok(status)
-    });
+    );
+    let reachable = status_response.is_ok();
+    let status_result = status_response
+        .and_then(RuntimeStatusResponse::validate_protocol)
+        .and_then(|status| {
+            validate_runtime_status_identity(&registered.descriptor, &status)?;
+            Ok(status)
+        });
     let (runtime_status, error_message) = match status_result {
         Ok(status) => (Some(status), None),
         Err(error) => (None, Some(error.message)),
@@ -121,7 +123,7 @@ fn inspect_descriptor(
         descriptor_path: registered.id,
         descriptor: registered.descriptor,
         pid_alive: true,
-        reachable: runtime_status.is_some(),
+        reachable,
         ready,
         runtime_status,
         capabilities,

--- a/cli-rs/src/execution/runtime/wire/rpc.rs
+++ b/cli-rs/src/execution/runtime/wire/rpc.rs
@@ -186,10 +186,16 @@ pub(crate) fn semantic_workspace_read_ready(
     raw_rpc_session_ready(requested_workspace_root)?.semantic_read()
 }
 
-pub(crate) fn semantic_graph_workspace_read_ready(
+pub(crate) fn semantic_workspace_read(
+    requested_workspace_root: Option<PathBuf>,
+) -> Result<SemanticWorkspaceRead> {
+    raw_rpc_session(requested_workspace_root)?.semantic_read()
+}
+
+pub(crate) fn semantic_graph_workspace_read(
     requested_workspace_root: Option<PathBuf>,
 ) -> Result<SemanticWorkspaceRead<lifecycle_typestate::GraphCapability>> {
-    raw_rpc_session_from_route(semantic_graph_workspace_route_ready(requested_workspace_root)?)?
+    raw_rpc_session_from_route(semantic_graph_workspace_route(requested_workspace_root)?)?
         .semantic_read()
 }
 
@@ -362,4 +368,23 @@ fn published_runtime_status_unavailable() -> CliError {
         "PUBLISHED_WORKSPACE_UNAVAILABLE",
         "The READY indexer runtime did not advertise its published workspace generation.",
     )
+}
+
+#[cfg(test)]
+mod semantic_demand_entrypoint_tests {
+    use super::*;
+
+    #[test]
+    fn graph_and_source_reads_expose_start_capable_semantic_demand_entrypoints() {
+        assert_eq!(
+            semantic_demand_availability(),
+            indexer_authority::SemanticRuntimeAvailability::StartIfMissing,
+        );
+        let _source_demand: fn(Option<PathBuf>) -> Result<SemanticWorkspaceRead> =
+            semantic_workspace_read;
+        let _graph_demand: fn(
+            Option<PathBuf>,
+        ) -> Result<SemanticWorkspaceRead<lifecycle_typestate::GraphCapability>> =
+            semantic_graph_workspace_read;
+    }
 }

--- a/cli-rs/src/operations/daemon.rs
+++ b/cli-rs/src/operations/daemon.rs
@@ -68,8 +68,14 @@ fn linux_indexer_java_command(args: &DaemonStartArgs, config: &KastConfig) -> Re
         write_runtime_config_file(args, config, Some(&runtime_libs_dir), &idea_home)?;
     command.extend(indexer_jvm_args(&idea_home, config));
     if let Ok(java_opts) = env::var("JAVA_OPTS") {
-        command.extend(java_opts.split_whitespace().map(ToOwned::to_owned));
+        command.extend(
+            java_opts
+                .split_whitespace()
+                .filter(|argument| !is_indexer_heap_argument(argument))
+                .map(ToOwned::to_owned),
+        );
     }
+    command.push(config.indexer.max_heap_megabytes.jvm_argument());
     command.push("-cp".to_string());
     command.push(classpath);
     command.push(INDEXER_MAIN_CLASS.to_string());
@@ -248,6 +254,10 @@ fn indexer_jvm_args(idea_home: &Path, config: &KastConfig) -> Vec<String> {
         .map(|module| format!("--add-opens={module}=ALL-UNNAMED")),
     );
     args
+}
+
+fn is_indexer_heap_argument(argument: &str) -> bool {
+    argument.starts_with("-Xmx")
 }
 
 fn read_classpath(runtime_libs_dir: &Path) -> Result<String> {

--- a/cli-rs/src/operations/package.rs
+++ b/cli-rs/src/operations/package.rs
@@ -311,6 +311,9 @@ include!("parts/package/filesystem.rs");
 mod sidecar_tests {
     use super::*;
 
+    const KOTLIN_JPS_SIDECAR_PATH: &str =
+        "idea-home/plugins/kast-indexer/lib/kotlin-jps-plugin.jar";
+
     #[test]
     fn macos_bundle_stages_only_the_indexer_payload() {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -328,6 +331,7 @@ mod sidecar_tests {
             "payload",
         )
         .expect("payload");
+        fs::write(source.join(KOTLIN_JPS_SIDECAR_PATH), "Kotlin JPS").expect("Kotlin JPS payload");
 
         stage_indexer_for_platform(&source, &target, "macos-arm64").expect("stage sidecar");
 
@@ -336,6 +340,13 @@ mod sidecar_tests {
             target
                 .join("idea-home/plugins/kast-indexer/lib/kast-indexer.jar")
                 .is_file()
+        );
+        assert_eq!(
+            fs::read_to_string(
+                target.join("idea-home/plugins/kast-indexer/lib/kotlin-jps-plugin.jar"),
+            )
+            .expect("bundled Kotlin JPS payload"),
+            "Kotlin JPS",
         );
         assert!(!target.join("runtime-libs").exists());
         assert!(!target.join("idea-home/lib").exists());

--- a/cli-rs/src/operations/parts/daemon/installed_idea.rs
+++ b/cli-rs/src/operations/parts/daemon/installed_idea.rs
@@ -107,8 +107,8 @@ fn installed_idea_sidecar_java_command(
             )
         })?;
     }
-    preflight_installed_idea_semantic_runtime(&idea_home, &idea_system)?;
     let payload_plugin = installed_sidecar_plugin(args, config)?;
+    preflight_installed_idea_semantic_runtime(&payload_plugin, &idea_system)?;
     let isolated_plugin = plugins.join("kast-indexer");
     ensure_isolated_plugin_link(&payload_plugin, &isolated_plugin)?;
     let runtime_config_file = write_runtime_config_file(args, config, None, &idea_home)?;
@@ -138,8 +138,14 @@ fn installed_idea_sidecar_java_command(
             .filter(|argument| !is_sidecar_managed_jvm_argument(argument)),
     );
     if let Ok(java_opts) = env::var("JAVA_OPTS") {
-        command.extend(java_opts.split_whitespace().map(ToOwned::to_owned));
+        command.extend(
+            java_opts
+                .split_whitespace()
+                .filter(|argument| !is_indexer_heap_argument(argument))
+                .map(ToOwned::to_owned),
+        );
     }
+    command.push(config.indexer.max_heap_megabytes.jvm_argument());
     command.extend([
         "-Djava.awt.headless=true".to_string(),
         "-Didea.is.internal=true".to_string(),
@@ -211,6 +217,9 @@ fn materialize_product_argument(argument: &str, app: &Path, idea_home: &Path) ->
 
 #[cfg(target_os = "macos")]
 fn is_sidecar_managed_jvm_argument(argument: &str) -> bool {
+    if is_indexer_heap_argument(argument) {
+        return true;
+    }
     [
         "-Djava.awt.headless=",
         "-Didea.home.path=",

--- a/cli-rs/src/operations/parts/daemon/installed_idea_preflight.rs
+++ b/cli-rs/src/operations/parts/daemon/installed_idea_preflight.rs
@@ -1,13 +1,16 @@
 #[cfg(target_os = "macos")]
-fn preflight_installed_idea_semantic_runtime(idea_home: &Path, idea_system: &Path) -> Result<()> {
+fn preflight_installed_idea_semantic_runtime(
+    payload_plugin: &Path,
+    idea_system: &Path,
+) -> Result<()> {
     const KOTLIN_BUILDER: &str = "org/jetbrains/kotlin/jps/build/KotlinBuilder.class";
 
-    let kotlin_jps = idea_home.join("plugins/Kotlin/lib/jps/kotlin-jps-plugin.jar");
+    let kotlin_jps = payload_plugin.join("lib/kotlin-jps-plugin.jar");
     let file = fs::File::open(&kotlin_jps).map_err(|error| {
         CliError::new(
             "INDEXER_DEPENDENCY_UNAVAILABLE",
             format!(
-                "Required Kotlin/JPS dependency org.jetbrains.kotlin:kotlin-jps-plugin is unavailable at {}: {error}. Repair the supported IDE installation before starting Kast.",
+                "The active Kast release is missing its pinned Kotlin/JPS dependency at {}: {error}. Run `kast setup` for the active release before starting Kast.",
                 kotlin_jps.display(),
             ),
         )
@@ -56,7 +59,7 @@ fn invalid_kotlin_jps_dependency(path: &Path, reason: &str) -> CliError {
     CliError::new(
         "INDEXER_DEPENDENCY_INVALID",
         format!(
-            "Required Kotlin/JPS dependency org.jetbrains.kotlin:kotlin-jps-plugin is invalid at {}: {reason}. Repair the supported IDE installation before starting Kast.",
+            "The active Kast release contains an invalid pinned Kotlin/JPS dependency at {}: {reason}. Run `kast setup` for the active release before starting Kast.",
             path.display(),
         ),
     )

--- a/cli-rs/src/operations/parts/daemon/tests.rs
+++ b/cli-rs/src/operations/parts/daemon/tests.rs
@@ -191,15 +191,12 @@ mod tests {
         let resources = contents.join("Resources");
         let java = contents.join("jbr/Contents/Home/bin/java");
         let boot_jar = contents.join("lib/platform-loader.jar");
-        let kotlin_jps = contents.join("plugins/Kotlin/lib/jps/kotlin-jps-plugin.jar");
         std::fs::create_dir(&workspace).unwrap();
         std::fs::create_dir_all(&resources).unwrap();
         std::fs::create_dir_all(java.parent().unwrap()).unwrap();
         std::fs::create_dir_all(boot_jar.parent().unwrap()).unwrap();
-        std::fs::create_dir_all(kotlin_jps.parent().unwrap()).unwrap();
         std::fs::write(&java, "fixture").unwrap();
         std::fs::write(&boot_jar, "fixture").unwrap();
-        write_kotlin_jps_fixture(&kotlin_jps);
         std::fs::write(
             resources.join("product-info.json"),
             serde_json::to_vec(&serde_json::json!({
@@ -210,7 +207,7 @@ mod tests {
                     "arch": if cfg!(target_arch = "aarch64") { "aarch64" } else { "x86_64" },
                     "javaExecutablePath": "../jbr/Contents/Home/bin/java",
                     "bootClassPathJarNames": ["platform-loader.jar"],
-                    "additionalJvmArguments": ["-Dfixture.product=true"],
+                    "additionalJvmArguments": ["-Dfixture.product=true", "-Xmx8192m"],
                     "mainClass": "com.intellij.idea.Main"
                 }]
             }))
@@ -227,6 +224,7 @@ mod tests {
             .join("current/lib/backends/indexer/current/idea-home/plugins/kast-indexer/lib");
         std::fs::create_dir_all(&payload).unwrap();
         std::fs::write(payload.join("kast-indexer.jar"), "fixture").unwrap();
+        write_kotlin_jps_fixture(&payload.join("kotlin-jps-plugin.jar"));
         let args = DaemonStartArgs {
             workspace_root: Some(workspace.clone()),
             runtime_libs_dir: None,
@@ -263,6 +261,14 @@ mod tests {
         );
         assert!(command.contains(&"com.intellij.idea.Main".to_string()));
         assert!(command.contains(&"kast-indexer".to_string()));
+        assert_eq!(
+            command
+                .iter()
+                .filter(|argument| argument.starts_with("-Xmx"))
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            vec!["-Xmx2048m"],
+        );
         assert!(!command.contains(&"-Didea.force.use.core.classloader=true".to_string()));
         let sidecar_root = config
             .paths
@@ -287,11 +293,8 @@ mod tests {
     fn installed_idea_preflight_rejects_missing_kotlin_jps_dependency() {
         let temp = tempfile::tempdir().unwrap();
         let error = preflight_installed_idea_semantic_runtime(
-            &temp.path().join("idea-home"),
-            &temp.path().join("idea-system"),
-        )
-        .unwrap_err();
-
+            &temp.path().join("kast-indexer"), &temp.path().join("idea-system"),
+        ).unwrap_err();
         assert_eq!(error.code, "INDEXER_DEPENDENCY_UNAVAILABLE");
         assert!(error.message.contains("kotlin-jps-plugin"));
     }
@@ -300,16 +303,13 @@ mod tests {
     #[test]
     fn installed_idea_preflight_rejects_truncated_kotlin_jps_dependency() {
         let temp = tempfile::tempdir().unwrap();
-        let idea_home = temp.path().join("idea-home");
-        let kotlin_jps = idea_home.join("plugins/Kotlin/lib/jps/kotlin-jps-plugin.jar");
+        let payload_plugin = temp.path().join("kast-indexer");
+        let kotlin_jps = payload_plugin.join("lib/kotlin-jps-plugin.jar");
         std::fs::create_dir_all(kotlin_jps.parent().unwrap()).unwrap();
         std::fs::write(&kotlin_jps, b"PK\x03\x04fixture").unwrap();
-
         let error = preflight_installed_idea_semantic_runtime(
-            &idea_home,
-            &temp.path().join("idea-system"),
-        )
-        .unwrap_err();
+            &payload_plugin, &temp.path().join("idea-system"),
+        ).unwrap_err();
 
         assert_eq!(error.code, "INDEXER_DEPENDENCY_INVALID");
         assert!(error.message.contains(&kotlin_jps.display().to_string()));
@@ -319,16 +319,16 @@ mod tests {
     #[test]
     fn installed_idea_preflight_rejects_corrupt_plugin_cache() {
         let temp = tempfile::tempdir().unwrap();
-        let idea_home = temp.path().join("idea-home");
+        let payload_plugin = temp.path().join("kast-indexer");
         let idea_system = temp.path().join("idea-system");
-        let kotlin_jps = idea_home.join("plugins/Kotlin/lib/jps/kotlin-jps-plugin.jar");
+        let kotlin_jps = payload_plugin.join("lib/kotlin-jps-plugin.jar");
         let cache = idea_system.join("plugins/pluginsXMLIds.json");
         std::fs::create_dir_all(kotlin_jps.parent().unwrap()).unwrap();
         std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
         write_kotlin_jps_fixture(&kotlin_jps);
         std::fs::write(&cache, "not-json").unwrap();
 
-        let error = preflight_installed_idea_semantic_runtime(&idea_home, &idea_system).unwrap_err();
+        let error = preflight_installed_idea_semantic_runtime(&payload_plugin, &idea_system).unwrap_err();
 
         assert_eq!(error.code, "INDEXER_CACHE_INVALID");
         assert!(error.message.contains(&cache.display().to_string()));

--- a/cli-rs/src/semantics/repository_intelligence/coverage/read.rs
+++ b/cli-rs/src/semantics/repository_intelligence/coverage/read.rs
@@ -3,7 +3,7 @@ include!("read/readiness.rs");
 pub(crate) fn semantic_graph_refresh_plan(
     workspace_root: &Path,
 ) -> Result<SemanticGraphRefreshPlan> {
-    let semantic_read = runtime::semantic_workspace_read_ready(Some(workspace_root.to_path_buf()))?;
+    let semantic_read = runtime::semantic_workspace_read(Some(workspace_root.to_path_buf()))?;
     let snapshot = read_coverage_from_published(
         workspace_root,
         RepositoryScope {
@@ -84,7 +84,7 @@ pub(crate) fn semantic_graph_read_admission(
     workspace_root: &Path,
 ) -> Result<SemanticGraphReadAdmission> {
     let semantic_read =
-        runtime::semantic_graph_workspace_read_ready(Some(workspace_root.to_path_buf()))?;
+        runtime::semantic_graph_workspace_read(Some(workspace_root.to_path_buf()))?;
     let snapshot = read_coverage_from_published(
         workspace_root,
         RepositoryScope {

--- a/cli-rs/tests/runtime/installed_idea_sidecar_smoke/main.rs
+++ b/cli-rs/tests/runtime/installed_idea_sidecar_smoke/main.rs
@@ -8,7 +8,8 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use support::{
-    default_install_root, default_socket_path_for_test, spawn_ready_indexer_backend_after_marker,
+    api_schema_version, default_install_root, default_socket_path_for_test,
+    spawn_ready_indexer_backend_after_marker, spawn_sequenced_indexer_backend,
 };
 
 const SIDECAR_LAUNCH_MARKER: &str = "__KAST_SIDECAR_LAUNCH__";
@@ -41,11 +42,9 @@ fn semantic_demand_launches_an_isolated_sidecar_from_a_supported_installed_idea(
     std::fs::create_dir_all(contents.join("Resources")).expect("resources");
     std::fs::create_dir_all(contents.join("bin")).expect("bin");
     std::fs::create_dir_all(contents.join("lib")).expect("lib");
-    std::fs::create_dir_all(contents.join("plugins/Kotlin/lib/jps")).expect("Kotlin JPS");
     std::fs::create_dir_all(java.parent().expect("JBR bin")).expect("JBR");
     std::fs::write(contents.join("Resources/build.txt"), "IU-262.1\n").expect("build");
     std::fs::write(contents.join("lib/platform-loader.jar"), b"fixture").expect("boot jar");
-    write_kotlin_jps_fixture(&contents.join("plugins/Kotlin/lib/jps/kotlin-jps-plugin.jar"));
     std::fs::write(
         contents.join("bin/idea.vmoptions"),
         format!(
@@ -79,10 +78,14 @@ fn semantic_demand_launches_an_isolated_sidecar_from_a_supported_installed_idea(
         b"fixture",
     )
     .expect("sidecar jar");
+    write_kotlin_jps_fixture(&sidecar_home.join("plugins/kast-indexer/lib/kotlin-jps-plugin.jar"));
     std::fs::create_dir_all(&config_home).expect("config home");
     std::fs::write(
         config_home.join("config.toml"),
-        format!("[indexer]\nhostCommand = \"{}\"\n", toml_path(&app)),
+        format!(
+            "[indexer]\nhostCommand = \"{}\"\nmaxHeapMegabytes = 3072\n",
+            toml_path(&app),
+        ),
     )
     .expect("config");
 
@@ -149,6 +152,7 @@ fn semantic_demand_launches_an_isolated_sidecar_from_a_supported_installed_idea(
         "{launch}",
     );
     assert!(launch.contains("\nkast-indexer\n"), "{launch}");
+    assert!(launch.contains("\n-Xmx3072m\n"), "{launch}");
     assert!(launch.contains("--workspace-root="), "{launch}");
     assert!(launch.contains("--runtime-config-file="), "{launch}");
     for path in [
@@ -162,6 +166,58 @@ fn semantic_demand_launches_an_isolated_sidecar_from_a_supported_installed_idea(
     assert!(
         !sidecar_home.join("../runtime-libs/classpath.txt").is_file(),
         "the macOS sidecar must not require packaged IDEA runtime libraries",
+    );
+}
+
+#[test]
+fn workspace_up_waits_for_reference_ready_epoch() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let home = fixture.path().join("home");
+    let config_home = fixture.path().join("config");
+    let workspace = fixture.path().join("workspace");
+    let socket = fixture.path().join("indexer.sock");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(workspace.join("settings.gradle.kts"), "").expect("Gradle settings");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let backend = spawn_sequenced_indexer_backend(
+        &home,
+        &config_home,
+        &workspace,
+        &socket,
+        vec![
+            ("runtime/status", runtime_status(&workspace, false)),
+            ("capabilities", semantic_capabilities(&workspace)),
+            ("runtime/status", runtime_status(&workspace, true)),
+            ("capabilities", semantic_capabilities(&workspace)),
+            ("runtime/status", runtime_status(&workspace, true)),
+        ],
+    );
+
+    let output = kast_public(&home, &config_home, &workspace)
+        .args(["--output", "json", "up"])
+        .output()
+        .expect("kast up");
+    let requests = backend.join().expect("sequenced backend");
+
+    assert!(
+        output.status.success(),
+        "up failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let output: serde_json::Value = serde_json::from_slice(&output.stdout).expect("up JSON");
+    assert_eq!(output["result"]["referenceIndexReady"], true, "{output:#}");
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request["method"].as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            Some("runtime/status"),
+            Some("capabilities"),
+            Some("runtime/status"),
+            Some("capabilities"),
+        ],
     );
 }
 
@@ -192,6 +248,46 @@ fn sidecar_semantic_demand_command(
         .stderr(Stdio::piped())
         .arg("up");
     command
+}
+
+fn kast_public(home: &Path, config_home: &Path, workspace: &Path) -> Command {
+    let mut command = support::kast(home, config_home);
+    command.arg0("kast").current_dir(workspace);
+    command
+}
+
+fn runtime_status(workspace: &Path, references_ready: bool) -> serde_json::Value {
+    serde_json::json!({
+        "state": "READY",
+        "backendName": "indexer",
+        "backendVersion": "scripted-test",
+        "workspaceRoot": workspace.display().to_string(),
+        "sourceModuleNames": [":fixture"],
+        "readiness": {
+            "runtime": {"type": "READY"},
+            "model": {"type": "READY"},
+            "references": {"type": if references_ready { "READY" } else { "BLOCKED" }},
+            "semanticGraph": {"type": "READY"},
+            "mutation": {"type": "READY"}
+        },
+        "schemaVersion": api_schema_version()
+    })
+}
+
+fn semantic_capabilities(workspace: &Path) -> serde_json::Value {
+    serde_json::json!({
+        "backendName": "indexer",
+        "backendVersion": "scripted-test",
+        "workspaceRoot": workspace.display().to_string(),
+        "readCapabilities": ["SEMANTIC_GRAPH"],
+        "mutationCapabilities": [],
+        "limits": {
+            "requestTimeoutMillis": 60000,
+            "maxResults": 1000,
+            "maxConcurrentRequests": 4
+        },
+        "schemaVersion": api_schema_version()
+    })
 }
 
 struct MarkerOnDrop(std::path::PathBuf);

--- a/cli-rs/tests/surface/config_cli/main.rs
+++ b/cli-rs/tests/surface/config_cli/main.rs
@@ -184,6 +184,51 @@ fn workspace_config_lists_sets_and_unsets_effective_values() {
 }
 
 #[test]
+fn workspace_config_owns_a_positive_tunable_indexer_heap() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let config_home = temp.path().join("config");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(workspace.join("settings.gradle.kts"), "").expect("Gradle marker");
+
+    let listed = run(&home, &config_home, &workspace, &["list"]);
+    assert!(listed.status.success());
+    let listed: serde_json::Value = serde_json::from_slice(&listed.stdout).expect("list JSON");
+    assert_eq!(listed["effective"]["indexer"]["maxHeapMegabytes"], 2048);
+    assert_eq!(
+        mutable_field(&listed, "indexer.maxHeapMegabytes")["valueType"],
+        "integer",
+    );
+
+    let set = run(
+        &home,
+        &config_home,
+        &workspace,
+        &["set", "indexer.maxHeapMegabytes", "3072"],
+    );
+    assert!(
+        set.status.success(),
+        "set failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&set.stdout),
+        String::from_utf8_lossy(&set.stderr),
+    );
+    let set: serde_json::Value = serde_json::from_slice(&set.stdout).expect("set JSON");
+    assert_eq!(set["effectiveValue"], 3072);
+
+    let zero = run(
+        &home,
+        &config_home,
+        &workspace,
+        &["set", "indexer.maxHeapMegabytes", "0"],
+    );
+    assert!(!zero.status.success());
+    let zero: serde_json::Value = serde_json::from_slice(&zero.stdout).expect("invalid JSON");
+    assert_eq!(zero["code"], "CONFIG_VALUE_INVALID");
+}
+
+#[test]
 fn workspace_config_mutates_inline_tables() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/codec/StringInterningCodec.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/codec/StringInterningCodec.kt
@@ -48,16 +48,10 @@ internal class StringInterningCodec(
     private val idColumn = domain.idColumn
     private val valueColumn = domain.valueColumn
     @Volatile
-    private var valueToId = ConcurrentHashMap<String, Int>()
+    private var effectiveValueToId = ConcurrentHashMap<String, Int>()
 
     @Volatile
-    private var idToValue = ConcurrentHashMap<Int, String>()
-
-    @Volatile
-    private var readValueToId = ConcurrentHashMap<String, Int>()
-
-    @Volatile
-    private var readIdToValue = ConcurrentHashMap<Int, String>()
+    private var effectiveIdToValue = ConcurrentHashMap<Int, String>()
 
     @Volatile
     private var loaded = false
@@ -97,10 +91,8 @@ internal class StringInterningCodec(
                 }
             }
         }
-        valueToId = loadedValues
-        idToValue = loadedIds
-        readValueToId = ConcurrentHashMap(loadedValues)
-        readIdToValue = ConcurrentHashMap(loadedIds)
+        effectiveValueToId = loadedValues
+        effectiveIdToValue = loadedIds
         loaded = true
     }
 
@@ -119,8 +111,6 @@ internal class StringInterningCodec(
         database: AttachedSqliteDatabase,
     ): ReadOnlyInterningAliasResolution {
         ensureLoaded(conn)
-        val values = ConcurrentHashMap(readValueToId)
-        val ids = ConcurrentHashMap(readIdToValue)
         conn.createStatement().use { statement ->
             statement.executeQuery("SELECT $idColumn, $valueColumn FROM $database.$tableName").use { rows ->
                 while (rows.next()) {
@@ -134,16 +124,14 @@ internal class StringInterningCodec(
                         ?: return ReadOnlyInterningAliasResolution.Rejected(
                             ReadOnlyInterningAliasFailure.MissingSourceValue(domain, sourceId),
                         )
-                    if (!values.containsKey(value)) {
+                    if (!effectiveValueToId.containsKey(value)) {
                         val effectiveId = Math.negateExact(sourceId)
-                        values[value] = effectiveId
-                        ids[effectiveId] = value
+                        effectiveIdToValue[effectiveId] = value
+                        effectiveValueToId[value] = effectiveId
                     }
                 }
             }
         }
-        readValueToId = values
-        readIdToValue = ids
         return ReadOnlyInterningAliasResolution.Loaded
     }
 
@@ -152,16 +140,14 @@ internal class StringInterningCodec(
         value: String,
     ): Int {
         ensureLoaded(conn)
-        valueToId[value]?.let { return it }
+        idFor(value)?.let { return it }
         conn.prepareStatement("INSERT OR IGNORE INTO $tableName ($valueColumn) VALUES (?)").use { stmt ->
             stmt.setString(1, value)
             stmt.executeUpdate()
         }
         val id = selectId(conn, value)
-        valueToId[value] = id
-        idToValue[id] = value
-        readValueToId[value] = id
-        readIdToValue[id] = value
+        effectiveIdToValue[id] = value
+        effectiveValueToId[value] = id
         return id
     }
 
@@ -171,7 +157,7 @@ internal class StringInterningCodec(
     ) {
         ensureLoaded(conn)
         val missingValues = ArrayList<String>(values.size)
-        values.filterTo(missingValues) { !valueToId.containsKey(it) }
+        values.filterTo(missingValues) { idFor(it) == null }
         if (missingValues.isEmpty()) return
         conn.prepareStatement("INSERT OR IGNORE INTO $tableName ($valueColumn) VALUES (?)").use { stmt ->
             for (value in missingValues) {
@@ -184,9 +170,9 @@ internal class StringInterningCodec(
     }
 
     fun resolve(id: Int): String =
-        readIdToValue[id] ?: throw IllegalStateException("Missing interned string in $tableName for $idColumn=$id")
+        effectiveIdToValue[id] ?: throw IllegalStateException("Missing interned string in $tableName for $idColumn=$id")
 
-    fun idFor(value: String): Int? = valueToId[value]
+    fun idFor(value: String): Int? = effectiveValueToId[value]?.takeIf { id -> id > 0 }
 
     /**
      * Proof transition: `String -> InternedStringReadIdResolution`.
@@ -195,7 +181,7 @@ internal class StringInterningCodec(
      * attached repository read authority. Absence is explicit; the raw SQLite
      * ID is extracted only while constructing or binding a query.
      */
-    fun idForRead(value: String): InternedStringReadIdResolution = readValueToId[value]
+    fun idForRead(value: String): InternedStringReadIdResolution = effectiveValueToId[value]
         ?.let(::InternedStringReadId)
         ?.let(InternedStringReadIdResolution::Resolved)
         ?: InternedStringReadIdResolution.Unavailable
@@ -221,16 +207,16 @@ internal class StringInterningCodec(
                     while (rs.next()) {
                         val id = rs.getInt(1)
                         val value = rs.getString(2)
-                        valueToId[value] = id
-                        idToValue[id] = value
-                        readValueToId[value] = id
-                        readIdToValue[id] = value
+                        effectiveIdToValue[id] = value
+                        effectiveValueToId[value] = id
                     }
                 }
             }
             start = end
         }
-        check(values.all(valueToId::containsKey)) { "Failed to load newly interned values from $tableName" }
+        check(values.all { value -> idFor(value) != null }) {
+            "Failed to load newly interned values from $tableName"
+        }
     }
 
     private fun selectId(

--- a/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/sqlite/lifecycle/SqliteSourceIndexStoreState.kt
+++ b/index-store/src/main/kotlin/io/github/amichne/kast/indexstore/store/sqlite/lifecycle/SqliteSourceIndexStoreState.kt
@@ -207,7 +207,7 @@ internal class SqliteSourceIndexStoreState(
                     stmt.execute("PRAGMA busy_timeout=5000")
                     stmt.execute("PRAGMA cache_size=-64000")
                     stmt.execute("PRAGMA mmap_size=268435456")
-                    stmt.execute("PRAGMA temp_store=MEMORY")
+                    stmt.execute("PRAGMA temp_store=FILE")
                     stmt.execute("PRAGMA foreign_keys=ON")
                 }
                 when (val attachment = repositoryOverlay.attachBase(conn)) {

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SourceIndexFilePolicyTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/SourceIndexFilePolicyTest.kt
@@ -37,6 +37,7 @@ class SourceIndexFilePolicyTest {
             "/workspace/plugin/build/distributions/Plugin.kt",
             "/workspace/.gradle/caches/Foo.kt",
             "/workspace/out/production/Foo.kt",
+            "/workspace/cli-rs/target/debug/deps/Foo.kt",
             "/workspace/.idea/Foo.kt",
         )) {
             assertFalse(policy.isEligible(Path.of(path)), path)

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/store/codec/StringInterningCodecTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/store/codec/StringInterningCodecTest.kt
@@ -17,6 +17,7 @@ import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.SQLException
 import java.sql.Statement
+import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.atomic.AtomicInteger
 
 class StringInterningCodecTest {
@@ -127,6 +128,63 @@ class StringInterningCodecTest {
             )
 
             assertTrue(resolution is ReadOnlyInterningAliasResolution.Rejected)
+        }
+    }
+
+    @Test
+    fun `large workspace and repository vocabularies retain one bidirectional cache`() {
+        Class.forName("org.sqlite.JDBC")
+        val base = workspaceRoot.resolve("repository-base.db")
+        val workspaceCount = 25_000
+        val repositoryCount = 25_000
+        DriverManager.getConnection("jdbc:sqlite:$base").use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute("CREATE TABLE fq_names (fq_id INTEGER PRIMARY KEY, fq_name TEXT NOT NULL UNIQUE)")
+            }
+            insertNames(connection, "repository", repositoryCount)
+        }
+        DriverManager.getConnection("jdbc:sqlite::memory:").use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute("CREATE TABLE fq_names (fq_id INTEGER PRIMARY KEY, fq_name TEXT NOT NULL UNIQUE)")
+                statement.execute("ATTACH DATABASE '${base.toAbsolutePath()}' AS repository_base")
+            }
+            insertNames(connection, "workspace", workspaceCount)
+            val codec = StringInterningCodec(StringInterningDomain.FQ_NAME)
+
+            codec.loadAll(connection)
+            assertEquals(
+                ReadOnlyInterningAliasResolution.Loaded,
+                codec.loadReadOnlyAliases(connection, AttachedSqliteDatabase.REPOSITORY_BASE),
+            )
+
+            val retainedMappings = codec.javaClass.declaredFields
+                .filter { field -> ConcurrentMap::class.java.isAssignableFrom(field.type) }
+                .sumOf { field ->
+                    field.isAccessible = true
+                    (field.get(codec) as ConcurrentMap<*, *>).size
+                }
+            assertEquals(
+                2 * (workspaceCount + repositoryCount),
+                retainedMappings,
+                "Each interned value should occupy only the forward and reverse cache",
+            )
+        }
+    }
+
+    private fun insertNames(connection: Connection, prefix: String, count: Int) {
+        val ownsTransaction = connection.autoCommit
+        if (ownsTransaction) connection.autoCommit = false
+        try {
+            connection.prepareStatement("INSERT INTO fq_names(fq_name) VALUES (?)").use { statement ->
+                repeat(count) { index ->
+                    statement.setString(1, "$prefix.example.type$index")
+                    statement.addBatch()
+                }
+                statement.executeBatch()
+            }
+            if (ownsTransaction) connection.commit()
+        } finally {
+            if (ownsTransaction) connection.autoCommit = true
         }
     }
 

--- a/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/store/lifecycle/WorkspaceWriteTransactionTest.kt
+++ b/index-store/src/test/kotlin/io/github/amichne/kast/indexstore/store/lifecycle/WorkspaceWriteTransactionTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import java.sql.DriverManager
+import java.sql.SQLException
 
 class WorkspaceWriteTransactionTest {
     @TempDir
@@ -34,6 +35,83 @@ class WorkspaceWriteTransactionTest {
             assertEquals(null, readHeadCommit(database))
         }
     }
+
+    @Test
+    fun `temporary SQLite state is file backed under large reconciliation pressure`() {
+        val workspaceRoot = tempDir.resolve("resource-workspace").toAbsolutePath().normalize()
+        val state = SqliteSourceIndexStoreState(
+            workspaceIdentity = WorkspaceIdentity.fromWorkspaceRoot(workspaceRoot),
+            pageReadObserver = SourceIndexPageReadObserver.Disabled,
+        )
+
+        state.use {
+            val tempStore = state.connection().createStatement().use { statement ->
+                statement.executeQuery("PRAGMA temp_store").use { rows ->
+                    check(rows.next())
+                    rows.getInt(1)
+                }
+            }
+
+            assertEquals(1, tempStore, "SQLite temp tables and sorts must spill to files, not native memory")
+        }
+    }
+
+    @Test
+    fun `simulated write exhaustion rolls back and leaves the store reusable`() {
+        val workspaceRoot = tempDir.resolve("write-pressure-workspace").toAbsolutePath().normalize()
+        val state = SqliteSourceIndexStoreState(
+            workspaceIdentity = WorkspaceIdentity.fromWorkspaceRoot(workspaceRoot),
+            pageReadObserver = SourceIndexPageReadObserver.Disabled,
+        )
+
+        state.use {
+            val connection = state.connection()
+            val generationBefore = state.readGenerationInTransaction(connection)
+            val currentPages = pragmaInt(connection, "page_count")
+            connection.createStatement().use { statement ->
+                statement.execute("PRAGMA max_page_count=${currentPages + 1}")
+            }
+
+            org.junit.jupiter.api.Assertions.assertThrows(SQLException::class.java) {
+                state.writeTransaction { transaction ->
+                    transaction.createStatement().use { statement ->
+                        statement.execute(
+                            "INSERT INTO workspace_discovery(cache_key, schema_version, payload) " +
+                                "VALUES ('write-pressure', 1, zeroblob(1048576))",
+                        )
+                    }
+                    state.incrementGenerationInTransaction(transaction)
+                }
+            }
+
+            assertEquals(generationBefore, state.readGenerationInTransaction(connection))
+            assertEquals(0, tableRowCount(connection, "workspace_discovery"))
+
+            connection.createStatement().use { statement ->
+                statement.execute("PRAGMA max_page_count=1073741823")
+            }
+            state.writeTransaction { transaction ->
+                state.incrementGenerationInTransaction(transaction)
+            }
+            assertEquals(generationBefore.value + 1, state.readGenerationInTransaction(connection).value)
+        }
+    }
+
+    private fun pragmaInt(connection: java.sql.Connection, name: String): Int =
+        connection.createStatement().use { statement ->
+            statement.executeQuery("PRAGMA $name").use { rows ->
+                check(rows.next())
+                rows.getInt(1)
+            }
+        }
+
+    private fun tableRowCount(connection: java.sql.Connection, table: String): Int =
+        connection.createStatement().use { statement ->
+            statement.executeQuery("SELECT COUNT(*) FROM $table").use { rows ->
+                check(rows.next())
+                rows.getInt(1)
+            }
+        }
 
     private fun readHeadCommit(database: Path): String? =
         DriverManager.getConnection("jdbc:sqlite:${database.toUri()}?mode=ro").use { connection ->

--- a/indexer/build.gradle.kts
+++ b/indexer/build.gradle.kts
@@ -305,6 +305,7 @@ val indexerPluginRequiredClassEntries = listOf(
     "io/github/amichne/kast/indexstore/store/SqliteSourceIndexStore.class",
     "io/github/amichne/kast/shared/analysis/PsiReferenceScanner.class",
     "io/github/amichne/kast/idea/IndexerServerRuntime.class",
+    "org/jetbrains/kotlin/jps/build/KotlinBuilder.class",
 )
 
 val indexerPluginRuntimeJarPrefixes = listOf(
@@ -326,8 +327,13 @@ tasks.named<Sync>("syncPortableDist") {
     from(indexerPluginJar) {
         into("idea-home/plugins/kast-indexer/lib")
     }
-    from(indexerPluginRuntime) {
-        into("idea-home/plugins/kast-indexer/lib")
+    into("idea-home/plugins/kast-indexer/lib") {
+        from(indexerPluginRuntime)
+        from(
+            extractedIdeaDistributionDirectory.file(
+                "plugins/Kotlin/lib/jps/kotlin-jps-plugin.jar",
+            ),
+        )
     }
     dependsOn("syncRuntimeLibs")
     dependsOn(extractIdeaDistribution)

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/workspace/indexing/WorkspaceIndexingScope.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/workspace/indexing/WorkspaceIndexingScope.kt
@@ -13,7 +13,6 @@ import java.nio.file.Path
 
 internal data class WorkspaceIndexingScope(
     val includedPaths: List<WorkspaceSourcePath>,
-    val ignoredPaths: List<Path>,
     val criticalPaths: List<WorkspaceSourcePath>,
     val unmatchedCriticalPatterns: List<WorkspaceIndexingPattern>,
 ) {
@@ -36,7 +35,6 @@ private data class WorkspaceIndexingRules(
         val sourceFilePolicy = SourceIndexFilePolicy.forWorkspace(rootPath)
         val matchedCriticalPatterns = linkedSetOf<WorkspaceIndexingPattern>()
         val included = mutableListOf<WorkspaceSourcePath>()
-        val ignored = mutableListOf<Path>()
         val critical = mutableListOf<WorkspaceSourcePath>()
 
         candidates
@@ -49,7 +47,6 @@ private data class WorkspaceIndexingRules(
             .forEach { path ->
                 val relative = WorkspaceRelativePath.resolve(rootPath, path)
                 if (relative == null) {
-                    ignored.add(path)
                     return@forEach
                 }
                 val matchingCriticalPatterns = criticalRules
@@ -67,7 +64,7 @@ private data class WorkspaceIndexingRules(
                     )
                 }
                 if (hardExcluded || ignoredByRule) {
-                    ignored.add(path)
+                    return@forEach
                 } else {
                     val sourcePath = checkNotNull(sourceFilePolicy.sourcePath(relative)) {
                         "Included indexing path is not an eligible Kotlin source file: ${relative.value}"
@@ -79,7 +76,6 @@ private data class WorkspaceIndexingRules(
 
         return WorkspaceIndexingScope(
             includedPaths = included,
-            ignoredPaths = ignored,
             criticalPaths = critical,
             unmatchedCriticalPatterns = criticalRules
                 .filterNot(matchedCriticalPatterns::contains),

--- a/indexer/src/main/kotlin/io/github/amichne/kast/idea/workspace/inventory/core/IdeaProjectModelWorkspaceFileInventory.kt
+++ b/indexer/src/main/kotlin/io/github/amichne/kast/idea/workspace/inventory/core/IdeaProjectModelWorkspaceFileInventory.kt
@@ -46,7 +46,10 @@ internal class IdeaProjectModelWorkspaceFileInventory private constructor(
         workspaceModelReader: () -> IdeaGradleProjectLoadBridge.GradleWorkspaceModel = {
             IdeaGradleProjectLoadBridge.readWorkspaceModel(project)
         },
-    ) : this(workspaceIdentity, IdeaProjectModelAccess(project, workspaceModelReader))
+    ) : this(
+        workspaceIdentity,
+        IdeaProjectModelAccess(project, workspaceIdentity.workspaceIdentity, workspaceModelReader),
+    )
 
     private constructor(
         workspaceIdentity: IdeaWorkspaceIdentity,
@@ -244,6 +247,7 @@ internal class IdeaProjectModelWorkspaceFileInventory private constructor(
 
     private class IdeaProjectModelAccess(
         private val project: Project,
+        private val workspaceIdentity: WorkspaceIdentity,
         private val workspaceModelReader: () -> IdeaGradleProjectLoadBridge.GradleWorkspaceModel,
     ) : IdeaWorkspaceFileProjectModelAccess {
         private val projectRootModificationTracker = ProjectRootModificationTracker.getInstance(project)
@@ -328,9 +332,15 @@ internal class IdeaProjectModelWorkspaceFileInventory private constructor(
             .filter(VirtualFile::isValid)
             .filterNot(VirtualFile::isDirectory)
             .filter { file -> file.path.endsWith(".kt") || file.path.endsWith(".kts") }
-            .distinctBy(VirtualFile::getPath)
-            .sortedBy(VirtualFile::getPath)
             .map(VirtualFile::toNioPath)
+            .map { path -> path.toAbsolutePath().normalize() }
+            .filter { path ->
+                workspaceIdentity.relativizeIfContained(path)
+                    ?.let { relative -> !WorkspacePathPolicy.isHardExcluded(relative) }
+                    ?: false
+            }
+            .distinct()
+            .sortedBy(Path::toString)
             .toList()
     }
 

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/workspace/IdeaProjectModelWorkspaceFileInventoryTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/workspace/IdeaProjectModelWorkspaceFileInventoryTest.kt
@@ -30,6 +30,7 @@ class IdeaProjectModelWorkspaceFileInventoryTest {
         val ordinaryScript = file(workspaceRoot.resolve("app/scripts/check.main.kts"))
         val rootSource = file(workspaceRoot.resolve("app/src/main/kotlin/App.kt"))
         val generatedOutput = file(workspaceRoot.resolve("build/generated/Generated.kt"))
+        val rustGeneratedOutput = file(workspaceRoot.resolve("cli-rs/target/debug/generated/Generated.kt"))
         val includedSource = file(includedRoot.resolve("app/src/main/kotlin/Included.kt"))
         val sharedSource = file(workspaceRoot.resolve("shared/Shared.kt"))
         val outsideSource = workspaceRoot.parent.resolve("outside-workspace/Outside.kt").toAbsolutePath().normalize()
@@ -44,6 +45,7 @@ class IdeaProjectModelWorkspaceFileInventoryTest {
                         ordinaryScript,
                         sharedSource,
                         generatedOutput,
+                        rustGeneratedOutput,
                         outsideSource,
                     ),
                 ),
@@ -96,6 +98,7 @@ class IdeaProjectModelWorkspaceFileInventoryTest {
         source.modules.forEach { module ->
             assertFalse(outsideSource.toString() in module.filePaths(WorkspaceFileKindDomain.SOURCE_ONLY))
             assertFalse(generatedOutput.toString() in module.filePaths(WorkspaceFileKindDomain.SOURCE_ONLY))
+            assertFalse(rustGeneratedOutput.toString() in module.filePaths(WorkspaceFileKindDomain.SOURCE_ONLY))
         }
     }
 

--- a/indexer/src/test/kotlin/io/github/amichne/kast/idea/workspace/WorkspaceIndexingScopeTest.kt
+++ b/indexer/src/test/kotlin/io/github/amichne/kast/idea/workspace/WorkspaceIndexingScopeTest.kt
@@ -37,10 +37,6 @@ class WorkspaceIndexingScopeTest {
             listOf("generated/keep.kt", "src/main/App.kt"),
             scope.includedPaths.map { it.relative.value },
         )
-        assertEquals(
-            listOf("generated/Drop.kt", "module/fixtures/Fixture.kt"),
-            scope.ignoredPaths.map { workspace.relativize(it).toString() },
-        )
     }
 
     @Test
@@ -63,7 +59,6 @@ class WorkspaceIndexingScopeTest {
             listOf("!important.kt", "#important.kt"),
             scope.includedPaths.map { it.relative.value },
         )
-        assertEquals(listOf("ordinary.kt"), scope.ignoredPaths.map(::relative))
     }
 
     @Test
@@ -100,6 +95,7 @@ class WorkspaceIndexingScopeTest {
             "src/main/App.kt",
             "src/test/AppTest.kt",
             "build/generated/Generated.kt",
+            "cli-rs/target/debug/generated/Generated.kt",
             ".gradle/cache/Cache.kt",
             "out/classes/Output.kt",
             ".idea/metadata/Idea.kt",
@@ -111,15 +107,28 @@ class WorkspaceIndexingScopeTest {
         val scope = WorkspaceIndexingScope.resolve(workspace, config, candidates)
 
         assertEquals(listOf("src/main/App.kt"), scope.includedPaths.map { it.relative.value })
+    }
+
+    @Test
+    fun `large excluded output scope does not remain retained after resolution`() {
+        val outputCandidates = List(20_000) { index ->
+            workspace.resolve("cli-rs/target/debug/incremental/$index/Generated.kt")
+        }
+        val sourceCandidates = List(64) { index ->
+            workspace.resolve("module-$index/src/main/kotlin/Source$index.kt")
+        }
+
+        val scope = WorkspaceIndexingScope.resolve(
+            workspace,
+            KastConfig.defaults().indexing,
+            outputCandidates + sourceCandidates,
+        )
+
+        assertEquals(64, scope.includedPaths.size)
         assertEquals(
-            listOf(
-                ".gradle/cache/Cache.kt",
-                ".idea/metadata/Idea.kt",
-                "build/generated/Generated.kt",
-                "out/classes/Output.kt",
-                "src/test/AppTest.kt",
-            ),
-            scope.ignoredPaths.map(::relative),
+            false,
+            WorkspaceIndexingScope::class.java.declaredFields.any { field -> field.name == "ignoredPaths" },
+            "Excluded build outputs must not be retained for the reconciliation lifetime",
         )
     }
 
@@ -134,7 +143,6 @@ class WorkspaceIndexingScopeTest {
         )
 
         assertEquals(listOf("nested/App.kt"), scope.includedPaths.map { it.relative.value })
-        assertEquals(listOf("App.kt"), scope.ignoredPaths.map(::relative))
     }
 
     @Test
@@ -170,7 +178,6 @@ class WorkspaceIndexingScopeTest {
         )
 
         assertEquals(listOf("src/main/Other.kt"), fallback.includedPaths.map { it.relative.value })
-        assertEquals(listOf("generated/New.kt"), fallback.ignoredPaths.map(::relative))
     }
 
     private fun candidates(vararg paths: String): List<Path> = paths.map { relative ->
@@ -179,6 +186,4 @@ class WorkspaceIndexingScopeTest {
             path.writeText("class Fixture\n")
         }
     }
-
-    private fun relative(path: Path): String = workspace.relativize(path).toString()
 }


### PR DESCRIPTION
## Summary

- exclude known Rust `target` output before project-model inventory and stop retaining rejected indexing candidates
- cut the interning cache from four retained maps to one forward/reverse pair and move SQLite temporary state from native memory to file-backed spill
- add a positive `indexer.maxHeapMegabytes` setting with a 2048 MiB default, emit one authoritative `-Xmx`, and remove inherited JVM heap overrides from service launches
- bundle the pinned Kotlin JPS jar in the portable indexer payload so macOS startup no longer resolves it from the installed host IDE
- require reference-ready evidence from `kast up`, restart source/graph demand after an idle stop, wait on an existing epoch only for explicit readiness demand, and never replace a live epoch merely because its capability is still publishing

## Resource-pressure evidence

Focused product tests passed with the Gradle daemon and test worker constrained by `_JAVA_OPTIONS=-Xmx256m` after normal compilation:

- 50,000 interned names retained exactly 100,000 forward/reverse mappings in 0.116 s
- 20,064 indexing candidates retained only the 64 admitted source paths in 1.003 s
- SQLite `temp_store=FILE` was observed in 0.436 s
- simulated `SQLITE_FULL` rolled back generation and payload writes, then the same store accepted the next transaction, in 0.021 s

Forcing the Kotlin compiler itself into 256 MiB failed in `:build-logic:compileKotlin`; that is a build-tool floor and occurred before product tests. The product tests above separate compilation memory from index-store/indexer behavior. No 1.6 GB fixture was constructed.

## Lifecycle and packaging evidence

- absent semantic demand launches exactly one isolated sidecar
- `kast up` waits for reference publication on the same live epoch
- graph demand against a live indexing epoch returns `RUNTIME_NOT_READY` without launch or replacement
- portable distribution verification requires `org/jetbrains/kotlin/jps/build/KotlinBuilder.class` from the bundled JPS jar
- configured 3072 MiB heap produces exactly one `-Xmx3072m`; host/product/implicit JVM overrides cannot supersede it

## Comparison with prior real-install evidence

The earlier JFR observed 2.8-3.2 GB daemon RSS during idle grace, while the graph CLI peak was 104.2 MB. This change addresses the mechanisms that scale toward memory/write exhaustion: retained path cardinality, duplicate string maps, SQLite temporary memory, uncontrolled heap arguments, and build-output ingestion. The new 2048 MiB setting bounds Java heap but does not claim total RSS is 2048 MiB because native, mapped, and IntelliJ memory remain separate. These constrained synthetic results are therefore mechanism-level confidence, not a replacement for a post-merge installed JFR at production scale.

## Validation

- `./gradlew :analysis-api:test :index-store:test :indexer:test :indexer:verifyPortableDistLayout --no-daemon`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `python3 .github/scripts/check-repository-shape.py`
- `git diff --check`