### PR TITLE
fix: make Codex session startup nonblocking

### DIFF
--- a/cli-rs/src/interface/codex/hook/runtime.rs
+++ b/cli-rs/src/interface/codex/hook/runtime.rs
@@ -206,31 +206,74 @@ fn diagnostics_args(workspace: &Path, path: &str) -> [OsString; 8] {
     ]
 }
 
+use crate::bundle::{AGENT_CLI_BUNDLE_PATH, CONTROL_CLI_BUNDLE_PATH};
+
+enum HookKastCommand<'a> {
+    PublicUp(PathBuf, &'a Path),
+    Control(PathBuf, &'a [OsString]),
+}
+
+fn route_hook_command(control: PathBuf, args: &[OsString]) -> Result<HookKastCommand<'_>> {
+    match args.get(2).and_then(|argument| argument.to_str()) {
+        Some("up") => {
+            if args.len() != 5
+                || args[0] != "--output"
+                || args[1] != "json"
+                || args[3] != "--workspace-root"
+                || !Path::new(&args[4]).is_absolute()
+            {
+                return Err(CliError::new(
+                    "CODEX_HOOK_COMMAND_ROUTE_UNSUPPORTED",
+                    "Kast SessionStart requires an exact absolute workspace for public `up`.",
+                ));
+            }
+            let public = control
+                .parent()
+                .and_then(Path::parent)
+                .filter(|_| control.is_absolute() && control.ends_with(CONTROL_CLI_BUNDLE_PATH))
+                .map(|root| root.join(AGENT_CLI_BUNDLE_PATH))
+                .filter(|path| path.is_file())
+                .ok_or_else(|| {
+                    CliError::new(
+                        "CODEX_HOOK_PUBLIC_ENTRYPOINT_UNAVAILABLE",
+                        format!("Kast SessionStart public entrypoint is unavailable for {}.", control.display()),
+                    )
+                })?;
+            Ok(HookKastCommand::PublicUp(public, Path::new(&args[4])))
+        }
+        Some("status" | "agent") => Ok(HookKastCommand::Control(control, args)),
+        _ => Err(CliError::new(
+            "CODEX_HOOK_COMMAND_ROUTE_UNSUPPORTED",
+            "The Kast hook requested an unknown public or control operation.",
+        )),
+    }
+}
+
 fn run_kast(args: &[OsString]) -> Result<String> {
-    let binary = std::env::current_exe()?;
-    let output = Command::new(&binary).args(args).output()?;
+    let command = route_hook_command(std::env::current_exe()?, args)?;
+    let (binary, routed_args) = match command {
+        HookKastCommand::PublicUp(binary, workspace) => {
+            Command::new(binary)
+                .args(&args[..3])
+                .current_dir(workspace)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()?;
+            return Ok(String::new());
+        }
+        HookKastCommand::Control(binary, args) => (binary, args),
+    };
+    let output = Command::new(&binary).args(routed_args).output()?;
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if output.status.success() {
         return Ok(stdout);
     }
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     let message = if stderr.is_empty() { stdout } else { stderr };
-    let mut error = CliError::new(
+    Err(CliError::new(
         "CODEX_HOOK_COMMAND_FAILED",
-        format!(
-            "{} exited with {}: {message}",
-            binary.display(),
-            output.status
-        ),
-    );
-    error.details.insert(
-        "command".to_string(),
-        args.iter()
-            .map(|argument| argument.to_string_lossy())
-            .collect::<Vec<_>>()
-            .join(" "),
-    );
-    Err(error)
+        format!("{} {routed_args:?} exited with {}: {message}", binary.display(), output.status),
+    ))
 }
 
 fn advisory_result(label: &str, result: Result<String>) -> String {

--- a/cli-rs/tests/agent/public/kast_resources/activation.rs
+++ b/cli-rs/tests/agent/public/kast_resources/activation.rs
@@ -269,3 +269,120 @@ fn session_activation_requires_provider_and_resource_root_identity() {
     );
     assert_copilot_tool_blocked(&denied, "resource-root identity is required");
 }
+
+#[test]
+fn codex_session_start_routes_up_through_public_entrypoint() {
+    let fixture = tempfile::tempdir().expect("temporary Codex SessionStart fixture");
+    let workspace = fixture.path().join("workspace");
+    fs::create_dir(&workspace).expect("create workspace");
+    fs::write(workspace.join("settings.gradle.kts"), "").expect("write workspace marker");
+
+    let provider_bin = fixture.path().join("provider-bin");
+    fs::create_dir(&provider_bin).expect("create provider bin directory");
+    write_provider(&provider_bin.join("codex"));
+    let mut path_entries = vec![provider_bin];
+    path_entries.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_else(|| OsString::from("/usr/bin:/bin")),
+    ));
+
+    let kast_home = fixture.path().join("kast");
+    let install = kast()
+        .args(["__internal", "resources", "install", "--harness", "codex"])
+        .env(
+            "PATH",
+            std::env::join_paths(path_entries).expect("provider PATH"),
+        )
+        .env("HOME", fixture.path().join("home"))
+        .env("KAST_HOME", &kast_home)
+        .env("KAST_PROVIDER_LOG", fixture.path().join("providers.log"))
+        .output()
+        .expect("materialize Codex resources");
+    assert!(
+        install.status.success(),
+        "Codex resource install: {install:?}"
+    );
+
+    install_control_binary(&kast_home);
+    let canonical_workspace = fs::canonicalize(&workspace).expect("canonical workspace");
+    let public_invocation = fixture.path().join("public-invocation");
+    let plugin_root = installed_plugin_root(&kast_home, "codex");
+    let command = hook_command(
+        &plugin_root,
+        "hooks/hooks.json",
+        "/hooks/SessionStart/0/hooks/0/command",
+    );
+    let unavailable = run_hook(
+        &command,
+        &workspace,
+        &kast_home,
+        &plugin_root,
+        session_start_input(&workspace),
+    );
+    let unavailable: serde_json::Value =
+        serde_json::from_slice(&unavailable.stdout).expect("parse unavailable entrypoint response");
+    assert!(
+        unavailable
+            .pointer("/hookSpecificOutput/additionalContext")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|context| context.contains("CODEX_HOOK_PUBLIC_ENTRYPOINT_UNAVAILABLE")),
+        "missing typed unavailable entrypoint response: {unavailable}",
+    );
+
+    let public_binary = kast_home.join("current/bin/kast");
+    fs::create_dir_all(public_binary.parent().expect("public binary parent"))
+        .expect("create public binary parent");
+    fs::write(
+        &public_binary,
+        format!(
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+test "$#" -eq 3
+test "$1" = "--output"
+test "$2" = "json"
+test "$3" = "up"
+test "$(pwd -P)" = "{}"
+printf 'started\n' > "{}"
+sleep 5
+printf '%s\n' '{{"status":"ready"}}'
+"#,
+            canonical_workspace.display(),
+            public_invocation.display(),
+        ),
+    )
+    .expect("write public Kast test double");
+    fs::set_permissions(&public_binary, fs::Permissions::from_mode(0o755))
+        .expect("make public Kast test double executable");
+
+    let started = std::time::Instant::now();
+    let output = run_hook(
+        &command,
+        &workspace,
+        &kast_home,
+        &plugin_root,
+        session_start_input(&workspace),
+    );
+
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(2),
+        "SessionStart waited for public semantic readiness",
+    );
+    for _ in 0..100 {
+        if public_invocation.is_file() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(
+        public_invocation.is_file(),
+        "public `kast up` was not launched"
+    );
+    assert!(
+        output.status.success(),
+        "Codex SessionStart hook: {output:?}"
+    );
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&output.stdout)
+            .expect("parse Codex SessionStart response"),
+        serde_json::json!({}),
+    );
+}


### PR DESCRIPTION
## Summary

- route Codex SessionStart semantic demand through the installed public `bin/kast` entrypoint
- derive the exact workspace through the child working directory and remove the control-only `--workspace-root` argument
- detach public `kast up` so the 30-second SessionStart hook does not wait for source/reference readiness
- retain synchronous control operations through installed `libexec/kastctl`

## Root cause

PR #602 changed the hook command from the nonblocking control-plane startup path to public `up`, but retained the control executable, control-only workspace argument, and synchronous wait. Released v0.24.0 therefore either returned `CLI_USAGE` or timed out during cold semantic startup.

## Validation

- `cargo nextest run --manifest-path cli-rs/Cargo.toml --locked --test kast_resources` — 6/6 passed
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `python3 .github/scripts/check-repository-shape.py`
- `git diff --check`
- verified development setup bundle activation
- installed SessionStart returns `{}` in 0.01 seconds
- subsequent public `kast up --output json` reaches `READY`, `referenceIndexReady=true`, and 17 source modules