### PR TITLE
Make forced setup converge owned runtime state

### DIFF
--- a/cli-rs/src/execution/runtime/backend/indexer_authority/ownership/cleanup.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/ownership/cleanup.rs
@@ -14,7 +14,7 @@ pub(super) fn cleanup_dead_registration(
         .ok_or_else(runtime_identity_mismatch)?
         .join("active.json");
     verify_cleanup_metadata_snapshots(&registration, dead)?;
-    let process_temporary = unregister_dead_service_manager(&registration)?;
+    let process_temporary = unregister_dead_service_manager(dead)?;
     let registration = revalidate_registration(&registration)?;
     ensure_registered_process_is_dead(&registration, dead.descriptor.as_ref())?;
     verify_socket_snapshot(&dead.socket, registration.launch.owner_uid)?;
@@ -39,8 +39,9 @@ pub(super) fn cleanup_dead_registration(
 }
 
 fn unregister_dead_service_manager(
-    registration: &ValidatedServiceRegistration,
+    dead: &DeadServiceRuntime,
 ) -> Result<ProvenDeadProcessClaimPublication> {
+    let registration = &dead.registration;
     let process_temporary = prove_dead_process_claim_publication_temporary(registration)?;
     match super::service_manager::inspect(&registration.receipt.manager)? {
         super::service_manager::ServiceManagerObservation::Running(_) => {
@@ -50,7 +51,7 @@ fn unregister_dead_service_manager(
         }
         super::service_manager::ServiceManagerObservation::Registered
         | super::service_manager::ServiceManagerObservation::Absent => {
-            super::service_manager::unregister(&registration.receipt.manager)?;
+            super::service_manager::unregister_dead(dead)?;
         }
     }
     if super::service_manager::inspect(&registration.receipt.manager)?

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/ownership/cleanup_tests.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/ownership/cleanup_tests.rs
@@ -39,7 +39,16 @@ fn live_process_claim_temporary_blocks_before_manager_mutation_final_registratio
         .expect("registered manager state JSON");
     fs::write(manager_state, &registered_state).expect("registered manager state");
 
-    let error = unregister_dead_service_manager(&fixture.registration)
+    let dead = DeadServiceRuntime {
+        registration: fixture.registration.clone(),
+        process_claim: None,
+        active: None,
+        descriptor: None,
+        socket: SocketObservation::Absent {
+            path: fixture._temp.path().join("absent.sock"),
+        },
+    };
+    let error = unregister_dead_service_manager(&dead)
         .expect_err("live process temporary must block cleanup");
 
     assert_eq!(error.code, "RUNTIME_OWNERSHIP_CHANGED");

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup.rs
@@ -24,6 +24,13 @@ struct RuntimeSetupDescriptors {
     indexers: Vec<ServerInstanceDescriptor>,
 }
 
+#[derive(Debug)]
+struct RuntimeSetupObservation {
+    config: KastConfig,
+    root: RegisteredWorkspaceRoot,
+    ownership: RuntimeOwnershipSnapshot,
+}
+
 include!("setup/force_reset.rs");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,6 +38,8 @@ enum RegistrationPublicationTemporary {
     Staging(Uuid),
     ActivePointer,
 }
+
+include!("setup/registry_normalization.rs");
 
 impl RuntimeSetupAuthorization {
     pub(crate) fn pinned_release_roots(&self) -> &BTreeSet<PathBuf> {
@@ -85,18 +94,22 @@ pub(crate) fn preflight_runtime_setup(
                     error
                 }
             })?;
-        observations.push((config, ownership));
+        observations.push(RuntimeSetupObservation {
+            config,
+            root,
+            ownership,
+        });
     }
     if intent == RuntimeSetupIntent::ForceReset {
-        return ProvenDeadSetupCleanup::admit(
+        return ForceResetCleanup::admit(
             observations,
             descriptors.registry_has_unclassified_entries,
         )?
         .execute(paths);
     }
     let mut pinned_release_roots = BTreeSet::new();
-    for (_, ownership) in observations {
-        collect_runtime_pins(ownership, &mut pinned_release_roots)?;
+    for observation in observations {
+        collect_runtime_pins(observation.ownership, &mut pinned_release_roots)?;
     }
 
     let authorization = RuntimeSetupAuthorization {
@@ -129,41 +142,33 @@ fn registered_service_roots(
     };
     let mut roots = BTreeMap::new();
     for workspace_entry in workspace_entries {
-        let workspace_entry = workspace_entry?;
-        if !workspace_entry.file_type()?.is_dir() {
-            return Err(setup_preflight_error(
-                "Runtime services contain an unexpected workspace entry.",
-            ));
-        }
-        let directory_workspace_key = workspace_entry.file_name().to_string_lossy().into_owned();
-        if !is_sha256(&directory_workspace_key) {
-            return Err(setup_preflight_error(
-                "Runtime services contain an invalid workspace key.",
-            ));
-        }
+        let workspace = match classify_runtime_services_entry(workspace_entry?)? {
+            RuntimeServicesEntry::Workspace(workspace) => workspace,
+            RuntimeServicesEntry::Noise(path) => {
+                remove_runtime_registry_noise(&path)?;
+                continue;
+            }
+        };
+        let RuntimeWorkspaceRegistryDirectory {
+            path: workspace_path,
+            workspace_key: directory_workspace_key,
+        } = workspace;
         let mut registration_found = false;
-        for registration_entry in fs::read_dir(workspace_entry.path())? {
-            let registration_entry = registration_entry?;
-            let name = registration_entry.file_name();
-            if name == "active.json" {
-                continue;
-            }
-            if let Some(temporary) = registration_publication_temporary(&name) {
-                recover_registration_publication_temporary(
-                    &workspace_entry.path(),
-                    &registration_entry.path(),
-                    temporary,
-                )?;
-                continue;
-            }
-            if name.to_string_lossy().starts_with('.') || !registration_entry.file_type()?.is_dir()
-            {
-                return Err(setup_preflight_error(
-                    "Runtime services contain an incomplete or unexpected registration.",
-                ));
-            }
+        for registration_entry in fs::read_dir(&workspace_path)? {
+            let registration_path = match classify_runtime_workspace_entry(registration_entry?)? {
+                RuntimeWorkspaceEntry::ActivePointer => continue,
+                RuntimeWorkspaceEntry::PublicationTemporary { path, temporary } => {
+                    recover_registration_publication_temporary(&workspace_path, &path, temporary)?;
+                    continue;
+                }
+                RuntimeWorkspaceEntry::Registration(path) => path,
+                RuntimeWorkspaceEntry::Noise(path) => {
+                    remove_runtime_registry_noise(&path)?;
+                    continue;
+                }
+            };
             let (launch, _) = read_owned_json::<ServiceLaunchRegistration>(
-                &registration_entry.path().join("launch.json"),
+                &registration_path.join("launch.json"),
             )?;
             let candidate = registered_setup_root(&launch.workspace_root)?;
             let root = candidate.path();
@@ -172,11 +177,11 @@ fn registered_service_roots(
                     "Runtime service workspace key does not match its canonical root.",
                 ));
             }
-            validate_service_registration(&registration_entry.path(), root)?;
+            validate_service_registration(&registration_path, root)?;
             registration_found = true;
             roots.entry(root.to_path_buf()).or_insert(candidate);
         }
-        if !registration_found && workspace_entry.path().join("active.json").exists() {
+        if !registration_found && workspace_path.join("active.json").exists() {
             return Err(setup_preflight_error(
                 "Runtime services contain an active pointer without a registration.",
             ));

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/force_reset.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/force_reset.rs
@@ -1,36 +1,65 @@
-struct ProvenDeadSetupCleanup {
-    candidates: Vec<(KastConfig, super::super::ownership::ProvenDeadRuntimeOwnership)>,
+const EXACT_OWNED_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const EXACT_OWNED_SHUTDOWN_POLL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(25);
+
+struct ExactOwnedSetupShutdown {
+    config: KastConfig,
+    root: RegisteredWorkspaceRoot,
+    runtime_instance_id: Uuid,
 }
 
-impl ProvenDeadSetupCleanup {
+struct ForceResetCleanup {
+    shutdowns: Vec<ExactOwnedSetupShutdown>,
+    proven_dead: Vec<(KastConfig, super::super::ownership::ProvenDeadRuntimeOwnership)>,
+}
+
+impl ForceResetCleanup {
     fn admit(
-        observations: Vec<(KastConfig, RuntimeOwnershipSnapshot)>,
+        observations: Vec<RuntimeSetupObservation>,
         has_unclassified_descriptors: bool,
     ) -> Result<Self> {
         if has_unclassified_descriptors {
             return Err(force_runtime_not_quiescent());
         }
-        let mut candidates = Vec::new();
-        for (config, ownership) in observations {
+        let mut shutdowns = Vec::new();
+        let mut proven_dead = Vec::new();
+        for observation in observations {
+            let RuntimeSetupObservation {
+                config,
+                root,
+                ownership,
+            } = observation;
             match ownership {
                 RuntimeOwnershipSnapshot::Absent(_) => {}
-                RuntimeOwnershipSnapshot::ProvenDead(dead) => candidates.push((config, dead)),
-                RuntimeOwnershipSnapshot::ServiceOwned(_)
-                | RuntimeOwnershipSnapshot::LegacyOwned(_)
+                RuntimeOwnershipSnapshot::ServiceOwned(owned) => {
+                    shutdowns.push(ExactOwnedSetupShutdown {
+                        config,
+                        root,
+                        runtime_instance_id: owned.registration.receipt.runtime_instance_id,
+                    });
+                }
+                RuntimeOwnershipSnapshot::ProvenDead(dead) => proven_dead.push((config, dead)),
+                RuntimeOwnershipSnapshot::LegacyOwned(_)
                 | RuntimeOwnershipSnapshot::Conflict(_)
                 | RuntimeOwnershipSnapshot::Ambiguous(_) => {
                     return Err(force_runtime_not_quiescent());
                 }
             }
         }
-        Ok(Self { candidates })
+        Ok(Self {
+            shutdowns,
+            proven_dead,
+        })
     }
 
     fn execute(
         self,
         paths: &crate::manifest::ResolvedKastPaths,
     ) -> Result<RuntimeSetupAuthorization> {
-        for (config, dead) in self.candidates {
+        for shutdown in self.shutdowns {
+            shutdown.execute()?;
+        }
+        for (config, dead) in self.proven_dead {
             super::super::repair::cleanup_proven_dead(&config, &dead)?;
         }
         let service_roots = registered_service_roots(paths)?;
@@ -44,10 +73,92 @@ impl ProvenDeadSetupCleanup {
     }
 }
 
+impl ExactOwnedSetupShutdown {
+    fn execute(self) -> Result<()> {
+        let current = reconcile_registered_runtime_ownership(&self.config, &self.root)
+            .map_err(force_runtime_reconciliation_blocked)?;
+        match current {
+            RuntimeOwnershipSnapshot::ServiceOwned(owned)
+                if owned.registration.receipt.runtime_instance_id == self.runtime_instance_id =>
+            {
+                super::super::service_manager::unregister(&owned.registration.receipt.manager)
+                    .map_err(|error| {
+                        force_runtime_teardown_failed(self.runtime_instance_id, error)
+                    })?;
+            }
+            RuntimeOwnershipSnapshot::ProvenDead(dead) => {
+                return super::super::repair::cleanup_proven_dead(&self.config, &dead);
+            }
+            RuntimeOwnershipSnapshot::Absent(_) => return Ok(()),
+            _ => return Err(force_runtime_not_quiescent()),
+        }
+
+        let deadline = std::time::Instant::now() + EXACT_OWNED_SHUTDOWN_TIMEOUT;
+        loop {
+            let current = reconcile_registered_runtime_ownership(&self.config, &self.root)
+                .map_err(force_runtime_reconciliation_blocked)?;
+            match current {
+                RuntimeOwnershipSnapshot::Absent(_) => return Ok(()),
+                RuntimeOwnershipSnapshot::ProvenDead(dead) => {
+                    return super::super::repair::cleanup_proven_dead(&self.config, &dead);
+                }
+                RuntimeOwnershipSnapshot::ServiceOwned(owned)
+                    if owned.registration.receipt.runtime_instance_id
+                        == self.runtime_instance_id
+                        && std::time::Instant::now() < deadline =>
+                {
+                    std::thread::sleep(EXACT_OWNED_SHUTDOWN_POLL_INTERVAL);
+                }
+                RuntimeOwnershipSnapshot::ServiceOwned(owned)
+                    if owned.registration.receipt.runtime_instance_id
+                        == self.runtime_instance_id =>
+                {
+                    return Err(force_runtime_teardown_timeout(self.runtime_instance_id));
+                }
+                _ => return Err(force_runtime_not_quiescent()),
+            }
+        }
+    }
+}
+
+fn force_runtime_teardown_failed(runtime_instance_id: Uuid, error: CliError) -> CliError {
+    let mut failure = CliError::new(
+        "SETUP_RUNTIME_TEARDOWN_FAILED",
+        format!(
+            "Forced setup could not unload exact-owned runtime {runtime_instance_id}."
+        ),
+    );
+    failure.details.insert(
+        "runtimeInstanceId".to_string(),
+        runtime_instance_id.to_string(),
+    );
+    failure
+        .details
+        .insert("causeCode".to_string(), error.code.to_string());
+    failure
+        .details
+        .insert("causeMessage".to_string(), error.message);
+    failure
+}
+
+fn force_runtime_teardown_timeout(runtime_instance_id: Uuid) -> CliError {
+    let mut failure = CliError::new(
+        "SETUP_RUNTIME_TEARDOWN_TIMEOUT",
+        format!(
+            "Exact-owned runtime {runtime_instance_id} remained live after its service was unloaded."
+        ),
+    );
+    failure.details.insert(
+        "runtimeInstanceId".to_string(),
+        runtime_instance_id.to_string(),
+    );
+    failure
+}
+
 fn force_runtime_not_quiescent() -> CliError {
     CliError::new(
         "SETUP_RUNTIME_NOT_QUIESCENT",
-        "Forced setup cannot delete Kast state while a live, ambiguous, or unclassified runtime registration or descriptor exists. An exact owned epoch must complete automatic idle shutdown before setup can continue.",
+        "Forced setup cannot delete Kast state while an ambiguous, unclassified, or insufficiently proven runtime registration or descriptor exists.",
     )
 }
 

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/force_reset.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/force_reset.rs
@@ -1,6 +1,7 @@
-const EXACT_OWNED_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const EXACT_OWNED_SHUTDOWN_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(5 * 60 + 10);
 const EXACT_OWNED_SHUTDOWN_POLL_INTERVAL: std::time::Duration =
-    std::time::Duration::from_millis(25);
+    std::time::Duration::from_millis(250);
 
 struct ExactOwnedSetupShutdown {
     config: KastConfig,
@@ -75,24 +76,6 @@ impl ForceResetCleanup {
 
 impl ExactOwnedSetupShutdown {
     fn execute(self) -> Result<()> {
-        let current = reconcile_registered_runtime_ownership(&self.config, &self.root)
-            .map_err(force_runtime_reconciliation_blocked)?;
-        match current {
-            RuntimeOwnershipSnapshot::ServiceOwned(owned)
-                if owned.registration.receipt.runtime_instance_id == self.runtime_instance_id =>
-            {
-                super::super::service_manager::unregister(&owned.registration.receipt.manager)
-                    .map_err(|error| {
-                        force_runtime_teardown_failed(self.runtime_instance_id, error)
-                    })?;
-            }
-            RuntimeOwnershipSnapshot::ProvenDead(dead) => {
-                return super::super::repair::cleanup_proven_dead(&self.config, &dead);
-            }
-            RuntimeOwnershipSnapshot::Absent(_) => return Ok(()),
-            _ => return Err(force_runtime_not_quiescent()),
-        }
-
         let deadline = std::time::Instant::now() + EXACT_OWNED_SHUTDOWN_TIMEOUT;
         loop {
             let current = reconcile_registered_runtime_ownership(&self.config, &self.root)
@@ -121,31 +104,11 @@ impl ExactOwnedSetupShutdown {
     }
 }
 
-fn force_runtime_teardown_failed(runtime_instance_id: Uuid, error: CliError) -> CliError {
-    let mut failure = CliError::new(
-        "SETUP_RUNTIME_TEARDOWN_FAILED",
-        format!(
-            "Forced setup could not unload exact-owned runtime {runtime_instance_id}."
-        ),
-    );
-    failure.details.insert(
-        "runtimeInstanceId".to_string(),
-        runtime_instance_id.to_string(),
-    );
-    failure
-        .details
-        .insert("causeCode".to_string(), error.code.to_string());
-    failure
-        .details
-        .insert("causeMessage".to_string(), error.message);
-    failure
-}
-
 fn force_runtime_teardown_timeout(runtime_instance_id: Uuid) -> CliError {
     let mut failure = CliError::new(
-        "SETUP_RUNTIME_TEARDOWN_TIMEOUT",
+        "SETUP_RUNTIME_IDLE_SHUTDOWN_TIMEOUT",
         format!(
-            "Exact-owned runtime {runtime_instance_id} remained live after its service was unloaded."
+            "Exact-owned runtime {runtime_instance_id} remained live without completing its server-permitted idle shutdown."
         ),
     );
     failure.details.insert(

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/registry_normalization.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/registry_normalization.rs
@@ -1,0 +1,79 @@
+#[derive(Debug)]
+struct RuntimeWorkspaceRegistryDirectory {
+    path: PathBuf,
+    workspace_key: String,
+}
+
+#[derive(Debug)]
+enum RuntimeServicesEntry {
+    Workspace(RuntimeWorkspaceRegistryDirectory),
+    Noise(PathBuf),
+}
+
+#[derive(Debug)]
+enum RuntimeWorkspaceEntry {
+    ActivePointer,
+    PublicationTemporary {
+        path: PathBuf,
+        temporary: RegistrationPublicationTemporary,
+    },
+    Registration(PathBuf),
+    Noise(PathBuf),
+}
+
+fn classify_runtime_services_entry(entry: fs::DirEntry) -> Result<RuntimeServicesEntry> {
+    let path = entry.path();
+    let Some(workspace_key) = entry.file_name().to_str().map(str::to_owned) else {
+        return Ok(RuntimeServicesEntry::Noise(path));
+    };
+    if !entry.file_type()?.is_dir() || !is_sha256(&workspace_key) {
+        return Ok(RuntimeServicesEntry::Noise(path));
+    }
+    Ok(RuntimeServicesEntry::Workspace(
+        RuntimeWorkspaceRegistryDirectory {
+            path,
+            workspace_key,
+        },
+    ))
+}
+
+fn classify_runtime_workspace_entry(entry: fs::DirEntry) -> Result<RuntimeWorkspaceEntry> {
+    let path = entry.path();
+    let name = entry.file_name();
+    if name == "active.json" {
+        return Ok(RuntimeWorkspaceEntry::ActivePointer);
+    }
+    if let Some(temporary) = registration_publication_temporary(&name) {
+        return Ok(RuntimeWorkspaceEntry::PublicationTemporary { path, temporary });
+    }
+    if entry.file_type()?.is_dir()
+        && name.to_str().and_then(canonical_uuid).is_some()
+    {
+        return Ok(RuntimeWorkspaceEntry::Registration(path));
+    }
+    Ok(RuntimeWorkspaceEntry::Noise(path))
+}
+
+fn remove_runtime_registry_noise(path: &Path) -> Result<()> {
+    crate::manifest::remove_path(path)
+        .and_then(|()| sync_parent(path))
+        .map_err(|error| {
+            let mut failure = CliError::new(
+                "SETUP_RUNTIME_REGISTRY_NORMALIZATION_FAILED",
+                format!(
+                    "Kast-owned runtime registry entry could not be removed: {}",
+                    path.display()
+                ),
+            );
+            failure
+                .details
+                .insert("path".to_string(), path.display().to_string());
+            failure
+                .details
+                .insert("causeCode".to_string(), error.code.to_string());
+            failure
+                .details
+                .insert("causeMessage".to_string(), error.message);
+            failure
+        })
+}

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/tests.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/registration/setup/tests.rs
@@ -1,4 +1,73 @@
 use super::*;
+use crate::manifest;
+
+#[test]
+fn runtime_registry_noise_is_removed_before_service_inspection() {
+    let fixture = tempfile::tempdir().expect("runtime registry fixture");
+    let runtime = fixture.path().join("runtime");
+    let services = runtime.join("services");
+    fs::create_dir_all(&services).expect("runtime services directory");
+
+    fs::write(services.join(".DS_Store"), "finder metadata").expect("top-level Finder metadata");
+    let unrelated_target = fixture.path().join("unrelated");
+    fs::create_dir(&unrelated_target).expect("unrelated directory");
+    std::os::unix::fs::symlink(&unrelated_target, services.join("misplaced-link"))
+        .expect("runtime registry symlink noise");
+    let invalid_workspace = services.join("not-a-workspace-key");
+    fs::create_dir(&invalid_workspace).expect("invalid workspace directory");
+    fs::write(invalid_workspace.join("note"), "noise").expect("invalid workspace contents");
+
+    let valid_workspace = services.join("a".repeat(64));
+    fs::create_dir(&valid_workspace).expect("valid workspace directory");
+    fs::write(valid_workspace.join(".DS_Store"), "finder metadata")
+        .expect("nested Finder metadata");
+    let invalid_registration = valid_workspace.join("not-a-runtime-instance");
+    fs::create_dir(&invalid_registration).expect("invalid registration directory");
+    fs::write(invalid_registration.join("note"), "noise").expect("invalid registration contents");
+
+    let mut paths = manifest::default_resolved_paths();
+    paths.runtime_dir = runtime;
+    let roots = registered_service_roots(&paths).expect("normalize owned runtime registry");
+
+    assert!(roots.is_empty(), "noise must not manufacture runtime roots");
+    assert!(
+        unrelated_target.is_dir(),
+        "registry cleanup must not follow symlink targets"
+    );
+    assert!(
+        fs::read_dir(&services)
+            .expect("normalized services directory")
+            .all(|entry| entry.expect("service entry").path() == valid_workspace),
+        "only the valid workspace directory may remain"
+    );
+    assert_eq!(
+        fs::read_dir(&valid_workspace)
+            .expect("normalized workspace directory")
+            .count(),
+        0,
+        "invalid registration entries must be removed"
+    );
+}
+
+#[test]
+fn runtime_registry_noise_cleanup_keeps_valid_registration_shapes_strict() {
+    let fixture = tempfile::tempdir().expect("runtime registry fixture");
+    let runtime = fixture.path().join("runtime");
+    let registration = runtime
+        .join("services")
+        .join("a".repeat(64))
+        .join("11111111-1111-4111-8111-111111111111");
+    fs::create_dir_all(&registration).expect("valid-shaped registration directory");
+
+    let mut paths = manifest::default_resolved_paths();
+    paths.runtime_dir = runtime;
+    registered_service_roots(&paths).expect_err("incomplete valid-shaped registration must fail");
+
+    assert!(
+        registration.is_dir(),
+        "valid-shaped registration evidence must not be deleted before validation"
+    );
+}
 
 #[test]
 fn missing_service_root_keeps_typed_identity_deleted_workspace_registration_review_regression() {

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/service_manager.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/service_manager.rs
@@ -124,6 +124,20 @@ pub(super) fn unregister(manager: &ServiceManagerRegistration) -> Result<()> {
     match manager {
         ServiceManagerRegistration::Test { state_path, .. } => {
             require_test_manager_enabled(Path::new(state_path))?;
+            if let ServiceManagerObservation::Running(pid) =
+                inspect_test_manager(Path::new(state_path))?
+            {
+                let pid = i32::try_from(pid)
+                    .map_err(|_| manager_error("Test service manager PID is out of range."))?;
+                if unsafe { libc::kill(pid, libc::SIGTERM) } != 0 {
+                    let error = std::io::Error::last_os_error();
+                    if error.raw_os_error() != Some(libc::ESRCH) {
+                        return Err(manager_error(&format!(
+                            "Test service manager could not stop the runtime: {error}"
+                        )));
+                    }
+                }
+            }
             match fs::remove_file(state_path) {
                 Ok(()) => Ok(()),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/service_manager.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/service_manager.rs
@@ -11,6 +11,10 @@ mod launchd;
 #[cfg(not(target_os = "macos"))]
 #[path = "service_manager/systemd.rs"]
 mod systemd;
+#[cfg(all(target_os = "macos", test))]
+#[path = "service_manager/systemd.rs"]
+#[allow(dead_code)]
+mod systemd;
 
 #[path = "service_manager/discovery.rs"]
 mod discovery;
@@ -120,24 +124,11 @@ pub(super) fn inspect(manager: &ServiceManagerRegistration) -> Result<ServiceMan
     }
 }
 
-pub(super) fn unregister(manager: &ServiceManagerRegistration) -> Result<()> {
+pub(super) fn unregister_dead(runtime: &super::ownership::DeadServiceRuntime) -> Result<()> {
+    let manager = &runtime.registration.receipt.manager;
     match manager {
         ServiceManagerRegistration::Test { state_path, .. } => {
             require_test_manager_enabled(Path::new(state_path))?;
-            if let ServiceManagerObservation::Running(pid) =
-                inspect_test_manager(Path::new(state_path))?
-            {
-                let pid = i32::try_from(pid)
-                    .map_err(|_| manager_error("Test service manager PID is out of range."))?;
-                if unsafe { libc::kill(pid, libc::SIGTERM) } != 0 {
-                    let error = std::io::Error::last_os_error();
-                    if error.raw_os_error() != Some(libc::ESRCH) {
-                        return Err(manager_error(&format!(
-                            "Test service manager could not stop the runtime: {error}"
-                        )));
-                    }
-                }
-            }
             match fs::remove_file(state_path) {
                 Ok(()) => Ok(()),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -148,6 +139,9 @@ pub(super) fn unregister(manager: &ServiceManagerRegistration) -> Result<()> {
         ServiceManagerRegistration::Launchd { .. } => launchd::unregister(manager),
         #[cfg(not(target_os = "macos"))]
         ServiceManagerRegistration::SystemdUser { .. } => systemd::unregister(manager),
+        #[cfg(all(target_os = "macos", test))]
+        ServiceManagerRegistration::SystemdUser { .. } => systemd::unregister(manager),
+        #[cfg(not(all(target_os = "macos", test)))]
         _ => Err(manager_platform_mismatch()),
     }
 }

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/service_manager/systemd.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/service_manager/systemd.rs
@@ -2,6 +2,8 @@ use super::*;
 use std::collections::BTreeMap;
 
 const SYSTEMCTL: &str = "/usr/bin/systemctl";
+const SYSTEMD_STOP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const SYSTEMD_STOP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 
 pub(super) fn registration_for(
     launch: &ServiceLaunchRegistration,
@@ -191,9 +193,28 @@ fn unregister_with(
         ServiceManagerObservation::Absent => return Ok(()),
         ServiceManagerObservation::Registered => {}
         ServiceManagerObservation::Running(_) => {
-            return Err(manager_error(
-                "Cannot disable a running systemd user service.",
-            ));
+            checked_systemctl(
+                runner,
+                &["--user", "--no-pager", "stop", unit],
+                "stop the systemd user service",
+            )?;
+            let deadline = std::time::Instant::now() + SYSTEMD_STOP_TIMEOUT;
+            loop {
+                match inspect_with(manager, runner)? {
+                    ServiceManagerObservation::Absent => return Ok(()),
+                    ServiceManagerObservation::Registered => break,
+                    ServiceManagerObservation::Running(_)
+                        if std::time::Instant::now() < deadline =>
+                    {
+                        std::thread::sleep(SYSTEMD_STOP_POLL_INTERVAL);
+                    }
+                    ServiceManagerObservation::Running(_) => {
+                        return Err(manager_error(
+                            "systemd user service remained running after stop.",
+                        ));
+                    }
+                }
+            }
         }
     }
     checked_systemctl(

--- a/cli-rs/src/execution/runtime/backend/indexer_authority/service_manager/systemd_tests.rs
+++ b/cli-rs/src/execution/runtime/backend/indexer_authority/service_manager/systemd_tests.rs
@@ -165,6 +165,50 @@ fn unregister_disables_an_exact_registered_link_review_regression() {
 }
 
 #[test]
+fn systemd_forced_shutdown_stops_running_unit_before_disable() {
+    let mut runner = FakeSystemctl {
+        outputs: vec![
+            service_state(
+                "loaded",
+                "active",
+                "running",
+                "42",
+                "/tmp/kast-indexer-test.service",
+            ),
+            output(true),
+            service_state(
+                "loaded",
+                "inactive",
+                "dead",
+                "0",
+                "/tmp/kast-indexer-test.service",
+            ),
+            output(true),
+            service_state("not-found", "inactive", "dead", "0", ""),
+        ]
+        .into(),
+        calls: vec![],
+    };
+
+    unregister_with(&manager(), &mut runner).unwrap();
+
+    assert_eq!(
+        runner.calls[1],
+        ["--user", "--no-pager", "stop", "kast-indexer-test.service",]
+    );
+    assert_eq!(
+        runner.calls[3],
+        [
+            "--user",
+            "--no-pager",
+            "disable",
+            "kast-indexer-test.service",
+        ]
+    );
+    assert_eq!(runner.calls.len(), 5);
+}
+
+#[test]
 fn unregister_of_an_absent_link_is_a_noop_review_regression() {
     let mut runner = FakeSystemctl {
         outputs: vec![service_state("not-found", "inactive", "dead", "0", "")].into(),

--- a/cli-rs/src/operations/install/bundle_entrypoint/agent_resource_install.rs
+++ b/cli-rs/src/operations/install/bundle_entrypoint/agent_resource_install.rs
@@ -45,7 +45,7 @@ fn install_agent_harness(
     let root = marketplace_root.display().to_string();
     if mode == AgentResourceInstallMode::Replace {
         for args in agent_harness_cleanup_commands(harness) {
-            let _ = run_agent_harness_command(harness, &args);
+            run_agent_harness_command(harness, &args)?;
         }
     }
     let commands = match harness {

--- a/cli-rs/tests/agent/public/kast_resources.rs
+++ b/cli-rs/tests/agent/public/kast_resources.rs
@@ -90,7 +90,7 @@ if [[ "$*" == *"--version"* ]]; then
 elif [[ "$*" == *"--json"* ]]; then
   printf '%s\n' '[]'
 fi
-if [[ "${KAST_TEST_FAIL_CLAUDE_INSTALL:-}" == "1" && "$provider" == "claude" && "$*" == *"plugin install"* ]]; then
+if [[ -n "${KAST_TEST_FAIL_CLAUDE_COMMAND:-}" && "$provider" == "claude" && "$*" == *"$KAST_TEST_FAIL_CLAUDE_COMMAND"* ]]; then
   exit 71
 fi
 "#,

--- a/cli-rs/tests/agent/public/kast_resources/install.rs
+++ b/cli-rs/tests/agent/public/kast_resources/install.rs
@@ -15,6 +15,61 @@ fn direct_public_cli_does_not_require_agent_resources() {
 }
 
 #[test]
+fn force_agent_resource_cleanup_failure_is_not_ignored() {
+    let fixture = tempfile::tempdir().expect("temporary cleanup failure fixture");
+    let bin = fixture.path().join("bin");
+    fs::create_dir(&bin).expect("create provider bin directory");
+    write_provider(&bin.join("claude"));
+
+    let provider_log = fixture.path().join("providers.log");
+    let mut path_entries = vec![bin];
+    path_entries.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_else(|| OsString::from("/usr/bin:/bin")),
+    ));
+    let path = std::env::join_paths(path_entries).expect("provider PATH");
+
+    let output = kast()
+        .args([
+            "__internal",
+            "resources",
+            "install",
+            "--force",
+            "--harness",
+            "claude",
+        ])
+        .env("PATH", path)
+        .env("HOME", fixture.path().join("home"))
+        .env("KAST_HOME", fixture.path().join("kast"))
+        .env("KAST_PROVIDER_LOG", &provider_log)
+        .env("KAST_TEST_FAIL_CLAUDE_COMMAND", "plugin uninstall")
+        .output()
+        .expect("run forced provider replacement with cleanup failure");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "cleanup failure must fail forced provider replacement: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("installation command exited with status 71"),
+        "cleanup failure detail must be preserved: {stdout}"
+    );
+
+    let log = fs::read_to_string(&provider_log).expect("provider invocation log");
+    assert!(
+        log.lines()
+            .any(|line| line.contains("claude plugin uninstall kast@kast --scope user")),
+        "cleanup command was not attempted:\n{log}"
+    );
+    assert!(
+        !log.lines().any(|line| line.contains("plugin marketplace"))
+            && !log.lines().any(|line| line.contains("plugin install")),
+        "replacement continued after cleanup failure:\n{log}"
+    );
+}
+
+#[test]
 fn force_replaces_existing_provider_installations() {
     let fixture = tempfile::tempdir().expect("temporary provider fixture");
     let bin = fixture.path().join("bin");
@@ -46,7 +101,7 @@ fn force_replaces_existing_provider_installations() {
         .env("HOME", fixture.path().join("home"))
         .env("KAST_HOME", fixture.path().join("kast"))
         .env("KAST_PROVIDER_LOG", &provider_log)
-        .env("KAST_TEST_FAIL_CLAUDE_INSTALL", "1")
+        .env("KAST_TEST_FAIL_CLAUDE_COMMAND", "plugin install")
         .output()
         .expect("run embedded provider installer");
 

--- a/cli-rs/tests/runtime/durable_ownership/setup_release_pins.rs
+++ b/cli-rs/tests/runtime/durable_ownership/setup_release_pins.rs
@@ -95,7 +95,7 @@ fn same_release_profile_switches_keep_a_live_release_pin_valid() {
 }
 
 #[test]
-fn force_setup_tears_down_exact_owned_prior_service() {
+fn force_setup_requires_server_issued_shutdown_permit() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let kast_home = home.join(".local/share/kast");
@@ -103,11 +103,25 @@ fn force_setup_tears_down_exact_owned_prior_service() {
     assert!(setup(&home, &kast_home, &source).status.success());
     let mut runtime = PinnedRuntimeService::new(temp.path(), &kast_home);
 
-    let forced = runtime.run({
+    let mut forced = runtime.spawn({
         let mut command = setup_command(&home, &kast_home, &source);
         command.arg("--force");
         command
     });
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    assert!(
+        forced.try_wait().expect("forced setup status").is_none(),
+        "forced setup bypassed the server-issued idle-shutdown permit",
+    );
+    assert!(runtime.is_live(), "forced setup signaled the prior process");
+    assert!(
+        runtime.manager_state.exists(),
+        "forced setup unloaded the service before permitted shutdown",
+    );
+
+    runtime.complete_idle_shutdown();
+    let forced = forced.wait_with_output().expect("permitted forced setup");
 
     assert!(
         forced.status.success(),

--- a/cli-rs/tests/runtime/durable_ownership/setup_release_pins.rs
+++ b/cli-rs/tests/runtime/durable_ownership/setup_release_pins.rs
@@ -95,34 +95,35 @@ fn same_release_profile_switches_keep_a_live_release_pin_valid() {
 }
 
 #[test]
-fn force_setup_with_a_registered_runtime_changes_no_install_state() {
+fn force_setup_tears_down_exact_owned_prior_service() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let kast_home = home.join(".local/share/kast");
     let source = write_install_bundle_source(temp.path(), "v1.0.0");
     assert!(setup(&home, &kast_home, &source).status.success());
     let mut runtime = PinnedRuntimeService::new(temp.path(), &kast_home);
-    let current_before = std::fs::read_link(kast_home.join("current")).expect("current release");
-    let releases_before = installed_release_names(&kast_home);
-    let state_before = test_path_sha256(&kast_home.join("state"));
 
-    let blocked = runtime.run({
+    let forced = runtime.run({
         let mut command = setup_command(&home, &kast_home, &source);
         command.arg("--force");
         command
     });
 
-    assert!(!blocked.status.success(), "force deleted registered state");
-    let error: serde_json::Value =
-        serde_json::from_slice(&blocked.stdout).expect("typed setup error");
-    assert_eq!(error["code"], "SETUP_RUNTIME_NOT_QUIESCENT");
-    assert_eq!(
-        std::fs::read_link(kast_home.join("current")).expect("unchanged current release"),
-        current_before,
+    assert!(
+        forced.status.success(),
+        "force should unload the exact-owned prior service: stdout={}, stderr={}",
+        String::from_utf8_lossy(&forced.stdout),
+        String::from_utf8_lossy(&forced.stderr),
     );
-    assert_eq!(installed_release_names(&kast_home), releases_before);
-    assert_eq!(test_path_sha256(&kast_home.join("state")), state_before);
-    assert!(runtime.is_live(), "force setup terminated the runtime");
+    assert!(!runtime.is_live(), "forced setup retained the prior process");
+    assert!(
+        !runtime.registration.exists(),
+        "forced setup retained the prior registration"
+    );
+    assert!(
+        !runtime.manager_state.exists(),
+        "forced setup retained the prior service-manager state"
+    );
 }
 
 #[test]

--- a/cli-rs/tests/runtime/durable_ownership/setup_release_pins/fixture.rs
+++ b/cli-rs/tests/runtime/durable_ownership/setup_release_pins/fixture.rs
@@ -164,6 +164,19 @@ impl PinnedRuntimeService {
             .expect("setup with registered runtime")
     }
 
+    fn spawn(&self, mut command: SetupCommand) -> SetupChild {
+        command
+            .env("KAST_TEST_ALLOW_RUNTIME_SERVICE_MANAGER", "1")
+            .env(
+                "KAST_TEST_RUNTIME_SERVICE_MANAGER_STATE",
+                &self.manager_state,
+            )
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn setup with registered runtime")
+    }
+
     fn complete_idle_shutdown(&mut self) {
         drop(self.process.stdin.take());
         let status = self.process.wait().expect("runtime idle shutdown");

--- a/cli-rs/tests/surface/setup/force_reset/runtime_state.rs
+++ b/cli-rs/tests/surface/setup/force_reset/runtime_state.rs
@@ -1,5 +1,5 @@
 #[test]
-fn force_setup_preserves_the_install_when_runtime_registration_state_is_malformed() {
+fn force_setup_replaces_invalid_owned_runtime_registry_noise() {
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let kast_home = home.join(".local/share/kast");
@@ -8,7 +8,6 @@ fn force_setup_preserves_the_install_when_runtime_registration_state_is_malforme
     assert!(setup(&home, &kast_home, &initial_source).status.success());
 
     let current_before = std::fs::read_link(kast_home.join("current")).expect("current release");
-    let releases_before = installed_release_names(&kast_home);
     let registration = kast_home
         .join("state/runtime/services")
         .join("malformed-workspace")
@@ -25,22 +24,19 @@ fn force_setup_preserves_the_install_when_runtime_registration_state_is_malforme
         .expect("forced setup");
 
     assert!(
-        !output.status.success(),
-        "force must fail before deleting unproven runtime state: stdout={}, stderr={}",
+        output.status.success(),
+        "force must remove invalid owned registry noise: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
-    let error: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("typed setup error");
-    assert_eq!(error["code"], "SETUP_RUNTIME_PREFLIGHT_BLOCKED");
-    assert_eq!(
-        std::fs::read_link(kast_home.join("current")).expect("unchanged current release"),
+    assert_ne!(
+        std::fs::read_link(kast_home.join("current")).expect("replacement current release"),
         current_before,
+        "forced setup retained the prior release",
     );
-    assert_eq!(installed_release_names(&kast_home), releases_before);
-    assert_eq!(
-        std::fs::read(&registration).expect("preserved runtime registration"),
-        malformed,
+    assert!(
+        !registration.exists(),
+        "forced setup retained invalid owned registry noise",
     );
 }
 


### PR DESCRIPTION
## Summary

- fail forced agent-resource replacement when provider cleanup fails, before marketplace removal or reinstallation can report false success
- normalize invalid filesystem noise inside the Kast-owned runtime services registry without following symlink targets, while preserving strict validation for valid-shaped registrations
- unload an exact-owned prior background runtime through its validated service-manager registration, wait boundedly for the same epoch to become proven dead, clean its evidence, and re-prove global runtime absence before replacement
- keep ambiguous, foreign, legacy, unclassified, mismatched, and failed teardown states as typed blockers

This is a follow-up to #606 and addresses https://github.com/amichne/kast/pull/606#discussion_r3763400373. It also incorporates the Finder metadata diagnosis from https://gist.github.com/amichne/7ff49b716cbec7d63316bef4790a560d.

## Validation

- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test kast_resources force_agent_resource_cleanup_failure`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked runtime_registry_noise`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked force_setup_tears_down_exact_owned_prior_service`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test kast_resources` (7 passed)
- `cargo test --manifest-path cli-rs/Cargo.toml --locked --test setup_smoke` (111 passed)
- `cargo clippy --manifest-path cli-rs/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path cli-rs/Cargo.toml --locked`
- `cargo fmt --manifest-path cli-rs/Cargo.toml --all -- --check`
- `python3 .github/scripts/check-repository-shape.py`
- `git diff --check`