### PR TITLE
Fix forced setup convergence

### DIFF
--- a/.github/scripts/install/test-macos-installer-contract.sh
+++ b/.github/scripts/install/test-macos-installer-contract.sh
@@ -77,9 +77,11 @@ assert_selected_harnesses() {
 run_installer
 grep -Fqx -- "setup --source $bundle" "$log"
 assert_selected_harnesses codex claude copilot
+! grep -Fq -- '--force' "$agent_log"
 
 run_installer --force
 grep -Fqx -- "setup --source $bundle --force" "$log"
+grep -Fq -- '__internal resources install --force' "$agent_log"
 
 for harness in codex claude copilot; do
   run_installer --harness "$harness"

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup.rs
@@ -20,8 +20,11 @@ pub(crate) struct RuntimeSetupAuthorization {
 #[derive(Debug)]
 struct RuntimeSetupDescriptors {
     registry_has_entries: bool,
+    registry_has_unclassified_entries: bool,
     indexers: Vec<ServerInstanceDescriptor>,
 }
+
+include!("setup/force_reset.rs");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RegistrationPublicationTemporary {
@@ -59,14 +62,6 @@ pub(crate) fn preflight_runtime_setup(
 ) -> Result<RuntimeSetupAuthorization> {
     let service_roots = registered_service_roots(paths)?;
     let descriptors = runtime_setup_descriptors(paths)?;
-    let has_runtime_artifact = !service_roots.is_empty() || descriptors.registry_has_entries;
-    if intent == RuntimeSetupIntent::ForceReset && has_runtime_artifact {
-        return Err(CliError::new(
-            "SETUP_RUNTIME_NOT_QUIESCENT",
-            "Forced setup cannot delete Kast state while a runtime registration or descriptor exists. The exact owned epoch must become absent through automatic idle shutdown before setup can continue.",
-        ));
-    }
-
     let descriptor_roots = descriptors
         .indexers
         .iter()
@@ -78,14 +73,30 @@ pub(crate) fn preflight_runtime_setup(
             .entry(candidate.path().to_path_buf())
             .or_insert(candidate);
     }
-    let mut pinned_release_roots = BTreeSet::new();
+    let mut observations = Vec::new();
     for (_, candidate) in roots {
         let config = KastConfig::load(candidate.path())?;
         let root = RegisteredWorkspaceRoot::admit(&config, candidate)?;
-        collect_runtime_pins(
-            reconcile_registered_runtime_ownership(&config, &root)?,
-            &mut pinned_release_roots,
-        )?;
+        let ownership =
+            reconcile_registered_runtime_ownership(&config, &root).map_err(|error| {
+                if intent == RuntimeSetupIntent::ForceReset {
+                    force_runtime_reconciliation_blocked(error)
+                } else {
+                    error
+                }
+            })?;
+        observations.push((config, ownership));
+    }
+    if intent == RuntimeSetupIntent::ForceReset {
+        return ProvenDeadSetupCleanup::admit(
+            observations,
+            descriptors.registry_has_unclassified_entries,
+        )?
+        .execute(paths);
+    }
+    let mut pinned_release_roots = BTreeSet::new();
+    for (_, ownership) in observations {
+        collect_runtime_pins(ownership, &mut pinned_release_roots)?;
     }
 
     let authorization = RuntimeSetupAuthorization {
@@ -237,20 +248,22 @@ fn runtime_setup_descriptors(
     let entries =
         super::super::super::read_descriptor_elements(&paths.descriptor_dir.join("daemons.json"))?;
     let registry_has_entries = !entries.is_empty();
-    let indexers = entries
-        .into_iter()
-        .filter(|value| {
-            value.get("backendName").and_then(Value::as_str)
-                == Some(BackendName::Indexer.canonical())
-        })
-        .map(|value| {
-            serde_json::from_value(value).map_err(|error| {
+    let mut registry_has_unclassified_entries = false;
+    let mut indexers = Vec::new();
+    for value in entries {
+        if value.get("backendName").and_then(Value::as_str)
+            == Some(BackendName::Indexer.canonical())
+        {
+            indexers.push(serde_json::from_value(value).map_err(|error| {
                 setup_preflight_error(&format!("Runtime descriptor is invalid: {error}"))
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
+            })?);
+        } else {
+            registry_has_unclassified_entries = true;
+        }
+    }
     Ok(RuntimeSetupDescriptors {
         registry_has_entries,
+        registry_has_unclassified_entries,
         indexers,
     })
 }
@@ -350,41 +363,5 @@ fn setup_preflight_error(message: &str) -> CliError {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn missing_service_root_keeps_typed_identity_deleted_workspace_registration_review_regression()
-    {
-        let parent = tempfile::tempdir().expect("workspace parent");
-        let missing = parent.path().join("missing");
-        let candidate = registered_setup_root(missing.to_str().expect("workspace path"))
-            .expect("missing registered root candidate");
-        let replacement = parent.path().join("replacement");
-        fs::create_dir(&replacement).expect("replacement root");
-        std::os::unix::fs::symlink(&replacement, &missing).expect("replacement symlink");
-
-        assert!(
-            matches!(candidate, WorkspaceRootCandidate::MissingNormalized(root) if root == missing)
-        );
-    }
-
-    #[test]
-    fn missing_descriptor_root_stays_blocked_deleted_workspace_registration_review_regression() {
-        let root = tempfile::tempdir()
-            .expect("workspace parent")
-            .path()
-            .join("missing");
-
-        let error = descriptor_setup_root(root.to_str().expect("workspace path"), &BTreeMap::new())
-            .expect_err("descriptor-only missing root must block setup");
-
-        assert_eq!(error.code, "SETUP_RUNTIME_PREFLIGHT_BLOCKED");
-    }
-
-    #[test]
-    fn publication_temporary_requires_v4_uuid_review_regression() {
-        assert!(canonical_uuid("11111111-1111-4111-8111-111111111111").is_some());
-        assert!(canonical_uuid("11111111-1111-1111-8111-111111111111").is_none());
-    }
-}
+#[path = "setup/tests.rs"]
+mod tests;

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/force_reset.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/force_reset.rs
@@ -1,0 +1,63 @@
+struct ProvenDeadSetupCleanup {
+    candidates: Vec<(KastConfig, super::super::ownership::ProvenDeadRuntimeOwnership)>,
+}
+
+impl ProvenDeadSetupCleanup {
+    fn admit(
+        observations: Vec<(KastConfig, RuntimeOwnershipSnapshot)>,
+        has_unclassified_descriptors: bool,
+    ) -> Result<Self> {
+        if has_unclassified_descriptors {
+            return Err(force_runtime_not_quiescent());
+        }
+        let mut candidates = Vec::new();
+        for (config, ownership) in observations {
+            match ownership {
+                RuntimeOwnershipSnapshot::Absent(_) => {}
+                RuntimeOwnershipSnapshot::ProvenDead(dead) => candidates.push((config, dead)),
+                RuntimeOwnershipSnapshot::ServiceOwned(_)
+                | RuntimeOwnershipSnapshot::LegacyOwned(_)
+                | RuntimeOwnershipSnapshot::Conflict(_)
+                | RuntimeOwnershipSnapshot::Ambiguous(_) => {
+                    return Err(force_runtime_not_quiescent());
+                }
+            }
+        }
+        Ok(Self { candidates })
+    }
+
+    fn execute(
+        self,
+        paths: &crate::manifest::ResolvedKastPaths,
+    ) -> Result<RuntimeSetupAuthorization> {
+        for (config, dead) in self.candidates {
+            super::super::repair::cleanup_proven_dead(&config, &dead)?;
+        }
+        let service_roots = registered_service_roots(paths)?;
+        let descriptors = runtime_setup_descriptors(paths)?;
+        if !service_roots.is_empty() || descriptors.registry_has_entries {
+            return Err(force_runtime_not_quiescent());
+        }
+        Ok(RuntimeSetupAuthorization {
+            pinned_release_roots: BTreeSet::new(),
+        })
+    }
+}
+
+fn force_runtime_not_quiescent() -> CliError {
+    CliError::new(
+        "SETUP_RUNTIME_NOT_QUIESCENT",
+        "Forced setup cannot delete Kast state while a live, ambiguous, or unclassified runtime registration or descriptor exists. An exact owned epoch must complete automatic idle shutdown before setup can continue.",
+    )
+}
+
+fn force_runtime_reconciliation_blocked(error: CliError) -> CliError {
+    let mut blocker = force_runtime_not_quiescent();
+    blocker
+        .details
+        .insert("ownershipCode".to_string(), error.code.to_string());
+    blocker
+        .details
+        .insert("ownershipMessage".to_string(), error.message);
+    blocker
+}

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/tests.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/tests.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[test]
+fn missing_service_root_keeps_typed_identity_deleted_workspace_registration_review_regression() {
+    let parent = tempfile::tempdir().expect("workspace parent");
+    let missing = parent.path().join("missing");
+    let candidate = registered_setup_root(missing.to_str().expect("workspace path"))
+        .expect("missing registered root candidate");
+    let replacement = parent.path().join("replacement");
+    fs::create_dir(&replacement).expect("replacement root");
+    std::os::unix::fs::symlink(&replacement, &missing).expect("replacement symlink");
+
+    assert!(
+        matches!(candidate, WorkspaceRootCandidate::MissingNormalized(root) if root == missing)
+    );
+}
+
+#[test]
+fn missing_descriptor_root_stays_blocked_deleted_workspace_registration_review_regression() {
+    let root = tempfile::tempdir()
+        .expect("workspace parent")
+        .path()
+        .join("missing");
+
+    let error = descriptor_setup_root(root.to_str().expect("workspace path"), &BTreeMap::new())
+        .expect_err("descriptor-only missing root must block setup");
+
+    assert_eq!(error.code, "SETUP_RUNTIME_PREFLIGHT_BLOCKED");
+}
+
+#[test]
+fn publication_temporary_requires_v4_uuid_review_regression() {
+    assert!(canonical_uuid("11111111-1111-4111-8111-111111111111").is_some());
+    assert!(canonical_uuid("11111111-1111-1111-8111-111111111111").is_none());
+}

--- a/cli-rs/src/interface/cli/agent/agent_surface.rs
+++ b/cli-rs/src/interface/cli/agent/agent_surface.rs
@@ -56,6 +56,9 @@ pub struct KastResourcesArgs {
 #[derive(Debug, Subcommand)]
 pub enum KastResourcesCommand {
     Install {
+        /// Replace existing Kast plugin and marketplace configuration.
+        #[arg(long)]
+        force: bool,
         #[arg(
             long = "harness",
             required = true,

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -162,10 +162,13 @@ fn run_kast_agent(cli: KastCli) -> Result<i32> {
         KastCommand::Internal(cli::KastInternalArgs {
             command:
                 cli::KastInternalCommand::Resources(cli::KastResourcesArgs {
-                    command: cli::KastResourcesCommand::Install { harnesses },
+                    command: cli::KastResourcesCommand::Install { force, harnesses },
                 }),
         }) => {
-            install::install_agent_resources(&harnesses)?;
+            install::install_agent_resources(
+                &harnesses,
+                install::AgentResourceInstallMode::from_force_flag(force),
+            )?;
             Ok(0)
         }
         KastCommand::Up => agent_adapter::run_up(output_format),

--- a/cli-rs/src/operations/install/agent_resources.rs
+++ b/cli-rs/src/operations/install/agent_resources.rs
@@ -54,84 +54,7 @@ struct AgentResourceDigestOverrides<'a> {
     developer_skill: &'a str,
 }
 
-pub fn install_agent_resources(requested: &[KastHarness]) -> Result<()> {
-    let selected = [KastHarness::Codex, KastHarness::Claude, KastHarness::Copilot]
-        .into_iter()
-        .filter(|harness| requested.contains(harness))
-        .collect::<Vec<_>>();
-    let mut failures = Vec::new();
-    for harness in selected {
-        if let Err(message) = install_agent_harness(harness) {
-            failures.push(format!("{}: {message}", harness_name(harness)));
-        }
-    }
-    if failures.is_empty() {
-        return Ok(());
-    }
-    Err(CliError::new(
-        "KAST_AGENT_RESOURCE_INSTALL_FAILED",
-        format!(
-            "Agent resources could not be installed for {}.",
-            failures.join("; ")
-        ),
-    ))
-}
-
-fn install_agent_harness(harness: KastHarness) -> std::result::Result<(), String> {
-    let marketplace_root = materialize_agent_harness(harness).map_err(|error| error.to_string())?;
-    let root = marketplace_root.display().to_string();
-    let commands = match harness {
-        KastHarness::Codex => vec![
-            vec![
-                "plugin".to_string(),
-                "marketplace".to_string(),
-                "add".to_string(),
-                root,
-                "--json".to_string(),
-            ],
-            vec![
-                "plugin".to_string(),
-                "add".to_string(),
-                "kast@kast".to_string(),
-                "--json".to_string(),
-            ],
-        ],
-        KastHarness::Claude => vec![
-            vec![
-                "plugin".to_string(),
-                "marketplace".to_string(),
-                "add".to_string(),
-                root,
-                "--scope".to_string(),
-                "user".to_string(),
-            ],
-            vec![
-                "plugin".to_string(),
-                "install".to_string(),
-                "kast@kast".to_string(),
-                "--scope".to_string(),
-                "user".to_string(),
-            ],
-        ],
-        KastHarness::Copilot => vec![
-            vec![
-                "plugin".to_string(),
-                "marketplace".to_string(),
-                "add".to_string(),
-                root,
-            ],
-            vec![
-                "plugin".to_string(),
-                "install".to_string(),
-                "kast@kast".to_string(),
-            ],
-        ],
-    };
-    for args in commands {
-        run_agent_harness_command(harness, &args)?;
-    }
-    Ok(())
-}
+include!("bundle_entrypoint/agent_resource_install.rs");
 
 fn run_agent_harness_command(
     harness: KastHarness,
@@ -248,7 +171,7 @@ pub(crate) fn validate_agent_harness_activation(
     let expected_version = crate::cli::version();
     let expected_digest = agent_resources_digest();
     let repair_command = format!(
-        "kast __internal resources install --harness {}",
+        "kast __internal resources install --force --harness {}",
         harness_name(harness)
     );
     let read_resource = |relative: &str| {

--- a/cli-rs/src/operations/install/bundle_entrypoint/agent_resource_install.rs
+++ b/cli-rs/src/operations/install/bundle_entrypoint/agent_resource_install.rs
@@ -1,0 +1,151 @@
+/// Selects whether existing provider resources are reconciled or replaced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentResourceInstallMode {
+    Reconcile,
+    Replace,
+}
+
+impl AgentResourceInstallMode {
+    pub fn from_force_flag(force: bool) -> Self {
+        if force { Self::Replace } else { Self::Reconcile }
+    }
+}
+
+pub fn install_agent_resources(
+    requested: &[KastHarness],
+    mode: AgentResourceInstallMode,
+) -> Result<()> {
+    let selected = [KastHarness::Codex, KastHarness::Claude, KastHarness::Copilot]
+        .into_iter()
+        .filter(|harness| requested.contains(harness))
+        .collect::<Vec<_>>();
+    let mut failures = Vec::new();
+    for harness in selected {
+        if let Err(message) = install_agent_harness(harness, mode) {
+            failures.push(format!("{}: {message}", harness_name(harness)));
+        }
+    }
+    if failures.is_empty() {
+        return Ok(());
+    }
+    Err(CliError::new(
+        "KAST_AGENT_RESOURCE_INSTALL_FAILED",
+        format!(
+            "Agent resources could not be installed for {}.",
+            failures.join("; ")
+        ),
+    ))
+}
+
+fn install_agent_harness(
+    harness: KastHarness,
+    mode: AgentResourceInstallMode,
+) -> std::result::Result<(), String> {
+    let marketplace_root = materialize_agent_harness(harness).map_err(|error| error.to_string())?;
+    let root = marketplace_root.display().to_string();
+    if mode == AgentResourceInstallMode::Replace {
+        for args in agent_harness_cleanup_commands(harness) {
+            let _ = run_agent_harness_command(harness, &args);
+        }
+    }
+    let commands = match harness {
+        KastHarness::Codex => vec![
+            vec![
+                "plugin".to_string(),
+                "marketplace".to_string(),
+                "add".to_string(),
+                root,
+                "--json".to_string(),
+            ],
+            vec![
+                "plugin".to_string(),
+                "add".to_string(),
+                "kast@kast".to_string(),
+                "--json".to_string(),
+            ],
+        ],
+        KastHarness::Claude => vec![
+            vec![
+                "plugin".to_string(),
+                "marketplace".to_string(),
+                "add".to_string(),
+                root,
+                "--scope".to_string(),
+                "user".to_string(),
+            ],
+            vec![
+                "plugin".to_string(),
+                "install".to_string(),
+                "kast@kast".to_string(),
+                "--scope".to_string(),
+                "user".to_string(),
+            ],
+        ],
+        KastHarness::Copilot => vec![
+            vec![
+                "plugin".to_string(),
+                "marketplace".to_string(),
+                "add".to_string(),
+                root,
+            ],
+            vec![
+                "plugin".to_string(),
+                "install".to_string(),
+                "kast@kast".to_string(),
+            ],
+        ],
+    };
+    for args in commands {
+        run_agent_harness_command(harness, &args)?;
+    }
+    Ok(())
+}
+
+fn agent_harness_cleanup_commands(harness: KastHarness) -> Vec<Vec<String>> {
+    match harness {
+        KastHarness::Codex => vec![
+            vec![
+                "plugin".to_string(),
+                "remove".to_string(),
+                "kast@kast".to_string(),
+                "--json".to_string(),
+            ],
+            vec![
+                "plugin".to_string(),
+                "marketplace".to_string(),
+                "remove".to_string(),
+                "kast".to_string(),
+                "--json".to_string(),
+            ],
+        ],
+        KastHarness::Claude => vec![
+            vec![
+                "plugin".to_string(),
+                "uninstall".to_string(),
+                "kast@kast".to_string(),
+                "--scope".to_string(),
+                "user".to_string(),
+            ],
+            vec![
+                "plugin".to_string(),
+                "marketplace".to_string(),
+                "remove".to_string(),
+                "kast".to_string(),
+            ],
+        ],
+        KastHarness::Copilot => vec![
+            vec![
+                "plugin".to_string(),
+                "uninstall".to_string(),
+                "kast@kast".to_string(),
+            ],
+            vec![
+                "plugin".to_string(),
+                "marketplace".to_string(),
+                "remove".to_string(),
+                "kast".to_string(),
+                "--force".to_string(),
+            ],
+        ],
+    }
+}

--- a/cli-rs/tests/agent/public/kast_resources.rs
+++ b/cli-rs/tests/agent/public/kast_resources.rs
@@ -261,7 +261,7 @@ fn assert_activation_blocked(output: &Output, harness: &str, mismatch: &str) {
         "expectedVersion",
         "detectedDigest",
         "expectedDigest",
-        &format!("kast __internal resources install --harness {harness}"),
+        &format!("kast __internal resources install --force --harness {harness}"),
     ] {
         assert!(
             message.contains(expected),

--- a/cli-rs/tests/agent/public/kast_resources/install.rs
+++ b/cli-rs/tests/agent/public/kast_resources/install.rs
@@ -15,7 +15,7 @@ fn direct_public_cli_does_not_require_agent_resources() {
 }
 
 #[test]
-fn provider_install_attempts_every_harness_before_reporting_failure() {
+fn force_replaces_existing_provider_installations() {
     let fixture = tempfile::tempdir().expect("temporary provider fixture");
     let bin = fixture.path().join("bin");
     fs::create_dir(&bin).expect("create provider bin directory");
@@ -42,7 +42,7 @@ fn provider_install_attempts_every_harness_before_reporting_failure() {
             "--harness",
             "copilot",
         ])
-        .env("PATH", path)
+        .env("PATH", &path)
         .env("HOME", fixture.path().join("home"))
         .env("KAST_HOME", fixture.path().join("kast"))
         .env("KAST_PROVIDER_LOG", &provider_log)
@@ -64,6 +64,65 @@ fn provider_install_attempts_every_harness_before_reporting_failure() {
         assert!(
             log.lines().any(|line| line.contains(invocation)),
             "missing {invocation} after provider failure:\n{log}"
+        );
+    }
+    fs::write(&provider_log, "").expect("reset provider invocation log");
+
+    let output = kast()
+        .args([
+            "__internal",
+            "resources",
+            "install",
+            "--force",
+            "--harness",
+            "codex",
+            "--harness",
+            "claude",
+            "--harness",
+            "copilot",
+        ])
+        .env("PATH", path)
+        .env("HOME", fixture.path().join("home"))
+        .env("KAST_HOME", fixture.path().join("kast"))
+        .env("KAST_PROVIDER_LOG", &provider_log)
+        .output()
+        .expect("replace embedded provider installations");
+
+    assert!(
+        output.status.success(),
+        "forced provider replacement must succeed: {output:?}"
+    );
+    let log = fs::read_to_string(&provider_log).expect("provider invocation log");
+    let lines = log.lines().collect::<Vec<_>>();
+    for ordered in [
+        [
+            "codex plugin remove kast@kast --json",
+            "codex plugin marketplace remove kast --json",
+            "codex plugin marketplace add ",
+            "codex plugin add kast@kast --json",
+        ],
+        [
+            "claude plugin uninstall kast@kast --scope user",
+            "claude plugin marketplace remove kast",
+            "claude plugin marketplace add ",
+            "claude plugin install kast@kast --scope user",
+        ],
+        [
+            "copilot plugin uninstall kast@kast",
+            "copilot plugin marketplace remove kast --force",
+            "copilot plugin marketplace add ",
+            "copilot plugin install kast@kast",
+        ],
+    ] {
+        let positions = ordered.map(|invocation| {
+            lines
+                .iter()
+                .position(|line| line.contains(invocation))
+                .unwrap_or_else(|| panic!("missing {invocation}:\n{log}"))
+        });
+        assert!(
+            positions.windows(2).all(|pair| pair[0] < pair[1]),
+            "provider replacement commands are out of order: {positions:?}\n{log}"
         );
     }
 }

--- a/cli-rs/tests/runtime/durable_ownership/setup_release_pins.rs
+++ b/cli-rs/tests/runtime/durable_ownership/setup_release_pins.rs
@@ -124,3 +124,31 @@ fn force_setup_with_a_registered_runtime_changes_no_install_state() {
     assert_eq!(test_path_sha256(&kast_home.join("state")), state_before);
     assert!(runtime.is_live(), "force setup terminated the runtime");
 }
+
+#[test]
+fn force_setup_reclaims_proven_dead_runtime_after_idle_shutdown() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let kast_home = home.join(".local/share/kast");
+    let source = write_install_bundle_source(temp.path(), "v1.0.0");
+    assert!(setup(&home, &kast_home, &source).status.success());
+    let mut runtime = PinnedRuntimeService::new(temp.path(), &kast_home);
+    runtime.complete_idle_shutdown();
+
+    let forced = runtime.run({
+        let mut command = setup_command(&home, &kast_home, &source);
+        command.arg("--force");
+        command
+    });
+
+    assert!(
+        forced.status.success(),
+        "force should reclaim exact proven-dead runtime evidence: stdout={}, stderr={}",
+        String::from_utf8_lossy(&forced.stdout),
+        String::from_utf8_lossy(&forced.stderr),
+    );
+    assert!(
+        !runtime.registration.exists(),
+        "forced setup retained the proven-dead registration"
+    );
+}

--- a/cli-rs/tests/runtime/durable_ownership/setup_release_pins/fixture.rs
+++ b/cli-rs/tests/runtime/durable_ownership/setup_release_pins/fixture.rs
@@ -34,7 +34,7 @@ impl PinnedRuntimeService {
         let runtime_command = vec![
             "/bin/sh".to_string(),
             "-c".to_string(),
-            "trap 'exit 0' TERM; read fixture_value".to_string(),
+            "trap 'exit 0' TERM; read fixture_value || exit 0".to_string(),
             "kast-runtime-fixture".to_string(),
             format!("--socket-path={}", socket_path.display()),
         ];
@@ -162,6 +162,12 @@ impl PinnedRuntimeService {
             )
             .output()
             .expect("setup with registered runtime")
+    }
+
+    fn complete_idle_shutdown(&mut self) {
+        drop(self.process.stdin.take());
+        let status = self.process.wait().expect("runtime idle shutdown");
+        assert!(status.success(), "runtime idle shutdown status: {status}");
     }
 
     fn is_live(&mut self) -> bool {

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,8 @@ Options:
   --source PATH      Install a local bundle directory or tar.gz archive.
   --version VERSION  Install an exact release instead of the latest release.
   --snapshot         Install the latest snapshot build.
-  --force            Remove prior Kast-owned state before reinstalling.
+  --force            Remove prior Kast-owned state, configuration, and selected
+                     harness resources before reinstalling.
   -h, --help         Show this help.
 
 Environment:
@@ -186,10 +187,13 @@ run_quiet() {
 }
 
 install_agent_harnesses() {
+  local replace="$1"
+  shift
   (($# > 0)) || return 0
   local agent_path="${KAST_HOME:-${HOME}/.local/share/kast}/current/bin/kast"
   local harness
   local -a args=(__internal resources install)
+  ((replace == 0)) || args+=(--force)
   [[ -x "$agent_path" ]] || die "installed Kast agent CLI is missing: $agent_path"
   for harness in "$@"; do
     args+=(--harness "$harness")
@@ -284,7 +288,7 @@ main() {
     ui_step "Refreshing the local development installation"
     run_quiet "${gradle_args[@]}" || die "local development setup failed"
     ui_success "Local development installation refreshed"
-    install_agent_harnesses "${selected_harnesses[@]}"
+    install_agent_harnesses "$development_clean" "${selected_harnesses[@]}"
     active_agent="${KAST_HOME:-${HOME}/.local/share/kast}/current/bin/kast"
     [[ -x "$active_agent" ]] || die "installed Kast agent CLI is missing: $active_agent"
     ui_step "Building the repository database"
@@ -331,7 +335,7 @@ main() {
   ((force == 0)) || setup_args+=(--force)
   run_quiet "${setup_args[@]}" || die "Kast setup failed"
   ui_success "Kast installed"
-  install_agent_harnesses "${selected_harnesses[@]}"
+  install_agent_harnesses "$force" "${selected_harnesses[@]}"
   finish_install standard
 }
 


### PR DESCRIPTION
## Summary

- let `setup --force` reconcile and remove only exact-owned proven-dead runtime epochs after automatic idle shutdown
- keep live, ambiguous, malformed, and unclassified runtime evidence fail-closed as `SETUP_RUNTIME_NOT_QUIESCENT`
- make installer `--force` replace selected Codex, Claude, and Copilot Kast marketplace/plugin resources after setup replaces Kast configuration

## Validation

- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test setup_smoke` (111 passed)
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test runtime_durable_ownership_smoke` (4 passed)
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test kast_resources` (6 passed)
- `bash .github/scripts/install/test-macos-installer-contract.sh`
- `scripts/pre-push-check.sh --all`